### PR TITLE
DXVA2: adjust memory limit for 4K decoding from 3000 MB to 2960 MB

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -10,6 +10,8 @@
 // which we don't use here
 #define FF_API_OLD_SAMPLE_FMT 0
 
+#define LIMIT_VIDEO_MEMORY_4K 2960ull
+
 #include "DXVA.h"
 
 #include "ServiceBroker.h"
@@ -1221,12 +1223,12 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
   }
 
   // Check if available video memory is sufficient for 4K decoding (is need ~3000 MB)
-  if (avctx->width >= 3840 && m_refs > 16 && videoMem < (3000ull * MB))
+  if (avctx->width >= 3840 && m_refs > 16 && videoMem < (LIMIT_VIDEO_MEMORY_4K * MB))
   {
     CLog::LogF(LOGWARNING,
                "Current available video memory ({} MB) is insufficient 4K video decoding (DXVA2) "
-               "using {} surfaces. Fallback to SW decode.", videoMem / MB, m_refs);
-    return false;
+               "using {} surfaces. Decoder surfaces has been limited to 16.", videoMem / MB, m_refs);
+    m_refs = 16;
   }
 
   /* On the Xbox 1/S with limited memory we have to


### PR DESCRIPTION
## Description
- Adjust memory limit for 4K decoding from 3000 MB to 2960 MB
- Change fallback strategy to limit decoder surfaces to 16 instead of exit

## Motivation and Context
Try to improve some situations where the hardware is at the limit to be able or not to use DXVA2 HEVC 4K decoding:

See https://forum.kodi.tv/showthread.php?tid=359216  This system has really 3 GB video memory: 2 GB dedicated (GT 1030) 1 GB shared (only 2GB system RAM).... number reported is 2989 MB and should be considered 3 GB.

See https://forum.kodi.tv/showthread.php?tid=359247 This system has only 4 GB RAM and no dedicated video memory and  Celeron J3455 has not power enough for SW HEVC decoding. The only possibility is limiting decoder surfaces to 16 as Intel video driver does not use additional refs by CPU cores and HEVC files never has more than 8 refs frames. Maybe on other cases does not work but is better that nothing (SW on 4K).

These changes are safe to merge because on more habitual systems  (+3 GB video memory or +4 GB RAM) nothing changes.

## How Has This Been Tested?
Tested on ASUS ZenBook UX305UA (4 GB RAM, Intel HD graphics 520) limiting decoder surfaces to 16 works pretty well on this system and able to use DXVA2 HEVC 4K decoding. Only observed some green glitch when seek to random point and it normalizes after a few seconds playing.

Waiting feedback from forum users....

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
