### PR TITLE
[kodi-standalone.sh] Remove dead pulse-session code path

### DIFF
--- a/tools/Linux/kodi-standalone.sh.in
+++ b/tools/Linux/kodi-standalone.sh.in
@@ -18,7 +18,6 @@
 #  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
 #  http://www.gnu.org/copyleft/gpl.html
 
-APP=@APP_NAME@
 prefix="@prefix@"
 exec_prefix="@exec_prefix@"
 bindir="@bindir@"

--- a/tools/Linux/kodi-standalone.sh.pulse
+++ b/tools/Linux/kodi-standalone.sh.pulse
@@ -4,6 +4,6 @@ if [ -n "$PULSE_START" ]; then
 else
   PULSE_SESSION="$(command -v pulse-session)"
   if [ -n "$PULSE_SESSION" ]; then
-    XBMC="$PULSE_SESSION $XBMC"
+    APP="$PULSE_SESSION $APP"
   fi
 fi

--- a/tools/Linux/kodi-standalone.sh.pulse
+++ b/tools/Linux/kodi-standalone.sh.pulse
@@ -1,9 +1,4 @@
 PULSE_START="$(command -v start-pulseaudio-x11)"
 if [ -n "$PULSE_START" ]; then
   $PULSE_START
-else
-  PULSE_SESSION="$(command -v pulse-session)"
-  if [ -n "$PULSE_SESSION" ]; then
-    APP="$PULSE_SESSION $APP"
-  fi
 fi


### PR DESCRIPTION
## Description

### [kodi-standalone.sh] Use APP instead of XBMC 5432bfe
The XBMC variable does not exist in the main kodi-standalone script, so
this assignment had no effect.

### [kodi-standalone.sh] Remove pulse-session usage 22e004b
This debian/ubuntu specific wrapper script was removed in 2009 in debian
and in 2014 in ubuntu.

See http://changelogs.ubuntu.com/changelogs/pool/main/p/pulseaudio/pulseaudio_11.1-1ubuntu7/changelog

### [kodi-standalone.sh] Remove unused APP variable 64f95c5
It gets overwritten a few lines below.

This is a leftover from before 1053435a6b7, when providing the lowercase
binary name was not handled by CMake.

## Motivation and Context

Just reading around what kodi-standalone was doing and saw this bit of dead code.

Happy to drop the second commit if you believe some user might still be using this, it wouldn't have been doing much since 1b449ef (2014) though.

## How Has This Been Tested?

Didn't test much as code path was unreachable on my machine, or any 

## Screenshots (if appropriate):

n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project (n/a)
- [ ] My change requires a change to the documentation, either Doxygen or wiki (n/a)
- [ ] I have updated the documentation accordingly (n/a)
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change (n/a)
- [ ] All new and existing tests passed (n/a)
