### PR TITLE
input/locale: split hardware and virtual keyboard setting in strings.po

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1452,7 +1452,7 @@ msgstr ""
 #. Setting in international settings
 #: system/settings/settings.xml
 msgctxt "#310"
-msgid "Keyboard layouts"
+msgid "Virtual keyboard layouts"
 msgstr ""
 
 #. Keyboard layout name e.g. "English QWERTY"
@@ -1926,7 +1926,11 @@ msgctxt "#406"
 msgid "Humidity"
 msgstr ""
 
-#empty strings from id 407 to 408
+msgctxt "#407"
+msgid "Hardware keyboard layouts"
+msgstr ""
+
+#empty strings from id 408 to 408
 
 msgctxt "#409"
 msgid "Defaults"
@@ -20340,7 +20344,9 @@ msgctxt "#36431"
 msgid "Shows all events in the event log for the current profile with options to only show specific levels."
 msgstr ""
 
-#. Description for setting #310: "Keyboard layouts"
+#. Description for setting #310: "Virtual keyboard layouts"
+#. Setting in Interface -> Regional -> Virtual keyboard layouts
+#. Select the layout of a virtual keyboard
 #: system/settings/settings.xml
 msgctxt "#36432"
 msgid "Select virtual keyboard layouts."
@@ -20359,10 +20365,13 @@ msgstr ""
 
 #empty string with id 36435
 
-#. Description for setting #310: "Keyboard layouts"
-#: system/settings/settings.xml
+#. Description for setting #407: "Hardware keyboard layouts"
+#. Setting in System -> Input -> Hardware keyboard layouts
+#. Select the layout of a physically attached keyboard
+#: system/settings/linux.xml
+#: system/settings/freebsd.xml
 msgctxt "#36436"
-msgid "Select OS keyboard layout."
+msgid "Select hardware keyboard layout."
 msgstr ""
 
 #. Option for setting "System -> Add-ons -> Update official add-ons from"

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -220,7 +220,7 @@
     </category>
     <category id="input">
       <group id="4" label="35150">
-        <setting id="input.libinputkeyboardlayout" type="string" label="310" help="36436">
+        <setting id="input.libinputkeyboardlayout" type="string" label="407" help="36436">
           <level>0</level>
           <default>us</default>
           <visible>false</visible>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Split hardware and virtual keyboard setting in strings.po.
Using the same string for both "Keyboard layouts" for both is just confusing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Clean keyboard layout settings

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On CoreELEC 19 Matrix with Kodi Matrix 19.0 beta2

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
