### PR TITLE
[VideoPlayer] fix menu handling of blu-rays and allow chapter seeking while in overlay menu mode

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -114,6 +114,7 @@ public:
     virtual double GetTimeStampCorrection() { return 0.0; };
     virtual bool GetState(std::string &xmlstate) = 0;
     virtual bool SetState(const std::string &xmlstate) = 0;
+    virtual bool CanSeek() { return !IsInMenu(); };
   };
 
   class IDemux

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -91,6 +91,7 @@ public:
   void SkipStill() override;
   bool GetState(std::string &xmlstate) override { return false; }
   bool SetState(const std::string &xmlstate) override { return false; }
+  bool CanSeek() override;
 
 
   void UserInput(bd_vk_key_e vk);
@@ -138,6 +139,8 @@ protected:
   BLURAY_CLIP_INFO* m_clip = nullptr;
   uint32_t m_angle = 0;
   bool m_menu = false;
+  bool m_isInMainMenu = false;
+  bool m_hasOverlay = false;
   bool m_navmode = false;
   int m_dispTimeBeforeRead = 0;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR fixes two things, a probably borked/inconsistent menu state of blurays and the related inability to skip/seek while a bluray is in menu state (which is an issue when the state is detected wrong)

To fix this, input handling of bluray menus does no longer rely on an internal pseudo "m_menu" state for bluray overlay menus, since there is no reliable way to actually know if a menu is actually rendered on screen or not. Also, this internally tracked stated tends to get out of sync and in those cases interaction with blurays in menu mode is utterly borked. Thus, when users decide to play a bluray in menu mode, user input (navigation keys + select) is always forwarded to the bluray (like on any other bluray player). The KODI menu can still be triggered via the usual keys defined in the keymaps (`m` button, etc).

However, menu mode in VideoPlayer does currently not allow any form of seeking or skipping, since menus must not be skipped. Bluray overlay menus however are displayed while the movie is playing, and thus skipping/seeking must still be allowed when the bluray is in overlay menu state. To indicate that seeking is still allowed, even while in menu mode, I added a new `CanBeSeeked` method to the DVDInputStream interface. That way all the bluray overlay logic can stay self contained in DVDInputStreamBluray and VP can check against a clean interface.

This is an alternative approach to #19102. It tries to keep bluray specific logic for these fixes out of VideoPlayer as much as possible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix bluray menu issues and the inability to skip/seek when the menu state is detected wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested by me and a couple users on the forum.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
