### PR TITLE
[PVR] Allow for URL-encoded PVR Recording directory names

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
@@ -164,7 +164,7 @@ public:
 
   /// @brief **optional**\n
   ///
-  /// Directory of this recording on the client.
+  /// Directory of this recording on the client. May be optionally URL-encoded to preserve special characters.
   void SetDirectory(const std::string& directory)
   {
     strncpy(m_cStructure->strDirectory, directory.c_str(), sizeof(m_cStructure->strDirectory) - 1);

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -297,7 +297,7 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     {
       item.reset(new CFileItem(strCurrent, true));
       item->SetPath(strFilePath);
-      item->SetLabel(strCurrent);
+      item->SetLabel(CURL::Decode(strCurrent));
       item->SetLabelPreformatted(true);
       item->m_dateTime = recording->RecordingTimeAsLocalTime();
       item->SetProperty("totalepisodes", 0);


### PR DESCRIPTION
## Description
This PR allows for URL-encoded PVR Recording directories to be specified to Kodi; more specifically when a PVR Recording directory name contains a forward-slash (/) there is no apparent way to escape that character and prevent an erroneous sub-directory to be generated.

## Motivation and Context
I received a defect report from a user of my custom PVR addon that recordings of the TV series "20/20" were appearing in Kodi as a directory of "20" with a subdirectory of "20" instead of the assumed single directory name of "20/20".  Upon investigation I found that there was no way to properly escape the forward-slash character in the series name in order to allow it to be used as the Kodi directory name.

## How Has This Been Tested?
The proposed fix has been tested successfully on Windows 10 (x64) using a build based on the most recent **master** branch as of this writing.  I forced the PVR Recording directory name to "20/20" for all recordings in order to duplicate the problem, and worked from there to try and find the least impactful method to resolve this.  I found that URL-decoding the directory name at the point where it becomes a GUI directory label solves the problem sufficiently and should have little to no impact on existing PVR addons. Future PVR addons may optionally URL-encode the directory name to escape "/" as "%2F" to prevent the condition, but if they do not the as-is behavior will persist.

I do not feel that this change would impact any portions of the Kodi code outside of PVR Recordings and since existing behavior will persist will mark as "Improvement" versus "Bug Fix".

I would like to suggest that @ksooo review this PR to determine it's basic validity or to suggest an alternate path to resolution; it's simple in practice but may have unintended consequences that I have failed to consider.

Thank you!

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
