### PR TITLE
[PVR] Change EPG overlapped event logging to DEBUG level instead of WARNING level

### DIFF
--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -96,7 +96,7 @@ bool FixOverlap(const std::shared_ptr<CPVREpgInfoTag>& previousTag,
   if (previousTag->EndAsUTC() >= currentTag->EndAsUTC())
   {
     // delete the current tag. it's completely overlapped
-    CLog::LogF(LOGWARNING,
+    CLog::LogF(LOGDEBUG,
                "Erasing completely overlapped event from EPG timeline "
                "({} - {} - {} - {}) "
                "({} - {} - {} - {}).",
@@ -111,7 +111,7 @@ bool FixOverlap(const std::shared_ptr<CPVREpgInfoTag>& previousTag,
   else if (previousTag->EndAsUTC() > currentTag->StartAsUTC())
   {
     // fix the end time of the predecessor of the event
-    CLog::LogF(LOGWARNING,
+    CLog::LogF(LOGDEBUG,
                "Fixing partly overlapped event in EPG timeline "
                "({} - {} - {} - {}) "
                "({} - {} - {} - {}).",


### PR DESCRIPTION
## Description
I've received a handful of complaints in regard to how Kodi 19 "Matrix" is logging WARNING messages for EPG events that are partially/completely overlapped during a data refresh.  I am of the opinion that Kodi 19 "Matrix" is handling these appropriately under all circumstances and that the events can be moved to DEBUG level events; relevant only if the end user is experiencing an Issue with the behavior and is in need of troubleshooting assistance, where a DEBUG level log will be required.

## Motivation and Context
End users are expressing concerns with (benign) WARNING events in their Kodi log that appear to be both normal and handled quite appropriately by Kodi for EPG event overlaps.  PVR addons may not have the ability to delete existing EPG tags before updating them, and given that Kodi is handling these overlaps as well as can seemingly be expected, I think that the logging can be transitioned to a DEBUG level to allay these end user concerns.

Thank you for your time and any consideration of this request; if it has no validity/merit I am happy to summarily cancel or close it.

## How Has This Been Tested?
Tested on Windows (Desktop) x64, latest **master** branch available as of 2021.03.03.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
