### PR TITLE
LibInputHandler: add suspend mode support

### DIFF
--- a/xbmc/platform/linux/input/LibInputHandler.h
+++ b/xbmc/platform/linux/input/LibInputHandler.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "interfaces/IAnnouncer.h"
 #include "threads/Thread.h"
 
 #include <memory>
@@ -21,11 +22,16 @@ class CLibInputPointer;
 class CLibInputSettings;
 class CLibInputTouch;
 
-class CLibInputHandler : CThread
+class CLibInputHandler : CThread, public ANNOUNCEMENT::IAnnouncer
 {
 public:
   CLibInputHandler();
   ~CLibInputHandler() override;
+
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
   void Start();
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
LibInputHandler: add suspend mode support
This will fix the 61662 (0xf0de) ShutDown action on suspend resume.

On some platforms like LibreELEC/CoreELEC the system get a power off command after resume from suspend if the suspend was initiated by libCEC.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
There are multiple hits on kodi forum like:
https://forum.kodi.tv/showthread.php?tid=220894&pid=1951421#pid1951421
https://forum.libreelec.tv/thread/8524-problem-with-sleep-mode/?postID=50264#post50264
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
CoreELEC, tested since Kodi Leia, 04.2019

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
