### PR TITLE
windowing/gbm/drm: log atomic request before commiting

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -121,6 +121,9 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
     AddProperty(m_gui_plane, "CRTC_ID", 0);
   }
 
+  if (CServiceBroker::GetLogging().CanLogComponent(LOGWINDOWING))
+    m_req->LogAtomicRequest();
+
   auto ret = drmModeAtomicCommit(m_fd, m_req->Get(), flags | DRM_MODE_ATOMIC_TEST_ONLY, nullptr);
   if (ret < 0)
   {
@@ -144,9 +147,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
     CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
               strerror(errno));
   }
-
-  if (CServiceBroker::GetLogging().CanLogComponent(LOGWINDOWING))
-    m_req->LogAtomicRequest();
 
   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
   {


### PR DESCRIPTION
if we log the atomic request it should be done before committing. If the commit fails we fall back to an old commit and would never be able to see what was in the request that failed.