### PR TITLE
keyboardlayouts/ukrainian: fix typo in АБВ layout

### DIFF
--- a/system/keyboardlayouts/ukrainian.xml
+++ b/system/keyboardlayouts/ukrainian.xml
@@ -29,7 +29,7 @@ Default font lacks support for all characters
       <row>0123456789</row>
       <row>абвгґдеєжзиі</row>
       <row>їйклмнопрст</row>
-      <row>уфхцчшцьюя'</row>
+      <row>уфхцчшщьюя'</row>
     </keyboard>
     <keyboard modifiers="shift">
       <row>0123456789</row>


### PR DESCRIPTION
## Description
Fixes typo in Ukrainian lower case АБВ layout.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Ukrainian lower case АБВ layout mistakes `щ` character with `ц`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
