### PR TITLE
[subtitles][ASS] Fix wrong screen position for 'fractional pts' muxed…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -61,7 +61,15 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
 
   double pts = pPacket->dts != DVD_NOPTS_VALUE ? pPacket->dts : pPacket->pts;
   if (pts == DVD_NOPTS_VALUE)
+  {
     pts = 0;
+  }
+  else
+  {
+    // libass only has a precision of msec
+    pts = round(pts / 1000) * 1000;
+  }
+
   uint8_t *data = pPacket->pData;
   int size = pPacket->iSize;
   double duration = pPacket->duration;


### PR DESCRIPTION
… ASS subs

## Description
ASS subtitles render sequentially, i.e. libass is asked to render images associated with a given timestamp. For muxed ass subtitles, Kodi videoplayer relies on the audio (or video) PTS to generate the overlays instead of the time values provided in the subtitle file. For ass subs this can lead to issues because the maximum resolution the subtitle file can provide is in the milliseconds range whereas the pts provided by ffmpeg in the demux packet is in the microseconds range.

If a movie has fractional frame rate, the pts value returned by the packet may have a fractional part - libass is asked to render the subtitle at the wrong timestamp. See the example below:

**Media info:**
```
Video
ID                                       : 1
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Format profile                           : High@L4
Format settings                          : CABAC / 4 Ref Frames
Format settings, CABAC                   : Yes
Format settings, Reference frames        : 4 frames
Codec ID                                 : V_MPEG4/ISO/AVC
Duration                                 : 24 min 10 s
Bit rate                                 : 7 514 kb/s
Nominal bit rate                         : 8 000 kb/s
Width                                    : 1 920 pixels
Height                                   : 1 080 pixels
Display aspect ratio                     : 16:9
Frame rate mode                          : Constant
Frame rate                               : 23.976 (24000/1001) FPS
```

**Subtitle file:**
```
Dialogue: 0,0:08:51.37,0:08:54.41,Default,,0,0,0,,So you're a witch, Mirarosé?
Dialogue: 0,0:08:54.41,0:08:57.29,Default,,0,0,0,,So you're a witch, too, Elaina?
Dialogue: 0,0:08:57.29,0:09:01.41,Default,,0,0,0,,That should've been obvious by my appearance.
```

When kodi gets to the second overlay, the returned pts value is `534409999.99999994`. Since ass events don't have this degree of time sensitivity, ceiling the pts value fixes this issue (and likely similar ones).

## Motivation and Context
Fixes an issue reported by xD_ on freenode.
Plan is still to use libass for all subtitle types in the future.

Not sure who to ping. This seems no-man's land by now :/

## How Has This Been Tested?
Sample provided in irc. It has been uploaded to the ftp server (folder `samples/pr18889/ASS-issue-at-08.50.mkv`). As the file indicates, the issue shows up around 08.50.
Also tested all the others samples with ASS subs I have available.

## Screenshots (if appropriate):

Following screenshots show the aforementioned 3 overlays. Note the wrong positioning of event 2.

**master**

![event1](https://i.imgur.com/qsjnyxb.png "event1")
![event2](https://i.imgur.com/4hgBULM.png "event2")
![event3](https://i.imgur.com/kbENrho.png "event3")

**pr**
![event1](https://i.imgur.com/qsjnyxb.png "event1")
![event2](https://i.imgur.com/JM78wZB.png "event2")
![event3](https://i.imgur.com/mziO1DZ.png "event3")



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
