### PR TITLE
CMake: fixed correct minimal CMake version for Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.4)
+if(WIN32)
+  # Version 3.15 is required to use "PREPEND" for dependencies
+  cmake_minimum_required(VERSION 3.15)
+endif()
 project(kodi LANGUAGES CXX C ASM)
 
 if(POLICY CMP0069)


### PR DESCRIPTION
[As found](https://github.com/xbmc/xbmc/pull/19165#discussion_r579637354) by @afedchin, recent [CMake win32 files changes](https://github.com/xbmc/xbmc/pull/19165) require higher minimal version.
It makes sense to increase minimal version for Win32 only where it's really required and keep CMake 3.4 version requirement for other platforms.

This combination has been tested locally: Windows now requires >=3.15, while other platforms still want >=3.4.