### PR TITLE
VideoPlayer: Change subtitle scanning order

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -777,6 +777,14 @@ bool CVideoPlayer::OpenInputStream()
     return false;
   }
 
+  m_clock.Reset();
+  m_dvd.Clear();
+
+  return true;
+}
+
+void CVideoPlayer::ScanExternalSubtitles()
+{
   // find any available external subtitles for non dvd files
   if (!m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) &&
       !m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
@@ -808,11 +816,6 @@ bool CVideoPlayer::OpenInputStream()
       }
     } // end loop over all subtitle files
   }
-
-  m_clock.Reset();
-  m_dvd.Clear();
-
-  return true;
 }
 
 bool CVideoPlayer::OpenDemuxStream()
@@ -1232,6 +1235,10 @@ void CVideoPlayer::Prepare()
     m_error = true;
     return;
   }
+
+  // scan for external subtitles
+  ScanExternalSubtitles();
+
   // give players a chance to reconsider now codecs are known
   CreatePlayers();
 
@@ -4492,6 +4499,7 @@ int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string
         m_SelectionStreams.Source(STREAM_SOURCE_DEMUX_SUB, filename),
         sub->demuxerId, sub->uniqueId);
       SelectionStream& stream = m_SelectionStreams.Get(STREAM_SUBTITLE, index);
+      CLog::Log(LOGDEBUG,"CVideoPlayer::AddSubtitleFile - add subtitle stream %d", index);
 
       if (stream.name.empty())
         stream.name = info.name;
@@ -4528,7 +4536,9 @@ int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string
 
   m_SelectionStreams.Update(s);
   UpdateContent();
-  return m_SelectionStreams.TypeIndexOf(STREAM_SUBTITLE, s.source, s.demuxerId, s.id);
+  int subId = m_SelectionStreams.TypeIndexOf(STREAM_SUBTITLE, s.source, s.demuxerId, s.id);
+  CLog::Log(LOGDEBUG,"CVideoPlayer::AddSubtitleFile - add subtitle stream %d", subId);
+  return subId;
 }
 
 void CVideoPlayer::UpdatePlayState(double timeout)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -428,6 +428,7 @@ protected:
   bool OpenDemuxStream();
   void CloseDemuxer();
   void OpenDefaultStreams(bool reset = true);
+  void ScanExternalSubtitles();
 
   void UpdatePlayState(double timeout);
   void GetGeneralInfo(std::string& strVideoInfo);


### PR DESCRIPTION
## Description
When a video is started, the VideoPlayer scans for external subtitle files and then for the subtitles included in the video. If a new subtitle is added during playback, it will be added at the end of the subtitle list.

I propose to change the scanning order: first internal, then external. This way the subtitles are scanned in the same order as when adding a new one (see issue #19211)

I've added a new ```ScanExternalSubtitles()``` method with the subtitles logic of ```OpenInputStream()```. The call to this method is made once the Demux has scanned the internal subtitles.

## How Has This Been Tested?
I've made several tests with subtitles and it works correctly.

## Screenshots
List of available subtitles when playing a video for the first time:

**Current:**
![current](https://user-images.githubusercontent.com/76552691/107876892-1ed9bc80-6ec9-11eb-9c6a-b3ed56f62557.png)

**PR:**
![new](https://user-images.githubusercontent.com/76552691/107876910-46308980-6ec9-11eb-84b4-6c64abafa582.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
