### PR TITLE
SMBFILE: Fixed samba FD leak on close

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -595,7 +595,7 @@ void CSMBFile::Close()
   {
     CLog::Log(LOGDEBUG,"CSMBFile::Close closing fd %d", m_fd);
     CSingleLock lock(smb);
-    if (smb.IsSmbValid())
+    if (!smb.IsSmbValid())
       return;
     smbc_close(m_fd);
   }


### PR DESCRIPTION
Fixed copy-past error.
Closes #19212

It's obvious typo.