### PR TITLE
[pvr] Modify API calls for EPG Timeframe to support past (archive) days as well as future days

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr.h
@@ -65,7 +65,8 @@ extern "C"
   {
     const char* strUserPath;
     const char* strClientPath;
-    int iEpgMaxDays;
+    int iEpgMaxFutureDays;
+    int iEpgMaxPastDays;
   } AddonProperties_PVR;
 
   /*!
@@ -208,7 +209,8 @@ extern "C"
                                                        const struct EPG_TAG*,
                                                        struct PVR_NAMED_VALUE*,
                                                        unsigned int*);
-    enum PVR_ERROR(__cdecl* SetEPGTimeFrame)(const struct AddonInstance_PVR*, int);
+    enum PVR_ERROR(__cdecl* SetEPGMaxPastDays)(const struct AddonInstance_PVR*, int);
+    enum PVR_ERROR(__cdecl* SetEPGMaxFutureDays)(const struct AddonInstance_PVR*, int);
     enum PVR_ERROR(__cdecl* CallEPGMenuHook)(const struct AddonInstance_PVR*,
                                              const struct PVR_MENUHOOK*,
                                              const struct EPG_TAG*);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -129,8 +129,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "7.0.2"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "7.0.2"
+#define ADDON_INSTANCE_VERSION_PVR                    "7.1.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "7.1.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \
                                                       "c-api/addon-instance/pvr/pvr_channel_groups.h" \

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -121,7 +121,9 @@ void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
 
   m_struct.props->strUserPath = m_strUserPath.c_str();
   m_struct.props->strClientPath = m_strClientPath.c_str();
-  m_struct.props->iEpgMaxDays =
+  m_struct.props->iEpgMaxPastDays =
+      CServiceBroker::GetPVRManager().EpgContainer().GetPastDaysToDisplay();
+  m_struct.props->iEpgMaxFutureDays =
       CServiceBroker::GetPVRManager().EpgContainer().GetFutureDaysToDisplay();
 
   m_struct.toKodi->kodiInstance = this;
@@ -683,11 +685,23 @@ PVR_ERROR CPVRClient::GetEPGForChannel(int iChannelUid, CPVREpg* epg, time_t sta
       m_clientCapabilities.SupportsEPG());
 }
 
-PVR_ERROR CPVRClient::SetEPGTimeFrame(int iDays)
+PVR_ERROR CPVRClient::SetEPGMaxPastDays(int iPastDays)
 {
   return DoAddonCall(
       __func__,
-      [iDays](const AddonInstance* addon) { return addon->toAddon->SetEPGTimeFrame(addon, iDays); },
+      [iPastDays](const AddonInstance* addon) {
+        return addon->toAddon->SetEPGMaxPastDays(addon, iPastDays);
+      },
+      m_clientCapabilities.SupportsEPG());
+}
+
+PVR_ERROR CPVRClient::SetEPGMaxFutureDays(int iFutureDays)
+{
+  return DoAddonCall(
+      __func__,
+      [iFutureDays](const AddonInstance* addon) {
+        return addon->toAddon->SetEPGMaxFutureDays(addon, iFutureDays);
+      },
       m_clientCapabilities.SupportsEPG());
 }
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -479,18 +479,36 @@ public:
   PVR_ERROR GetEPGForChannel(int iChannelUid, CPVREpg* epg, time_t start, time_t end);
 
   /*!
-   * @brief Tell the client the time frame to use when notifying epg events back
+   * @brief Tell the client the past time frame to use when notifying epg events back
    * to Kodi.
    *
    * The client might push epg events asynchronously to Kodi using the callback
    * function EpgEventStateChange. To be able to only push events that are
-   * actually of interest for Kodi, client needs to know about the epg time
+   * actually of interest for Kodi, client needs to know about the past epg time
    * frame Kodi uses.
    *
-   * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
+   * @param[in] iPastDays number of days before "now".
+                @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events,
+                regardless of event times.
    * @return PVR_ERROR_NO_ERROR if new value was successfully set.
    */
-  PVR_ERROR SetEPGTimeFrame(int iDays);
+  PVR_ERROR SetEPGMaxPastDays(int iPastDays);
+
+  /*!
+   * @brief Tell the client the future time frame to use when notifying epg events back
+   * to Kodi.
+   *
+   * The client might push epg events asynchronously to Kodi using the callback
+   * function EpgEventStateChange. To be able to only push events that are
+   * actually of interest for Kodi, client needs to know about the future epg time
+   * frame Kodi uses.
+   *
+   * @param[in] iFutureDays number of days after "now".
+                @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events,
+                regardless of event times.
+   * @return PVR_ERROR_NO_ERROR if new value was successfully set.
+   */
+  PVR_ERROR SetEPGMaxFutureDays(int iFutureDays);
 
   //@}
   /** @name PVR channel group methods */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -529,10 +529,17 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
   });
 }
 
-PVR_ERROR CPVRClients::SetEPGTimeFrame(int iDays)
+PVR_ERROR CPVRClients::SetEPGMaxPastDays(int iPastDays)
 {
-  return ForCreatedClients(__FUNCTION__, [iDays](const std::shared_ptr<CPVRClient>& client) {
-    return client->SetEPGTimeFrame(iDays);
+  return ForCreatedClients(__FUNCTION__, [iPastDays](const std::shared_ptr<CPVRClient>& client) {
+    return client->SetEPGMaxPastDays(iPastDays);
+  });
+}
+
+PVR_ERROR CPVRClients::SetEPGMaxFutureDays(int iFutureDays)
+{
+  return ForCreatedClients(__FUNCTION__, [iFutureDays](const std::shared_ptr<CPVRClient>& client) {
+    return client->SetEPGMaxFutureDays(iFutureDays);
   });
 }
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -219,13 +219,34 @@ namespace PVR
     //@{
 
     /*!
-     * Tell all clients the time frame to use when notifying epg events back to Kodi. The clients might push epg events asynchronously
-     * to Kodi using the callback function EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
-     * clients need to know about the epg time frame Kodi uses.
-     * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
+     * @brief Tell all clients the past time frame to use when notifying epg events back to Kodi.
+     *
+     * The clients might push epg events asynchronously to Kodi using the callback function
+     * EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
+     * clients need to know about the future epg time frame Kodi uses.
+     *
+     * @param[in] iPastDays number of days before "now".
+     *                        @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all
+     *                        epg events, regardless of event times.
+     * @return @ref PVR_ERROR_NO_ERROR if the operation succeeded, the respective @ref PVR_ERROR
+     *         value otherwise.
      */
-    PVR_ERROR SetEPGTimeFrame(int iDays);
+    PVR_ERROR SetEPGMaxPastDays(int iPastDays);
+
+    /*!
+     * @brief Tell all clients the future time frame to use when notifying epg events back to Kodi.
+     *
+     * The clients might push epg events asynchronously to Kodi using the callback function
+     * EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
+     * clients need to know about the future epg time frame Kodi uses.
+     *
+     * @param[in] iFutureDays number of days from "now".
+     *                        @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all
+     *                        epg events, regardless of event times.
+     * @return @ref PVR_ERROR_NO_ERROR if the operation succeeded, the respective @ref PVR_ERROR
+     *         value otherwise.
+     */
+    PVR_ERROR SetEPGMaxFutureDays(int iFutureDays);
 
     //@}
 

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -48,6 +48,7 @@ CPVRGUIActionListener::CPVRGUIActionListener()
     CSettings::SETTING_PVRMANAGER_CHANNELSCAN,
     CSettings::SETTING_PVRMENU_SEARCHICONS,
     CSettings::SETTING_PVRCLIENT_MENUHOOK,
+    CSettings::SETTING_EPG_PAST_DAYSTODISPLAY,
     CSettings::SETTING_EPG_FUTURE_DAYSTODISPLAY
   });
 }
@@ -293,9 +294,15 @@ void CPVRGUIActionListener::OnSettingChanged(const std::shared_ptr<const CSettin
         std::static_pointer_cast<CSettingBool>(std::const_pointer_cast<CSetting>(setting))->SetValue(false);
     }
   }
+  else if (settingId == CSettings::SETTING_EPG_PAST_DAYSTODISPLAY)
+  {
+    CServiceBroker::GetPVRManager().Clients()->SetEPGMaxPastDays(
+        std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+  }
   else if (settingId == CSettings::SETTING_EPG_FUTURE_DAYSTODISPLAY)
   {
-    CServiceBroker::GetPVRManager().Clients()->SetEPGTimeFrame(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+    CServiceBroker::GetPVRManager().Clients()->SetEPGMaxFutureDays(
+        std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Now that there is support for archive there needs to be a way for add-ons to be informed of the past number of days stored by kodi in the EPG.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

No way for add-ons to preload the correct amount of past/archive data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

MacOSX

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
