### PR TITLE
[exif] fix gps altitude values (float)

### DIFF
--- a/xbmc/pictures/ExifParse.cpp
+++ b/xbmc/pictures/ExifParse.cpp
@@ -936,7 +936,7 @@ void CExifParse::ProcessGpsInfo(
       case TAG_GPS_ALT:
         {
           char temp[18];
-          sprintf(temp,"%dm", Get32(ValuePtr, m_MotorolaOrder));
+          sprintf(temp, "%.2fm", static_cast<float>(ConvertAnyFormat(ValuePtr, Format)));
           strcat(m_ExifInfo->GpsAlt, temp);
         }
       break;


### PR DESCRIPTION
## Description
This fixes the incorrect conversion of altitude values in exif (float/fractional values)

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18891

## How Has This Been Tested?
With the sample provided in the issue report

## Screenshots (if appropriate):
**master**
![master](https://i.imgur.com/nIA5tYo.png "master")


**pr**
![pr1](https://i.imgur.com/rlNcAVW.png "PR1")
![pr2t](https://i.imgur.com/blrQMil.png "pr2")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

