### PR TITLE
[VideoInfoTag] Add m_type to Merge

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -459,7 +459,10 @@ void CVideoInfoTag::Merge(CVideoInfoTag& other)
 
   if (!m_dateAdded.IsValid())
     m_dateAdded = other.m_dateAdded;
-  // m_type
+
+  if (m_type.empty())
+    m_type = other.m_type;
+
   if (m_relevance == -1)
     m_relevance = other.m_relevance;
   if (!m_parsedDetails)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
I have re-add the possibility to specify the "mediatype" to VideoInfoTag of `setResolvedUrl` callback ListItem in case the source ListItem does not specify it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When i have add the `Merge` feature #17993,
I have left out the possibility of adding "mediatype" param if missing,
because i had assumed that it should always be present,
but for example in UpNext add-on make use of Json-RPC `Playlist.Add` to play a video from an add-on path (instead use `xbmc.PlayList(xbmc.PLAYLIST_VIDEO)` that allow to specify it)

But Json-RPC `Playlist.Add` implicitly creates an empty ListItem and when Kodi do the add-on callback to get the ListItem to be played (with setResolvedUrl) the add-on have to set the "mediatype" or otherwise the Skin video info will be missing or wrong.

Perhaps this problem could be solved directly by the add-ons, but this addition does not create any particular change and reintroduces the original behaviour.

Fixes Issue #19378

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Build locally and playes some video with Ntfx add-on + UpNext add-on

## Screenshots (if appropriate):
Before, see the missing episode info on the top:
![immagine](https://user-images.githubusercontent.com/3257156/111038237-3785b580-8428-11eb-8ea6-598cedb2c1f8.png)

After, now there is the episode info:
![immagine](https://user-images.githubusercontent.com/3257156/111038252-466c6800-8428-11eb-9f98-71ae00ef9395.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
