### PR TITLE
[PVR] Fix GUI not updated on removal/insert/hide/unhide of channel groups.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1159,7 +1159,7 @@ bool CPVRChannelGroup::CreateChannelEpgs(bool bForce /* = false */)
   return true;
 }
 
-void CPVRChannelGroup::SetHidden(bool bHidden)
+bool CPVRChannelGroup::SetHidden(bool bHidden)
 {
   CSingleLock lock(m_critSection);
 
@@ -1168,6 +1168,8 @@ void CPVRChannelGroup::SetHidden(bool bHidden)
     m_bHidden = bHidden;
     m_bChanged = true;
   }
+
+  return m_bChanged;
 }
 
 bool CPVRChannelGroup::IsHidden() const

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -461,7 +461,7 @@ namespace PVR
     std::shared_ptr<PVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id);
     const std::shared_ptr<PVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id) const;
 
-    void SetHidden(bool bHidden);
+    bool SetHidden(bool bHidden);
     bool IsHidden() const;
 
     int GetPosition() const;

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -597,6 +597,22 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup& group)
   return bFound;
 }
 
+bool CPVRChannelGroups::HideGroup(const std::shared_ptr<CPVRChannelGroup>& group, bool bHide)
+{
+  bool bReturn = false;
+
+  if (group)
+  {
+    if (group->SetHidden(bHide))
+    {
+      // state changed
+      CServiceBroker::GetPVRManager().PublishEvent(PVREvent::ChannelGroupsInvalidated);
+    }
+    bReturn = true;
+  }
+  return bReturn;
+}
+
 bool CPVRChannelGroups::CreateChannelEpgs()
 {
   bool bReturn(false);

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -216,8 +216,10 @@ void CPVRChannelGroups::RemoveFromAllGroups(const std::shared_ptr<CPVRChannel>& 
 
 bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
 {
-  bool bUpdateAllGroups = !bChannelsOnly && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS);
-  bool bReturn(true);
+  bool bSyncWithBackends = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+      CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS);
+  bool bUpdateAllGroups = !bChannelsOnly && bSyncWithBackends;
+  bool bReturn = true;
 
   // sync groups
   if (bUpdateAllGroups)
@@ -230,6 +232,8 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
     groups = m_groups;
   }
 
+  std::vector<std::shared_ptr<CPVRChannelGroup>> emptyGroups;
+
   for (const auto& group : groups)
   {
     if (bUpdateAllGroups || group->IsInternalGroup())
@@ -238,6 +242,10 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
       bReturn = group->Update(channelsToRemove) && bReturn;
       RemoveFromAllGroups(channelsToRemove);
     }
+
+    // remove empty groups when sync with backend is enabled
+    if (bSyncWithBackends && group->Size() == 0)
+      emptyGroups.emplace_back(group);
 
     if (bReturn && group == m_selectedGroup)
       UpdateSelectedGroup();
@@ -249,6 +257,14 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
       CServiceBroker::GetPVRManager().TriggerSearchMissingChannelIcons(group);
     }
   }
+
+  for (const auto& group : emptyGroups)
+  {
+    CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting empty channel group '{}'", group->GroupName());
+    DeleteGroup(*group);
+  }
+
+  CServiceBroker::GetPVRManager().PublishEvent(PVREvent::ChannelGroupsInvalidated);
 
   // persist changes
   return PersistAll() && bReturn;
@@ -544,6 +560,8 @@ bool CPVRChannelGroups::AddGroup(const std::string& strName)
 
       m_groups.push_back(group);
       bPersist = true;
+
+      CServiceBroker::GetPVRManager().PublishEvent(PVREvent::ChannelGroupsInvalidated);
     }
   }
 
@@ -577,6 +595,8 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup& group)
 
         it = m_groups.erase(it);
         bFound = true;
+
+        CServiceBroker::GetPVRManager().PublishEvent(PVREvent::ChannelGroupsInvalidated);
       }
       else
       {

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -181,6 +181,14 @@ namespace PVR
     bool DeleteGroup(const CPVRChannelGroup& group);
 
     /*!
+     * @brief Hide/unhide a group in this container.
+     * @param group The group to hide/unhide.
+     * @param bHide True to hide the group, false to unhide it.
+     * @return True on success, false otherwise.
+     */
+    bool HideGroup(const std::shared_ptr<CPVRChannelGroup>& group, bool bHide);
+
+    /*!
      * @brief Create EPG tags for all channels of the internal group.
      * @return True if EPG tags where created successfully, false if not.
      */

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -270,7 +270,10 @@ bool CGUIDialogPVRGroupManager::ActionButtonHideGroup(CGUIMessage& message)
     CGUIRadioButtonControl* button = static_cast<CGUIRadioButtonControl*>(GetControl(message.GetSenderId()));
     if (button)
     {
-      m_selectedGroup->SetHidden(button->IsSelected());
+      CServiceBroker::GetPVRManager()
+          .ChannelGroups()
+          ->Get(m_bIsRadio)
+          ->HideGroup(m_selectedGroup, button->IsSelected());
       Update();
     }
 

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -476,7 +476,7 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
     }
     else if (path.IsChannelsRoot())
     {
-      return GetChannelGroupsDirectory(path.IsRadio(), false, results);
+      return GetChannelGroupsDirectory(path.IsRadio(), true, results);
     }
     else if (path.IsChannelGroup())
     {

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -349,7 +349,15 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
           m_viewControl.SetFocused();
           break;
         }
-
+        case PVREvent::ChannelGroupsInvalidated:
+        {
+          std::shared_ptr<CPVRChannelGroup> group =
+              CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(m_bRadio);
+          m_channelGroupsSelector->Initialize(this, m_bRadio);
+          m_channelGroupsSelector->SelectChannelGroup(group);
+          SetChannelGroup(std::move(group));
+          break;
+        }
         default:
           break;
       }


### PR DESCRIPTION
Fixes #19325 plus GUI not updating instantly on removal of channel groups and when new channel groups appear.

Runtime-tested on macOS, latest Matrix.

@phunkyfish when you are in the mood for a review.