### PR TITLE
[video] Fix missing sizing information after zooming a video

### DIFF
--- a/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
+++ b/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
@@ -60,6 +60,7 @@ struct VideoStreamInfo : StreamInfo
   int width = 0;
   CRect SrcRect;
   CRect DestRect;
+  CRect VideoRect;
   std::string stereoMode;
   int angles = 0;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4949,12 +4949,15 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo &info)
   if (s.name.length() > 0)
     info.name = s.name;
 
+  m_renderManager.GetVideoRect(s.SrcRect, s.DestRect, s.VideoRect);
+
   info.valid = true;
   info.bitrate = s.bitrate;
   info.width = s.width;
   info.height = s.height;
   info.SrcRect = s.SrcRect;
   info.DestRect = s.DestRect;
+  info.VideoRect = s.VideoRect;
   info.codecName = s.codec;
   info.videoAspectRatio = s.aspect_ratio;
   info.stereoMode = s.stereo_mode;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -192,6 +192,7 @@ struct SelectionStream
   int height = 0;
   CRect SrcRect;
   CRect DestRect;
+  CRect VideoRect;
   std::string stereo_mode;
   float aspect_ratio = 0.0f;
 };


### PR DESCRIPTION
## Description
This fixes the sizing information displayed in the info panel when a video is zoomed. SourceRect and DestRect were never populated in the VideoStreamInfo struct. As a result, rects were always shown with the initialised values (0,0). 

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/14634
Fixes https://github.com/xbmc/xbmc/issues/15733

## How Has This Been Tested?
Playing movie, hit z on the keyboard.

## Screenshots (if appropriate):

![zoomfix](https://i.imgur.com/VCUSjip.png "Zoom fix")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
