### PR TITLE
Set "Show empty TV shows" setting true by default

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -948,7 +948,7 @@
         </setting>
         <setting id="videolibrary.showemptytvshows" type="boolean" label="20471" help="36163">
           <level>2</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="videolibrary.tvshowsselectfirstunwatcheditem" type="integer" label="21416" help="21466">


### PR DESCRIPTION
A minor default setting change which I consider a "fix", that will only impact fresh installations not upgrades. Showing empty TV shows by default will help out new users (and those providing user support) when something goes wrong with scraping TV Show episodes. 

Failure in scraping episodes is a more common reason for a TV show to be empty (there are files in the folder but no library entries) than the user having empty folders. Since the user can't see the TV Show in Kodi they often just keep trying to scrape it to no avail. If they do manage to correct an episode file naming issue, rescraping still would not work as the show has been successfully scraped, but the user can't see the TV Show in Kodi so they can not delete it and scrape again.

@KarellenX as requested
