### PR TITLE
CDVDVideoCodecDRMPRIME: skip frames when requested

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -29,7 +29,7 @@ public:
   CDVDVideoCodec::VCReturn GetPicture(VideoPicture* pVideoPicture) override;
   const char* GetName() override { return m_name.c_str(); }
   unsigned GetAllowedReferences() override { return 5; }
-  void SetCodecControl(int flags) override { m_codecControlFlags = flags; }
+  void SetCodecControl(int flags) override;
 
 protected:
   void Drain();


### PR DESCRIPTION
## Description
DRMPRIME codec currently doesn't skip any frames, even when skip flags are set. Fix that by instructing ffmpeg to drop non-reference frames when flag is set or mark frame as dropped when ffmpeg returns empty frame. Concept is taken from ffmpeg codec.

## Motivation and Context
If display refresh rate is below video fps or decoder can't keep up, DRMPRIME codec should start skipping frames. However, because this was not implemented, audio and video sync issue became apparent pretty quickly.

## How Has This Been Tested?
This was tested on Kodi 19.0 (LibreELEC, board PineH64 model B) with 60 fps video and refresh rate manually set to 30 Hz. Without this patch, audio and video were out of sync.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
