### PR TITLE
Include cstddef to fix build with gcc 4.9

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -13,6 +13,8 @@
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "utils/log.h"
 
+#include <cstddef>
+
 using namespace KODI;
 using namespace RETRO;
 

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -16,6 +16,8 @@
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
+#include <cstddef>
+
 CGUITexture* CGUITexture::CreateTexture(
     float posX, float posY, float width, float height, const CTextureInfo& texture)
 {


### PR DESCRIPTION
## Description
Fixes build error with
  gcc version 4.9.1 (Sourcery CodeBench Lite 2014.11-95)

```
kodi/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp: In constructor 'KODI::RETRO::CRPRendererOpenGL::CRPRendererOpenGL(const KODI::RETRO::CRenderSettings&, KODI::RETRO::CRenderContext&, std::shared_ptr<KODI::RETRO::IRenderBufferPool>)':
kodi/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp:65:78: error: expected primary-expression before ',' token
                         reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));

kodi/xbmc/guilib/GUITextureGL.cpp: In member function 'virtual void CGUITextureGL::End()':
kodi/xbmc/guilib/GUITextureGL.cpp:118:82: error: expected primary-expression before ',' token
                             reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u2)));
```
Needed after commit: https://github.com/xbmc/xbmc/commit/cd5ff67a79287284fc88a31d0dba7f626f3c9f6a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
