### PR TITLE
[addons] prevent unneccesary dependency install dialog popup

### DIFF
--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -515,6 +515,6 @@ void CAddonRepos::BuildCompatibleVersionsList(
   std::sort(officialVersions.begin(), officialVersions.end(), comparator);
   std::sort(privateVersions.begin(), privateVersions.end(), comparator);
 
-  compatibleVersions = officialVersions;
-  std::copy(privateVersions.begin(), privateVersions.end(), back_inserter(compatibleVersions));
+  compatibleVersions = std::move(officialVersions);
+  std::move(privateVersions.begin(), privateVersions.end(), std::back_inserter(compatibleVersions));
 }

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -597,7 +597,7 @@ void CGUIDialogAddonInfo::OnSettings()
 bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint entryPoint)
 {
   if (entryPoint != EntryPoint::INSTALL ||
-      (entryPoint == EntryPoint::INSTALL && !m_allDepsInstalled))
+      (entryPoint == EntryPoint::INSTALL && m_showDepDialogOnInstall))
   {
     auto pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
         WINDOW_DIALOG_SELECT);
@@ -743,7 +743,7 @@ void CGUIDialogAddonInfo::BuildDependencyList()
   if (!m_item)
     return;
 
-  m_allDepsInstalled = true;
+  m_showDepDialogOnInstall = false;
   m_depsInstalledWithAvailable.clear();
   m_deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(m_item->GetAddonInfo()->ID(),
                                                           OnlyEnabledRootAddon::NO);
@@ -761,7 +761,6 @@ void CGUIDialogAddonInfo::BuildDependencyList()
                                                 OnlyEnabled::YES))
     {
       addonInstalled = nullptr;
-      m_allDepsInstalled = false;
     }
 
     // Find add-on in repositories
@@ -770,7 +769,19 @@ void CGUIDialogAddonInfo::BuildDependencyList()
       addonAvailable = nullptr;
     }
 
-    // Depending on advancedsettings.xml <showalldependencies>:
+    if (!addonInstalled)
+    {
+      // after pushing the install button the dependency install dialog will
+      // pop up only if non-module dependencies are going to be installed or
+      // dependencies are unavailable. the latter is for informational purposes
+
+      if (showAllDependencies || !addonAvailable ||
+          addonAvailable->MainType() != ADDON_SCRIPT_MODULE)
+      {
+        m_showDepDialogOnInstall = true;
+      }
+    }
+
     // AddonType ADDON_SCRIPT_MODULE needs to be filtered as these low-level add-ons
     // should be hidden to the user in the dependency select dialog
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -131,7 +131,7 @@ private:
    */
   bool m_silentUninstall = false;
 
-  bool m_allDepsInstalled = true;
+  bool m_showDepDialogOnInstall = false;
   std::vector<ADDON::DependencyInfo> m_deps;
   std::vector<CInstalledWithAvailable> m_depsInstalledWithAvailable;
 };


### PR DESCRIPTION
## Description
this prevents popup of `"The following additional add-ons will be installed"` when only modules are missing, as they are usually not visible to the user.

second commit uses `std::move` instead of copying vectors around

## Motivation and Context
while installing `Tubed` i encountered a dependency install dialog announcing installation of `inputstream.adaptive` which was already installed.

## How Has This Been Tested?
debian buster

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@phunkyfish mind having a look at it?