### PR TITLE
[json-rpc] Addons.SetAddonEnabled: add optional parameter disabledReason

### DIFF
--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -1962,7 +1962,8 @@
     "permission": "ManageAddon",
     "params": [
       { "name": "addonid", "type": "string", "required": true },
-      { "name": "enabled", "$ref": "Global.Toggle", "required": true }
+      { "name": "enabled", "$ref": "Global.Toggle", "required": true },
+      { "name": "disabledReason", "type": "number", "required": false, "default": 0 }
     ],
     "returns": "string"
   },


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
By the optional parameter it is possible to use user defined disable reason.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
A while ago the possibility to set a disable reason was added: https://github.com/xbmc/xbmc/commit/8c028fe255491a5c340cf50e134511f865867c30
Since merge of PR #19033 a pop up happen if a addon is getting disabled by `jsonrpc`.
I just think the optional parameter got missed by https://github.com/xbmc/xbmc/commit/8c028fe255491a5c340cf50e134511f865867c30

When disabledReason is not set (0) it get automatic set to AddonDisabledReason::NONE and you will get a pop up on next Kodi start. If disabledReason is set to AddonDisabledReason::USER on disable by `jsonrpc` there is no pop up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On last master HEAD.

**Enable by not using param disabledReason**
```text
./json.sh '{"jsonrpc":"2.0","method":"Addons.SetAddonEnabled","params":{"addonid":"driver.dvb.crazycat","enabled":true},"id":1}'

---------------------------------------------------
Request: {
    "jsonrpc": "2.0",
    "method": "Addons.SetAddonEnabled",
    "params": {
        "addonid": "driver.dvb.crazycat",
        "enabled": true
    },
    "id": 1
}
---------------------------------------------------
Response: {
    "id": 1,
    "jsonrpc": "2.0",
    "result": "OK"
}
```
**Disable by using param disabledReason**
```text
./json.sh '{"jsonrpc":"2.0","method":"Addons.SetAddonEnabled","params":{"addonid":"driver.dvb.crazycat","enabled":false,"disabledReason":1},"id":1}'

---------------------------------------------------
Request: {
    "jsonrpc": "2.0",
    "method": "Addons.SetAddonEnabled",
    "params": {
        "addonid": "driver.dvb.crazycat",
        "enabled": false,
        "disabledReason": 1
    },
    "id": 1
}
---------------------------------------------------
Response: {
    "id": 1,
    "jsonrpc": "2.0",
    "result": "OK"
}
```
**Disable by not using param disabledReason**
```text
./json.sh '{"jsonrpc":"2.0","method":"Addons.SetAddonEnabled","params":{"addonid":"driver.dvb.crazycat","enabled":false},"id":1}'

---------------------------------------------------
Request: {
    "jsonrpc": "2.0",
    "method": "Addons.SetAddonEnabled",
    "params": {
        "addonid": "driver.dvb.crazycat",
        "enabled": false
    },
    "id": 1
}
---------------------------------------------------
Response: {
    "id": 1,
    "jsonrpc": "2.0",
    "result": "OK"
}
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
