### PR TITLE
Local connection to MySQL using Unix sockets

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -147,7 +147,7 @@ int MysqlDatabase::connect(bool create_new) {
     return DB_CONNECTION_NONE;
 
   std::string resolvedHost;
-  if (CDNSNameCache::Lookup(host, resolvedHost))
+  if (!StringUtils::EqualsNoCase(host,"localhost") && CDNSNameCache::Lookup(host, resolvedHost))
   {
     CLog::Log(LOGDEBUG, "{} replacing configured host {} with resolved host {}", __FUNCTION__, host,
               resolvedHost);


### PR DESCRIPTION
## Description
As described in the issue #19245, to connect to a local MySQL using Unix sockets or shared memory on Windows, we shouldn't do a name resolution when it's ```localhost```

## How Has This Been Tested?
Connection tests with ```localhost``` on Windows and Linux.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
