### PR TITLE
[estuary] fix overlap in fanart view

### DIFF
--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -126,7 +126,7 @@
 				<right>$PARAM[right]</right>
 				<top>list_y_offset</top>
 				<bottom>list_y_offset</bottom>
-				<movement>5</movement>
+				<movement>4</movement>
 				<focusposition>6</focusposition>
 				<scrolltime tween="cubic" easing="out">500</scrolltime>
 				<orientation>vertical</orientation>


### PR DESCRIPTION
## Description
cleans a little overlap in Fanart-View of estuary.

for a very long time i'm thinking.. that must be an accident, this is not intended. but could be it is just me.
not sure if it's fixed correctly, but the result is fine imo.

## Screenshots (if appropriate):

before:
![ugly](https://user-images.githubusercontent.com/58829855/110549510-71a63d00-8132-11eb-8b91-6845a84ddd50.png)

after:
![cute](https://user-images.githubusercontent.com/58829855/110549532-78cd4b00-8132-11eb-8fec-e5132b0ee3a7.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)


## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
