### PR TITLE
[addons] Reset addon settings when destroying the addon instance.

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -125,6 +125,11 @@ bool CAddon::ReloadSettings()
   return LoadSettings(true);
 }
 
+void CAddon::ResetSettings()
+{
+  m_settings.reset();
+}
+
 bool CAddon::LoadUserSettings()
 {
   if (!SettingsInitialized())

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -242,6 +242,8 @@ public:
   }
   bool ReloadSettings() override;
 
+  void ResetSettings() override;
+
   /*! \brief retrieve the running instance of an add-on if it persists while running.
    */
   AddonPtr GetRunningInstance() const override { return AddonPtr(); }

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -82,6 +82,7 @@ namespace ADDON
     virtual bool MeetsVersion(const AddonVersion& versionMin,
                               const AddonVersion& version) const = 0;
     virtual bool ReloadSettings() =0;
+    virtual void ResetSettings() = 0;
     virtual AddonPtr GetRunningInstance() const=0;
     virtual void OnPreInstall() =0;
     virtual void OnPostInstall(bool update, bool modal) =0;

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -224,6 +224,9 @@ void CAddonDll::Destroy()
     m_pDll = nullptr;
     CLog::Log(LOGINFO, "ADDON: Dll Destroyed - %s", Name().c_str());
   }
+
+  ResetSettings();
+
   m_initialized = false;
 }
 


### PR DESCRIPTION
When destroying an addon instance, the settings it holds must be reset, because the instance can be reused later, for example, when switching from a profile with the addon enabled to an addon with the same addon but different settings enabled.

@AlwinEsch as discussed internally, this regression was introduced by your recent binary addon changes.

Runtime-tested on Android and macOS, latest Kodi master.