### PR TITLE
[swig/python] improve performance of generated typemaps

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -830,10 +830,6 @@ namespace XBMCAddon
 
     CVideoInfoTag* ListItem::GetVideoInfoTag()
     {
-      // make sure the playcount is reset to -1
-      if (!item->HasVideoInfoTag())
-        item->GetVideoInfoTag()->ResetPlayCount();
-
       return item->GetVideoInfoTag();
     }
 

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -87,7 +87,7 @@ Helper.setup(this,classes,
       'int' : '${api} = (int)PyLong_AsLong(${slarg});',
       'double' : '${api} = PyFloat_AsDouble(${slarg});',
       'float' : '${api} = (float)PyFloat_AsDouble(${slarg});',
-      'XBMCAddon::StringOrInt' : 'if (${slarg}) PyXBMCGetUnicodeString(${api},${slarg},PyLong_Check(${slarg}) || PyLong_Check(${slarg}) || PyFloat_Check(${slarg}),"${api}","${method.@name}");'
+      'XBMCAddon::StringOrInt' : 'if (${slarg}) PyXBMCGetUnicodeString(${api},${slarg},PyLong_Check(${slarg}) || PyFloat_Check(${slarg}),"${api}","${method.@name}");'
     ], '${api} = (${swigTypeParser.SwigType_str(ltype)})retrieveApiInstance(${slarg},"${ltype}","${helper.findNamespace(method)}","${helper.callingName(method)}");')
 // ---------------------------------------------------------
 

--- a/xbmc/interfaces/python/typemaps/python.dict.intm
+++ b/xbmc/interfaces/python/typemaps/python.dict.intm
@@ -18,6 +18,6 @@
         PyXBMCGetUnicodeString(key,pykey,false,"${api}","${method.@name}");
         ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(valtype))} value;
         ${helper.getInConversion(valtype, 'value', 'pyvalue' ,method)}
-        ${api}[key] = value;
+        ${api}.emplace(std::move(key), std::move(value));
       }
     }

--- a/xbmc/interfaces/python/typemaps/python.map.intm
+++ b/xbmc/interfaces/python/typemaps/python.map.intm
@@ -19,6 +19,6 @@
         ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(valtype))} value;
         ${helper.getInConversion(keytype, 'key', 'pykey', method)}
         ${helper.getInConversion(valtype, 'value', 'pyvalue' ,method)}
-        ${api}[key] = value;
+        ${api}.emplace(std::move(key), std::move(value));
       }
     }

--- a/xbmc/interfaces/python/typemaps/python.vector.intm
+++ b/xbmc/interfaces/python/typemaps/python.vector.intm
@@ -21,6 +21,7 @@
       <%  if (ispointer) print("${api} = new std::vector<${swigTypeParser.SwigType_str(vectype)}>();") %>
       PyObject *pyentry${seq} = NULL;
       Py_ssize_t vecSize = (isTuple ? PyTuple_Size(${slarg}) : PyList_Size(${slarg}));
+      ${api}${accessor}reserve(vecSize);
       for(Py_ssize_t i = 0; i < vecSize; i++)
       {
         pyentry${seq} = (isTuple ? PyTuple_GetItem(${slarg}, i) : PyList_GetItem(${slarg}, i));
@@ -30,6 +31,6 @@
                                    'ltype' : swigTypeParser.SwigType_ltype(vectype),
                                    'sequence' : sequence
                                    ])}
-        ${api}${accessor}push_back(entry${seq});
+        ${api}${accessor}push_back(std::move(entry${seq}));
       }
     }


### PR DESCRIPTION
## Description
This PR improves the performance of Python typemaps generated by the code generator by using C++ `move` semantic. Furthermore I removed a duplicate `PyLong_Check()` which was introduced in the Python 3 migration.

## Motivation and Context
I was investigating the performance of creating and passing `ListItem` instances from a Python add-on to Kodi and realized that `ListItem.setInfo()` and `ListItem.setCast()` made up 90% of the time it took to put together a new `ListItem`. By improving the typemaps using `std::move()`, `std::map::emplace` and `std::vector::reserve()` I saw a performance improvement of ~20-25% for `ListItem.setInfo()` and `ListItem.setCast()`. This might be useful for other add-ons as well but I haven't really tested or profiled it on any other add-ons creating `ListItem` instances.

Even greater performance improvements could be achieved by replacing `ListItem.setCast()` which expects a python `dict` with an implementation which expects a proper object with specific members. But that would also require add-on developers to adjust their code while the changes above are purely Kodi internal.

## How Has This Been Tested?
Manually as part of my media import work.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed