### PR TITLE
Fixed native resolution choose

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -215,10 +215,17 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
             LOGDEBUG,
             "[WHITELIST] Matched an exact resolution with a 3:2 pulldown refresh rate {} ({})",
             info.strMode, i);
-        resolution = i;
-        return;
+        unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width);
+        if (pen < penalty)
+        {
+          resolution = i;
+          found = true;
+          penalty = pen;
+        }
       }
     }
+    if (found)
+      return;
 
     CLog::Log(LOGDEBUG, "[WHITELIST] No match for a resolution with a 3:2 pulldown refresh rate");
   }

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -152,10 +152,9 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       }
     }
   }
-  if (found)
-    return;
 
-  CLog::Log(LOGDEBUG, "[WHITELIST] No match for an exact resolution with an exact refresh rate");
+  if (!found)
+    CLog::Log(LOGDEBUG, "[WHITELIST] No match for an exact resolution with an exact refresh rate");
 
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE))


### PR DESCRIPTION
This is simplified fix for https://github.com/xbmc/xbmc/pull/19124

Current code selects 4096x2160 30Hz as output resolution for 3840x2160 30fps video, even if output supports 3840x2160 60Hz and double frame-rate is allowed.
The first commit fixed it.

Current code may select 4096x2160 59.9Hz as output resolution for 3840x2160 23.97fps video, even if output supports 3840x2160 59.9Hz.
The second commit fixed it.
