### PR TITLE
Updated: If using old settings.xml default them to level Basic

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -541,6 +541,12 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(
       // process general properties
       if (setting != nullptr)
       {
+        // set the default level to be Basic
+        if (setting->GetLevel() != SettingLevel::Internal)
+        {
+          setting->SetLevel(SettingLevel::Basic);
+        }
+        
         // use the setting's ID if there's no label
         if (settingLabel < 0)
         {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
For add-ons that did not upgrade, all settings from settings.xml are read in the old format. Because the old system did not have any levels for settings, the default settings are set to `Standard`. This cause the `Basic` settings to become completely empty:

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
As there were no setttings levels before, I would suggest to always show all levels to the users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1310443/101703632-3fc60180-3a83-11eb-9a27-8125c0470776.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
