### PR TITLE
[PVR] We must only persist CPVRChannelGroup if it is already fully loaded

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -168,7 +168,9 @@ void CPVRChannelGroup::SetPath(const CPVRChannelsPath& path)
   {
     m_path = path;
     m_bChanged = true;
-    Persist();
+
+    if (m_bLoaded)
+      Persist();
   }
 }
 
@@ -1023,7 +1025,9 @@ void CPVRChannelGroup::SetGroupName(const std::string& strGroupName)
   {
     m_path = CPVRChannelsPath(m_path.IsRadio(), strGroupName);
     m_bChanged = true;
-    Persist();
+
+    if (m_bLoaded)
+      Persist();
   }
 }
 


### PR DESCRIPTION
Just a small fix. Under special conditions (no network, loss to pvr backend, ...) it can happen that not fully loaded channel groups shall be persisted, leading to incomplete entries in the pvr database.

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish could you review, please?