### PR TITLE
[build] fix CMake-related build quoting issue

### DIFF
--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -19,7 +19,7 @@ function(addstep_autoreconf module_name)
   ExternalProject_Add_Step(${module_name} autoreconf
                                   DEPENDEES download update patch
                                   DEPENDERS configure
-                                  COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
+                                  COMMAND ${CMAKE_COMMAND} -E env PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
                                   WORKING_DIRECTORY <SOURCE_DIR>)
 endfunction()
 


### PR DESCRIPTION
## Description

CMake on my Debian 10 machine was quoting the PATH environment variable being set here, which made the shell interpret that not as a variable being set but as a command, which it then would print a confusing error message about not being able to find. The build would then fail.

We work around this by using CMake's built-in environment modification utility.

## Motivation and Context

See above.

## How Has This Been Tested?

I successfully ran a build with this patch applied.

## Screenshots (if appropriate):

N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
