### PR TITLE
[Music]Fix deprecated uses of TagLib API

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -229,7 +229,7 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
   if (tag.GetArtist().empty())
     tag.SetArtist(asf->artist().toCString(true));
 
-  if (asf->comment() != String::null)
+  if (!asf->comment().isEmpty())
     tag.SetComment(asf->comment().toCString(true));
   tag.SetReplayGain(replayGainInfo);
   tag.SetLoaded(true);
@@ -479,7 +479,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, EmbeddedArt *art, MUSIC_INFO:
     }
 
 
-  if (id3v2->comment() != String::null)
+  if (!id3v2->comment().isEmpty())
     tag.SetComment(id3v2->comment().toCString(true));
 
   tag.SetReplayGain(replayGainInfo);
@@ -817,7 +817,7 @@ bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusic
   }
 #endif
 
-  if (xiph->comment() != String::null)
+  if (!xiph->comment().isEmpty())
     tag.SetComment(xiph->comment().toCString(true));
 
   tag.SetReplayGain(replayGainInfo);
@@ -831,8 +831,8 @@ bool CTagLoaderTagLib::ParseTag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& 
     return false;
 
   ReplayGain replayGainInfo;
-  MP4::ItemListMap& itemListMap = mp4->itemListMap();
-  for (MP4::ItemListMap::ConstIterator it = itemListMap.begin(); it != itemListMap.end(); ++it)
+  const MP4::ItemMap itemMap = mp4->itemMap();
+  for (auto it = itemMap.begin(); it != itemMap.end(); ++it)
   {
     if (it->first == "\251nam")
       tag.SetTitle(it->second.toStringList().front().to8Bit(true));
@@ -943,7 +943,7 @@ bool CTagLoaderTagLib::ParseTag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& 
     }
   }
 
-  if (mp4->comment() != String::null)
+  if (!mp4->comment().isEmpty())
     tag.SetComment(mp4->comment().toCString(true));
 
   tag.SetReplayGain(replayGainInfo);


### PR DESCRIPTION
Fix deprecated uses of TagLib API:
- `string::null` tests on `TagLib::String` and `TagLib::ByteVector` replaced by `isEmpty()`
- `MP4::ItemListMap` has been renamed to `ItemMap`

Both depreacted long before TagLib v1.11, but will cause Wdeprecated-declarations build warnings when bumped to v1.12. Hence merge before https://github.com/xbmc/xbmc/pull/19432

See TagLib https://github.com/taglib/taglib/issues/1001 and https://github.com/taglib/taglib/commit/bba562b5570de7815437044b404ca185dcf46669

Tested with tag scanning of FLAC, mp3 (both ID3 v2.3 and ID3 v2.4) and mp4 files.

Thanks for doing the initial leg work @fuzzard, @the-black-eagle perhaps worth a quick test on Linux too.