### PR TITLE
Fixed crash on start of debug Kodi build

### DIFF
--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -8,6 +8,7 @@
 
 #include <signal.h>
 #include <sys/resource.h>
+#include <cstdio>
 
 #include <cstring>
 
@@ -58,7 +59,7 @@ int main(int argc, char* argv[])
   struct rlimit rlim;
   rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
   if (setrlimit(RLIMIT_CORE, &rlim) == -1)
-    CLog::Log(LOGDEBUG, "Failed to set core size limit (%s)", strerror(errno));
+    fprintf(stderr, "Failed to set core size limit (%s).\n", strerror(errno));
 #endif
 
   // Set up global SIGINT/SIGTERM handler


### PR DESCRIPTION
This is a pretty obvious fix.
Currently any debug Kodi build crashes right after start on any Posix-like platform if started without rights to set rlimit.
The problem is null pointer deference in CLog as CLog is not yet initialized.
The best possible replacement is output to stderr.