### PR TITLE
[estuary] disable sounds selection setting when play GUI sounds is never

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2829,6 +2829,9 @@
         <setting id="lookandfeel.soundskin" type="addon" label="24006" help="36110">
           <level>0</level>
           <default>resource.uisounds.kodi</default>
+          <dependencies>
+            <dependency type="enable" setting="audiooutput.guisoundmode" operator="!is">0</dependency>
+          </dependencies>          
           <constraints>
             <addontype>kodi.resource.uisounds</addontype>
             <allowempty>true</allowempty>


### PR DESCRIPTION
## Description
Cosmetic change in Settings > System >  GUI Sounds:

when Play GUI sounds is set to Never, the setting to select the sounds used in the interface should be disabled.

## Screenshots:
before:
![before](https://user-images.githubusercontent.com/76552691/111143466-1f2bad00-8586-11eb-88f7-41df488cef78.png)

after:
![after](https://user-images.githubusercontent.com/76552691/111143536-2bb00580-8586-11eb-9ce4-6b5dbd8482e4.png)



## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
