### PR TITLE
Improve HDR related message strings (for friendly translation)

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17159,27 +17159,27 @@ msgstr ""
 
 #: xbmc/Application.cpp
 msgctxt "#34220"
-msgid "HDR is OFF"
+msgid "HDR OFF"
 msgstr ""
 
 #: xbmc/Application.cpp
 msgctxt "#34221"
-msgid "Display HDR is Off"
+msgid "HDR screen off"
 msgstr ""
 
 #: xbmc/Application.cpp
 msgctxt "#34222"
-msgid "HDR is ON"
+msgid "HDR ON"
 msgstr ""
 
 #: xbmc/Application.cpp
 msgctxt "#34223"
-msgid "Display HDR is On"
+msgid "HDR screen on"
 msgstr ""
 
 #: xbmc/Application.cpp
 msgctxt "#34224"
-msgid "Tone map method is:"
+msgid "Tone mapping method"
 msgstr ""
 
 #empty strings from id 34225 to 34299


### PR DESCRIPTION
## Description
Improve HDR related message strings (for friendly translation)

## Motivation and Context
Some messages gets "wrong" translated to Spanish probably because are wrong in English too. e.g. display is translated to "mostrar" (show)   something like  "Show HDR is on". 

And "Tone map method is:" becomes too long for a toast title (in spanish)

I think it will now be better translated into other languages in general. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
