### PR TITLE
[PVR] Fix EPG thread safety issues

### DIFF
--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -14,6 +14,7 @@
 #include "threads/CriticalSection.h"
 #include "utils/EventStream.h"
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -292,15 +293,6 @@ namespace PVR
     bool UpdateFromScraper(time_t start, time_t end, bool bForceUpdate);
 
     /*!
-     * @brief Load all EPG entries from clients into a temporary table and update this table with the contents of that temporary table.
-     * @param start Only get entries after this start time. Use 0 to get all entries before "end".
-     * @param end Only get entries before this end time. Use 0 to get all entries after "begin". If both "begin" and "end" are 0, all entries will be updated.
-     * @param bForceUpdate Force update from client even if it's not the time to
-     * @return True if the update was successful, false otherwise.
-     */
-    bool LoadFromClients(time_t start, time_t end, bool bForceUpdate);
-
-    /*!
      * @brief Update the contents of this table with the contents provided in "epg"
      * @param epg The updated contents.
      * @return True if the update was successful, false otherwise.
@@ -314,7 +306,7 @@ namespace PVR
     void Cleanup(int iPastDays);
 
     bool m_bChanged = false; /*!< true if anything changed that needs to be persisted, false otherwise */
-    bool m_bUpdatePending = false; /*!< true if manual update is pending */
+    std::atomic<bool> m_bUpdatePending = {false}; /*!< true if manual update is pending */
     int m_iEpgID = 0; /*!< the database ID of this table */
     std::string m_strName; /*!< the name of this table */
     std::string m_strScraperName; /*!< the name of the scraper to use */

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -283,7 +283,8 @@ namespace PVR
     std::shared_ptr<CPVREpgDatabase> m_database; /*!< the EPG database */
 
     bool m_bIsUpdating = false; /*!< true while an update is running */
-    bool m_bIsInitialising = true; /*!< true while the epg manager hasn't loaded all tables */
+    std::atomic<bool> m_bIsInitialising = {
+        true}; /*!< true while the epg manager hasn't loaded all tables */
     bool m_bStarted = false; /*!< true if EpgContainer has fully started */
     bool m_bLoaded = false; /*!< true after epg data is initially loaded from the database */
     bool m_bPreventUpdates = false; /*!< true to prevent EPG updates */


### PR DESCRIPTION
`CPVREpgContainer`and `CPVREpg`had some thread safety flaws (races due to missing mutex protection) which should be fixed by this PR.

@lrusak this should fix the crash on suspend/resume you mentioned internally.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish not self-explaining stuff, but maybe you find some time to review.