### PR TITLE
[PVR] Delete stale 'all channels' group members from database.

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -390,6 +390,20 @@ int CPVRDatabase::Get(CPVRChannelGroup& results, bool bCompressDB)
 
 /********** Channel group methods **********/
 
+bool CPVRDatabase::QueueDeleteChannelGroupMembersQuery(int iGroupID)
+{
+  Filter filter;
+  filter.AppendWhere(PrepareSQL("idGroup = %u", iGroupID));
+
+  CSingleLock lock(m_critSection);
+
+  std::string strQuery;
+  if (BuildSQL(PrepareSQL("DELETE FROM %s ", "map_channelgroups_channels"), filter, strQuery))
+    return CDatabase::QueueDeleteQuery(strQuery);
+
+  return false;
+}
+
 bool CPVRDatabase::RemoveChannelsFromGroup(const CPVRChannelGroup& group)
 {
   Filter filter;

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -150,6 +150,13 @@ namespace PVR
     bool Delete(const CPVRChannelGroup& group);
 
     /*!
+     * @brief Remove all channel members of the given group from the database
+     * @param iGroupID The id of the group.
+     * @return True if all channel members were removed, false otherwise.
+     */
+    bool QueueDeleteChannelGroupMembersQuery(int iGroupID);
+
+    /*!
      * @brief Get the channel groups.
      * @param results The container to store the results in.
      * @return True if the list was fetched successfully, false otherwise.


### PR DESCRIPTION
## Description
Fixes an issue reported by @phunkyfish.

```
Recently when enabling/disabling PVR add-ons I get these a lot. Do we need to log them?
2021-03-14 16:00:54.515 kodi.bin[11811:2882505] 2021-03-14 16:00:54.515 T:2882505   ERROR <general>: UpdateFromScraper: No EPG scraper defined for table ''
2021-03-14 16:00:54.515 kodi.bin[11811:2882505] 2021-03-14 16:00:54.515 T:2882505   ERROR <general>: Update: Failed to update table ''
```
If you want to reproduce you need two PVR add-ons installed and enabled.
Client 1 must have no radio channels. And client 2 must have radio channels.
Clear PVR data with both clients enabled
Disable client 2
Now in your TV DB, the channel group mappings for group radio all channels will still exist even though the channels do not. When you restart they will cause empty EPGs to be created, which causes the log ERRORs.

## Motivation and ContextI
Inconsistent  PVR database content producing log ERRORs, possibly functional misbehavior.

## How Has This Been Tested?
Runtime-tested be me on macOS and Android, latest kodi master with this PR applied.
Runtime-tested by @phunkyfish, fix confirmed.
 
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
