### PR TITLE
[Windows][GUI] Tonemap Kodi GUI to HDR PQ while in playback of HDR pass-through mode

### DIFF
--- a/system/shaders/guishader_default.hlsl
+++ b/system/shaders/guishader_default.hlsl
@@ -22,7 +22,7 @@
 
 float4 PS(PS_INPUT input) : SV_TARGET
 {
-  return adjustColorRange(input.color);
+  return tonemapHDR(adjustColorRange(input.color));
 }
 
 

--- a/system/shaders/guishader_fonts.hlsl
+++ b/system/shaders/guishader_fonts.hlsl
@@ -25,7 +25,7 @@ Texture2D texFont : register(t0);
 float4 PS(PS_INPUT input) : SV_TARGET
 {
   input.color.a *= texFont.Sample(LinearSampler, input.tex).r;
-  return adjustColorRange(input.color);
+  return tonemapHDR(adjustColorRange(input.color));
 }
 
 

--- a/system/shaders/guishader_multi_texture_blend.hlsl
+++ b/system/shaders/guishader_multi_texture_blend.hlsl
@@ -24,8 +24,8 @@ Texture2D txDiffuse[2] : register(t0);
 
 float4 PS(PS_INPUT input) : SV_TARGET
 {
-  return adjustColorRange(input.color * txDiffuse[0].Sample(LinearSampler, input.tex)
-                          * txDiffuse[1].Sample(LinearSampler, input.tex2));
+  return tonemapHDR(adjustColorRange(input.color * txDiffuse[0].Sample(LinearSampler, input.tex) *
+                                     txDiffuse[1].Sample(LinearSampler, input.tex2)));
 }
 
 

--- a/system/shaders/guishader_texture.hlsl
+++ b/system/shaders/guishader_texture.hlsl
@@ -24,7 +24,7 @@ Texture2D texMain : register(t0);
 
 float4 PS(PS_INPUT input) : SV_TARGET
 {
-  return adjustColorRange(input.color * texMain.Sample(LinearSampler, input.tex));
+  return tonemapHDR(adjustColorRange(input.color * texMain.Sample(LinearSampler, input.tex)));
 }
 
 

--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -337,6 +337,7 @@ void CGUIShaderDX::ApplyChanges(void)
       buffer->wvp = worldViewProj;
       buffer->blackLevel = (DX::Windowing()->UseLimitedColor() ? 16.f / 255.f : 0.f);
       buffer->colorRange = (DX::Windowing()->UseLimitedColor() ? (235.f - 16.f) / 255.f : 1.0f);
+      buffer->PQ = (DX::Windowing()->IsTransferPQ() ? 1 : 0);
 
       pContext->Unmap(m_pWVPBuffer.Get(), 0);
       m_bIsWVPDirty = false;

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -106,6 +106,7 @@ private:
     DirectX::XMMATRIX wvp;
     float blackLevel;
     float colorRange;
+    int PQ;
   };
 
   void Release(void);

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -81,6 +81,7 @@ DX::DeviceResources::DeviceResources()
   , m_stereoEnabled(false)
   , m_bDeviceCreated(false)
   , m_IsHDROutput(false)
+  , m_IsTransferPQ(false)
 {
 }
 
@@ -1164,7 +1165,7 @@ void DX::DeviceResources::SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const
   }
 }
 
-void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace) const
+void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace)
 {
   ComPtr<IDXGISwapChain3> swapChain3;
 
@@ -1188,6 +1189,9 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
     }
     if (SUCCEEDED(swapChain3->SetColorSpace1(cs)))
     {
+      m_IsTransferPQ = cs == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020 ||
+                       cs == DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020;
+
       CLog::LogF(LOGDEBUG, "DXGI SetColorSpace1 success");
     }
     else
@@ -1220,6 +1224,7 @@ HDR_STATUS DX::DeviceResources::ToggleHDR()
     m_swapChain = nullptr;
     m_deferrContext->Flush();
     m_d3dContext->Flush();
+    m_IsTransferPQ = false;
   }
 
   DX::Windowing()->SetAlteringWindow(false);

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -81,8 +81,9 @@ namespace DX
     // HDR display support
     HDR_STATUS ToggleHDR();
     void SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const;
-    void SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace) const;
+    void SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace);
     bool IsHDROutput() const { return m_IsHDROutput; }
+    bool IsTransferPQ() const { return m_IsTransferPQ; }
 
     // DX resources registration
     void Register(ID3DResource *resource);
@@ -167,6 +168,7 @@ namespace DX
     bool m_stereoEnabled;
     bool m_bDeviceCreated;
     bool m_IsHDROutput;
+    bool m_IsTransferPQ;
     bool m_NV12SharedTexturesSupport{false};
   };
 }

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -182,6 +182,11 @@ bool CWinSystemWin10DX::IsHDROutput() const
   return m_deviceResources->IsHDROutput();
 }
 
+bool CWinSystemWin10DX::IsTransferPQ() const
+{
+  return m_deviceResources->IsTransferPQ();
+}
+
 void CWinSystemWin10DX::SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const
 {
   m_deviceResources->SetHdrMetaData(hdr10);

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -73,6 +73,7 @@ public:
 
   // HDR support
   bool IsHDROutput() const;
+  bool IsTransferPQ() const;
   void SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const;
   void SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace) const;
 

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -407,6 +407,11 @@ bool CWinSystemWin32DX::IsHDROutput() const
   return m_deviceResources->IsHDROutput();
 }
 
+bool CWinSystemWin32DX::IsTransferPQ() const
+{
+  return m_deviceResources->IsTransferPQ();
+}
+
 void CWinSystemWin32DX::SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const
 {
   m_deviceResources->SetHdrMetaData(hdr10);

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -75,6 +75,7 @@ public:
 
   // HDR support
   bool IsHDROutput() const;
+  bool IsTransferPQ() const;
   void SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const;
   void SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace) const;
 


### PR DESCRIPTION
## Description
- Tonemap Kodi GUI to HDR PQ while in playback of HDR pass-through mode.
- Fixes very bright OSD, subtitles, etc. and wrong color space (oversaturated).

## Motivation and Context
While in playback HDR pass-through Windows color space is switched to HDR PQ and since Kodi GUI is still SRD, the colors and brightness are totally altered. 

SDR GUI (BT.709) needs to be "tone mapped" to HDR color space (BT.2020) and from Gamma transfer to PQ transfer. In this way it is achieved that the Kodi GUI has a peak brightness of 100 nits while the video HDR content can have a peak brightness of 1000 nits for example. PQ uses an absolute scale, so the normal pure white (SDR) must still have 100 nits maximum on the PQ scale and all over 100 nits to 10000 nits is HDR range...

In other words: the GUI will still look the same as when in SDR mode.

## How Has This Been Tested?
Runtime tested on Intel NUC8i3BEK 
Also some forum users are testing in https://forum.kodi.tv/showthread.php?tid=359366

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
