### PR TITLE
[linux][discs][iso9660] Fix playback of encrypted dvds

### DIFF
--- a/xbmc/filesystem/ISO9660File.cpp
+++ b/xbmc/filesystem/ISO9660File.cpp
@@ -9,6 +9,7 @@
 #include "ISO9660File.h"
 
 #include "URL.h"
+#include "utils/log.h"
 
 #include <cmath>
 
@@ -115,7 +116,19 @@ int64_t CISO9660File::GetPosition()
 
 bool CISO9660File::Exists(const CURL& url)
 {
-  return Open(url);
+  if (!m_iso)
+    return false;
+
+  if (!m_iso->open(url.GetHostName().c_str()))
+  {
+    CLog::Log(LOGDEBUG, "{}: ISO 9660 open failed, attempting open_fuzzy", __FUNCTION__);
+    if (!m_iso->open_fuzzy(url.GetHostName().c_str()))
+    {
+      CLog::Log(LOGDEBUG, "{}: ISO 9660 open_fuzzy also failed", __FUNCTION__);
+      return false;
+    }
+  }
+  return true;
 }
 
 int CISO9660File::GetChunkSize()


### PR DESCRIPTION
## Description
This PR fixes the playback of physical encrypted DVD discs in Matrix. The issue happens because the new `CISO9660File::Open` returns early in the call to `open`.
Changed `open` to `open_fuzzy`:

```
Open an ISO 9660 image for "fuzzy" reading. This means that we
      will try to guess various internal offset based on internal
      checks. This may be useful when trying to read an ISO 9660 image
      contained in a file format that libiso9660 doesn't know natively
      (or knows imperfectly.). NULL is returned on
      error.

```

v2 changes:
- Decided to replace the implementation of `CISO9660` `Exists` to avoid changing the `Open` method itself
- For v 19.1

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18896
Restores optical disc playback functionality in Matrix (still used by a lot of users)

## How Has This Been Tested?

Tested under linux using the following steps:
- Unplug and plug external usb dvd drive
- Launch kodi
- Hit Play Disc

Also tested some of the my ISO samples without noticing any regression.


## Screenshots (if appropriate):
**Master:**
![master](https://imgur.com/download/kwaf1O4/)


**PR:**
![pr](https://imgur.com/download/2vKswe9/)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
