### PR TITLE
[addons] fix: check minversion on dependency installation

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15891,7 +15891,14 @@ msgctxt "#24184"
 msgid " (optional)"
 msgstr ""
 
-#empty strings from id 24185 to 24990
+#. The minimum version, only lower versions are available for install
+#. {3:s} reserved for an empty string or the " (optional)" optional string. see #24184
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#24185"
+msgid "Minimum: {0:s} / Not available{3:s}"
+msgstr ""
+
+#empty strings from id 24186 to 24990
 
 #. Used as error message in add-on browser when add-on repository data could not be downloaded
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -929,6 +929,19 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
             ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
             return false;
           }
+          else
+          {
+            if (!dependencyToInstall->MeetsVersion(versionMin, version))
+            {
+              CLog::Log(LOGERROR,
+                        "CAddonInstallJob[{}]: found dependency [{}/{}] doesn't meet minimum "
+                        "version [{}]",
+                        m_addon->ID(), addonID, dependencyToInstall->Version().asString(),
+                        versionMin.asString());
+              ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
+              return false;
+            }
+          }
 
           if (IsModal())
           {

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -621,11 +621,21 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
           int messageId = 24180; // minversion only
 
           // dep not installed locally, but it is available from a repo!
+          // make sure only non-optional add-ons that meet versionMin are
+          // announced for installation
+
           if (!it.m_installed)
           {
-            if (entryPoint != EntryPoint::SHOW_DEPENDENCIES)
+            if (entryPoint != EntryPoint::SHOW_DEPENDENCIES && !it.m_depInfo.optional)
             {
-              messageId = 24181; // => install
+              if (it.m_depInfo.versionMin <= it.m_available->Version())
+              {
+                messageId = 24181; // => install
+              }
+              else
+              {
+                messageId = 24185; // => not available, only lower versions available in the repos
+              }
             }
           }
           else // dep is installed locally


### PR DESCRIPTION
## Description
adds a minimum version check on installation of addon dependencies.
for deps there was no check at all, so we could end up with installations that do not meet the requirements.

## Motivation and Context
closes #19297 

## How Has This Been Tested?
unmet version requirements are now logged and rejected:
```
ERROR <general>: CAddonInstallJob[skin.arctic.horizon]:
   found dependency [script.skinvariables/0.0.3] doesn't meet minimum version [0.2.3]
```

## Screenshots

![dependencyversion](https://user-images.githubusercontent.com/58829855/109412783-4725e880-79aa-11eb-869b-28a59e31e0d5.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document


EDIT:
also tested with addon setting `Install from any repository` => `Skin Variables`, `TheMovieDB Helper` and the skin itself installed fine from the 3rd party repo; updated log-message and screenshot