### PR TITLE
[Android] Use c++11 range for loops

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1208,14 +1208,14 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
 void CXBMCApp::onActivityResult(int requestCode, int resultCode, CJNIIntent resultData)
 {
   CSingleLock lock(m_activityResultMutex);
-  for (auto it = m_activityResultEvents.begin(); it != m_activityResultEvents.end(); ++it)
+  for (auto& activityResultEvent : m_activityResultEvents)
   {
-    if ((*it)->GetRequestCode() == requestCode)
+    if (activityResultEvent->GetRequestCode() == requestCode)
     {
-      (*it)->SetResultCode(resultCode);
-      (*it)->SetResultData(resultData);
-      (*it)->Set();
-      m_activityResultEvents.erase(it);
+      activityResultEvent->SetResultCode(resultCode);
+      activityResultEvent->SetResultData(resultData);
+      activityResultEvent->Set();
+      m_activityResultEvents.erase(activityResultEvent);
       break;
     }
   }
@@ -1251,13 +1251,13 @@ int CXBMCApp::WaitForActivityResult(const CJNIIntent &intent, int requestCode, C
     ret = event->GetResultCode();
   }
 
-  // delete from m_activityResultEvents map before deleting the event
+  // delete from m_activityResultEvents before deleting the event
   CSingleLock lock(m_activityResultMutex);
-  for (auto it = m_activityResultEvents.begin(); it != m_activityResultEvents.end(); ++it)
+  for (const auto& activityResultEvent : m_activityResultEvents)
   {
-    if ((*it)->GetRequestCode() == requestCode)
+    if (activityResultEvent->GetRequestCode() == requestCode)
     {
-      m_activityResultEvents.erase(it);
+      m_activityResultEvents.erase(activityResultEvent);
       break;
     }
   }


### PR DESCRIPTION
## Description
Follow up to https://github.com/xbmc/xbmc/pull/19232 implements the changes requested in https://github.com/xbmc/xbmc/pull/19291#discussion_r583641084

Decided to adjust the other loop over m_activityResultEvents too (the source of the original problem).

## Motivation and Context
New standards

## How Has This Been Tested?
Untested. I'll trigger a test build from jenkins and test tonight.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
