### PR TITLE
Shaders: require profile level 9.3 only when is needed (ACES, Hable or HLG to PQ)

### DIFF
--- a/system/shaders/output_d3d.fx
+++ b/system/shaders/output_d3d.fx
@@ -169,6 +169,13 @@ float4 output(float3 color, float2 uv)
 
 #if defined(KODI_OUTPUT_T)
 #include "convolution_d3d.fx"
+
+#if (defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE) || defined(KODI_HLG_TO_PQ))
+#define PS_PROFILE ps_4_0_level_9_3
+#else
+#define PS_PROFILE ps_4_0_level_9_1
+#endif
+
 float3 m_params; // 0 - range (0 - full, 1 - limited), 1 - contrast, 2 - brightness
 
 float4 OUTPUT_PS(VS_OUTPUT In) : SV_TARGET
@@ -189,7 +196,7 @@ technique11 OUTPUT_T
   pass P0
   {
     SetVertexShader( VS_SHADER );
-    SetPixelShader( CompileShader( ps_4_0_level_9_3, OUTPUT_PS() ) );
+    SetPixelShader( CompileShader( PS_PROFILE, OUTPUT_PS() ) );
   }
 };
 #endif


### PR DESCRIPTION
## Description
Require profile level 9.3 only when is needed (ACES, Hable or HLG to PQ).

Fix crash playing any file on very old systems (or outdated drivers) that does not supports DX profile level 9.3

## Motivation and Context
From dither fix (https://github.com/xbmc/xbmc/pull/18850) pixel shaders profile was increased from `ps_4_0_level_9_1` to `ps_4_0_level_9_3`. This breaks compatibility with older systems.

See https://forum.kodi.tv/showthread.php?tid=359320

Now is restored compatibility in these systems when not using advanced tone map methods or HLG to PQ (which cannot be used in these obsolete systems anyway). Dither can run with 9.1 profile, only can not run dither + ACES or Hable or HLG to PQ.

## How Has This Been Tested?
1) Tested on present system (DX 12.1 capable) running profile level 9.1 (1080p) and profile level 9.3 (Hable tone mapping).

2) Forum user has confirmed crash is fixed on DX 9.1 system https://forum.kodi.tv/showthread.php?tid=359320&pid=2997652#pid2997652

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
