### PR TITLE
fixed: add braces to avoid compiler warning

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -169,11 +169,13 @@ void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   {
     auto settingAction = std::dynamic_pointer_cast<const CSettingAction>(setting);
     if (settingAction != nullptr && settingAction->HasData())
+    {
       actionData = settingAction->GetData();
       // replace $CWD with the url of the add-on
       StringUtils::Replace(actionData, "$CWD", m_addonPath);
       // replace $ID with the id of the add-on
       StringUtils::Replace(actionData, "$ID", m_addonId);
+    }
   }
 
   // check if the setting control's is a button and its format is action


### PR DESCRIPTION
## Description
Quell a warning due to confusing indentation / missing braces.

## Motivation and Context
Quell some OCD.

## How Has This Been Tested?
It builds.