### PR TITLE
Display unknown subtitle in dialog notification

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5049,7 +5049,7 @@ void CVideoPlayer::GetSubtitleStreamInfo(int index, SubtitleStreamInfo &info)
 {
   CSingleLock lock(m_content.m_section);
 
-  if (index == CURRENT_STREAM && GetSubtitleVisible())
+  if (index == CURRENT_STREAM)
     index = m_content.m_subtitleIndex;
 
   if (index < 0 || index > GetSubtitleCount() - 1)


### PR DESCRIPTION
The subtitle language is displayed again in the notification dialog as it should.

Resolve #19125