### PR TITLE
[PVR] PVRGUIInfo: Fix crashes in LISTITEM_IS_(NEW|PREMIERE|FINALE|LIVE).

### DIFF
--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1330,9 +1330,10 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
         bValue = item->GetPVRTimerInfoTag()->GetEpgInfoTag()->IsNew();
         return true;
       }
-      else if (item->IsPVRChannel() && item->GetPVRChannelInfoTag()->GetEPGNow())
+      else if (item->IsPVRChannel())
       {
-        bValue = item->GetPVRChannelInfoTag()->GetEPGNow()->IsNew();
+        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        bValue = epgNow ? epgNow->IsNew() : false;
         return true;
       }
       break;
@@ -1352,9 +1353,10 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
         bValue = item->GetPVRTimerInfoTag()->GetEpgInfoTag()->IsPremiere();
         return true;
       }
-      else if (item->IsPVRChannel() && item->GetPVRChannelInfoTag()->GetEPGNow())
+      else if (item->IsPVRChannel())
       {
-        bValue = item->GetPVRChannelInfoTag()->GetEPGNow()->IsPremiere();
+        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        bValue = epgNow ? epgNow->IsPremiere() : false;
         return true;
       }
       break;
@@ -1374,9 +1376,10 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
         bValue = item->GetPVRTimerInfoTag()->GetEpgInfoTag()->IsFinale();
         return true;
       }
-      else if (item->IsPVRChannel() && item->GetPVRChannelInfoTag()->GetEPGNow())
+      else if (item->IsPVRChannel())
       {
-        bValue = item->GetPVRChannelInfoTag()->GetEPGNow()->IsFinale();
+        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        bValue = epgNow ? epgNow->IsFinale() : false;
         return true;
       }
       break;
@@ -1396,9 +1399,10 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
         bValue = item->GetPVRTimerInfoTag()->GetEpgInfoTag()->IsLive();
         return true;
       }
-      else if (item->IsPVRChannel() && item->GetPVRChannelInfoTag()->GetEPGNow())
+      else if (item->IsPVRChannel())
       {
-        bValue = item->GetPVRChannelInfoTag()->GetEPGNow()->IsLive();
+        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        bValue = epgNow ? epgNow->IsLive() : false;
         return true;
       }
       break;


### PR DESCRIPTION
This fixes random crashes I encountered. 

```c++
if (item->IsPVRChannel() && item->GetPVRChannelInfoTag()->GetEPGNow())
  bValue = item->GetPVRChannelInfoTag()->GetEPGNow()->IsXXX();
```

This pattern does not work, because the check does not guarantee that the tag will be available in the very next moment, for example, because the programme returned in the if clause is no longer active when the if block is executed and there is no successor of that programme in the EPG.

Runtime-tested on macOS, latest master.

@phunkyfish something for you to review, I guess.