### PR TITLE
YUV to RGB conversion rework

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,5 +1,6 @@
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders
 xbmc/filesystem/test              test/filesystem
 xbmc/interfaces/python/test       test/python
 xbmc/music/tags/test              test/music_tags

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
@@ -8,6 +8,9 @@
 
 #include "ConversionMatrix.h"
 
+#include <stdexcept>
+#include <string>
+
 //------------------------------------------------------------------------------
 // constants for primaries and transfers functions and color models
 //------------------------------------------------------------------------------
@@ -44,21 +47,24 @@ const Primaries PrimariesBT2020 = {{{0.708, 0.292}, {0.170, 0.797}, {0.131, 0.04
 //------------------------------------------------------------------------------
 // source: http://timjones.io/blog/archive/2014/10/20/the-matrix-inverted
 
-template <unsigned Order>
-float CalculateDeterminant(float (&src)[Order][Order]);
+template<uint8_t Order>
+float CalculateDeterminant(const std::array<std::array<float, Order>, Order>& src);
 
-template <unsigned Order>
-void GetSubmatrix(float (&dest)[Order-1][Order-1], float (&src)[Order][Order], unsigned row, unsigned col)
+template<uint8_t Order>
+std::array<std::array<float, Order - 1>, Order - 1> GetSubmatrix(
+    const std::array<std::array<float, Order>, Order>& src, uint8_t row, uint8_t col)
 {
-  unsigned colCount = 0;
-  unsigned rowCount = 0;
+  uint8_t colCount = 0;
+  uint8_t rowCount = 0;
 
-  for (unsigned i = 0; i < Order; i++)
+  std::array<std::array<float, Order - 1>, Order - 1> dest;
+
+  for (int i = 0; i < Order; i++)
   {
     if (i != row)
     {
       colCount = 0;
-      for (unsigned j = 0; j < Order; j++)
+      for (int j = 0; j < Order; j++)
       {
         if (j != col)
         {
@@ -69,22 +75,26 @@ void GetSubmatrix(float (&dest)[Order-1][Order-1], float (&src)[Order][Order], u
       rowCount++;
     }
   }
+
+  return dest;
 }
 
-template <unsigned Order>
-float CalculateMinor(float (&src)[Order][Order], unsigned row, unsigned col)
+template<uint8_t Order>
+float CalculateMinor(const std::array<std::array<float, Order>, Order>& src,
+                     uint8_t row,
+                     uint8_t col)
 {
-  float sub[Order-1][Order-1];
-  GetSubmatrix<Order>(sub, src, row, col);
+  const std::array<std::array<float, Order - 1>, Order - 1> sub =
+      GetSubmatrix<Order>(src, row, col);
   return CalculateDeterminant<Order - 1>(sub);
 }
 
-template <unsigned Order>
-float CalculateDeterminant(float (&src)[Order][Order])
+template<uint8_t Order>
+float CalculateDeterminant(const std::array<std::array<float, Order>, Order>& src)
 {
   float det = 0.0f;
 
-  for (unsigned i = 0; i < Order; i++)
+  for (int i = 0; i < Order; i++)
   {
     // Get minor of element (0, i)
     float minor = CalculateMinor<Order>(src, 0, i);
@@ -97,8 +107,8 @@ float CalculateDeterminant(float (&src)[Order][Order])
   return det;
 }
 
-template <>
-float CalculateDeterminant<2>(float (&src)[2][2])
+template<>
+float CalculateDeterminant<2>(const std::array<std::array<float, 2>, 2>& src)
 {
   return src[0][0] * src[1][1] - src[0][1] * src[1][0];
 }
@@ -107,103 +117,99 @@ float CalculateDeterminant<2>(float (&src)[2][2])
 // Matrix classes
 //------------------------------------------------------------------------------
 
-template <unsigned Order>
-CMatrix<Order>::CMatrix(float (&src)[Order][Order])
+template<uint8_t Order>
+CMatrix<Order>::CMatrix(const std::array<std::array<float, Order - 1>, Order - 1>& other)
 {
-  Copy(m_mat, src);
+  *this = other;
 }
 
-template <unsigned Order>
-CMatrix<Order>::CMatrix(float (&src)[Order-1][Order-1])
+template<uint8_t Order>
+CMatrix<Order>::CMatrix(const CMatrix<Order - 1>& other)
 {
-  *this = src;
+  *this = other.Get();
 }
 
-template <unsigned Order>
-CMatrix<Order>& CMatrix<Order>::operator=(const CMatrix& src)
+template<uint8_t Order>
+CMatrix<Order>& CMatrix<Order>::operator=(
+    const std::array<std::array<float, Order - 1>, Order - 1>& other)
 {
-  Copy(m_mat, src.m_mat);
-  return *this;
-}
+  for (int i = 0; i < Order - 1; ++i)
+    for (int j = 0; j < Order - 1; ++j)
+      m_mat[i][j] = other[i][j];
 
-template <unsigned Order>
-CMatrix<Order>& CMatrix<Order>::operator=(const float (&src)[Order-1][Order-1])
-{
-  for (unsigned i=0; i<Order-1; ++i)
-    for (unsigned j=0; j<Order-1; ++j)
-      m_mat[i][j] = src[i][j];
-
-  for (unsigned i=0; i<Order; ++i)
+  for (int i = 0; i < Order; ++i)
     m_mat[i][Order-1] = 0;
 
-  for (unsigned i=0; i<Order; ++i)
+  for (int i = 0; i < Order; ++i)
     m_mat[Order-1][i] = 0;
 
   return *this;
 }
 
-template <unsigned Order>
-float (&CMatrix<Order>::Get())[Order][Order]
+template<uint8_t Order>
+std::array<std::array<float, Order>, Order>& CMatrix<Order>::Get()
 {
   return m_mat;
 }
 
-template <unsigned Order>
-CMatrix<Order> CMatrix<Order>::Invert()
+template<uint8_t Order>
+const std::array<std::array<float, Order>, Order>& CMatrix<Order>::Get() const
 {
-  CMatrix<Order> ret;
-  Invert(ret.m_mat, m_mat);
-  return ret;
+  return m_mat;
 }
 
-template <unsigned Order>
+template<uint8_t Order>
 CMatrix<Order> CMatrix<Order>::operator*(const CMatrix& other)
 {
   return *this * other.m_mat;
 }
 
-template <unsigned Order>
-CMatrix<Order> CMatrix<Order>::operator*=(const CMatrix& other)
+template<uint8_t Order>
+CMatrix<Order>& CMatrix<Order>::operator*=(const CMatrix& other)
 {
   CMatrix<Order> tmp = *this * other.m_mat;
   *this = tmp;
   return *this;
 }
 
-template <unsigned Order>
-CMatrix<Order> CMatrix<Order>::operator*(const float (&other)[Order][Order])
+template<uint8_t Order>
+CMatrix<Order> CMatrix<Order>::operator*(const std::array<std::array<float, Order>, Order>& other)
 {
   CMatrix<Order> ret;
-  for (unsigned i=0; i<Order; ++i)
-    for (unsigned j=0; j<Order; ++j)
-      for (unsigned k=0; k<Order; ++k)
+  for (int i = 0; i < Order; ++i)
+    for (int j = 0; j < Order; ++j)
+      for (int k = 0; k < Order; ++k)
         ret.m_mat[i][j] += m_mat[i][k] * other[k][j];
 
   return ret;
 }
 
-template <unsigned Order>
-void CMatrix<Order>::Copy(float (&dst)[Order][Order], const float (&src)[Order][Order])
+template<uint8_t Order>
+CMatrix<Order>& CMatrix<Order>::Invert()
 {
-  for (unsigned i=0; i<Order; ++i)
-    for (unsigned j=0; j<Order; ++j)
-      dst[i][j] = src[i][j];
+  CMatrix<Order> tmp;
+  tmp.m_mat = Invert(m_mat);
+  *this = tmp;
+  return *this;
 }
 
-template <unsigned Order>
-void CMatrix<Order>::Invert(float (&dst)[Order][Order], float (&src)[Order][Order])
+template<uint8_t Order>
+std::array<std::array<float, Order>, Order> CMatrix<Order>::Invert(
+    std::array<std::array<float, Order>, Order>& other) const
 {
   // Calculate the inverse of the determinant of src.
-  float det = CalculateDeterminant<Order>(src);
+  float det = CalculateDeterminant<Order>(other);
   float inverseDet = 1.0f / det;
 
-  for (unsigned j = 0; j < Order; j++)
+  std::array<std::array<float, Order>, Order> dst;
+
+  for (int j = 0; j < Order; j++)
   {
-    for (unsigned i = 0; i < Order; i++)
+    for (int i = 0; i < Order; i++)
     {
       // Get minor of element (j, i) - not (i, j) because
       // this is where the transpose happens.
-      float minor = CalculateMinor<Order>(src, j, i);
+      float minor = CalculateMinor<Order>(other, j, i);
 
       // Multiply by (−1)^{i+j}
       float factor = ((i + j) % 2 == 1) ? -1.0f : 1.0f;
@@ -212,19 +218,24 @@ void CMatrix<Order>::Invert(float (&dst)[Order][Order], float (&src)[Order][Orde
       dst[i][j] = inverseDet * cofactor;
     }
   }
+
+  return dst;
 }
 
-CGlMatrix::CGlMatrix(float (&src)[3][3]) : CMatrix<4>(src)
+CGlMatrix::CGlMatrix(const CMatrix<3>& other) : CMatrix<4>(other)
 {
-
 }
 
-CGlMatrix::CMatrix CGlMatrix::operator*(const float (&other)[4][4])
+CGlMatrix::CGlMatrix(const std::array<std::array<float, 3>, 3>& other) : CMatrix<4>(other)
+{
+}
+
+CGlMatrix::CMatrix CGlMatrix::operator*(const std::array<std::array<float, 4>, 4>& other)
 {
   CGlMatrix ret;
 
-  float (&left)[4][4] = m_mat;
-  const float (&right)[4][4] = other;
+  std::array<std::array<float, 4>, 4>& left = m_mat;
+  const std::array<std::array<float, 4>, 4>& right = other;
 
   ret.m_mat[0][0] = left[0][0] * right[0][0] + left[0][1] * right[1][0] + left[0][2] * right[2][0];
   ret.m_mat[0][1] = left[0][0] * right[0][1] + left[0][1] * right[1][1] + left[0][2] * right[2][1];
@@ -278,15 +289,8 @@ ConversionToRGB::ConversionToRGB(float Kr, float Kb)
   m_mat[1][0] = -Kr/CbDen; m_mat[1][1] = -Kg/CbDen; m_mat[1][2] = 0.5;
   m_mat[2][0] = 0.5;       m_mat[2][1] = -Kg/CrDen; m_mat[2][2] = -Kb/CrDen;
 
-  CMatrix<3> inv(m_mat);
-  Copy(m_mat, inv.Invert().Get());
+  m_mat = Invert(m_mat);
 };
-
-ConversionToRGB& ConversionToRGB::operator=(const float (&src)[3][3])
-{
-  Copy(m_mat, src);
-  return *this;
-}
 
 PrimaryToXYZ::PrimaryToXYZ(const float (&primaries)[3][2], const float (&whitepoint)[2])
 {
@@ -331,8 +335,7 @@ float PrimaryToXYZ::CalcRy(const float By, const float Gy)
 
 PrimaryToRGB::PrimaryToRGB(float (&primaries)[3][2], float (&whitepoint)[2]) : PrimaryToXYZ(primaries, whitepoint)
 {
-  CMatrix<3> inv(m_mat);
-  Copy(m_mat, inv.Invert().Get());
+  m_mat = Invert(m_mat);
 }
 
 //------------------------------------------------------------------------------
@@ -391,74 +394,74 @@ CConvertMatrix& CConvertMatrix::SetDestinationLimitedRange(bool limited)
   return *this;
 }
 
-void CConvertMatrix::GenPrimMat()
+const CMatrix<3>& CConvertMatrix::GenPrimMat()
 {
-  if (m_colPrimariesDst != m_colPrimariesSrc)
-  {
-    Primaries primToRGB;
-    Primaries primToXYZ;
-    switch (m_colPrimariesSrc)
-    {
-      case AVCOL_PRI_BT709:
-        primToXYZ = PrimariesBT709;
-        m_gammaSrc = 2.2;
-        break;
-      case AVCOL_PRI_BT470BG:
-        primToXYZ = PrimariesBT610_625;
-        m_gammaSrc = 2.2;
-        break;
-      case AVCOL_PRI_SMPTE170M:
-      case AVCOL_PRI_SMPTE240M:
-        primToXYZ = PrimariesBT610_525;
-        m_gammaSrc = 2.2;
-        break;
-      case AVCOL_PRI_BT2020:
-        primToXYZ = PrimariesBT2020;
-        m_gammaSrc = 2.4;
-        break;
-      default:
-        primToXYZ = PrimariesBT709;
-        m_gammaSrc = 2.2;
-        break;
-    }
-    switch (m_colPrimariesDst)
-    {
-      case AVCOL_PRI_BT709:
-        primToRGB = PrimariesBT709;
-        m_gammaDst = 2.2;
-        break;
-      case AVCOL_PRI_BT470BG:
-        primToRGB = PrimariesBT610_625;
-        m_gammaDst = 2.2;
-        break;
-      case AVCOL_PRI_SMPTE170M:
-      case AVCOL_PRI_SMPTE240M:
-        primToRGB = PrimariesBT610_525;
-        m_gammaDst = 2.2;
-        break;
-      case AVCOL_PRI_BT2020:
-        primToRGB = PrimariesBT2020;
-        m_gammaDst = 2.4;
-        break;
-      default:
-        primToRGB = PrimariesBT709;
-        m_gammaDst = 2.2;
-        break;
-    }
-    PrimaryToXYZ toXYZ(primToXYZ.primaries, primToXYZ.whitepoint);
-    PrimaryToRGB toRGB(primToRGB.primaries, primToRGB.whitepoint);
+  if (m_matPrim)
+    return *m_matPrim;
 
-    CMatrix<3> tmp = toRGB*toXYZ;
-    m_pMatPrim.reset(new CMatrix<3>(tmp));
-  }
-  else
+  Primaries primToRGB;
+  Primaries primToXYZ;
+  switch (m_colPrimariesSrc)
   {
-    m_pMatPrim.reset();
+    case AVCOL_PRI_BT709:
+      primToXYZ = PrimariesBT709;
+      m_gammaSrc = 2.2;
+      break;
+    case AVCOL_PRI_BT470BG:
+      primToXYZ = PrimariesBT610_625;
+      m_gammaSrc = 2.2;
+      break;
+    case AVCOL_PRI_SMPTE170M:
+    case AVCOL_PRI_SMPTE240M:
+      primToXYZ = PrimariesBT610_525;
+      m_gammaSrc = 2.2;
+      break;
+    case AVCOL_PRI_BT2020:
+      primToXYZ = PrimariesBT2020;
+      m_gammaSrc = 2.4;
+      break;
+    default:
+      primToXYZ = PrimariesBT709;
+      m_gammaSrc = 2.2;
+      break;
   }
+  switch (m_colPrimariesDst)
+  {
+    case AVCOL_PRI_BT709:
+      primToRGB = PrimariesBT709;
+      m_gammaDst = 2.2;
+      break;
+    case AVCOL_PRI_BT470BG:
+      primToRGB = PrimariesBT610_625;
+      m_gammaDst = 2.2;
+      break;
+    case AVCOL_PRI_SMPTE170M:
+    case AVCOL_PRI_SMPTE240M:
+      primToRGB = PrimariesBT610_525;
+      m_gammaDst = 2.2;
+      break;
+    case AVCOL_PRI_BT2020:
+      primToRGB = PrimariesBT2020;
+      m_gammaDst = 2.4;
+      break;
+    default:
+      primToRGB = PrimariesBT709;
+      m_gammaDst = 2.2;
+      break;
+  }
+  PrimaryToXYZ toXYZ(primToXYZ.primaries, primToXYZ.whitepoint);
+  PrimaryToRGB toRGB(primToRGB.primaries, primToRGB.whitepoint);
+
+  m_matPrim = std::make_unique<CMatrix<3>>(toRGB * toXYZ);
+
+  return *m_matPrim;
 }
 
-void CConvertMatrix::GenMat()
+const CGlMatrix& CConvertMatrix::GenMat()
 {
+  if (m_mat)
+    return *m_mat;
+
   ConvYCbCr convYCbCr;
   switch (m_colSpace)
   {
@@ -482,11 +485,10 @@ void CConvertMatrix::GenMat()
   }
 
   ConversionToRGB mConvRGB(convYCbCr.Kr, convYCbCr.Kb);
-
-  m_pMat.reset(new CGlMatrix(mConvRGB.Get()));
+  CGlMatrix mat(mConvRGB);
 
   CTranslate trans(0, -0.5, -0.5);
-  *m_pMat *= trans;
+  mat *= trans;
 
   if (m_limitedSrc)
   {
@@ -494,22 +496,22 @@ void CConvertMatrix::GenMat()
     {
       CScale scale(4080.0f / (3760 - 256), 4080.0f / (3840 - 256), 4080.0f / (3840 - 256));
       CTranslate trans(- 256.0f / 4080, - 256.0f / 4080, - 256.0f / 4080);
-      *m_pMat *= scale;
-      *m_pMat *= trans;
+      mat *= scale;
+      mat *= trans;
     }
     else if (m_srcBits == 10)
     {
       CScale scale(1020.0f / (940 - 64), 1020.0f / (960 - 64), 1020.0f / (960 - 64));
       CTranslate trans(- 64.0f / 1020, - 64.0f / 1020, - 64.0f / 1020);
-      *m_pMat *= scale;
-      *m_pMat *= trans;
+      mat *= scale;
+      mat *= trans;
     }
     else
     {
       CScale scale(255.0f / (235 - 16), 255.0f / (240 - 16), 255.0f / (240 - 16));
       CTranslate trans(- 16.0f / 255, - 16.0f / 255, - 16.0f / 255);
-      *m_pMat *= scale;
-      *m_pMat *= trans;
+      mat *= scale;
+      mat *= trans;
     }
   }
 
@@ -517,16 +519,17 @@ void CConvertMatrix::GenMat()
   {
     float val = 65535.0f / ((1 << m_srcTextureBits) - 1);
     CScale scale(val, val, val);
-    *m_pMat *= scale;
+    mat *= scale;
   }
+
+  m_mat = std::make_unique<CGlMatrix>(mat);
+
+  return *m_mat;
 }
 
-void CConvertMatrix::GetYuvMat(float (&mat)[4][4])
+Matrix4 CConvertMatrix::GetYuvMat()
 {
-  GenMat();
-
-  if (!m_pMat)
-    return;
+  const CGlMatrix& mat = GenMat();
 
   CScale contrast(m_contrast, m_contrast, m_contrast);
   CTranslate black(m_black, m_black, m_black);
@@ -543,33 +546,36 @@ void CConvertMatrix::GetYuvMat(float (&mat)[4][4])
     ret *= scale;
   }
 
-  ret *= m_pMat->Get();
-  float (&src)[4][4] = ret.Get();
+  ret *= mat;
 
-  for (int i=0; i<4; ++i)
-    for (int j=0; j<4; ++j)
-      mat[i][j] = src[j][i];
+  Matrix4 dst;
 
-  mat[0][3] = 0.0f;
-  mat[1][3] = 0.0f;
-  mat[2][3] = 0.0f;
-  mat[3][3] = 1.0f;
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j)
+      dst[i][j] = ret[j][i];
+
+  dst[0][3] = 0.0f;
+  dst[1][3] = 0.0f;
+  dst[2][3] = 0.0f;
+  dst[3][3] = 1.0f;
+
+  return dst;
 }
 
-bool CConvertMatrix::GetPrimMat(float (&mat)[3][3])
+Matrix3 CConvertMatrix::GetPrimMat()
 {
-  GenPrimMat();
+  if (m_colPrimariesDst == m_colPrimariesSrc)
+    return Matrix3();
 
-  if (!m_pMatPrim)
-    return false;
+  const Matrix3& matPrim = GenPrimMat();
 
-  float (&src)[3][3] = m_pMatPrim->Get();
+  Matrix3 dst;
 
-  for (int i=0; i<3; ++i)
-    for (int j=0; j<3; ++j)
-      mat[i][j] = src[j][i];
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      dst[i][j] = matPrim[j][i];
 
-  return true;
+  return dst;
 }
 
 float CConvertMatrix::GetGammaSrc()
@@ -582,8 +588,10 @@ float CConvertMatrix::GetGammaDst()
   return m_gammaDst;
 }
 
-bool CConvertMatrix::GetRGBYuvCoefs(AVColorSpace colspace, float (&coefs)[3])
+Matrix3x1 CConvertMatrix::GetRGBYuvCoefs(AVColorSpace colspace)
 {
+  Matrix3x1 coefs;
+
   switch (colspace)
   {
     case AVCOL_SPC_BT709:
@@ -609,7 +617,8 @@ bool CConvertMatrix::GetRGBYuvCoefs(AVColorSpace colspace, float (&coefs)[3])
       coefs[2] = BT2020YCbCr.Kb;
       break;
     default:
-      return false;
+      throw std::invalid_argument("unknown colorspace: " + std::to_string(colspace));
   }
-  return true;
+
+  return coefs;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
@@ -28,19 +28,19 @@ struct Primaries
   float whitepoint[2];
 };
 
-const ConvYCbCr BT709YCbCr = {0.2126, 0.0722};
-const ConvYCbCr BT601YCbCr = {0.299, 0.114};
-const ConvYCbCr BT2020YCbCr = {0.2627, 0.0593};
-const ConvYCbCr ST240YCbCr = {0.212, 0.087};
+constexpr ConvYCbCr BT709YCbCr = {0.2126, 0.0722};
+constexpr ConvYCbCr BT601YCbCr = {0.299, 0.114};
+constexpr ConvYCbCr BT2020YCbCr = {0.2627, 0.0593};
+constexpr ConvYCbCr ST240YCbCr = {0.212, 0.087};
 
-const Primaries PrimariesBT709 = {{{0.640, 0.330}, {0.300, 0.600}, {0.150, 0.060}},
-  {0.3127, 0.3290} };
-const Primaries PrimariesBT610_525 = {{{0.640, 0.340}, {0.310, 0.595}, {0.155, 0.070}},
-  {0.3127, 0.3290} };
-const Primaries PrimariesBT610_625 = {{{0.640, 0.330}, {0.290, 0.600}, {0.150, 0.060}},
-  {0.3127, 0.3290} };
-const Primaries PrimariesBT2020 = {{{0.708, 0.292}, {0.170, 0.797}, {0.131, 0.046}},
-  {0.3127, 0.3290} };
+constexpr Primaries PrimariesBT709 = {{{0.640, 0.330}, {0.300, 0.600}, {0.150, 0.060}},
+                                      {0.3127, 0.3290}};
+constexpr Primaries PrimariesBT610_525 = {{{0.640, 0.340}, {0.310, 0.595}, {0.155, 0.070}},
+                                          {0.3127, 0.3290}};
+constexpr Primaries PrimariesBT610_625 = {{{0.640, 0.330}, {0.290, 0.600}, {0.150, 0.060}},
+                                          {0.3127, 0.3290}};
+constexpr Primaries PrimariesBT2020 = {{{0.708, 0.292}, {0.170, 0.797}, {0.131, 0.046}},
+                                       {0.3127, 0.3290}};
 
 //------------------------------------------------------------------------------
 // Matrix helpers

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
@@ -337,28 +337,62 @@ PrimaryToRGB::PrimaryToRGB(float (&primaries)[3][2], float (&whitepoint)[2]) : P
 
 //------------------------------------------------------------------------------
 
-void CConvertMatrix::SetColParams(AVColorSpace colSpace, int bits, bool limited, int textuteBits)
+CConvertMatrix& CConvertMatrix::SetSourceColorSpace(AVColorSpace colorSpace)
 {
-  if (m_colSpace == colSpace &&
-      m_srcBits == bits &&
-      m_limitedSrc == limited &&
-      m_srcTextureBits == textuteBits &&
-      m_pMat)
-    return;
-
-  m_colSpace = colSpace;
-  m_srcBits = bits;
-  m_limitedSrc = limited;
-  m_srcTextureBits = textuteBits;
-
-  GenMat();
+  m_colSpace = colorSpace;
+  return *this;
 }
 
-void CConvertMatrix::SetColPrimaries(AVColorPrimaries dst, AVColorPrimaries src)
+CConvertMatrix& CConvertMatrix::SetSourceBitDepth(int bits)
+{
+  m_srcBits = bits;
+  return *this;
+}
+
+CConvertMatrix& CConvertMatrix::SetSourceLimitedRange(bool limited)
+{
+  m_limitedSrc = limited;
+  return *this;
+}
+
+CConvertMatrix& CConvertMatrix::SetSourceTextureBitDepth(int textureBits)
+{
+  m_srcTextureBits = textureBits;
+  return *this;
+}
+
+CConvertMatrix& CConvertMatrix::SetSourceColorPrimaries(AVColorPrimaries src)
+{
+  m_colPrimariesSrc = src;
+  return *this;
+}
+
+CConvertMatrix& CConvertMatrix::SetDestinationColorPrimaries(AVColorPrimaries dst)
 {
   m_colPrimariesDst = dst;
-  m_colPrimariesSrc = src;
+  return *this;
+}
 
+CConvertMatrix& CConvertMatrix::SetDestinationContrast(float contrast)
+{
+  m_contrast = contrast;
+  return *this;
+}
+
+CConvertMatrix& CConvertMatrix::SetDestinationBlack(float black)
+{
+  m_black = black;
+  return *this;
+}
+
+CConvertMatrix& CConvertMatrix::SetDestinationLimitedRange(bool limited)
+{
+  m_limitedDst = limited;
+  return *this;
+}
+
+void CConvertMatrix::GenPrimMat()
+{
   if (m_colPrimariesDst != m_colPrimariesSrc)
   {
     Primaries primToRGB;
@@ -421,13 +455,6 @@ void CConvertMatrix::SetColPrimaries(AVColorPrimaries dst, AVColorPrimaries src)
   {
     m_pMatPrim.reset();
   }
-}
-
-void CConvertMatrix::SetParams(float contrast, float black, bool limited)
-{
-  m_contrast = contrast;
-  m_black = black;
-  m_limitedDst = limited;
 }
 
 void CConvertMatrix::GenMat()
@@ -496,6 +523,8 @@ void CConvertMatrix::GenMat()
 
 void CConvertMatrix::GetYuvMat(float (&mat)[4][4])
 {
+  GenMat();
+
   if (!m_pMat)
     return;
 
@@ -529,6 +558,8 @@ void CConvertMatrix::GetYuvMat(float (&mat)[4][4])
 
 bool CConvertMatrix::GetPrimMat(float (&mat)[3][3])
 {
+  GenPrimMat();
+
   if (!m_pMatPrim)
     return false;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
@@ -342,36 +342,54 @@ PrimaryToRGB::PrimaryToRGB(float (&primaries)[3][2], float (&whitepoint)[2]) : P
 
 CConvertMatrix& CConvertMatrix::SetSourceColorSpace(AVColorSpace colorSpace)
 {
+  if (m_colSpace != colorSpace)
+    m_mat.reset();
+
   m_colSpace = colorSpace;
   return *this;
 }
 
 CConvertMatrix& CConvertMatrix::SetSourceBitDepth(int bits)
 {
+  if (m_srcBits != bits)
+    m_mat.reset();
+
   m_srcBits = bits;
   return *this;
 }
 
 CConvertMatrix& CConvertMatrix::SetSourceLimitedRange(bool limited)
 {
+  if (m_limitedSrc != limited)
+    m_mat.reset();
+
   m_limitedSrc = limited;
   return *this;
 }
 
 CConvertMatrix& CConvertMatrix::SetSourceTextureBitDepth(int textureBits)
 {
+  if (m_srcTextureBits != textureBits)
+    m_mat.reset();
+
   m_srcTextureBits = textureBits;
   return *this;
 }
 
 CConvertMatrix& CConvertMatrix::SetSourceColorPrimaries(AVColorPrimaries src)
 {
+  if (m_colPrimariesSrc != src)
+    m_matPrim.reset();
+
   m_colPrimariesSrc = src;
   return *this;
 }
 
 CConvertMatrix& CConvertMatrix::SetDestinationColorPrimaries(AVColorPrimaries dst)
 {
+  if (m_colPrimariesDst != dst)
+    m_matPrim.reset();
+
   m_colPrimariesDst = dst;
   return *this;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
@@ -17,6 +17,8 @@
 
 // source: https://www.khronos.org/registry/DataFormat/specs/1.2/dataformat.1.2.html#PRIMARY_CONVERSION
 
+namespace
+{
 struct ConvYCbCr
 {
   float Kr, Kb;
@@ -41,6 +43,7 @@ constexpr Primaries PrimariesBT610_625 = {{{0.640, 0.330}, {0.290, 0.600}, {0.15
                                           {0.3127, 0.3290}};
 constexpr Primaries PrimariesBT2020 = {{{0.708, 0.292}, {0.170, 0.797}, {0.131, 0.046}},
                                        {0.3127, 0.3290}};
+} // namespace
 
 //------------------------------------------------------------------------------
 // Matrix helpers

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
@@ -104,9 +104,17 @@ public:
   CConvertMatrix() = default;
   virtual ~CConvertMatrix() = default;
 
-  void SetColParams(AVColorSpace colSpace, int bits, bool limited, int textuteBits);
-  void SetColPrimaries(AVColorPrimaries dst, AVColorPrimaries src);
-  void SetParams(float contrast, float black, bool limited);
+  CConvertMatrix& SetSourceColorSpace(AVColorSpace colorSpace);
+  CConvertMatrix& SetSourceBitDepth(int bits);
+  CConvertMatrix& SetSourceLimitedRange(bool limited);
+  CConvertMatrix& SetSourceTextureBitDepth(int textureBits);
+  CConvertMatrix& SetSourceColorPrimaries(AVColorPrimaries src);
+
+  CConvertMatrix& SetDestinationColorPrimaries(AVColorPrimaries dst);
+  CConvertMatrix& SetDestinationContrast(float contrast);
+  CConvertMatrix& SetDestinationBlack(float black);
+  CConvertMatrix& SetDestinationLimitedRange(bool limited);
+
   void GetYuvMat(float (&mat)[4][4]);
   bool GetPrimMat(float (&mat)[3][3]);
   float GetGammaSrc();
@@ -116,6 +124,7 @@ public:
 
 protected:
   void GenMat();
+  void GenPrimMat();
 
   std::unique_ptr<CGlMatrix> m_pMat;
   std::unique_ptr<CMatrix<3>> m_pMatPrim;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
@@ -235,7 +235,6 @@ private:
   bool m_limitedDst = false;
   int m_srcBits = 8;
   int m_srcTextureBits = 8;
-  int m_dstBits = 8;
   float m_contrast = 1.0;
   float m_black = 0.0;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
@@ -136,28 +136,87 @@ using Matrix4 = CMatrix<4>;
 using Matrix3 = CMatrix<3>;
 using Matrix3x1 = std::array<float, 3>;
 
+/**
+ * @brief Helper class used for YUV to RGB conversions. This class can
+ *        take into account different source/destination primaries and
+ *        various other parameters.
+ */
 class CConvertMatrix
 {
 public:
   CConvertMatrix() = default;
   ~CConvertMatrix() = default;
 
+  /**
+   * @brief Set the source color space.
+   */
   CConvertMatrix& SetSourceColorSpace(AVColorSpace colorSpace);
+
+  /**
+   * @brief Set the source bit depth.
+   */
   CConvertMatrix& SetSourceBitDepth(int bits);
+
+  /**
+   * @brief Set the source limited range boolean.
+   */
   CConvertMatrix& SetSourceLimitedRange(bool limited);
+
+  /**
+   * @brief Set the source texture bit depth. This is need to normalize values
+   *        when using > 8 bit texture formats in OpenGL/DirectX. For example
+   *        GL_R16 is a 16 bit texture which needs to normalize the 10 bit format.
+   */
   CConvertMatrix& SetSourceTextureBitDepth(int textureBits);
+
+  /**
+   * @brief Set the source color primaries.
+   */
   CConvertMatrix& SetSourceColorPrimaries(AVColorPrimaries src);
 
+  /**
+   * @brief Set the destination color primaries.
+   */
   CConvertMatrix& SetDestinationColorPrimaries(AVColorPrimaries dst);
+
+  /**
+   * @brief Set the destination contrast.
+   */
   CConvertMatrix& SetDestinationContrast(float contrast);
+
+  /**
+   * @brief Set the destination black level.
+   */
   CConvertMatrix& SetDestinationBlack(float black);
+
+  /**
+   * @brief Set the destination limited range boolean.
+   */
   CConvertMatrix& SetDestinationLimitedRange(bool limited);
 
+  /**
+   * @brief Get the YUV Matrix for the YUV to RGB conversion.
+   */
   Matrix4 GetYuvMat();
+
+  /**
+   * @brief Get the Primaries Matrix for the primaries conversion.
+   */
   Matrix3 GetPrimMat();
+
+  /**
+   * @brief Get the gamma source value. Used for color primary conversion..
+   */
   float GetGammaSrc();
+
+  /**
+   * @brief Get the gamma destination value. Used for color primary conversion.
+   */
   float GetGammaDst();
 
+  /**
+   * @brief Get the YUV coeffecients used for tonemapping.
+   */
   static Matrix3x1 GetRGBYuvCoefs(AVColorSpace colspace);
 
 private:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
@@ -8,44 +8,79 @@
 
 #pragma once
 
+#include <array>
+#include <cmath>
 #include <memory>
 
 extern "C" {
 #include <libavutil/pixfmt.h>
 }
 
-template <unsigned Order>
+template<uint8_t Order>
 class CMatrix
 {
 public:
-  CMatrix(float (&src)[Order][Order]);
-  CMatrix(float (&src)[Order-1][Order-1]);
-  CMatrix& operator=(const CMatrix& src);
-  CMatrix& operator=(const float (&src)[Order-1][Order-1]);
+  CMatrix() = default;
+  explicit CMatrix(const CMatrix<Order - 1>& other);
+  explicit CMatrix(const std::array<std::array<float, Order>, Order>& other) { m_mat = other; }
+  explicit CMatrix(const std::array<std::array<float, Order - 1>, Order - 1>& other);
   virtual ~CMatrix() = default;
 
-  float (&Get())[Order][Order];
-  CMatrix Invert();
+  virtual CMatrix operator*(const std::array<std::array<float, Order>, Order>& other);
+
   CMatrix operator*(const CMatrix& other);
-  CMatrix operator*=(const CMatrix& other);
-  virtual CMatrix operator*(const float (&other)[Order][Order]);
+  CMatrix& operator*=(const CMatrix& other);
+
+  CMatrix& operator=(const std::array<std::array<float, Order - 1>, Order - 1>& other);
+
+  bool operator==(const CMatrix<Order>& other) const
+  {
+    for (int i = 0; i < Order; ++i)
+    {
+      for (int j = 0; j < Order; ++j)
+      {
+        if (m_mat[i][j] == other.m_mat[i][j])
+          continue;
+
+        // some floating point comparisions should be done by checking if the difference is within a tolerance
+        if (std::abs(m_mat[i][j] - other.m_mat[i][j]) <=
+            (std::max(std::abs(other.m_mat[i][j]), std::abs(m_mat[i][j])) * 1e-2f))
+          continue;
+
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  std::array<float, Order>& operator[](int index) { return m_mat[index]; }
+
+  const std::array<float, Order>& operator[](int index) const { return m_mat[index]; }
+
+  std::array<std::array<float, Order>, Order>& Get();
+
+  const std::array<std::array<float, Order>, Order>& Get() const;
+
+  CMatrix& Invert();
+
+  float* ToRaw() { return &m_mat[0][0]; }
 
 protected:
-  CMatrix() = default;
+  std::array<std::array<float, Order>, Order> Invert(
+      std::array<std::array<float, Order>, Order>& other) const;
 
-  void Copy(float (&dst)[Order][Order], const float (&src)[Order][Order]);
-  void Invert(float (&dst)[Order][Order], float (&src)[Order][Order]);
-
-  float m_mat[Order][Order] = {};
+  std::array<std::array<float, Order>, Order> m_mat{{}};
 };
 
 class CGlMatrix : public CMatrix<4>
 {
 public:
   CGlMatrix() = default;
-  CGlMatrix(float (&src)[3][3]);
+  explicit CGlMatrix(const CMatrix<3>& other);
+  explicit CGlMatrix(const std::array<std::array<float, 3>, 3>& other);
   ~CGlMatrix() override = default;
-  CMatrix operator*(const float (&other)[4][4]) override;
+  CMatrix operator*(const std::array<std::array<float, 4>, 4>& other) override;
 };
 
 class CScale : public CGlMatrix
@@ -67,7 +102,6 @@ class ConversionToRGB : public CMatrix<3>
 public:
   ConversionToRGB(float Kr, float Kb);
   ~ConversionToRGB() override = default;
-  ConversionToRGB& operator=(const float (&src)[3][3]);
 
 protected:
   ConversionToRGB() = default;
@@ -98,11 +132,15 @@ public:
 
 //------------------------------------------------------------------------------
 
+using Matrix4 = CMatrix<4>;
+using Matrix3 = CMatrix<3>;
+using Matrix3x1 = std::array<float, 3>;
+
 class CConvertMatrix
 {
 public:
   CConvertMatrix() = default;
-  virtual ~CConvertMatrix() = default;
+  ~CConvertMatrix() = default;
 
   CConvertMatrix& SetSourceColorSpace(AVColorSpace colorSpace);
   CConvertMatrix& SetSourceBitDepth(int bits);
@@ -115,19 +153,20 @@ public:
   CConvertMatrix& SetDestinationBlack(float black);
   CConvertMatrix& SetDestinationLimitedRange(bool limited);
 
-  void GetYuvMat(float (&mat)[4][4]);
-  bool GetPrimMat(float (&mat)[3][3]);
+  Matrix4 GetYuvMat();
+  Matrix3 GetPrimMat();
   float GetGammaSrc();
   float GetGammaDst();
 
-  static bool GetRGBYuvCoefs(AVColorSpace colspace, float (&coefs)[3]);
+  static Matrix3x1 GetRGBYuvCoefs(AVColorSpace colspace);
 
-protected:
-  void GenMat();
-  void GenPrimMat();
+private:
+  const CGlMatrix& GenMat();
+  const CMatrix<3>& GenPrimMat();
 
-  std::unique_ptr<CGlMatrix> m_pMat;
-  std::unique_ptr<CMatrix<3>> m_pMatPrim;
+  std::unique_ptr<CGlMatrix> m_mat;
+  std::unique_ptr<CMatrix<3>> m_matPrim;
+
   AVColorSpace m_colSpace = AVCOL_SPC_BT709;
   AVColorPrimaries m_colPrimariesSrc = AVCOL_PRI_BT709;
   float m_gammaSrc = 2.2f;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -617,8 +617,8 @@ bool CYUV2RGBShader::Create(AVPixelFormat fmt, AVColorPrimaries dstPrimaries,
     return false;
   }
 
-  m_pConvMatrix.reset(new CConvertMatrix());
-  m_pConvMatrix->SetColPrimaries(dstPrimaries, srcPrimaries);
+  m_convMatrix.SetDestinationColorPrimaries(dstPrimaries).SetSourceColorPrimaries(srcPrimaries);
+
   return true;
 }
 
@@ -629,12 +629,14 @@ void CYUV2RGBShader::Render(CRect sourceRect, CPoint dest[], CRenderBuffer* vide
   Execute({ &target }, 4);
 }
 
-void CYUV2RGBShader::SetParams(float contrast, float black, bool limited) const
+void CYUV2RGBShader::SetParams(float contrast, float black, bool limited)
 {
-  m_pConvMatrix->SetParams(contrast * 0.02f, black * 0.01f - 0.5f, limited);
+  m_convMatrix.SetDestinationContrast(contrast * 0.02f)
+      .SetDestinationBlack(black * 0.01f - 0.5f)
+      .SetDestinationLimitedRange(limited);
 }
 
-void CYUV2RGBShader::SetColParams(AVColorSpace colSpace, int bits, bool limited, int texBits) const
+void CYUV2RGBShader::SetColParams(AVColorSpace colSpace, int bits, bool limited, int texBits)
 {
   if (colSpace == AVCOL_SPC_UNSPECIFIED)
   {
@@ -643,7 +645,11 @@ void CYUV2RGBShader::SetColParams(AVColorSpace colSpace, int bits, bool limited,
     else
       colSpace = AVCOL_SPC_BT470BG;
   }
-  m_pConvMatrix->SetColParams(colSpace, bits, limited, texBits);
+
+  m_convMatrix.SetSourceColorSpace(colSpace)
+      .SetSourceBitDepth(bits)
+      .SetSourceLimitedRange(limited)
+      .SetSourceTextureBitDepth(texBits);
 }
 
 void CYUV2RGBShader::PrepareParameters(CRenderBuffer* videoBuffer, CRect sourceRect, CPoint dest[])
@@ -717,11 +723,11 @@ void CYUV2RGBShader::SetShaderParameters(CRenderBuffer* videoBuffer)
   m_effect.SetFloatArray("g_StepXY", m_texSteps, ARRAY_SIZE(m_texSteps));
 
   float yuvMat[4][4];
-  m_pConvMatrix->GetYuvMat(yuvMat);
+  m_convMatrix.GetYuvMat(yuvMat);
   m_effect.SetMatrix("g_ColorMatrix", reinterpret_cast<float*>(yuvMat));
 
   float primMat[3][3];
-  if (m_pConvMatrix->GetPrimMat(primMat))
+  if (m_convMatrix.GetPrimMat(primMat))
   {
     // looks like FX11 doesn't like 3x3 matrix, so used 4x4 for its happiness
     float dxMat[4][4] = {};
@@ -729,8 +735,8 @@ void CYUV2RGBShader::SetShaderParameters(CRenderBuffer* videoBuffer)
     dxMat[1][0] = primMat[1][0]; dxMat[1][1] = primMat[1][1]; dxMat[1][2] = primMat[1][2];
     dxMat[2][0] = primMat[2][0]; dxMat[2][1] = primMat[2][1]; dxMat[2][2] = primMat[2][2];
     m_effect.SetMatrix("g_primMat", reinterpret_cast<float*>(dxMat));
-    m_effect.SetScalar("g_gammaSrc", m_pConvMatrix->GetGammaSrc());
-    m_effect.SetScalar("g_gammaDstInv", 1/m_pConvMatrix->GetGammaDst());
+    m_effect.SetScalar("g_gammaSrc", m_convMatrix.GetGammaSrc());
+    m_effect.SetScalar("g_gammaDstInv", 1 / m_convMatrix.GetGammaDst());
   }
 
   unsigned numPorts = 1;
@@ -867,10 +873,8 @@ void CConvolutionShader1Pass::Render(CD3DTexture& sourceTexture, CD3DTexture& ta
   const unsigned int sourceHeight = sourceTexture.GetHeight();
 
   PrepareParameters(sourceWidth, sourceHeight, sourceRect, destRect);
-  float texSteps[] = { 
-    1.0f / static_cast<float>(sourceWidth),
-    1.0f / static_cast<float>(sourceHeight)
-  };
+  float texSteps[] = {1.0f / static_cast<float>(sourceWidth),
+                      1.0f / static_cast<float>(sourceHeight)};
   SetShaderParameters(sourceTexture, &texSteps[0], ARRAY_SIZE(texSteps), useLimitRange);
   Execute({ &target }, 4);
 }
@@ -1032,9 +1036,9 @@ bool CConvolutionShaderSeparable::ChooseIntermediateD3DFormat()
   const D3D11_FORMAT_SUPPORT usage = D3D11_FORMAT_SUPPORT_RENDER_TARGET;
 
   // Need a float texture, as the output of the first pass can contain negative values.
-  if (DX::Windowing()->IsFormatSupport(DXGI_FORMAT_R16G16B16A16_FLOAT, usage)) 
+  if (DX::Windowing()->IsFormatSupport(DXGI_FORMAT_R16G16B16A16_FLOAT, usage))
     m_IntermediateFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
-  else if (DX::Windowing()->IsFormatSupport(DXGI_FORMAT_R32G32B32A32_FLOAT, usage)) 
+  else if (DX::Windowing()->IsFormatSupport(DXGI_FORMAT_R32G32B32A32_FLOAT, usage))
     m_IntermediateFormat = DXGI_FORMAT_R32G32B32A32_FLOAT;
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -74,7 +74,7 @@ public:
   static bool CreateLUTView(int lutSize, uint16_t* lutData, bool isRGB, ID3D11ShaderResourceView** ppLUTView);
 
 private:
-  struct Vertex 
+  struct Vertex
   {
     float x, y, z;
     float tu, tv;
@@ -116,11 +116,13 @@ public:
   explicit CYUV2RGBShader() = default;
   ~CYUV2RGBShader() = default;
 
-  bool Create(AVPixelFormat fmt, AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries, 
+  bool Create(AVPixelFormat fmt,
+              AVColorPrimaries dstPrimaries,
+              AVColorPrimaries srcPrimaries,
               const std::shared_ptr<COutputShader>& pOutShader = nullptr);
   void Render(CRect sourceRect, CPoint dest[], CRenderBuffer* videoBuffer, CD3DTexture& target);
-  void SetParams(float contrast, float black, bool limited) const;
-  void SetColParams(AVColorSpace colSpace, int bits, bool limited, int texBits) const;
+  void SetParams(float contrast, float black, bool limited);
+  void SetColParams(AVColorSpace colSpace, int bits, bool limited, int texBits);
 
 protected:
   void PrepareParameters(CRenderBuffer* videoBuffer, CRect sourceRect, CPoint dest[]);
@@ -140,7 +142,7 @@ private:
   AVPixelFormat m_format = AV_PIX_FMT_NONE;
   float m_texSteps[2] = {};
   std::shared_ptr<COutputShader> m_pOutShader = nullptr;
-  std::shared_ptr<CConvertMatrix> m_pConvMatrix;
+  CConvertMatrix m_convMatrix;
 };
 
 class CConvolutionShader : public CWinShader

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -143,6 +143,7 @@ private:
   float m_texSteps[2] = {};
   std::shared_ptr<COutputShader> m_pOutShader = nullptr;
   CConvertMatrix m_convMatrix;
+  bool m_colorConversion{false};
 };
 
 class CConvolutionShader : public CWinShader

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -8,11 +8,12 @@
 
 #pragma once
 
-#include "utils/TransformMatrix.h"
-#include "ShaderFormats.h"
+#include "ConversionMatrix.h"
 #include "GLSLOutput.h"
-#include "guilib/Shader.h"
+#include "ShaderFormats.h"
 #include "cores/VideoSettings.h"
+#include "guilib/Shader.h"
+#include "utils/TransformMatrix.h"
 
 #include <memory>
 
@@ -89,7 +90,7 @@ protected:
   std::string m_defines;
 
   std::shared_ptr<Shaders::GLSLOutput> m_glslOutput;
-  std::shared_ptr<CConvertMatrix> m_pConvMatrix;
+  CConvertMatrix m_convMatrix;
 
   // pixel shader attribute handles
   GLint m_hYTex = -1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -79,6 +79,8 @@ protected:
   int m_toneMappingMethod = VS_TONEMAPMETHOD_REINHARD;
   float m_toneMappingParam = 1.0;
 
+  bool m_colorConversion{false};
+
   float m_black;
   float m_contrast;
   float m_stretch;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -46,6 +46,7 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format, AVColorPrimar
 
   if (dstPrimaries != srcPrimaries)
   {
+    m_colorConversion = true;
     m_defines += "#define XBMC_COL_CONVERSION\n";
   }
 
@@ -97,23 +98,20 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
   glUniform1i(m_hVTex, 2);
   glUniform2f(m_hStep, 1.0 / m_width, 1.0 / m_height);
 
-  GLfloat yuvMat[4][4];
-  // keep video levels
-
   m_convMatrix.SetDestinationContrast(m_contrast)
       .SetDestinationBlack(m_black)
       .SetDestinationLimitedRange(!m_convertFullRange);
 
-  m_convMatrix.GetYuvMat(yuvMat);
-  glUniformMatrix4fv(m_hYuvMat, 1, GL_FALSE, (GLfloat*)yuvMat);
+  Matrix4 yuvMat = m_convMatrix.GetYuvMat();
+  glUniformMatrix4fv(m_hYuvMat, 1, GL_FALSE, yuvMat.ToRaw());
   glUniformMatrix4fv(m_hProj,  1, GL_FALSE, m_proj);
   glUniformMatrix4fv(m_hModel, 1, GL_FALSE, m_model);
   glUniform1f(m_hAlpha, m_alpha);
 
-  GLfloat primMat[3][3];
-  if (m_convMatrix.GetPrimMat(primMat))
+  if (m_colorConversion)
   {
-    glUniformMatrix3fv(m_hPrimMat, 1, GL_FALSE, (GLfloat*)primMat);
+    Matrix3 primMat = m_convMatrix.GetPrimMat();
+    glUniformMatrix3fv(m_hPrimMat, 1, GL_FALSE, primMat.ToRaw());
     glUniform1f(m_hGammaSrc, m_convMatrix.GetGammaSrc());
     glUniform1f(m_hGammaDstInv, 1 / m_convMatrix.GetGammaDst());
   }
@@ -139,8 +137,7 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
 
     param *= m_toneMappingParam;
 
-    float coefs[3];
-    m_convMatrix.GetRGBYuvCoefs(AVColorSpace::AVCOL_SPC_BT709, coefs);
+    Matrix3x1 coefs = m_convMatrix.GetRGBYuvCoefs(AVColorSpace::AVCOL_SPC_BT709);
     glUniform3f(m_hCoefsDst, coefs[0], coefs[1], coefs[2]);
     glUniform1f(m_hToneP1, param);
   }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -8,17 +8,15 @@
 
 #pragma once
 
-#include "utils/TransformMatrix.h"
+#include "ConversionMatrix.h"
 #include "ShaderFormats.h"
-
 #include "guilib/Shader.h"
+#include "utils/TransformMatrix.h"
 
 extern "C" {
 #include <libavutil/mastering_display_metadata.h>
 #include <libavutil/pixfmt.h>
 }
-
-class CConvertMatrix;
 
 namespace Shaders {
 
@@ -69,7 +67,7 @@ namespace Shaders {
 
     std::string m_defines;
 
-    std::shared_ptr<CConvertMatrix> m_pConvMatrix;
+    CConvertMatrix m_convMatrix;
 
     // shader attribute handles
     GLint m_hYTex{-1};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -62,6 +62,8 @@ namespace Shaders {
     bool m_toneMapping{false};
     float m_toneMappingParam{1.0};
 
+    bool m_colorConversion{false};
+
     float m_black;
     float m_contrast;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestConversionMatrix.cpp)
+
+core_add_test_library(videoshaders_test)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+
+#include "cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h"
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+// clang-format off
+
+namespace
+{
+
+constexpr bool DEBUG_PRINT{false};
+
+void DebugPrint(Matrix3 matrix)
+{
+  if (!DEBUG_PRINT)
+    return;
+
+  std::cout << std::fixed;
+
+  std::cout << "===== Matrix Start =====" << std::endl;
+
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    std::cout << std::setprecision(10)
+              << "{" << matrix[i][0] << ", "
+              <<        matrix[i][1] << ", "
+              <<        matrix[i][2] << "}," << std::endl;
+  }
+
+  std::cout << "===== Matrix End =====" << std::endl;
+}
+
+void DebugPrint(Matrix4 matrix)
+{
+  if (!DEBUG_PRINT)
+    return;
+
+  std::cout << std::fixed;
+
+  std::cout << "===== Matrix Start =====" << std::endl;
+
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    std::cout << std::setprecision(10)
+              << "{" << matrix[i][0] << ", "
+              <<        matrix[i][1] << ", "
+              <<        matrix[i][2] << ", "
+              <<        matrix[i][3] << "}," << std::endl;
+  }
+
+  std::cout << "===== Matrix End =====" << std::endl;
+}
+
+std::array<std::array<float, 4>, 4> bt709_8bit =
+{{
+  {1.1643834114, 1.1643834114, 1.1643834114, 0.0000000000},
+  {0.0000000000, -0.2132485956, 2.1124014854, 0.0000000000},
+  {1.7927408218, -0.5329092145, 0.0000000000, 0.0000000000},
+  {-0.9729449749, 0.3014826477, -1.1334021091, 1.0000000000}
+}};
+
+Matrix4 bt709Mat_8bit(bt709_8bit);
+
+std::array<std::array<float, 4>, 4> bt709_10bit =
+{{
+  {1.1643834114, 1.1643834114, 1.1643834114, 0.0000000000},
+  {0.0000000000, -0.2132485956, 2.1124014854, 0.0000000000},
+  {1.7927408218, -0.5329092145, 0.0000000000, 0.0000000000},
+  {-0.9729449749, 0.3014826477, -1.1334021091, 1.0000000000},
+}};
+
+Matrix4 bt709Mat_10bit(bt709_10bit);
+
+std::array<std::array<float, 4>, 4> bt709_10bit_texture =
+{{
+  {74.5922470093, 74.5922470093, 74.5922470093, 0.0000000000},
+  {0.0000000000, -13.6610431671, 135.3237915039, 0.0000000000},
+  {114.8458175659, -34.1390075684, 0.0000000000, 0.0000000000},
+  {-0.9729449749, 0.3014826477, -1.1334021091, 1.0000000000},
+}};
+
+Matrix4 bt709Mat_10bit_texture(bt709_10bit_texture);
+
+std::array<std::array<float, 3>, 3> bt601_to_bt709 =
+{{
+  {1.0440435410, -0.0000000230, 0.0000000056},
+  {-0.0440433398, 0.9999997616, 0.0117934495},
+  {-0.0000000298, -0.0000000075, 0.9882065654},
+}};
+
+Matrix3 bt601_to_bt709_Mat(bt601_to_bt709);
+
+std::array<std::array<float, 3>, 3> bt2020_to_bt709 =
+{{
+  {1.6604905128, -0.1245504916, -0.0181507617},
+  {-0.5876411796, 1.1328998804, -0.1005788445},
+  {-0.0728498399, -0.0083493963, 1.1187294722},
+}};
+
+Matrix3 bt2020_to_bt709_Mat(bt2020_to_bt709);
+
+} // namespace
+
+TEST(TestConvertMatrix, YUV2RGB)
+{
+  CConvertMatrix convMat;
+  convMat.SetSourceColorSpace(AVCOL_SPC_BT709)
+         .SetSourceLimitedRange(true);
+
+  convMat.SetDestinationBlack(0.0f)
+         .SetDestinationContrast(1.0f)
+         .SetDestinationLimitedRange(false);
+
+  Matrix4 yuvMat;
+
+  convMat.SetSourceBitDepth(8)
+         .SetSourceTextureBitDepth(8);
+  yuvMat = convMat.GetYuvMat();
+  DebugPrint(yuvMat);
+
+  EXPECT_EQ(bt709Mat_8bit, yuvMat);
+
+  convMat.SetSourceBitDepth(10)
+         .SetSourceTextureBitDepth(8);
+  yuvMat = convMat.GetYuvMat();
+  DebugPrint(yuvMat);
+
+  EXPECT_EQ(bt709Mat_10bit, yuvMat);
+
+  convMat.SetSourceBitDepth(10)
+         .SetSourceTextureBitDepth(10);
+  yuvMat = convMat.GetYuvMat();
+  DebugPrint(yuvMat);
+
+  EXPECT_EQ(bt709Mat_10bit_texture, yuvMat);
+}
+
+TEST(TestConvertMatrix, ColorSpaceConversion)
+{
+  CConvertMatrix convMat;
+  Matrix3 primMat;
+
+  convMat.SetSourceColorPrimaries(AVCOL_PRI_BT470BG)
+         .SetDestinationColorPrimaries(AVCOL_PRI_BT709);
+  primMat = convMat.GetPrimMat();
+  DebugPrint(primMat);
+
+  EXPECT_EQ(bt601_to_bt709_Mat, primMat);
+
+  convMat.SetSourceColorPrimaries(AVCOL_PRI_BT2020)
+         .SetDestinationColorPrimaries(AVCOL_PRI_BT709);
+  primMat = convMat.GetPrimMat();
+  DebugPrint(primMat);
+
+  EXPECT_EQ(bt2020_to_bt709_Mat, primMat);
+}
+
+// clang-format on


### PR DESCRIPTION
This rework improves (IMO) the `CConvertMatrix` class and related classes.

This does a few things:
 1) Changes some of the setters to be individually acting. This makes the interface much more clear. This also allows chaining the setters which IMO looks better.
 2) Changes the `CMatrix` class to use `std::array` instead of c-arrays. This allow us to remove the custom copy methods. This also improves the interface because passing c-arrays by reference isn't very nice (IMO).
 3) Makes some methods have a more c++ style by returning a value rather than passing in a reference.

I've also added a basic test for the `CConvertMatrix` class. This is used to not only test the matrix operations but to demonstrate the usage of the class.

I've added some basic doxygen as I think it helps explain the interface further.

For a little more context I've done this rework because I want to use the class for our `CRendererDRMPRIMEGLES` renderer but the class was difficult to understand and unclear about it's usage so I thought I would try and improve it.

Just as an FYI this class does 3 main things:
 1) provides the YUV to RGB conversion matrix
 2) provides the color primary conversion matrix.
 3) provides the RGB/YUV coefficients needed for tonemapping.

I've separated the commits for each render method but likely they will need to be squashed to avoid breaking the build in a bisect.