### PR TITLE
Fix Music Playlist Editor system sources panel to not show "New playlist..." etc.

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -988,8 +988,10 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       items.SetArt(artmap);
     }
 
-    // add in the "New Playlist" item if we're in the playlists folder
-    if ((items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))
+    int iWindow = GetID();
+    // Add "New Playlist" items when in the playlists folder, except on playlist editor screen
+    if ((iWindow != WINDOW_MUSIC_PLAYLIST_EDITOR) &&
+        (items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))
     {
       const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 


### PR DESCRIPTION
In Music Playlist Editor when navigating in the playlists folder on the left hand panel (system sources of items to add to the edited playlist) avoid adding  "New playlist...", "New smart playlist...", and "Party mode playlist" items. Only actual playlists and smart playlists are shown so user can add items from one playlist into the one they are editing.

A minor follow on fix from https://github.com/xbmc/xbmc/pull/18852
