### PR TITLE
use spdlog's dup_filter_sink to avoid duplicate log messages (fixes #18535)

### DIFF
--- a/xbmc/platform/android/utils/AndroidInterfaceForCLog.cpp
+++ b/xbmc/platform/android/utils/AndroidInterfaceForCLog.cpp
@@ -22,5 +22,5 @@ void CAndroidInterfaceForCLog::AddSinks(
     std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const
 {
   distributionSink->add_sink(
-      std::make_shared<spdlog::sinks::android_sink_mt>(CCompileInfo::GetAppName()));
+      std::make_shared<spdlog::sinks::android_sink_st>(CCompileInfo::GetAppName()));
 }

--- a/xbmc/platform/darwin/utils/DarwinInterfaceForCLog.h
+++ b/xbmc/platform/darwin/utils/DarwinInterfaceForCLog.h
@@ -11,7 +11,6 @@
 #include "platform/posix/utils/PosixInterfaceForCLog.h"
 
 #include <memory>
-#include <mutex>
 
 #include <spdlog/formatter.h>
 #include <spdlog/sinks/sink.h>
@@ -34,5 +33,4 @@ public:
 
 private:
   std::unique_ptr<spdlog::formatter> m_formatter;
-  std::mutex m_mutex;
 };

--- a/xbmc/platform/darwin/utils/DarwinInterfaceForCLog.mm
+++ b/xbmc/platform/darwin/utils/DarwinInterfaceForCLog.mm
@@ -33,7 +33,6 @@ void CDarwinInterfaceForCLog::AddSinks(
 
 void CDarwinInterfaceForCLog::log(const spdlog::details::log_msg& msg)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
   spdlog::memory_buf_t formatted;
   m_formatter->format(msg, formatted);
   formatted.push_back('\0');
@@ -42,7 +41,6 @@ void CDarwinInterfaceForCLog::log(const spdlog::details::log_msg& msg)
 
 void CDarwinInterfaceForCLog::flush()
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
   fflush(stderr);
 }
 
@@ -53,6 +51,5 @@ void CDarwinInterfaceForCLog::set_pattern(const std::string& pattern)
 
 void CDarwinInterfaceForCLog::set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
   m_formatter = std::move(sink_formatter);
 }

--- a/xbmc/platform/win32/utils/Win32InterfaceForCLog.cpp
+++ b/xbmc/platform/win32/utils/Win32InterfaceForCLog.cpp
@@ -30,5 +30,5 @@ spdlog_filename_t CWin32InterfaceForCLog::GetLogFilename(const std::string& file
 void CWin32InterfaceForCLog::AddSinks(
     std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const
 {
-  distributionSink->add_sink(std::make_shared<spdlog::sinks::msvc_sink_mt>());
+  distributionSink->add_sink(std::make_shared<spdlog::sinks::msvc_sink_st>());
 }

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -120,7 +120,7 @@ void CLog::Initialize(const std::string& path)
   }
 
   // create the file sink
-  m_fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+  m_fileSink = std::make_shared<spdlog::sinks::basic_file_sink_st>(
       m_platform->GetLogFilename(filePath), false);
   m_fileSink->set_pattern(LogPattern);
 

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -33,6 +33,7 @@
 
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/dist_sink.h>
+#include <spdlog/sinks/dup_filter_sink.h>
 
 static constexpr unsigned char Utf8Bom[3] = {0xEF, 0xBB, 0xBF};
 static const std::string LogFileExtension = ".log";
@@ -119,10 +120,14 @@ void CLog::Initialize(const std::string& path)
       file.Write(Utf8Bom, sizeof(Utf8Bom));
   }
 
-  // create the file sink
-  m_fileSink = std::make_shared<spdlog::sinks::basic_file_sink_st>(
+  // create the file sink within a duplicate filter sink
+  auto duplicateFilterSink =
+      std::make_shared<spdlog::sinks::dup_filter_sink_st>(std::chrono::seconds(10));
+  auto basicFileSink = std::make_shared<spdlog::sinks::basic_file_sink_st>(
       m_platform->GetLogFilename(filePath), false);
-  m_fileSink->set_pattern(LogPattern);
+  basicFileSink->set_pattern(LogPattern);
+  duplicateFilterSink->add_sink(basicFileSink);
+  m_fileSink = duplicateFilterSink;
 
   // add it to the existing sinks
   m_sinks->add_sink(m_fileSink);

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -28,8 +28,7 @@ namespace spdlog
 {
 namespace sinks
 {
-template<typename Mutex>
-class basic_file_sink;
+class sink;
 
 template<typename Mutex>
 class dist_sink;
@@ -195,7 +194,7 @@ private:
   std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> m_sinks;
   Logger m_defaultLogger;
 
-  std::shared_ptr<spdlog::sinks::basic_file_sink<spdlog::details::null_mutex>> m_fileSink;
+  std::shared_ptr<spdlog::sinks::sink> m_fileSink;
 
   int m_logLevel;
 

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -195,7 +195,7 @@ private:
   std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> m_sinks;
   Logger m_defaultLogger;
 
-  std::shared_ptr<spdlog::sinks::basic_file_sink<std::mutex>> m_fileSink;
+  std::shared_ptr<spdlog::sinks::basic_file_sink<spdlog::details::null_mutex>> m_fileSink;
 
   int m_logLevel;
 


### PR DESCRIPTION
## Description
This puts a `spdlog::sinks::dup_filter_sink_mt` between the existing distribution sink and the `spdlog::sinks::basic_file_sink_mt` which is responsible for writing all log messages to Kodi's log file. Therefore the duplicate log filtering is only applied to the log messages going to the log file but not to log messages going to other channels (e.g. Android's logcat or Visual Studio debug output).

I've configured the `dup_filter_sink` to filter duplicates for 10 seconds. Is that OK or should I increase / decrease it? Log messages are only considered duplicates if they have the exact same log message and if they are logged within the specified time window.

This should fix #18535 and all other cases where we log the same messages multiple times in a row. The new log output in Kodi's log file now looks like this:
```
...
2021-01-18 07:56:56.204 T:8340  WARNING <general>: CRenderManager::WaitForBuffer - timeout waiting for buffer
2021-01-18 07:57:06.497 T:8340  WARNING <general>: Skipped 19 duplicate messages..
2021-01-18 07:57:06.496 T:8340  WARNING <general>: CRenderManager::WaitForBuffer - timeout waiting for buffer
2021-01-18 07:57:16.822 T:8340  WARNING <general>: Skipped 19 duplicate messages..
...
```

## How Has This Been Tested?
Manually by pausing playback of a video as described in #18535.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed