### PR TITLE
[VideoPlayer] Suppress 'Playback Failed' toast for DVD content that has reached EOF

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -296,7 +296,7 @@ int CDVDInputStreamNavigator::Read(uint8_t* buf, int buf_size)
       {
         m_bEOF = true;
         CLog::Log(LOGERROR,"CDVDInputStreamNavigator: Stopping playback due to infinite loop, caused by badly authored DVD navigation structure. Try enabling 'Attempt to skip introduction before DVD menu'.");
-        m_pVideoPlayer->OnDiscNavResult(NULL, DVDNAV_STOP);
+        m_pVideoPlayer->OnDiscNavResult(nullptr, DVDNAV_ERROR);
         return -1; // fail and stop playback.
       }
     }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -28,6 +28,8 @@
 #define LIBDVDNAV_BUTTON_NORMAL 0
 #define LIBDVDNAV_BUTTON_CLICKED 1
 
+#define DVDNAV_ERROR -1
+
 class CDVDDemuxSPU;
 class CSPUInfo;
 class CDVDOverlayPicture;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4088,7 +4088,14 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
       {
         CLog::Log(LOGDEBUG, "DVDNAV_STOP");
         m_dvd.state = DVDSTATE_NORMAL;
-        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026), g_localizeStrings.Get(16029));
+      }
+      break;
+    case DVDNAV_ERROR:
+      {
+        CLog::Log(LOGDEBUG, "DVDNAV_ERROR");
+        m_dvd.state = DVDSTATE_NORMAL;
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026),
+                                              g_localizeStrings.Get(16029));
       }
       break;
     default:


### PR DESCRIPTION
## Description
For quite some time (basically forever) I have noted that Kodi will display a "Playback Failed" toast for DVD Movies that were ripped from the original media without the original DVD menu(s).  While most people are likely not using raw DVD (.IFO) VIDEO_TS data at this point, it's still erroneous in my opinion -- there is nothing "wrong" with the content.

## Motivation and Context
I am of the mindset that Kodi should not display this toast for valid ripped DVD (.IFO) content that should indeed stop when a DVDNAV_STOP message is encountered and there is no DVD menu to navigate to.  In my testing, I found that the most minimal impact way to accomplish this was to add a test In VideoPlayer to determine if the DVD content is "end of the stream" and suppress the toast if that condition is true.

## How Has This Been Tested?
Tested on Windows x64, latest Matrix nightly as of 12/29/2020.  I (legally) ripped "Trolls World Tour" with AnyDVD(HD) both with and without the DVD menus.  As expected playback of the physical DVD as well as the "with menus" rip version of the content worked fine and did not produce any toasts/errors from Kodi as the movie approached its conclusion.

Before the proposed change, the "without menus" version of the same DVD would produce this error, as does all other AnyDVD(HD) ripped content, after the change both versions worked as I expected.

While I do not envision any negative implications of suppressing this 'Playback Failed' toast message when DVD content has reached the end of the stream, I am of course happy to make/test any adjustments deemed necessary in order for this change to be accepted.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
