### PR TITLE
[docs] Document missing force opt for xbmcvfs.rmdir()

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.h
@@ -278,11 +278,15 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmcvfs
-    /// @brief \python_func{ xbmcvfs.rmdir(path) }
+    /// @brief \python_func{ xbmcvfs.rmdir(path, [force]) }
     /// Remove a folder.
     ///
-    /// @param path                  Folder to remove
-    /// @return                      True if successed
+    /// @param path                  string - Folder to remove
+    /// @param force                 [opt] bool - Force directory removal
+    ///                              (default False). This can be useful
+    ///                              if the directory is not empty.
+    /// @return                      bool - True if successful, False
+    ///                              otherwise
     ///
     ///
     /// ------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Found by @robweber in https://forum.kodi.tv/showthread.php?tid=361395
The "force" argument of xbmcvfs.rmdir() was missing in doxygen.


## Motivation and Context
Complete docs

## How Has This Been Tested?
Compile doxygen and check the result

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
