### PR TITLE
Added "exactcleanstrings" advanced setting.

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -187,6 +187,8 @@ void CAdvancedSettings::Initialize()
   m_videoCleanStringRegExps.clear();
   m_videoCleanStringRegExps.emplace_back("[ _\\,\\.\\(\\)\\[\\]\\-](aka|ac3|dts|custom|dc|remastered|divx|divx5|dsr|dsrip|dutch|dvd|dvd5|dvd9|dvdrip|dvdscr|dvdscreener|screener|dvdivx|cam|fragment|fs|hdtv|hdrip|hdtvrip|internal|limited|multisubs|ntsc|ogg|ogm|pal|pdtv|proper|repack|rerip|retail|r3|r5|bd5|se|svcd|swedish|german|read.nfo|nfofix|unrated|extended|ws|telesync|ts|telecine|tc|brrip|bdrip|480p|480i|576p|576i|720p|720i|1080p|1080i|3d|hrhd|hrhdtv|hddvd|bluray|x264|h264|xvid|xvidvd|xxx|www.www|cd[1-9]|\\[.*\\])([ _\\,\\.\\(\\)\\[\\]\\-]|$)");
   m_videoCleanStringRegExps.emplace_back("(\\[.*\\])");
+  
+  m_videoExactCleanStringRegExps.clear();
 
   // this vector will be inserted at the end to
   // m_moviesExcludeFromScanRegExps, m_tvshowExcludeFromScanRegExps and
@@ -608,6 +610,10 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     pVideoExcludes = pElement->FirstChildElement("cleanstrings");
     if (pVideoExcludes)
       GetCustomRegexps(pVideoExcludes, m_videoCleanStringRegExps);
+  
+    pVideoExcludes = pElement->FirstChildElement("exactcleanstrings");
+    if (pVideoExcludes)
+      GetCustomRegexps(pVideoExcludes, m_videoExactCleanStringRegExps);  
 
     XMLUtils::GetString(pElement,"cleandatetime", m_videoCleanDateTimeRegExp);
     XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProc);
@@ -1221,6 +1227,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 void CAdvancedSettings::Clear()
 {
   m_videoCleanStringRegExps.clear();
+  m_videoExactCleanStringRegExps.clear();  
   m_moviesExcludeFromScanRegExps.clear();
   m_tvshowExcludeFromScanRegExps.clear();
   m_videoExcludeFromListingRegExps.clear();

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -197,6 +197,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_cachePath;
     std::string m_videoCleanDateTimeRegExp;
     std::vector<std::string> m_videoCleanStringRegExps;
+    std::vector<std::string> m_videoExactCleanStringRegExps;	
     std::vector<std::string> m_videoExcludeFromListingRegExps;
     std::vector<std::string> m_allExcludeFromScanRegExps;
     std::vector<std::string> m_moviesExcludeFromScanRegExps;


### PR DESCRIPTION
## Description
~Modified `cleanstrings` to remove only the regex match (rather than the match onward), if it is at the beginning of the string.~
Added `exactcleanstrings` advanced setting that removes only the regex match.

## Motivation and Context
~This enables prefix removal while preserving the existing suffix removal behavior.~
This is an alternative to the the existing `cleanstrings` advanced setting, which removes the regex match and everything after it.
The motivation is to enable more precise string cleaning (such as prefix removal).

## How Has This Been Tested?
~Applied this to the Leia branch and compiled for Windows x64 then tested 3 cases:~
~1. Match at beginning of movie name.~
~2. Match partway through movie name.~
~3. No match in movie name.~

~advancedsettings.xml:~
~`<advancedsettings>`~
~`	<video>`~
~`		<cleanstrings>`~
~`			<regexp>BD</regexp>`~
~`		</cleanstrings>`~
~`	</video>	`~
~`</advancedsettings>`~

~1. BD 50 First Dates (2004).mp4~
~2. 7 Days in Hell (2015) BD HEVC.mp4~
~3. 40 Days and 40 Nights (2002).mp4~

~All movies were successfully scraped in UI with log providing confirmation:~
~`2021-02-12 10:19:09.678 T:12620   DEBUG: ADDON::CScraper::FindMovie: Searching for '7 Days in Hell' using The Movie Database scraper (path: 'C:\Users\Bejhan\AppData\Roaming\Kodi\addons\metadata.themoviedb.org', content: 'movies', version: '5.2.6')`~
~`...`~
~`2021-02-12 10:19:10.622 T:12620   DEBUG: VideoInfoScanner: Adding new item to movies:smb://BEJHAN-PC/Videos/Test/7 Days in Hell (2015) BD HEVC.mp4`~
~`...`~
~`2021-02-12 10:19:11.634 T:12620   DEBUG: ADDON::CScraper::FindMovie: Searching for '40 Days and 40 Nights' using The Movie Database scraper (path: 'C:\Users\Bejhan\AppData\Roaming\Kodi\addons\metadata.themoviedb.org', content: 'movies', version: '5.2.6')`~
~`...`~
~`2021-02-12 10:19:12.606 T:12620   DEBUG: VideoInfoScanner: Adding new item to movies:smb://BEJHAN-PC/Videos/Test/40 Days and 40 Nights (2002).mp4`~
~`...`~
~`2021-02-12 10:19:13.525 T:12620   DEBUG: ADDON::CScraper::FindMovie: Searching for '50 First Dates' using The Movie Database scraper (path: 'C:\Users\Bejhan\AppData\Roaming\Kodi\addons\metadata.themoviedb.org', content: 'movies', version: ~'5.2.6')`~
~`...`~
~`2021-02-12 10:19:13.865 T:12620   DEBUG: VideoInfoScanner: Adding new item to movies:smb://BEJHAN-PC/Videos/Test/BD 50 First Dates (2004).mp4`~

Applied this to the Leia branch and compiled for Windows x64 then tested 4 cases:
1. Match at beginning of movie name.
2. Match partway through movie name.
3. Match at the end of movie name.
4. No match in movie name.

advancedsettings.xml:
```
<advancedsettings>
	<video>
		<exactcleanstrings>
			<regexp>BD</regexp>
		</exactcleanstrings>
	</video>	
</advancedsettings>
```

1. BD 50 First Dates (2004).mp4
2. 8 BD Mile (2002).mp4
3. 7 Days in Hell (2015) BD.mp4
4. 40 Days and 40 Nights (2002).mp4

All movies were successfully scraped in UI with log providing confirmation:
```
2021-02-28 20:43:56.104 T:7148   DEBUG: ADDON::CScraper::FindMovie: Searching for '7 Days in Hell' using The Movie Database scraper (path: 'C:\Users\Bejhan\AppData\Roaming\Kodi\addons\metadata.themoviedb.org', content: 'movies', version: '5.2.6')
...
2021-02-28 20:43:57.071 T:7148   DEBUG: VideoInfoScanner: Adding new item to movies:smb://BEJHAN-PC/Videos/Test Movies/7 Days in Hell (2015) BD.mp4
...
2021-02-28 20:43:57.103 T:7148   DEBUG: ADDON::CScraper::FindMovie: Searching for '8  Mile' using The Movie Database scraper (path: 'C:\Users\Bejhan\AppData\Roaming\Kodi\addons\metadata.themoviedb.org', content: 'movies', version: '5.2.6')
...
2021-02-28 20:43:57.450 T:7148   DEBUG: VideoInfoScanner: Adding new item to movies:smb://BEJHAN-PC/Videos/Test Movies/8 BD Mile (2002).mp4
...
2021-02-28 20:43:57.468 T:7148   DEBUG: ADDON::CScraper::FindMovie: Searching for '40 Days and 40 Nights' using The Movie Database scraper (path: 'C:\Users\Bejhan\AppData\Roaming\Kodi\addons\metadata.themoviedb.org', content: 'movies', version: '5.2.6')
...
2021-02-28 20:43:58.235 T:7148   DEBUG: VideoInfoScanner: Adding new item to movies:smb://BEJHAN-PC/Videos/Test Movies/40 Days and 40 Nights (2002).mp4
...
2021-02-28 20:43:58.258 T:7148   DEBUG: ADDON::CScraper::FindMovie: Searching for '50 First Dates' using The Movie Database scraper (path: 'C:\Users\Bejhan\AppData\Roaming\Kodi\addons\metadata.themoviedb.org', content: 'movies', version: '5.2.6')
...
2021-02-28 20:43:58.650 T:7148   DEBUG: VideoInfoScanner: Adding new item to movies:smb://BEJHAN-PC/Videos/Test Movies/BD 50 First Dates (2004).mp4
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
