### PR TITLE
FFmpegImage: Use image2 instead of the jpeg_pipe

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -196,7 +196,7 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
 
   AVInputFormat* inp = nullptr;
   if (is_jpeg)
-    inp = av_find_input_format("jpeg_pipe");
+    inp = av_find_input_format("image2");
   else if (m_strMimeType == "image/apng")
     inp = av_find_input_format("apng");
   else if (is_png)
@@ -209,7 +209,7 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
     inp = av_find_input_format("webp_pipe");
   // brute force parse if above check already failed
   else if (m_strMimeType == "image/jpeg" || m_strMimeType == "image/jpg")
-    inp = av_find_input_format("jpeg_pipe");
+    inp = av_find_input_format("image2");
   else if (m_strMimeType == "image/png")
     inp = av_find_input_format("png_pipe");
   else if (m_strMimeType == "image/tiff")


### PR DESCRIPTION
With the jpeg_pipe having changed behaviour in recent ffmpeg version, let's use image2 for now. This involves another demuxer also for when we properly detect jpeg and others in the first bytes.

I call this rather a workaround, but upstream communication was a bit difficult this time, while it might have been obvious to these colleagues what we are doing wrong, but it sadly was not obvious to me.

Fixes: #19103 and #18744 - upstream report: https://trac.ffmpeg.org/ticket/8967