### PR TITLE
Resolution: Always prefer truly exact resolution match

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -130,7 +130,6 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
     // allow resolutions that are exact and have the correct refresh rate
-    // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
     if ((height == info.iScreenHeight && width == info.iScreenWidth)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -130,8 +130,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
     // allow resolutions that are exact and have the correct refresh rate
-    // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
-    if ((height == info.iScreenHeight && width == info.iScreenWidth + 8)) &&
+    // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
+    if ((height == info.iScreenHeight && width == info.iScreenWidth)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
@@ -149,7 +149,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
     // allow resolutions that are exact in only one dimension and have the correct refresh rate
-    // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+    // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
     if (((height == info.iScreenHeight && width < info.iScreenWidth + 8) ||
          (width == info.iScreenWidth && height < info.iScreenHeight + 8)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
@@ -177,7 +177,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
       // allow resolutions that are exact and have double the refresh rate
-      // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+      // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
       if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
            (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
           (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
@@ -207,7 +207,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
       // allow resolutions that are exact and have 2.5 times the refresh rate
-      // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+      // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
       if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
            (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
           (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -149,8 +149,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
 
     // allow resolutions that are exact in only one dimension and have the correct refresh rate
     // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
-    if (((height == info.iScreenHeight && width < info.iScreenWidth + 8) ||
-         (width == info.iScreenWidth && height < info.iScreenHeight + 8)) &&
+    if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
+         (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -131,13 +131,32 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
 
     // allow resolutions that are exact and have the correct refresh rate
     // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
-    if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
-         (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
+    if ((height == info.iScreenHeight && width == info.iScreenWidth + 8)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
       CLog::Log(LOGDEBUG,
                 "[WHITELIST] Matched an exact resolution with an exact refresh rate {} ({})",
+                info.strMode, i);
+      resolution = i;
+      return;
+    }
+  }
+
+  for (const auto& mode : indexList)
+  {
+    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+    // allow resolutions that are exact in only one dimension and have the correct refresh rate
+    // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+    if (((height == info.iScreenHeight && width < info.iScreenWidth + 8) ||
+         (width == info.iScreenWidth && height < info.iScreenHeight + 8)) &&
+        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+        MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
+    {
+      CLog::Log(LOGDEBUG,
+                "[WHITELIST] Matched an exact resolution (1D only) with an exact refresh rate {} ({})",
                 info.strMode, i);
       resolution = i;
       return;


### PR DESCRIPTION
## Description

Changes the output resolution choice logic to prefer an exact resolution match in both dimensions over an exact match in only one dimension.

## Motivation and Context

This fixes https://github.com/xbmc/xbmc/issues/19037.

For a real-life example where it matters, see https://github.com/xbmc/xbmc/issues/19037#issuecomment-766551412.

## How Has This Been Tested?

Untested so far.

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
