### PR TITLE
[PVR] Allow timers with invalid channel uid 

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -143,9 +143,27 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
   // Channel
   m_channel = ChannelDescriptor();
 
-  if (m_timerInfoTag->m_iClientChannelUid == PVR_CHANNEL_INVALID_UID)
+  bool bChannelSet(false);
+
+  if (m_timerInfoTag->m_iClientChannelUid != PVR_CHANNEL_INVALID_UID)
   {
-    bool bChannelSet(false);
+    // Find matching channel entry
+    for (const auto& channel : m_channelEntries)
+    {
+      if ((channel.second.channelUid == m_timerInfoTag->m_iClientChannelUid) &&
+          (channel.second.clientId == m_timerInfoTag->m_iClientId))
+      {
+        m_channel = channel.second;
+        bChannelSet = true;
+        break;
+      }
+    }
+    if (!bChannelSet)
+      CLog::LogF(LOGERROR, "Unable to map channel uid to channel entry treat, as invalid");
+  }
+
+  if (!bChannelSet)
+  {
     if (m_timerType->SupportsAnyChannel())
     {
       // Select first matching "Any channel" entry.
@@ -156,6 +174,7 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
         {
           m_channel = channel.second;
           bChannelSet = true;
+          break;
         }
       }
     }
@@ -173,27 +192,8 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
         }
       }
     }
-
     if (!bChannelSet)
-      CLog::LogF(LOGERROR, "Unable to map PVR_CHANNEL_INVALID_UID to channel entry!");
-  }
-  else
-  {
-    // Find matching channel entry
-    bool bChannelSet(false);
-    for (const auto& channel : m_channelEntries)
-    {
-      if ((channel.second.channelUid == m_timerInfoTag->m_iClientChannelUid) &&
-          (channel.second.clientId == m_timerInfoTag->m_iClientId))
-      {
-        m_channel = channel.second;
-        bChannelSet = true;
-        break;
-      }
-    }
-
-    if (!bChannelSet)
-      CLog::LogF(LOGERROR, "Unable to map channel uid to channel entry!");
+      CLog::LogF(LOGERROR, "Unable to map PVR_CHANNEL_INVALID_UID or channel uid to channel entry!");
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
If a PVR timer is received from the backend that is not included in the channel list, modifications to that timer are not send to the backend.  The feedback to a user is to check logs. The log entry indicates an invalid channel uid but that is when the update dialog is opened.

There is no to way to correct the error in Kodi without saving the recording to a valid channel first.  Saving with the default dialog setting "Any Channel" doesn't work.

This change moves the test for valid channels uid before other channel matching tests.  If the channel uid is not valid handle the timer using the existing logic when then timer is already marked invalid.  Use "Any channel" for timers that support that, otherwise choose the first channel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Users should be able to update timers in Kodi that are not marked managed by the backend only.  Also This condition was changed in Matrix.  In Leia users could modify these timers.

An alternate solution providing user feedback that the channel is not valid was not tested because the dialog shows "Any Channel" which shouldn't be an error.

This is a potential improvement over Leia because using "Any channel" is usual a better default than the first channel.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested with timers with valid and invalid channel uid's

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [] All new and existing tests passed
