### PR TITLE
[Doxygen] Improve docs of VideoPlayer.SubtitlesLanguage

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3555,6 +3555,8 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///                  _string_,
 ///     @return The language of the subtitle of the currently playing video
 ///     (possible values: see \ref ListItem_SubtitleLanguage "ListItem.SubtitleLanguage").
+///     @note `VideoPlayer.SubtitlesLanguage` holds the language of the next available
+///     subtitle stream if subtitles are disabled in the player
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link VideoPlayer_SubtitlesLanguage `VideoPlayer.SubtitlesLanguage`\endlink
 ///     <p>


### PR DESCRIPTION
Found this while working with https://github.com/xbmc/xbmc/pull/19128 and https://github.com/xbmc/xbmc/pull/19001.

The `VideoPlayer.SubtitlesLanguage` infolabel always holds a language identifier even in the cases subtitles are disabled in the player (and the file being played has actual subtitles). Since this can be misleading, this PR adds a note to the documentation explaining this fact.