### PR TITLE
[SmartRedraw] Fix for dialog kai toast notifications not being marked…

### DIFF
--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -129,7 +129,10 @@ void CGUIDialog::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregi
     dirtyregions.push_back(CDirtyRegion(m_renderRegion));
 
   if (m_active)
+  {
     CGUIWindow::DoProcess(currentTime, dirtyregions);
+    MarkDirtyRegion();
+  }
 
   m_wasRunning = m_active;
 }


### PR DESCRIPTION
… as Dirty, Issue #15354

## Description
In issue #15354 (issue #18391 appears to be the same) it is seen that toast notifications break when using SmartReDraw.  The source of this appears to be that the dialog windows are not marked as dirty.

## Motivation and Context
Issue #15354 
Issue #18391 
[Kodi Forum thread report](https://forum.kodi.tv/showthread.php?tid=359240&pid=3011002#pid3011002)

I'm not sure if toast notifications are the only dialog windows that should be marked dirty, so I've marked all dialog windows as dirty.

## How Has This Been Tested?
Tested on Ubuntu 20.04 x86-64.  Enabled and disabled smartredraw.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
