### PR TITLE
Improvements to Python's ListItem, InfoTagVideo and Player wrappers

### DIFF
--- a/tools/codegenerator/SwigTypeParser.groovy
+++ b/tools/codegenerator/SwigTypeParser.groovy
@@ -270,6 +270,20 @@ public class SwigTypeParser
    }
 
    /**
+    * SwigType_lrtype(const SwigType *ty)
+    *
+    * Create a locally assignable reference type
+    */
+   public static String SwigType_lrtype(String s) {
+      String ltype = SwigType_ltype(s);
+      if (SwigType_ispointer(s)) {
+         return ltype;
+      } else {
+         return "r." + ltype;
+      }
+   }
+   
+   /**
    * This creates the C++ declaration for a valid ltype for the type string
    * given. For example, if the type is a "const char*" which is equivalent
    * to the type string 'p.q(const).char', the return value from this method

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -252,6 +252,12 @@ namespace XBMCAddon
       return item->GetArt(key);
     }
 
+    bool ListItem::isFolder() const
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+      return item->m_bIsFolder;
+    }
+
     String ListItem::getUniqueID(const char* key)
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -659,7 +659,11 @@ namespace XBMCAddon
           else if (key == "role")
             info.strRole = value;
           else if (key == "thumbnail")
+          {
             info.thumbUrl = CScraperUrl(value);
+            if (!info.thumbUrl.GetFirstThumbUrl().empty())
+              info.thumb = CScraperUrl::GetThumbUrl(info.thumbUrl.GetFirstUrlByType());
+          }
           else if (key == "order")
             info.order = strtol(value.c_str(), nullptr, 10);
         }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -102,6 +102,32 @@ namespace XBMCAddon
       }
     }
 
+    String ListItem::getDateTime()
+    {
+      if (!item)
+        return "";
+
+      String ret;
+      {
+        XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+        if (item->m_dateTime.IsValid())
+          ret = item->m_dateTime.GetAsW3CDateTime();
+      }
+
+      return ret;
+    }
+
+    void ListItem::setDateTime(const String& dateTime)
+    {
+      if (!item)
+        return;
+      // set datetime
+      {
+        XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+        item->m_dateTime.SetFromW3CDateTime(dateTime);
+      }
+    }
+
     void ListItem::setArt(const Properties& dictionary)
     {
       if (!item) return;

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -216,6 +216,68 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ getDateTime() }
+      ///-----------------------------------------------------------------------
+      /// Returns the list item's datetime in W3C format (YYYY-MM-DDThh:mm:ssTZD).
+      ///
+      /// @return                   string or unicode - datetime string (W3C).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// # getDateTime()
+      /// strDateTime = listitem.getDateTime()
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      getDateTime();
+#else
+      String getDateTime();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ setDateTime(dateTime) }
+      ///-----------------------------------------------------------------------
+      /// Sets the list item's datetime in W3C format.
+      /// The following formats are supported:
+      /// - YYYY
+      /// - YYYY-MM-DD
+      /// - YYYY-MM-DDThh:mm[TZD]
+      /// - YYYY-MM-DDThh:mm:ss[TZD]
+      /// where the timezone (TZD) is always optional and can be in one of the
+      /// following formats:
+      /// - Z (for UTC)
+      /// - +hh:mm
+      /// - -hh:mm
+      ///
+      /// @param label              string or unicode - datetime string (W3C).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// # setDate(dateTime)
+      /// listitem.setDateTime('2021-03-09T12:30:00Z')
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      setDateTime(...);
+#else
+      void setDateTime(const String& dateTime);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ setArt(values) }
       /// Sets the listitem's art
       ///

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -411,6 +411,28 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ isFolder() }
+      ///-----------------------------------------------------------------------
+      /// Returns whether the item is a folder or not.
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// isFolder = listitem.isFolder()
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      isFolder();
+#else
+      bool isFolder() const;
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ getUniqueID(key) }
       /// Returns a listitem uniqueID as a string, similar to an infolabel.\n
       ///

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -345,7 +345,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       if (!g_application.GetAppPlayer().IsPlaying())
-        throw PlayerException("XBMC is not playing any file");
+        throw PlayerException("Kodi is not playing any file");
 
       return g_application.CurrentFileItem().GetDynPath();
     }
@@ -364,7 +364,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       if (!g_application.GetAppPlayer().IsPlayingVideo())
-        throw PlayerException("XBMC is not playing any videofile");
+        throw PlayerException("Kodi is not playing any videofile");
 
       const CVideoInfoTag* movie = CServiceBroker::GetGUI()->GetInfoManager().GetCurrentMovieTag();
       if (movie)
@@ -377,7 +377,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       if (g_application.GetAppPlayer().IsPlayingVideo() || !g_application.GetAppPlayer().IsPlayingAudio())
-        throw PlayerException("XBMC is not playing any music file");
+        throw PlayerException("Kodi is not playing any music file");
 
       const MUSIC_INFO::CMusicInfoTag* tag = CServiceBroker::GetGUI()->GetInfoManager().GetCurrentSongTag();
       if (tag)
@@ -413,7 +413,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       if (!g_application.GetAppPlayer().IsPlaying())
-        throw PlayerException("XBMC is not playing any media file");
+        throw PlayerException("Kodi is not playing any media file");
 
       return g_application.GetTotalTime();
     }
@@ -422,7 +422,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       if (!g_application.GetAppPlayer().IsPlaying())
-        throw PlayerException("XBMC is not playing any media file");
+        throw PlayerException("Kodi is not playing any media file");
 
       return g_application.GetTime();
     }
@@ -431,7 +431,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       if (!g_application.GetAppPlayer().IsPlaying())
-        throw PlayerException("XBMC is not playing any media file");
+        throw PlayerException("Kodi is not playing any media file");
 
       g_application.SeekTime( pTime );
     }

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -350,6 +350,16 @@ namespace XBMCAddon
       return g_application.CurrentFileItem().GetDynPath();
     }
 
+    XBMCAddon::xbmcgui::ListItem* Player::getPlayingItem()
+    {
+      XBMC_TRACE;
+      if (!g_application.GetAppPlayer().IsPlaying())
+        throw PlayerException("Kodi is not playing any item");
+
+      CFileItemPtr itemPtr = std::make_shared<CFileItem>(g_application.CurrentFileItem());
+      return new XBMCAddon::xbmcgui::ListItem(itemPtr);
+    }
+
     InfoTagVideo* Player::getVideoInfoTag()
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -461,6 +461,24 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Player
+      /// @brief \python_func{ getPlayingItem() }
+      ///-----------------------------------------------------------------------
+      /// Returns the current playing item.
+      ///
+      /// @return                    Playing item
+      /// @throws Exception          If player is not playing a file.
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getPlayingItem();
+#else
+      XBMCAddon::xbmcgui::ListItem* getPlayingItem();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Player
       /// @brief \python_func{ getTime() }
       /// Get playing time.
       ///

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -680,7 +680,7 @@ void doClassMethodInfo(Node clazz, List initTypeCalls)
 %>
 
     pythonType.tp_base = ${baseclass ? ('&(Ty' + PythonTools.getClassNameAsVariable(baseclass) + '_Type.pythonType)') : "NULL"};
-    pythonType.tp_new = <% Helper.hasHiddenConstructor(clazz) ? print('NULL') : print("${module.@name}_${classNameAsVariable}_New") %>;
+    pythonType.tp_new = <% !Helper.hasDefinedConstructor(clazz) || Helper.hasHiddenConstructor(clazz) ? print('NULL') : print("${module.@name}_${classNameAsVariable}_New") %>;
     pythonType.tp_init = dummy_tp_init;
 
     Ty${classNameAsVariable}_Type.swigType="p.${fullClassName}";<%

--- a/xbmc/interfaces/python/typemaps/python.Alternative.outtm
+++ b/xbmc/interfaces/python/typemaps/python.Alternative.outtm
@@ -21,7 +21,7 @@
 %>
       if (pos == XBMCAddon::${altSwitch[entryIndex]})
       {
-        ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(curType))}& entry${seq} = ${api}${accessor}${altAccess[entryIndex]}();
+        ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_lrtype(curType))} entry${seq} = ${api}${accessor}${altAccess[entryIndex]}();
         {
           ${helper.getOutConversion(curType,result,method,[ 'api' : 'entry' + seq, 'sequence' : sequence ])}
         }

--- a/xbmc/interfaces/python/typemaps/python.Tuple.outtm
+++ b/xbmc/interfaces/python/typemaps/python.Tuple.outtm
@@ -27,7 +27,7 @@
 
       if (vecSize > ${entryIndex})
       {
-        ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(curType))}& entry${seq} = ${api}${accessor}${tupleAccess[entryIndex]}();
+        ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_lrtype(curType))} entry${seq} = ${api}${accessor}${tupleAccess[entryIndex]}();
         {
           ${helper.getOutConversion(curType,'result',method,[ 'result' : 'pyentry' + seq, 'api' : 'entry' + seq, 'sequence' : sequence ])}
         }


### PR DESCRIPTION
## Description
These commits contain a few improvements from my media import work which are not media import specific:
* improve the swig code generator for local reference types
* support classes without a constructor
* fix thumb handling in `ListItem.setCast()`
* add `isFolder()`, `getDateTime()` and `setDateTime()` to `ListItem`
* add `getUniqueID()` and `setUniqueIDs()` to `InfoTagVideo`
* add `Player.getPlayingItem()`

## Motivation and Context
These methods extend the Python API with some additional methods which expose parts of Kodi core which have been there for a long time and might be useful for Python add-ons.

## How Has This Been Tested?
Manually as part of my media import work.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed