### PR TITLE
VideoBufferDRMPRIME: fix enum for HDMI_STATIC_METADATA_TYPE1

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -24,7 +24,7 @@ namespace DRMPRIME
 // HDR enums is copied from linux include/linux/hdmi.h (strangely not part of uapi)
 enum hdmi_metadata_type
 {
-  HDMI_STATIC_METADATA_TYPE1 = 1,
+  HDMI_STATIC_METADATA_TYPE1 = 0,
 };
 enum hdmi_eotf
 {


### PR DESCRIPTION
This fixes HDR enabling on my LG TV. I've been struggling with this for over a year now.

Big thanks to @kleinerm for pointing this out in #19122 

cc @emersion