### PR TITLE
Fixed crash on suspend with library being scanned on SMB

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -82,6 +82,8 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   struct smbc_dirent* dirEnt;
 
   lock.Enter();
+  if (!smb.IsSmbValid())
+    return false;
   while ((dirEnt = smbc_readdir(fd)))
   {
     CachedDirEntry aDir;
@@ -128,6 +130,11 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
           const std::string strFullName = strAuth + smb.URLEncode(strFile);
 
           lock.Enter();
+          if (!smb.IsSmbValid())
+          {
+            items.ClearItems();
+            return false;
+          }
 
           if( smbc_stat(strFullName.c_str(), &info) == 0 )
           {
@@ -235,6 +242,8 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
   CLog::LogF(LOGDEBUG, LOGSAMBA, "Using authentication url %s", CURL::GetRedacted(s).c_str());
 
   { CSingleLock lock(smb);
+    if (!smb.IsSmbValid())
+      return -1;
     fd = smbc_opendir(s.c_str());
   }
 

--- a/xbmc/platform/posix/filesystem/SMBFile.h
+++ b/xbmc/platform/posix/filesystem/SMBFile.h
@@ -35,6 +35,8 @@ public:
   ~CSMB();
   void Init();
   void Deinit();
+  /* Makes sense to be called after acquiring the lock */
+  bool IsSmbValid() const { return m_context != nullptr; };
   void CheckIfIdle();
   void SetActivityTime();
   void AddActiveConnection();


### PR DESCRIPTION
## Description
Fixed Kodi crash on every suspend when library is scanned in background on SMB share.

## Motivation and Context
I have Kodi on a small HTPC. OS is Gentoo, all media files are located on server and accessed by SMB.
"Watchdog" addon scans library in background. Every time when HTPC goes to suspend, Kodi crashes.

Typical example of the end of the log file:
``` log
2021-01-28 02:15:54.461 T:492     DEBUG <general>: ------ Window Init (DialogBusy.xml) ------
2021-01-28 02:15:54.461 T:492      INFO <general>: OnSleep: Running sleep jobs
2021-01-28 02:15:54.461 T:15996   DEBUG <general>: Thread JobWorker start, auto delete: true
2021-01-28 02:15:54.461 T:492     DEBUG <general>: CApplication::CloseNetworkShares: Closing all network shares
```

Backtrace is always the same:
``` backtrace
Process 492 (kodi-x11) of user 1001 dumped core.

Stack trace of thread 579:
#0  0x00007f1cd126e890 SMBC_stat_ctx (libsmbclient.so.0 + 0x16890)
#1  0x0000562bc786d536 _ZN5XFILE13CSMBDirectory12GetDirectoryERK4CURLR13CFileItemList (kodi-x11 + 0x910536)
#2  0x0000562bc84996c6 _ZN5XFILE10CDirectory12GetDirectoryERK4CURLRKSt10shared_ptrINS_10IDirectoryEER13CFileItemListRKNS0_6CHintsE (kodi-x11 + 0x153c6c6)
#3  0x0000562bc849a24f _ZN5XFILE10CDirectory12GetDirectoryERK4CURLR13CFileItemListRKNS0_6CHintsE (kodi-x11 + 0x153d24f)
#4  0x0000562bc849a331 _ZN5XFILE10CDirectory12GetDirectoryERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEER13CFileItemListS8_i (kodi-x11 + 0x153d331)
#5  0x0000562bc783cf89 _ZN9XBMCAddon7xbmcvfs7listdirERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE (kodi-x11 + 0x8dff89)
#6  0x0000562bc77f752d xbmcvfs_listdir (kodi-x11 + 0x89a52d)
#7  0x00007f1cd131f3c7 n/a (libpython3.8.so.1.0 + 0x943c7)
#8  0x00007f1cd131f9ec _PyObject_MakeTpCall (libpython3.8.so.1.0 + 0x949ec)
```
This happens because smh.Deinit() is called by [`CApplication::CloseNetworkShares`](https://github.com/xbmc/xbmc/blob/90a1e12804e2c051818e1eecfec8bc6ddb1e66af/xbmc/Application.cpp#L5051), Deinit() [tries to set smbc context to `NULL`](https://github.com/xbmc/xbmc/blob/90a1e12804e2c051818e1eecfec8bc6ddb1e66af/xbmc/platform/posix/filesystem/SMBFile.cpp#L77) (but this is [ignored by `libsmbclient`](https://github.com/samba-team/samba/blob/1bd81cac381872633bdcbe9fb0622ede94ba5b97/source3/libsmb/libsmb_compat.c#L146)) and [frees the `context`](https://github.com/xbmc/xbmc/blob/90a1e12804e2c051818e1eecfec8bc6ddb1e66af/xbmc/platform/posix/filesystem/SMBFile.cpp#L78) (which actually [frees memory regions](https://github.com/samba-team/samba/blob/1bd81cac381872633bdcbe9fb0622ede94ba5b97/source3/libsmb/libsmb_context.c#L322)) , and later in another thread the call of [`smbc_stat()` in `CSMBDirectory::GetDirectory`](https://github.com/xbmc/xbmc/blob/90a1e12804e2c051818e1eecfec8bc6ddb1e66af/xbmc/platform/posix/filesystem/SMBDirectory.cpp#L132), which [call `SMBC_stat_ctx()`](https://github.com/samba-team/samba/blob/1bd81cac381872633bdcbe9fb0622ede94ba5b97/source3/libsmb/libsmb_compat.c#L337) and it finally [dereference of the `internal` pointer](https://github.com/samba-team/samba/blob/1bd81cac381872633bdcbe9fb0622ede94ba5b97/source3/libsmb/libsmb_stat.c#L166) which is null pointer.

The only way to avoid situation like this is to check whether SMB is still valid under the lock. (Another way is to completely redesign SMBFile/Directory, but this is much more intrusive).

## How Has This Been Tested?
The code has been tested under Ubuntu and used on my HTPC.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
