### PR TITLE
[addons] allow configure and enable add-ons at kodi startup 

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4175,11 +4175,23 @@ void CApplication::ConfigureAndEnableAddons()
   if (addonMgr.GetDisabledAddons(disabledAddons) && !disabledAddons.empty())
   {
     // only look at disabled addons with disabledReason == NONE
-    // usually those are installed from package managers or manually.
-    // also omit addons of type dependency
+    // usually those are installed from package managers or manually. omit add-ons of type dependecy
+    // also try to enable add-ons with disabledReason == INCOMPATIBLE at startup
 
     for (const auto& addon : disabledAddons)
     {
+      if (addonMgr.IsAddonDisabledWithReason(addon->ID(), ADDON::AddonDisabledReason::INCOMPATIBLE))
+      {
+        auto addonInfo = addonMgr.GetAddonInfo(addon->ID());
+        if (addonInfo && addonMgr.IsCompatible(addonInfo))
+        {
+          CLog::Log(LOGDEBUG, "CApplication::{}: enabling the compatible version of [{}].",
+                    __FUNCTION__, addon->ID());
+          addonMgr.EnableAddon(addon->ID());
+        }
+        continue;
+      }
+
       if (addonMgr.IsAddonDisabledExcept(addon->ID(), ADDON::AddonDisabledReason::NONE) ||
           CAddonType::IsDependencyType(addon->MainType()))
       {

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -207,6 +207,7 @@ public:
   void ActivateScreenSaver(bool forceType = false);
   void CloseNetworkShares();
 
+  void ConfigureAndEnableAddons();
   void ShowAppMigrationMessage();
   void Process() override;
   void ProcessSlow();

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -226,6 +226,9 @@ namespace ADDON
     /*! \brief Disable an addon. Returns true on success, false on failure. */
     bool DisableAddon(const std::string& ID, AddonDisabledReason disabledReason);
 
+    /*! \brief Updates reason for a disabled addon. Returns true on success, false on failure. */
+    bool UpdateDisabledReason(const std::string& id, AddonDisabledReason newDisabledReason);
+
     /*! \brief Enable an addon. Returns true on success, false on failure. */
     bool EnableAddon(const std::string& ID);
 


### PR DESCRIPTION
## Description
#### Commit 1
when trying to enable an incompatible add-on, e.g. manually installed old skin, its `disabledReason` in the database should be updated to `DisabledReason::INCOMPATIBLE`

#### Commit 2 adresses https://github.com/xbmc/xbmc/issues/19017
add-ons installed via a package manager (or even manually which is essentially the same) they're picked up from the filesystem, but stay disabled. the average user wouldn't notice why their installed addon isn't working.

#### Commit 3
enable the compatible versions of add-ons at startup if they're installed meanwhile via package manager or manually

## How Has This Been Tested?
debian buster with `pvr.hts` and `inputstream-adaptive`

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
