### PR TITLE
Resolution: Use Minkowski Distance for exact match

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -19,6 +19,7 @@
 #include "utils/log.h"
 
 #include <cstdlib>
+#include <limits>
 
 namespace
 {
@@ -124,6 +125,9 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
 
   CLog::Log(LOGDEBUG, "[WHITELIST] Searching for an exact resolution with an exact refresh rate");
 
+  unsigned int penalty = std::numeric_limits<unsigned int>::max();
+  bool found = false;
+
   for (const auto& mode : indexList)
   {
     auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
@@ -139,10 +143,17 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       CLog::Log(LOGDEBUG,
                 "[WHITELIST] Matched an exact resolution with an exact refresh rate {} ({})",
                 info.strMode, i);
-      resolution = i;
-      return;
+      unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width);
+      if (pen < penalty)
+      {
+        resolution = i;
+        found = true;
+        penalty = pen;
+      }
     }
   }
+  if (found)
+    return;
 
   CLog::Log(LOGDEBUG, "[WHITELIST] No match for an exact resolution with an exact refresh rate");
 
@@ -167,10 +178,17 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
         CLog::Log(LOGDEBUG,
                   "[WHITELIST] Matched an exact resolution with double the refresh rate {} ({})",
                   info.strMode, i);
-        resolution = i;
-        return;
+        unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width);
+        if (pen < penalty)
+        {
+          resolution = i;
+          found = true;
+          penalty = pen;
+        }
       }
     }
+    if (found)
+      return;
 
     CLog::Log(LOGDEBUG,
               "[WHITELIST] No match for an exact resolution with double the refresh rate");


### PR DESCRIPTION
Depening on the order of resolutions, e.g. 4096 x 2160 is chosen for 3840x2160. This distance chooses, only for this "exact" match the best penalty.