### PR TITLE
[WIP] Fix build with musl-based toolchains

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -39,6 +39,7 @@
 #include <time.h>
 #include <signal.h>
 #ifdef TARGET_POSIX
+#include <paths.h>
 #include "PlatformDefs.h" // for __stat64
 #endif
 #include "FileItem.h"
@@ -1479,7 +1480,7 @@ extern "C"
     int ret;
 
     ret = dll_fgetpos64(stream, &tmpPos);
-#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
+#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || !defined(__GLIBC__)
     *pos = (fpos_t)tmpPos;
 #else
     pos->__pos = (off_t)tmpPos.__pos;
@@ -1492,8 +1493,9 @@ extern "C"
     CFile* pFile = g_emuFileWrapper.GetFileXbmcByStream(stream);
     if (pFile != NULL)
     {
-#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
-      *pos = pFile->GetPosition();
+#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || !defined(__GLIBC__)
+    uint64_t *ppos = (uint64_t *) pos;
+    *ppos = pFile->GetPosition();
 #else
       pos->__pos = pFile->GetPosition();
 #endif
@@ -1508,8 +1510,9 @@ extern "C"
     int fd = g_emuFileWrapper.GetDescriptorByStream(stream);
     if (fd >= 0)
     {
-#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
-      if (dll_lseeki64(fd, *pos, SEEK_SET) >= 0)
+#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || !defined(__GLIBC__)
+    const uint64_t *ppos = (const uint64_t *) pos;
+    if (dll_lseeki64(fd, *ppos, SEEK_SET) >= 0)
 #else
       if (dll_lseeki64(fd, (__off64_t)pos->__pos, SEEK_SET) >= 0)
 #endif
@@ -1531,7 +1534,7 @@ extern "C"
     if (fd >= 0)
     {
       fpos64_t tmpPos;
-#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
+#if !defined(TARGET_POSIX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || !defined(__GLIBC__)
       tmpPos= *pos;
 #else
       tmpPos.__pos = (off64_t)(pos->__pos);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.h
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.h
@@ -17,7 +17,7 @@
 #define _onexit_t void*
 #endif
 
-#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || !defined(__GLIBC__)
 typedef off_t __off_t;
 typedef int64_t off64_t;
 typedef off64_t __off64_t;

--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -23,7 +23,7 @@
 #include <dirent.h>
 #include <dlfcn.h>
 
-#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || !defined(__GLIBC__)
 typedef off_t     __off_t;
 typedef int64_t   off64_t;
 typedef off64_t   __off64_t;

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -49,7 +49,7 @@
 #ifdef  __cplusplus
 extern "C" {
 #endif
-#if defined(TARGET_ANDROID) && (defined(__i386__) || defined(__x86_64__)) && !defined(modify_ldt)
+#if defined(__linux__) && !defined(__GLIBC__) && !defined(modify_ldt)
 #define modify_ldt(a,b,c) syscall( __NR_modify_ldt,  a, b, c);
 #else
 int modify_ldt(int func, void *ptr, unsigned long bytecount);


### PR DESCRIPTION
## Description
Kodi currently fails to build with a musl-based toolchain, this is a follow-up for https://github.com/xbmc/xbmc/pull/9672

These two patches are used by the Gentoo musl project:
https://gitweb.gentoo.org/proj/musl.git/tree/media-tv/kodi/files/musl/19.0/0002-fix-fileemu.patch
https://gitweb.gentoo.org/proj/musl.git/tree/media-tv/kodi/files/musl/19.0/0004-Fix-ldt-for-musl.patch
and were build-tested with buildroot using a musl-based toolchain.
## Motivation and Context
Fix musl build.

## How Has This Been Tested?
Build-tested using
```
$ output/host/bin/x86_64-linux-gcc --version
x86_64-linux-gcc.br_real (Buildroot 2020.02) 8.3.0
$ output/host/bin/x86_64-linux-gcc -dumpmachine
x86_64-buildroot-linux-musl
```
and with an uClibc- and a glibc-based toolchain
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
