### PR TITLE
[linux] allow using VAAPI with DRM PRIME

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -232,12 +232,15 @@ if(NOT FFMPEG_FOUND)
     message(STATUS "dav1d not found, internal ffmpeg build will be missing AV1 support!")
   endif()
 
+  find_package(LibDRM)
+
   set(FFMPEG_OPTIONS -DENABLE_CCACHE=${ENABLE_CCACHE}
                      -DCCACHE_PROGRAM=${CCACHE_PROGRAM}
                      -DENABLE_VAAPI=${ENABLE_VAAPI}
                      -DENABLE_VDPAU=${ENABLE_VDPAU}
                      -DENABLE_DAV1D=${DAV1D_FOUND}
-                     -DEXTRA_FLAGS=${FFMPEG_EXTRA_FLAGS})
+                     -DEXTRA_FLAGS=${FFMPEG_EXTRA_FLAGS}
+                     -DENABLE_LIBDRM=${LIBDRM_FOUND})
 
   if(KODI_DEPENDSBUILD)
     set(CROSS_ARGS -DDEPENDS_PATH=${DEPENDS_PATH}

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -68,6 +68,7 @@ ifeq ($(OS),linux)
   DEPENDS += dbus libuuid alsa-lib libdrm libxkbcommon libinput libudev libevdev mtdev wayland waylandpp wayland-protocols linux-system-x11-libs
   ALSA_LIB = alsa-lib
   LIBUUID = libuuid
+  LIBDRM = libdrm
 
   ifeq ($(RENDER_SYSTEM),gl)
     WAYLANDPP_DEPS += linux-system-gl-libs
@@ -114,7 +115,7 @@ pythonmodule-pycryptodome: $(PYMODULE_DEPS) python3 pythonmodule-setuptools
 pythonmodule-pil: bzip2 $(PYMODULE_DEPS) $(ZLIB) libjpeg-turbo libpng freetype2 python3 pythonmodule-setuptools
 pythonmodule-setuptools: $(PYMODULE_DEPS) python3
 libxslt: libgcrypt libxml2
-ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)
+ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA) $(LIBDRM)
 libcec: p8-platform
 crossguid: $(LIBUUID)
 libdvdnav: libdvdread

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -82,6 +82,12 @@ if(GNUTLS_FOUND)
   list(APPEND ffmpeg_conf --enable-gnutls)
 endif()
 
+if(ENABLE_LIBDRM)
+  list(APPEND ffmpeg_conf --enable-libdrm)
+else()
+  list(APPEND ffmpeg_conf --disable-libdrm)
+endif()
+
 if(ENABLE_DAV1D)
   list(APPEND ffmpeg_conf --enable-libdav1d)
   set(pkgconf_path "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}")

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -30,6 +30,7 @@ endif
 ifeq ($(OS), linux)
   ffmpg_config += --target-os=$(OS)
   ffmpg_config += --enable-pic
+  ffmpg_config += --enable-libdrm
 endif
 ifeq ($(OS), android)
   ifeq ($(findstring arm64, $(CPU)), arm64)

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -102,10 +102,44 @@ void CVideoBufferDRMPRIMEFFmpeg::Unref()
   av_frame_unref(m_pFrame);
 }
 
+AVDRMFrameDescriptor* CVideoBufferDRMPRIMEFFmpeg::GetDescriptor() const
+{
+  if (m_pMapFrame)
+    return reinterpret_cast<AVDRMFrameDescriptor*>(m_pMapFrame->data[0]);
+
+  return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]);
+}
+
 bool CVideoBufferDRMPRIMEFFmpeg::IsValid() const
 {
+  if (m_pFrame->format == AV_PIX_FMT_VAAPI)
+    return true;
+
   AVDRMFrameDescriptor* descriptor = GetDescriptor();
   return descriptor && descriptor->nb_layers;
+}
+
+bool CVideoBufferDRMPRIMEFFmpeg::AcquireDescriptor()
+{
+  if (m_pFrame->format == AV_PIX_FMT_VAAPI)
+  {
+    m_pMapFrame = av_frame_alloc();
+    m_pMapFrame->format = AV_PIX_FMT_DRM_PRIME;
+
+    int ret = av_hwframe_map(m_pMapFrame, m_pFrame, 0);
+    if (ret)
+    {
+      av_frame_free(&m_pMapFrame);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void CVideoBufferDRMPRIMEFFmpeg::ReleaseDescriptor()
+{
+  av_frame_free(&m_pMapFrame);
 }
 
 CVideoBufferPoolDRMPRIMEFFmpeg::~CVideoBufferPoolDRMPRIMEFFmpeg()

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -75,14 +75,14 @@ public:
   void SetRef(AVFrame* frame);
   void Unref();
 
-  AVDRMFrameDescriptor* GetDescriptor() const override
-  {
-    return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]);
-  }
+  AVDRMFrameDescriptor* GetDescriptor() const override;
   bool IsValid() const override;
+  bool AcquireDescriptor() override;
+  void ReleaseDescriptor() override;
 
 protected:
   AVFrame* m_pFrame = nullptr;
+  AVFrame* m_pMapFrame = nullptr;
 };
 
 class CVideoBufferPoolDRMPRIMEFFmpeg : public IVideoBufferPool

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -132,7 +132,7 @@ static bool IsSupportedHwFormat(const enum AVPixelFormat fmt)
   bool hw = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
       SETTING_VIDEOPLAYER_USEPRIMEDECODERFORHW);
 
-  return fmt == AV_PIX_FMT_DRM_PRIME && hw;
+  return (fmt == AV_PIX_FMT_DRM_PRIME || fmt == AV_PIX_FMT_VAAPI) && hw;
 }
 
 static bool IsSupportedSwFormat(const enum AVPixelFormat fmt)
@@ -153,7 +153,8 @@ static const AVCodecHWConfig* FindHWConfig(const AVCodec* codec)
       continue;
 
     if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
-        config->device_type == AV_HWDEVICE_TYPE_DRM)
+        (config->device_type == AV_HWDEVICE_TYPE_DRM ||
+         config->device_type == AV_HWDEVICE_TYPE_VAAPI))
       return config;
 
     if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_INTERNAL))
@@ -264,8 +265,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   m_hints = hints;
 
   const AVCodecHWConfig* pConfig = FindHWConfig(pCodec);
-  if (pConfig && (pConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
-      pConfig->device_type == AV_HWDEVICE_TYPE_DRM)
+  if (pConfig && (pConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX))
   {
     const char* device = nullptr;
 
@@ -311,10 +311,15 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   m_pCodecContext->codec_tag = hints.codec_tag;
   m_pCodecContext->coded_width = hints.width;
   m_pCodecContext->coded_height = hints.height;
+  m_pCodecContext->level = hints.level;
+  m_pCodecContext->profile = hints.profile;
   m_pCodecContext->bits_per_coded_sample = hints.bitsperpixel;
   m_pCodecContext->time_base.num = 1;
   m_pCodecContext->time_base.den = DVD_TIME_BASE;
   m_pCodecContext->thread_count = CServiceBroker::GetCPUInfo()->GetCPUCount();
+
+  if (pConfig && pConfig->device_type == AV_HWDEVICE_TYPE_VAAPI)
+    m_pCodecContext->extra_hw_frames = 6;
 
   if (hints.extradata && hints.extrasize > 0)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -539,7 +539,7 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
   pVideoPicture->iFlags = 0;
   pVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;
   pVideoPicture->iFlags |= m_pFrame->top_field_first ? DVP_FLAG_TOP_FIELD_FIRST : 0;
-  pVideoPicture->iFlags |= m_pFrame->data[0] ? 0 : DVP_FLAG_DROPPED;
+  pVideoPicture->iFlags |= m_pFrame->buf[0] ? 0 : DVP_FLAG_DROPPED;
 
   if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
   {


### PR DESCRIPTION
This is in conjunction with #19140 as it won't work on it's own. I'm PRing it separate to keep review smaller (and because I'm able to as the decoder is separate from the renderer).

This allow using ffmpegs `av_hwframe_map` to convert `AV_PIX_FMT_VAAPI` to `AV_PIX_FMT_DRM_PRIME`. The difference is basically a struct and doesn't require any copying.

This allow us to use the direct-to-plane rendering and EGL render methods for DRM PRIME.

Currently this PR doesn't offer any reason to use DRM PRIME with vaapi over our normal vaapi renderer. However in the future we will be able to activate HDR with VAAPI.
