### PR TITLE
Media settings: repeat/shuffle fix load to playlistplayer on startup

### DIFF
--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -154,6 +154,13 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
       m_musicNeedsUpdate = 0;
   }
 
+  // Set music playlist player repeat and shuffle from loaded settings
+  if (m_musicPlaylistRepeat)
+    CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_ALL);
+  else
+    CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_NONE);
+  CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_MUSIC, m_musicPlaylistShuffle);
+
   // Read the watchmode settings for the various media views
   pElement = settings->FirstChildElement("myvideos");
   if (pElement != NULL)
@@ -178,15 +185,14 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
       m_videoNeedsUpdate = 0;
   }
 
-  return true;
-}
-
-void CMediaSettings::OnSettingsLoaded()
-{
-  CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, m_musicPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
-  CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_MUSIC, m_musicPlaylistShuffle);
-  CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, m_videoPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
+  // Set video playlist player repeat and shuffle from loaded settings
+  if (m_videoPlaylistRepeat)
+    CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_ALL);
+  else
+    CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_NONE);
   CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_VIDEO, m_videoPlaylistShuffle);
+
+  return true;
 }
 
 bool CMediaSettings::Save(TiXmlNode *settings) const

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -40,7 +40,6 @@ public:
 
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
-  void OnSettingsLoaded() override;
 
   const CVideoSettings& GetDefaultVideoSettings() const { return m_defaultVideoSettings; }
   CVideoSettings& GetDefaultVideoSettings() { return m_defaultVideoSettings; }


### PR DESCRIPTION
The repeat and shuffle settings from the previous session of using Kodi,  for both music and video current playlists,  should be reapplied when Kodi is restarted. This fix restores that functionality which was lost in v19.

This regression was introduced by https://github.com/xbmc/xbmc/pull/17062 the introduction of the serializer interface for settings. Since then `CMediaSettings::OnSettingsLoaded()`, which sets the repeat and shuffle for the playlist players, is triggered _before_  `CMediaSettings::Load()`, which reads the shuffle/repeat settings from xml.

The effect was masked by the fact that settings were being loaded twice until that was corrected by https://github.com/xbmc/xbmc/pull/17720

The solution is to set repeat and shuffle for the playlist players at the point when they are read from xml.

Testing
Queue a number of music items and start playback, goto the current playlist screen and on the sideblade menu set shuffle on and repeat = all. Exit Kodi. Restart Kodi, and again queue a number of music items and start playback. On looking at the sideblade menu of the current playlist screen, shuffle should be on and repeat should be all.

Likewise for video.

Note repeat = one is a once off setting that is applied to the currenty playing item until playback stopped or repeat reset. Only repeat = all is preserved from one session of using Kodi to another.
