### PR TITLE
[PVR] CPVRChannel: Fix dangling EPG instance member

### DIFF
--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -75,6 +75,7 @@ namespace PVR
     EpgContainer,
     EpgItemUpdate,
     EpgUpdatePending,
+    EpgDeleted,
 
     // Item events
     CurrentItem,

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -41,7 +41,12 @@ bool CPVRChannel::operator!=(const CPVRChannel& right) const
   return !(*this == right);
 }
 
-CPVRChannel::CPVRChannel(bool bRadio /* = false */)
+CPVRChannel::CPVRChannel()
+{
+  UpdateEncryptionName();
+}
+
+CPVRChannel::CPVRChannel(bool bRadio)
   : m_bIsRadio(bRadio)
 {
   UpdateEncryptionName();

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -23,6 +23,8 @@ class CDateTime;
 
 namespace PVR
 {
+  enum class PVREvent;
+
   class CPVREpg;
   class CPVREpgInfoTag;
   class CPVRRadioRDSInfoTag;
@@ -35,7 +37,7 @@ namespace PVR
     explicit CPVRChannel(bool bRadio);
     CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId);
 
-    virtual ~CPVRChannel() = default;
+    virtual ~CPVRChannel();
 
     bool operator ==(const CPVRChannel& right) const;
     bool operator !=(const CPVRChannel& right) const;
@@ -444,6 +446,12 @@ namespace PVR
      */
     void SetClientOrder(int iOrder);
 
+    /*!
+     * @brief CEventStream callback for PVR events.
+     * @param event The event.
+     */
+    void Notify(const PVREvent& event);
+
     //@}
   private:
     CPVRChannel();
@@ -454,6 +462,11 @@ namespace PVR
      * @brief Update the encryption name after SetEncryptionSystem() has been called.
      */
     void UpdateEncryptionName();
+
+    /*!
+     * @brief Reset the EPG instance pointer.
+     */
+    void ResetEPG();
 
     /*! @name XBMC related channel data
      */

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -32,7 +32,7 @@ namespace PVR
     friend class CPVRDatabase;
 
   public:
-    explicit CPVRChannel(bool bRadio = false);
+    explicit CPVRChannel(bool bRadio);
     CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId);
 
     virtual ~CPVRChannel() = default;
@@ -446,6 +446,7 @@ namespace PVR
 
     //@}
   private:
+    CPVRChannel();
     CPVRChannel(const CPVRChannel& tag) = delete;
     CPVRChannel& operator=(const CPVRChannel& channel) = delete;
 

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -547,3 +547,8 @@ bool CPVREpg::IsValid() const
 
   return true;
 }
+
+void CPVREpg::RemovedFromContainer()
+{
+  m_events.Publish(PVREvent::EpgDeleted);
+}

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -277,6 +277,11 @@ namespace PVR
      */
     void Unlock() { m_critSection.unlock(); }
 
+    /*!
+     * @brief Called to inform the EPG that it has been removed from the EPG container.
+     */
+    void RemovedFromContainer();
+
   private:
     CPVREpg() = delete;
     CPVREpg(const CPVREpg&) = delete;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -206,7 +206,10 @@ void CPVREpgContainer::Unload()
   }
 
   for (const auto& epg : epgs)
+  {
     epg->Events().Unsubscribe(this);
+    epg->RemovedFromContainer();
+  }
 
   m_events.Publish(PVREvent::EpgContainer);
 }
@@ -642,6 +645,7 @@ bool CPVREpgContainer::QueueDeleteEpg(const std::shared_ptr<CPVREpg>& epg)
   }
 
   epgToDelete->Events().Unsubscribe(this);
+  epgToDelete->RemovedFromContainer();
   return true;
 }
 


### PR DESCRIPTION
`CPVRChannel` instances hold a shared pointer to it's `CPVREpg`, for performance reasons.

As the EPG container and all its content can be emptied asynchronously at any time, the channel must be informed that the EPG instance is no longer valid to avoid dangling EPG instance pointers. This PR fixes this problem by channel subscribing now to the EPG and the EPG firing an event in case it gets invalid making the channel reset its EPG pointer.

Runtime-tested on macOS and Android, latest Kodi master.

Second commit is just a small fix for a problem I discovered along the way.

@phunkyfish when you find some time...