### PR TITLE
Hide the toggle audio stream when there's only one

### DIFF
--- a/addons/skin.estuary/xml/Custom_1101_SettingsList.xml
+++ b/addons/skin.estuary/xml/Custom_1101_SettingsList.xml
@@ -58,6 +58,7 @@
 						<label>$LOCALIZE[31112]</label>
 						<label2>[B]$INFO[VideoPlayer.AudioLanguage][/B]</label2>
 						<onclick>AudioNextLanguage</onclick>
+						<visible>Integer.IsGreater(VideoPlayer.AudioStreamCount,1)</visible>
 					</control>
 					<control type="button" id="11105">
 						<width>700</width>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3691,6 +3691,15 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     @skinning_v19 **[New Infolabel]** \link VideoPlayer_TvShowDBID `VideoPlayer.TvShowDBID`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`VideoPlayer.AudioStreamCount`</b>,
+///                  \anchor VideoPlayer_AudioStreamCount
+///                  _integer_,
+///     @return The number of audio streams of the currently playing video.
+///     @note If the video contains no audio streams it returns 0.
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link VideoPlayer_AudioStreamCount `VideoPlayer.AudioStreamCount`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
@@ -3763,6 +3772,7 @@ const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
                                   { "dbid",             VIDEOPLAYER_DBID },
                                   { "uniqueid",         VIDEOPLAYER_UNIQUEID },
                                   { "tvshowdbid",       VIDEOPLAYER_TVSHOWDBID },
+                                  { "audiostreamcount", VIDEOPLAYER_AUDIOSTREAMCOUNT },
 };
 
 /// \page modules__infolabels_boolean_conditions

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -267,6 +267,7 @@
 #define VIDEOPLAYER_CAST              292
 #define VIDEOPLAYER_CAST_AND_ROLE     293
 #define VIDEOPLAYER_UNIQUEID          294
+#define VIDEOPLAYER_AUDIOSTREAMCOUNT  295
 
 // Videoplayer infobools
 #define VIDEOPLAYER_HASSUBTITLES      300

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -685,6 +685,18 @@ bool CVideoGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWin
     }
   }
 
+  switch (info.m_info)
+  {
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // VIDEOPLAYER_*
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    case VIDEOPLAYER_AUDIOSTREAMCOUNT:
+      value = g_application.GetAppPlayer().GetAudioStreamCount();
+      return true;
+    default:
+      break;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
## Description
Hide **Toggle audio stream** in Settings dialog when there's only one audio stream in the video that is playing.

Create a new ~~boolean~~ InfoLabel (_VideoPlayer.AudioStreamCount_ ~~_VideoPlayer.HasManyAudios_~~) to control the skin visibility of the toggle.

## How Has This Been Tested?
Works fine, the toggle is visible if the playing video has more than one audio stream.

Build and test on Linux x64.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
