### PR TITLE
Rework Restoring of GUI Elements

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -109,6 +109,18 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
   return CLinuxRendererGL::Configure(picture, fps, orientation);
 }
 
+bool CRendererVAAPI::Flush(bool saveBuffers)
+{
+  for (auto &vaapiTexture : m_vaapiTextures)
+  {
+    if (m_isVAAPIBuffer)
+    {
+      vaapiTexture->Unmap();
+    }
+  }
+  return CLinuxRendererGL::Flush(saveBuffers);
+}
+
 bool CRendererVAAPI::ConfigChanged(const VideoPicture &picture)
 {
   CVaapiRenderPicture *pic = dynamic_cast<CVaapiRenderPicture*>(picture.videoBuffer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
@@ -33,6 +33,7 @@ public:
   bool ConfigChanged(const VideoPicture &picture) override;
   void ReleaseBuffer(int idx) override;
   bool NeedBuffer(int idx) override;
+  bool Flush(bool saveBuffers) override;
 
   // Feature support
   bool Supports(ERENDERFEATURE feature) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
@@ -101,6 +101,15 @@ bool CRendererVDPAU::NeedBuffer(int idx)
   return false;
 }
 
+bool CRendererVDPAU::Flush(bool saveBuffers)
+{
+  for (int i = 0; i < NUM_BUFFERS; i++)
+      m_vdpauTextures[i].Unmap();
+
+  return CLinuxRendererGL::Flush(saveBuffers);
+}
+
+
 void CRendererVDPAU::ReleaseBuffer(int idx)
 {
   if (glIsSync(m_fences[idx]))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.h
@@ -26,6 +26,7 @@ public:
   void ReleaseBuffer(int idx) override;
   bool ConfigChanged(const VideoPicture &picture) override;
   bool NeedBuffer(int idx) override;
+  bool Flush(bool saveBuffers) override;
 
   // Feature support
   bool Supports(ERENDERFEATURE feature) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -440,6 +440,11 @@ bool CLinuxRendererGL::Flush(bool saveBuffers)
     DeleteTexture(i);
   }
 
+  delete m_pYUVShader;
+  m_pYUVShader = nullptr;
+  delete m_pVideoFilterShader;
+  m_pVideoFilterShader = nullptr;
+
   glFinish();
   m_bValidated = false;
   m_fbo.fbo.Cleanup();

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -14,6 +14,9 @@
 #include "addons/AddonManager.h"
 #include "addons/FontResource.h"
 #include "GUIFontTTF.h"
+#if defined(HAS_GLES) || defined (HAS_GL)
+#include "GUIFontTTFGL.h"
+#endif
 #include "GUIFont.h"
 #include "utils/XMLUtils.h"
 #include "GUIControlFactory.h"
@@ -339,6 +342,10 @@ void GUIFontManager::Clear()
   m_vecFonts.clear();
   m_vecFontFiles.clear();
   m_vecFontInfo.clear();
+
+#if defined(HAS_GLES) || defined (HAS_GL)
+  CGUIFontTTFGL::DestroyStaticVertexBuffers();
+#endif
 }
 
 void GUIFontManager::LoadFonts(const std::string& fontSet)

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -41,9 +41,6 @@ bool CWinSystemBase::InitWindowSystem()
 
 bool CWinSystemBase::DestroyWindowSystem()
 {
-#if HAS_GLES
-  CGUIFontTTFGL::DestroyStaticVertexBuffers();
-#endif
   m_screenSaverManager.reset();
   return false;
 }

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -221,12 +221,19 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
   bool success = false;
   if (m_pGLContext)
   {
+    if (force)
+    {
+      g_application.UnloadSkin();
+      CRenderSystemGL::DestroyRenderSystem();
+    }
     success = m_pGLContext->Refresh(force, m_screen, m_glWindow, m_newGlContext);
     if (!success)
     {
       success = m_pGLContext->CreatePB();
       m_newGlContext = true;
     }
+    if (force)
+      CRenderSystemGL::InitRenderSystem();
     return success;
   }
 


### PR DESCRIPTION
With external events taking place (e.g. TV turned off) Fonts and textures might not be visible on screen anymore. The key reason here is that though things are changing we don't properly invalidate the shaders that draw them and also don't recreate the contents.

This needs testing. It only forward ported code given in the forum: https://forum.kodi.tv/showthread.php?tid=344992
The VDPAU additions might even be wrong.