### PR TITLE
[addons] declare inputstream.adaptive as optional system add-on

### DIFF
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -57,4 +57,5 @@
   <addon>xbmc.python</addon>
   <addon>xbmc.webinterface</addon>
   <addon optional="true">peripheral.joystick</addon>
+  <addon optional="true">inputstream.adaptive</addon>
 </addons>


### PR DESCRIPTION
## Description
though in https://github.com/xbmc/xbmc/pull/19091 platform android is excluded from enabling add-ons on startup, this behavior was reported on freenode recently.

so let's turn `inputstream.adaptive` into an optional system add-on, like it as already done for `peripheral.joystick` (which is also part of the resulting apk like ia is)

this will change the origin of IA from manual install to 'origin-system' and therefor prevent the unwanted startup query.
it also auto-enables IA on startup if it's installed on the filesystem.
should go definitely into v19 final in my opinion.

## Motivation and Context
reported on freenode, forwarded by @lrusak 

## How Has This Been Tested?
inputstream.adaptive got auto-enabled on runtime test

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
