### PR TITLE
Add support for ngx-fancyindex HTTP directories

### DIFF
--- a/cmake/installdata/test-reference-data.txt
+++ b/cmake/installdata/test-reference-data.txt
@@ -13,6 +13,7 @@ xbmc/filesystem/test/data/httpdirectory/basic.html
 xbmc/filesystem/test/data/httpdirectory/basic-multiline.html
 xbmc/filesystem/test/data/httpdirectory/lighttp-default.html
 xbmc/filesystem/test/data/httpdirectory/nginx-default.html
+xbmc/filesystem/test/data/httpdirectory/nginx-fancyindex.html
 xbmc/network/test/data/test.html
 xbmc/network/test/data/test.png
 xbmc/network/test/data/test-ranges.txt

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -41,7 +41,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   }
 
   CRegExp reItem(true); // HTML is case-insensitive
-  reItem.RegComp("<a href=\"(.*?)\">\\s*(.*?)\\s*</a>(.+?)(?=<a|</tr|$)");
+  reItem.RegComp("<a href=\"([^\"]*)\"[^>]*>\\s*(.*?)\\s*</a>(.+?)(?=<a|</tr|$)");
 
   CRegExp reDateTimeHtml(true);
   reDateTimeHtml.RegComp(
@@ -54,6 +54,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   CRegExp reDateTimeNginx(true);
   reDateTimeNginx.RegComp("([0-9]{2})-([A-Z]{3})-([0-9]{4}) ([0-9]{2}):([0-9]{2})");
 
+  CRegExp reDateTimeNginxFancy(true);
+  reDateTimeNginxFancy.RegComp(
+      "<td class=\"date\">([0-9]{4})-([A-Z]{3})-([0-9]{2}) ([0-9]{2}):([0-9]{2})</td>");
+
   CRegExp reDateTimeApacheNewFormat(true);
   reDateTimeApacheNewFormat.RegComp(
       "<td align=\"right\">([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}) +</td>");
@@ -62,7 +66,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   reDateTime.RegComp("([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})");
 
   CRegExp reSizeHtml(true);
-  reSizeHtml.RegComp("> *([0-9.]+)(B|K|M|G| )</td>");
+  reSizeHtml.RegComp("> *([0-9.]+) *(B|K|M|G| )(iB)?</td>");
 
   CRegExp reSize(true);
   reSize.RegComp(" +([0-9]+)(B|K|M|G)?(?=\\s|<|$)");
@@ -116,7 +120,14 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         strLinkOptions = strLinkBase.substr(pos);
         strLinkBase.erase(pos);
       }
-      
+
+      // strip url fragment from the link
+      pos = strLinkBase.find('#');
+      if (pos != std::string::npos)
+      {
+        strLinkBase.erase(pos);
+      }
+
       // encoding + and ; to URL encode if it is not already encoded by http server used on the remote server (example: Apache)
       // more characters may be added here when required when required by certain http servers
       pos = strLinkBase.find_first_of("+;");
@@ -155,7 +166,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
       // we detect http directory items by its display name and its stripped link
       // if same, we consider it as a valid item.
-      if (NameMatchesLink(strNameTemp, strLinkTemp) && strLinkTemp != "..")
+      if (strLinkTemp != ".." && strLinkTemp != "" && NameMatchesLink(strNameTemp, strLinkTemp))
       {
         CFileItemPtr pItem(new CFileItem(strNameTemp));
         pItem->SetProperty("IsHTTPDirectory", true);
@@ -187,6 +198,14 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
           year = reDateTimeHtml.GetMatch(3);
           hour = reDateTimeHtml.GetMatch(4);
           minute = reDateTimeHtml.GetMatch(5);
+        }
+        else if (reDateTimeNginxFancy.RegFind(strMetadata.c_str()) >= 0)
+        {
+          day = reDateTimeNginxFancy.GetMatch(3);
+          month = reDateTimeNginxFancy.GetMatch(2);
+          year = reDateTimeNginxFancy.GetMatch(1);
+          hour = reDateTimeNginxFancy.GetMatch(4);
+          minute = reDateTimeNginxFancy.GetMatch(5);
         }
         else if (reDateTimeNginx.RegFind(strMetadata.c_str()) >= 0)
         {

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -36,6 +36,7 @@ using namespace XFILE;
 #define TEST_FILE_BASIC_MULTILINE "basic-multiline.html"
 #define TEST_FILE_LIGHTTP_DEFAULT "lighttp-default.html"
 #define TEST_FILE_NGINX_DEFAULT "nginx-default.html"
+#define TEST_FILE_NGINX_FANCYINDEX "nginx-fancyindex.html"
 
 #define SAMPLE_ITEM_COUNT 6
 
@@ -285,6 +286,16 @@ TEST_F(TestHTTPDirectory, NginxDefaultIndex)
 
   ASSERT_TRUE(m_httpDirectory.Exists(CURL(GetUrlOfTestFile(TEST_FILE_NGINX_DEFAULT))));
   ASSERT_TRUE(m_httpDirectory.GetDirectory(CURL(GetUrlOfTestFile(TEST_FILE_NGINX_DEFAULT)), items));
+
+  CheckFileItemsAndMetadata(items);
+}
+
+TEST_F(TestHTTPDirectory, NginxFancyIndex)
+{
+  CFileItemList items;
+
+  ASSERT_TRUE(m_httpDirectory.Exists(CURL(GetUrlOfTestFile(TEST_FILE_NGINX_FANCYINDEX))));
+  ASSERT_TRUE(m_httpDirectory.GetDirectory(CURL(GetUrlOfTestFile(TEST_FILE_NGINX_FANCYINDEX)), items));
 
   CheckFileItemsAndMetadata(items);
 }

--- a/xbmc/filesystem/test/data/httpdirectory/nginx-fancyindex.html
+++ b/xbmc/filesystem/test/data/httpdirectory/nginx-fancyindex.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+  <meta name="viewport" content="width=device-width"/>
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+  <title>Files...</title>
+</head>
+<body>
+<div class="box box-breadcrumbs">
+    <div class="box-header">
+      <div class="box-header-content">
+        <div id="breadcrumbs" class="breadcrumbs">
+          <a href="#"></a>
+        </div>
+      </div>
+    </div>
+    <div class="box-content clearfix">
+      <h1>Index of:
+/</h1>
+<table id="list"><thead><tr><th style="width:55%"><a href="?C=N&amp;O=A">File Name</a>&nbsp;<a href="?C=N&amp;O=D">&nbsp;&darr;&nbsp;</a></th><th style="width:20%"><a href="?C=S&amp;O=A">File Size</a>&nbsp;<a href="?C=S&amp;O=D">&nbsp;&darr;&nbsp;</a></th><th style="width:25%"><a href="?C=M&amp;O=A">Date</a>&nbsp;<a href="?C=M&amp;O=D">&nbsp;&darr;&nbsp;</a></th></tr></thead>
+<tbody><tr><td class="link"><a href="../">Parent directory/</a></td><td class="size">-</td><td class="date">-</td></tr>
+<tr><td class="link"><a href="folder1/" title="folder1">folder1/</a></td><td class="size">-</td><td class="date">2019-Jan-01 01:01</td></tr>
+<tr><td class="link"><a href="folder2/" title="folder2">folder2/</a></td><td class="size">-</td><td class="date">2019-Feb-02 02:02</td></tr>
+<tr><td class="link"><a href="sample3%3A%20the%20sampling.mpg" title="sample3: the sampling.mpg">sample3: the sampling.mpg</a></td><td class="size">123 B</td><td class="date">2019-Mar-03 03:03</td></tr>
+<tr><td class="link"><a href="sample4.mpg" title="sample4.mpg">sample4.mpg</a></td><td class="size">123.0 KiB</td><td class="date">2019-Apr-04 04:04</td></tr>
+<tr><td class="link"><a href="sample5.mpg" title="sample5.mpg">sample5.mpg</a></td><td class="size">123.0 MiB</td><td class="date">2019-May-05 05:05</td></tr>
+<tr><td class="link"><a href="sample6.mpg" title="sample6.mpg">sample6.mpg</a></td><td class="size">123.0 GiB</td><td class="date">2019-Jun-06 06:06</td></tr>
+</tbody></table>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Description
This gives Kodi the ability to parse the indexes generated by Nginx's [ngx-fancyindex][0] module.

## Motivation and Context
Webservers running Nginx can use the [`ngx-fancyindex`][0] module to make their index pages more human-friendly and apply basic theming. These "fancy" index pages are currently incompatible with Kodi's web server directory parser. This change adds support for these pages to Kodi.

## How Has This Been Tested?
This has been tested by the included test case, as well as by running it against a local webserver running latest Nginx with the latest version of the `ngx-fancyindex` module enabled. All the existing web server test cases pass and it should not have an impact on any other areas of the code.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed

 [0]: https://github.com/aperezdc/ngx-fancyindex