### PR TITLE
Disable tone mapping method switch shortcut key (Alt+F11) if is an HDR capable display and use HDR is enabled

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1700,6 +1700,12 @@ bool CApplication::OnAction(const CAction &action)
   // Tone Mapping : switch to next tone map method
   if (action.GetID() == ACTION_CYCLE_TONEMAP_METHOD)
   {
+    // Only enables tone mapping switch if display is not HDR capable or HDR is not enabled
+    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+            CServiceBroker::GetWinSystem()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
+        CServiceBroker::GetWinSystem()->IsHDRDisplay())
+      return true;
+
     if (m_appPlayer.IsPlayingVideo())
     {
       CVideoSettings vs = m_appPlayer.GetVideoSettings();


### PR DESCRIPTION
## Description
Disable tone mapping method switch shortcut key (Alt+F11) if is an HDR capable display and use HDR is enabled on settings / Player / Use HDR display capabilities.

## Motivation and Context
Some users may find confusing / weird that pressing Alt+F11 (cycle tone mapping method) shows toast notification but does nothing when playing HDR pass-through mode. 

Tone mapping is anyway disabled but toast message suggest that tone map method is changed. Is better disable notification too. In the same way, it is already disabled tone mapping in video OSD menu.

## How Has This Been Tested?
Runtime tested on systems with/without HDR display and HDR display but "Use HDR display capabilities" disabled.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
