### PR TITLE
[PVR] Fix PVR manager start/stop races

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -311,7 +311,6 @@ void CPVRManager::Clear()
 {
   m_playbackState->Clear();
   m_pendingUpdates->Clear();
-  m_epgContainer.Clear();
 
   CSingleLock lock(m_critSection);
 
@@ -507,8 +506,11 @@ void CPVRManager::Process()
     return;
   }
 
+  // Load EPGs from database.
+  m_epgContainer.Load();
+
   m_guiInfo->Start();
-  m_epgContainer.Start(true);
+  m_epgContainer.Start();
   m_timers->Start();
   m_pendingUpdates->Start();
 
@@ -663,6 +665,7 @@ void CPVRManager::UnloadComponents()
   m_recordings->Unload();
   m_timers->Unload();
   m_channelGroups->Unload();
+  m_epgContainer.Unload();
 }
 
 void CPVRManager::TriggerPlayChannelOnStartup()

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -393,6 +393,7 @@ void CPVRManager::Stop()
 
   m_addons->Stop();
   m_pendingUpdates->Stop();
+  m_timers->Stop();
   m_epgContainer.Stop();
   m_guiInfo->Stop();
 
@@ -508,6 +509,7 @@ void CPVRManager::Process()
 
   m_guiInfo->Start();
   m_epgContainer.Start(true);
+  m_timers->Start();
   m_pendingUpdates->Start();
 
   SetState(ManagerStateStarted);

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -65,19 +65,24 @@ namespace PVR
 
     /*!
      * @brief Start the EPG update thread.
-     * @param bAsync Should the EPG container starts asynchronously
      */
-    void Start(bool bAsync);
+    void Start();
 
     /*!
      * @brief Stop the EPG update thread.
      */
     void Stop();
 
-    /*!
-     * @brief Clear all EPG entries.
+    /**
+     * @brief (re)load EPG data.
+     * @return True if loaded successfully, false otherwise.
      */
-    void Clear();
+    bool Load();
+
+    /**
+     * @brief unload all EPG data.
+     */
+    void Unload();
 
     /*!
      * @brief Check whether the EpgContainer has fully started.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -101,22 +101,31 @@ bool CPVRTimers::Load()
   // load local timers from database
   bool bReturn = LoadFromDatabase();
 
-  Update(); // update from clients
-
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Subscribe(this, &CPVRTimers::Notify);
-  Create();
+  // update from clients
+  Update();
 
   return bReturn;
 }
 
 void CPVRTimers::Unload()
 {
-  StopThread();
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Unsubscribe(this);
-
   // remove all tags
   CSingleLock lock(m_critSection);
   m_tags.clear();
+}
+
+void CPVRTimers::Start()
+{
+  Stop();
+
+  CServiceBroker::GetPVRManager().EpgContainer().Events().Subscribe(this, &CPVRTimers::Notify);
+  Create();
+}
+
+void CPVRTimers::Stop()
+{
+  StopThread();
+  CServiceBroker::GetPVRManager().EpgContainer().Events().Unsubscribe(this);
 }
 
 bool CPVRTimers::Update()

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -69,6 +69,16 @@ namespace PVR
     ~CPVRTimers() override = default;
 
     /**
+     * @brief start the timer update thread.
+     */
+    void Start();
+
+    /**
+     * @brief stop the timer update thread.
+     */
+    void Stop();
+
+    /**
      * @brief (re)load the timers from the clients.
      * @return True if loaded successfully, false otherwise.
      */


### PR DESCRIPTION
Stopping PVR Manager must follow the strict two-step logic for all (!) of its sub components.

1. Stop all sub components (means, stop their worker threads to hold processing)
2. Unload all sub components (clearing all data)

Starting must follow the exact revere logic

1. Load all sub components (loading their data from clients and/or database)
2. Start all sub components

This was not implemented properly for CPVRTimers and CPVREpgContainer components and should be fixed by this PR.

Runtime-tested on macOS and Android, latest kodi master. I had a testcase reproducible on my Mac which led to all kind of errors and even crashes.