### PR TITLE
[backport] [linux] fix drm object build with gcc-4.9

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -100,7 +100,7 @@ std::tuple<bool, uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
     if (prop->enums[j].name != valueName)
       continue;
 
-    return {true, prop->enums[j].value};
+    return std::make_tuple(true, prop->enums[j].value);
   }
 
   return std::make_tuple(false, 0);


### PR DESCRIPTION
Fixes build error introduced by PR #18858

kodi/xbmc/windowing/gbm/drm/DRMObject.cpp: In member function 'std::tuple<bool, long unsigned int> KODI::WINDOWING::GBM::CDRMObject::GetPropertyValue(const string&, const string&) const':
kodi/xbmc/windowing/gbm/drm/DRMObject.cpp:103:39: error: converting to 'std::tuple<bool, long unsigned int>' from initializer list would use explicit constructor 'constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = bool; _U2 = long long unsigned int&; <template-parameter-2-3> = void; _T1 = bool; _T2 = long unsigned int]'
     return {true, prop->enums[j].value};

Backport of https://github.com/xbmc/xbmc/pull/19020

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] All new and existing tests passed
