### PR TITLE
[Backport][music]Fix rescan of music from cuesheets

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -217,9 +217,9 @@ public:
 
   //// Misc Song
   bool GetSongByFileName(const std::string& strFileName, CSong& song, int64_t startOffset = 0);
-  bool GetSongsByPath(const std::string& strPath, MAPSONGS& songs, bool bAppendToMap = false);
+  bool GetSongsByPath(const std::string& strPath, MAPSONGS& songmap, bool bAppendToMap = false);
   bool Search(const std::string& search, CFileItemList &items);
-  bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songs, bool exact=true);
+  bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songmap, bool exact=true);
   void CheckArtistLinksChanged();
   bool SetSongUserrating(const std::string &filePath, int userrating);
   bool SetSongUserrating(int idSong, int userrating);

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -194,20 +194,23 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         m_databaseHits++;
       }
 
-      /* Note for songs from embedded or separate cuesheets strFileName is not unique, so only the first song from such a file
-         gets added to the song map. Any such songs from a cuesheet can be identified by having a non-zero offset value.
-         When the item we are looking up has a cue document or is a music file with a cuesheet embedded in the tags, it needs
-         to have the cuesheet fully processed replacing that item with items for every track etc. This is done elsewhere, as
-         changes to the list of items is not possible from here. This method only loads the item with the song from the database
-         when it maps to a single song.
+      /*
+      This only loads the item with the song from the database when it maps to a single song,
+      it can not load song data for items with cuesheets that expand to multiple songs.
+      For songs from embedded or separate cuesheets strFileName is not unique, so the song map for
+      the path will have the list of songs from that file. But items with cuesheets are expanded
+      (replacing each item with items for every track) elsewhere. When the item we are looking up
+      has a cuesheet document or is a music file with a cuesheet embedded in the tags, and it maps
+      to more than one song then we can not fill the tag data and thumb from the database.
       */
-
-      MAPSONGS::iterator it = m_songsMap.find(pItem->GetPath());
-      if (it != m_songsMap.end() && !pItem->HasCueDocument() && it->second.iStartOffset == 0 && it->second.iEndOffset == 0)
-      {  // Have we loaded this item from database before (and it is not a cuesheet nor has an embedded cue sheet)
-        pItem->GetMusicInfoTag()->SetSong(it->second);
-        if (!it->second.strThumb.empty())
-          pItem->SetArt("thumb", it->second.strThumb);
+      MAPSONGS::iterator it = m_songsMap.find(pItem->GetPath()); // Find file in song map
+      if (it != m_songsMap.end() && it->second.size() == 1)
+      {
+        // Have we loaded this item from database before,
+        // and even if it has a cuesheet it has only one song
+        pItem->GetMusicInfoTag()->SetSong(it->second[0]);
+        if (!it->second[0].strThumb.empty())
+          pItem->SetArt("thumb", it->second[0].strThumb);
       }
       else if (pItem->IsMusicDb())
       { // a music db item that doesn't have tag loaded - grab details from the database

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -205,16 +205,16 @@ private:
 
 /*!
  \ingroup music
- \brief A map of CSong objects, used for CMusicDatabase
- */
-typedef std::map<std::string, CSong> MAPSONGS;
-
-/*!
- \ingroup music
  \brief A vector of CSong objects, used for CMusicDatabase
  \sa CMusicDatabase
  */
 typedef std::vector<CSong> VECSONGS;
+
+/*!
+ \ingroup music
+ \brief A map of a vector of CSong objects key by filename, used for CMusicDatabase
+ */
+typedef std::map<std::string, VECSONGS> MAPSONGS;
 
 /*!
  \ingroup music

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -628,16 +628,33 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
     // keep the db-only fields intact on rescan...
     if (songsMap != NULL)
     {
-      MAPSONGS::iterator it = songsMap->find(items[i]->GetPath());
-      if (it != songsMap->end())
+      // Match up item to songs in library previously scanned with this path
+      MAPSONGS::iterator songlist = songsMap->find(items[i]->GetPath());
+      if (songlist != songsMap->end())
       {
-        song.idSong = it->second.idSong; // Reuse ID
-        song.dateNew = it->second.dateNew; // Keep date originally created
-        song.iTimesPlayed = it->second.iTimesPlayed;
-        song.lastPlayed = it->second.lastPlayed;
-        if (song.rating == 0)    song.rating = it->second.rating;
-        if (song.userrating == 0)    song.userrating = it->second.userrating;
-        if (song.strThumb.empty()) song.strThumb = it->second.strThumb;
+        VECSONGS::iterator foundsong;
+        if (songlist->second.size() == 1)
+          foundsong = songlist->second.begin();
+        else
+        {
+          // When filename mapped to multiple songs it is from cuesheet, match on disc/track number
+          int disctrack = tag.GetTrackAndDiscNumber();
+          foundsong = std::find_if(songlist->second.begin(), songlist->second.end(),
+                                   [&](const CSong& song) { return disctrack == song.iTrack; });
+        }
+        if (foundsong != songlist->second.end())
+        {
+          song.idSong = foundsong->idSong; // Reuse ID
+          song.dateNew = foundsong->dateNew; // Keep date originally created
+          song.iTimesPlayed = foundsong->iTimesPlayed;
+          song.lastPlayed = foundsong->lastPlayed;
+          if (song.rating == 0)
+            song.rating = foundsong->rating;
+          if (song.userrating == 0)
+            song.userrating = foundsong->userrating;
+          if (song.strThumb.empty())
+            song.strThumb = foundsong->strThumb;
+        }
       }
     }
 


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/19392 fixes issue https://github.com/xbmc/xbmc/issues/19277

Fix rescan of music from cuesheets into the library by allowing for multiple songs with same file when making song maps.
On rescan:
- fix v19.0 regression which removed all but first cuesheet song.
- accurately keep song playback history

