### PR TITLE
Make libcdio optional if not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,6 @@ endif()
 
 # Required dependencies. Keep in alphabetical order please
 set(required_deps ASS>=0.15.0
-                  Cdio
                   CrossGUID
                   Curl
                   Exiv2
@@ -312,6 +311,7 @@ if(ENABLE_UPNP)
 endif()
 
 if(ENABLE_OPTICAL)
+  core_require_dep(Cdio>=0.80)
   list(APPEND DEP_DEFINES -DHAS_OPTICAL_DRIVE -DHAS_CDDA_RIPPER)
 endif()
 

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -52,7 +52,7 @@ endif
 
 FONTCONFIG=fontconfig
 ifeq ($(OS),darwin_embedded)
-  EXCLUDED_DEPENDS = libusb gtest
+  EXCLUDED_DEPENDS = libusb gtest libcdio libcdio-gplv3
   FONTCONFIG=
   ifeq ($(TARGET_PLATFORM),appletvos)
     EXCLUDED_DEPENDS += libshairplay libplist
@@ -70,7 +70,7 @@ ifeq ($(OS),osx)
 endif
 
 ifeq ($(OS),android)
-  EXCLUDED_DEPENDS = libusb gtest
+  EXCLUDED_DEPENDS = libusb gtest libcdio libcdio-gplv3
   DEPENDS += dummy-libxbmc libdovi libuuid
   PYMODULE_DEPS = dummy-libxbmc
   LIBUUID = libuuid

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -46,7 +46,9 @@
 #include "platform/posix/filesystem/SMBDirectory.h"
 #endif
 #endif
+#ifdef HAS_OPTICAL_DRIVE
 #include "CDDADirectory.h"
+#endif // HAS_OPTICAL_DRIVE
 #include "PluginDirectory.h"
 #if defined(HAS_ISO9660PP)
 #include "ISO9660Directory.h"

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -26,7 +26,9 @@
 #include "platform/posix/filesystem/SMBFile.h"
 #endif
 #endif
+#ifdef HAS_OPTICAL_DRIVE
 #include "CDDAFile.h"
+#endif // HAS_OPTICAL_DRIVE
 #if defined(HAS_ISO9660PP)
 #include "ISO9660File.h"
 #endif

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -46,7 +46,9 @@
 #include "music/MusicLibraryQueue.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/Network.h"
+#ifdef HAS_OPTICAL_DRIVE
 #include "network/cddb.h"
+#endif // HAS_OPTICAL_DRIVE
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/music/tags/CMakeLists.txt
+++ b/xbmc/music/tags/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(SOURCES MusicInfoTag.cpp
-            MusicInfoTagLoaderCDDA.cpp
             MusicInfoTagLoaderDatabase.cpp
             MusicInfoTagLoaderFactory.cpp
             MusicInfoTagLoaderFFmpeg.cpp
@@ -10,7 +9,6 @@ set(SOURCES MusicInfoTag.cpp
 
 set(HEADERS ImusicInfoTagLoader.h
             MusicInfoTag.h
-            MusicInfoTagLoaderCDDA.h
             MusicInfoTagLoaderDatabase.h
             MusicInfoTagLoaderFactory.h
             MusicInfoTagLoaderFFmpeg.h
@@ -18,5 +16,10 @@ set(HEADERS ImusicInfoTagLoader.h
             ReplayGain.h
             TagLibVFSStream.h
             TagLoaderTagLib.h)
+
+if(ENABLE_OPTICAL)
+  list(APPEND SOURCES MusicInfoTagLoaderCDDA.cpp)
+  list(APPEND HEADERS MusicInfoTagLoaderCDDA.h)
+endif()
 
 core_add_library(music_tags)

--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -9,7 +9,9 @@
 #include "MusicInfoTagLoaderFactory.h"
 
 #include "FileItem.h"
+#ifdef HAS_OPTICAL_DRIVE
 #include "MusicInfoTagLoaderCDDA.h"
+#endif // HAS_OPTICAL_DRIVE
 #include "MusicInfoTagLoaderDatabase.h"
 #include "MusicInfoTagLoaderFFmpeg.h"
 #include "MusicInfoTagLoaderShn.h"

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -16,7 +16,6 @@
 #include "my_ntddscsi.h"
 #include "rendering/dx/DirectXHelper.h"
 #include "storage/MediaManager.h"
-#include "storage/cdioSupport.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"


### PR DESCRIPTION
Many Kodi instances never use any optical drives.
Currently Kodi requires to use libcdio even if `ENABLE_OPTICAL` is `OFF` and `ENABLE_ISO9660PP` is `OFF` as well.

The problem is hard dependency on libcdio, regardless of any setting.

This PR makes libcdio optional (could be useful for embedded devices), removed some of the unused `#include` directives, shielded some includes with `#ifdef` (mostly cosmetics and readability as code is compiled just fine without shielding), and finally removed compilation of `MusicInfoTagLoaderCDDA.cpp` when it's not used (current code builds and links `MusicInfoTagLoaderCDDA.cpp` even if usage of it is fully blocked, resulting in dead binary segments).

Code was tested on Win32 and Ubuntu.