### PR TITLE
BitstreamConverter: Add header size exception for UNSPEC62 NALUs

### DIFF
--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -109,8 +109,13 @@ protected:
   bool              BitstreamConvertInitAVC(void *in_extradata, int in_extrasize);
   bool              BitstreamConvertInitHEVC(void *in_extradata, int in_extrasize);
   bool              BitstreamConvert(uint8_t* pData, int iSize, uint8_t **poutbuf, int *poutbuf_size);
-  static void       BitstreamAllocAndCopy(uint8_t **poutbuf, int *poutbuf_size,
-                      const uint8_t *sps_pps, uint32_t sps_pps_size, const uint8_t *in, uint32_t in_size);
+  static void BitstreamAllocAndCopy(uint8_t** poutbuf,
+                                    int* poutbuf_size,
+                                    const uint8_t* sps_pps,
+                                    uint32_t sps_pps_size,
+                                    const uint8_t* in,
+                                    uint32_t in_size,
+                                    uint8_t nal_type);
 
   typedef struct omx_bitstream_ctx {
       uint8_t  length_size;


### PR DESCRIPTION
## Description
Currently, Dolby Vision only works on Android using an NVIDIA Shield TV (and other Android TV devices).
This change adds an exception to the bitstream converted to force type 62 NALUs to use a header of size 4.

The effects of this makes the FireTV Android devices decode Dolby Vision properly, as the metadata is otherwise ignored.

## Motivation and Context
It allows playback of Dolby Vision files (those hinted as `video/dolby-vision`) with both FireTV Stick 4K (2018), and FireTV Stick 4K Max (2021).
I have not tested the FireTV Cube.

Without the change, profile 4/5 files would play in SDR, and other profiles in HDR10 only.
Fixes #18890, #17451

## How Has This Been Tested?
Tested on both FireTV Stick 4K 2018 and FireTV Stick 4K Max (2021) devices, with an LG OLED C8 TV.
Playback through files shared with DLNA, as well as PlexKodiConnect now playback properly in Dolby Vision.
Before the change, all Dolby Vision files would not trigger Dolby Vision mode on the display.

Since NALU type 62 only exists for HEVC, this should not affect any other codec.


## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
