### PR TITLE
[PVR] Fix deadlock while deleting EPG

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -118,10 +118,7 @@ bool CPVRChannel::QueueDelete()
 
   const std::shared_ptr<CPVREpg> epg = GetEPG();
   if (epg)
-  {
-    CServiceBroker::GetPVRManager().EpgContainer().QueueDeleteEpg(epg);
     ResetEPG();
-  }
 
   bReturn = database->QueueDeleteQuery(*this);
   return bReturn;

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -452,6 +452,16 @@ namespace PVR
      */
     void Notify(const PVREvent& event);
 
+    /*!
+     * @brief Lock the instance. No other thread gets access to this channel until Unlock was called.
+     */
+    void Lock() { m_critSection.lock(); }
+
+    /*!
+     * @brief Unlock the instance. Other threads may get access to this channel again.
+     */
+    void Unlock() { m_critSection.unlock(); }
+
     //@}
   private:
     CPVRChannel();

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -268,7 +268,7 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
       if (epg.second && epg.second->NeedsSave())
       {
         // Note: We need to obtain a lock for every epg instance before we can lock
-        //       the epg db. This order is important. Otherwise deadlocks may occure.
+        //       the epg db. This order is important. Otherwise deadlocks may occur.
         epg.second->Lock();
         changedEpgs.emplace_back(epg.second);
       }
@@ -279,7 +279,7 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
 
   if (!changedEpgs.empty())
   {
-    // Note: We must lock the db the whole time, otherwise races may occure.
+    // Note: We must lock the db the whole time, otherwise races may occur.
     database->Lock();
 
     XbmcThreads::EndTime processTimeslice(iMaxTimeslice);
@@ -612,6 +612,41 @@ bool CPVREpgContainer::RemoveOldEntries()
   return true;
 }
 
+bool CPVREpgContainer::QueueDeleteEpgs(const std::vector<std::shared_ptr<CPVREpg>>& epgs)
+{
+  if (epgs.empty())
+    return true;
+
+  const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
+  if (!database)
+  {
+    CLog::LogF(LOGERROR, "No EPG database");
+    return false;
+  }
+
+  for (const auto& epg : epgs)
+  {
+    // Note: We need to obtain a lock for every epg instance before we can lock
+    //       the epg db. This order is important. Otherwise deadlocks may occur.
+    epg->Lock();
+  }
+
+  database->Lock();
+  for (const auto& epg : epgs)
+  {
+    QueueDeleteEpg(epg);
+    epg->Unlock();
+
+    size_t queryCount = database->GetDeleteQueriesCount();
+    if (queryCount > EPG_COMMIT_QUERY_COUNT_LIMIT)
+      database->CommitDeleteQueries();
+  }
+  database->CommitDeleteQueries();
+  database->Unlock();
+
+  return true;
+}
+
 bool CPVREpgContainer::QueueDeleteEpg(const std::shared_ptr<CPVREpg>& epg)
 {
   if (!epg || epg->EpgID() < 0)
@@ -747,17 +782,7 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   if (bShowProgress && !bOnlyPending)
     progressHandler->DestroyProgress();
 
-  database->Lock();
-  for (const auto& epg : invalidTables)
-  {
-    QueueDeleteEpg(epg);
-
-    size_t queryCount = database->GetDeleteQueriesCount();
-    if (queryCount > EPG_COMMIT_QUERY_COUNT_LIMIT)
-      database->CommitDeleteQueries();
-  }
-  database->CommitDeleteQueries();
-  database->Unlock();
+  QueueDeleteEpgs(invalidTables);
 
   if (bInterrupted)
   {

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -91,11 +91,11 @@ namespace PVR
     bool IsStarted() const;
 
     /*!
-     * @brief Queue the deletion of an EPG table from this container.
-     * @param epg The table to delete.
+     * @brief Queue the deletion of the given EPG tables from this container.
+     * @param epg The tables to delete.
      * @return True on success, false otherwise.
      */
-    bool QueueDeleteEpg(const std::shared_ptr<CPVREpg>& epg);
+    bool QueueDeleteEpgs(const std::vector<std::shared_ptr<CPVREpg>>& epgs);
 
     /*!
      * @brief CEventStream callback for PVR events.
@@ -279,6 +279,13 @@ namespace PVR
      * @param newEpg the EPG containing the updated data.
      */
     void InsertFromDB(const std::shared_ptr<CPVREpg>& newEpg);
+
+    /*!
+     * @brief Queue the deletion of an EPG table from this container.
+     * @param epg The table to delete.
+     * @return True on success, false otherwise.
+     */
+    bool QueueDeleteEpg(const std::shared_ptr<CPVREpg>& epg);
 
     std::shared_ptr<CPVREpgDatabase> m_database; /*!< the EPG database */
 


### PR DESCRIPTION
To speedup database operations, we use external locking for epg and epg database instances. External locking always has potential for deadlocks, because mutexes can easily be acquired in wrong order. This PR fixes a deadlock of exactly this category by ensuring the correct order of locking the involved mutexes.

T1 owns epg database mutex (obtained the lock via external locking in CPVRChannelGroupInternal::RemoveDeletedChannels), wants epg instance mutex
T 33 owns epg instance mutex (obtained via internal locking in CPVREpg::Update), wants epg database mutex

```
Thread 1 (Thread 0xd6bff2a0 (LWP 3048)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
#1  0xf5850798 in __GI_abort () at abort.c:79
#2  0xf585f4b0 in __assert_fail_base (fmt=0xf59559a0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0xf7f2c0f0 "e != EDEADLK || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)", assertion@entry=0xf7f2c2f8 "pthread_mutex_lock.c", file=0xf7f2c2f8 "pthread_mutex_lock.c", file@entry=0xf59559a0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", line=line@entry=423, function=0xf7f2c1e8 <__PRETTY_FUNCTION__.1> "__pthread_mutex_lock_full", function@entry=0xd6bff2a0 "\001") at assert.c:92
#3  0xf585f560 in __GI___assert_fail (assertion=0xf7f2c2f8 "pthread_mutex_lock.c", file=0xf59559a0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", line=line@entry=423, function=0xd6bff2a0 "\001") at assert.c:101
#4  0xf7f1fff4 in __pthread_mutex_lock_full (mutex=0xd6bff2a0) at pthread_mutex_lock.c:423
#5  0xf7f20104 in __GI___pthread_mutex_lock (mutex=mutex@entry=0xd5a32d7c) at pthread_mutex_lock.c:73
#6  0x004b0560 in XbmcThreads::CRecursiveMutex::lock (this=0xd5a32d7c) at ../xbmc/threads/platform/RecursiveMutex.h:33
#7  XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock (this=0xd5a32d7c) at ../xbmc/threads/Lockables.h:49
#8  0x00b4ac04 in XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock (lockable=..., this=0xd6bfe724) at ../xbmc/threads/Lockables.h:112
#9  CSingleLock::CSingleLock (cs=..., this=0xd6bfe724) at ../xbmc/threads/SingleLock.h:27
#10 PVR::CPVREpg::EpgID (this=0xd5a32d58) at ../xbmc/pvr/epg/Epg.cpp:527
#11 0x00b471c4 in PVR::CPVREpgContainer::QueueDeleteEpg (this=0x30ec318, epg=...) at ../xbmc/pvr/epg/EpgContainer.cpp:614
#12 0x00b7664c in PVR::CPVRChannel::QueueDelete (this=0xf301d768) at ../xbmc/pvr/channels/PVRChannel.cpp:114
#13 0x00b81450 in PVR::CPVRChannelGroupInternal::RemoveDeletedChannels (this=<optimized out>, channels=...) at /tmp/libreelec/build.LibreELEC-H6.arm-9.80-devel/toolchain/armv8a-libreelec-linux-gnueabihf/include/c++/10.2.0/bits/shared_ptr_base.h:1324
#14 0x00b7d178 in PVR::CPVRChannelGroup::UpdateGroupEntries (this=this@entry=0xf3014730, channels=..., channelsToRemove=...) at ../xbmc/pvr/channels/PVRChannelGroup.cpp:634
#15 0x00b81568 in PVR::CPVRChannelGroupInternal::UpdateGroupEntries (this=0xf3014730, channels=..., channelsToRemove=...) at ../xbmc/pvr/channels/PVRChannelGroupInternal.cpp:330
#16 0x00b80d38 in PVR::CPVRChannelGroupInternal::Update (this=0xf3014730, channelsToRemove=...) at ../xbmc/pvr/channels/PVRChannelGroupInternal.cpp:115
#17 0x00b84810 in PVR::CPVRChannelGroups::Update (this=0x310eeb8, bChannelsOnly=bChannelsOnly@entry=false) at /tmp/libreelec/build.LibreELEC-H6.arm-9.80-devel/toolchain/armv8a-libreelec-linux-gnueabihf/include/c++/10.2.0/bits/shared_ptr_base.h:1324
#18 0x00b86ac0 in PVR::CPVRChannelGroupsContainer::Update (this=0x311ae80, bChannelsOnly=bChannelsOnly@entry=false) at ../xbmc/pvr/channels/PVRChannelGroupsContainer.cpp:43
#19 0x00bb03c8 in operator() (__closure=<optimized out>) at /tmp/libreelec/build.LibreELEC-H6.arm-9.80-devel/toolchain/armv8a-libreelec-linux-gnueabihf/include/c++/10.2.0/bits/shared_ptr_base.h:1324
#20 PVR::CPVRLambdaJob<PVR::CPVRManager::TriggerChannelGroupsUpdate()::<lambda()> >::DoWork(void) (this=<optimized out>) at ../xbmc/pvr/PVRManager.cpp:59
#21 0x00bb0cfc in PVR::CPVRManagerJobQueue::ExecutePendingJobs (this=<optimized out>) at ../xbmc/pvr/PVRManager.cpp:168
#22 0x00bb24b8 in PVR::CPVRManager::Process (this=0x30ec188) at /tmp/libreelec/build.LibreELEC-H6.arm-9.80-devel/toolchain/armv8a-libreelec-linux-gnueabihf/include/c++/10.2.0/bits/unique_ptr.h:173

...

Thread 33 (Thread 0xd4ffd2a0 (LWP 3052)):
#0  futex_lock_pi (private=0, abstime=0x0, futex_word=0x3191188) at ../sysdeps/nptl/futex-internal.h:412
#1  __pthread_mutex_lock_full (mutex=0x3191188) at pthread_mutex_lock.c:419
#2  0xf7f20104 in __GI___pthread_mutex_lock (mutex=mutex@entry=0x3191188) at pthread_mutex_lock.c:73
#3  0x004b0560 in XbmcThreads::CRecursiveMutex::lock (this=0x3191188) at ../xbmc/threads/platform/RecursiveMutex.h:33
#4  XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock (this=0x3191188) at ../xbmc/threads/Lockables.h:49
#5  0x00b4d314 in XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock (lockable=..., this=0xd4ffc8f4) at ../xbmc/threads/Lockables.h:112
#6  CSingleLock::CSingleLock (cs=..., this=0xd4ffc8f4) at ../xbmc/threads/SingleLock.h:27
#7  PVR::CPVREpgDatabase::GetFirstStartTime (this=0x3191150, iEpgID=778) at ../xbmc/pvr/epg/EpgDatabase.cpp:400
#8  0x00b599c8 in PVR::CPVREpgTagsContainer::IsEmpty (this=this@entry=0xd5a32da4) at ../xbmc/pvr/epg/EpgTagsContainer.cpp:337
#9  0x00b4c3d0 in PVR::CPVREpg::Update (this=0xd5a32d58, this@entry=0x5ffb4c40, start=52463412, start@entry=15, end=7087972, end@entry=0, iUpdateTime=iUpdateTime@entry=7200, iPastDays=1, database=..., bForceUpdate=bForceUpdate@entry=false) at ../xbmc/pvr/epg/Epg.cpp:275
#10 0x00b47890 in PVR::CPVREpgContainer::UpdateEPG (this=this@entry=0x30ec318, bOnlyPending=bOnlyPending@entry=196) at ../xbmc/pvr/epg/EpgContainer.cpp:728
#11 0x00b47f7c in PVR::CPVREpgContainer::Process (this=0x30ec318) at ../xbmc/pvr/epg/EpgContainer.cpp:338
```

Runtime-tested on macOs and Android, latest kodi master.

@lrusak fyi (you submitted the stack traces for this deadlock)
@phunkyfish when you find some time for a review...