### PR TITLE
Use GetDynPath to save subtitles

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -437,7 +437,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
   SUBTITLE_STORAGEMODE storageMode = (SUBTITLE_STORAGEMODE) CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_SUBTITLES_STORAGEMODE);
 
   // Get (unstacked) path
-  std::string strCurrentFile = g_application.CurrentUnstackedItem().GetPath();
+  std::string strCurrentFile = g_application.CurrentUnstackedItem().GetDynPath();
 
   std::string strDownloadPath = "special://temp";
   std::string strDestPath;


### PR DESCRIPTION
Some users have reported problems when saving downloaded subtitles #19168 and #19064.

When "**Play next video automatically**" is turned in Settings > Player > Videos, if you download a subtitle, it's saved in the temp folder instead of next to the video.

When this option is enabled the path is **videodb://** and needs the **actual path**.

Fixed using GetDynPath()