### PR TITLE
Audiotrack: Disable multi channel float once again

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -1078,8 +1078,9 @@ void CAESinkAUDIOTRACK::UpdateAvailablePCMCapabilities()
   m_sinkSupportsFloat = VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_STEREO, CJNIAudioFormat::ENCODING_PCM_FLOAT);
   // Only try for Android 7 or later - there are a lot of old devices that open successfully
   // but won't work correctly under the hood (famouse example: old FireTV)
-  if (CJNIAudioManager::GetSDKVersion() > 23)
-    m_sinkSupportsMultiChannelFloat = VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_7POINT1_SURROUND, CJNIAudioFormat::ENCODING_PCM_FLOAT);
+  // As even newish devices like Android Chromecast don't do it properly - just disable it ... and use 16 bit Integer
+  //if (CJNIAudioManager::GetSDKVersion() > 23)
+  //  m_sinkSupportsMultiChannelFloat = VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_7POINT1_SURROUND, CJNIAudioFormat::ENCODING_PCM_FLOAT);
 
   if (m_sinkSupportsFloat)
   {


### PR DESCRIPTION
The more device appear, the less are able to actually do multi channel float _even_ they open correctly. Newest example: Chromecast Android device.

While using multi channel float (32 bit precission) is nice to have, it's less worthy than having no multi channel out at all. As there is no method to properly detect this, let's disable it again ...