### PR TITLE
[guiinfo] Fix fallback handling for 'offset' and 'position' info labels.

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -571,6 +571,12 @@ bool CMusicGUIInfo::GetFallbackLabel(std::string& value,
                                      const CGUIInfo& info,
                                      std::string* fallback)
 {
+  // No fallback for musicplayer "offset" and "position" info labels
+  if (info.GetData1() && ((info.m_info >= MUSICPLAYER_OFFSET_POSITION_FIRST &&
+      info.m_info <= MUSICPLAYER_OFFSET_POSITION_LAST) ||
+      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
+    return false;
+
   const CMusicInfoTag* tag = item->GetMusicInfoTag();
   if (tag)
   {

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -639,6 +639,12 @@ bool CVideoGUIInfo::GetFallbackLabel(std::string& value,
                                      const CGUIInfo& info,
                                      std::string* fallback)
 {
+  // No fallback for videoplayer "offset" and "position" info labels
+  if (info.GetData1() && ((info.m_info >= VIDEOPLAYER_OFFSET_POSITION_FIRST &&
+      info.m_info <= VIDEOPLAYER_OFFSET_POSITION_LAST) ||
+      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
+    return false;
+
   const CVideoInfoTag* tag = item->GetVideoInfoTag();
   if (tag)
   {


### PR DESCRIPTION
Fixes a regression introduced by #18630 - details https://github.com/xbmc/xbmc/pull/18630#issuecomment-770395824 ff.

@jjd-uk could you please runtime-test?