### PR TITLE
[Android] fixed crash on harmony os TV. #19133

### DIFF
--- a/tools/android/packaging/xbmc/src/channels/util/SharedPreferencesHelper.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/SharedPreferencesHelper.java.in
@@ -116,7 +116,7 @@ public final class SharedPreferencesHelper {
         list.add(mGson.fromJson(contactString, clazz));
       }
     } catch (JsonSyntaxException e) {
-      Log.e(TAG, "Could not parse json.", e);
+      // Log.e(TAG, "Could not parse json.", e);
       return Collections.emptyList();
     }
     return list;

--- a/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
@@ -113,11 +113,22 @@ public class TvUtil
             .setAppLinkIntent(playlistIntent);
 
     Log.d(TAG, "Creating channel: " + subscription.getName());
-    Uri channelUrl =
-            context.getContentResolver()
-                    .insert(
-                            TvContractCompat.Channels.CONTENT_URI,
-                            builder.build().toContentValues());
+
+    Uri channelUrl = null;
+    try
+    {
+      channelUrl =
+              context.getContentResolver()
+                      .insert(
+                              TvContractCompat.Channels.CONTENT_URI,
+                              builder.build().toContentValues());
+    } catch (SQLException | IllegalArgumentException | SecurityException e) {
+      Log.e(TAG, "Failed to add channel to the tv provider");
+      e.printStackTrace();
+    }
+
+    if (channelUrl == null)
+      return 0;
 
     Log.d(TAG, "channel insert at " + channelUrl);
     long channelId = ContentUris.parseId(channelUrl);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Kodi(version 18.9) kept crash on my TV when startsup.
The key line of the exception log is attatched below.
This log shows that the TV might not have interface at URL content://android.media.tv/channel, so IllegalArgumentException had been thrown out.
So exception handling code is added in the correspoding line in TvUtil.java.in.
Please refer to the details show in the commit diff.

E/AndroidRuntime(10829): FATAL EXCEPTION: AsyncTask #1
E/AndroidRuntime(10829): Process: org.xbmc.kodi, PID: 10829
...
**E/AndroidRuntime(10829): Caused by: java.lang.IllegalArgumentException: Unknown URL content://android.media.tv/channel
E/AndroidRuntime(10829): at android.content.ContentResolver.insert(ContentResolver.java:1840)
E/AndroidRuntime(10829): at org.xbmc.kodi.channels.util.TvUtil.createChannel(TvUtil.java:118)**
E/AndroidRuntime(10829): at org.xbmc.kodi.channels.SyncChannelJobService$SyncChannelTask.doInBackground(SyncChannelJobService.java:150)
E/AndroidRuntime(10829): at 
...
E/ActivityThread(10829): Failed to find provider info for android.media.tv

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This crash happens when kodi starts up.
So kodi(version 18.9, actually version later then 18.0) can not be used on my device.

Please refer to issue: https://github.com/xbmc/xbmc/issues/19133

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I have tested this change on my device, and the crash did not happen.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ X] I have added tests to cover my change
- [ ] All new and existing tests passed
