### PR TITLE
[macos][packaging] include only darwin settings files

### DIFF
--- a/tools/darwin/Support/CopyRootFiles-osx.command
+++ b/tools/darwin/Support/CopyRootFiles-osx.command
@@ -43,7 +43,7 @@ ${SYNC} "$SRCROOT/addons/skin.estuary/resources" "$TARGET_PATH/addons/skin.estua
 ${SYNCSKIN} "$SRCROOT/addons/skin.estouchy" "$TARGET_PATH/addons"
 ${SYNC} "$SRCROOT/addons/skin.estouchy/background" "$TARGET_PATH/addons/skin.estouchy"
 ${SYNC} "$SRCROOT/addons/skin.estouchy/resources" "$TARGET_PATH/addons/skin.estouchy"
-${SYNC} "$SRCROOT/system" "$TARGET_PATH"
+${SYNC} --include 'settings/settings.xml' --include 'settings/darwin*' --exclude 'settings/*.xml' "$SRCROOT/system" "$TARGET_PATH"
 ${SYNC} "$SRCROOT/userdata" "$TARGET_PATH"
 
 # copy extra packages if applicable


### PR DESCRIPTION
## Description
Copies only `darwin*` settings instead of all available.

## Motivation and Context
After #18835 all macOS builds (including 19.0 beta 2) have broken code signature because `freebsd.xml` symlink points to non-existent file (`linux.xml` isn't copied).

```
❯ codesign --verify --deep --strict --verbose=4 /Volumes/Kodi/Kodi.app 
/Volumes/Kodi/Kodi.app: No such file or directory

❯ codesign --verify --deep --strict=symlinks --verbose=4 /Volumes/Kodi/Kodi.app
/Volumes/Kodi/Kodi.app: invalid destination for symbolic link in bundle
file modified: /Volumes/Kodi/Kodi.app/Contents/Resources/Kodi/system/settings/freebsd.xml
```

## How Has This Been Tested?
Ran modified `rsync` command to ensure that broken symlink is no longer copied to app bundle.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
