### PR TITLE
[Android] Fix crash due to lock on destroyed mutex

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1250,6 +1250,18 @@ int CXBMCApp::WaitForActivityResult(const CJNIIntent &intent, int requestCode, C
     result = event->GetResultData();
     ret = event->GetResultCode();
   }
+
+  // delete from m_activityResultEvents map before deleting the event
+  CSingleLock lock(m_activityResultMutex);
+  for (auto it = m_activityResultEvents.begin(); it != m_activityResultEvents.end(); ++it)
+  {
+    if ((*it)->GetRequestCode() == requestCode)
+    {
+      m_activityResultEvents.erase(it);
+      break;
+    }
+  }
+
   delete event;
   return ret;
 }


### PR DESCRIPTION
## Description
Found while testing voice recognition/search in android tv a while ago. Hitting many times on the voice/chromecast button in quick succession will cause Kodi to crash:

https://paste.kodi.tv/oxafucovut.kodi

The problem occurs because `onActivityResult` we call `Set()` on a `CEvent` (base class of `CActivityResultEvent`) that has been already deleted. So this PR makes sure the event is removed from the list before it is actually destroyed, so that we don't attempt to set a result on a destroyed event.

## Motivation and Context
Kodi shouldn't crash

## How Has This Been Tested?
Runtime tested in Android TV (xiaomi mi box S) trying hard to make it crash. Voice recognition works as expected.
testbuild in the mirrors: http://mirrors.kodi.tv/test-builds/android/arm/kodi-20210214-727eb323-PR14-merge-armeabi-v7a.apk

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
