### PR TITLE
[Backport][Estuary] Increase VideoPlayer OSD channel number label width

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -270,7 +270,7 @@
 			<height>380</height>
 			<control type="label">
 				<left>20</left>
-				<width>220</width>
+				<width>290</width>
 				<top>-80</top>
 				<height>25</height>
 				<label>$INFO[VideoPlayer.ChannelNumberLabel]</label>


### PR DESCRIPTION
## Description
Backport of PR https://github.com/xbmc/xbmc/pull/19407:

Per Issue https://github.com/xbmc/xbmc/issues/19400, the Estuary Skin's VideoPlayer OSD does not currently handle 4-digit channel numbers (e.g. 1827), or 3-digit channel numbers with a subchannel (e.g. 888.8) without truncating and obfuscating the number with a "..."

This is a very minor/cosmetic change to Estuary that should have no impact on any other system functionality.  If accepted, I would also like to backport this to the Matrix branch.

Thanks to @ksooo for pointing out exactly where the change needed to be made. Appreciated; it took about 30 seconds to fix with your guidance.

## Motivation and Context
Resolves Issue https://github.com/xbmc/xbmc/issues/19400

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on master branch, current as of 2021.03.03, on Windows x64 (Desktop).  Installed XML was modified in place to produce the desired effect with 5-unit increments.

## Screenshots (if appropriate):

As documented in https://github.com/xbmc/xbmc/issues/19400:
![osd-channelnumber](https://user-images.githubusercontent.com/706055/111055475-31053700-8444-11eb-8fa1-2a73d3cbc390.png)

Same 4-digit channel after increasing the width:
![1827](https://user-images.githubusercontent.com/706055/111055480-3e222600-8444-11eb-9981-95d132f6c68e.png)

Also tested "888.8", which should be a fairly reasonable width limitation for Radio channels that use an FM frequency as the channel number:
![888 8](https://user-images.githubusercontent.com/706055/111055499-67db4d00-8444-11eb-8a41-94c68563ec1b.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
