### PR TITLE
AddonDatabase: fix build with gcc-4.9

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -169,7 +169,7 @@ void CAddonDatabaseSerializer::DeserializeExtensions(const CVariant& variant,
     for (auto content = (*value)["content"].begin_array();
          content != (*value)["content"].end_array(); ++content)
     {
-      extValues.emplace_back((*content)["key"].asString(), (*content)["value"].asString());
+      extValues.emplace_back((*content)["key"].asString(), SExtValue{(*content)["value"].asString()});
     }
 
     addonType.m_values.emplace_back(id, extValues);


### PR DESCRIPTION
Suggested by yasji:
https://forum.kodi.tv/showthread.php?tid=358086&pid=2994354#pid2994354

## Description
Fixes a build error with gcc-4.9, first found with gcc-4.9.1
```
output/host/opt/ext-toolchain/aarch64-amd-linux-gnu/include/c++/4.9.1/ext/new_allocator.h: In instantiation of 'void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = std::pair<std::basic_string<char>, ADDON::SExtValue>; _Args = {std::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::basic_string<char, std::char_traits<char>, std::allocator<char> >}; _Tp = std::pair<std::basic_string<char>, ADDON::SExtValue>]':

output/build/kodi-efa9ec691491ea3311f8de36b16b665f188afef4/xbmc/addons/AddonDatabase.cpp:172:90:   required from here
output/host/opt/ext-toolchain/aarch64-amd-linux-gnu/include/c++/4.9.1/ext/new_allocator.h:120:4: error: no matching function for call to 'std::pair<std::basic_string<char>, ADDON::SExtValue>::pair(std::basic_string<char>, std::basic_string<char>)'
```
## How Has This Been Tested?
Build- and runtime-tested with gcc-4.9.2
```
Starting Kodi (19.0-BETA2 (18.9.821) Git:20201211-96e386e88b78c009). Platform: Linux x86 64-bit
Using Debug Kodi x64
Kodi compiled 2020-12-11 by GCC 4.9.2 for Linux x86 64-bit version 3.16.7 (200711)
```
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
