### PR TITLE
[Fix] Bad picture on some VP9 HDR streams due not detection of video metadata

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -987,6 +987,10 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
            (m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10||
             m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10_INTRA))
     pVideoPicture->colorBits = 10;
+  else if (m_pCodecContext->codec_id == AV_CODEC_ID_VP9 &&
+           (m_pCodecContext->profile == FF_PROFILE_VP9_2 ||
+            m_pCodecContext->profile == FF_PROFILE_VP9_3))
+    pVideoPicture->colorBits = 10;
 
   if (m_pCodecContext->color_range == AVCOL_RANGE_JPEG ||
     m_pCodecContext->pix_fmt == AV_PIX_FMT_YUVJ420P)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1619,6 +1619,28 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->iBitsPerPixel = pStream->codecpar->bits_per_coded_sample;
         st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
 
+        st->colorPrimaries = pStream->codecpar->color_primaries;
+        st->colorSpace = pStream->codecpar->color_space;
+        st->colorTransferCharacteristic = pStream->codecpar->color_trc;
+        st->colorRange = pStream->codecpar->color_range;
+
+        int size = 0;
+        uint8_t* side_data = nullptr;
+
+        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
+        if (side_data && size)
+        {
+          st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
+              *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
+        }
+
+        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);
+        if (side_data && size)
+        {
+          st->contentLightMetaData = std::make_shared<AVContentLightMetadata>(
+              *reinterpret_cast<AVContentLightMetadata*>(side_data));
+        }
+
         AVDictionaryEntry* rtag = av_dict_get(pStream->metadata, "rotate", NULL, 0);
         if (rtag)
           st->iOrientation = atoi(rtag->value);


### PR DESCRIPTION
## Description
- Fix bad picture on some VP9 HDR streams due not detection of video metadata.
- Also they are not detected the common video parameters (color bit depth, color space, matrix, transfer, video range).

## Motivation and Context
Found while testing new improved OSD debug info (Alt+O) (https://github.com/xbmc/xbmc/pull/19126).
See https://forum.kodi.tv/showthread.php?tid=359964&pid=3015976#pid3015976

Current Kodi code can pick metadata both from every frame or from m_hints (initialized once at beginning):

https://github.com/xbmc/xbmc/blob/ce595fb16711a985b7011d98af105dbc9f6f2cff/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp#L1003-L1015

This VP9 HDR stream (and probably others) has not metadata in every frame but only at beginning so is need to read from m_hints however, for some reason, this data is not read from source.

This PR enables read this data when is available (xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp ) and add it to m_hints also other missing video parameters (color space, matrix, transfer, video range).

A "part 2" of the fix consists on obtain correct bit depth from pixel format. Due the way of ffmpeg handles pixel format when HW decoding is used becomes hidden and currently is used a "workaround" using video codec / profile infos:

https://github.com/xbmc/xbmc/blob/ce595fb16711a985b7011d98af105dbc9f6f2cff/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp#L978-L989

In this way is need add every particular case (new codecs / profiles) and one option is add `AV_CODEC_ID_VP9` with profile 2 as 10 bits. However same is need to do for AV1 codec, etc...

I found a better way using `m_pCodecContext->sw_pix_fmt`. Unlike `pix_fmt` it always specifies the pixel format even when using HW decoding. Then can be used a generic way of obtaining pixel bit depth (valid for all codecs):

```c++
  if (m_pCodecContext->sw_pix_fmt == AV_PIX_FMT_YUV420P)
    pVideoPicture->colorBits = 8;
  else if (m_pCodecContext->sw_pix_fmt == AV_PIX_FMT_YUV420P10)
    pVideoPicture->colorBits = 10;
  else if (m_pCodecContext->sw_pix_fmt == AV_PIX_FMT_YUV420P12)
    pVideoPicture->colorBits = 12;
  else if (m_pCodecContext->sw_pix_fmt == AV_PIX_FMT_YUV420P16)
    pVideoPicture->colorBits = 16;
  else
    pVideoPicture->colorBits = 8;
```

## How Has This Been Tested?
Used VP9 test file: 
https://www.mediafire.com/file/p9nbcenggjk8ofv/2560x1440_vp9_hdr_60fps.mkv/file
or from Kodi Wiki Samples:
20. VP9 Profile 2 HDR 59.940fps The World in HDR
https://mega.nz/#!hJdFEIBI!uSOjZtkkjIVYSfqD9aSfONf1yq__uQvlsf47pCtFvdQ

Tested in both tone mapping and HDR passtrough modes.

## Screenshots (if appropriate):
Before
![screenshot00001](https://user-images.githubusercontent.com/58434170/109431546-7880d180-7a07-11eb-885e-89e617ef8b6d.png)

After
![screenshot00002](https://user-images.githubusercontent.com/58434170/109431582-a6661600-7a07-11eb-9cad-5b008f706045.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
