### PR TITLE
[Estuary] PVR Guide window: Fix truncated channel numbers.

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -407,7 +407,7 @@
 					<control type="label">
 						<left>2</left>
 						<top>-2</top>
-						<width>75</width>
+						<width>90</width>
 						<height>60</height>
 						<font>font32_title</font>
 						<label>$INFO[ListItem.ChannelNumberLabel]</label>
@@ -415,7 +415,7 @@
 						<aligny>center</aligny>
 					</control>
 					<control type="label" id="1">
-						<left>68</left>
+						<left>83</left>
 						<top>-2</top>
 						<height>60</height>
 						<font>font13</font>
@@ -428,7 +428,7 @@
 					<control type="label">
 						<left>2</left>
 						<top>-2</top>
-						<width>75</width>
+						<width>90</width>
 						<height>60</height>
 						<font>font32_title</font>
 						<label>$INFO[ListItem.ChannelNumberLabel]</label>
@@ -437,7 +437,7 @@
 						<aligny>center</aligny>
 					</control>
 					<control type="label" id="1">
-						<left>68</left>
+						<left>83</left>
 						<top>-2</top>
 						<height>60</height>
 						<font>font13</font>


### PR DESCRIPTION
Fixes #19214 

Runtime-tested on macOS, with a setup containing >4000 channels.

@djp952 could you test and confirm the fix, please.

@DaveTBlake we should take this one for v19 final. No risk.