### PR TITLE
Try reading /etc/localtime as symbolic link

### DIFF
--- a/xbmc/platform/posix/PosixTimezone.cpp
+++ b/xbmc/platform/posix/PosixTimezone.cpp
@@ -204,6 +204,11 @@ std::string CPosixTimezone::GetOSConfiguredTimezone()
    // try Slackware approach first
    ssize_t rlrc = readlink("/etc/localtime-copied-from"
                            , timezoneName, sizeof(timezoneName)-1);
+
+   // RHEL and maybe other distros make /etc/localtime a symlink
+   if (rlrc == -1)
+     rlrc = readlink("/etc/localtime", timezoneName, sizeof(timezoneName)-1);
+
    if (rlrc != -1)
    {
      timezoneName[rlrc] = '\0';


### PR DESCRIPTION
## Description

Some distros symlink /etc/localtime to the zoneinfo directory. The
slackware approach of getting the last two path parts should work fine
here as well.

## Motivation and Context
My timezone wasn't getting detected

## How Has This Been Tested?
Yes, ran on my NixOS machine.

