### PR TITLE
Fix MKV metadata loading

### DIFF
--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -191,7 +191,7 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
       std::vector<std::string> dirs = StringUtils::Split(avtag->value, " / ");
       tag.SetDirector(dirs);
     }
-    else if (StringUtils::CompareNoCase(avtag->key, "date_released") == 0)
+    else if (StringUtils::CompareNoCase(avtag->key, "DATE") == 0)
       tag.SetYear(atoi(avtag->value));
     hastag = true;
   }


### PR DESCRIPTION
The correct Mastroska tag used by ffmpeg is 'DATE', not 'date_released'.

## Description

I'd like to be able to retrieve both 'title' and 'date' as stored in different containers (eg. avi, mp4 and mkv) in a portable manner.

## Motivation and Context

The makes the mkv scrapping consistant with other containers (eg. avi or mp4).

## How Has This Been Tested?

Setup kodi to load Video/tag. Settings/Media>'Advanced'>Videos>'Extract thumbnails and video information'

Prepare a folder with:

```
$ mkdir /tmp/demo
$ cd /tmp/demo
$ wget http://techslides.com/demos/sample-videos/small.mp4
$ ffmpeg -i small.mp4 -map_metadata -1 -metadata title="the mummy" -metadata date="1932" movie.mp4
$ ffmpeg -i small.mp4 -map_metadata -1 -metadata title="the mummy" -metadata date="1932" movie.avi
$ ffmpeg -i small.mp4 -map_metadata -1 -metadata title="the mummy" -metadata date="1932" movie.mkv
$ ffmpeg -i movie.avi movie.avi.mkv
$ ffmpeg -i movie.mp4 movie.mp4.mkv
$ rm small.mp4

```
All 5 files should load the exact same movie:

* https://www.themoviedb.org/movie/15849-the-mummy

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
