### PR TITLE
Improve "parse_nfo_url" function and add function to convert external IDs

### DIFF
--- a/addons/metadata.tvshows.themoviedb.org.python/libs/actions.py
+++ b/addons/metadata.tvshows.themoviedb.org.python/libs/actions.py
@@ -74,7 +74,7 @@ def get_show_id_from_nfo(nfo):
     parse_result = data_utils.parse_nfo_url(nfo)
     if parse_result:
         if parse_result.provider == 'themoviedb':
-            show_info = tmdb.load_show_info(parse_result.show_id, ep_grouping=parse_result.ep_grouping)
+            show_info = tmdb.load_show_info(show_id = parse_result.show_id, ep_grouping = parse_result.ep_grouping)
         else:
             show_info = None
         if show_info is not None:

--- a/addons/metadata.tvshows.themoviedb.org.python/libs/tmdb.py
+++ b/addons/metadata.tvshows.themoviedb.org.python/libs/tmdb.py
@@ -386,3 +386,17 @@ def _image_sort(images):
                 lang_null.append(image)
         firstimage = False
     return lang_pref + lang_null + lang_en
+
+
+def _convert_ext_id(ext_provider, ext_id):
+    providers_dict = {'imdb' : 'imdb_id',
+                     'thetvdb' : 'tvdb_id',
+                     'tvdb' : 'tvdb_id'}
+    show_url = FIND_URL.format(ext_id)
+    params = TMDB_PARAMS.copy()
+    params['external_source'] = providers_dict[ext_provider]
+    show_info = api_utils.load_info(show_url, params=params)
+    if show_info:
+        return show_info.get('tv_results')[0].get('id')
+    return None
+


### PR DESCRIPTION
Right now the regular expressions covers many providers, but once it finds a match from a different provider (ex. IMDB or TheTVDB) , the function "actions.get_show_id_from_nfo(nfo)"  will accept only TMDB links and we end up with no scrapping.

So, I reorganized the REGEXPS and added a function to convert external IDs to TMDB ID. 


