### PR TITLE
Adjust punctuation in RTL Subtitles

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -315,7 +315,8 @@ std::wstring CGUITextLayout::BidiFlip(const std::wstring& text,
 
   // Convert to utf32, call bidi then convert the result back to utf16
   g_charsetConverter.wToUtf32(text, utf32logical);
-  g_charsetConverter.utf32logicalToVisualBiDi(utf32logical, utf32visual, false, false,
+  g_charsetConverter.utf32logicalToVisualBiDi(utf32logical, utf32visual, forceLTRReadingOrder,
+                                              false,
                                               visualToLogicalMap);
   g_charsetConverter.utf32ToW(utf32visual, visualText);
 


### PR DESCRIPTION
## Description
Use "forceLTRReadingOrder" in call to "utf32logicalToVisualBiDi" inside "BidiFlip" function
Fixes #18648

## Motivation and Context
This modification fixes the misplaced punctuation marks in RTL subtitles.

## How Has This Been Tested?
This change was tested on windows 10 (64-bit) with Kodi 19.0 (compiled from master)

## Screenshots (if appropriate):
See issue #18648

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
