### PR TITLE
Resolution: fixed choosing native resolution when double fps is disabled

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -192,6 +192,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     CLog::Log(LOGDEBUG,
               "[WHITELIST] No match for an exact resolution with double the refresh rate");
   }
+  else if (found)
+    return;
 
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN))


### PR DESCRIPTION
This is a simple fix for #19178 (and #19124).

When user disabled both double refresh rate and 3:2 refresh rate, native resolution will not be chosen even if exact framerate match is available.

This PR fixed it.