### PR TITLE
[android] Rework sleep/wakeup power event handling

### DIFF
--- a/xbmc/platform/android/powermanagement/AndroidPowerSyscall.h
+++ b/xbmc/platform/android/powermanagement/AndroidPowerSyscall.h
@@ -32,8 +32,8 @@ public:
 
   bool PumpPowerEvents(IPowerEventsCallback* callback) override;
 
-  void SetOnPause() { m_state = SUSPENDED; }
-  void SetOnResume() { m_state = RESUMED; }
+  void SetSuspended() { m_state = SUSPENDED; }
+  void SetResumed() { m_state = RESUMED; }
 
 private:
   enum STATE : unsigned int


### PR DESCRIPTION
## Description
Fixes resume playback of the item that was playing while system was suspended (went to sleep mode), when system comes back normal mode.

## Motivation and Context
Functionality was broken, because the power state code was at the wrong place (onStart/onStop instead of the official power state intents) and the Android code stopped playback on suspend while this should be and will be done by Kodi core at the right time, so that Kodi power manager can store the playing item to later resume playback when the system wakes up again.

## How Has This Been Tested?
Runtime-tested on 2015 and 2019 Nvidia Shield TV and macOS (regression testing).

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
