### PR TITLE
Add support for Matroska DolbyVision

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=ffmpeg
-BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=4.3.1-Matrix-Beta1
+BASE_URL=https://github.com/fandangos/FFmpeg
+VERSION=4.3.1-Matrix-DV1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -498,6 +498,12 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
         m_mime = "video/dolby-vision";
         m_formatname = "amc-dvh1";
       }
+      else if (m_hints.codec_tag == MKBETAG('d', 'v', 'v', 'C') ||
+               m_hints.codec_tag == MKBETAG('d', 'v', 'c', 'C'))
+      {
+        m_mime = "video/dolby-vision";
+        m_formatname = "amc-dvh1";
+      }
       else
       {
         m_mime = "video/hevc";
@@ -1103,7 +1109,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
     // try to fetch an input buffer
     if (m_indexInputBuffer < 0)
     {
-      m_indexInputBuffer = m_codec->dequeueInputBuffer(5000 /*timout*/);
+      m_indexInputBuffer = m_codec->dequeueInputBuffer(10000 /*timout*/);
       if (xbmc_jnienv()->ExceptionCheck())
       {
         xbmc_jnienv()->ExceptionClear();
@@ -1364,7 +1370,7 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
 int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
 {
   int rtn = 0;
-  int64_t timeout_us = (m_state == MEDIACODEC_STATE_WAIT_ENDOFSTREAM) ? 100000 : 10000;
+  int64_t timeout_us = (m_state == MEDIACODEC_STATE_WAIT_ENDOFSTREAM) ? 1000000 : 10000;
   CJNIMediaCodecBufferInfo bufferInfo;
 
   ssize_t index = m_codec->dequeueOutputBuffer(bufferInfo, timeout_us);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -213,7 +213,7 @@ void CMediaCodecVideoBuffer::UpdateTexImage()
   // we hook the SurfaceTexture OnFrameAvailable callback
   // using CJNISurfaceTextureOnFrameAvailableListener and wait
   // on a CEvent to fire. 50ms seems to be a good max fallback.
-  WaitForFrame(50);
+  WaitForFrame(250);
 
   m_surfacetexture->updateTexImage();
   if (xbmc_jnienv()->ExceptionCheck())
@@ -1109,7 +1109,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
     // try to fetch an input buffer
     if (m_indexInputBuffer < 0)
     {
-      m_indexInputBuffer = m_codec->dequeueInputBuffer(5000 /*timout*/);
+      m_indexInputBuffer = m_codec->dequeueInputBuffer(10000 /*timout*/);
       if (xbmc_jnienv()->ExceptionCheck())
       {
         xbmc_jnienv()->ExceptionClear();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1109,7 +1109,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
     // try to fetch an input buffer
     if (m_indexInputBuffer < 0)
     {
-      m_indexInputBuffer = m_codec->dequeueInputBuffer(10000 /*timout*/);
+      m_indexInputBuffer = m_codec->dequeueInputBuffer(5000 /*timout*/);
       if (xbmc_jnienv()->ExceptionCheck())
       {
         xbmc_jnienv()->ExceptionClear();
@@ -1370,7 +1370,7 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
 int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
 {
   int rtn = 0;
-  int64_t timeout_us = (m_state == MEDIACODEC_STATE_WAIT_ENDOFSTREAM) ? 1000000 : 10000;
+  int64_t timeout_us = (m_state == MEDIACODEC_STATE_WAIT_ENDOFSTREAM) ? 100000 : 10000;
   CJNIMediaCodecBufferInfo bufferInfo;
 
   ssize_t index = m_codec->dequeueOutputBuffer(bufferInfo, timeout_us);
@@ -1379,6 +1379,13 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
     xbmc_jnienv()->ExceptionClear();
     CLog::Log(LOGERROR,
               "CDVDVideoCodecAndroidMediaCodec:GetOutputPicture dequeueOutputBuffer failed");
+    
+    if (m_mime == "video/dolby-vision")
+    {
+    CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_STOP);
+    m_state = MEDIACODEC_STATE_STOPPED;
+    } 
+    
     return -2;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -47,6 +47,7 @@
 #endif
 
 extern "C" {
+#include "libavutil/dovi_meta.h"
 #include <libavutil/dict.h>
 #include <libavutil/opt.h>
 }
@@ -1629,7 +1630,20 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           stereoMode = GetStereoModeFromMetadata(m_pFormatContext->metadata);
         if (!stereoMode.empty())
           st->stereo_mode = stereoMode;
-
+	  
+        if (m_bMatroska)
+        {
+          int size;
+          uint8_t* side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+          if (size > 0 && side_data)
+          {
+            auto dovi = reinterpret_cast<AVDOVIDecoderConfigurationRecord*>(side_data);
+            if (dovi->dv_profile > 7)
+              pStream->codecpar->codec_tag = MKBETAG('d', 'v', 'v', 'C');
+            else
+              pStream->codecpar->codec_tag = MKBETAG('d', 'v', 'c', 'C');
+          }
+        }
 
         if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
         {

--- a/xbmc/platform/android/PlatformAndroid.cpp
+++ b/xbmc/platform/android/PlatformAndroid.cpp
@@ -25,6 +25,14 @@ bool CPlatformAndroid::Init()
   if (!CPlatformPosix::Init())
     return false;
   setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+  
+  setenv("JAVA_HOME", CSpecialProtocol::TranslatePath("special://xbmcbin/j2re-image/").c_str(), 1);
+
+  setenv("JDK_HOME", CSpecialProtocol::TranslatePath("special://xbmcbin/j2re-image/").c_str(), 1);
+
+  setenv("LIBBLURAY_CP", CSpecialProtocol::TranslatePath("special://xbmcbin/j2re-image/").c_str(), 1);
+
+  setenv("LIBBLURAY_CACHE_ROOT", CSpecialProtocol::TranslatePath("special://userdata/cache/bluray/cache/").c_str(), 1);
 
   setenv("OS", "Linux", true); // for python scripts that check the OS
 


### PR DESCRIPTION
This commit adds support to Dolby Vision combined layer present on mkv files.

## Description
Matroska recently added a AdditionBlockMapping to support Dolby Vision or other private metadata. 

~The changes present here also need ffmpeg changes that are already present in Kodi's FFmpeg fork.~

EDIT: My mistake, the changes are still pending with FFmpeg.

## Motivation and Context
This commit is important to bring support to the ever growing format of Dolby Vision in mkv files.

## How Has This Been Tested?
This has been tested exclusively with the Nvidia Shield TV Pro (2019). 
Dolby Vision pass through is only possible with Apple TV and a few android boxes like the Nvidia Shield, or the Fire Stick. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
