### PR TITLE
CScriptRunner: fix regression introduced by CPluginDirectory refactoring.

### DIFF
--- a/xbmc/interfaces/generic/ScriptRunner.cpp
+++ b/xbmc/interfaces/generic/ScriptRunner.cpp
@@ -27,6 +27,9 @@ ADDON::AddonPtr CScriptRunner::GetAddon() const
   return m_addon;
 }
 
+CScriptRunner::CScriptRunner() : m_scriptDone(true)
+{ }
+
 bool CScriptRunner::StartScript(ADDON::AddonPtr addon, const std::string& path)
 {
   return RunScriptInternal(addon, path, 0, false);

--- a/xbmc/interfaces/generic/ScriptRunner.h
+++ b/xbmc/interfaces/generic/ScriptRunner.h
@@ -16,7 +16,7 @@
 class CScriptRunner
 {
 protected:
-  CScriptRunner() = default;
+  CScriptRunner();
   virtual ~CScriptRunner() = default;
 
   virtual bool IsSuccessful() const = 0;


### PR DESCRIPTION
## Description
#19310 introduced a regression which caused unnecessary 30 seconds delay after successful script execution.
Fix this by restoring the same behavior there was before the refactoring.
m_scriptDone need to be initialized as as m_scriptDone(true) in order to prevent the event from auto resetting.

## Motivation and Context
See https://forum.kodi.tv/showthread.php?tid=356934&pid=3022430#pid3022430 and a few posts below for debug logs and context.

Before this PR:
```
2021-03-14 02:06:51.845 T:10559   DEBUG <general>: [plugin.video.youtube] Shutdown of Kodion after |1.2845| seconds
2021-03-14 02:06:51.845 T:10559    INFO <general>: CPythonInvoker(4, /home/kodi/.kodi/addons/plugin.video.youtube/resources/lib/default.py): script successfully run
2021-03-14 02:07:20.595 T:10564   DEBUG <general>: Thread JobWorker 139726509233728 terminating (autodelete)
2021-03-14 02:07:20.596 T:10565   DEBUG <general>: Thread JobWorker 139727567058496 terminating (autodelete)
2021-03-14 02:07:21.881 T:10566   DEBUG <general>: Thread waiting 139727701276224 terminating
2021-03-14 02:07:21.886 T:10482   DEBUG <general>: ------ Window Deinit (DialogBusy.xml) ------
```
Notice the 30 seconds delay.

After this PR:
```
2021-03-14 17:20:11.131 T:18074   DEBUG <general>: [plugin.video.youtube] Shutdown of Kodion after |2.8333| seconds
2021-03-14 17:20:11.131 T:18074    INFO <general>: CPythonInvoker(4, /home/kodi/.kodi/addons/plugin.video.youtube/resources/lib/default.py): script successfully run
2021-03-14 17:20:11.132 T:18076   DEBUG <general>: Thread waiting 140554119652928 terminating
2021-03-14 17:20:11.143 T:17998   DEBUG <general>: ------ Window Deinit (DialogBusy.xml) ------
```

cc @Montellese

Note: backport is unnecessary as this PR touches v20 code only.

## How Has This Been Tested?
Tested by heavily (ab)using the youtube plugin.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
