### PR TITLE
Don't close settings dialogs invalidated on save and use on PVR Timer Settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9597,7 +9597,11 @@ msgctxt "#19071"
 msgid "Update interval"
 msgstr ""
 
-#empty string with id 19072
+#. Dialog warning text for invalid timer setting
+#: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+msgctxt "#19072"
+msgid "In order to add/update a timer the end date and time must be greater than the start date and time."
+msgstr ""
 
 #. pvr settings "delay channel switch" setting label
 #: system/settings/settings.xml

--- a/xbmc/addons/gui/GUIDialogAddonSettings.h
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.h
@@ -36,7 +36,7 @@ protected:
 
   // implementation of CGUIDialogSettingsManagerBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override {}
+  bool Save() override { return true; }
   CSettingsManager* GetSettingsManager() const override;
 
   // implementation of ISettingCallback

--- a/xbmc/dialogs/GUIDialogMediaFilter.h
+++ b/xbmc/dialogs/GUIDialogMediaFilter.h
@@ -59,7 +59,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override { }
+  bool Save() override { return true; }
   unsigned int GetDelayMs() const override { return 500; }
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -242,10 +242,10 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
   }
 }
 
-void CGUIDialogInfoProviderSettings::Save()
+bool CGUIDialogInfoProviderSettings::Save()
 {
   if (m_showSingleScraper)
-    return;  //Save done by caller of ::Show
+    return true; //Save done by caller of ::Show
 
   // Save default settings for fetching additional information and art
   CLog::Log(LOGINFO, "%s called", __FUNCTION__);
@@ -260,6 +260,8 @@ void CGUIDialogInfoProviderSettings::Save()
   // Save artist information folder
   settings->SetString(CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER, m_strArtistInfoPath);
   settings->Save();
+
+  return true;
 }
 
 void CGUIDialogInfoProviderSettings::SetupView()

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.h
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.h
@@ -62,7 +62,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override;
+  bool Save() override;
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -47,7 +47,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override { }
+  bool Save() override { return true; }
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -77,16 +77,18 @@ void CGUIDialogPeripheralSettings::OnSettingChanged(const std::shared_ptr<const 
   itSetting->second->FromString(setting->ToString());
 }
 
-void CGUIDialogPeripheralSettings::Save()
+bool CGUIDialogPeripheralSettings::Save()
 {
   if (m_item == NULL || m_initialising)
-    return;
+    return true;
 
   PeripheralPtr peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
   if (!peripheral)
-    return;
+    return true;
 
   peripheral->PersistSettings();
+
+  return true;
 }
 
 void CGUIDialogPeripheralSettings::OnResetSettings()

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
@@ -31,7 +31,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override;
+  bool Save() override;
   void OnResetSettings() override;
   void SetupView() override;
 

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.h
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.h
@@ -28,7 +28,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override { }
+  bool Save() override { return true; }
   void OnCancel() override;
   void SetupView() override;
 

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.h
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.h
@@ -31,7 +31,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override { }
+  bool Save() override { return true; }
   void OnCancel() override;
   void SetupView() override;
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
@@ -89,7 +89,7 @@ void CGUIDialogPVRClientPriorities::OnSettingChanged(const std::shared_ptr<const
   m_changedValues[setting->GetId()] = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
 }
 
-void CGUIDialogPVRClientPriorities::Save()
+bool CGUIDialogPVRClientPriorities::Save()
 {
   for (const auto& changedClient : m_changedValues)
   {
@@ -98,4 +98,6 @@ void CGUIDialogPVRClientPriorities::Save()
     if (clientEntry != m_clients.end())
       clientEntry->second->SetPriority(changedClient.second);
   }
+
+  return true;
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.h
@@ -28,7 +28,7 @@ namespace PVR
     // specialization of CGUIDialogSettingsBase
     std::string GetSettingsLabel(const std::shared_ptr<ISetting>& pSetting) override;
     bool AllowResettingSettings() const override { return false; }
-    void Save() override;
+    bool Save() override;
     void SetupView() override;
 
     // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -168,7 +168,7 @@ void CGUIDialogPVRRecordingSettings::OnSettingChanged(
   }
 }
 
-void CGUIDialogPVRRecordingSettings::Save()
+bool CGUIDialogPVRRecordingSettings::Save()
 {
   // Name
   m_recording->m_strTitle = m_strTitle;
@@ -178,6 +178,8 @@ void CGUIDialogPVRRecordingSettings::Save()
 
   // Lifetime
   m_recording->m_iLifetime = m_iLifetime;
+
+  return true;
 }
 
 void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& setting,

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
@@ -38,7 +38,7 @@ namespace PVR
 
     // specialization of CGUIDialogSettingsBase
     bool AllowResettingSettings() const override { return false; }
-    void Save() override;
+    bool Save() override;
     void SetupView() override;
 
     // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -526,7 +526,7 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const std::shared_ptr<const CSe
   }
 }
 
-void CGUIDialogPVRTimerSettings::Save()
+bool CGUIDialogPVRTimerSettings::Save()
 {
   // Timer type
   m_timerInfoTag->SetTimerType(m_timerType);
@@ -638,6 +638,8 @@ void CGUIDialogPVRTimerSettings::Save()
 
   // Update summary
   m_timerInfoTag->UpdateSummary();
+
+  return true;
 }
 
 void CGUIDialogPVRTimerSettings::SetButtonLabels()

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -12,6 +12,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClients.h"
@@ -36,6 +37,7 @@
 #include <vector>
 
 using namespace PVR;
+using namespace KODI::MESSAGING;
 
 #define SETTING_TMR_TYPE          "timer.type"
 #define SETTING_TMR_ACTIVE        "timer.active"
@@ -526,8 +528,41 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const std::shared_ptr<const CSe
   }
 }
 
+bool CGUIDialogPVRTimerSettings::Validate()
+{
+  bool bStartAnyTime = m_bStartAnyTime;
+  bool bEndAnyTime = m_bEndAnyTime;
+
+  if (!m_timerType->SupportsStartAnyTime() ||
+      !m_timerType->IsEpgBased()) // Start anytime toggle is not displayed
+    bStartAnyTime = false; // Assume start time change needs checking for
+
+  if (!m_timerType->SupportsEndAnyTime() ||
+      !m_timerType->IsEpgBased()) // End anytime toggle is not displayed
+    bEndAnyTime = false; // Assume end time change needs checking for
+
+  // Begin and end time
+  if (!bStartAnyTime && !bEndAnyTime)
+  {
+    if (!(m_timerType->SupportsStartTime() && // has start clock entry
+          m_timerType->SupportsEndTime() && // and end clock entry
+          m_timerType->IsTimerRule()) && // but no associated start/end day spinners
+        m_endLocalTime < m_startLocalTime)
+    {
+      HELPERS::ShowOKDialogText(CVariant{19065}, // "Timer settings"
+                                CVariant{19072}); // In order to add/update a timer
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool CGUIDialogPVRTimerSettings::Save()
 {
+  if (!Validate())
+    return false;
+
   // Timer type
   m_timerInfoTag->SetTimerType(m_timerType);
 
@@ -585,9 +620,9 @@ bool CGUIDialogPVRTimerSettings::Save()
         }
       }
     }
-    else if (m_endLocalTime < m_startLocalTime) // Assume the user knows what they are doing, but log a warning just in case
+    else if (m_endLocalTime < m_startLocalTime)
     {
-      CLog::Log(LOGWARNING, "Timer settings dialog: Specified recording end time < start time: expect errors!");
+      // this case will fail validation so this can't be reached.
     }
     m_timerInfoTag->SetStartFromLocalTime(m_startLocalTime);
     m_timerInfoTag->SetEndFromLocalTime(m_endLocalTime);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -22,7 +22,6 @@
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimerType.h"
 #include "settings/SettingUtils.h"
-#include "settings/Settings.h"
 #include "settings/dialogs/GUIDialogSettingsBase.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
@@ -67,10 +66,9 @@ using namespace PVR;
 #define START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX  "visibi.startanytimedep"
 #define END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX    "visibi.endanytimedep"
 
-CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings()
-  : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogSettings.xml"),
-    m_settings({CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME}),
-    m_iWeekdays(PVR_WEEKDAY_NONE)
+CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings() :
+  CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogSettings.xml"),
+  m_iWeekdays(PVR_WEEKDAY_NONE)
 {
   m_loadType = LOAD_EVERY_TIME;
 }
@@ -587,15 +585,9 @@ void CGUIDialogPVRTimerSettings::Save()
         }
       }
     }
-    else if (m_endLocalTime <= m_startLocalTime) // Use a sensible default if end time is invalid
+    else if (m_endLocalTime < m_startLocalTime) // Assume the user knows what they are doing, but log a warning just in case
     {
-      int iDefaultDurationMins =
-          m_settings.GetIntValue(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
-      CLog::Log(LOGWARNING,
-                "Timer settings dialog: Specified recording end time < start. Setting "
-                "end time to start time plus instant timer duration of {} minutes.",
-                iDefaultDurationMins);
-      m_endLocalTime = m_startLocalTime + CDateTimeSpan(0, 0, iDefaultDurationMins, 0);
+      CLog::Log(LOGWARNING, "Timer settings dialog: Specified recording end time < start time: expect errors!");
     }
     m_timerInfoTag->SetStartFromLocalTime(m_startLocalTime);
     m_timerInfoTag->SetEndFromLocalTime(m_endLocalTime);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h" // PVR_CHANNEL_INVALID_UID
-#include "pvr/settings/PVRSettings.h"
 #include "settings/SettingConditions.h"
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
 #include "settings/lib/SettingDependency.h"
@@ -163,8 +162,6 @@ namespace PVR
       }
 
     } ChannelDescriptor;
-
-    CPVRSettings m_settings;
 
     typedef std::map <int, ChannelDescriptor> ChannelEntriesMap;
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -52,6 +52,7 @@ namespace PVR
     void InitializeSettings() override;
 
   private:
+    bool Validate();
     void InitializeTypesList();
     void InitializeChannelsList();
     void SetButtonLabels();

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -45,7 +45,7 @@ namespace PVR
 
     // specialization of CGUIDialogSettingsBase
     bool AllowResettingSettings() const override { return false; }
-    void Save() override;
+    bool Save() override;
     void SetupView() override;
 
     // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -260,9 +260,10 @@ void CGUIDialogContentSettings::OnSettingAction(const std::shared_ptr<const CSet
     CGUIDialogAddonSettings::ShowForAddon(m_scraper, false);
 }
 
-void CGUIDialogContentSettings::Save()
+bool CGUIDialogContentSettings::Save()
 {
   //Should be saved by caller of ::Show
+  return true;
 }
 
 void CGUIDialogContentSettings::SetupView()

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.h
@@ -56,7 +56,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override;
+  bool Save() override;
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -235,7 +235,7 @@ void CGUIDialogLibExportSettings::OnOK()
   Close();
 }
 
-void CGUIDialogLibExportSettings::Save()
+bool CGUIDialogLibExportSettings::Save()
 {
   CLog::Log(LOGINFO, "CGUIDialogMusicExportSettings: Save() called");
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -247,6 +247,8 @@ void CGUIDialogLibExportSettings::Save()
   settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK, m_settings.m_artwork);
   settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, m_settings.m_skipnfo);
   settings->Save();
+
+  return true;
 }
 
 void CGUIDialogLibExportSettings::SetupView()

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
@@ -33,7 +33,7 @@ protected:
   // specialization of CGUIDialogSettingsBase
   bool OnMessage(CGUIMessage& message) override;
   bool AllowResettingSettings() const override { return false; }
-  void Save() override;
+  bool Save() override;
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -193,9 +193,13 @@ bool CGUIDialogSettingsBase::OnMessage(CGUIMessage& message)
       int iControl = message.GetSenderId();
       if (iControl == CONTROL_SETTINGS_OKAY_BUTTON)
       {
-        OnOkay();
-        Close();
-        return true;
+        if (OnOkay())
+        {
+          Close();
+          return true;
+        }
+
+        return false;
       }
 
       if (iControl == CONTROL_SETTINGS_CANCEL_BUTTON)

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -95,7 +95,11 @@ protected:
   virtual unsigned int GetDelayMs() const { return 1500; }
   virtual std::string GetLocalizedString(uint32_t labelId) const;
 
-  virtual void OnOkay() { m_confirmed = true; }
+  virtual bool OnOkay()
+  {
+    m_confirmed = true;
+    return true;
+  }
   virtual void OnCancel() {}
 
   virtual void SetupView();

--- a/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
@@ -25,11 +25,15 @@ std::shared_ptr<CSetting> CGUIDialogSettingsManagerBase::GetSetting(const std::s
   return GetSettingsManager()->GetSetting(settingId);
 }
 
-void CGUIDialogSettingsManagerBase::OnOkay()
+bool CGUIDialogSettingsManagerBase::OnOkay()
 {
-  Save();
+  if (Save())
+  {
+    CGUIDialogSettingsBase::OnOkay();
+    return true;
+  }
 
-  CGUIDialogSettingsBase::OnOkay();
+  return false;
 }
 
 std::set<std::string> CGUIDialogSettingsManagerBase::CreateSettings()

--- a/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.h
@@ -19,12 +19,12 @@ public:
   ~CGUIDialogSettingsManagerBase() override;
 
 protected:
-  virtual void Save() = 0;
+  virtual bool Save() = 0;
   virtual CSettingsManager* GetSettingsManager() const = 0;
 
   // implementation of CGUIDialogSettingsBase
   std::shared_ptr<CSetting> GetSetting(const std::string &settingId) override;
-  void OnOkay() override;
+  bool OnOkay() override;
 
   std::set<std::string> CreateSettings() override;
   void FreeSettingsControls() override;

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -186,9 +186,11 @@ SettingSectionPtr CGUIWindowSettingsCategory::GetSection()
   return NULL;
 }
 
-void CGUIWindowSettingsCategory::Save()
+bool CGUIWindowSettingsCategory::Save()
 {
   m_settings->Save();
+
+  return true;
 }
 
 CSettingsManager* CGUIWindowSettingsCategory::GetSettingsManager() const

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.h
@@ -34,7 +34,7 @@ protected:
   // implementation of CGUIDialogSettingsBase
   int GetSettingLevel() const override;
   std::shared_ptr<CSettingSection> GetSection() override;
-  void Save() override;
+  bool Save() override;
 
   // implementation of CGUIDialogSettingsManagerBase
   CSettingsManager* GetSettingsManager() const override;

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -146,22 +146,22 @@ void CGUIDialogAudioSettings::OnSettingAction(const std::shared_ptr<const CSetti
     Save();
 }
 
-void CGUIDialogAudioSettings::Save()
+bool CGUIDialogAudioSettings::Save()
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
       profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
-    return;
+    return true;
 
   // prompt user if they are sure
   if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12376}, CVariant{12377}))
-    return;
+    return true;
 
   // reset the settings
   CVideoDatabase db;
   if (!db.Open())
-    return;
+    return true;
 
   db.EraseAllVideoSettings();
   db.Close();
@@ -169,6 +169,8 @@ void CGUIDialogAudioSettings::Save()
   CMediaSettings::GetInstance().GetDefaultVideoSettings() = g_application.GetAppPlayer().GetVideoSettings();
   CMediaSettings::GetInstance().GetDefaultVideoSettings().m_AudioStream = -1;
   CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
+
+  return true;
 }
 
 void CGUIDialogAudioSettings::SetupView()

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.h
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.h
@@ -38,7 +38,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override;
+  bool Save() override;
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -203,10 +203,12 @@ bool CGUIDialogCMSSettings::OnBack(int actionID)
   return CGUIDialogSettingsBase::OnBack(actionID);
 }
 
-void CGUIDialogCMSSettings::Save()
+bool CGUIDialogCMSSettings::Save()
 {
   CLog::Log(LOGINFO, "CGUIDialogCMSSettings: Save() called");
   CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
+
+  return true;
 }
 
 void CGUIDialogCMSSettings::Cms3dLutsFiller(const SettingConstPtr& setting,

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.h
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.h
@@ -25,7 +25,7 @@ protected:
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
   bool OnBack(int actionID) override;
-  void Save() override;
+  bool Save() override;
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -184,22 +184,22 @@ void CGUIDialogSubtitleSettings::OnSettingAction(const std::shared_ptr<const CSe
     Save();
 }
 
-void CGUIDialogSubtitleSettings::Save()
+bool CGUIDialogSubtitleSettings::Save()
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
       profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
-    return;
+    return true;
 
   // prompt user if they are sure
   if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12376}, CVariant{12377}))
-    return;
+    return true;
 
   // reset the settings
   CVideoDatabase db;
   if (!db.Open())
-    return;
+    return true;
 
   db.EraseAllVideoSettings();
   db.Close();
@@ -207,6 +207,8 @@ void CGUIDialogSubtitleSettings::Save()
   CMediaSettings::GetInstance().GetDefaultVideoSettings() = g_application.GetAppPlayer().GetVideoSettings();
   CMediaSettings::GetInstance().GetDefaultVideoSettings().m_SubtitleStream = -1;
   CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
+
+  return true;
 }
 
 void CGUIDialogSubtitleSettings::SetupView()

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
@@ -37,7 +37,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override;
+  bool Save() override;
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -241,20 +241,20 @@ void CGUIDialogVideoSettings::OnSettingAction(const std::shared_ptr<const CSetti
     Save();
 }
 
-void CGUIDialogVideoSettings::Save()
+bool CGUIDialogVideoSettings::Save()
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
       !g_passwordManager.CheckSettingLevelLock(::SettingLevel::Expert))
-    return;
+    return true;
 
   // prompt user if they are sure
   if (CGUIDialogYesNo::ShowAndGetInput(CVariant(12376), CVariant(12377)))
   { // reset the settings
     CVideoDatabase db;
     if (!db.Open())
-      return;
+      return true;
     db.EraseAllVideoSettings();
     db.Close();
 
@@ -263,6 +263,8 @@ void CGUIDialogVideoSettings::Save()
     CMediaSettings::GetInstance().GetDefaultVideoSettings().m_AudioStream = -1;
     CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
   }
+
+  return true;
 }
 
 void CGUIDialogVideoSettings::SetupView()

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.h
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.h
@@ -43,7 +43,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
-  void Save() override;
+  bool Save() override;
   void SetupView() override;
 
   // specialization of CGUIDialogSettingsManualBase


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Proper solution which reverts https://github.com/xbmc/xbmc/pull/19050 which was a work around forcing a default value as it was the only possible solution. Thanks to @Montellese for the guidance on the correct way t fix this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Any PVR add-on could receive a invalid manual timer. Instead of fixing in each add-on it is better to fix in core.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On OSX creating various manual timers with pvr.vuplus

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
