### PR TITLE
[Security] Use passwords.xml for more protocols

### DIFF
--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -118,7 +118,13 @@ bool CPasswordManager::IsURLSupported(const CURL &url)
 {
   return url.IsProtocol("smb")
     || url.IsProtocol("nfs")
-    || url.IsProtocol("sftp");
+    || url.IsProtocol("ftp")
+    || url.IsProtocol("ftps")
+    || url.IsProtocol("sftp")
+    || url.IsProtocol("http")
+    || url.IsProtocol("https")
+    || url.IsProtocol("dav")
+    || url.IsProtocol("davs");
 }
 
 void CPasswordManager::Clear()


### PR DESCRIPTION
## Description

This expands the use of PasswordManager so that it is used for `dav://`, `davs://`, `http://`, `https://`, `ftp://`, and `ftps://` protocol schemes, such that if the user adds a source using these schemes the secrets are put into `passwords.xml` and not `sources.xml`.

**Note:** existing `sources.xml` files aren't migrated in any way. If the user modifies any entries those individual entries will be migrated.

## Motivation and Context

See also #18241 and osmc/osmc#422

## How Has This Been Tested?

I tested on a Linux build. I added DAVS and FTPS sources before this patch, applied the patch and recompiled, and then modified the sources entries. I verified that the credentials in `sources.xml` for these sources were correctly migrated to `passwords.xml`. I also verified that the WebDAV connection still worked after applying the patch by playing a media file from it (I didn't do so for any of the other protocols because the WebDAV connection was the only one that represented a real network resource - I didn't want to set up an FTP/NFS/etc. server just for this).

I then created NFS and DAV sources and verified that they also went into `password.xml` as expected. Finally, I ran `make check` (see below).

I added HTTP and HTTPS to the list after doing all this testing - the test suite is running again right now. Will comment here when it's done.

## Screenshots (if appropriate):

N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

Note: two tests didn't pass, but they seem unrelated and have never passed on my platform (even before this change). Also I'm not sure if the component in the commit message is right - I kinda made it up but I wasn't sure since some commits in the log don't appear to use components at all?

I'm unclear as to whether this requires doc changes. https://kodi.wiki/view/Sources.xml/Types possibly should be changed to talk about `passwords.xml`, but that was true before this patch, too.
