### PR TITLE
Resolution choose fix and improvement

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -152,10 +152,9 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       }
     }
   }
-  if (found)
-    return;
 
-  CLog::Log(LOGDEBUG, "[WHITELIST] No match for an exact resolution with an exact refresh rate");
+  if (!found)
+    CLog::Log(LOGDEBUG, "[WHITELIST] No match for an exact resolution with an exact refresh rate");
 
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE))


### PR DESCRIPTION
This is an improvement for https://github.com/xbmc/xbmc/pull/19124 by @fritsch.

The [first commit](d7a06b63c680229fc46d5f8a73cf4f15c3a91051) allow to find ideal fit resolution in double framerate resolutions (if allowed by settings) even if something was found in single framerate match.

The [second commit](b140f7fdc39ee7a65f00c8b1e30357d409e59207) basically improve choosing of the best match by `fit percentage` instead of absolute value. Also it contains some optimisation (return early if ideal match is found, better logging) and applied the same algorithm for 3:2 pulldown resolutions as well.

It's up to @DaveTBlake whether to use in for v19 or for v20, but I would recommend to take at least the [first commit](d7a06b63c680229fc46d5f8a73cf4f15c3a91051) for v19.