### PR TITLE
Add default select action for Episodes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14852,7 +14852,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#22079"
-msgid "Default select action"
+msgid "Default select action - EPG"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -22484,4 +22484,14 @@ msgstr ""
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#39153"
 msgid "Windowing system:"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39158"
+msgid "Default select action - Movies & others"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39159"
+msgid "Default select action - Episodes"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -855,7 +855,21 @@
     </category>
     <category id="video" label="14215" help="38107">
       <group id="1" label="593">
-        <setting id="myvideos.selectaction" type="integer" label="22079" help="36177">
+       <setting id="myvideos.selectaction" type="integer" label="39158" help="36177">
+          <level>0</level>
+          <default>1</default> <!-- SELECT_ACTION_PLAY_OR_RESUME -->
+          <constraints>
+            <options>
+              <option label="22080">0</option> <!-- SELECT_ACTION_CHOOSE -->
+              <option label="208">1</option> <!-- SELECT_ACTION_PLAY_OR_RESUME -->
+              <option label="13404">2</option> <!-- SELECT_ACTION_RESUME -->
+              <option label="22081">3</option> <!-- SELECT_ACTION_INFO -->
+              <option label="13347">7</option> <!-- SELECT_ACTION_QUEUE -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="myvideos.selectepisodeaction" type="integer" label="39159" help="36177">
           <level>0</level>
           <default>1</default> <!-- SELECT_ACTION_PLAY_OR_RESUME -->
           <constraints>

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -382,10 +382,18 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
 {
   CFileItem fileItem(*std::static_pointer_cast<CFileItem>(item));
 
-  if (fileItem.HasVideoInfoTag()
-      && CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION) == SELECT_ACTION_INFO
-      && OnInfo(item))
-    return true;
+  if (fileItem.HasVideoInfoTag())
+  {
+    if (fileItem.GetVideoContentType() == VIDEODB_CONTENT_EPISODES)
+    {
+        if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTEPISODEACTION) == SELECT_ACTION_INFO
+            && OnInfo(item))
+            return true;
+    }        
+    else if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION) == SELECT_ACTION_INFO
+            && OnInfo(item))
+        return true;
+  }    
 
   if (fileItem.HasProperty("node.target_url"))
     fileItem.SetPath(fileItem.GetProperty("node.target_url").asString());

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -152,6 +152,7 @@ constexpr const char* CSettings::SETTING_VIDEOPLAYER_USESTAGEFRIGHT;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_LIMITGUIUPDATE;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC;
 constexpr const char* CSettings::SETTING_MYVIDEOS_SELECTACTION;
+constexpr const char* CSettings::SETTING_MYVIDEOS_SELECTEPISODEACTION;
 constexpr const char* CSettings::SETTING_MYVIDEOS_USETAGS;
 constexpr const char* CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS;
 constexpr const char* CSettings::SETTING_MYVIDEOS_EXTRACTCHAPTERTHUMBS;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -130,6 +130,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_LIMITGUIUPDATE = "videoplayer.limitguiupdate";
   static constexpr auto SETTING_VIDEOPLAYER_SUPPORTMVC = "videoplayer.supportmvc";
   static constexpr auto SETTING_MYVIDEOS_SELECTACTION = "myvideos.selectaction";
+  static constexpr auto SETTING_MYVIDEOS_SELECTEPISODEACTION = "myvideos.selectepisodeaction";
   static constexpr auto SETTING_MYVIDEOS_USETAGS = "myvideos.usetags";
   static constexpr auto SETTING_MYVIDEOS_EXTRACTFLAGS = "myvideos.extractflags";
   static constexpr auto SETTING_MYVIDEOS_EXTRACTCHAPTERTHUMBS = "myvideos.extractchapterthumbs";

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -638,8 +638,12 @@ bool CGUIWindowVideoBase::OnSelect(int iItem)
       !StringUtils::StartsWith(path, "newplaylist://") &&
       !StringUtils::StartsWith(path, "newtag://") &&
       !StringUtils::StartsWith(path, "script://"))
-    return OnFileAction(iItem, CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION), "");
-
+  {
+      if (item->GetVideoInfoTag()->m_type == MediaTypeEpisode)                                                                                            
+          return OnFileAction(iItem, CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTEPISODEACTION), "");  // Episodes
+      else
+      return OnFileAction(iItem, CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION), "");             // Movies and others
+  }
   return CGUIMediaWindow::OnSelect(iItem);
 }
 
@@ -1067,7 +1071,12 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         // any other select actions but play or resume, resume, play or playpart
         // don't make any sense here since the user already decided that he'd
         // like to play the item (just with a specific player)
-        VideoSelectAction selectAction = (VideoSelectAction)CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION);
+        VideoSelectAction selectAction;
+        if (item->GetVideoInfoTag()->m_type == MediaTypeEpisode)
+            selectAction = (VideoSelectAction)CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTEPISODEACTION);
+        else
+            selectAction = (VideoSelectAction)CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION);
+
         if (selectAction != SELECT_ACTION_PLAY_OR_RESUME &&
             selectAction != SELECT_ACTION_RESUME &&
             selectAction != SELECT_ACTION_PLAY &&


### PR DESCRIPTION
## Description
Add option to chose the "default select action for episodes"

## Motivation and Context
It makes sense having the info window coming up  for movies before playing. But I believe not many users want that for episodes.

https://forum.kodi.tv/showthread.php?tid=343371


## How Has This Been Tested?
Windows 10 x64

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
