### PR TITLE
[PVR] Fix EPG last scan time handling.

### DIFF
--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -1008,6 +1008,26 @@ bool CPVREpgDatabase::QueuePersistLastEpgScanTimeQuery(int iEpgId, const CDateTi
   return QueueInsertQuery(strQuery);
 }
 
+bool CPVREpgDatabase::QueueDeleteLastEpgScanTimeQuery(const CPVREpg& table)
+{
+  if (table.EpgID() <= 0)
+  {
+    CLog::LogF(LOGERROR, "Invalid EPG id: {}", table.EpgID());
+    return false;
+  }
+
+  Filter filter;
+
+  CSingleLock lock(m_critSection);
+  filter.AppendWhere(PrepareSQL("idEpg = %u", table.EpgID()));
+
+  std::string strQuery;
+  if (BuildSQL(PrepareSQL("DELETE FROM %s ", "lastepgscan"), filter, strQuery))
+    return QueueDeleteQuery(strQuery);
+
+  return false;
+}
+
 int CPVREpgDatabase::Persist(const CPVREpg& epg, bool bQueueWrite)
 {
   int iReturn = -1;

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -237,6 +237,13 @@ namespace PVR
     bool QueuePersistLastEpgScanTimeQuery(int iEpgId, const CDateTime& lastScanTime);
 
     /*!
+     * @brief Write the query to delete the last scan time for the given EPG to db query queue.
+     * @param iEpgId The table to delete the time for.
+     * @return True on success, false otherwise.
+     */
+    bool QueueDeleteLastEpgScanTimeQuery(const CPVREpg& table);
+
+    /*!
      * @brief Persist an EPG table. It's entries are not persisted.
      * @param epg The table to persist.
      * @param bQueueWrite If true, don't execute the query immediately but queue it.


### PR DESCRIPTION
Three fixes:
1. Last epg scan time was not always stored in the epg db 
2. Last epg scan time was never loaded from the db - 1. and 2. leading to too many EPG data fetches from the clients.
2. Last epg scan time row was not removed from the db when the associated EPG was deleted from the db - leaving the db with orphaned data.

Runtime.tested on macOS and Android, latest Kodi master.

@phunkyfish are you in the mood for a code review?