### PR TITLE
[addons] Make sure service addons properly handle the AddonUnload event

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -687,6 +687,7 @@ bool CAddonMgr::UnloadAddon(const std::string& addonId)
 
   lock.Leave();
   AddonEvents::Unload event(addonId);
+  m_unloadEvents.HandleEvent(event);
 
   return true;
 }

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -24,6 +24,7 @@ CServiceAddonManager::CServiceAddonManager(CAddonMgr& addonMgr) :
 CServiceAddonManager::~CServiceAddonManager()
 {
   m_addonMgr.Events().Unsubscribe(this);
+  m_addonMgr.UnloadEvents().Unsubscribe(this);
 }
 
 void CServiceAddonManager::OnEvent(const ADDON::AddonEvent& event)
@@ -38,7 +39,7 @@ void CServiceAddonManager::OnEvent(const ADDON::AddonEvent& event)
     Start(event.id);
   }
   else if (typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
-           typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
+           typeid(event) == typeid(ADDON::AddonEvents::Unload))
   {
     Stop(event.id);
   }
@@ -47,6 +48,7 @@ void CServiceAddonManager::OnEvent(const ADDON::AddonEvent& event)
 void CServiceAddonManager::Start()
 {
   m_addonMgr.Events().Subscribe(this, &CServiceAddonManager::OnEvent);
+  m_addonMgr.UnloadEvents().Subscribe(this, &CServiceAddonManager::OnEvent);
   VECADDONS addons;
   if (m_addonMgr.GetAddons(addons, ADDON_SERVICE))
   {
@@ -91,6 +93,7 @@ void CServiceAddonManager::Start(const AddonPtr& addon)
 void CServiceAddonManager::Stop()
 {
   m_addonMgr.Events().Unsubscribe(this);
+  m_addonMgr.UnloadEvents().Unsubscribe(this);
   CSingleLock lock(m_criticalSection);
   for (const auto& service : m_services)
   {


### PR DESCRIPTION
## Description

At the moment service addons (i.e. their script instances) are only stopped after the `ServiceManager` receives the `AddonUnistalled` event. This event is only triggered at the end of the uninstallation process...long after kodi has tried to move the addon installation folder (for removal) and the addon userdata. The problem is that if a service addon is holding a handler to some file in the installation folder (or userdata) such as some binary component the service depends on - the addon will fail to uninstall (at least on specific platforms like windows).

While debugging this I found the addon manager already has a blocking event source used for when the addon is unloaded (first step of the uninstallation process). The event was created but not sent to the event source (some leftover or unfinished work?). Furthermore, no other component was registered for those events.

Thus, make the ServiceManager listen to those events and stop the respective scripts in the same job thread instead of trying to stop the scripts when it is already too late.


## Motivation and Context
Fix addon uninstallation process

## How Has This Been Tested?
Compiled kodi on OSX, uninstalled addons. Testbuild created for windows, confirmed the problem is no longer reproducible.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
