### PR TITLE
[addons] introduce advanced setting to allow showing all dependencies in dialog

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -32,6 +32,7 @@
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "pictures/GUIWindowSlideShow.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
@@ -737,6 +738,9 @@ void CGUIDialogAddonInfo::BuildDependencyList()
   m_deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(m_item->GetAddonInfo()->ID(),
                                                           OnlyEnabledRootAddon::NO);
 
+  const bool showAllDependencies =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_showAllDependencies;
+
   for (const auto& dep : m_deps)
   {
     std::shared_ptr<IAddon> addonInstalled;
@@ -756,10 +760,12 @@ void CGUIDialogAddonInfo::BuildDependencyList()
       addonAvailable = nullptr;
     }
 
+    // Depending on advancedsettings.xml <showalldependencies>:
     // AddonType ADDON_SCRIPT_MODULE needs to be filtered as these low-level add-ons
     // should be hidden to the user in the dependency select dialog
 
-    if ((addonInstalled && addonInstalled->MainType() != ADDON_SCRIPT_MODULE) ||
+    if (showAllDependencies ||
+        (addonInstalled && addonInstalled->MainType() != ADDON_SCRIPT_MODULE) ||
         (addonAvailable && addonAvailable->MainType() != ADDON_SCRIPT_MODULE) ||
         (!addonAvailable && !addonInstalled))
     {

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -347,6 +347,7 @@ void CAdvancedSettings::Initialize()
 #endif
   m_showExitButton = true;
   m_splashImage = true;
+  m_showAllDependencies = false;
 
   m_playlistRetries = 100;
   m_playlistTimeout = 20; // 20 seconds timeout
@@ -883,6 +884,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   XMLUtils::GetBoolean(pRootElement, "fullscreen", m_startFullScreen);
 #endif
   XMLUtils::GetBoolean(pRootElement, "splash", m_splashImage);
+  XMLUtils::GetBoolean(pRootElement, "showalldependencies", m_showAllDependencies);
   XMLUtils::GetBoolean(pRootElement, "showexitbutton", m_showExitButton);
   XMLUtils::GetBoolean(pRootElement, "canwindowed", m_canWindowed);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -299,6 +299,12 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_GLRectangleHack;
     int m_iSkipLoopFilter;
 
+    /*!< @brief Decision flag to show or hide specific dependencies in the list of the AddonInfo dialog
+    as this information usually adds no value for a consumer.
+    True to recursively show any dependency of the selected add-on
+    False to hide 'low-level' dependencies like e.g. scripts/modules (default) */
+    bool m_showAllDependencies;
+
     bool m_bVirtualShares;
     bool m_bTry10bitOutput;
 


### PR DESCRIPTION
## Description
+ allows to disable filtering of low-level dependencies (e.g. ADDON_SCRIPT_MODULE) in the dependency select dialog
by setting `<showalldependencies>yes</showalldependencies>` in advancedsettings.xml

## How Has This Been Tested?
examined the depends dialog for the YouTube add-on in the official repository

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

like discussed on slack with @basrieter 
