### PR TITLE
Add keymap support for OSMC remote controllers

### DIFF
--- a/system/keymaps/osmc/osmc_remote.xml
+++ b/system/keymaps/osmc/osmc_remote.xml
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The second and third generation OSMC remotes use i and c keys that stop functioning with some keyboard languages in OSMC.           -->
+<!-- We have remapped those keys in OSMC to kpleftparen and kprightparen with udev to overcome this issue. This file maps those keys to  -->
+<!-- Kodi actions and adds tweaks to provide enhanced function. Home was remapped in v1&2 for consistency. The buttons map in Kodi as... -->
+<!--                                                                                                                                     -->
+<!-- OSMC with udev remap                            non-OSMCv1                 non-OSMCv2                 non-OSMCv3                    -->
+<!-- Home  = escape        <key id="61467">          Home  = home               Home  = home               Home  = escape                -->
+<!-- Info  = leftbracket   <key id="61480">          Info  =                    Info  = i                  Info  = i                     -->
+<!-- Up    = up            <key id="61568">          Up    = up                 Up    = up                 Up    = up                    -->
+<!-- Down  = down          <key id="61569">          Down  = down               Down  = down               Down  = down                  -->
+<!-- Left  = left          <key id="61570">          Left  = left               Left  = left               Left  = left                  -->
+<!-- Right = right         <key id="61571">          Right = right              Right = right              Right = right                 -->
+<!-- OK    = return        <key id="61453">          OK    = return             OK    = return             OK    = return                -->
+<!-- Back  = browser_back  <key id="61616">          Back  = browser_back       Back  = browser_back       Back  = browser_back          -->
+<!-- Menu  = rightbracket  <key id="61481">          Menu  =                    Menu  = c                  Menu  = c                     -->
+<!-- Play  = play_pause    <key id="61629">          Play  = play_pause         Play  = play_pause         Play  = play_pause            -->
+<!-- Stop  = stop          <key id="61628">          Stop  = stop               Stop  = stop               Stop  = stop                  -->
+<!-- Vol-  = volume_down   <key id="61624">          RW    = rewind             Vol-  = minus              Vol-  = minus                 -->
+<!-- Vol+  = volume_up     <key id="61625">          FF    = fastforward        Vol+  = equals             Vol+  = equals                -->
+<!--                                                                                                                                     -->
+<!-- Keymap created by DarwinDesign version 20-11-02                                                                                     -->
+<!--                                                                                                                                     -->
+<keymap>
+	<global>
+		<keyboard>
+			<escape>PreviousMenu</escape>
+			<home>PreviousMenu</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+			<leftbracket>Info</leftbracket>
+			<i>Info</i>
+			<leftbracket mod="longpress">noop</leftbracket> <!-- stops cycling -->
+			<i mod="longpress">noop</i> <!-- stops cycling -->
+			<left>Left</left>
+			<right>Right</right>
+			<up>Up</up>
+			<down>Down</down>
+			<return>Select</return>
+			<return mod="longpress">noop</return> <!-- removes default context menu & stops cycling -->
+			<browser_back>Back</browser_back>
+			<rightbracket>ContextMenu</rightbracket>
+			<c>ContextMenu</c>
+			<rightbracket mod="longpress">Menu</rightbracket>
+			<c mod="longpress">Menu</c>
+			<play_pause>PlayPause</play_pause>
+			<p>PlayPause</p>
+			<play_pause mod="longpress">noop</play_pause> <!-- removes default info & stops cycling -->
+			<p mod="longpress">noop</p>
+			<stop>Stop</stop>
+			<x>Stop</x>
+			<volume_down>VolumeDown</volume_down>
+			<volume_up>VolumeUp</volume_up>
+			<f2>Notification(OSMC Remote Controller, Low Battery Please Replace,5000)</f2>
+		</keyboard>
+	</global>
+	<Home>
+		<keyboard>
+			<escape>CECActivateSource</escape>
+			<home>CECActivateSource</home>
+			<escape mod="longpress">CECStandby</escape>
+			<home mod="longpress">CECStandby</home>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<browser_back mod="longpress">ActivateWindow(ShutdownMenu)</browser_back>
+			<return mod="longpress">ReloadSkin()</return>
+			<play_pause mod="longpress">UpdateLibrary(video)</play_pause>
+			<p mod="longpress">UpdateLibrary(video)</p>
+		</keyboard>
+	</Home>
+	<VirtualKeyboard>
+		<keyboard>
+			<rightbracket mod="longpress">noop</rightbracket>
+			<c mod="longpress">noop</c>
+			<up mod="longpress">Shift</up>
+			<down mod="longpress">Symbols</down>
+			<return mod="longpress">Enter</return>
+		</keyboard>
+	</VirtualKeyboard>
+	<FileManager>
+		<keyboard>
+			<right mod="longpress">Highlight</right>
+			<left mod="longpress">Highlight</left>
+		</keyboard>
+	</FileManager>
+	<FullscreenVideo>
+		<keyboard>
+			<escape>ActivateWindow(videobookmarks)</escape>
+			<home>ActivateWindow(videobookmarks)</home>
+			<escape mod="longpress">playerdebug</escape>
+			<home mod="longpress">playerdebug</home>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<return mod="longpress">Playlist</return>
+			<up mod="longpress">SkipNext</up>
+			<down mod="longpress">SkipPrevious</down>
+			<left mod="longpress">AudioDelay</left>
+			<right mod="longpress">subtitledelay</right>
+			<rightbracket>ActivateWindow(osdvideosettings)</rightbracket>
+			<c>ActivateWindow(osdvideosettings)</c>
+			<rightbracket mod="longpress">ActivateWindow(osdaudiosettings)</rightbracket>
+			<c mod="longpress">ActivateWindow(osdaudiosettings)</c>
+			<play_pause mod="longpress">showsubtitles</play_pause>
+			<p mod="longpress">showsubtitles</p>
+			<stop mod="longpress">ActivateWindow(osdsubtitlesettings)</stop>
+			<x mod="longpress">ActivateWindow(osdsubtitlesettings)</x>
+		</keyboard>
+	</FullscreenVideo>
+	<FullscreenGame>
+		<keyboard>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<rightbracket>OSD</rightbracket>
+			<c>OSD</c>
+		</keyboard>
+	</FullscreenGame>
+	<FullscreenInfo>
+		<keyboard>
+			<leftbracket>Back</leftbracket>
+			<i>Back</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<rightbracket>Back</rightbracket>
+			<c>Back</c>
+		</keyboard>
+	</FullscreenInfo>
+	<Visualisation>
+		<keyboard>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+			<return mod="longpress">ActivateWindow(MusicPlaylist)</return>
+			<rightbracket>Addon.Default.OpenSettings(xbmc.player.musicviz)</rightbracket>
+			<c>Addon.Default.OpenSettings(xbmc.player.musicviz)</c>
+			<rightbracket mod="longpress">ActivateWindow(VisualisationPresetList)</rightbracket>
+			<c mod="longpress">ActivateWindow(VisualisationPresetList)</c>
+			<p/>
+		</keyboard>
+	</Visualisation>
+	<MusicOSD>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<return mod="longpress">back</return>
+			<rightbracket>Addon.Default.OpenSettings(xbmc.player.musicviz)</rightbracket>
+			<c>Addon.Default.OpenSettings(xbmc.player.musicviz)</c>
+			<rightbracket mod="longpress">ActivateWindow(VisualisationPresetList)</rightbracket>
+			<c mod="longpress">ActivateWindow(VisualisationPresetList)</c>
+			<p/>
+		</keyboard>
+	</MusicOSD>
+	<VisualisationPresetList>
+		<keyboard>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<rightbracket>back</rightbracket>
+			<c>back</c>
+			<p/>
+		</keyboard>
+	</VisualisationPresetList>
+	<slideshow>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<play_pause>pause</play_pause>
+			<p>pause</p>
+			<up mod="longpress">ZoomIn</up>
+			<down mod="longpress">ZoomOut</down>
+			<return mod="longpress">ZoomNormal</return>
+			<rightbracket></rightbracket> <!-- removes mapping from osmc-classic -->
+		</keyboard>
+	</slideshow>
+	<VideoOSD>
+		<keyboard>
+			<escape>ActivateWindow(videobookmarks)</escape>
+			<home>ActivateWindow(videobookmarks)</home>
+			<escape mod="longpress">playerdebug</escape>
+			<home mod="longpress">playerdebug</home>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<up mod="longpress">SkipNext</up>
+			<down mod="longpress">SkipPrevious</down>
+			<left mod="longpress">AudioDelay</left>
+			<right mod="longpress">subtitledelay</right>
+			<rightbracket>ActivateWindow(osdvideosettings)</rightbracket>
+			<return mod="longpress">back</return>
+			<c>ActivateWindow(osdvideosettings)</c>
+			<rightbracket mod="longpress">ActivateWindow(osdaudiosettings)</rightbracket>
+			<c mod="longpress">ActivateWindow(osdaudiosettings)</c>
+			<play_pause mod="longpress">showsubtitles</play_pause>
+			<p mod="longpress">showsubtitles</p>
+			<stop mod="longpress">ActivateWindow(osdsubtitlesettings)</stop>
+			<x mod="longpress">ActivateWindow(osdsubtitlesettings)</x>
+		</keyboard>
+	</VideoOSD>
+	<VideoMenu>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<rightbracket></rightbracket> <!-- removes mapping from osmc-classic -->
+		</keyboard>
+	</VideoMenu>
+	<OSDVideoSettings>
+		<keyboard>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<rightbracket>back</rightbracket>
+			<c>back</c>
+			<stop>back</stop>
+			<x>back</x>
+		</keyboard>
+	</OSDVideoSettings>
+	<OSDAudioSettings>
+		<keyboard>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<rightbracket>back</rightbracket>
+			<c>back</c>
+			<stop>back</stop>
+			<x>back</x>
+		</keyboard>
+	</OSDAudioSettings>
+	<osdsubtitlesettings>
+		<keyboard>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<rightbracket>back</rightbracket>
+			<c>back</c>
+			<stop>back</stop>
+			<x>back</x>
+		</keyboard>
+	</osdsubtitlesettings>
+	<VideoBookmarks>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<rightbracket mod="longpress">back</rightbracket>
+			<c mod="longpress">back</c>
+		</keyboard>
+	</VideoBookmarks>
+	<Videos>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+			<return mod="longpress">SendClick(14)</return> <!-- Toggle view between unwatched and all videos -->
+			<play_pause mod="longpress">togglewatched</play_pause>
+			<p mod="longpress">togglewatched</p>
+		</keyboard>
+	</Videos>
+	<VideoPlaylist>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+			<return mod="longpress">Back</return>
+		</keyboard>
+	</VideoPlaylist>
+	<ContextMenu>
+		<keyboard>
+			<rightbracket>Back</rightbracket>
+			<c>Back</c>
+		</keyboard>
+	</ContextMenu>
+	<MusicInformation>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<leftbracket>Back</leftbracket>
+			<i>Back</i>
+			<leftbracket mod="longpress">noop</leftbracket> <!-- stops cycling -->
+			<i mod="longpress">noop</i> <!-- stops cycling -->
+			<rightbracket>Back</rightbracket>
+			<c>Back</c>
+		</keyboard>
+	</MusicInformation>
+	<MusicPlaylist>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+			<return mod="longpress">back</return>
+		</keyboard>
+	</MusicPlaylist>
+	<SongInformation>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<leftbracket>Back</leftbracket>
+			<i>Back</i>
+			<leftbracket mod="longpress">noop</leftbracket> <!-- stops cycling -->
+			<i mod="longpress">noop</i> <!-- stops cycling -->
+			<rightbracket>Back</rightbracket>
+			<c>Back</c>
+		</keyboard>
+	</SongInformation>
+	<MovieInformation>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<leftbracket>Back</leftbracket>
+			<i>Back</i>
+			<leftbracket mod="longpress">noop</leftbracket> <!-- stops cycling -->
+			<i mod="longpress">noop</i> <!-- stops cycling -->
+			<rightbracket>Back</rightbracket>
+			<c>Back</c>
+		</keyboard>
+	</MovieInformation>
+	<PictureInfo>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<leftbracket>Back</leftbracket>
+			<i>Back</i>
+			<leftbracket mod="longpress">noop</leftbracket> <!-- stops cycling -->
+			<i mod="longpress">noop</i> <!-- stops cycling -->
+			<rightbracket>Back</rightbracket>
+			<c>Back</c>
+		</keyboard>
+	</PictureInfo>
+	<FullscreenLiveTV>
+		<keyboard>
+			<rightbracket>ActivateWindow(PVROSDChannels)</rightbracket>
+			<c>ActivateWindow(PVROSDChannels)</c>
+			<leftbracket>info</leftbracket>
+			<i>info</i>
+			<leftbracket mod="longpress">playerprocessinfo</leftbracket>
+			<i mod="longpress">playerprocessinfo</i>
+			<left mod="longpress">AudioDelay</left>
+			<right mod="longpress">subtitledelay</right>
+			<return mod="longpress">Record</return>
+			<play_pause mod="longpress">showsubtitles</play_pause>
+			<p mod="longpress">showsubtitles</p>
+			<stop mod="longpress">ActivateWindow(Teletext)</stop>
+			<x mod="longpress">ActivateWindow(Teletext)</x>
+		</keyboard>
+	</FullscreenLiveTV>
+	<TVGuide>
+		<keyboard>
+			<return mod="longpress">Record</return>
+		</keyboard>
+	</TVGuide>
+	<FullscreenRadio>
+		<keyboard>
+			<rightbracket>ActivateWindow(PVROSDChannels)</rightbracket>
+			<c>ActivateWindow(PVROSDChannels)</c>
+		</keyboard>
+	</FullscreenRadio>
+	<AddonInformation>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+			<leftbracket>Back</leftbracket>
+			<i>Back</i>
+			<leftbracket mod="longpress">noop</leftbracket> <!-- stops cycling -->
+			<i mod="longpress">noop</i> <!-- stops cycling -->
+			<rightbracket>Back</rightbracket>
+			<c>Back</c>
+		</keyboard>
+	</AddonInformation>
+	<PlayerProcessInfo>
+		<keyboard>
+			<leftbracket>back</leftbracket>
+			<i>back</i>
+			<rightbracket>ActivateWindow(osdvideosettings)</rightbracket>
+			<c>ActivateWindow(osdvideosettings)</c>
+			<rightbracket mod="longpress">noop</rightbracket>
+			<c mod="longpress">noop</c>
+			<stop mod="longpress">ActivateWindow(osdsubtitlesettings)</stop>
+			<x mod="longpress">ActivateWindow(osdsubtitlesettings)</x>
+		</keyboard>
+	</PlayerProcessInfo>
+	<yesnodialog> <!-- Added to allow CEC when update dialog box appears -->
+		<keyboard>
+			<escape>CECActivateSource</escape>
+			<home>CECActivateSource</home>
+			<escape mod="longpress">CECStandby</escape>
+			<home mod="longpress">CECStandby</home>
+		</keyboard>
+	</yesnodialog>
+	<selectdialog>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+		</keyboard>
+	</selectdialog>
+	<contextmenu>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+		</keyboard>
+	</contextmenu>
+	<addonsettings>
+		<keyboard>
+			<escape>back</escape>
+			<home>back</home>
+		</keyboard>
+	</addonsettings>
+	<addonbrowser>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</addonbrowser>
+	<filemanager>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</filemanager>
+	<interfacesettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</interfacesettings>
+	<systeminfo>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</systeminfo>
+	<eventlog>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</eventlog>
+	<playersettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</playersettings>
+	<mediasettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</mediasettings>
+	<pvrsettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</pvrsettings>
+	<servicesettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</servicesettings>
+	<gamesettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</gamesettings>
+	<profiles>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</profiles>
+	<systemsettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</systemsettings>
+	<music>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</music>
+	<pictures>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</pictures>
+	<skinsettings>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</skinsettings>
+	<musicplaylisteditor>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</musicplaylisteditor>
+	<games>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</games>
+	<programs>
+		<keyboard>
+			<escape>ActivateWindow(Home)</escape>
+			<home>ActivateWindow(Home)</home>
+			<escape mod="longpress">fullscreen</escape>
+			<home mod="longpress">fullscreen</home>
+		</keyboard>
+	</programs>
+	</keymap>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -52,6 +52,11 @@
     <setting key="keymap" value="wetek-play" label="35007" configurable="0" />
   </peripheral>
 
+  <peripheral vendor_product="2252:1037,2017:1688,2017:1689" bus="usb" name="OSMC RF Remote" mapTo="hid">
+     <setting key="do_not_use_custom_keymap" type="bool" value="0" label="35009" order="1"/>
+     <setting key="keymap" value="osmc" label="35007" configurable="1"/>
+  </peripheral>
+
   <peripheral class="joystick" mapTo="joystick">
     <setting key="left_stick_deadzone" type="float" label="35078" order="1" value="0.2" min="0.0" step="0.05" max="1.0" />
     <setting key="right_stick_deadzone" type="float" label="35079" order="2" value="0.2" min="0.0" step="0.05" max="1.0" />


### PR DESCRIPTION
## Description

This adds support for OSMC remote controllers directly so that they work out of the box better on a number of platforms.

## Motivation and Context

Kodi's default keymaps are required to be generic as they cover a wide number of remotes with a large number of permutations regarding button layout.

We have a specific remote and userbase that want a keymap that is highly optimised for 13 buttons.
We don't believe that anyone has gone this far in to tweaking a keymap before, and this example could be used as a template to start a trend for other devices.

## How Has This Been Tested?

These changes have been tested on Windows, OSMC, LibreELEC and Ubuntu versions of Kodi.
As this keymap is only loaded with a match on the VID/PID of our remote, this will not affect other users. Furthermore, there is an option to disable the keymap under Settings -> Input -> Peripherals when the remote controller keymap is loaded after detection of a USB receiver.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed