### PR TITLE
Add HDR metadata info to debug info OSD

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -17,7 +17,7 @@ using namespace OVERLAY;
 
 CDebugRenderer::CDebugRenderer()
 {
-  for (int i=0; i<4; i++)
+  for (int i = 0; i < MAX_LINES; i++)
   {
     m_overlay[i] = nullptr;
     m_strDebug[i] = " ";
@@ -33,47 +33,24 @@ CDebugRenderer::~CDebugRenderer()
   }
 }
 
-void CDebugRenderer::SetInfo(std::string &info1, std::string &info2, std::string &info3, std::string &info4)
+void CDebugRenderer::SetInfo(SInfo& info)
 {
   m_overlayRenderer.Release(0);
 
-  if (info1 != m_strDebug[0])
+  for (int i = 0; i < MAX_LINES; i++)
   {
-    m_strDebug[0] = info1;
-    if (m_overlay[0])
-      m_overlay[0]->Release();
-    m_overlay[0] = new CDVDOverlayText();
-    m_overlay[0]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[0]));
-  }
-  if (info2 != m_strDebug[1])
-  {
-    m_strDebug[1] = info2;
-    if (m_overlay[1])
-      m_overlay[1]->Release();
-    m_overlay[1] = new CDVDOverlayText();
-    m_overlay[1]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[1]));
-  }
-  if (info3 != m_strDebug[2])
-  {
-    m_strDebug[2] = info3;
-    if (m_overlay[2])
-      m_overlay[2]->Release();
-    m_overlay[2] = new CDVDOverlayText();
-    m_overlay[2]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[2]));
-  }
-  if (info4 != m_strDebug[3])
-  {
-    m_strDebug[3] = info4;
-    if (m_overlay[3])
-      m_overlay[3]->Release();
-    m_overlay[3] = new CDVDOverlayText();
-    m_overlay[3]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[3]));
+    if (info.line[i] != m_strDebug[i])
+    {
+      m_strDebug[i] = info.line[i];
+      if (m_overlay[i])
+        m_overlay[i]->Release();
+      m_overlay[i] = new CDVDOverlayText();
+      m_overlay[i]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[i]));
+    }
   }
 
-  m_overlayRenderer.AddOverlay(m_overlay[0], 0, 0);
-  m_overlayRenderer.AddOverlay(m_overlay[1], 0, 0);
-  m_overlayRenderer.AddOverlay(m_overlay[2], 0, 0);
-  m_overlayRenderer.AddOverlay(m_overlay[3], 0, 0);
+  for (int i = 0; i < MAX_LINES; i++)
+    m_overlayRenderer.AddOverlay(m_overlay[i], 0, 0);
 }
 
 void CDebugRenderer::Render(CRect &src, CRect &dst, CRect &view)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
@@ -12,6 +12,13 @@
 
 #include <string>
 
+#define MAX_LINES 6
+
+struct SInfo
+{
+  std::string line[MAX_LINES];
+};
+
 class CDVDOverlayText;
 
 class CDebugRenderer
@@ -19,7 +26,7 @@ class CDebugRenderer
 public:
   CDebugRenderer();
   virtual ~CDebugRenderer();
-  void SetInfo(std::string &info1, std::string &info2, std::string &info3, std::string &info4);
+  void SetInfo(SInfo& info);
   void Render(CRect &src, CRect &dst, CRect &view);
   void Flush();
 
@@ -32,7 +39,7 @@ protected:
     void Render(int idx) override;
   };
 
-  std::string m_strDebug[4];
-  CDVDOverlayText *m_overlay[4];
+  std::string m_strDebug[MAX_LINES];
+  CDVDOverlayText* m_overlay[MAX_LINES];
   CRenderer m_overlayRenderer;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -25,6 +25,11 @@
 
 #include "PlatformDefs.h"
 
+extern "C"
+{
+#include <libavutil/mastering_display_metadata.h>
+}
+
 class CRenderCapture;
 struct VideoPicture;
 
@@ -232,4 +237,9 @@ protected:
   //set to true when adding something to m_captures, set to false when m_captures is made empty
   //std::list::empty() isn't thread safe, using an extra bool will save a lock per render when no captures are requested
   bool m_hasCaptures = false;
+
+  bool m_hasDisplayMetadata = false;
+  bool m_hasLightMetadata = false;
+  AVMasteringDisplayMetadata m_displayMetadata = {};
+  AVContentLightMetadata m_lightMetadata = {};
 };


### PR DESCRIPTION
## Description
Add HDR metadata info to debug info OSD

If the metadata is present in the source it is added to debug info OSD, otherwise it is shown the same as before. 
This is valid for both HDR passthrough and tone mapping playback.

## Motivation and Context
Source video streams may have incomplete, incorrect, or missing metadata values. This helps to understand the possible unexpected results when something happens.

## How Has This Been Tested?
Runtime tested.

## Screenshots (if appropriate):
![screenshot00000](https://user-images.githubusercontent.com/58434170/103685763-0c956600-4f8e-11eb-8ef1-0f3dd2418adb.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
