### PR TITLE
[Windows] Adjust of HLG to PQ metadata to get a more accurate black level

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -564,7 +564,8 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
     if (m_HdrType != HDR_TYPE::HDR_HLG)
     {
       // Windows 10 doesn't support HLG HDR passthrough
-      // It's used HDR10 with dummy metadata and shaders to convert HLG transfer to PQ transfer
+      // It's used HDR10 with reference metadata and shaders to convert HLG transfer to PQ transfer
+      // Values according BT.2100 recommendations
       DXGI_HDR_METADATA_HDR10 hdr10 = {};
       hdr10.RedPrimary[0] = 34000; // Display P3 primaries
       hdr10.RedPrimary[1] = 16000;
@@ -575,7 +576,7 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
       hdr10.WhitePoint[0] = 15635;
       hdr10.WhitePoint[1] = 16450;
       hdr10.MaxMasteringLuminance = 1000 * 10000; // 1000 nits
-      hdr10.MinMasteringLuminance = 100; // 0.01 nits
+      hdr10.MinMasteringLuminance = 50; // 0.005 nits
       DX::Windowing()->SetHdrMetaData(hdr10);
       CLog::LogF(LOGINFO, "Switching to HDR rendering");
       DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);


### PR DESCRIPTION
## Description
Adjust of HLG to PQ metadata to get a more accurate black level.

## Motivation and Context
According BT.2100 standard HLG should use a black level of 0.005 nits or less (in a reference environment):

> HLG is supported in Rec. 2100 with a nominal peak luminance of 1,000 cd/m2 and a system gamma value that can be adjusted depending on background luminance.[1] For a reference viewing environment the peak luminance should be 1,000 cd/m2 or more and the black level should be 0.005 cd/m2 or less.

https://en.wikipedia.org/wiki/Rec._2100
https://www.itu.int/rec/recommendation.asp?lang=en&parent=R-REC-BT.2100-2-201807-I

Changed min ML metadata from actual 0.01 to 0.005.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
