### PR TITLE
[fix] remove whitespaces between curly brackets in language files

### DIFF
--- a/xbmc/utils/POUtils.cpp
+++ b/xbmc/utils/POUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "URL.h"
 #include "filesystem/File.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <stdlib.h>
@@ -123,6 +124,8 @@ void CPODocument::ParseEntry(bool bisSourceLang)
     if (FindLineStart ("\nmsgstr ", m_Entry.msgStr.Pos))
     {
       GetString(m_Entry.msgStr);
+      StringUtils::RemoveBetween({'{', '}'}, ' ', m_Entry.msgStr.Str);
+
       GetString(m_Entry.msgID);
     }
     else

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1810,3 +1810,24 @@ const std::locale& StringUtils::GetOriginalLocale() noexcept
 {
   return g_langInfo.GetOriginalLocale();
 }
+
+void StringUtils::RemoveBetween(std::pair<char, char> bounderies,
+                                char charToRemove,
+                                std::string& str)
+{
+  if (bounderies.first != bounderies.second)
+  {
+    int remove = 0;
+
+    auto shouldRemove = [&](char c) {
+      if (c == bounderies.first)
+        remove++;
+      else if (c == bounderies.second && remove)
+        remove--;
+
+      return (remove && c == charToRemove);
+    };
+
+    str.erase(std::remove_if(str.begin(), str.end(), shouldRemove), str.end());
+  }
+}

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -388,6 +388,14 @@ public:
    */
   static std::string FormatFileSize(uint64_t bytes);
 
+  /*! \brief Remove certain character from a string inside of given bounderies.
+             Bear in mind bounderies must be a pair of different characters.
+      \param bounderies pair of chars that mark the boundery e.g. {'(',')'}
+      \param charToRemove the character to remove
+      \param str reference to the string
+   */
+  static void RemoveBetween(std::pair<char, char> bounderies, char charToRemove, std::string& str);
+
 private:
   /*!
    * Wrapper for CLangInfo::GetOriginalLocale() which allows us to

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -603,3 +603,24 @@ TEST(TestStringUtils, ToHexadecimal)
   std::string ff{"\xFF", 1};
   EXPECT_STREQ("ff", StringUtils::ToHexadecimal(ff).c_str());
 }
+
+TEST(TestStringUtils, RemoveBetween)
+{
+  std::string refstr = "Teststring: (x)";
+  std::string varstr = "Teststring: ( x )";
+
+  std::string refstr2 = "Teststring: ((y)..)";
+  std::string varstr2 = "Teststring: ( (y )..)";
+
+  std::string refstr3 = "Teststring: / /z /../";
+  std::string varstr3 = "Teststring: / /z /../";
+
+  StringUtils::RemoveBetween({'(', ')'}, ' ', varstr);
+  EXPECT_EQ(refstr, varstr);
+
+  StringUtils::RemoveBetween({'(', ')'}, ' ', varstr2);
+  EXPECT_EQ(refstr2, varstr2);
+
+  StringUtils::RemoveBetween({'/', '/'}, ' ', varstr3);
+  EXPECT_EQ(refstr3, varstr3);
+}


### PR DESCRIPTION
## Description
because they crash `libfmt`
ref. https://forum.kodi.tv/showthread.php?tid=361096

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
