### PR TITLE
[Windows][Fix] Wrong black level using limited-full-limited chain with HDR PQ output

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1174,23 +1174,9 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
 
   if (SUCCEEDED(m_swapChain.As(&swapChain3)))
   {
-    DXGI_COLOR_SPACE_TYPE cs = colorSpace;
-    if (DX::Windowing()->UseLimitedColor())
+    if (SUCCEEDED(swapChain3->SetColorSpace1(colorSpace)))
     {
-      switch (cs)
-      {
-        case DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709:
-          cs = DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709;
-          break;
-        case DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020:
-          cs = DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020;
-          break;
-      }
-    }
-    if (SUCCEEDED(swapChain3->SetColorSpace1(cs)))
-    {
-      m_IsTransferPQ = cs == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020 ||
-                       cs == DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020;
+      m_IsTransferPQ = (colorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
 
       CLog::LogF(LOGDEBUG, "DXGI SetColorSpace1 success");
     }


### PR DESCRIPTION
## Description
Fix: wrong black level using limited-full-limited chain with HDR PQ output.
Fixes https://github.com/xbmc/xbmc/issues/18367

## Motivation and Context
In current Kodi versions limited range video adjustments is handled with pixel shaders (for both GUI and video output stage). At swapchain, DX and video driver level is always working in full range.

It seemed logical to use the DXGI format `DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020` for HDR in limited range but this results in a "double conversion": first at the swapchain level and then at the pixel shaders level.

The bottom line is that the DXGI format should always be `DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020` and for limited range do adjustment with shaders (same as for SDR).

At shaders level signal gets normalized to range 0 - 1.0 so does not matters if output is 8-bit or 10-bit depth. Current formula for full-range to limited-range transformation is valid for both 10-bit / 8-bit video.

https://github.com/xbmc/xbmc/blob/c01b0f5778c7397325e29238a861d8dc62289e2b/system/shaders/output_d3d.fx#L180

e.g. black level is 0.0626 value in normalized 0 - 1.0 range independent of bit depth.

Probably very few people have realized it because today almost everyone (myself included) uses RGB full-full-full chain. However, merging this PR, people with prefers limited-full-limited chain can continue using this setup for HDR passthrough.

I at least am not able to find any quality difference or downside in using one configuration or another. It just works fine both ways now.

## How Has This Been Tested?
Setup: limited (Kodi) - full (PC) - limited (TV) and compare black level playing HDR10 content. 
Should be the same as setup with full-full-full chain. 
Tested on Intel NUC8i3BEK and Sony AG9 TV.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
