### PR TITLE
SystemInfo: Cleanup and make some items conditional

### DIFF
--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -326,7 +326,7 @@ int CCPUInfoLinux::GetUsedPercentage()
 float CCPUInfoLinux::GetCPUFrequency()
 {
   if (m_freqPath.empty())
-    return -1;
+    return 0;
 
   CSysfsPath path{m_freqPath};
   return path.Get<float>() / 1000.0;

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -132,36 +132,78 @@ void CGUIWindowSystemInfo::FrameMove()
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20159));
     SET_CONTROL_LABEL(i++,CServiceBroker::GetGUI()->GetInfoManager().GetLabel(SYSTEM_VIDEO_ENCODER_INFO));
     SetControlLabel(i++, "%s %s", 13287, SYSTEM_SCREEN_RESOLUTION);
-#ifndef HAS_DX
-    SetControlLabel(i++, "%s %s", 22007, SYSTEM_RENDER_VENDOR);
-    SetControlLabel(i++, "%s %s", 22009, SYSTEM_RENDER_VERSION);
-#if defined(TARGET_LINUX)
-    SetControlLabel(i++, "%s %s", 39153, SYSTEM_PLATFORM_WINDOWING);
-#endif
+
+    auto renderingSystem = CServiceBroker::GetRenderSystem();
+    if (renderingSystem)
+    {
+      static std::string vendor = renderingSystem->GetRenderVendor();
+      if (!vendor.empty())
+        SET_CONTROL_LABEL(i++, StringUtils::Format("%s %s", g_localizeStrings.Get(22007), vendor));
+
+#if defined(HAS_DX)
+      int renderVersionLabel = 22024;
 #else
-    SetControlLabel(i++, "%s %s", 22024, SYSTEM_RENDER_VERSION);
+      int renderVersionLabel = 22009;
 #endif
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(HAS_DX)
+      static std::string version = renderingSystem->GetRenderVersionString();
+      if (!version.empty())
+        SET_CONTROL_LABEL(
+            i++, StringUtils::Format("%s %s", g_localizeStrings.Get(renderVersionLabel), version));
+    }
+
+    auto windowSystem = CServiceBroker::GetWinSystem();
+    if (windowSystem)
+    {
+      static std::string platform = windowSystem->GetName();
+      if (platform != "platform default")
+        SET_CONTROL_LABEL(i++,
+                          StringUtils::Format("%s %s", g_localizeStrings.Get(39153), platform));
+    }
+
     SetControlLabel(i++, "%s %s", 22010, SYSTEM_GPU_TEMPERATURE);
-#endif
   }
 
   else if (m_section == CONTROL_BT_HARDWARE)
   {
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20160));
-    SET_CONTROL_LABEL(i++, "CPU: " + CServiceBroker::GetCPUInfo()->GetCPUModel());
-#if defined(__arm__) && defined(TARGET_LINUX)
-    SET_CONTROL_LABEL(i++, "BogoMips: " + CServiceBroker::GetCPUInfo()->GetCPUBogoMips());
-    if (!CServiceBroker::GetCPUInfo()->GetCPUSoC().empty())
-      SET_CONTROL_LABEL(i++, "SoC: " + CServiceBroker::GetCPUInfo()->GetCPUSoC());
-    SET_CONTROL_LABEL(i++, "Hardware: " + CServiceBroker::GetCPUInfo()->GetCPUHardware());
-    SET_CONTROL_LABEL(i++, "Revision: " + CServiceBroker::GetCPUInfo()->GetCPURevision());
-    SET_CONTROL_LABEL(i++, "Serial: " + CServiceBroker::GetCPUInfo()->GetCPUSerial());
-#endif
-    SetControlLabel(i++, "%s %s", 22011, SYSTEM_CPU_TEMPERATURE);
-#if (!defined(__arm__) && !defined(__aarch64__))
-    SetControlLabel(i++, "%s %s", 13284, SYSTEM_CPUFREQUENCY);
-#endif
+
+    auto cpuInfo = CServiceBroker::GetCPUInfo();
+    if (cpuInfo)
+    {
+      static std::string model = cpuInfo->GetCPUModel();
+      if (!model.empty())
+        SET_CONTROL_LABEL(i++, "CPU: " + model);
+
+      static std::string mips = cpuInfo->GetCPUBogoMips();
+      if (!mips.empty())
+        SET_CONTROL_LABEL(i++, "BogoMips: " + mips);
+
+      static std::string soc = cpuInfo->GetCPUSoC();
+      if (!soc.empty())
+        SET_CONTROL_LABEL(i++, "SoC: " + soc);
+
+      static std::string hardware = cpuInfo->GetCPUHardware();
+      if (!hardware.empty())
+        SET_CONTROL_LABEL(i++, "Hardware: " + hardware);
+
+      static std::string revision = cpuInfo->GetCPURevision();
+      if (!revision.empty())
+        SET_CONTROL_LABEL(i++, "Revision: " + revision);
+
+      static std::string serial = cpuInfo->GetCPUSerial();
+      if (!serial.empty())
+        SET_CONTROL_LABEL(i++, "Serial: " + serial);
+
+      // temperature can't really be conditional because of localization units
+      SetControlLabel(i++, "%s %s", 22011, SYSTEM_CPU_TEMPERATURE);
+
+      // we can check if the cpufrequency is not 0 (default if not implemented)
+      // but we have to call through CGUIInfoManager -> CSystemGUIInfo -> CSysInfo
+      // to limit the frequency of updates
+      static float cpuFreq = cpuInfo->GetCPUFrequency();
+      if (cpuFreq > 0)
+        SetControlLabel(i++, "%s %s", 13284, SYSTEM_CPUFREQUENCY);
+    }
   }
 
   else if (m_section == CONTROL_BT_PVR)

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -162,12 +162,6 @@ void CGUIWindowSystemInfo::FrameMove()
 #if (!defined(__arm__) && !defined(__aarch64__))
     SetControlLabel(i++, "%s %s", 13284, SYSTEM_CPUFREQUENCY);
 #endif
-#if !(defined(__arm__) && defined(TARGET_LINUX))
-    SetControlLabel(i++, "%s %s", 13271, SYSTEM_CPU_USAGE);
-#endif
-    i++;  // empty line
-    SetControlLabel(i++, "%s: %s", 22012, SYSTEM_TOTAL_MEMORY);
-    SetControlLabel(i++, "%s: %s", 158, SYSTEM_FREE_MEMORY);
   }
 
   else if (m_section == CONTROL_BT_PVR)


### PR DESCRIPTION
This updates the video and hardware systeminfo screens.

1) Remove some redundant info (we already show cpu usage and memory usage below)
2) Make some items conditional (some are platform specific and if they are empty they shouldn't be shown
3) ~~Add a couple extra locations for information on linux arm platforms~~

I've made some items static as to only be initialised once (there is no need to constantly read the cpu info)

This affects all platforms so they should all be tested to make sure nothing is completely broken (it's only info anyways)

I've attached some screenshots to show the difference (before on left, after on right)

x86 linux:
![x86-hw](https://user-images.githubusercontent.com/1616460/110865449-7bd25380-8278-11eb-8886-99751e29bb0e.jpg)
![x86-video](https://user-images.githubusercontent.com/1616460/110865450-7c6aea00-8278-11eb-8f00-831a6cd9d30f.jpg)

----

arm linux:
![arm-hw](https://user-images.githubusercontent.com/1616460/110865517-9a384f00-8278-11eb-8a8d-4a74b0c3deeb.jpg)
![arm-video](https://user-images.githubusercontent.com/1616460/110865518-9ad0e580-8278-11eb-9d3b-ed64f346f973.jpg)
