### PR TITLE
[Docs][Python] Document xbmcgui.Listitem initializer

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -47,25 +47,6 @@ namespace XBMCAddon
     /// @{
     /// @brief **Selectable window list item.**
     ///
-    /// The list item control is used for creating item lists in Kodi
-    ///
-    /// \python_class{ ListItem([label, label2, path]) }
-    ///
-    /// @param label                [opt] string
-    /// @param label2               [opt] string
-    /// @param path                 [opt] string
-    ///
-    ///
-    ///-----------------------------------------------------------------------
-    /// @python_v16 **iconImage** and **thumbnailImage** are deprecated. Use **setArt()**.
-    /// @python_v19 Removed **iconImage** and **thumbnailImage**. Use **setArt()**.
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ...
-    /// listitem = xbmcgui.ListItem('Casino Royale')
-    /// ...
-    /// ~~~~~~~~~~~~~
     class ListItem : public AddonClass
     {
     public:
@@ -74,10 +55,52 @@ namespace XBMCAddon
       bool m_offscreen;
 #endif
 
-      ListItem(const String& label = emptyString,
-               const String& label2 = emptyString,
-               const String& path = emptyString,
-               bool offscreen = false);
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmcgui_listitem
+    /// @brief Selectable window list item.
+    ///
+    /// The list item control is used for creating item lists in Kodi
+    ///
+    /// \python_class{ ListItem([label, label2, path, offscreen]) }
+    ///
+    /// @param label                [opt] string (default `""`) - the label to display on the item
+    /// @param label2               [opt] string (default `""`) - the label2 of the item
+    /// @param path                 [opt] string (default `""`) - the path for the item
+    /// @param offscreen            [opt] bool (default `False`) - if GUI based locks should be
+    ///                                          avoided. Most of the times listitems are created
+    ///                                          offscreen and added later to a container
+    ///                                          for display (e.g. plugins) or they are not
+    ///                                          even displayed (e.g. python scrapers).
+    ///                                          In such cases, there is no need to lock the
+    ///                                          GUI when creating the items (increasing your addon
+    ///                                          performance).
+    ///                                          Note however, that if you are creating listitems
+    ///                                          and managing the container itself (e.g using
+    ///                                          WindowXML or WindowXMLDialog classes) subsquent
+    ///                                          modifications to the item will require locking.
+    ///                                          Thus, in such cases, use the default value (`False`).
+    ///
+    ///
+    ///-----------------------------------------------------------------------
+    /// @python_v16 **iconImage** and **thumbnailImage** are deprecated. Use **setArt()**.
+    /// @python_v18 Added **offscreen** argument.
+    /// @python_v19 Removed **iconImage** and **thumbnailImage**. Use **setArt()**.
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// listitem = xbmcgui.ListItem('Casino Royale')
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
+    ListItem([label, label2, path, offscreen]);
+#else
+    ListItem(const String& label = emptyString,
+             const String& label2 = emptyString,
+             const String& path = emptyString,
+             bool offscreen = false);
+#endif
 
 #if !defined SWIG && !defined DOXYGEN_SHOULD_SKIP_THIS
       inline explicit ListItem(CFileItemPtr pitem) : item(std::move(pitem)), m_offscreen(false) {}
@@ -90,7 +113,9 @@ namespace XBMCAddon
       }
 #endif
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
       ~ListItem() override;
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///


### PR DESCRIPTION
## Description
The xbmcgui.Listitem initializer was not documented. In this scope, there was no info regarding the `offscreen` argument nor the version this argument was introduced. I thought it existed in kodi for a long time but learned the hard way (by breaking a support library in gotham) it was only introduced in Leia :)
This also hides the destructor from doxygen.

@notspiff can you check if the description is 100% correct?

## How Has This Been Tested?
Compiled docs

## Screenshots (if appropriate):
![docs](https://i.imgur.com/SPsQGfg.png "Docs")

