### PR TITLE
fixed: level Calculation in FileCache was wrong due to incorrect cast

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -416,7 +416,7 @@ void CFileCache::Process()
     // NOTE: Hysteresis (20-80%) for filling-logic
     const int64_t forward = m_pCache->WaitForData(0, 0);
     const float level =
-        (m_forwardCacheSize == 0) ? 0.0 : static_cast<float>(forward / m_forwardCacheSize);
+        (m_forwardCacheSize == 0) ? 0.0 : static_cast<float>(forward) / m_forwardCacheSize;
 
     if (level > 0.8f)
     {


### PR DESCRIPTION
Contains a bugfix for a stupid casting mistake (introduced by 431e10a5e4d9cf09e80adda8f66654cd83962ac4) causing level calculation to be wrong. This in turn could cause VideoPlayer to display false "low readrate" toasts.

Should be safe for Matrix, hopefully can make it for release.
