### PR TITLE
Fix chapter skipping and seeking in Blurays with popup menus

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -484,20 +484,29 @@ void CDVDInputStreamBluray::ProcessEvent() {
   case BD_EVENT_TITLE:
   {
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_TITLE %d", m_event.param);
+    m_player->OnDiscNavResult(nullptr, BD_EVENT_TITLE);
     const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
 
     if (m_event.param == BLURAY_TITLE_TOP_MENU)
     {
       m_title = disc_info->top_menu;
+      m_player->OnDiscNavResult(nullptr, BLURAY_TITLE_TOP_MENU);
       m_menu = true;
       break;
     }
     else if (m_event.param == BLURAY_TITLE_FIRST_PLAY)
+    {
       m_title = disc_info->first_play;
+      m_player->OnDiscNavResult(nullptr, BLURAY_TITLE_FIRST_PLAY);
+    }
     else if (m_event.param <= disc_info->num_titles)
       m_title = disc_info->titles[m_event.param];
     else
       m_title = nullptr;
+  
+    if (m_event.param == BLURAY_UO_TITLE_SEARCH)
+      m_player->OnDiscNavResult(nullptr, BLURAY_UO_TITLE_SEARCH);
+  
     m_menu = false;
 
     break;
@@ -547,6 +556,7 @@ void CDVDInputStreamBluray::ProcessEvent() {
   case BD_EVENT_MENU:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_MENU %d",
         m_event.param);
+    m_player->OnDiscNavResult(nullptr, BD_EVENT_MENU);
     m_menu = (m_event.param != 0);
     break;
 
@@ -759,6 +769,7 @@ void CDVDInputStreamBluray::OverlayFlush(int64_t pts)
 
   m_player->OnDiscNavResult(static_cast<void*>(group), BD_EVENT_MENU_OVERLAY);
   group->Release();
+  m_menu = true;
 #endif
 }
 
@@ -1113,7 +1124,6 @@ void CDVDInputStreamBluray::OnMenu()
 
   if(bd_user_input(m_bd, -1, BD_VK_POPUP) >= 0)
   {
-    m_menu = !m_menu;
     return;
   }
   CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::OnMenu - popup failed, trying root");

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -262,6 +262,7 @@ public:
   float GetAVDelay() override;
   bool IsInMenu() const override;
   bool HasMenu() const override;
+  bool IsBlurayTopMenu;
 
   void SetSubTitleDelay(float fValue = 0.0f) override;
   float GetSubTitleDelay() override;


### PR DESCRIPTION
## Description
This is a continuation of a work that started in this commit here, that got merged:
https://github.com/xbmc/xbmc/pull/17210

Everything stated there is still true as we don't have any means to findout when a popup menu is closed. I have debuged every line in the popup rendering and nothing is consistent when the popup menu is gone.

A Bluray and Bluray UHD has 2 kind of menus, a top menu, which is static, and a popup menu that can be controlled during movie playback. Kodi, on the other hand, has 2 states or it is inside a menu or it is not. 

This causes a few problems because, as it should, chapter skipping and seeking should not be allowed during top menus, but it should be allowed during popup menus. 

The previewsly proposed solution requires the end user to identify whenever a popup menu is present and control it by setting it to on and off with the menu key. This isn't ideal since it can break if the user just closes the popup menu without performing any action to restart playback (like chapter skipping, subtitle changing and others) or if the user just closes the popup menu. The state would be out of sync.

The proposed solution here tries to solve (for good) the issue while preserving playback of DVDs. 
It identifies whenever it is in a TopMenu and blocks chapter skipping and seeking, as it should, but enables it for all other menus, which in this case it is the popup menu. 
It reverts back the previews commit so a menu state is triggered whenever a popup menu is flushed to the display and is set to off whenever a new title/chapter plays.


## How Has This Been Tested?
I have tested this on Windows x64, since Java Runtime Enviroment is needed and this can only be used on Windows and Linux.
Other users in the forum have expressed that the solution do work as can be seen here:
https://forum.kodi.tv/showthread.php?tid=359995&pid=3008492#pid3008492
and here:
https://forum.kodi.tv/showthread.php?tid=316378&pid=3008563#pid3008563

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X ] I have added tests to cover my change
- [ ] All new and existing tests passed
