### PR TITLE
[VideoPlayer] Revert audio/video stream state on VideoPlayer reset

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1199,8 +1199,6 @@ void CVideoPlayer::Prepare()
   m_offset_pts = 0;
   m_CurrentAudio.lastdts = DVD_NOPTS_VALUE;
   m_CurrentVideo.lastdts = DVD_NOPTS_VALUE;
-  m_HasAudio = false;
-  m_HasVideo = false;
 
   IPlayerCallback *cb = &m_callback;
   CFileItem fileItem = m_item;


### PR DESCRIPTION
## Description

This reverts commit 4f8a656aed05ff6d63aacac0d3a610381a4343c4.

The original PR did not address a race condition on these flags, which had a detrimental affect on video playlists.  If the flags are reset, the main thread will still interrogate them before VideoPlayer has a chance to set them based on the new stream states.

My opinion is that problems with video playlists would impact a significantly larger user base than would have been able to benefit from the original PR.

The discussion in https://github.com/xbmc/xbmc/issues/19153 shows the problem to be more systemic than can be addressed easily for Kodi Matrix.

## Motivation and Context
Resolves https://github.com/xbmc/xbmc/issues/19153
Suggest reopens https://github.com/xbmc/xbmc/issues/18025

## How Has This Been Tested?
Tested on Windows x64 (Desktop), recent Matrix nightly as of 2/3/2021.  Confirmed that video playlists no longer exhibit the symptoms reported in https://github.com/xbmc/xbmc/issues/19153

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
