### PR TITLE
Added the ability to minimize to system tray (Windows)

### DIFF
--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -18,6 +18,7 @@
 
 #define BONJOUR_EVENT             ( WM_USER + 0x100 )	// Message sent to the Window when a Bonjour event occurs.
 #define BONJOUR_BROWSER_EVENT     ( WM_USER + 0x110 )
+#define TRAY_ICON_NOTIFY          ( WM_USER + 0x120 )
 
 class CURL; // forward declaration
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -342,6 +342,9 @@ void CAdvancedSettings::Initialize()
                                   //with ipv6.
   m_curlDisableHTTP2 = false;
 
+#if defined(TARGET_WINDOWS_DESKTOP)
+  m_minimizeToTray = false;
+#endif
 #if defined(TARGET_DARWIN_EMBEDDED)
   m_startFullScreen = true;
 #else
@@ -887,6 +890,9 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   XMLUtils::GetBoolean(pRootElement, "handlemounting", m_handleMounting);
 
+#if defined(TARGET_WINDOWS_DESKTOP)
+  XMLUtils::GetBoolean(pRootElement, "minimizetotray", m_minimizeToTray);
+#endif
 #if defined(HAS_SDL) || defined(TARGET_WINDOWS)
   XMLUtils::GetBoolean(pRootElement, "fullscreen", m_startFullScreen);
 #endif

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -291,6 +291,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     std::string m_caTrustFile;
 
+    bool m_minimizeToTray; /* win32 only */
     bool m_fullScreen;
     bool m_startFullScreen;
     bool m_showExitButton; /* Ideal for appliances to hide a 'useless' button */

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -797,6 +797,23 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case BONJOUR_BROWSER_EVENT:
       CZeroconfBrowser::GetInstance()->ProcessResults();
       break;
+    case TRAY_ICON_NOTIFY:
+    {
+      switch (LOWORD(lParam))
+      {
+        case WM_LBUTTONDBLCLK:
+        {
+          DX::Windowing()->SetMinimized(false);
+          if (!g_application.GetRenderGUI())
+          {
+            if (appPort)
+              appPort->SetRenderGUI(true);
+          }
+          break;
+        }
+      }
+      break;
+    }
     default:;
   }
   return(DefWindowProc(hWnd, uMsg, wParam, lParam));

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -13,6 +13,7 @@
 #include "threads/SystemClock.h"
 #include "windowing/WinSystem.h"
 
+#include <shellapi.h>
 #include <vector>
 
 static const DWORD WINDOWED_STYLE = WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN;
@@ -109,7 +110,7 @@ public:
   void SetAlteringWindow(bool altering) { m_IsAlteringWindow = altering; }
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
-  void SetMinimized(bool minimized) { m_bMinimized = minimized; }
+  void SetMinimized(bool minimized);
   void GetConnectedOutputs(std::vector<std::string> *outputs);
 
   // touchscreen support
@@ -191,6 +192,8 @@ protected:
   bool m_bFirstResChange = true;
   std::unique_ptr<CIRServerSuite> m_irss;
   std::vector<MONITOR_DETAILS> m_displays;
+  
+  NOTIFYICONDATA m_trayIcon;  
 };
 
 extern HWND g_hWnd;


### PR DESCRIPTION
## Description
Added a "minimizetotray" advanced setting that defaults to `false`.
When this is set to `true`, the application window minimizes to the Windows system tray.

## Motivation and Context
There are a few use cases which benefit from running Kodi in the background (UPnP server, updates from Sonarr, etc.)
Minimizing to the system tray rather than the taskbar makes this more convenient.

## How Has This Been Tested?
Applied this to the Leia branch and compiled for Windows x64 then tested 3 cases on Windows 10.

* With the "minimizetotray" advanced setting set to `true`, verified the following:
  * On minimize: 
    * The window is hidden
    * The taskbar entry is removed.
    * A system tray icon is added.
    * The system tray icon uses the Kodi icon and shows "Kodi" when hovered over.
  * On system tray icon double click: 
    * The window is restored.
    * A taskbar entry is added. 
    * The system tray icon is removed.
* With the "minimizetotray" advanced setting set to `false`, verified that the window minimizes to the taskbar.
* With the "minimizetotray" not specified, verified that the window minimizes to the taskbar.

## Screenshots (if appropriate):
![Tray Icon](https://user-images.githubusercontent.com/7863845/110538011-b6a18380-80e0-11eb-9983-b30bfefd7e5d.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
