### PR TITLE
windowing/gbm: hide and disable setting Use Display As Clock

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -77,14 +77,21 @@ bool CWinSystemGbm::InitWindowSystem()
     return false;
   }
 
-  CServiceBroker::GetSettingsComponent()
-      ->GetSettings()
-      ->GetSetting(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE)
-      ->SetVisible(true);
-  CServiceBroker::GetSettingsComponent()
-      ->GetSettings()
-      ->GetSetting("videoscreen.limitguisize")
-      ->SetVisible(true);
+  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return false;
+
+  auto settings = settingsComponent->GetSettings();
+  if (!settings)
+    return false;
+
+  auto setting = settings->GetSetting(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+  if (setting)
+    setting->SetVisible(true);
+
+  setting = settings->GetSetting("videoscreen.limitguisize");
+  if (setting)
+    setting->SetVisible(true);
 
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - initialized DRM", __FUNCTION__);
   return CWinSystemBase::InitWindowSystem();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -93,6 +93,13 @@ bool CWinSystemGbm::InitWindowSystem()
   if (setting)
     setting->SetVisible(true);
 
+  setting = settings->GetSetting(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
+  if (setting)
+  {
+    setting->SetVisible(false);
+    settings->SetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK, false);
+  }
+
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - initialized DRM", __FUNCTION__);
   return CWinSystemBase::InitWindowSystem();
 }


### PR DESCRIPTION
## Description
Use display as clock is not supported on GBM and before the
multi-windowing change it has been hidden in settings via gbm.xml.

Hide it in settings so it can't be enabled in player settings and
also make sure it's disabled in case it had been enabled before,
otherwise users would be left without audio passthrough and no
option to fix this via the GUI.

## Motivation and Context
Restore behaviour prior to the multi-windowing change and make sure
users aren't able to select a known non-working option

## How Has This Been Tested?
Runtime tested on LibreELEC RPi4, checked that previously enabled setting
is getting disabled (with a WARN in log) and that option is not shown in video
player settings.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
