### PR TITLE
[Python] Remove xbmc.translatePath (use xbmcvfs.translatePath)

### DIFF
--- a/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_python.dox
@@ -148,8 +148,11 @@ web applications or frameworks for the Python programming language.
 
 /*!
 @page python_v20 Python API v20
-*/
-/*!
+\python_removed_function{
+      translatePath,
+      "",
+      <b>xbmc.translatePath()</b> function was removed completely. Use <b>xbmcvfs.translatePath()</b>.
+}
 @page python_v19 Python API v19
 \python_removed_function{
       onDatabaseUpdated,

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -22,7 +22,6 @@
 #include "aojsonrpc.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "filesystem/File.h"
-#include "filesystem/SpecialProtocol.h" //! @todo remove me when dropping translatePath from this file
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -375,14 +374,6 @@ namespace XBMCAddon
       XBMC_TRACE;
       auto crc = Crc32::ComputeFromLowerCase(path);
       return StringUtils::Format("%08x.tbn", crc);
-    }
-
-    String translatePath(const String& path)
-    {
-      XBMC_TRACE;
-      CLog::Log(LOGWARNING, "xbmc.translatePath is deprecated and might be removed in future kodi "
-                            "versions. Please use xbmcvfs.translatePath instead.");
-      return CSpecialProtocol::TranslatePath(path);
     }
 
     Tuple<String,String> getCleanMovieTitle(const String& path, bool usefoldername)

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -613,35 +613,6 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmc
-    /// @brief \python_func{ xbmc.translatePath(path)  }
-    /// Returns the translated path.
-    ///
-    /// @param path                  string - Path to format
-    /// @return                      Translated path
-    ///
-    /// @note Only useful if you are coding for both Linux and Windows.
-    ///        e.g. Converts 'special://home' -> '/home/[username]/.kodi'
-    ///        on Linux.
-    ///
-    ///
-    /// ------------------------------------------------------------------------
-    /// @python_v19 Deprecated **xbmc.translatePath**. Moved to **xbmcvfs.translatePath**
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ..
-    /// fpath = xbmc.translatePath('special://home')
-    /// ..
-    /// ~~~~~~~~~~~~~
-    ///
-    translatePath(...);
-#else
-    String translatePath(const String& path);
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmc
     /// @brief \python_func{ xbmc.getCleanMovieTitle(path[, usefoldername]) }
     /// Get clean movie title and year string if available.
     ///


### PR DESCRIPTION
## Description
Removes `xbmc.translatePath` in favor of `xbmcvfs.translatePath` for kodi N and above. It was deprecated in Matrix, we've been enforcing the transition for any addons in Matrix.
This is basically the only api cleanup we decided not to enforce in Matrix to give addon devs enough time to adjust.

## Motivation and Context
Cleanup

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
