### PR TITLE
[music]Fix rescan of music from cuesheets

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3610,7 +3610,7 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
   }
 }
 
-bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songs, bool bAppendToMap)
+bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songmap, bool bAppendToMap)
 {
   std::string strPath(strPath1);
   try
@@ -3619,14 +3619,19 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songs
       URIUtils::AddSlashAtEnd(strPath);
 
     if (!bAppendToMap)
-      songs.clear();
+      songmap.clear();
 
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL=PrepareSQL("SELECT * FROM songview WHERE strPath='%s'", strPath.c_str());
+    // Filename is not unique for a path as songs from a cuesheet have same filename.
+    // Songs from cuesheets often have consecutive ID but not always e.g. more than one cuesheet
+    // in a folder and some edited and rescanned.    
+    // Hence order by filename so these songs can be gathered together.
+    std::string strSQL =
+        PrepareSQL("SELECT * FROM songview WHERE strPath='%s' ORDER BY strFileName", strPath.c_str());
     if (!m_pDS->query(strSQL)) return false;
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     int iRowsFound = m_pDS->num_rows();
@@ -3635,14 +3640,25 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songs
       m_pDS->close();
       return false;
     }
+
+    // Each file is potentially mapped to a list of songs, gather these and save as list
+    VECSONGS songs;
+    std::string filename;
     while (!m_pDS->eof())
     {
       CSong song = GetSongFromDataset();
-      // For songs from cue sheets strFileName is not unique, so only 1st song gets added to song map
-      songs.insert(std::make_pair(song.strFileName, song));
+      if (!filename.empty() && filename != song.strFileName)
+      {
+        // Save songs for previous filename
+        songmap.insert(std::make_pair(filename, songs));
+        songs.clear();
+      }
+      filename = song.strFileName;
+      songs.emplace_back(song);
       m_pDS->next();
     }
     m_pDS->close(); // cleanup recordset data
+    songmap.insert(std::make_pair(filename, songs)); // Save songs for last filename
     return true;
   }
   catch (...)
@@ -10463,7 +10479,7 @@ bool CMusicDatabase::GetPathHash(const std::string &path, std::string &hash)
   return false;
 }
 
-bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& songs, bool exact)
+bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& songmap, bool exact)
 {
   // We need to remove all songs from this path, as their tags are going
   // to be re-read.  We need to remove all songs from the song table + all links to them
@@ -10503,31 +10519,47 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& son
     if (nullptr == m_pDS)
       return false;
 
+    // Filename is not unique for a path as songs from a cuesheet have same filename.
+    // Songs from cuesheets often have consecutive ID but not always e.g. more than one cuesheet
+    // in a folder and some edited and rescanned.    
+    // Hence order by filename so these songs can be gathered together.
     std::string where;
     if (exact)
       where = PrepareSQL(" where strPath='%s'", path.c_str());
     else
       where = PrepareSQL(" where SUBSTR(strPath,1,%i)='%s'", StringUtils::utf8_strlen(path.c_str()), path.c_str());
-    std::string sql = "select * from songview" + where;
+    std::string sql = "select * from songview" + where + " ORDER BY strFileName";
     if (!m_pDS->query(sql)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound > 0)
     {
+      // Each file is potentially mapped to a list of songs, gather these and save as list
+      VECSONGS songs;
+      std::string filename;
       std::vector<std::string> songIds;
       while (!m_pDS->eof())
       {
         CSong song = GetSongFromDataset();
+        if (!filename.empty() && filename != song.strFileName)
+        {
+          // Save songs for previous filename
+          songmap.insert(std::make_pair(filename, songs));
+          songs.clear();
+        }
         song.strThumb = GetArtForItem(song.idSong, MediaTypeSong, "thumb");
-        songs.insert(std::make_pair(song.strFileName, song));
+        songs.emplace_back(song);
         songIds.push_back(PrepareSQL("%i", song.idSong));
+        filename = song.strFileName;
+
         m_pDS->next();
       }
       m_pDS->close();
+      songmap.insert(std::make_pair(filename, songs));  // Save songs for last filename
 
       //! @todo move this below the m_pDS->exec block, once UPnP doesn't rely on this anymore
-      for (const auto &song : songs)
-        AnnounceRemove(MediaTypeSong, song.second.idSong);
-            
+      for (const auto& id : songIds)
+        AnnounceRemove(MediaTypeSong, atoi(id.c_str()));
+
       // Delete all songs, and anything linked to them via triggers
       std::string strIDs = StringUtils::Join(songIds, ",");
       sql = "DELETE FROM song WHERE idSong in (" + strIDs + ")";

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -217,9 +217,9 @@ public:
 
   //// Misc Song
   bool GetSongByFileName(const std::string& strFileName, CSong& song, int64_t startOffset = 0);
-  bool GetSongsByPath(const std::string& strPath, MAPSONGS& songs, bool bAppendToMap = false);
+  bool GetSongsByPath(const std::string& strPath, MAPSONGS& songmap, bool bAppendToMap = false);
   bool Search(const std::string& search, CFileItemList &items);
-  bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songs, bool exact=true);
+  bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songmap, bool exact=true);
   void CheckArtistLinksChanged();
   bool SetSongUserrating(const std::string &filePath, int userrating);
   bool SetSongUserrating(int idSong, int userrating);

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -194,20 +194,23 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         m_databaseHits++;
       }
 
-      /* Note for songs from embedded or separate cuesheets strFileName is not unique, so only the first song from such a file
-         gets added to the song map. Any such songs from a cuesheet can be identified by having a non-zero offset value.
-         When the item we are looking up has a cue document or is a music file with a cuesheet embedded in the tags, it needs
-         to have the cuesheet fully processed replacing that item with items for every track etc. This is done elsewhere, as
-         changes to the list of items is not possible from here. This method only loads the item with the song from the database
-         when it maps to a single song.
+      /*
+      This only loads the item with the song from the database when it maps to a single song,
+      it can not load song data for items with cuesheets that expand to multiple songs.
+      For songs from embedded or separate cuesheets strFileName is not unique, so the song map for
+      the path will have the list of songs from that file. But items with cuesheets are expanded
+      (replacing each item with items for every track) elsewhere. When the item we are looking up
+      has a cuesheet document or is a music file with a cuesheet embedded in the tags, and it maps
+      to more than one song then we can not fill the tag data and thumb from the database.
       */
-
-      MAPSONGS::iterator it = m_songsMap.find(pItem->GetPath());
-      if (it != m_songsMap.end() && !pItem->HasCueDocument() && it->second.iStartOffset == 0 && it->second.iEndOffset == 0)
-      {  // Have we loaded this item from database before (and it is not a cuesheet nor has an embedded cue sheet)
-        pItem->GetMusicInfoTag()->SetSong(it->second);
-        if (!it->second.strThumb.empty())
-          pItem->SetArt("thumb", it->second.strThumb);
+      MAPSONGS::iterator it = m_songsMap.find(pItem->GetPath()); // Find file in song map
+      if (it != m_songsMap.end() && it->second.size() == 1)
+      {
+        // Have we loaded this item from database before, 
+        // and even if it has a cuesheet it has only one song
+        pItem->GetMusicInfoTag()->SetSong(it->second[0]);
+        if (!it->second[0].strThumb.empty())
+          pItem->SetArt("thumb", it->second[0].strThumb);
       }
       else if (pItem->IsMusicDb())
       { // a music db item that doesn't have tag loaded - grab details from the database

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -205,16 +205,16 @@ private:
 
 /*!
  \ingroup music
- \brief A map of CSong objects, used for CMusicDatabase
- */
-typedef std::map<std::string, CSong> MAPSONGS;
-
-/*!
- \ingroup music
  \brief A vector of CSong objects, used for CMusicDatabase
  \sa CMusicDatabase
  */
 typedef std::vector<CSong> VECSONGS;
+
+/*!
+ \ingroup music
+ \brief A map of a vector of CSong objects key by filename, used for CMusicDatabase
+ */
+typedef std::map<std::string, VECSONGS> MAPSONGS;
 
 /*!
  \ingroup music

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -628,16 +628,33 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
     // keep the db-only fields intact on rescan...
     if (songsMap != NULL)
     {
-      MAPSONGS::iterator it = songsMap->find(items[i]->GetPath());
-      if (it != songsMap->end())
+      // Match up item to songs in library previously scanned with this path
+      MAPSONGS::iterator songlist = songsMap->find(items[i]->GetPath());
+      if (songlist != songsMap->end())
       {
-        song.idSong = it->second.idSong; // Reuse ID
-        song.dateNew = it->second.dateNew; // Keep date originally created
-        song.iTimesPlayed = it->second.iTimesPlayed;
-        song.lastPlayed = it->second.lastPlayed;
-        if (song.rating == 0)    song.rating = it->second.rating;
-        if (song.userrating == 0)    song.userrating = it->second.userrating;
-        if (song.strThumb.empty()) song.strThumb = it->second.strThumb;
+        VECSONGS::iterator foundsong;
+        if (songlist->second.size() == 1)
+          foundsong = songlist->second.begin();
+        else
+        {
+          // When filename mapped to multiple songs it is from cuesheet, match on disc/track number
+          int disctrack = tag.GetTrackAndDiscNumber();
+          foundsong = std::find_if(songlist->second.begin(), songlist->second.end(),
+                                   [&](const CSong& song) { return disctrack == song.iTrack; });
+        }
+        if (foundsong != songlist->second.end())
+        {
+          song.idSong = foundsong->idSong; // Reuse ID
+          song.dateNew = foundsong->dateNew; // Keep date originally created
+          song.iTimesPlayed = foundsong->iTimesPlayed;
+          song.lastPlayed = foundsong->lastPlayed;
+          if (song.rating == 0)
+            song.rating = foundsong->rating;
+          if (song.userrating == 0)
+            song.userrating = foundsong->userrating;
+          if (song.strThumb.empty())
+            song.strThumb = foundsong->strThumb;
+        }
       }
     }
 


### PR DESCRIPTION
Fix rescan of music from cuesheets into the library by allowing for multiple songs with same file when making song maps. See issue https://github.com/xbmc/xbmc/issues/19277

A regression was introduced in v19.0 that caused the rescanning (but not the first scan into the library) of music files with cuesheets to remove all but the first track. Since v19.0 features processing of new tag data, migration of the music library from previous versions prompts for a forced rescan of  music files, it meant that users with cuesheets experienced this issue on upgrading.

Investigation of this issue revealed a much older flaw where rescanning copied the playback history - playcount, lastplayed and user rating - of the first track onto all songs from the cuesheet.

The underlying cause of both things was that the rescranning process for a path involved making a one-to-one map against filename of the songs with that path previously in the library , and did not allow for cuesheets which can mean multiple songs from a file. 

This PR fixes both issues, and needs to be backported.

Testing has included:
- Migration from MyMuisc72.db to MyMusic82.db of a library populated from cuesheets and with extensive song playback history (user rating, playcount and lastplayed varying for each song)
- Library update after editing cuesheets
- Both hirearchical (one cuesheet per album folder) and flat (many cuesheets in a folder) music file layouts
- Cuesheet with one track (where file view mode can pick-up db data, otherwise it can't as `CMusicInfoLoader::LoadItemLookup` is run before the single cuseheet item is expanded into individual songs and so can not be matched up)
