### PR TITLE
[Subtitles][ASS] Do not reinitialize the libass handler upon seek

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -41,8 +41,14 @@ bool CDVDOverlayCodecSSA::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   Dispose();
 
   m_hints  = hints;
-  m_libass = new CDVDSubtitlesLibass();
-  return m_libass->DecodeHeader((char *)hints.extradata, hints.extrasize);
+  return InitLibass();
+}
+
+bool CDVDOverlayCodecSSA::InitLibass()
+{
+  if (!m_libass)
+    m_libass = new CDVDSubtitlesLibass();
+  return m_libass->DecodeHeader(static_cast<char*>(m_hints.extradata), m_hints.extrasize);
 }
 
 void CDVDOverlayCodecSSA::Dispose()
@@ -143,15 +149,14 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
 void CDVDOverlayCodecSSA::Reset()
 {
   Dispose();
-  m_order  = 0;
-  m_output = false;
-  m_libass = new CDVDSubtitlesLibass();
-  m_libass->DecodeHeader((char *)m_hints.extradata, m_hints.extrasize);
+  Flush();
 }
 
 void CDVDOverlayCodecSSA::Flush()
 {
-  Reset();
+  m_order = 0;
+  m_output = false;
+  InitLibass();
 }
 
 CDVDOverlay* CDVDOverlayCodecSSA::GetOverlay()
@@ -163,5 +168,3 @@ CDVDOverlay* CDVDOverlayCodecSSA::GetOverlay()
   }
   return NULL;
 }
-
-

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
@@ -27,6 +27,10 @@ public:
   CDVDOverlay* GetOverlay() override;
 
 private:
+  /*! \brief Initializes the libass handler
+   */
+  bool InitLibass();
+
   CDVDSubtitlesLibass* m_libass;
   CDVDOverlaySSA*      m_pOverlay;
   bool                 m_output;


### PR DESCRIPTION
## Description
Right now whenever we play a video file with muxed ASS subtitles we are destructing and recreating the libass handler upon seek (it calls flush). This is an expensive operation (we initialize the library, the options, the render, extract fonts, etc) which leads to a few seconds without any subtitles displayed on the player.

## Motivation and Context
Display subtitles right away upon seek.

## How Has This Been Tested?
Runtime tested with all my ASS samples

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
