### PR TITLE
[gui] fix all seasons poster in case movies are linked to a tvshow

### DIFF
--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -82,14 +82,24 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
     pItem->SetProperty("watchedepisodes", watched);
     pItem->SetProperty("unwatchedepisodes", unwatched);
 
-    // @note: the items list contains the (..) upper directory navigation fileitem plus all the
-    // season directory fileitems for a given show. We want to assign the "All Seasons" listitem
-    // the infotag of the tv show - so do not use the first item in the list!
-    if (items.Size() && items[items.Size() - 1]->GetVideoInfoTag())
+    // @note: The items list may contain additional items that do not belong to the show.
+    // This is the case of the up directory (..) or movies linked to the tvshow.
+    // Iterate through the list till the first season type is found and the infotag can safely be copied.
+
+    if (items.Size() > 1)
     {
-      *pItem->GetVideoInfoTag() = *items[items.Size() - 1]->GetVideoInfoTag();
-      pItem->GetVideoInfoTag()->m_iSeason = -1;
+      for (int i = 1; i < items.Size(); i++)
+      {
+        if (items[i]->GetVideoInfoTag() && items[i]->GetVideoInfoTag()->m_type == MediaTypeSeason &&
+            items[i]->GetVideoInfoTag()->m_iSeason > 0)
+        {
+          *pItem->GetVideoInfoTag() = *items[i]->GetVideoInfoTag();
+          pItem->GetVideoInfoTag()->m_iSeason = -1;
+          break;
+        }
+      }
     }
+
     pItem->GetVideoInfoTag()->m_strTitle = strLabel;
     pItem->GetVideoInfoTag()->m_iEpisode = watched + unwatched;
     pItem->GetVideoInfoTag()->SetPlayCount((unwatched == 0) ? 1 : 0);


### PR DESCRIPTION
## Description
if a movie is linked to a tvshow "all seasons posters" are shown faulty in any view.

![screenshot00000](https://user-images.githubusercontent.com/58829855/102022325-5a9bbd00-3d86-11eb-8796-5efac47e11c6.png)

right after the movie is played and stopped we see this

![screenshot00001](https://user-images.githubusercontent.com/58829855/102022342-7737f500-3d86-11eb-8fa8-c41aeaea4795.png)

reason is that the last item in the `CFileItemList` is picked for the poster, in this particular case it is the movie.
i am not sure if it is guaranteed, that the movie is always last on the list. so let's loop though the list and take the first season item we can find.

corrected view with this pr (before and after playing the movie).

![screenshot00002](https://user-images.githubusercontent.com/58829855/102022434-13fa9280-3d87-11eb-91a0-2dfde3813c48.png)

## How Has This Been Tested?
debian buster

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

please have a look, enen.

