### PR TITLE
Workaround for PVR returning wrong uniqueid 

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -77,6 +77,10 @@ bool CFileItemHandler::GetField(const std::string &field, const CVariant &info, 
         result[field] = StringUtils::Split(info[field].asString(), EPG_STRING_TOKEN_SEPARATOR);
         return true;
       }
+      else if (field == "uniqueid" && result["channelid"].isNull())
+	  {
+        return false;
+	  }
     }
   }
 


### PR DESCRIPTION
when asking for Player.GetItem but keep proper value when asking for channel uniqueid

## Description

Fix for https://github.com/xbmc/xbmc/issues/19151

This is mostly a workaround as https://github.com/xbmc/xbmc/pull/18632

## Motivation and Context
Fix for https://github.com/xbmc/xbmc/issues/19151

## How Has This Been Tested?
```
{"id":831,"jsonrpc":"2.0","method":"Player.GetItem","params":{"properties":["album","albumartist","artist","episode","art","file","genre","plot","rating","season","showtitle","studio","tagline","title","track","year","streamdetails","originaltitle","playcount","runtime","duration","cast","writer","director","userrating","firstaired","displayartist","uniqueid"],"playerid":1}}
```

```
{"id":69,"jsonrpc":"2.0","method":"PVR.GetChannels","params":{"channelgroupid":"alltv","properties":["channel","channeltype","hidden","lastplayed","locked","thumbnail","broadcastnow","broadcastnext","channelnumber","subchannelnumber","isrecording","uniqueid"]}}
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
