### PR TITLE
[build] fix new warning introduced by #19185

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4889,8 +4889,8 @@ std::vector<CScraperUrl::SUrlEntry> GetBasicItemAvailableArt(
     if (urlEntry.m_aspect.empty())
       urlEntry.m_aspect = tag.m_type == MediaTypeEpisode ? "thumb" : "poster";
     if ((urlEntry.m_aspect == artType ||
-        artType.empty() && !StringUtils::StartsWith(urlEntry.m_aspect, "set.")) &&
-      urlEntry.m_type == CScraperUrl::UrlType::General)
+         (artType.empty() && !StringUtils::StartsWith(urlEntry.m_aspect, "set."))) &&
+        urlEntry.m_type == CScraperUrl::UrlType::General)
     {
       result.push_back(urlEntry);
     }


### PR DESCRIPTION
## Description
looks like https://github.com/xbmc/xbmc/pull/19185 introduced a new warning.
so pr's based on this will miss the quality gate.

hope i fixed it correctly.
@rmrector please have a look

## Motivation and Context
https://jenkins.kodi.tv/job/Android-ARM64/17261/clang/new/source.87d64e10-5b41-4db3-bda0-ae16102a872d/#4892

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
