### PR TITLE
[configure][darwin] fix macos11 sysroot required for compiler tests

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([xbmc-depends], [2.00], [http://trac.xbmc.org])
+AC_INIT([xbmc-depends], [2.00], [https://github.com/xbmc/xbmc])
 :${CFLAGS=""}
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_FILES([target/config.site native/config.site.native Makefile.include target/Toolchain.cmake
@@ -243,9 +243,24 @@ AC_PATH_TOOL([NM], [nm],, $PATH_FOR_HOST)
 AC_PATH_TOOL([OBJDUMP], [objdump],, $PATH_FOR_HOST)
 AC_PATH_TOOL([CC],[$platform_cc],,$PATH_FOR_HOST)
 AC_PATH_TOOL([CXX],[$platform_cxx],,$PATH_FOR_HOST)
-AC_PROG_CPP
 
+case $build in
+  *darwin*)
+    # MacOS 11 requires explicit isysroot for autoconf compiler tests
+    # However we do not want to pollute CFLAGS/CXXFLAGS once compiler tests are complete
+    CFLAGS+=$host_includes
+    CXXFLAGS+=$host_includes
+esac
+
+AC_PROG_CPP
 AX_CXX_COMPILE_STDCXX_14([noext],[mandatory])
+
+case $build in
+  *darwin*)
+    CFLAGS=$(echo "$CFLAGS" | sed "s|$host_includes||")
+    CXXFLAGS=$(echo "$CXXFLAGS" | sed "s|$host_includes||")
+esac
+
 c14_flags=$(echo "$CFLAGS" | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ //g')
 cxx14_flags=$(echo "$CXXFLAGS" | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ //g')
 
@@ -422,12 +437,10 @@ case $host in
 
     platform_min_version="$target_platform-version-min=$target_minver"
 
-    platform_cflags+=" -arch $use_cpu -m$platform_min_version"
-    platform_ldflags+=" -arch $use_cpu -m$platform_min_version -isysroot $use_sdk_path -stdlib=libc++"
-    platform_cxxflags+=" -arch $use_cpu -m$platform_min_version -stdlib=libc++"
-    platform_includes="-isysroot $use_sdk_path"
+    platform_includes="-arch $use_cpu -m$platform_min_version -isysroot $use_sdk_path"
+    platform_ldflags+=" $platform_includes -stdlib=libc++"
+    platform_cxxflags+=" -stdlib=libc++"
     deps_dir="${sdk_name}_${use_cpu}-target-${build_type}"
-    AC_CHECK_LIB([z], [main], has_zlib=1, AC_MSG_WARN("No zlib support in toolchain. Will build libz."); has_zlib=0)
   ;;
   *)
     AC_MSG_ERROR(unsupported host ($use_host))
@@ -451,8 +464,20 @@ esac
 
 XBMC_SETUP_ARCH_DEFINES()
 
+case $build in
+  *darwin*)
+    # MacOS 11 requires explicit isysroot for autoconf link tests
+    # However we do not want to pollute LDFLAGS once lib link tests are complete
+    LDFLAGS="$platform_includes"
+    AC_CHECK_LIB([z], [main], has_zlib=1, AC_MSG_WARN("No zlib support in toolchain. Will build libz."); has_zlib=0)
+esac
 
 AC_SEARCH_LIBS([iconv_open],iconv, link_iconv=$ac_cv_search_iconv_open, link_iconv=-liconv; AC_MSG_WARN("No iconv support in toolchain. Will build libiconv."); need_libiconv=1)
+
+case $build in
+  *darwin*)
+    LDFLAGS=$(echo "$LDFLAGS" | sed "s|$platform_includes||")
+esac
 
 if test "$link_iconv" = "none required"; then
   link_iconv=
@@ -659,16 +684,17 @@ cp -vf native/config.site.native $prefix/$tool_dir/share/config.site
 
 echo -e "\n\n#------- configuration -------#"
 echo -e "ccache:\t\t $use_ccache"
-echo -e "build type:\t $build_type"
-echo -e "toolchain:\t $use_toolchain"
-echo -e "cpu:\t\t $use_cpu"
+echo -e "build type:\t\t $build_type"
+echo -e "toolchain:\t\t $use_toolchain"
+echo -e "cpu:\t\t\t $use_cpu"
 echo -e "host:\t\t $use_host"
 echo -e "cflags:\t\t $platform_cflags"
-echo -e "cxxflags:\t $platform_cxxflags"
-echo -e "ldflags:\t $platform_ldflags"
+echo -e "cxxflags:\t\t $platform_cxxflags"
+echo -e "ldflags:\t\t $platform_ldflags"
+echo -e "platform_includes:\t $platform_includes"
 echo -e "ffmpeg options:\t $ffmpeg_options"
 echo -e "prefix:\t\t $prefix"
-echo -e "depends:\t $prefix/$deps_dir"
+echo -e "depends:\t\t $prefix/$deps_dir"
 if test "$platform_os" == "android"; then
   echo -e "ndk-api-level:\t $use_ndk_api"
   echo -e "build-tools:\t $build_tools_path"


### PR DESCRIPTION
## Description
Depends build fix with MacOS 11 host

@ksooo @phunkyfish give this a run if you have time.

## Motivation and Context
macos11 throws a linker error when running autoconf compiler/linker tests
we need to supply isysroot, however we do not want to pollute CFLAGS/CXXFLAGS/LDFLAGS with host/target sysroot,
So we clean up after the tests are carried out


## How Has This Been Tested?
Locally against target macos and tvos

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
