### PR TITLE
[depends] fix wayland build in release mode

### DIFF
--- a/tools/depends/target/config.site.in
+++ b/tools/depends/target/config.site.in
@@ -70,6 +70,14 @@ ac_cv_file__dev_ptc=no
 #gnutls
 gl_cv_func_gettimeofday_clobber=no
 
+#wayland
+if test "${PACKAGE_NAME}" = "wayland"; then
+  # wayland insists on building tests which rely on assert, which cannot work with -DNDEBUG
+  # Maybe it would be better not to define -DNDEBUG globally for release builds?
+  export CFLAGS=`echo ${CFLAGS} | sed 's/-DNDEBUG=1//g'`
+  export CPPFLAGS=`echo ${CPPFLAGS} | sed 's/-DNDEBUG=1//g'`
+fi
+
 
 if test "@platform_os@" = "android"; then
   ac_cv_func_srand=yes


### PR DESCRIPTION
_Emergency fix for beta 2 release not building on Jenkins_

configure.ac sets -DNDEBUG=1 for all packages in release mode, which
libwayland cannot cope with in newer releases.

