### PR TITLE
[Android] added multi-language support

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -93,7 +93,7 @@ python: | xbmc/assets
 	cd xbmc/assets/python@PYTHON_VERSION@/lib/python@PYTHON_VERSION@/; rm -rf test config lib-dynload
 
 res:
-	mkdir -p xbmc/res xbmc/res/raw xbmc/res/values images
+	mkdir -p xbmc/res xbmc/res/raw images
 	@echo "native_arch=$(CPU)" > xbmc/res/raw/xbmc.properties
 	cp -fp $(CMAKE_SOURCE_DIR)/media/splash.* xbmc/res/drawable/
 	cp -fp media/drawable-hdpi/ic_launcher.png xbmc/res/drawable-hdpi/ic_launcher.png
@@ -105,7 +105,7 @@ res:
 	cp -fp media/drawable-xxxhdpi/ic_launcher.png xbmc/res/drawable-xxxhdpi/ic_launcher.png
 	cp -fp media/drawable-xhdpi/banner.png xbmc/res/drawable-xhdpi/banner.png
 	cp -fp $(CMAKE_SOURCE_DIR)/media/icon80x80.png xbmc/res/drawable/ic_recommendation_80dp.png
-	cp xbmc/strings.xml xbmc/res/values/
+	DIR=$(CMAKE_SOURCE_DIR)/tools/android/packaging/language/; for LANGUAGE_FOLDER in $$(ls -a $$DIR | grep values); do mkdir -p xbmc/res/$$LANGUAGE_FOLDER; LANGUAGE_STRINGS=$$(cat $$DIR$$LANGUAGE_FOLDER/strings.xml); sed "s|##LANGUAGE_STRINGS##|$$LANGUAGE_STRINGS|" xbmc/strings.xml > xbmc/res/$$LANGUAGE_FOLDER/strings.xml; done
 	cp xbmc/colors.xml xbmc/res/values/
 	cp xbmc/searchable.xml xbmc/res/xml/
 

--- a/tools/android/packaging/language/values-de/strings.xml
+++ b/tools/android/packaging/language/values-de/strings.xml
@@ -1,0 +1,1 @@
+<string name="suggestion_channel">Vorschläge</string>

--- a/tools/android/packaging/language/values/strings.xml
+++ b/tools/android/packaging/language/values/strings.xml
@@ -1,0 +1,1 @@
+<string name="suggestion_channel">Suggestions</string>

--- a/tools/android/packaging/xbmc/strings.xml.in
+++ b/tools/android/packaging/xbmc/strings.xml.in
@@ -4,5 +4,5 @@
     <string name="app_name">@APP_NAME@</string>
     <string name="search_hint">@APP_NAME@</string>
 
-    <string name="suggestion_channel">Suggestions</string>
+    ##LANGUAGE_STRINGS##
 </resources>


### PR DESCRIPTION
## Description
This PR adds the ability for language specific strings, e.g. for the title of suggestion channel on android tv.
Here only for default and german, but other languages ​​could easily be added.

First, the folders within `tools/android/packaging/language` are read and the corresponding folders are created within `build/tools/android/packaging/xbmc/res`.

Example: `tools/android/packaging/language/values-de` -> `build/tools/android/packaging/xbmc/res/values-de`

Then the content from `tools/android/packaging/language/{FOLDERNAME}/strings.xml` supplements the template `build/tools/android/packaging/xbmc/strings.xml` and writes the new content to `tools/android/packaging/xbmc/res/{FOLDERNAME}/strings. xml`.

## Motivation and Context
Higher user experience.

## How Has This Been Tested?
With private builds on my Shield TV.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
