### PR TITLE
CDVDSubtitlesLibass: remove use of deprecated method ass_set_aspect_ratio

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -165,7 +165,7 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(int frameWidth, int frameHeight, int
   ass_set_margins(m_renderer, topmargin, topmargin, leftmargin, leftmargin);
   ass_set_use_margins(m_renderer, useMargin);
   ass_set_line_position(m_renderer, position);
-  ass_set_aspect_ratio(m_renderer, dar, sar);
+  ass_set_pixel_aspect(m_renderer, sar / dar);
   return ass_render_frame(m_renderer, m_track, DVD_TIME_TO_MSEC(pts), changes);
 }
 


### PR DESCRIPTION
as of libass 0.15.0 the method `ass_set_aspect_ratio` will be marked as deprecated and throw a warning. Let's fix that.

This fix is to use `ass_set_pixel_aspect` instead

see: https://github.com/libass/libass/commit/42aa6ee392a25a5f699c44bca329fd6363879779

```
[1303/1477] Building CXX object build/cores/VideoPlayer/subtitles/CMakeFiles/dvdsubtitles.dir/DVDSubtitlesLibass.cpp.o
../xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp: In member function 'ASS_Image* CDVDSubtitlesLibass::RenderImage(int, int, int, int, int, int, double, int, double, int*)':
../xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp:168:44: warning: 'void ass_set_aspect_ratio(ASS_Renderer*, double, double)' is deprecated: use 'ass_set_pixel_aspect' instead [-Wdeprecated-declarations]
  168 |   ass_set_aspect_ratio(m_renderer, dar, sar);
      |                                            ^
In file included from ../xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h:14,
                 from ../xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp:9:
/home/lukas/git/libreelec/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/ass/ass.h:421:59: note: declared here
  421 | ASS_DEPRECATED("use 'ass_set_pixel_aspect' instead") void ass_set_aspect_ratio(ASS_Renderer *priv, double dar, double sar);
      |                                                           ^~~~~~~~~~~~~~~~~~~~
```