### PR TITLE
[CC] Fix basic american and special american charsets for EIA-608 CC …

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder.h
@@ -37,6 +37,7 @@ typedef struct cc_char_cell_s
   uint8_t c;                   /* character code, not the same as ASCII */
   cc_attribute_t attributes;   /* attributes of this character, if changed */
 			       /* here */
+  uint8_t charset; /* charset type */
   int midrow_attr;             /* true if this cell changes an attribute */
 } cc_char_cell_t;
 


### PR DESCRIPTION
…decoder

## Description
This PR fixes the closed caption EIA-608 decoder that was incorrectly mapping exceptions in the Basic North American character set and Special North American character set. Those characters are usually mapped to unicode, thus taking more than 1 byte (`sizeof(char)`).
The map was taken from the ffmpeg decoder (c.f. https://github.com/FFmpeg/FFmpeg/blob/ce297b44d3b107150c07017993c267a4b9bb41b0/libavcodec/ccaption_dec.c#L69-L170), for more information on those overrides please check https://en.wikipedia.org/wiki/EIA-608#Characters.

This also allows to further extend the supported overrides to also cover the Extended Western European character set (spanish, french, portuguese, german, danish) in the future.

Please carefully review, I'm not sure I'm not leaking somewhere.

@hudokkow can you check if the license should in fact change?

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18845

## How Has This Been Tested?
With the sample provided in the issue report. Also tested other samples containing the same closed captions.

## Screenshots (if appropriate):

**master**
![master](https://i.imgur.com/lvttjit.png "Master")

**pr**
![pr](https://i.imgur.com/5Qv7Z7V.png "pr")

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
