### PR TITLE
Fix swapping to fullscreen for video from music OSD in mixed m3u playlists

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -537,7 +537,7 @@ bool CMusicGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo &info) co
     return false;
 
   const CFileItemPtr playlistItem = playlist[index];
-  if (!playlistItem->GetMusicInfoTag()->Loaded())
+  if (playlistItem->HasMusicInfoTag() && !playlistItem->GetMusicInfoTag()->Loaded())
   {
     playlistItem->LoadMusicTag();
     playlistItem->GetMusicInfoTag()->SetLoaded();

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -172,7 +172,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
       pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsMusicDb()))
     return false;
 
-  if (!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded())
+  if ((!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded()) && pItem->IsAudio())
   {
     // first check the cached item
     CFileItemPtr mapItem = (*m_mapFileItems)[pItem->GetPath()];


### PR DESCRIPTION
M3U playlist files can include a mix of music and video files e.g music videos, which the player handles correctly. However if the user switched to the viz or OSD screens during playback then swapping to full screen for the video did not work correctly for all types of video file, the user being left in the music OSD with a infinitely increasing duration showing.

The underlying cause was that the video items accidentally gained a `CMusicInfoTag` during processing, and hence the `CApplication::PlayFile()` treated video as if it was music and set `options.fullscreen` incorrectly. The fix is to prevent `CMusicInfoTag` from being created for video items.

Tested by @KarellenX (thanks) and positive user feedback on forum see https://forum.kodi.tv/showthread.php?tid=349498&pid=2993577#pid2993577
