### PR TITLE
[PVR] Fix: On recordings update, do only overwrite play count / play …

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1776,7 +1776,7 @@ void CPVRClient::cb_transfer_recording_entry(void* kodiInstance,
 
   /* transfer this entry to the recordings container */
   std::shared_ptr<CPVRRecording> transferRecording(new CPVRRecording(*recording, client->GetID()));
-  kodiRecordings->UpdateFromClient(transferRecording);
+  kodiRecordings->UpdateFromClient(transferRecording, *client);
 }
 
 void CPVRClient::cb_transfer_timer_entry(void* kodiInstance,

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1019,7 +1019,8 @@ namespace PVR
     }
 
     std::shared_ptr<CPVRRecording> origRecording(new CPVRRecording);
-    origRecording->Update(*recording);
+    origRecording->Update(*recording,
+                          *CServiceBroker::GetPVRManager().GetClient(recording->m_iClientId));
 
     if (!ShowRecordingSettings(recording))
       return false;

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -42,6 +42,7 @@ struct PVR_RECORDING;
 namespace PVR
 {
   class CPVRChannel;
+  class CPVRClient;
   class CPVRTimerInfoTag;
 
   /*!
@@ -184,14 +185,17 @@ namespace PVR
     /*!
      * @brief Get the resume point and play count from the database if the
      * client doesn't handle it itself.
+     * @param db The database to read the data from.
+     * @param client The client this recording belongs to.
      */
-    void UpdateMetadata(CVideoDatabase& db);
+    void UpdateMetadata(CVideoDatabase& db, const CPVRClient& client);
 
     /*!
      * @brief Update this tag with the contents of the given tag.
      * @param tag The new tag info.
+     * @param client The client this recording belongs to.
      */
-    void Update(const CPVRRecording& tag);
+    void Update(const CPVRRecording& tag, const CPVRClient& client);
 
     /*!
      * @brief Retrieve the recording start as UTC time

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -199,7 +199,8 @@ std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(int iClientId, const std:
   return retVal;
 }
 
-void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag)
+void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag,
+                                      const CPVRClient& client)
 {
   CSingleLock lock(m_critSection);
 
@@ -214,12 +215,12 @@ void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag)
   std::shared_ptr<CPVRRecording> existingTag = GetById(tag->m_iClientId, tag->m_strRecordingId);
   if (existingTag)
   {
-    existingTag->Update(*tag);
+    existingTag->Update(*tag, client);
     existingTag->SetDirty(false);
   }
   else
   {
-    tag->UpdateMetadata(GetVideoDatabase());
+    tag->UpdateMetadata(GetVideoDatabase(), client);
     tag->m_iRecordingId = ++m_iLastId;
     m_recordings.insert({CPVRRecordingUid(tag->m_iClientId, tag->m_strRecordingId), tag});
     if (tag->IsRadio())

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -19,6 +19,7 @@ class CVideoDatabase;
 
 namespace PVR
 {
+  class CPVRClient;
   class CPVREpgInfoTag;
   class CPVRRecording;
   class CPVRRecordingUid;
@@ -41,7 +42,12 @@ namespace PVR
      */
     void Unload();
 
-    void UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag);
+    /*!
+     * @brief client has delivered a new/updated recording.
+     * @param tag The recording
+     * @param client The client the recording belongs to.
+     */
+    void UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag, const CPVRClient& client);
 
     /*!
      * @brief refresh the recordings list from the clients.


### PR DESCRIPTION
…position if client does support play position / play count.

If the PVR client add-on does not support "server-side" play count / play position, those data shall be managed locally by Kodi, in the video database. This worked in Leia and is broken in Matrix.  This PR fixes the regression.

@phunkyfish could you do a runtime-test?

I runtime-tested on macOS and Android, latest master and Matrix branches.