### PR TITLE
[VideoInfoScanner] Implement parsing TV episode files by episode title

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -243,6 +243,10 @@ void CAdvancedSettings::Initialize()
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
   // Part I, Pt.VI, Part 1
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\/._ -]p(?:ar)?t[_. -]()([ivx]+|[0-9]+)([._ -][^\\/]*)$"));
+  // This regexp is for matching special episodes by their title, e.g. foo.special.mp4
+  m_tvshowEnumRegExps.push_back(
+      TVShowRegexp(false, "[\\\\/]([^\\\\/]+)\\.special\\.[a-z0-9]+$", 0, true));
+
   // foo.103*, 103 foo
   // XXX: This regex is greedy and will match years in show names.  It should always be last.
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ -]([0-9]+)([0-9][0-9](?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([\\._ -][^\\\\/]*)$"));
@@ -1286,6 +1290,7 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
       if (pRegExp->FirstChild())
       {
         bool bByDate = false;
+        bool byTitle = false;
         int iDefaultSeason = 1;
         if (pRegExp->ToElement())
         {
@@ -1294,6 +1299,8 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
           {
             bByDate = true;
           }
+          std::string byTitleAttr = XMLUtils::GetAttribute(pRegExp->ToElement(), "bytitle");
+          byTitle = (byTitleAttr == "true");
           std::string defaultSeason = XMLUtils::GetAttribute(pRegExp->ToElement(), "defaultseason");
           if(!defaultSeason.empty())
           {
@@ -1302,9 +1309,14 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
         }
         std::string regExp = pRegExp->FirstChild()->Value();
         if (iAction == 2)
-          settings.insert(settings.begin() + i++, 1, TVShowRegexp(bByDate,regExp,iDefaultSeason));
+        {
+          settings.insert(settings.begin() + i++, 1,
+                          TVShowRegexp(bByDate, regExp, iDefaultSeason, byTitle));
+        }
         else
-          settings.push_back(TVShowRegexp(bByDate,regExp,iDefaultSeason));
+        {
+          settings.push_back(TVShowRegexp(bByDate, regExp, iDefaultSeason, byTitle));
+        }
       }
       pRegExp = pRegExp->NextSibling("regexp");
     }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -72,13 +72,14 @@ public:
 struct TVShowRegexp
 {
   bool byDate;
+  bool byTitle;
   std::string regexp;
   int defaultSeason;
-  TVShowRegexp(bool d, const std::string& r, int s = 1):
-    regexp(r)
+  TVShowRegexp(bool d, const std::string& r, int s = 1, bool t = false) : regexp(r)
   {
     byDate = d;
     defaultSeason = s;
+    byTitle = t;
   }
 };
 

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -169,6 +169,13 @@ namespace VIDEO
      */
     bool GetAirDateFromRegExp(CRegExp &reg, EPISODE &episodeInfo);
 
+    /*! \brief Extract episode title from a processed regexp
+     \param reg Regular expression object with at least 1 match
+     \param episodeInfo Episode information to fill in.
+     \return true on success (1 match), false on failure (no matches)
+     */
+    bool GetEpisodeTitleFromRegExp(CRegExp& reg, EPISODE& episodeInfo);
+
     /*! \brief Fetch thumbs for actors
      Updates each actor with their thumb (local or online)
      \param actors - vector of SActorInfo

--- a/xbmc/video/test/TestVideoInfoScanner.cpp
+++ b/xbmc/video/test/TestVideoInfoScanner.cpp
@@ -62,3 +62,13 @@ TEST_P(TestVideoInfoScanner, EnumerateEpisodeItem)
 }
 
 INSTANTIATE_TEST_SUITE_P(VideoInfoScanner, TestVideoInfoScanner, ValuesIn(TestData));
+
+TEST(TestVideoInfoScanner, EnumerateEpisodeItemByTitle)
+{
+  CVideoInfoScanner scanner;
+  CFileItem item("/foo.special.mp4", false);
+  EPISODELIST result;
+  ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
+  ASSERT_EQ(result.size(), 1);
+  ASSERT_EQ(result[0].strTitle, "foo");
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR adds support for naming TV episode files using episode titles in addition to existing season/episode and airdate naming conventions. It also adds support for custom regexps for scraping TV episode files by title.

## Motivation and Context
Some TV information providers, specifically TVmaze, do not use the common convention of numbering special episode files with zero season number. As a result scraping files with special episodes is difficult. A current workaround is to name files using airdate but this workaround fails if several episodes have the same airdate. This PR allows to match episode files by title. By default only files that include `.special.` suffix in their names are matched by title. The PR also fixes the existing mechanism of comparing scraped episode titles with ones retrieved from a TV information provider. This mechanism was broken and never used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I have build the code and scraped some dummy files named using episode titles of several TV shows.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
