### PR TITLE
[Matrix][PVR] CPVRChannelGroups::Update: Don't try to delete the 'all channel…

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -244,7 +244,7 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
     }
 
     // remove empty groups when sync with backend is enabled
-    if (bSyncWithBackends && group->Size() == 0)
+    if (bSyncWithBackends && !group->IsInternalGroup() && group->Size() == 0)
       emptyGroups.emplace_back(group);
 
     if (bReturn && group == m_selectedGroup)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -458,6 +458,8 @@ void CGUIDialogPVRGroupManager::Update()
     SET_CONTROL_LABEL(CONTROL_CURRENT_GROUP_LABEL, m_selectedGroup->GroupName());
     SET_CONTROL_SELECTED(GetID(), BUTTON_HIDE_GROUP, m_selectedGroup->IsHidden());
 
+    CONTROL_ENABLE_ON_CONDITION(BUTTON_DELGROUP, !m_selectedGroup->IsInternalGroup());
+
     if (m_selectedGroup->IsInternalGroup())
     {
       std::string strNewLabel = StringUtils::Format("%s %s",


### PR DESCRIPTION
…s' group.

Backport of #19385. Followup to #19366. Trying to delete the 'all channels' group produces log error, which is fixed by this PR.

@phunkyfish ping 