### PR TITLE
[linux] Crash report: read kodi.log from $KODI_TEMP directory if set.

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -138,7 +138,11 @@ print_crash_report()
   echo >> $FILE
   echo "################# LOG FILE ##################" >> $FILE
   echo >> $FILE
-  if [ -f $KODI_DATA/temp/@APP_NAME_LC@.log ]
+  if [ -f $KODI_TEMP/@APP_NAME_LC@.log ]
+  then
+    cat $KODI_TEMP/@APP_NAME_LC@.log >> $FILE
+    echo >> $FILE
+  elif [ -f $KODI_DATA/temp/@APP_NAME_LC@.log ]
   then
     cat $KODI_DATA/temp/@APP_NAME_LC@.log >> $FILE
     echo >> $FILE


### PR DESCRIPTION
If $KODI_TEMP is set, kodi.log is located there rather than in $KODI_DATA/temp, so look there first.

## Description
If $KODI_TEMP is set, the kodi.log is located there rather than in $KODI_DATA/temp, so look there first.

## Motivation and Context
Logfile is not included in crash report if $KODI_TEMP (special://temp) is set to a non-default location.
It's simple to include the logfile manually, but it should be done by default.

## How Has This Been Tested?
Runtime tested: crashed kodi with SIGSEGV, logfile is properly included in crash report now.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
