### PR TITLE
[VideoPlayer] Reset audio/video stream state on VideoPlayer reset [Issue 18025]

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1199,6 +1199,8 @@ void CVideoPlayer::Prepare()
   m_offset_pts = 0;
   m_CurrentAudio.lastdts = DVD_NOPTS_VALUE;
   m_CurrentVideo.lastdts = DVD_NOPTS_VALUE;
+  m_HasAudio = false;
+  m_HasVideo = false;
 
   IPlayerCallback *cb = &m_callback;
   CFileItem fileItem = m_item;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Issue (https://github.com/xbmc/xbmc/issues/18025) describes a condition where Kodi will render a still video frame if the input stream has been switched from an audio+video stream to an audio-only stream.

Due to a recent bug report against my third-party PVR addon that referenced this Issue from the UK, I took another look at this.  I found that while the Windows platform build does indeed not create the proper all-black video frame as many/all other platforms do (*nix ARMHF, Android, etc.), Adhering to @FernetMenta's advice in that Issue's discussion provided a better solution for all platform(s) that I am able to test.

On non-Windows platforms I found that an all-black still frame will be rendered as expected, but that end result is not equivalent to how the non-Windows system(s) behave.  I expected the audio-only interface to be shown, with the Kodi skin background as opposed to a black screen.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Intends to resolve: [Issue 18025](https://github.com/xbmc/xbmc/issues/18025)

Motivation: Come up with an acceptable/quick-fix way to deal with the problem described in [Issue 18025](https://github.com/xbmc/xbmc/issues/18025), and was reported to me as a third-party PVR addon problem to solve.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Primarily tested on Windows 10 (x64) 'standard' (not UWP) build, but was also tested on an ARM-based Android device and an ARMHF-based Linux device (OSMC).  I found that this PR improves the default behavior on all tested platforms such that Kodi will render the "no video stream is present here" image and not cause any additional problems.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

While simple in nature, I am perfectly wiling to accept any changeset(s) that can move this forward.

Suggest "WIP" tag until @FernetMenta has the bandwidth to look at this.
