### PR TITLE
[win32] Fixed CMake out-of-source build on Windows

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -221,11 +221,19 @@ function(copy_file_to_buildtree file)
   endif()
 
   if(NOT file STREQUAL ${CMAKE_BINARY_DIR}/${outfile})
-    if(VERBOSE)
-      message(STATUS "copy_file_to_buildtree - copying file: ${file} -> ${CMAKE_BINARY_DIR}/${outfile}")
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" OR NOT IS_SYMLINK "${file}")
+      if(VERBOSE)
+        message(STATUS "copy_file_to_buildtree - copying file: ${file} -> ${CMAKE_BINARY_DIR}/${outfile}")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ExportFiles.cmake
+           "file(COPY \"${file}\" DESTINATION \"${CMAKE_BINARY_DIR}/${outdir}\")\n" )
+    else()
+      if(VERBOSE)
+        message(STATUS "copy_file_to_buildtree - copying symlinked file: ${file} -> ${CMAKE_BINARY_DIR}/${outfile}")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ExportFiles.cmake
+           "execute_process(COMMAND \"\${CMAKE_COMMAND}\" -E copy_if_different \"${file}\" \"${CMAKE_BINARY_DIR}/${outfile}\")\n")
     endif()
-    file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ExportFiles.cmake
-         "file(COPY \"${file}\" DESTINATION \"${CMAKE_BINARY_DIR}/${outdir}\")\n")
   endif()
 
   if(NOT arg_NO_INSTALL)


### PR DESCRIPTION
When building with separate directory for binaries and for source code, CMake needs to copy some files to the build directory.
CMake is smart enough to detect symlink on Windows, but at the same time is not smart enough to copy symlink itself or linked content on Windows.
Currently it fails to copy 'freebsd.xml' which is symlink to 'linux.xml'. Note: my system has `core.symlinks=true` git setting as suggested by recent versions of Git For Windows.
```
13>Copying files into build tree
13>CMake Error at build/ExportFiles.cmake:1131 (file):
13>  file COPY cannot read symlink
13>  "D:/The/Path/xbmc/xbmc-git/system/settings/freebsd.xml" to duplicate at
13>  "D:/The/Path/xbmc/xbmc-build/system/settings/freebsd.xml": No error.
```
Visual Studio rejects to link Kodi binary as it thinks that build process fails.

Suggested workaround uses CMake internal command and avoids copy of unchanged file.
