### PR TITLE
[GUI][ControlGroupList] Update scroller sizes when list size changes

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -49,8 +49,13 @@ void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &d
     GUIPROFILER_VISIBILITY_END(control);
   }
 
-  ValidateOffset();
-  if (m_pageControl && m_lastScrollerValue != m_scroller.GetValue())
+  // visibility status of some of the list items may have changed. Thus, the group list size
+  // may now be different and the scroller needs to be updated
+  int previousTotalSize = m_totalSize;
+  ValidateOffset(); // m_totalSize is updated here
+  bool sizeChanged = previousTotalSize != m_totalSize;
+
+  if (m_pageControl && (m_lastScrollerValue != m_scroller.GetValue() || sizeChanged))
   {
     CGUIMessage message(GUI_MSG_LABEL_RESET, GetParentID(), m_pageControl, (int)Size(), (int)m_totalSize);
     SendWindowMessage(message);


### PR DESCRIPTION

## Description
This fixes the scroller size and position for cases in which the respective container is updated to contain additional items. This is visible for example in the addon settings dialog when you enable a setting that changes the visibility status of other items in the same list.

@CastagnaIT I think you'll have to be the testing monkey here :)

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18637

## How Has This Been Tested?
With netflix settings dialog as shown in the issue report. Tested a bunch of other windows with no regressions observed.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

