### PR TITLE
Shaders: simplification/clean up HLG to PQ code

### DIFF
--- a/system/shaders/output_d3d.fx
+++ b/system/shaders/output_d3d.fx
@@ -96,16 +96,13 @@ float3 inversePQ(float3 x)
 }
 #endif
 #if defined(KODI_HLG_TO_PQ)
-float inverseHLG(float x)
+float3 inverseHLG(float3 x)
 {
   const float B67_a = 0.17883277f;
   const float B67_b = 0.28466892f;
   const float B67_c = 0.55991073f;
   const float B67_inv_r2 = 4.0f;
-  if (x <= 0.5f)
-    x = x * x * B67_inv_r2;
-  else
-    x = exp((x - B67_c) / B67_a) + B67_b;
+  x = (x <= 0.5f) ? x * x * B67_inv_r2 : exp((x - B67_c) / B67_a) + B67_b;
   return x;
 }
 
@@ -139,9 +136,7 @@ float4 output4(float4 color, float2 uv)
   color.rgb = pow(color.rgb, 1.0f / 2.2f);
 #endif
 #if defined(KODI_HLG_TO_PQ)
-  color.r = inverseHLG(color.r);
-  color.g = inverseHLG(color.g);
-  color.b = inverseHLG(color.b);
+  color.rgb = inverseHLG(color.rgb);
   float3 ootf_2020 = float3(0.2627f, 0.6780f, 0.0593f);
   float ootf_ys = 2000.0f * dot(ootf_2020, color.rgb);
   color.rgb *= pow(ootf_ys, 0.2f);


### PR DESCRIPTION
## Description
Shaders: simplification/clean up HLG to PQ code

## Motivation and Context
`if` operator only can be used on scalar context, due this `inverseHLG` function it was `float` type and not `float3` like the others. Replacing `if` by `?` operator overcomes this limitation. It's only coding simplification, no change in video output.

## How Has This Been Tested?
Runtime test.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
