### PR TITLE
Refactor CPluginDirectory into separatly usable classes

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -8,7 +8,6 @@
 
 #include "PluginDirectory.h"
 
-#include "Application.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -16,17 +15,11 @@
 #include "addons/AddonManager.h"
 #include "addons/IAddon.h"
 #include "addons/PluginSource.h"
-#include "dialogs/GUIDialogBusy.h"
-#include "dialogs/GUIDialogProgress.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
 #include "interfaces/generic/RunningScriptObserver.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
-#include "threads/SystemClock.h"
-#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
@@ -35,9 +28,7 @@ using namespace XFILE;
 using namespace ADDON;
 using namespace KODI::MESSAGING;
 
-CPluginDirectory::CPluginDirectory()
-  : m_fetchComplete(true)
-  , m_cancelled(false)
+CPluginDirectory::CPluginDirectory() : m_cancelled(false)
 {
   m_listItems = new CFileItemList;
   m_fileResult = new CFileItem;
@@ -53,76 +44,30 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)
 {
   CURL url(strPath);
 
+  ADDON::AddonPtr addon;
   // try the plugin type first, and if not found, try an unknown type
-  if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), m_addon, ADDON_PLUGIN,
+  if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN,
                                               OnlyEnabled::YES) &&
-      !CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), m_addon, ADDON_UNKNOWN,
+      !CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_UNKNOWN,
                                               OnlyEnabled::YES) &&
-      !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), m_addon,
+      !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), addon,
                                                    InstallModalPrompt::PROMPT))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;
   }
 
-  // get options
-  std::string options = url.GetOptions();
-  url.SetOptions(""); // do this because we can then use the url to generate the basepath
-                      // which is passed to the plugin (and represents the share)
-
-  std::string basePath(url.Get());
-  // reset our wait event, and grab a new handle
-  m_fetchComplete.Reset();
-  int handle = CScriptInvocationManager::GetInstance().GetReusablePluginHandle(m_addon->LibPath());
-
-  if (handle < 0)
-    handle = GetNewScriptHandle(this);
-  else
-    ReuseScriptHandle(handle, this);
-
   // clear out our status variables
   m_fileResult->Reset();
   m_listItems->Clear();
   m_listItems->SetPath(strPath);
-  m_listItems->SetLabel(m_addon->Name());
+  m_listItems->SetLabel(addon->Name());
   m_cancelled = false;
   m_success = false;
   m_totalItems = 0;
 
-  // setup our parameters to send the script
-  std::string strHandle = StringUtils::Format("%i", handle);
-  std::vector<std::string> argv;
-  argv.push_back(basePath);
-  argv.push_back(strHandle);
-  argv.push_back(options);
-
-  std::string strResume = "resume:false";
-  if (resume)
-    strResume = "resume:true";
-  argv.push_back(strResume);
-
   // run the script
-  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s','%s')", __FUNCTION__, m_addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str(), argv[3].c_str());
-  bool success = false;
-  std::string file = m_addon->LibPath();
-  bool reuseLanguageInvoker = false;
-  if (m_addon->ExtraInfo().find("reuselanguageinvoker") != m_addon->ExtraInfo().end())
-    reuseLanguageInvoker = m_addon->ExtraInfo().at("reuselanguageinvoker") == "true";
-
-  int id = CScriptInvocationManager::GetInstance().ExecuteAsync(file, m_addon, argv,
-                                                                reuseLanguageInvoker, handle);
-  if (id >= 0)
-  { // wait for our script to finish
-    std::string scriptName = m_addon->Name();
-    success = WaitOnScriptResult(file, id, scriptName);
-  }
-  else
-    CLog::Log(LOGERROR, "Unable to run plugin %s", m_addon->Name().c_str());
-
-  // free our handle
-  RemoveScriptHandle(handle);
-
-  return success;
+  return RunScript(this, addon, strPath, resume);
 }
 
 bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &resultItem, bool resume)
@@ -193,7 +138,7 @@ void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceList
     dir->m_listItems->AddSortMethod(SortByNone, 552, LABEL_MASKS("%L", "%D"));
 
   // set the event to mark that we're done
-  dir->m_fetchComplete.Set();
+  dir->SetDone();
 }
 
 void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const std::string &labelMask, const std::string &label2Mask)
@@ -409,88 +354,7 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
     return false;
   }
 
-  // options
-  std::string options = url.GetOptions();
-  url.SetOptions(""); // do this because we can then use the url to generate the basepath
-                      // which is passed to the plugin (and represents the share)
-
-  std::string basePath(url.Get());
-
-  // setup our parameters to send the script
-  std::string strHandle = StringUtils::Format("%i", -1);
-  std::vector<std::string> argv;
-  argv.push_back(basePath);
-  argv.push_back(strHandle);
-  argv.push_back(options);
-
-  std::string strResume = "resume:false";
-  if (resume)
-    strResume = "resume:true";
-  argv.push_back(strResume);
-
-  // run the script
-  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s','%s')", __FUNCTION__, addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str(), argv[3].c_str());
-  if (CScriptInvocationManager::GetInstance().ExecuteAsync(addon->LibPath(), addon, argv) >= 0)
-    return true;
-  else
-    CLog::Log(LOGERROR, "Unable to run plugin %s", addon->Name().c_str());
-
-  return false;
-}
-
-bool CPluginDirectory::WaitOnScriptResult(const std::string& scriptPath,
-                                          int scriptId,
-                                          const std::string& scriptName)
-{
-  // CPluginDirectory::GetDirectory can be called from the main and other threads.
-  // If called form the main thread, we need to bring up the BusyDialog in order to
-  // keep the render loop alive
-  if (g_application.IsCurrentThread())
-  {
-    if (!m_fetchComplete.WaitMSec(20))
-    {
-      CRunningScriptObserver scriptObs(scriptId, m_fetchComplete);
-
-      CGUIDialogProgress* progress = nullptr;
-      CGUIWindowManager& wm = CServiceBroker::GetGUI()->GetWindowManager();
-      if (wm.IsModalDialogTopmost(WINDOW_DIALOG_PROGRESS))
-        progress = wm.GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
-
-      if (progress != nullptr)
-      {
-        if (!progress->WaitOnEvent(m_fetchComplete))
-          m_cancelled = true;
-      }
-      else if (!CGUIDialogBusy::WaitOnEvent(m_fetchComplete, 200))
-        m_cancelled = true;
-
-      scriptObs.Abort();
-    }
-  }
-  else
-  {
-    // Wait for directory fetch to complete, end, or be cancelled
-    while (!m_cancelled
-        && CScriptInvocationManager::GetInstance().IsRunning(scriptId)
-        && !m_fetchComplete.WaitMSec(20));
-
-    // Give the script 30 seconds to exit before we attempt to stop it
-    XbmcThreads::EndTime timer(30000);
-    while (!timer.IsTimePast()
-          && CScriptInvocationManager::GetInstance().IsRunning(scriptId)
-          && !m_fetchComplete.WaitMSec(20));
-  }
-
-  if (m_cancelled)
-  { // cancel our script
-    if (scriptId != -1 && CScriptInvocationManager::GetInstance().IsRunning(scriptId))
-    {
-      CLog::Log(LOGDEBUG, "%s- cancelling plugin %s (id=%d)", __FUNCTION__, scriptName.c_str(), scriptId);
-      CScriptInvocationManager::GetInstance().Stop(scriptId);
-    }
-  }
-
-  return !m_cancelled && m_success;
+  return ExecuteScript(addon, strPath, resume) >= 0;
 }
 
 void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem *resultItem)
@@ -504,15 +368,15 @@ void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem 
   *dir->m_fileResult = *resultItem;
 
   // set the event to mark that we're done
-  dir->m_fetchComplete.Set();
+  dir->SetDone();
 }
 
 std::string CPluginDirectory::GetSetting(int handle, const std::string &strID)
 {
   CSingleLock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
-  if(dir && dir->m_addon)
-    return dir->m_addon->GetSetting(strID);
+  if (dir && dir->GetAddon())
+    return dir->GetAddon()->GetSetting(strID);
   else
     return "";
 }
@@ -521,8 +385,8 @@ void CPluginDirectory::SetSetting(int handle, const std::string &strID, const st
 {
   CSingleLock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
-  if(dir && dir->m_addon)
-    dir->m_addon->UpdateSetting(strID, value);
+  if (dir && dir->GetAddon())
+    dir->GetAddon()->UpdateSetting(strID, value);
 }
 
 void CPluginDirectory::SetContent(int handle, const std::string &strContent)
@@ -548,7 +412,6 @@ void CPluginDirectory::SetProperty(int handle, const std::string &strProperty, c
 void CPluginDirectory::CancelDirectory()
 {
   m_cancelled = true;
-  m_fetchComplete.Set();
 }
 
 float CPluginDirectory::GetProgress() const

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -20,7 +20,7 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "interfaces/generic/ScriptInvocationManager.h"
+#include "interfaces/generic/RunningScriptObserver.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -34,31 +34,6 @@
 using namespace XFILE;
 using namespace ADDON;
 using namespace KODI::MESSAGING;
-
-CPluginDirectory::CScriptObserver::CScriptObserver(int scriptId, CEvent &event) :
-  CThread("scriptobs"), m_scriptId(scriptId), m_event(event)
-{
-  Create();
-}
-
-void CPluginDirectory::CScriptObserver::Process()
-{
-  while (!m_bStop)
-  {
-    if (!CScriptInvocationManager::GetInstance().IsRunning(m_scriptId))
-    {
-      m_event.Set();
-      break;
-    }
-    CThread::Sleep(20);
-  }
-}
-
-void CPluginDirectory::CScriptObserver::Abort()
-{
-  // will wait until thread exits
-  StopThread();
-}
 
 CPluginDirectory::CPluginDirectory()
   : m_fetchComplete(true)
@@ -472,7 +447,7 @@ bool CPluginDirectory::WaitOnScriptResult(const std::string &scriptPath, int scr
   {
     if (!m_fetchComplete.WaitMSec(20))
     {
-      CScriptObserver scriptObs(scriptId, m_fetchComplete);
+      CRunningScriptObserver scriptObs(scriptId, m_fetchComplete);
 
       CGUIDialogProgress* progress = nullptr;
       CGUIWindowManager& wm = CServiceBroker::GetGUI()->GetWindowManager();

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -35,10 +35,6 @@ using namespace XFILE;
 using namespace ADDON;
 using namespace KODI::MESSAGING;
 
-std::map<int, CPluginDirectory *> CPluginDirectory::globalHandles;
-int CPluginDirectory::handleCounter = 0;
-CCriticalSection CPluginDirectory::m_handleLock;
-
 CPluginDirectory::CScriptObserver::CScriptObserver(int scriptId, CEvent &event) :
   CThread("scriptobs"), m_scriptId(scriptId), m_event(event)
 {
@@ -78,37 +74,6 @@ CPluginDirectory::~CPluginDirectory(void)
   delete m_fileResult;
 }
 
-int CPluginDirectory::getNewHandle(CPluginDirectory *cp)
-{
-  CSingleLock lock(m_handleLock);
-  int handle = ++handleCounter;
-  globalHandles[handle] = cp;
-  return handle;
-}
-
-void CPluginDirectory::reuseHandle(int handle, CPluginDirectory* cp)
-{
-  CSingleLock lock(m_handleLock);
-  globalHandles[handle] = cp;
-}
-
-void CPluginDirectory::removeHandle(int handle)
-{
-  CSingleLock lock(m_handleLock);
-  if (!globalHandles.erase(handle))
-    CLog::Log(LOGWARNING, "Attempt to erase invalid handle %i", handle);
-}
-
-CPluginDirectory *CPluginDirectory::dirFromHandle(int handle)
-{
-  CSingleLock lock(m_handleLock);
-  std::map<int, CPluginDirectory *>::iterator i = globalHandles.find(handle);
-  if (i != globalHandles.end())
-    return i->second;
-  CLog::Log(LOGWARNING, "Attempt to use invalid handle %i", handle);
-  return NULL;
-}
-
 bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDir, bool resume)
 {
   CURL url(strPath);
@@ -136,9 +101,9 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   int handle = CScriptInvocationManager::GetInstance().GetReusablePluginHandle(m_addon->LibPath());
 
   if (handle < 0)
-    handle = getNewHandle(this);
+    handle = GetNewScriptHandle(this);
   else
-    reuseHandle(handle, this);
+    ReuseScriptHandle(handle, this);
 
   // clear out our status variables
   m_fileResult->Reset();
@@ -180,7 +145,7 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
     CLog::Log(LOGERROR, "Unable to run plugin %s", m_addon->Name().c_str());
 
   // free our handle
-  removeHandle(handle);
+  RemoveScriptHandle(handle);
 
   return success;
 }
@@ -209,8 +174,8 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
 
 bool CPluginDirectory::AddItem(int handle, const CFileItem *item, int totalItems)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return false;
 
@@ -223,8 +188,8 @@ bool CPluginDirectory::AddItem(int handle, const CFileItem *item, int totalItems
 
 bool CPluginDirectory::AddItems(int handle, const CFileItemList *items, int totalItems)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return false;
 
@@ -238,8 +203,8 @@ bool CPluginDirectory::AddItems(int handle, const CFileItemList *items, int tota
 
 void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceListing, bool cacheToDisc)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
 
@@ -258,8 +223,8 @@ void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceList
 
 void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const std::string &labelMask, const std::string &label2Mask)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
 
@@ -553,8 +518,8 @@ bool CPluginDirectory::WaitOnScriptResult(const std::string &scriptPath, int scr
 
 void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem *resultItem)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
 
@@ -567,8 +532,8 @@ void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem 
 
 std::string CPluginDirectory::GetSetting(int handle, const std::string &strID)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if(dir && dir->m_addon)
     return dir->m_addon->GetSetting(strID);
   else
@@ -577,24 +542,24 @@ std::string CPluginDirectory::GetSetting(int handle, const std::string &strID)
 
 void CPluginDirectory::SetSetting(int handle, const std::string &strID, const std::string &value)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if(dir && dir->m_addon)
     dir->m_addon->UpdateSetting(strID, value);
 }
 
 void CPluginDirectory::SetContent(int handle, const std::string &strContent)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (dir)
     dir->m_listItems->SetContent(strContent);
 }
 
 void CPluginDirectory::SetProperty(int handle, const std::string &strProperty, const std::string &strValue)
 {
-  CSingleLock lock(m_handleLock);
-  CPluginDirectory *dir = dirFromHandle(handle);
+  CSingleLock lock(GetScriptsLock());
+  CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
   if (strProperty == "fanart_image")

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -49,7 +49,7 @@ CPluginDirectory::~CPluginDirectory(void)
   delete m_fileResult;
 }
 
-bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDir, bool resume)
+bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)
 {
   CURL url(strPath);
 
@@ -114,7 +114,7 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   if (id >= 0)
   { // wait for our script to finish
     std::string scriptName = m_addon->Name();
-    success = WaitOnScriptResult(file, id, scriptName, retrievingDir);
+    success = WaitOnScriptResult(file, id, scriptName);
   }
   else
     CLog::Log(LOGERROR, "Unable to run plugin %s", m_addon->Name().c_str());
@@ -130,7 +130,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
   CURL url(strPath);
   CPluginDirectory newDir;
 
-  bool success = newDir.StartScript(strPath, false, resume);
+  bool success = newDir.StartScript(strPath, resume);
 
   if (success)
   { // update the play path and metadata, saving the old one as needed
@@ -385,7 +385,7 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const s
 bool CPluginDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   const std::string pathToUrl(url.Get());
-  bool success = StartScript(pathToUrl, true, false);
+  bool success = StartScript(pathToUrl, false);
 
   // append the items to the list
   items.Assign(*m_listItems, true); // true to keep the current items
@@ -438,7 +438,9 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
   return false;
 }
 
-bool CPluginDirectory::WaitOnScriptResult(const std::string &scriptPath, int scriptId, const std::string &scriptName, bool retrievingDir)
+bool CPluginDirectory::WaitOnScriptResult(const std::string& scriptPath,
+                                          int scriptId,
+                                          const std::string& scriptName)
 {
   // CPluginDirectory::GetDirectory can be called from the main and other threads.
   // If called form the main thread, we need to bring up the BusyDialog in order to

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -11,12 +11,11 @@
 #include "IDirectory.h"
 #include "SortFileItem.h"
 #include "addons/IAddon.h"
-#include "threads/CriticalSection.h"
+#include "interfaces/generic/RunningScriptsHandler.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
 
 #include <atomic>
-#include <map>
 #include <string>
 
 #include "PlatformDefs.h"
@@ -28,7 +27,7 @@ class CFileItemList;
 namespace XFILE
 {
 
-class CPluginDirectory : public IDirectory
+class CPluginDirectory : public IDirectory, public CRunningScriptsHandler<CPluginDirectory>
 {
 public:
   CPluginDirectory();
@@ -72,15 +71,6 @@ private:
   ADDON::AddonPtr m_addon;
   bool StartScript(const std::string& strPath, bool retrievingDir, bool resume);
   bool WaitOnScriptResult(const std::string &scriptPath, int scriptId, const std::string &scriptName, bool retrievingDir);
-
-  static std::map<int,CPluginDirectory*> globalHandles;
-  static int getNewHandle(CPluginDirectory *cp);
-  static void reuseHandle(int handle, CPluginDirectory* cp);
-
-  static void removeHandle(int handle);
-  static CPluginDirectory *dirFromHandle(int handle);
-  static CCriticalSection m_handleLock;
-  static int handleCounter;
 
   CFileItemList* m_listItems;
   CFileItem*     m_fileResult;

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -68,8 +68,10 @@ public:
 
 private:
   ADDON::AddonPtr m_addon;
-  bool StartScript(const std::string& strPath, bool retrievingDir, bool resume);
-  bool WaitOnScriptResult(const std::string &scriptPath, int scriptId, const std::string &scriptName, bool retrievingDir);
+  bool StartScript(const std::string& strPath, bool resume);
+  bool WaitOnScriptResult(const std::string& scriptPath,
+                          int scriptId,
+                          const std::string& scriptName);
 
   CFileItemList* m_listItems;
   CFileItem*     m_fileResult;

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -10,14 +10,11 @@
 
 #include "IDirectory.h"
 #include "SortFileItem.h"
-#include "addons/IAddon.h"
 #include "interfaces/generic/RunningScriptsHandler.h"
 #include "threads/Event.h"
 
 #include <atomic>
 #include <string>
-
-#include "PlatformDefs.h"
 
 class CURL;
 class CFileItem;
@@ -66,19 +63,19 @@ public:
   static void SetResolvedUrl(int handle, bool success, const CFileItem* resultItem);
   static void SetLabel2(int handle, const std::string& ident);
 
+protected:
+  // implementations of CRunningScriptsHandler / CScriptRunner
+  bool IsSuccessful() const override { return m_success; }
+  bool IsCancelled() const override { return m_cancelled; }
+
 private:
-  ADDON::AddonPtr m_addon;
   bool StartScript(const std::string& strPath, bool resume);
-  bool WaitOnScriptResult(const std::string& scriptPath,
-                          int scriptId,
-                          const std::string& scriptName);
 
   CFileItemList* m_listItems;
-  CFileItem*     m_fileResult;
-  CEvent         m_fetchComplete;
+  CFileItem* m_fileResult;
 
   std::atomic<bool> m_cancelled;
-  bool          m_success = false;      // set by script in EndOfDirectory
-  int    m_totalItems = 0;   // set by script in AddDirectoryItem
+  bool m_success = false; // set by script in EndOfDirectory
+  int m_totalItems = 0; // set by script in AddDirectoryItem
 };
 }

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -13,7 +13,6 @@
 #include "addons/IAddon.h"
 #include "interfaces/generic/RunningScriptsHandler.h"
 #include "threads/Event.h"
-#include "threads/Thread.h"
 
 #include <atomic>
 #include <string>
@@ -79,16 +78,5 @@ private:
   std::atomic<bool> m_cancelled;
   bool          m_success = false;      // set by script in EndOfDirectory
   int    m_totalItems = 0;   // set by script in AddDirectoryItem
-
-  class CScriptObserver : public CThread
-  {
-  public:
-    CScriptObserver(int scriptId, CEvent &event);
-    void Abort();
-  protected:
-    void Process() override;
-    int m_scriptId;
-    CEvent &m_event;
-  };
 };
 }

--- a/xbmc/interfaces/generic/CMakeLists.txt
+++ b/xbmc/interfaces/generic/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES ILanguageInvoker.cpp
 set(HEADERS ILanguageInvocationHandler.h
             ILanguageInvoker.h
             LanguageInvokerThread.h
+            RunningScriptsHandler.h
             ScriptInvocationManager.h)
 
 core_add_library(generic_interface)

--- a/xbmc/interfaces/generic/CMakeLists.txt
+++ b/xbmc/interfaces/generic/CMakeLists.txt
@@ -1,11 +1,13 @@
 set(SOURCES ILanguageInvoker.cpp
             LanguageInvokerThread.cpp
+            RunningScriptObserver.cpp
             ScriptInvocationManager.cpp)
 
 set(HEADERS ILanguageInvocationHandler.h
             ILanguageInvoker.h
             LanguageInvokerThread.h
             RunningScriptsHandler.h
+            RunningScriptObserver.h
             ScriptInvocationManager.h)
 
 core_add_library(generic_interface)

--- a/xbmc/interfaces/generic/CMakeLists.txt
+++ b/xbmc/interfaces/generic/CMakeLists.txt
@@ -1,13 +1,15 @@
 set(SOURCES ILanguageInvoker.cpp
             LanguageInvokerThread.cpp
             RunningScriptObserver.cpp
-            ScriptInvocationManager.cpp)
+            ScriptInvocationManager.cpp
+            ScriptRunner.cpp)
 
 set(HEADERS ILanguageInvocationHandler.h
             ILanguageInvoker.h
             LanguageInvokerThread.h
             RunningScriptsHandler.h
             RunningScriptObserver.h
-            ScriptInvocationManager.h)
+            ScriptInvocationManager.h
+            ScriptRunner.h)
 
 core_add_library(generic_interface)

--- a/xbmc/interfaces/generic/RunningScriptObserver.cpp
+++ b/xbmc/interfaces/generic/RunningScriptObserver.cpp
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2017-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RunningScriptObserver.h"
+
+#include "interfaces/generic/ScriptInvocationManager.h"
+
+CRunningScriptObserver::CRunningScriptObserver(int scriptId, CEvent& evt)
+  : m_scriptId(scriptId),
+  m_event(evt),
+  m_thread(this, "ScriptObs"),
+  m_stopEvent(true)
+{
+  m_thread.Create();
+}
+
+void CRunningScriptObserver::Run()
+{
+  do
+  {
+    if (!CScriptInvocationManager::GetInstance().IsRunning(m_scriptId))
+    {
+      m_event.Set();
+      break;
+    }
+  } while (!m_stopEvent.WaitMSec(20));
+}
+
+void CRunningScriptObserver::Abort()
+{
+  m_stopEvent.Set();
+}

--- a/xbmc/interfaces/generic/RunningScriptObserver.h
+++ b/xbmc/interfaces/generic/RunningScriptObserver.h
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2017-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/Event.h"
+#include "threads/IRunnable.h"
+#include "threads/Thread.h"
+
+#include <atomic>
+
+class CRunningScriptObserver : public IRunnable
+{
+public:
+  CRunningScriptObserver(int scriptId, CEvent& evt);
+  ~CRunningScriptObserver() = default;
+
+  void Abort();
+
+protected:
+  // implementation of IRunnable
+  void Run() override;
+
+  int m_scriptId;
+  CEvent& m_event;
+
+  CThread m_thread;
+  CEvent m_stopEvent;
+};

--- a/xbmc/interfaces/generic/RunningScriptsHandler.h
+++ b/xbmc/interfaces/generic/RunningScriptsHandler.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2017-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+#include "threads/SingleLock.h"
+
+#include <cstdint>
+#include <map>
+
+template<class TScript>
+class CRunningScriptsHandler
+{
+protected:
+  using HandleType = int;
+
+  CRunningScriptsHandler() = default;
+  virtual ~CRunningScriptsHandler() = default;
+
+  static HandleType GetNewScriptHandle(TScript* script)
+  {
+    CSingleLock lock(s_critical);
+    uint32_t handle = ++s_scriptHandleCounter;
+    s_scriptHandles[handle] = script;
+
+    return handle;
+  }
+
+  static void ReuseScriptHandle(HandleType handle, TScript* script)
+  {
+    CSingleLock lock(s_critical);
+    s_scriptHandles[handle] = script;
+  }
+
+  static void RemoveScriptHandle(HandleType handle)
+  {
+    CSingleLock lock(s_critical);
+    s_scriptHandles.erase(handle);
+  }
+
+  static TScript* GetScriptFromHandle(HandleType handle)
+  {
+    CSingleLock lock(s_critical);
+    auto scriptHandle = s_scriptHandles.find(handle);
+    if (scriptHandle == s_scriptHandles.end())
+      return nullptr;
+
+    return scriptHandle->second;
+  }
+
+  static inline CCriticalSection& GetScriptsLock() { return s_critical; }
+
+private:
+  static std::map<HandleType, TScript*> s_scriptHandles;
+  static CCriticalSection s_critical;
+  static HandleType s_scriptHandleCounter;
+};
+
+template<class TScript>
+std::map<typename CRunningScriptsHandler<TScript>::HandleType, TScript*>
+    CRunningScriptsHandler<TScript>::s_scriptHandles;
+template<class TScript>
+CCriticalSection CRunningScriptsHandler<TScript>::s_critical;
+template<class TScript>
+typename CRunningScriptsHandler<TScript>::HandleType
+    CRunningScriptsHandler<TScript>::s_scriptHandleCounter = 0;

--- a/xbmc/interfaces/generic/ScriptRunner.cpp
+++ b/xbmc/interfaces/generic/ScriptRunner.cpp
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (C) 2017-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ScriptRunner.h"
+
+#include "Application.h"
+#include "URL.h"
+#include "dialogs/GUIDialogBusy.h"
+#include "dialogs/GUIDialogProgress.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "interfaces/generic/RunningScriptObserver.h"
+#include "interfaces/generic/ScriptInvocationManager.h"
+#include "threads/SystemClock.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <vector>
+
+ADDON::AddonPtr CScriptRunner::GetAddon() const
+{
+  return m_addon;
+}
+
+bool CScriptRunner::StartScript(ADDON::AddonPtr addon, const std::string& path)
+{
+  return RunScriptInternal(addon, path, 0, false);
+}
+
+bool CScriptRunner::RunScript(ADDON::AddonPtr addon,
+                              const std::string& path,
+                              int handle,
+                              bool resume)
+{
+  return RunScriptInternal(addon, path, handle, resume, true);
+}
+
+void CScriptRunner::SetDone()
+{
+  m_scriptDone.Set();
+}
+
+int CScriptRunner::ExecuteScript(ADDON::AddonPtr addon, const std::string& path, bool resume)
+{
+  return ExecuteScript(addon, path, -1, resume);
+}
+
+int CScriptRunner::ExecuteScript(ADDON::AddonPtr addon,
+                                 const std::string& path,
+                                 int handle,
+                                 bool resume)
+{
+  if (addon == nullptr || path.empty())
+    return false;
+
+  CURL url(path);
+
+  // get options and remove them from the URL because we can then use the url
+  // to generate the base path which is passed to the add-on script
+  auto options = url.GetOptions();
+  url.SetOptions("");
+
+  // setup our parameters to send the script
+  std::vector<std::string> argv = {url.Get(), // base path
+                                   StringUtils::Format("{:d}", handle), options,
+                                   StringUtils::Format("resume:{}", resume)};
+
+  bool reuseLanguageInvoker = false;
+  const auto reuseLanguageInvokerIt = addon->ExtraInfo().find("reuselanguageinvoker");
+  if (reuseLanguageInvokerIt != addon->ExtraInfo().end())
+    reuseLanguageInvoker = reuseLanguageInvokerIt->second == "true";
+
+  // run the script
+  CLog::Log(LOGDEBUG, "CScriptRunner: running add-on script {:s}('{:s}', '{:s}', '{:s}')",
+            addon->Name(), argv[0], argv[1], argv[2]);
+  int scriptId = CScriptInvocationManager::GetInstance().ExecuteAsync(addon->LibPath(), addon, argv,
+                                                                      reuseLanguageInvoker, handle);
+  if (scriptId < 0)
+    CLog::Log(LOGERROR, "CScriptRunner: unable to run add-on script {:s}", addon->Name());
+
+  return scriptId;
+}
+
+bool CScriptRunner::RunScriptInternal(
+    ADDON::AddonPtr addon, const std::string& path, int handle, bool resume, bool wait /* = true */)
+{
+  if (addon == nullptr || path.empty())
+    return false;
+
+  // reset our wait event
+  m_scriptDone.Reset();
+
+  // store the add-on
+  m_addon = addon;
+
+  int scriptId = ExecuteScript(addon, path, handle, resume);
+  if (scriptId < 0)
+    return false;
+
+  // we don't need to wait for the script to end
+  if (!wait)
+    return true;
+
+  // wait for our script to finish
+  return WaitOnScriptResult(scriptId, addon->LibPath(), addon->Name());
+}
+
+bool CScriptRunner::WaitOnScriptResult(int scriptId,
+                                       const std::string& path,
+                                       const std::string& name)
+{
+  bool cancelled = false;
+
+  // Add-on scripts can be called from the main and other threads. If called
+  // form the main thread, we need to bring up the BusyDialog in order to
+  // keep the render loop alive
+  if (g_application.IsCurrentThread())
+  {
+    if (!m_scriptDone.WaitMSec(20))
+    {
+      // observe the script until it's finished while showing the busy dialog
+      CRunningScriptObserver scriptObs(scriptId, m_scriptDone);
+
+      auto& wm = CServiceBroker::GetGUI()->GetWindowManager();
+      if (wm.IsModalDialogTopmost(WINDOW_DIALOG_PROGRESS))
+      {
+        auto progress = wm.GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+        if (!progress->WaitOnEvent(m_scriptDone))
+          cancelled = true;
+      }
+      else if (!CGUIDialogBusy::WaitOnEvent(m_scriptDone, 200))
+        cancelled = true;
+
+      scriptObs.Abort();
+    }
+  }
+  else
+  {
+    // wait for the script to finish or be cancelled
+    while (!IsCancelled() && CScriptInvocationManager::GetInstance().IsRunning(scriptId) &&
+           !m_scriptDone.WaitMSec(20))
+      ;
+
+    // give the script 30 seconds to exit before we attempt to stop it
+    XbmcThreads::EndTime timer(30000);
+    while (!timer.IsTimePast() && CScriptInvocationManager::GetInstance().IsRunning(scriptId) &&
+           !m_scriptDone.WaitMSec(20))
+      ;
+  }
+
+  if (cancelled || IsCancelled())
+  {
+    // cancel the script
+    if (scriptId != -1 && CScriptInvocationManager::GetInstance().IsRunning(scriptId))
+    {
+      CLog::Log(LOGDEBUG, "CScriptRunner: cancelling add-on script {:s} (id = {:d})", name,
+                scriptId);
+      CScriptInvocationManager::GetInstance().Stop(scriptId);
+    }
+  }
+
+  return !cancelled && !IsCancelled() && IsSuccessful();
+}

--- a/xbmc/interfaces/generic/ScriptRunner.h
+++ b/xbmc/interfaces/generic/ScriptRunner.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2017-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "addons/IAddon.h"
+#include "threads/Event.h"
+
+#include <string>
+
+class CScriptRunner
+{
+protected:
+  CScriptRunner() = default;
+  virtual ~CScriptRunner() = default;
+
+  virtual bool IsSuccessful() const = 0;
+  virtual bool IsCancelled() const = 0;
+
+  ADDON::AddonPtr GetAddon() const;
+
+  bool StartScript(ADDON::AddonPtr addon, const std::string& path);
+  bool RunScript(ADDON::AddonPtr addon, const std::string& path, int handle, bool resume);
+
+  void SetDone();
+
+  static int ExecuteScript(ADDON::AddonPtr addon, const std::string& path, bool resume);
+  static int ExecuteScript(ADDON::AddonPtr addon, const std::string& path, int handle, bool resume);
+
+private:
+  bool RunScriptInternal(
+      ADDON::AddonPtr addon, const std::string& path, int handle, bool resume, bool wait = true);
+  bool WaitOnScriptResult(int scriptId, const std::string& path, const std::string& name);
+
+  ADDON::AddonPtr m_addon;
+
+  CEvent m_scriptDone;
+};


### PR DESCRIPTION
## Description
This PR splits up `CPluginDirectory` into the following classes:
* `CRunningScriptObserver`: Helper to track whether a script is still running or not.
* `CScriptRunner`: abstract base class to execute / run a script from an add-on synchronously or asynchronously. For synchronous execution it uses `CRunningScriptObserver` to wait for the script to finish.
* `CRunningScriptsHandler<>`: Template specialization of `CScriptRunner` with the added functionality to track running scripts and their state of a specific type. Right now this is only used by `CPluginDirectory` but in my media import work this is also used by the code that runs the media importer add-ons.

## Motivation and Context
My main goal was to extract the logic from `CPluginDirectory` to run add-on scripts and get a result back. `CPluginDirectory` now only contains plugin specific logic (i.e. processing a list of items). It uses `CRunningScriptsHandler<>` to execute the plugin scripts and wait for the result.

@enen92 asked me to PR this refactoring early for v20 because he wants to tackle the busy dialog issue and my work provides a decent cleanup of the existing code.

## How Has This Been Tested?
These commits have been part of my media import work for almost four years without any issues.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
