### PR TITLE
[PVR] Do not stop playback when restarting PVR Manager.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -359,7 +359,7 @@ void CPVRManager::Start()
   // StopThread() which can deadlock if the worker thread tries to acquire pvr manager's
   // lock while StopThread() is waiting for the worker to exit. Thus, we introduce another
   // lock here (m_startStopMutex), which only gets hold while starting/restarting pvr manager.
-  Stop();
+  Stop(true);
 
   if (!m_addons->HasCreatedClients())
     return;
@@ -372,7 +372,7 @@ void CPVRManager::Start()
   SetPriority(-1);
 }
 
-void CPVRManager::Stop()
+void CPVRManager::Stop(bool bRestart /* = false */)
 {
   CSingleLock initLock(m_startStopMutex);
 
@@ -381,7 +381,7 @@ void CPVRManager::Stop()
     return;
 
   /* stop playback if needed */
-  if (m_playbackState->IsPlaying())
+  if (!bRestart && m_playbackState->IsPlaying())
   {
     CLog::LogFC(LOGDEBUG, LOGPVR, "Stopping PVR playback");
     CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -171,7 +171,7 @@ namespace PVR
     /*!
      * @brief Stop PVRManager.
      */
-    void Stop();
+    void Stop(bool bRestart = false);
 
     /*!
      * @brief Stop PVRManager, unload data.


### PR DESCRIPTION
When restarting the PVR manager, for example after a network outage, any playing media should not be stopped, so playback can continue. Playback should only be stopped if PVr manager is actually stopped, for example, when shutting down Kodi.

Runtime-tested on macOS and Android on latest Kodi master.

@phunkyfish when you find some time...