### PR TITLE
[powermanagement] OnSleep: Send PVR to sleep after stopping playback.

### DIFF
--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -185,9 +185,10 @@ void CPowerManager::OnSleep()
 
   CLog::Log(LOGINFO, "%s: Running sleep jobs", __FUNCTION__);
 
-  CServiceBroker::GetPVRManager().OnSleep();
   StorePlayerState();
+
   g_application.StopPlaying();
+  CServiceBroker::GetPVRManager().OnSleep();
   g_application.StopShutdownTimer();
   g_application.StopScreenSaverTimer();
   g_application.CloseNetworkShares();


### PR DESCRIPTION
As @FernetMenta pointed out here https://github.com/xbmc/xbmc/pull/18997#issuecomment-752882351 , "sending PVR to sleep before stopping playback is wrong. in this case player can't stop pvr streaming anymore."

