### PR TITLE
Add the option to show the highest rating for movie set

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22454,7 +22454,7 @@ msgctxt "#39147"
 msgid "Episode art types whitelist"
 msgstr ""
 
-#. Description of setting with label #39154 "Episode art types whitelist"
+#. Description of setting with label #39147 "Episode art types whitelist"
 #: system/settings/settings.xml
 msgctxt "#39148"
 msgid "Limit the episode artwork fetched locally or applied from scraper remote art results to just those art types in the whitelist"
@@ -22465,7 +22465,7 @@ msgctxt "#39149"
 msgid "Music video art types whitelist"
 msgstr ""
 
-#. Description of setting with label #39156 "Music video art types whitelist"
+#. Description of setting with label #39149 "Music video art types whitelist"
 #: system/settings/settings.xml
 msgctxt "#39150"
 msgid "Limit the music video artwork fetched locally or applied from scraper remote art results to just those art types in the whitelist"
@@ -22484,4 +22484,29 @@ msgstr ""
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#39153"
 msgid "Windowing system:"
+msgstr ""
+
+#. Main label of the setting which selects the "Movie sets rating" calculation method, it can be toggled between [Average] or [Highest]
+#: system/settings/settings.xml
+msgctxt "#39154"
+msgid "Movie set rating"
+msgstr ""
+
+#. Select option for the setting "Movie set rating". When selecting "Average", the "Movie set rating" will be equal to the average rating of the movies in the set
+#: system/settings/settings.xml
+msgctxt "#39155"
+msgid "Average"
+msgstr ""
+
+#. 
+#. Select option for the setting "Movie set rating". When selecting "Highest", the "Movie set rating" will be equal to the movie with the Highest rating in the set
+#: system/settings/settings.xml
+msgctxt "#39156"
+msgid "Highest"
+msgstr ""
+
+#. Description of the setting with label "Movie set rating". It describes what happens when selecting [Average] or [Highest] optionss
+#: system/settings/settings.xml
+msgctxt "#39157"
+msgid "Movie set rating calc method. Toggle between [Average] (the average rating of the movies in the set), or [Highest] (the movie with the Highest rating in the set)."
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -924,6 +924,20 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.moviesetrating" type="integer" parent="videolibrary.groupmoviesets" label="39154" help="39157">
+          <level>1</level>
+          <default>0</default> <!-- SELECT_MOVIESETRATING_AVERAGE -->
+          <constraints>
+            <options>
+              <option label="39155">0</option> <!-- SELECT_MOVIESETRATING_AVERAGE -->
+              <option label="39156">1</option> <!-- SELECT_MOVIESETRATING_HIGHEST -->
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="videolibrary.groupmoviesets" operator="is">true</dependency>
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
         <setting id="videolibrary.groupsingleitemsets" type="boolean" label="20470" help="36157">
           <level>1</level>
           <default>false</default>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -108,6 +108,7 @@ constexpr const char* CSettings::SETTING_VIDEOLIBRARY_TVSHOWSSELECTFIRSTUNWATCHE
 constexpr const char* CSettings::SETTING_VIDEOLIBRARY_TVSHOWSINCLUDEALLSEASONSANDSPECIALS;
 constexpr const char* CSettings::SETTING_VIDEOLIBRARY_SHOWALLITEMS;
 constexpr const char* CSettings::SETTING_VIDEOLIBRARY_GROUPMOVIESETS;
+constexpr const char* CSettings::SETTING_VIDEOLIBRARY_MOVIESETRATING;
 constexpr const char* CSettings::SETTING_VIDEOLIBRARY_GROUPSINGLEITEMSETS;
 constexpr const char* CSettings::SETTING_VIDEOLIBRARY_UPDATEONSTARTUP;
 constexpr const char* CSettings::SETTING_VIDEOLIBRARY_BACKGROUNDUPDATE;
@@ -936,6 +937,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_MUSICFILES_TRACKFORMAT);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_FLATTENTVSHOWS);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_GROUPMOVIESETS);
+  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_MOVIESETRATING);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_CLEANUP);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_IMPORT);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_EXPORT);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -77,6 +77,7 @@ public:
       "videolibrary.tvshowsincludeallseasonsandspecials";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWALLITEMS = "videolibrary.showallitems";
   static constexpr auto SETTING_VIDEOLIBRARY_GROUPMOVIESETS = "videolibrary.groupmoviesets";
+  static constexpr auto SETTING_VIDEOLIBRARY_MOVIESETRATING = "videolibrary.moviesetrating";
   static constexpr auto SETTING_VIDEOLIBRARY_GROUPSINGLEITEMSETS =
       "videolibrary.groupsingleitemsets";
   static constexpr auto SETTING_VIDEOLIBRARY_UPDATEONSTARTUP = "videolibrary.updateonstartup";
@@ -437,6 +438,11 @@ public:
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES = 0;
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES = 1;
   static const int VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE = 2;
+
+  // values for SETTING_VIDEOLIBRARY_MOVIESETRATING
+  static const int VIDEOLIBRARY_MOVIESETRATING_AVERAGE = 0;
+  static const int VIDEOLIBRARY_MOVIESETRATING_HIGHEST = 1;
+
   // values for SETTING_VIDEOLIBRARY_ARTWORK_LEVEL
   static const int VIDEOLIBRARY_ARTWORK_LEVEL_ALL = 0;
   static const int VIDEOLIBRARY_ARTWORK_LEVEL_BASIC = 1;

--- a/xbmc/utils/GroupUtils.h
+++ b/xbmc/utils/GroupUtils.h
@@ -26,7 +26,7 @@ typedef enum {
 class GroupUtils
 {
 public:
-  static bool Group(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
-  static bool Group(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItems, CFileItemList &ungroupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
-  static bool GroupAndMix(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItemsMixed, GroupAttribute groupAttributes = GroupAttributeNone);
+  static bool Group(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItems, int groupRating, GroupAttribute groupAttributes = GroupAttributeNone);
+  static bool Group(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItems, CFileItemList &ungroupedItems, int groupRating, GroupAttribute groupAttributes = GroupAttributeNone);
+  static bool GroupAndMix(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItemsMixed, int groupRating, GroupAttribute groupAttributes = GroupAttributeNone);
 };

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1386,7 +1386,8 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
     {
       CFileItemList groupedItems;
       GroupAttribute groupAttributes = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_GROUPSINGLEITEMSETS) ? GroupAttributeNone : GroupAttributeIgnoreSingleItems;
-      if (GroupUtils::GroupAndMix(GroupBySet, m_strFilterPath, items, groupedItems, groupAttributes))
+      int groupRating = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOLIBRARY_MOVIESETRATING);
+      if (GroupUtils::GroupAndMix(GroupBySet, m_strFilterPath, items, groupedItems, groupRating, groupAttributes))
       {
         items.ClearItems();
         items.Append(groupedItems);


### PR DESCRIPTION
## Description
Add the option to select how the user wants to calculate movie sets rating.

## Motivation and Context
There are some movie sequels with one movie having a high rating and the others movies of the sequel having a really low rating which pushes the average rating down. If the user is interested in movies with high ratings, average rating is not the best scenario here. I understand that there are users who prefers average method, but I don't see why we cannot have it as optional.

I am not alone with this though, someone have suggested it in the link below.
https://forum.kodi.tv/showthread.php?tid=234841 

## How Has This Been Tested?
windows 10 x64


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
