### PR TITLE
[addons] Fix addon specials to work with make install

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -607,6 +607,8 @@ bool CAddonMgr::FindAddon(const std::string& addonId,
   FindAddons(installedAddons, "special://xbmcbin/addons");
   FindAddons(installedAddons, "special://xbmc/addons");
   FindAddons(installedAddons, "special://home/addons");
+  FindAddons(installedAddons, "special://xbmcbinaddons");
+  FindAddons(installedAddons, "special://xbmcaltbinaddons");
 
   const auto it = installedAddons.find(addonId);
   if (it == installedAddons.cend() || it->second->Version() != addonVersion)
@@ -637,6 +639,8 @@ bool CAddonMgr::FindAddons()
   FindAddons(installedAddons, "special://xbmcbin/addons");
   FindAddons(installedAddons, "special://xbmc/addons");
   FindAddons(installedAddons, "special://home/addons");
+  FindAddons(installedAddons, "special://xbmcbinaddons");
+  FindAddons(installedAddons, "special://xbmcaltbinaddons");
 
   std::set<std::string> installed;
   for (const auto& addon : installedAddons)


### PR DESCRIPTION
Apparently, special://xbmcbin/addons is not the same thing as
special://xbmcbinaddons when running "make install":

$ ls -ld /usr/local/stow/kodi-git/lib/kodi/addons /usr/local/stow/kodi-git/share/kodi/addons
ls: cannot access '/usr/local/stow/kodi-git/lib/kodi/addons': No such file or directory
drwxr-sr-x 59 rah staff 4096 Feb 25 21:46 /usr/local/stow/kodi-git/share/kodi/addons

which can give rise to errors loading addons:

2021-02-27 16:56:29.585 T:19028   ERROR <general>: GetDirectory - Error getting /usr/local/stow/kodi-git/lib/kodi/addons
2021-02-27 16:56:29.585 T:19028   ERROR <general>: GetDirectory - Error getting special://xbmcbin/addons

To fix this, we add special://xbmcbinaddons and
special://xbmcaltbinaddons to the search path for addons.