### PR TITLE
[python][xbmcgui] Revert yesno(customlabel=...) and add Dialog.yesnocustom()

### DIFF
--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -179,7 +179,7 @@ int CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
 
   dialog->SetHeading(heading);
   dialog->SetText(text);
-  if (autoCloseTime)
+  if (autoCloseTime > 0)
     dialog->SetAutoClose(autoCloseTime);
   dialog->m_bCanceled = false;
   dialog->m_bCustom = false;

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -45,7 +45,6 @@ namespace XBMCAddon
     bool Dialog::yesno(const String& heading, const String& message,
                        const String& nolabel,
                        const String& yeslabel,
-                       const String& customlabel,
                        int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
@@ -62,8 +61,6 @@ namespace XBMCAddon
         pDialog->SetChoice(0, CVariant{nolabel});
       if (!yeslabel.empty())
         pDialog->SetChoice(1, CVariant{yeslabel});
-      if (!customlabel.empty())
-        pDialog->SetChoice(2, CVariant{customlabel});
 
       if (autoclose > 0)
         pDialog->SetAutoClose(autoclose);

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -47,27 +47,35 @@ namespace XBMCAddon
                        const String& yeslabel,
                        int autoclose)
     {
+      return yesNoCustomInternal(heading, message, nolabel, yeslabel, emptyString, autoclose) == 1;
+    }
+
+    int Dialog::yesnocustom(const String& heading,
+                            const String& message,
+                            const String& customlabel,
+                            const String& nolabel,
+                            const String& yeslabel,
+                            int autoclose)
+    {
+      return yesNoCustomInternal(heading, message, nolabel, yeslabel, customlabel, autoclose);
+    }
+
+    int Dialog::yesNoCustomInternal(const String& heading,
+                                    const String& message,
+                                    const String& nolabel,
+                                    const String& yeslabel,
+                                    const String& customlabel,
+                                    int autoclose)
+    {
       DelayedCallGuard dcguard(languageHook);
-      CGUIDialogYesNo* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-      if (pDialog == NULL)
-        throw WindowException("Error: Window is NULL, this is not possible :-)");
+      CGUIDialogYesNo* pDialog =
+          CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(
+              WINDOW_DIALOG_YES_NO);
+      if (pDialog == nullptr)
+        throw WindowException("Error: Window is null");
 
-      if (!heading.empty())
-        pDialog->SetHeading(CVariant{heading});
-      if (!message.empty())
-        pDialog->SetText(CVariant{message});
-
-      if (!nolabel.empty())
-        pDialog->SetChoice(0, CVariant{nolabel});
-      if (!yeslabel.empty())
-        pDialog->SetChoice(1, CVariant{yeslabel});
-
-      if (autoclose > 0)
-        pDialog->SetAutoClose(autoclose);
-
-      pDialog->Open();
-
-      return pDialog->IsConfirmed();
+      return pDialog->ShowAndGetInput(CVariant{heading}, CVariant{message}, CVariant{nolabel},
+                                      CVariant{yeslabel}, CVariant{customlabel}, autoclose);
     }
 
     bool Dialog::info(const ListItem* item)

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -52,7 +52,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Dialog
-      /// \python_func{ xbmcgui.Dialog().yesno(heading, message, nolabel, yeslabel, autoclose]) }
+      /// \python_func{ xbmcgui.Dialog().yesno(heading, message, [nolabel, yeslabel, autoclose]) }
       /// **Yes / no dialog**
       ///
       /// The Yes / No dialog can be used to inform the user about questions and

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -92,6 +92,47 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Dialog
+      /// \python_func{ xbmcgui.Dialog().yesnocustom(heading, message, customlabel, [nolabel, yeslabel, autoclose]) }
+      /// **Yes / no / custom dialog**
+      ///
+      /// The YesNoCustom dialog can be used to inform the user about questions and
+      /// get the answer. The dialog provides a third button appart from yes and no.
+      /// Button labels are fully customizable.
+      ///
+      /// @param heading        string or unicode - dialog heading.
+      /// @param message        string or unicode - message text.
+      /// @param customlabel    string or unicode - label to put on the custom button.
+      /// @param nolabel        [opt] label to put on the no button.
+      /// @param yeslabel       [opt] label to put on the yes button.
+      /// @param autoclose      [opt] integer - milliseconds to autoclose dialog. (default=do not autoclose)
+      /// @return Returns the integer value for the selected button (-1:cancelled, 0:no, 1:yes, 2:custom)
+      ///
+      ///
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v19 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// dialog = xbmcgui.Dialog()
+      /// ret = dialog.yesnocustom('Kodi', 'Question?', 'Maybe')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      yesnocustom(...);
+#else
+      int yesnocustom(const String& heading,
+                      const String& message,
+                      const String& customlabel,
+                      const String& nolabel = emptyString,
+                      const String& yeslabel = emptyString,
+                      int autoclose = 0);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Dialog
       /// \python_func{ xbmcgui.Dialog().info(listitem) }
       /// **Info dialog**
       ///
@@ -578,6 +619,17 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
                    int type = INPUT_ALPHANUM,
                    int option = 0,
                    int autoclose = 0);
+#endif
+
+    private:
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+      // used by both yesno() and yesnocustom()
+      int yesNoCustomInternal(const String& heading,
+                              const String& message,
+                              const String& nolabel,
+                              const String& yeslabel,
+                              const String& customlabel,
+                              int autoclose);
 #endif
     };
     //@}

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -52,7 +52,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Dialog
-      /// \python_func{ xbmcgui.Dialog().yesno(heading, message, nolabel, yeslabel, customlabel, autoclose]) }
+      /// \python_func{ xbmcgui.Dialog().yesno(heading, message, nolabel, yeslabel, autoclose]) }
       /// **Yes / no dialog**
       ///
       /// The Yes / No dialog can be used to inform the user about questions and
@@ -62,7 +62,6 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// @param message        string or unicode - message text.
       /// @param nolabel        [opt] label to put on the no button.
       /// @param yeslabel       [opt] label to put on the yes button.
-      /// @param customlabel    [opt] label to put on the custom button.
       /// @param autoclose      [opt] integer - milliseconds to autoclose dialog. (default=do not autoclose)
       /// @return Returns True if 'Yes' was pressed, else False.
       ///
@@ -73,7 +72,6 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// @python_v19 Renamed option **line1** to **message**.
       /// @python_v19 Removed option **line2**.
       /// @python_v19 Removed option **line3**.
-      /// @python_v19 Added new option **customlabel**.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -88,7 +86,6 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       bool yesno(const String& heading, const String& message,
                  const String& nolabel = emptyString,
                  const String& yeslabel = emptyString,
-                 const String& customlabel = emptyString,
                  int autoclose = 0);
 #endif
 


### PR DESCRIPTION
## Description
In https://github.com/xbmc/xbmc/commit/120e2174d8f68a6d5a15c36494a56de09b842aad customlabel option was added to DialogYesNo providing a 3rd option besides yes/no, but the dialog still returns the confirmed state only. This reverts the aforementioned PR and implements a new method `xbmcgui.Dialog().yesnocustom()` to have a custom yesno with 3 buttons where the selection (int) is returned.

~~Furthermore while testing this I found another bug. Due to the way the python api code is written and if a yesno dialog already exists in cache (from a previous execution) the same instance will be reused. As a result, there is a likelihood the m_cancelled or m_custom member variables to have the values from a previous selection. In GetResult cancelled and custom take precedence over isConfirmed, leading to wrong results for the selection. A second commit is added to fix this.~~

The new implementation simplifies the code and calls `ShowAndGetInput` where both variables are set, thus simplifying the code and avoiding the previous problem.

Adding @DaveTBlake to the loop due to the "breaking" change.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18937

## How Has This Been Tested?
Compile and runtime tested with a sample addon:

```python
import xbmcgui
result = xbmcgui.Dialog().yesno('Kodi', 'Do you want to exit this script?')
result2 = xbmcgui.Dialog().yesnocustom('Kodi', 'Do you want to exit this script?', 'custombutton')
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
