### PR TITLE
[gbm] default to original crtc mode

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMCrtc.h
+++ b/xbmc/windowing/gbm/drm/DRMCrtc.h
@@ -30,6 +30,7 @@ public:
   uint32_t GetX() const { return m_crtc->x; }
   uint32_t GetY() const { return m_crtc->y; }
   drmModeModeInfoPtr GetMode() const { return &m_crtc->mode; }
+  bool GetModeValid() const { return m_crtc->mode_valid != 0; }
 
 private:
   struct DrmModeCrtcDeleter

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -144,6 +144,9 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
 
 bool CDRMUtils::FindPreferredMode()
 {
+  if (m_mode)
+    return true;
+
   for (int i = 0, area = 0; i < m_connector->GetModesCount(); i++)
   {
     drmModeModeInfo* current_mode = m_connector->GetModeForIndex(i);
@@ -534,6 +537,13 @@ bool CDRMUtils::FindCrtc()
       if (m_crtcs[i]->GetCrtcId() == m_encoder->GetCrtcId())
       {
         m_orig_crtc = m_crtcs[i].get();
+        if (m_orig_crtc->GetModeValid())
+        {
+          m_mode = m_orig_crtc->GetMode();
+          CLog::Log(LOGDEBUG, "CDRMUtils::{} - original crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
+                    m_mode->hdisplay, m_mode->vdisplay,
+                    m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
+        }
         return true;
       }
     }


### PR DESCRIPTION
## Description
This brings RES_DESKTOP handling of gbm in line with other windowing systems.

If the framebuffer has been set up with a valid mode before kodi
startup then use that as the default / DESKTOP mode, otherwise fall
back to the previous behaviour of setting DESKTOP to the preferred
mode reported by drm.

## Motivation and Context
This avoids unnecessary mode switches at kodi startup (which usually
lead to screen blanking for a short time) and allows users to easily
override broken video/edid/... setups by manually configuring a mode
in linux which then kodi uses too. That is especially important when
running kodi for the first time, if it switches to a different mode
that might not be working with the user's monitor the result is a
black screen with no easy possibility to fix the settings.

## How Has This Been Tested?
Tested on RPi4 / LibreELEC, manually configured a video mode on kernel command line, checked with modetest to see if the mode was set before kodi startup, then started kodi with .kodi folder removed and checked that kodi used that mode instead of the DRM reported preferred mode.

Debug log (with 1360x768@60 mode used for testing): http://ix.io/2PMr

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
