### PR TITLE
A couple coverity fixes

### DIFF
--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -43,7 +43,7 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
     return;
 
   auto settingsManager = settings->GetSettingsManager();
-  if (!settingsComponent)
+  if (!settingsManager)
     return;
 
   auto setting = settings->GetSetting(SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT);

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -183,7 +183,7 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
       }
       else
       {
-        if (eglAttrKey->first == EGL_LINUX_DRM_FOURCC_EXT)
+        if (eglAttrKey != eglAttributes.end() && eglAttrKey->first == EGL_LINUX_DRM_FOURCC_EXT)
           valueStr = FourCCToString(attrs[i + 1]);
         else
           valueStr = std::to_string(attrs[i + 1]);


### PR DESCRIPTION
Should fix the following issues found by coverity

```
*** CID 1470569:  API usage errors  (INVALIDATE_ITERATOR)
/xbmc/utils/EGLImage.cpp: 186 in CEGLImage::CreateImage(CEGLImage::EglAttrs)()
180           if (eglAttrValue != eglAttributes.end())
181           {
182             valueStr = eglAttrValue->second;
183           }
184           else
185           {
>>>     CID 1470569:  API usage errors  (INVALIDATE_ITERATOR)
>>>     Dereferencing iterator "eglAttrKey" though it is already past the end of its container.
186             if (eglAttrKey->first == EGL_LINUX_DRM_FOURCC_EXT)
187               valueStr = FourCCToString(attrs[i + 1]);
188             else
189               valueStr = std::to_string(attrs[i + 1]);
190           }
191     
```

and 
```
*** CID 1470568:  Control flow issues  (DEADCODE)
/xbmc/platform/linux/input/LibInputSettings.cpp: 47 in CLibInputSettings::CLibInputSettings(CLibInputHandler *)()
41       auto settings = settingsComponent->GetSettings();
42       if (!settings)
43         return;
44     
45       auto settingsManager = settings->GetSettingsManager();
46       if (!settingsComponent)
>>>     CID 1470568:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "return;".
47         return;
48     
49       auto setting = settings->GetSetting(SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT);
50       if (!setting)
51       {
52         CLog::Log(LOGERROR, "Failed to load setting for: {}", SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT);
```