### PR TITLE
[PVR] Reinit playback state after PVR Manager restart.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -509,6 +509,9 @@ void CPVRManager::Process()
   // Load EPGs from database.
   m_epgContainer.Load();
 
+  // Reinit playbackstate
+  m_playbackState->ReInit();
+
   m_guiInfo->Start();
   m_epgContainer.Start();
   m_timers->Start();

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -37,9 +37,14 @@ public:
   virtual ~CPVRPlaybackState();
 
   /*!
-   * @brief clear all data.
+   * @brief clear instances, keep stored UIDs.
    */
   void Clear();
+
+  /*!
+   * @brief re-init using stored UIDs.
+   */
+  void ReInit();
 
   /*!
    * @brief Inform that playback of an item just started.
@@ -228,6 +233,9 @@ private:
   std::string m_strPlayingClientName;
   int m_playingClientId = -1;
   int m_playingChannelUniqueId = -1;
+  std::string m_strPlayingRecordingUniqueId;
+  int m_playingEpgTagChannelUniqueId = -1;
+  unsigned int m_playingEpgTagUniqueId = 0;
 
   class CLastWatchedUpdateTimer;
   std::unique_ptr<CLastWatchedUpdateTimer> m_lastWatchedUpdateTimer;


### PR DESCRIPTION
When PVR client addon's backend connection gets lost during playback of a channel/recording, PVR Manager will restart automatically once the network comes back online (the PVR client addon signals successful reconnect to the backend, that is) and the playback of the channel/recording will continue. The internal PVR playback state must be re-initialized accordingly (esp. the instances held by class CPVRPlaybackState).

Runtime-tested on macOS, latest kodi master.

@phunkyfish when you find some time... Please note that this class has some potential for refactoring, but I wanted the code changes for v19 to be as small as possible. 