### PR TITLE
[PVR] Guide window: Fix crash while switching channel groups.

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -777,6 +777,22 @@ void CGUIEPGGridContainer::UpdateItems()
       int iBlockIndex = CGUIEPGGridContainerModel::INVALID_INDEX;
       m_gridModel->FindChannelAndBlockIndex(channelUid, broadcastUid, eventOffset, iChannelIndex, iBlockIndex);
 
+      if (iBlockIndex != CGUIEPGGridContainerModel::INVALID_INDEX)
+      {
+        newBlockIndex = iBlockIndex;
+      }
+      else if (newBlockIndex > m_gridModel->GetLastBlock())
+      {
+        // default to now
+        newBlockIndex = m_gridModel->GetNowBlock();
+
+        if (newBlockIndex > m_gridModel->GetLastBlock())
+        {
+          // last block is in the past. default to last block
+          newBlockIndex = m_gridModel->GetLastBlock();
+        }
+      }
+
       if (iChannelIndex != CGUIEPGGridContainerModel::INVALID_INDEX)
       {
         newChannelIndex = iChannelIndex;
@@ -787,16 +803,6 @@ void CGUIEPGGridContainer::UpdateItems()
       {
         // default to first channel
         newChannelIndex = 0;
-      }
-
-      if (iBlockIndex != CGUIEPGGridContainerModel::INVALID_INDEX)
-      {
-        newBlockIndex = iBlockIndex;
-      }
-      else if (newBlockIndex > m_gridModel->GetLastBlock())
-      {
-        // default to now
-        newBlockIndex = m_gridModel->GetNowBlock();
       }
     }
 


### PR DESCRIPTION
Fixes a crash in the Guide window with a rare edge case where the most recent EPG event is in the past.

Runtime-tested on macOS and Android, latest kodi master, with test data provided by @phunkyfish 

@phunkyfish hope you find some time for a code review.