### PR TITLE
strings.po: Add weather token 'Breezy'

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4348,8 +4348,13 @@ msgctxt "#1302"
 msgid "Volume control steps"
 msgstr ""
 
-#empty strings from id 1303 to 1374
+#empty strings from id 1303 to 1373
 #strings from 1350 to 1449 are reserved for weather translation
+
+#. Weather token
+msgctxt "#1374"
+msgid "Breezy"
+msgstr ""
 
 #. Weather token
 msgctxt "#1375"


### PR DESCRIPTION
This adds a missing weather token string "Breezy", which I encountered occasionally on my German living room setup. I thought it would be just a missing translation, but root cause was that there was no weather token defined so far, which is ofc a precondition for a translation.

![IMG_5559](https://user-images.githubusercontent.com/3226626/105243209-08ad3a80-5b6f-11eb-9c2e-9f6bddd66f89.JPG)

Please note that a had to add the new string before the current first weather token string, because the last string in the defined string range (1449) was already taken.

@ronie we talked about this some time ago. Good to go?