### PR TITLE
[addons] platform dependent addon activation at startup

### DIFF
--- a/xbmc/platform/Platform.h
+++ b/xbmc/platform/Platform.h
@@ -34,4 +34,9 @@ public:
    * or initialisation (like setting environment variables for example)
    */
   virtual bool Init();
+
+  /**\brief Flag whether disabled add-ons - installed via packagemanager or manually - should be
+   * offered for configuration and activation on kodi startup for this platform
+   */
+  virtual bool IsConfigureAddonsAtStartupEnabled() { return false; };
 };

--- a/xbmc/platform/linux/PlatformLinux.h
+++ b/xbmc/platform/linux/PlatformLinux.h
@@ -21,6 +21,7 @@ public:
   ~CPlatformLinux() override = default;
 
   bool Init() override;
+  bool IsConfigureAddonsAtStartupEnabled() override { return true; };
 
 private:
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;


### PR DESCRIPTION
## Description
PR https://github.com/xbmc/xbmc/pull/19033 allows to configure and enable add-ons at kodi startup for all platforms. This is not suitable for platforms like `TVOS` and `Windows UWP` where certain add-ons need to be shipped by default. ref. https://github.com/xbmc/xbmc/issues/19079

~~thus a new environment variable `ENABLEADDONS` is introduced per platform, which controls this behavior and allows a better finetuning:~~

- disabled add-ons are now only offered for Configuration/Activation on the Linux platform (including LibreElec).
- disabled incompatible add-ons (e.g. after migration) are still checked on all platforms.

EDIT:
env var approach has been discarded. the flag will be passed through `CPlatform` -> `CServiceManager` -> `CServiceBroker`

## How Has This Been Tested?
debian buster

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
