### PR TITLE
[Doxygen] Add xrefitems for v20 (python and skinning engine)

### DIFF
--- a/docs/doxygen/Doxyfile.doxy
+++ b/docs/doxygen/Doxyfile.doxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Kodi Documentation"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 19.0
+PROJECT_NUMBER         = 20.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -260,6 +260,7 @@ ALIASES                = "table_start=<table width=\"100%\" style=\"border\" bgc
                          "python_v17=\xrefitem python_v17 \"v17 Python API changes\" \"\"" \
                          "python_v18=\xrefitem python_v18 \"v18 Python API changes\" \"\"" \
                          "python_v19=\xrefitem python_v19 \"v19 Python API changes\" \"\"" \
+                         "python_v20=\xrefitem python_v20 \"v20 Python API changes\" \"\"" \
                          "skinning_v12=\xrefitem skinning_v12 \"v12 Skinning engine changes\" \"\"" \
                          "skinning_v13=\xrefitem skinning_v13 \"v13 Skinning engine changes\" \"\"" \
                          "skinning_v14=\xrefitem skinning_v14 \"v14 Skinning engine changes\" \"\"" \
@@ -268,6 +269,7 @@ ALIASES                = "table_start=<table width=\"100%\" style=\"border\" bgc
                          "skinning_v17=\xrefitem skinning_v17 \"v17 Skinning engine changes\" \"\"" \
                          "skinning_v18=\xrefitem skinning_v18 \"v18 Skinning engine changes\" \"\"" \
                          "skinning_v19=\xrefitem skinning_v19 \"v19 Skinning engine changes\" \"\""
+                         "skinning_v20=\xrefitem skinning_v20 \"v20 Skinning engine changes\" \"\""
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_python.dox
@@ -147,6 +147,9 @@ web applications or frameworks for the Python programming language.
 */
 
 /*!
+@page python_v20 Python API v20
+*/
+/*!
 @page python_v19 Python API v19
 \python_removed_function{
       onDatabaseUpdated,
@@ -280,6 +283,7 @@ web applications or frameworks for the Python programming language.
 @page python_revisions Python API Changes
 @brief Overview of changes on Python API for Kodi
 
+- @subpage python_v20
 - @subpage python_v19
 - @subpage python_v18
 - @subpage python_v17
@@ -289,4 +293,4 @@ web applications or frameworks for the Python programming language.
 - @subpage python_v13
 - @subpage python_v12
 
-+*/
+*/

--- a/xbmc/addons/kodi-dev-kit/doxygen/Skin/skin.dox
+++ b/xbmc/addons/kodi-dev-kit/doxygen/Skin/skin.dox
@@ -25,6 +25,9 @@ or two by adding a button, or altering the textures or layout.
 */
 
 /*!
+@page skinning_v20 Skinning engine v20
+*/
+/*!
 @page skinning_v19 Skinning engine v19
 */
 /*!
@@ -53,6 +56,7 @@ or two by adding a button, or altering the textures or layout.
 @page skinning_revisions Skinning engine changes
 @brief Overview of changes on Skinning engine for Kodi
 
+- @subpage skinning_v20
 - @subpage skinning_v19
 - @subpage skinning_v18
 - @subpage skinning_v17
@@ -61,4 +65,4 @@ or two by adding a button, or altering the textures or layout.
 - @subpage skinning_v14
 - @subpage skinning_v13
 - @subpage skinning_v12
-+*/
+*/


### PR DESCRIPTION
## Description
To get the ball rolling, and just like the similar PR for v19 (https://github.com/xbmc/xbmc/pull/15133)  this adds the necessary xrefitems for the python and skinning engine changes to be done in the scope of the v20 release.

## Motivation and Context
Should be merged once matrix is branched so that we have proper revision history for skinning and python

## How Has This Been Tested?
Compiled docs and see


## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
