### PR TITLE
[Android] read playlists from path substitutions for android tv channels

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -70,6 +70,7 @@ set(package_files strings.xml
                   src/XBMCProperties.java
                   src/XBMCVideoView.java
                   src/XBMCFile.java
+                  src/XBMCURIUtils.java
                   src/channels/SyncChannelJobService.java
                   src/channels/SyncProgramsJobService.java
                   src/channels/model/XBMCDatabase.java

--- a/tools/android/packaging/xbmc/src/XBMCURIUtils.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCURIUtils.java.in
@@ -1,0 +1,29 @@
+package @APP_PACKAGE@;
+
+import android.util.Log;
+
+public class XBMCURIUtils
+{
+  native String _substitutePath(String path);
+
+  private static String TAG = "@APP_NAME@uriutils";
+
+  public XBMCURIUtils()
+  {
+  }
+
+  public String substitutePath(String path)
+  {
+    try
+    {
+      return _substitutePath(path);
+    }
+    catch (Exception e)
+    {
+      e.printStackTrace();
+      Log.e(TAG, "substitutePath: Exception");
+      return null;
+    }
+  }
+
+}

--- a/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
@@ -29,6 +29,7 @@ import androidx.tvprovider.media.tv.TvContractCompat;
 
 import @APP_PACKAGE@.R;
 import @APP_PACKAGE@.XBMCJsonRPC;
+import @APP_PACKAGE@.XBMCURIUtils;
 import @APP_PACKAGE@.channels.model.Subscription;
 import @APP_PACKAGE@.channels.model.XBMCDatabase;
 import @APP_PACKAGE@.channels.util.TvUtil;
@@ -85,6 +86,28 @@ public class SyncChannelJobService extends JobService
       this.mContext = context;
     }
 
+    List<File> getFilesFromUrl(String url)
+    {
+      List<File> list = new ArrayList<>();
+
+      try (Cursor cursor =
+                   mContext.getContentResolver()
+                           .query(
+                                   XBMCFileContentProvider.buildUri(url),
+                                   null,
+                                   null,
+                                   null,
+                                   null))
+      {
+        if (cursor != null)
+        {
+          while (cursor.moveToNext())
+            list.add(File.fromCursor(cursor));
+        }
+      }
+      return list;
+    }
+
     @Override
     protected Boolean doInBackground(Void... voids)
     {
@@ -96,52 +119,11 @@ public class SyncChannelJobService extends JobService
       List<Subscription> subscriptions = XBMCDatabase.getSubscriptions(mContext);
       List<Subscription> freshsubscriptions = new ArrayList<>();
       List<File> playlistsContent = new ArrayList<>();
+      XBMCURIUtils uriutils = new XBMCURIUtils();
 
-      try (Cursor cursor =
-                   mContext.getContentResolver()
-                           .query(
-                                   XBMCFileContentProvider.buildUri("special://profile/playlists/video/"),
-                                   null,
-                                   null,
-                                   null,
-                                   null))
-      {
-        if (cursor != null)
-        {
-          while (cursor.moveToNext())
-            playlistsContent.add(File.fromCursor(cursor));
-        }
-      }
-      try (Cursor cursor =
-                   mContext.getContentResolver()
-                           .query(
-                                   XBMCFileContentProvider.buildUri("special://profile/playlists/mixed/"),
-                                   null,
-                                   null,
-                                   null,
-                                   null))
-      {
-        if (cursor != null)
-        {
-          while (cursor.moveToNext())
-            playlistsContent.add(File.fromCursor(cursor));
-        }
-      }
-      try (Cursor cursor =
-                   mContext.getContentResolver()
-                           .query(
-                                   XBMCFileContentProvider.buildUri("special://profile/playlists/music/"),
-                                   null,
-                                   null,
-                                   null,
-                                   null))
-      {
-        if (cursor != null)
-        {
-          while (cursor.moveToNext())
-            playlistsContent.add(File.fromCursor(cursor));
-        }
-      }
+      playlistsContent.addAll(getFilesFromUrl(uriutils.substitutePath("special://profile/playlists/video/")));
+      playlistsContent.addAll(getFilesFromUrl(uriutils.substitutePath("special://profile/playlists/mixed/")));
+      playlistsContent.addAll(getFilesFromUrl(uriutils.substitutePath("special://profile/playlists/music/")));
 
       Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.ic_recommendation_80dp);
       freshsubscriptions.add(sub);

--- a/xbmc/platform/android/activity/CMakeLists.txt
+++ b/xbmc/platform/android/activity/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES android_main.cpp
             JNIXBMCNsdManagerResolveListener.cpp
             JNIXBMCJsonHandler.cpp
             JNIXBMCFile.cpp
+            JNIXBMCURIUtils.cpp
             JNIXBMCDisplayManagerDisplayListener.cpp
             ${NDKROOT}/sources/android/native_app_glue/android_native_app_glue.c
             ${NDKROOT}/sources/android/cpufeatures/cpu-features.c)
@@ -42,6 +43,7 @@ set(HEADERS AndroidExtra.h
             JNIXBMCNsdManagerResolveListener.h
             JNIXBMCJsonHandler.h
             JNIXBMCFile.h
+            JNIXBMCURIUtils.h
             JNIXBMCDisplayManagerDisplayListener.h
             XBMCApp.h)
 

--- a/xbmc/platform/android/activity/JNIXBMCURIUtils.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCURIUtils.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JNIXBMCURIUtils.h"
+
+#include "CompileInfo.h"
+#include "utils/URIUtils.h"
+
+#include <androidjni/Context.h>
+#include <androidjni/jutils-details.hpp>
+
+using namespace jni;
+
+static std::string s_className = std::string(CCompileInfo::GetClass()) + "/XBMCURIUtils";
+
+void CJNIXBMCURIUtils::RegisterNatives(JNIEnv *env)
+{
+  jclass cClass = env->FindClass(s_className.c_str());
+  if(cClass)
+  {
+    JNINativeMethod methods[] =
+    {
+      {"_substitutePath", "(Ljava/lang/String;)Ljava/lang/String;", (void*)&CJNIXBMCURIUtils::_substitutePath},
+    };
+
+    env->RegisterNatives(cClass, methods, sizeof(methods)/sizeof(methods[0]));
+  }
+}
+
+jstring CJNIXBMCURIUtils::_substitutePath(JNIEnv *env, jobject thiz, jstring path)
+{
+  std::string strPath = jcast<std::string>(jhstring::fromJNI(path));
+  std::string responseData = URIUtils::SubstitutePath(strPath);
+
+  jstring jres = env->NewStringUTF(responseData.c_str());
+  return jres;
+}

--- a/xbmc/platform/android/activity/JNIXBMCURIUtils.h
+++ b/xbmc/platform/android/activity/JNIXBMCURIUtils.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <androidjni/JNIBase.h>
+
+namespace jni
+{
+
+  class CJNIXBMCURIUtils : public CJNIBase
+  {
+  public:
+	CJNIXBMCURIUtils(const jni::jhobject &object) : CJNIBase(object) {}
+
+    static void RegisterNatives(JNIEnv* env);
+
+
+  protected:
+    ~CJNIXBMCURIUtils() override = default;
+
+    static jstring _substitutePath(JNIEnv* env, jobject thiz, jstring path);
+
+  };
+
+}

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -22,6 +22,7 @@
 #include "platform/android/activity/JNIXBMCNsdManagerRegistrationListener.h"
 #include "platform/android/activity/JNIXBMCNsdManagerResolveListener.h"
 #include "platform/android/activity/JNIXBMCSurfaceTextureOnFrameAvailableListener.h"
+#include "platform/android/activity/JNIXBMCURIUtils.h"
 #include "platform/android/activity/JNIXBMCVideoView.h"
 
 #include <errno.h>
@@ -146,6 +147,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
   jni::CJNIXBMCMediaSession::RegisterNatives(env);
   jni::CJNIXBMCJsonHandler::RegisterNatives(env);
   jni::CJNIXBMCFile::RegisterNatives(env);
+  jni::CJNIXBMCURIUtils::RegisterNatives(env);
 
   jclass cMain = env->FindClass(mainClass.c_str());
   if(cMain)


### PR DESCRIPTION
## Description
This PR enables the reading of playlists from path substitutions (advancedsetting.xml), when Kodi syncs the program for android tv channels.

## Motivation and Context
At the moment, the paths for the playlists are set to `special://profile/playlists/video/`, `special://profile/playlists/music/` or `special://profile/playlists/mixed/`.

If you use path substitutions for these paths, no channels are created for android tv.

During synchronization, my PR checks whether there are path substitutions for these paths and uses them.

## How Has This Been Tested?
On my Shield TV with custom kodi builds.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
