### PR TITLE
[python/legacy] ListItem: support setting information through JSON or dict

### DIFF
--- a/xbmc/interfaces/legacy/CMakeLists.txt
+++ b/xbmc/interfaces/legacy/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES AddonCallback.cpp
             DrmCryptoSession.cpp
             File.cpp
             InfoTagMusic.cpp
+            InfoTagPicture.cpp
             InfoTagRadioRDS.cpp
             InfoTagVideo.cpp
             Keyboard.cpp
@@ -43,6 +44,7 @@ set(HEADERS Addon.h
             Exception.h
             File.h
             InfoTagMusic.h
+            InfoTagPicture.h
             InfoTagRadioRDS.h
             InfoTagVideo.h
             Keyboard.h

--- a/xbmc/interfaces/legacy/CMakeLists.txt
+++ b/xbmc/interfaces/legacy/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES AddonCallback.cpp
             Dialog.cpp
             DrmCryptoSession.cpp
             File.cpp
+            InfoTagGame.cpp
             InfoTagMusic.cpp
             InfoTagPicture.cpp
             InfoTagRadioRDS.cpp
@@ -43,6 +44,7 @@ set(HEADERS Addon.h
             DrmCryptoSession.h
             Exception.h
             File.h
+            InfoTagGame.h
             InfoTagMusic.h
             InfoTagPicture.h
             InfoTagRadioRDS.h

--- a/xbmc/interfaces/legacy/InfoTagGame.cpp
+++ b/xbmc/interfaces/legacy/InfoTagGame.cpp
@@ -1,0 +1,172 @@
+/*
+ *  Copyright (C) 2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "InfoTagGame.h"
+
+#include "AddonUtils.h"
+#include "games/tags/GameInfoTag.h"
+
+using namespace KODI::GAME;
+using namespace XBMCAddonUtils;
+
+namespace XBMCAddon
+{
+namespace xbmc
+{
+
+InfoTagGame::InfoTagGame(bool offscreen /* = false */)
+  : infoTag(new CGameInfoTag), offscreen(offscreen), owned(true)
+{
+}
+
+InfoTagGame::InfoTagGame(const CGameInfoTag* tag)
+  : infoTag(new CGameInfoTag(*tag)), offscreen(true), owned(true)
+{
+}
+
+InfoTagGame::InfoTagGame(CGameInfoTag* tag, bool offscreen /* = false */)
+  : infoTag(tag), offscreen(offscreen), owned(false)
+{
+}
+
+InfoTagGame::~InfoTagGame()
+{
+  if (owned)
+    delete infoTag;
+}
+
+String InfoTagGame::getTitle()
+{
+  return infoTag->GetTitle();
+}
+
+String InfoTagGame::getPlatform()
+{
+  return infoTag->GetPlatform();
+}
+
+std::vector<String> InfoTagGame::getGenres()
+{
+  return infoTag->GetGenres();
+}
+
+String InfoTagGame::getPublisher()
+{
+  return infoTag->GetPublisher();
+}
+
+String InfoTagGame::getDeveloper()
+{
+  return infoTag->GetDeveloper();
+}
+
+String InfoTagGame::getOverview()
+{
+  return infoTag->GetOverview();
+}
+
+unsigned int InfoTagGame::getYear()
+{
+  return infoTag->GetYear();
+}
+
+String InfoTagGame::getGameClient()
+{
+  return infoTag->GetGameClient();
+}
+
+void InfoTagGame::setTitle(const String& title)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setTitleRaw(infoTag, title);
+}
+
+void InfoTagGame::setPlatform(const String& platform)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setPlatformRaw(infoTag, platform);
+}
+
+void InfoTagGame::setGenres(const std::vector<String>& genres)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setGenresRaw(infoTag, genres);
+}
+
+void InfoTagGame::setPublisher(const String& publisher)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setPublisherRaw(infoTag, publisher);
+}
+
+void InfoTagGame::setDeveloper(const String& developer)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setDeveloperRaw(infoTag, developer);
+}
+
+void InfoTagGame::setOverview(const String& overview)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setOverviewRaw(infoTag, overview);
+}
+
+void InfoTagGame::setYear(unsigned int year)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setYearRaw(infoTag, year);
+}
+
+void InfoTagGame::setGameClient(const String& gameClient)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setGameClientRaw(infoTag, gameClient);
+}
+
+void InfoTagGame::setTitleRaw(KODI::GAME::CGameInfoTag* infoTag, const String& title)
+{
+  infoTag->SetTitle(title);
+}
+
+void InfoTagGame::setPlatformRaw(KODI::GAME::CGameInfoTag* infoTag, const String& platform)
+{
+  infoTag->SetPlatform(platform);
+}
+
+void InfoTagGame::setGenresRaw(KODI::GAME::CGameInfoTag* infoTag, std::vector<String> genres)
+{
+  infoTag->SetGenres(genres);
+}
+
+void InfoTagGame::setPublisherRaw(KODI::GAME::CGameInfoTag* infoTag, const String& publisher)
+{
+  infoTag->SetPublisher(publisher);
+}
+
+void InfoTagGame::setDeveloperRaw(KODI::GAME::CGameInfoTag* infoTag, const String& developer)
+{
+  infoTag->SetDeveloper(developer);
+}
+
+void InfoTagGame::setOverviewRaw(KODI::GAME::CGameInfoTag* infoTag, const String& overview)
+{
+  infoTag->SetOverview(overview);
+}
+
+void InfoTagGame::setYearRaw(KODI::GAME::CGameInfoTag* infoTag, unsigned int year)
+{
+  infoTag->SetYear(year);
+}
+
+void InfoTagGame::setGameClientRaw(KODI::GAME::CGameInfoTag* infoTag, const String& gameClient)
+{
+  infoTag->SetGameClient(gameClient);
+}
+
+} // namespace xbmc
+} // namespace XBMCAddon

--- a/xbmc/interfaces/legacy/InfoTagGame.h
+++ b/xbmc/interfaces/legacy/InfoTagGame.h
@@ -1,0 +1,391 @@
+/*
+ *  Copyright (C) 2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AddonClass.h"
+
+namespace KODI
+{
+namespace GAME
+{
+class CGameInfoTag;
+}
+} // namespace KODI
+
+namespace XBMCAddon
+{
+namespace xbmc
+{
+///
+/// \defgroup python_InfoTagGame InfoTagGame
+/// \ingroup python_xbmc
+/// @{
+/// @brief **Kodi's game info tag class.**
+///
+/// \python_class{ InfoTagGame() }
+///
+/// Access and / or modify the game metadata of a ListItem.
+///
+///-------------------------------------------------------------------------
+/// @python_v20 New class added.
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.py}
+/// ...
+/// tag = item.getGameInfoTag()
+///
+/// title = tag.getTitle()
+/// tag.setDeveloper('John Doe')
+/// ...
+/// ~~~~~~~~~~~~~
+///
+class InfoTagGame : public AddonClass
+{
+private:
+  KODI::GAME::CGameInfoTag* infoTag;
+  bool offscreen;
+  bool owned;
+
+public:
+#ifndef SWIG
+  explicit InfoTagGame(const KODI::GAME::CGameInfoTag* tag);
+  explicit InfoTagGame(KODI::GAME::CGameInfoTag* tag, bool offscreen = false);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ xbmc.InfoTagGame([offscreen]) }
+  /// Create a game info tag.
+  ///
+  /// @param offscreen            [opt] bool (default `False`) - if GUI based locks should be
+  ///                                          avoided. Most of the times listitems are created
+  ///                                          offscreen and added later to a container
+  ///                                          for display (e.g. plugins) or they are not
+  ///                                          even displayed (e.g. python scrapers).
+  ///                                          In such cases, there is no need to lock the
+  ///                                          GUI when creating the items (increasing your addon
+  ///                                          performance).
+  ///                                          Note however, that if you are creating listitems
+  ///                                          and managing the container itself (e.g using
+  ///                                          WindowXML or WindowXMLDialog classes) subsquent
+  ///                                          modifications to the item will require locking.
+  ///                                          Thus, in such cases, use the default value (`False`).
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ...
+  /// gameinfo = xbmc.InfoTagGame(offscreen=False)
+  /// ...
+  /// ~~~~~~~~~~~~~
+  ///
+  InfoTagGame(...);
+#else
+  explicit InfoTagGame(bool offscreen = false);
+#endif
+  ~InfoTagGame() override;
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getTitle() }
+  /// Gets the title of the game.
+  ///
+  /// @return [string] title
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getTitle();
+#else
+  String getTitle();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getPlatform() }
+  /// Gets the platform on which the game is run.
+  ///
+  /// @return [string] platform
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getPlatform();
+#else
+  String getPlatform();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getGenres() }
+  /// Gets the genres of the game.
+  ///
+  /// @return [list] genres
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getGenres();
+#else
+  std::vector<String> getGenres();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getPublisher() }
+  /// Gets the publisher of the game.
+  ///
+  /// @return [string] publisher
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getPublisher();
+#else
+  String getPublisher();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getDeveloper() }
+  /// Gets the developer of the game.
+  ///
+  /// @return [string] developer
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getDeveloper();
+#else
+  String getDeveloper();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getOverview() }
+  /// Gets the overview of the game.
+  ///
+  /// @return [string] overview
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getOverview();
+#else
+  String getOverview();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getYear() }
+  /// Gets the year in which the game was published.
+  ///
+  /// @return [integer] year
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getYear();
+#else
+  unsigned int getYear();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ getGameClient() }
+  /// Gets the add-on ID of the game client executing the game.
+  ///
+  /// @return [string] game client
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getGameClient();
+#else
+  String getGameClient();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setTitle(title) }
+  ///-----------------------------------------------------------------------
+  /// Sets the title of the game.
+  ///
+  /// @param title              string - title.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setTitle(...);
+#else
+  void setTitle(const String& title);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setPlatform(platform) }
+  ///-----------------------------------------------------------------------
+  /// Sets the platform on which the game is run.
+  ///
+  /// @param platform           string - platform.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setPlatform(...);
+#else
+  void setPlatform(const String& platform);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setGenres(genres) }
+  ///-----------------------------------------------------------------------
+  /// Sets the genres of the game.
+  ///
+  /// @param genres             list - genres.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setGenres(...);
+#else
+  void setGenres(const std::vector<String>& genres);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setPublisher(publisher) }
+  ///-----------------------------------------------------------------------
+  /// Sets the publisher of the game.
+  ///
+  /// @param publisher          string - publisher.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setPublisher(...);
+#else
+  void setPublisher(const String& publisher);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setDeveloper(developer) }
+  ///-----------------------------------------------------------------------
+  /// Sets the developer of the game.
+  ///
+  /// @param developer          string - title.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setDeveloper(...);
+#else
+  void setDeveloper(const String& developer);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setOverview(overview) }
+  ///-----------------------------------------------------------------------
+  /// Sets the overview of the game.
+  ///
+  /// @param overview           string - overview.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setOverview(...);
+#else
+  void setOverview(const String& overview);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setYear(year) }
+  ///-----------------------------------------------------------------------
+  /// Sets the year in which the game was published.
+  ///
+  /// @param year               integer - year.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setYear(...);
+#else
+  void setYear(unsigned int year);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagGame
+  /// @brief \python_func{ setGameClient(gameClient) }
+  ///-----------------------------------------------------------------------
+  /// Sets the add-on ID of the game client executing the game.
+  ///
+  /// @param gameClient         string - game client.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setGameClient(...);
+#else
+  void setGameClient(const String& gameClient);
+#endif
+
+#ifndef SWIG
+  static void setTitleRaw(KODI::GAME::CGameInfoTag* infoTag, const String& title);
+  static void setPlatformRaw(KODI::GAME::CGameInfoTag* infoTag, const String& platform);
+  static void setGenresRaw(KODI::GAME::CGameInfoTag* infoTag, std::vector<String> genres);
+  static void setPublisherRaw(KODI::GAME::CGameInfoTag* infoTag, const String& publisher);
+  static void setDeveloperRaw(KODI::GAME::CGameInfoTag* infoTag, const String& developer);
+  static void setOverviewRaw(KODI::GAME::CGameInfoTag* infoTag, const String& overview);
+  static void setYearRaw(KODI::GAME::CGameInfoTag* infoTag, unsigned int year);
+  static void setGameClientRaw(KODI::GAME::CGameInfoTag* infoTag, const String& gameClient);
+#endif
+};
+
+} // namespace xbmc
+} // namespace XBMCAddon

--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -81,9 +81,19 @@ namespace XBMCAddon
       return StringUtils::Join(infoTag->GetGenre(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
     }
 
+    std::vector<String> InfoTagMusic::getGenres()
+    {
+      return infoTag->GetGenre();
+    }
+
     int InfoTagMusic::getDuration()
     {
       return infoTag->GetDuration();
+    }
+
+    int InfoTagMusic::getYear()
+    {
+      return infoTag->GetYear();
     }
 
     int InfoTagMusic::getRating()
@@ -167,6 +177,291 @@ namespace XBMCAddon
     std::vector<String> InfoTagMusic::getMusicBrainzAlbumArtistID()
     {
       return infoTag->GetMusicBrainzAlbumArtistID();
+    }
+
+    void InfoTagMusic::setDbId(int dbId, const String& type)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setDbIdRaw(infoTag, dbId, type);
+    }
+
+    void InfoTagMusic::setURL(const String& url)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setURLRaw(infoTag, url);
+    }
+
+    void InfoTagMusic::setMediaType(const String& mediaType)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setMediaTypeRaw(infoTag, mediaType);
+    }
+
+    void InfoTagMusic::setTrack(int track)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTrackRaw(infoTag, track);
+    }
+
+    void InfoTagMusic::setDisc(int disc)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setDiscRaw(infoTag, disc);
+    }
+
+    void InfoTagMusic::setDuration(int duration)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setDurationRaw(infoTag, duration);
+    }
+
+    void InfoTagMusic::setYear(int year)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setYearRaw(infoTag, year);
+    }
+
+    void InfoTagMusic::setReleaseDate(const String& releaseDate)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setReleaseDateRaw(infoTag, releaseDate);
+    }
+
+    void InfoTagMusic::setListeners(int listeners)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setListenersRaw(infoTag, listeners);
+    }
+
+    void InfoTagMusic::setPlayCount(int playcount)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setPlayCountRaw(infoTag, playcount);
+    }
+
+    void InfoTagMusic::setGenres(const std::vector<String>& genres)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setGenresRaw(infoTag, genres);
+    }
+
+    void InfoTagMusic::setAlbum(const String& album)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setAlbumRaw(infoTag, album);
+    }
+
+    void InfoTagMusic::setArtist(const String& artist)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setArtistRaw(infoTag, artist);
+    }
+
+    void InfoTagMusic::setAlbumArtist(const String& albumArtist)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setAlbumArtistRaw(infoTag, albumArtist);
+    }
+
+    void InfoTagMusic::setTitle(const String& title)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTitleRaw(infoTag, title);
+    }
+
+    void InfoTagMusic::setRating(float rating)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setRatingRaw(infoTag, rating);
+    }
+
+    void InfoTagMusic::setUserRating(int userrating)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setUserRatingRaw(infoTag, userrating);
+    }
+
+    void InfoTagMusic::setLyrics(const String& lyrics)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setLyricsRaw(infoTag, lyrics);
+    }
+
+    void InfoTagMusic::setLastPlayed(const String& lastPlayed)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setLastPlayedRaw(infoTag, lastPlayed);
+    }
+
+    void InfoTagMusic::setMusicBrainzTrackID(const String& musicBrainzTrackID)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setMusicBrainzTrackIDRaw(infoTag, musicBrainzTrackID);
+    }
+
+    void InfoTagMusic::setMusicBrainzArtistID(const std::vector<String>& musicBrainzArtistID)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setMusicBrainzArtistIDRaw(infoTag, musicBrainzArtistID);
+    }
+
+    void InfoTagMusic::setMusicBrainzAlbumID(const String& musicBrainzAlbumID)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setMusicBrainzAlbumIDRaw(infoTag, musicBrainzAlbumID);
+    }
+
+    void InfoTagMusic::setMusicBrainzReleaseGroupID(const String& musicBrainzReleaseGroupID)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setMusicBrainzReleaseGroupIDRaw(infoTag, musicBrainzReleaseGroupID);
+    }
+
+    void InfoTagMusic::setMusicBrainzAlbumArtistID(
+        const std::vector<String>& musicBrainzAlbumArtistID)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setMusicBrainzAlbumArtistIDRaw(infoTag, musicBrainzAlbumArtistID);
+    }
+
+    void InfoTagMusic::setComment(const String& comment)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setCommentRaw(infoTag, comment);
+    }
+
+    void InfoTagMusic::setDbIdRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int dbId, const String& type)
+    {
+      infoTag->SetDatabaseId(dbId, type);
+    }
+
+    void InfoTagMusic::setURLRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& url)
+    {
+      infoTag->SetURL(url);
+    }
+
+    void InfoTagMusic::setMediaTypeRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& mediaType)
+    {
+      infoTag->SetType(mediaType);
+    }
+
+    void InfoTagMusic::setTrackRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int track)
+    {
+      infoTag->SetTrackNumber(track);
+    }
+
+    void InfoTagMusic::setDiscRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int disc)
+    {
+      infoTag->SetDiscNumber(disc);
+    }
+
+    void InfoTagMusic::setDurationRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int duration)
+    {
+      infoTag->SetDuration(duration);
+    }
+
+    void InfoTagMusic::setYearRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int year)
+    {
+      infoTag->SetYear(year);
+    }
+
+    void InfoTagMusic::setReleaseDateRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                         const String& releaseDate)
+    {
+      infoTag->SetReleaseDate(releaseDate);
+    }
+
+    void InfoTagMusic::setListenersRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int listeners)
+    {
+      infoTag->SetListeners(listeners);
+    }
+
+    void InfoTagMusic::setPlayCountRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int playcount)
+    {
+      infoTag->SetPlayCount(playcount);
+    }
+
+    void InfoTagMusic::setGenresRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                    const std::vector<String>& genres)
+    {
+      infoTag->SetGenre(genres);
+    }
+
+    void InfoTagMusic::setAlbumRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& album)
+    {
+      infoTag->SetAlbum(album);
+    }
+
+    void InfoTagMusic::setArtistRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& artist)
+    {
+      infoTag->SetArtist(artist);
+    }
+
+    void InfoTagMusic::setAlbumArtistRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                         const String& albumArtist)
+    {
+      infoTag->SetAlbumArtist(albumArtist);
+    }
+
+    void InfoTagMusic::setTitleRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& title)
+    {
+      infoTag->SetTitle(title);
+    }
+
+    void InfoTagMusic::setRatingRaw(MUSIC_INFO::CMusicInfoTag* infoTag, float rating)
+    {
+      infoTag->SetRating(rating);
+    }
+
+    void InfoTagMusic::setUserRatingRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int userrating)
+    {
+      infoTag->SetUserrating(userrating);
+    }
+
+    void InfoTagMusic::setLyricsRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& lyrics)
+    {
+      infoTag->SetLyrics(lyrics);
+    }
+
+    void InfoTagMusic::setLastPlayedRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                        const String& lastPlayed)
+    {
+      infoTag->SetLastPlayed(lastPlayed);
+    }
+
+    void InfoTagMusic::setMusicBrainzTrackIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                                const String& musicBrainzTrackID)
+    {
+      infoTag->SetMusicBrainzTrackID(musicBrainzTrackID);
+    }
+
+    void InfoTagMusic::setMusicBrainzArtistIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                                 const std::vector<String>& musicBrainzArtistID)
+    {
+      infoTag->SetMusicBrainzArtistID(musicBrainzArtistID);
+    }
+
+    void InfoTagMusic::setMusicBrainzAlbumIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                                const String& musicBrainzAlbumID)
+    {
+      infoTag->SetMusicBrainzAlbumID(musicBrainzAlbumID);
+    }
+
+    void InfoTagMusic::setMusicBrainzReleaseGroupIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                                       const String& musicBrainzReleaseGroupID)
+    {
+      infoTag->SetMusicBrainzReleaseGroupID(musicBrainzReleaseGroupID);
+    }
+
+    void InfoTagMusic::setMusicBrainzAlbumArtistIDRaw(
+        MUSIC_INFO::CMusicInfoTag* infoTag, const std::vector<String>& musicBrainzAlbumArtistID)
+    {
+      infoTag->SetMusicBrainzAlbumArtistID(musicBrainzAlbumArtistID);
+    }
+
+    void InfoTagMusic::setCommentRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& comment)
+    {
+      infoTag->SetComment(comment);
     }
   }
 }

--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -12,6 +12,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
+#include "utils/log.h"
 
 namespace XBMCAddon
 {
@@ -115,7 +116,15 @@ namespace XBMCAddon
 
     String InfoTagMusic::getLastPlayed()
     {
+      CLog::Log(LOGWARNING, "InfoTagMusic.getLastPlayed() is deprecated and might be removed in "
+                            "future Kodi versions. Please use InfoTagMusic.getLastPlayedAsW3C().");
+
       return infoTag->GetLastPlayed().GetAsLocalizedDate();
+    }
+
+    String InfoTagMusic::getLastPlayedAsW3C()
+    {
+      return infoTag->GetLastPlayed().GetAsW3CDateTime();
     }
 
     String InfoTagMusic::getComment()

--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -9,6 +9,7 @@
 #include "InfoTagMusic.h"
 
 #include "ServiceBroker.h"
+#include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -18,20 +19,23 @@ namespace XBMCAddon
 {
   namespace xbmc
   {
-    InfoTagMusic::InfoTagMusic()
+    InfoTagMusic::InfoTagMusic() : infoTag(new MUSIC_INFO::CMusicInfoTag()), owned(true)
     {
-      infoTag = new MUSIC_INFO::CMusicInfoTag();
     }
 
-    InfoTagMusic::InfoTagMusic(const MUSIC_INFO::CMusicInfoTag& tag)
+    InfoTagMusic::InfoTagMusic(const MUSIC_INFO::CMusicInfoTag* tag) : InfoTagMusic()
     {
-      infoTag = new MUSIC_INFO::CMusicInfoTag();
-      *infoTag = tag;
+      *infoTag = *tag;
+    }
+
+    InfoTagMusic::InfoTagMusic(MUSIC_INFO::CMusicInfoTag* tag) : infoTag(tag), owned(false)
+    {
     }
 
     InfoTagMusic::~InfoTagMusic()
     {
-      delete infoTag;
+      if (owned)
+        delete infoTag;
     }
 
     int InfoTagMusic::getDbId()

--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -8,6 +8,7 @@
 
 #include "InfoTagMusic.h"
 
+#include "AddonUtils.h"
 #include "ServiceBroker.h"
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
@@ -19,16 +20,18 @@ namespace XBMCAddon
 {
   namespace xbmc
   {
-    InfoTagMusic::InfoTagMusic() : infoTag(new MUSIC_INFO::CMusicInfoTag()), owned(true)
+    InfoTagMusic::InfoTagMusic(bool offscreen /* = false */)
+      : infoTag(new MUSIC_INFO::CMusicInfoTag()), offscreen(offscreen), owned(true)
     {
     }
 
-    InfoTagMusic::InfoTagMusic(const MUSIC_INFO::CMusicInfoTag* tag) : InfoTagMusic()
+    InfoTagMusic::InfoTagMusic(const MUSIC_INFO::CMusicInfoTag* tag) : InfoTagMusic(true)
     {
       *infoTag = *tag;
     }
 
-    InfoTagMusic::InfoTagMusic(MUSIC_INFO::CMusicInfoTag* tag) : infoTag(tag), owned(false)
+    InfoTagMusic::InfoTagMusic(MUSIC_INFO::CMusicInfoTag* tag, bool offscreen /* = false */)
+      : infoTag(tag), offscreen(offscreen), owned(false)
     {
     }
 

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -345,11 +345,28 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getLastPlayedAsW3C()** instead.
       ///
       getLastPlayed();
 #else
       String getLastPlayed();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ getLastPlayedAsW3C() }
+      /// Returns last played time as string in W3C format (YYYY-MM-DDThh:mm:ssTZD).
+      ///
+      /// @return [string] Last played datetime (W3C)
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getLastPlayedAsW3C();
+#else
+      String getLastPlayedAsW3C();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -21,11 +21,9 @@ namespace XBMCAddon
     /// @{
     /// @brief **Kodi's music info tag class.**
     ///
-    /// \python_class{ InfoTagMusic() }
+    /// \python_class{ xbmc.InfoTagMusic() }
     ///
-    /// To get music info tag data of currently played source.
-    ///
-    /// @note Info tag load is only be possible from present player class.
+    /// To get music info tag data of a music item.
     ///
     ///
     ///-------------------------------------------------------------------------

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -9,7 +9,11 @@
 #pragma once
 
 #include "AddonClass.h"
-#include "music/tags/MusicInfoTag.h"
+
+namespace MUSIC_INFO
+{
+class CMusicInfoTag;
+}
 
 namespace XBMCAddon
 {
@@ -23,7 +27,7 @@ namespace XBMCAddon
     ///
     /// \python_class{ xbmc.InfoTagMusic() }
     ///
-    /// To get music info tag data of a music item.
+    /// Access and / or modify the music metadata of a ListItem.
     ///
     ///
     ///-------------------------------------------------------------------------
@@ -42,10 +46,12 @@ namespace XBMCAddon
     {
     private:
       MUSIC_INFO::CMusicInfoTag* infoTag;
+      bool owned;
 
     public:
 #ifndef SWIG
-      explicit InfoTagMusic(const MUSIC_INFO::CMusicInfoTag& tag);
+      explicit InfoTagMusic(const MUSIC_INFO::CMusicInfoTag* tag);
+      explicit InfoTagMusic(MUSIC_INFO::CMusicInfoTag* tag);
 #endif
       InfoTagMusic();
       ~InfoTagMusic() override;

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -10,6 +10,8 @@
 
 #include "AddonClass.h"
 
+#include <vector>
+
 namespace MUSIC_INFO
 {
 class CMusicInfoTag;
@@ -230,11 +232,29 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getGenres()** instead.
       ///
       getGenre();
 #else
       String getGenre();
+#endif
+
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ getGenres() }
+      /// Returns the list of genres  from music tag if present.
+      ///
+      /// @return [list] List of genres
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getGenres();
+#else
+      std::vector<String> getGenres();
 #endif
 
 
@@ -253,6 +273,25 @@ namespace XBMCAddon
       getDuration();
 #else
       int getDuration();
+#endif
+
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ getYear() }
+      /// Returns the year of music as integer from info tag.
+      ///
+      /// @return [integer] Year
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      ///
+      getYear();
+#else
+      int getYear();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -528,6 +567,466 @@ namespace XBMCAddon
       getMusicBrainzAlbumArtistID();
 #else
       std::vector<String> getMusicBrainzAlbumArtistID();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setDbId(dbId, type) }
+      /// Set the database identifier of the music item.
+      ///
+      /// @param dbId               integer - Database identifier.
+      /// @param type               string - Media type of the item.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDbId(...);
+#else
+      void setDbId(int dbId, const String& type);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setURL(url) }
+      /// Set the URL of the music item.
+      ///
+      /// @param url                string - URL.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setURL(...);
+#else
+      void setURL(const String& url);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setMediaType(mediaType) }
+      /// Set the media type of the music item.
+      ///
+      /// @param mediaType          string - Media type.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMediaType(...);
+#else
+      void setMediaType(const String& mediaType);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setTrack(track) }
+      /// Set the track number of the song.
+      ///
+      /// @param track              integer - Track number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTrack(...);
+#else
+      void setTrack(int track);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setDisc(disc) }
+      /// Set the disc number of the song.
+      ///
+      /// @param disc               integer - Disc number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDisc(...);
+#else
+      void setDisc(int disc);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setDuration(duration) }
+      /// Set the duration of the song.
+      ///
+      /// @param duration           integer - Duration in seconds.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDuration(...);
+#else
+      void setDuration(int duration);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setYear(year) }
+      /// Set the year of the music item.
+      ///
+      /// @param year               integer - Year.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setYear(...);
+#else
+      void setYear(int year);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setReleaseDate(releaseDate) }
+      /// Set the release date of the music item.
+      ///
+      /// @param releaseDate        string - Release date in ISO8601 format (YYYY, YYYY-MM or YYYY-MM-DD).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setReleaseDate(...);
+#else
+      void setReleaseDate(const String& releaseDate);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setListeners(listeners) }
+      /// Set the number of listeners of the music item.
+      ///
+      /// @param listeners          integer - Number of listeners.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setListeners(...);
+#else
+      void setListeners(int listeners);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setPlayCount(playcount) }
+      /// Set the playcount of the music item.
+      ///
+      /// @param playcount          integer - Playcount.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setPlayCount(...);
+#else
+      void setPlayCount(int playcount);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setGenres(genres) }
+      /// Set the genres of the music item.
+      ///
+      /// @param genres             list - Genres.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setGenres(...);
+#else
+      void setGenres(const std::vector<String>& genres);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setAlbum(album) }
+      /// Set the album of the music item.
+      ///
+      /// @param album              string - Album.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setAlbum(...);
+#else
+      void setAlbum(const String& album);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setArtist(artist) }
+      /// Set the artist(s) of the music item.
+      ///
+      /// @param artist             string - Artist(s).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setArtist(...);
+#else
+      void setArtist(const String& artist);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setAlbumArtist(albumArtist) }
+      /// Set the album artist(s) of the music item.
+      ///
+      /// @param albumArtist        string - Album artist(s).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setAlbumArtist(...);
+#else
+      void setAlbumArtist(const String& albumArtist);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setTitle(title) }
+      /// Set the title of the music item.
+      ///
+      /// @param title              string - Title.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTitle(...);
+#else
+      void setTitle(const String& title);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setRating(rating) }
+      /// Set the rating of the music item.
+      ///
+      /// @param rating             float - Rating.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setRating(...);
+#else
+      void setRating(float rating);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setUserRating(userrating) }
+      /// Set the user rating of the music item.
+      ///
+      /// @param userrating         integer - User rating.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setUserRating(...);
+#else
+      void setUserRating(int userrating);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setLyrics(lyrics) }
+      /// Set the lyrics of the song.
+      ///
+      /// @param lyrics             string - Lyrics.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setLyrics(...);
+#else
+      void setLyrics(const String& lyrics);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setLastPlayed(lastPlayed) }
+      /// Set the last played date of the music item.
+      ///
+      /// @param lastPlayed         string - Last played date (YYYY-MM-DD HH:MM:SS).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setLastPlayed(...);
+#else
+      void setLastPlayed(const String& lastPlayed);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setMusicBrainzTrackID(musicBrainzTrackID) }
+      /// Set the MusicBrainz track ID of the song.
+      ///
+      /// @param musicBrainzTrackID  string - MusicBrainz track ID.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMusicBrainzTrackID(...);
+#else
+      void setMusicBrainzTrackID(const String& musicBrainzTrackID);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setMusicBrainzArtistID(musicBrainzArtistID) }
+      /// Set the MusicBrainz artist IDs of the music item.
+      ///
+      /// @param musicBrainzArtistID  list - MusicBrainz artist IDs.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMusicBrainzArtistID(...);
+#else
+      void setMusicBrainzArtistID(const std::vector<String>& musicBrainzArtistID);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setMusicBrainzAlbumID(musicBrainzAlbumID) }
+      /// Set the MusicBrainz album ID of the music item.
+      ///
+      /// @param musicBrainzAlbumID  string - MusicBrainz album ID.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMusicBrainzAlbumID(...);
+#else
+      void setMusicBrainzAlbumID(const String& musicBrainzAlbumID);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setMusicBrainzReleaseGroupID(musicBrainzReleaseGroupID) }
+      /// Set the MusicBrainz release group ID of the music item.
+      ///
+      /// @param musicBrainzReleaseGroupID  string - MusicBrainz release group ID.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMusicBrainzReleaseGroupID(...);
+#else
+      void setMusicBrainzReleaseGroupID(const String& musicBrainzReleaseGroupID);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setMusicBrainzAlbumArtistID(musicBrainzAlbumArtistID) }
+      /// Set the MusicBrainz album artist IDs of the music item.
+      ///
+      /// @param musicBrainzAlbumArtistID  list - MusicBrainz album artist IDs.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMusicBrainzAlbumArtistID(...);
+#else
+      void setMusicBrainzAlbumArtistID(const std::vector<String>& musicBrainzAlbumArtistID);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setComment(comment) }
+      /// Set the comment of the music item.
+      ///
+      /// @param comment            string - Comment.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setComment(...);
+#else
+      void setComment(const String& comment);
+#endif
+
+#ifndef SWIG
+      static void setDbIdRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int dbId, const String& type);
+      static void setURLRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& url);
+      static void setMediaTypeRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& mediaType);
+      static void setTrackRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int track);
+      static void setDiscRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int disc);
+      static void setDurationRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int duration);
+      static void setYearRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int year);
+      static void setReleaseDateRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& releaseDate);
+      static void setListenersRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int listeners);
+      static void setPlayCountRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int playcount);
+      static void setGenresRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                               const std::vector<String>& genres);
+      static void setAlbumRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& album);
+      static void setArtistRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& artist);
+      static void setAlbumArtistRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& albumArtist);
+      static void setTitleRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& title);
+      static void setRatingRaw(MUSIC_INFO::CMusicInfoTag* infoTag, float rating);
+      static void setUserRatingRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int userrating);
+      static void setLyricsRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& lyrics);
+      static void setLastPlayedRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& lastPlayed);
+      static void setMusicBrainzTrackIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                           const String& musicBrainzTrackID);
+      static void setMusicBrainzArtistIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                            const std::vector<String>& musicBrainzArtistID);
+      static void setMusicBrainzAlbumIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                           const String& musicBrainzAlbumID);
+      static void setMusicBrainzReleaseGroupIDRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                                  const String& musicBrainzReleaseGroupID);
+      static void setMusicBrainzAlbumArtistIDRaw(
+          MUSIC_INFO::CMusicInfoTag* infoTag, const std::vector<String>& musicBrainzAlbumArtistID);
+      static void setCommentRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& comment);
 #endif
     };
     //@}

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -25,7 +25,7 @@ namespace XBMCAddon
     /// @{
     /// @brief **Kodi's music info tag class.**
     ///
-    /// \python_class{ xbmc.InfoTagMusic() }
+    /// \python_class{ xbmc.InfoTagMusic([offscreen]) }
     ///
     /// Access and / or modify the music metadata of a ListItem.
     ///
@@ -46,14 +46,50 @@ namespace XBMCAddon
     {
     private:
       MUSIC_INFO::CMusicInfoTag* infoTag;
+      bool offscreen;
       bool owned;
 
     public:
 #ifndef SWIG
       explicit InfoTagMusic(const MUSIC_INFO::CMusicInfoTag* tag);
-      explicit InfoTagMusic(MUSIC_INFO::CMusicInfoTag* tag);
+      explicit InfoTagMusic(MUSIC_INFO::CMusicInfoTag* tag, bool offscreen = false);
 #endif
-      InfoTagMusic();
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ xbmc.InfoTagMusic([offscreen]) }
+      /// Create a music info tag.
+      ///
+      /// @param offscreen            [opt] bool (default `False`) - if GUI based locks should be
+      ///                                          avoided. Most of the times listitems are created
+      ///                                          offscreen and added later to a container
+      ///                                          for display (e.g. plugins) or they are not
+      ///                                          even displayed (e.g. python scrapers).
+      ///                                          In such cases, there is no need to lock the
+      ///                                          GUI when creating the items (increasing your addon
+      ///                                          performance).
+      ///                                          Note however, that if you are creating listitems
+      ///                                          and managing the container itself (e.g using
+      ///                                          WindowXML or WindowXMLDialog classes) subsquent
+      ///                                          modifications to the item will require locking.
+      ///                                          Thus, in such cases, use the default value (`False`).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 Added **offscreen** argument.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// musicinfo = xbmc.InfoTagMusic(offscreen=False)
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      InfoTagMusic(...);
+#else
+      explicit InfoTagMusic(bool offscreen = false);
+#endif
       ~InfoTagMusic() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/InfoTagPicture.cpp
+++ b/xbmc/interfaces/legacy/InfoTagPicture.cpp
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (C) 2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "InfoTagPicture.h"
+
+#include "AddonUtils.h"
+#include "guilib/guiinfo/GUIInfoLabels.h"
+#include "interfaces/legacy/Exception.h"
+#include "pictures/PictureInfoTag.h"
+#include "utils/StringUtils.h"
+
+using namespace XBMCAddonUtils;
+
+namespace XBMCAddon
+{
+namespace xbmc
+{
+
+InfoTagPicture::InfoTagPicture(bool offscreen /* = false */)
+  : infoTag(new CPictureInfoTag), offscreen(offscreen), owned(true)
+{
+}
+
+InfoTagPicture::InfoTagPicture(const CPictureInfoTag* tag)
+  : infoTag(new CPictureInfoTag(*tag)), offscreen(true), owned(true)
+{
+}
+
+InfoTagPicture::InfoTagPicture(CPictureInfoTag* tag, bool offscreen /* = false */)
+  : infoTag(tag), offscreen(offscreen), owned(false)
+{
+}
+
+InfoTagPicture::~InfoTagPicture()
+{
+  if (owned)
+    delete infoTag;
+}
+
+String InfoTagPicture::getResolution()
+{
+  return infoTag->GetInfo(SLIDESHOW_RESOLUTION);
+}
+
+String InfoTagPicture::getDateTimeTaken()
+{
+  return infoTag->GetDateTimeTaken().GetAsW3CDateTime();
+}
+
+void InfoTagPicture::setResolution(int width, int height)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setResolutionRaw(infoTag, width, height);
+}
+
+void InfoTagPicture::setDateTimeTaken(const String& datetimetaken)
+{
+  XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+  setDateTimeTakenRaw(infoTag, datetimetaken);
+}
+
+void InfoTagPicture::setResolutionRaw(CPictureInfoTag* infoTag, String resolution)
+{
+  infoTag->SetInfo("resolution", resolution);
+}
+
+void InfoTagPicture::setResolutionRaw(CPictureInfoTag* infoTag, int width, int height)
+{
+  if (width <= 0)
+    throw WrongTypeException("InfoTagPicture.setResolution: width must be greater than zero (0)");
+  if (height <= 0)
+    throw WrongTypeException("InfoTagPicture.setResolution: height must be greater than zero (0)");
+
+  setResolutionRaw(infoTag, StringUtils::Format("%d,%d", width, height));
+}
+
+void InfoTagPicture::setDateTimeTakenRaw(CPictureInfoTag* infoTag, String datetimetaken)
+{
+  // try to parse the datetimetaken as from W3C format and adjust it to the EXIF datetime format YYYY:MM:DD HH:MM:SS
+  CDateTime w3cDateTimeTaken;
+  if (w3cDateTimeTaken.SetFromW3CDateTime(datetimetaken))
+  {
+    datetimetaken = StringUtils::Format("%4d:%2d:%2d %2d:%2d:%2d", w3cDateTimeTaken.GetYear(),
+                                        w3cDateTimeTaken.GetMonth(), w3cDateTimeTaken.GetDay(),
+                                        w3cDateTimeTaken.GetHour(), w3cDateTimeTaken.GetMinute(),
+                                        w3cDateTimeTaken.GetSecond());
+  }
+
+  infoTag->SetInfo("exiftime", datetimetaken);
+}
+
+} // namespace xbmc
+} // namespace XBMCAddon

--- a/xbmc/interfaces/legacy/InfoTagPicture.h
+++ b/xbmc/interfaces/legacy/InfoTagPicture.h
@@ -1,0 +1,181 @@
+/*
+ *  Copyright (C) 2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AddonClass.h"
+
+class CPictureInfoTag;
+
+namespace XBMCAddon
+{
+namespace xbmc
+{
+
+///
+/// \defgroup python_InfoTagPicture InfoTagPicture
+/// \ingroup python_xbmc
+/// @{
+/// @brief **Kodi's picture info tag class.**
+///
+/// \python_class{ InfoTagPicture() }
+///
+/// Access and / or modify the picture metadata of a ListItem.
+///
+///-------------------------------------------------------------------------
+/// @python_v20 New class added.
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.py}
+/// ...
+/// tag = item.getPictureInfoTag()
+///
+/// datetime_taken  = tag.getDateTimeTaken()
+/// tag.setResolution(1920, 1080)
+/// ...
+/// ~~~~~~~~~~~~~
+///
+class InfoTagPicture : public AddonClass
+{
+private:
+  CPictureInfoTag* infoTag;
+  bool offscreen;
+  bool owned;
+
+public:
+#ifndef SWIG
+  explicit InfoTagPicture(const CPictureInfoTag* tag);
+  explicit InfoTagPicture(CPictureInfoTag* tag, bool offscreen = false);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagPicture
+  /// @brief \python_func{ xbmc.InfoTagPicture([offscreen]) }
+  /// Create a picture info tag.
+  ///
+  /// @param offscreen            [opt] bool (default `False`) - if GUI based locks should be
+  ///                                          avoided. Most of the times listitems are created
+  ///                                          offscreen and added later to a container
+  ///                                          for display (e.g. plugins) or they are not
+  ///                                          even displayed (e.g. python scrapers).
+  ///                                          In such cases, there is no need to lock the
+  ///                                          GUI when creating the items (increasing your addon
+  ///                                          performance).
+  ///                                          Note however, that if you are creating listitems
+  ///                                          and managing the container itself (e.g using
+  ///                                          WindowXML or WindowXMLDialog classes) subsquent
+  ///                                          modifications to the item will require locking.
+  ///                                          Thus, in such cases, use the default value (`False`).
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ...
+  /// pictureinfo = xbmc.InfoTagPicture(offscreen=False)
+  /// ...
+  /// ~~~~~~~~~~~~~
+  ///
+  InfoTagPicture(...);
+#else
+  explicit InfoTagPicture(bool offscreen = false);
+#endif
+  ~InfoTagPicture() override;
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagPicture
+  /// @brief \python_func{ getResolution() }
+  /// Get the resolution of the picture in the format "w x h".
+  ///
+  /// @return [string] Resolution of the picture in the format "w x h".
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getResolution();
+#else
+  String getResolution();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagPicture
+  /// @brief \python_func{ getDateTimeTaken() }
+  /// Get the date and time at which the picture was taken in W3C format.
+  ///
+  /// @return [string] Date and time at which the picture was taken in W3C format.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  getDirector();
+#else
+  String getDateTimeTaken();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagPicture
+  /// @brief \python_func{ setResolution(width, height) }
+  ///-----------------------------------------------------------------------
+  /// Sets the resolution of the picture.
+  ///
+  /// @param width              int - Width of the picture in pixels.
+  /// @param height             int - Height of the picture in pixels.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setResolution(...);
+#else
+  void setResolution(int width, int height);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_InfoTagPicture
+  /// @brief \python_func{ setDateTimeTaken(datetimetaken) }
+  /// Sets the date and time at which the picture was taken in W3C format.
+  /// The following formats are supported:
+  /// - YYYY
+  /// - YYYY-MM-DD
+  /// - YYYY-MM-DDThh:mm[TZD]
+  /// - YYYY-MM-DDThh:mm:ss[TZD]
+  /// where the timezone (TZD) is always optional and can be in one of the
+  /// following formats:
+  /// - Z (for UTC)
+  /// - +hh:mm
+  /// - -hh:mm
+  ///
+  /// @param datetimetaken      string - Date and time at which the picture was taken in W3C format.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  setDateTimeTaken(...);
+#else
+  void setDateTimeTaken(const String& datetimetaken);
+#endif
+
+#ifndef SWIG
+  static void setResolutionRaw(CPictureInfoTag* infoTag, String resolution);
+  static void setResolutionRaw(CPictureInfoTag* infoTag, int width, int height);
+  static void setDateTimeTakenRaw(CPictureInfoTag* infoTag, String datetimetaken);
+#endif
+};
+
+} // namespace xbmc
+} // namespace XBMCAddon

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -162,7 +162,15 @@ namespace XBMCAddon
 
     String InfoTagVideo::getLastPlayed()
     {
+      CLog::Log(LOGWARNING, "InfoTagVideo.getLastPlayed() is deprecated and might be removed in "
+                            "future Kodi versions. Please use InfoTagVideo.getLastPlayedAsW3C().");
+
       return infoTag->m_lastPlayed.GetAsLocalizedDateTime();
+    }
+
+    String InfoTagVideo::getLastPlayedAsW3C()
+    {
+      return infoTag->m_lastPlayed.GetAsW3CDateTime();
     }
 
     String InfoTagVideo::getOriginalTitle()
@@ -172,12 +180,28 @@ namespace XBMCAddon
 
     String InfoTagVideo::getPremiered()
     {
+      CLog::Log(LOGWARNING, "InfoTagVideo.getPremiered() is deprecated and might be removed in "
+                            "future Kodi versions. Please use InfoTagVideo.getPremieredAsW3C().");
+
       return infoTag->GetPremiered().GetAsLocalizedDate();
+    }
+
+    String InfoTagVideo::getPremieredAsW3C()
+    {
+      return infoTag->GetPremiered().GetAsW3CDate();
     }
 
     String InfoTagVideo::getFirstAired()
     {
+      CLog::Log(LOGWARNING, "InfoTagVideo.getFirstAired() is deprecated and might be removed in "
+                            "future Kodi versions. Please use InfoTagVideo.getFirstAiredAsW3C().");
+
       return infoTag->m_firstAired.GetAsLocalizedDate();
+    }
+
+    String InfoTagVideo::getFirstAiredAsW3C()
+    {
+      return infoTag->m_firstAired.GetAsW3CDate();
     }
 
     String InfoTagVideo::getTrailer()

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -18,20 +18,23 @@ namespace XBMCAddon
 {
   namespace xbmc
   {
-    InfoTagVideo::InfoTagVideo()
+    InfoTagVideo::InfoTagVideo() : infoTag(new CVideoInfoTag), owned(true)
     {
-      infoTag = new CVideoInfoTag();
     }
 
-    InfoTagVideo::InfoTagVideo(const CVideoInfoTag& tag)
+    InfoTagVideo::InfoTagVideo(const CVideoInfoTag* tag)
+      : infoTag(new CVideoInfoTag(*tag)), owned(true)
     {
-      infoTag = new CVideoInfoTag();
-      *infoTag = tag;
+    }
+
+    InfoTagVideo::InfoTagVideo(CVideoInfoTag* tag) : infoTag(tag), owned(false)
+    {
     }
 
     InfoTagVideo::~InfoTagVideo()
     {
-      delete infoTag;
+      if (owned)
+        delete infoTag;
     }
 
     int InfoTagVideo::getDbId()

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -12,6 +12,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
+#include "utils/log.h"
 
 namespace XBMCAddon
 {
@@ -91,7 +92,17 @@ namespace XBMCAddon
 
     String InfoTagVideo::getVotes()
     {
-      return std::to_string(infoTag->GetRating().votes);
+      CLog::Log(
+          LOGWARNING,
+          "InfoTagVideo.getVotes() is deprecated and might be removed in future Kodi versions. "
+          "Please use InfoTagVideo.getVotesAsInt().");
+
+      return std::to_string(getVotesAsInt());
+    }
+
+    int InfoTagVideo::getVotesAsInt(const String& type /* = "" */)
+    {
+      return infoTag->GetRating(type).votes;
     }
 
     String InfoTagVideo::getCast()

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -8,6 +8,7 @@
 
 #include "InfoTagVideo.h"
 
+#include "AddonUtils.h"
 #include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -18,16 +19,18 @@ namespace XBMCAddon
 {
   namespace xbmc
   {
-    InfoTagVideo::InfoTagVideo() : infoTag(new CVideoInfoTag), owned(true)
+    InfoTagVideo::InfoTagVideo(bool offscreen /* = false */)
+      : infoTag(new CVideoInfoTag), offscreen(offscreen), owned(true)
     {
     }
 
     InfoTagVideo::InfoTagVideo(const CVideoInfoTag* tag)
-      : infoTag(new CVideoInfoTag(*tag)), owned(true)
+      : infoTag(new CVideoInfoTag(*tag)), offscreen(true), owned(true)
     {
     }
 
-    InfoTagVideo::InfoTagVideo(CVideoInfoTag* tag) : infoTag(tag), owned(false)
+    InfoTagVideo::InfoTagVideo(CVideoInfoTag* tag, bool offscreen /* = false */)
+      : infoTag(tag), offscreen(offscreen), owned(false)
     {
     }
 
@@ -74,6 +77,7 @@ namespace XBMCAddon
 
     String InfoTagVideo::getPictureURL()
     {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
       infoTag->m_strPictureURL.Parse();
       return infoTag->m_strPictureURL.GetFirstThumbUrl();
     }

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -134,9 +134,9 @@ namespace XBMCAddon
       return infoTag->GetYear();
     }
 
-    double InfoTagVideo::getRating()
+    double InfoTagVideo::getRating(const String& type /* = "" */)
     {
-      return static_cast<double>(infoTag->GetRating().rating);
+      return static_cast<double>(infoTag->GetRating(type).rating);
     }
 
     int InfoTagVideo::getUserRating()

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -193,5 +193,20 @@ namespace XBMCAddon
     {
       return infoTag->GetDuration();
     }
+
+    double InfoTagVideo::getResumeTime()
+    {
+      return infoTag->GetResumePoint().timeInSeconds;
+    }
+
+    double InfoTagVideo::getResumeTimeTotal()
+    {
+      return infoTag->GetResumePoint().totalTimeInSeconds;
+    }
+
+    String InfoTagVideo::getUniqueID(const char* key)
+    {
+      return infoTag->GetUniqueID(key);
+    }
   }
 }

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -10,6 +10,7 @@
 
 #include "AddonUtils.h"
 #include "ServiceBroker.h"
+#include "interfaces/legacy/Exception.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -19,6 +20,90 @@ namespace XBMCAddon
 {
   namespace xbmc
   {
+    Actor::Actor(const String& name /* = emptyString */,
+                 const String& role /* = emptyString */,
+                 int order /* = -1 */,
+                 const String& thumbnail /* = emptyString */)
+      : m_name(name), m_role(role), m_order(order), m_thumbnail(thumbnail)
+    {
+      if (m_name.empty())
+        throw WrongTypeException("Actor: name property must not be empty");
+    }
+
+    SActorInfo Actor::ToActorInfo() const
+    {
+      SActorInfo actorInfo;
+      actorInfo.strName = m_name;
+      actorInfo.strRole = m_role;
+      actorInfo.order = m_order;
+      actorInfo.thumbUrl = CScraperUrl(m_thumbnail);
+      if (!actorInfo.thumbUrl.GetFirstThumbUrl().empty())
+        actorInfo.thumb = CScraperUrl::GetThumbUrl(actorInfo.thumbUrl.GetFirstUrlByType());
+
+      return actorInfo;
+    }
+
+    VideoStreamDetail::VideoStreamDetail(int width /* = 0 */,
+                                         int height /* = 0 */,
+                                         float aspect /* = 0.0f */,
+                                         int duration /* = 0 */,
+                                         const String& codec /* = emptyString */,
+                                         const String& stereoMode /* = emptyString */,
+                                         const String& language /* = emptyString */)
+      : m_width(width),
+        m_height(height),
+        m_aspect(aspect),
+        m_duration(duration),
+        m_codec(codec),
+        m_stereoMode(stereoMode),
+        m_language(language)
+    {
+    }
+
+    CStreamDetailVideo* VideoStreamDetail::ToStreamDetailVideo() const
+    {
+      auto streamDetail = new CStreamDetailVideo();
+      streamDetail->m_iWidth = m_width;
+      streamDetail->m_iHeight = m_height;
+      streamDetail->m_fAspect = m_aspect;
+      streamDetail->m_iDuration = m_duration;
+      streamDetail->m_strCodec = m_codec;
+      streamDetail->m_strStereoMode = m_stereoMode;
+      streamDetail->m_strLanguage = m_language;
+
+      return streamDetail;
+    }
+
+    AudioStreamDetail::AudioStreamDetail(int channels /* = -1 */,
+                                         const String& codec /* = emptyString */,
+                                         const String& language /* = emptyString */)
+      : m_channels(channels), m_codec(codec), m_language(language)
+    {
+    }
+
+    CStreamDetailAudio* AudioStreamDetail::ToStreamDetailAudio() const
+    {
+      auto streamDetail = new CStreamDetailAudio();
+      streamDetail->m_iChannels = m_channels;
+      streamDetail->m_strCodec = m_codec;
+      streamDetail->m_strLanguage = m_language;
+
+      return streamDetail;
+    }
+
+    SubtitleStreamDetail::SubtitleStreamDetail(const String& language /* = emptyString */)
+      : m_language(language)
+    {
+    }
+
+    CStreamDetailSubtitle* SubtitleStreamDetail::ToStreamDetailSubtitle() const
+    {
+      auto streamDetail = new CStreamDetailSubtitle();
+      streamDetail->m_strLanguage = m_language;
+
+      return streamDetail;
+    }
+
     InfoTagVideo::InfoTagVideo(bool offscreen /* = false */)
       : infoTag(new CVideoInfoTag), offscreen(offscreen), owned(true)
     {
@@ -50,14 +135,29 @@ namespace XBMCAddon
       return StringUtils::Join(infoTag->m_director, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
     }
 
+    std::vector<String> InfoTagVideo::getDirectors()
+    {
+      return infoTag->m_director;
+    }
+
     String InfoTagVideo::getWritingCredits()
     {
       return StringUtils::Join(infoTag->m_writingCredits, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
     }
 
+    std::vector<String> InfoTagVideo::getWriters()
+    {
+      return infoTag->m_writingCredits;
+    }
+
     String InfoTagVideo::getGenre()
     {
       return StringUtils::Join(infoTag->m_genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+    }
+
+    std::vector<String> InfoTagVideo::getGenres()
+    {
+      return infoTag->m_genre;
     }
 
     String InfoTagVideo::getTagLine()
@@ -115,6 +215,17 @@ namespace XBMCAddon
     String InfoTagVideo::getCast()
     {
       return infoTag->GetCast(true);
+    }
+
+    std::vector<Actor*> InfoTagVideo::getActors()
+    {
+      std::vector<Actor*> actors;
+      actors.reserve(infoTag->m_cast.size());
+
+      for (const auto& cast : infoTag->m_cast)
+        actors.push_back(new Actor(cast.strName, cast.strRole, cast.order, cast.thumbUrl.GetFirstUrlByType().m_url));
+
+      return actors;
     }
 
     String InfoTagVideo::getFile()
@@ -249,6 +360,699 @@ namespace XBMCAddon
     String InfoTagVideo::getUniqueID(const char* key)
     {
       return infoTag->GetUniqueID(key);
+    }
+
+    void InfoTagVideo::setUniqueID(const String& uniqueID,
+                                   const String& type /* = "" */,
+                                   bool isDefault /* = false */)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setUniqueIDRaw(infoTag, uniqueID, type, isDefault);
+    }
+
+    void InfoTagVideo::setUniqueIDs(const std::map<String, String>& uniqueIDs,
+                                    const String& defaultUniqueID /* = "" */)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setUniqueIDsRaw(infoTag, uniqueIDs, defaultUniqueID);
+    }
+
+    void InfoTagVideo::setDbId(int dbId)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setDbIdRaw(infoTag, dbId);
+    }
+
+    void InfoTagVideo::setYear(int year)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setYearRaw(infoTag, year);
+    }
+
+    void InfoTagVideo::setEpisode(int episode)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setEpisodeRaw(infoTag, episode);
+    }
+
+    void InfoTagVideo::setSeason(int season)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSeasonRaw(infoTag, season);
+    }
+
+    void InfoTagVideo::setSortEpisode(int sortEpisode)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSortEpisodeRaw(infoTag, sortEpisode);
+    }
+
+    void InfoTagVideo::setSortSeason(int sortSeason)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSortSeasonRaw(infoTag, sortSeason);
+    }
+
+    void InfoTagVideo::setEpisodeGuide(const String& episodeGuide)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setEpisodeGuideRaw(infoTag, episodeGuide);
+    }
+
+    void InfoTagVideo::setTop250(int top250)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTop250Raw(infoTag, top250);
+    }
+
+    void InfoTagVideo::setSetId(int setId)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSetIdRaw(infoTag, setId);
+    }
+
+    void InfoTagVideo::setTrackNumber(int trackNumber)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTrackNumberRaw(infoTag, trackNumber);
+    }
+
+    void InfoTagVideo::setRating(float rating,
+                                 int votes /* = 0 */,
+                                 const String& type /* = "" */,
+                                 bool isDefault /* = false */)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setRatingRaw(infoTag, rating, votes, type, isDefault);
+    }
+
+    void InfoTagVideo::setRatings(const std::map<String, Tuple<float, int>>& ratings,
+                                  const String& defaultRating /* = "" */)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setRatingsRaw(infoTag, ratings, defaultRating);
+    }
+
+    void InfoTagVideo::setUserRating(int userRating)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setUserRatingRaw(infoTag, userRating);
+    }
+
+    void InfoTagVideo::setPlaycount(int playcount)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setPlaycountRaw(infoTag, playcount);
+    }
+
+    void InfoTagVideo::setMpaa(const String& mpaa)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setMpaaRaw(infoTag, mpaa);
+    }
+
+    void InfoTagVideo::setPlot(const String& plot)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setPlotRaw(infoTag, plot);
+    }
+
+    void InfoTagVideo::setPlotOutline(const String& plotOutline)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setPlotOutlineRaw(infoTag, plotOutline);
+    }
+
+    void InfoTagVideo::setTitle(const String& title)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTitleRaw(infoTag, title);
+    }
+
+    void InfoTagVideo::setOriginalTitle(const String& originalTitle)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setOriginalTitleRaw(infoTag, originalTitle);
+    }
+
+    void InfoTagVideo::setSortTitle(const String& sortTitle)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSortTitleRaw(infoTag, sortTitle);
+    }
+
+    void InfoTagVideo::setTagLine(const String& tagLine)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTagLineRaw(infoTag, tagLine);
+    }
+
+    void InfoTagVideo::setTvShowTitle(const String& tvshowTitle)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTvShowTitleRaw(infoTag, tvshowTitle);
+    }
+
+    void InfoTagVideo::setTvShowStatus(const String& tvshowStatus)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTvShowStatusRaw(infoTag, tvshowStatus);
+    }
+
+    void InfoTagVideo::setGenres(std::vector<String> genre)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setGenresRaw(infoTag, std::move(genre));
+    }
+
+    void InfoTagVideo::setCountries(std::vector<String> countries)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setCountriesRaw(infoTag, std::move(countries));
+    }
+
+    void InfoTagVideo::setDirectors(std::vector<String> directors)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setDirectorsRaw(infoTag, std::move(directors));
+    }
+
+    void InfoTagVideo::setStudios(std::vector<String> studios)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setStudiosRaw(infoTag, std::move(studios));
+    }
+
+    void InfoTagVideo::setWriters(std::vector<String> writers)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setWritersRaw(infoTag, std::move(writers));
+    }
+
+    void InfoTagVideo::setDuration(int duration)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setDurationRaw(infoTag, duration);
+    }
+
+    void InfoTagVideo::setPremiered(const String& premiered)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setPremieredRaw(infoTag, premiered);
+    }
+
+    void InfoTagVideo::setSet(const String& set)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSetRaw(infoTag, set);
+    }
+
+    void InfoTagVideo::setSetOverview(const String& setOverview)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSetOverviewRaw(infoTag, setOverview);
+    }
+
+    void InfoTagVideo::setTags(std::vector<String> tags)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTagsRaw(infoTag, tags);
+    }
+
+    void InfoTagVideo::setProductionCode(const String& productionCode)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setProductionCodeRaw(infoTag, productionCode);
+    }
+
+    void InfoTagVideo::setFirstAired(const String& firstAired)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setFirstAiredRaw(infoTag, firstAired);
+    }
+
+    void InfoTagVideo::setLastPlayed(const String& lastPlayed)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setLastPlayedRaw(infoTag, lastPlayed);
+    }
+
+    void InfoTagVideo::setAlbum(const String& album)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setAlbumRaw(infoTag, album);
+    }
+
+    void InfoTagVideo::setVotes(int votes)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setVotesRaw(infoTag, votes);
+    }
+
+    void InfoTagVideo::setTrailer(const String& trailer)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setTrailerRaw(infoTag, trailer);
+    }
+
+    void InfoTagVideo::setPath(const String& path)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setPathRaw(infoTag, path);
+    }
+
+    void InfoTagVideo::setFilenameAndPath(const String& filenameAndPath)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setFilenameAndPathRaw(infoTag, filenameAndPath);
+    }
+
+    void InfoTagVideo::setIMDBNumber(const String& imdbNumber)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setIMDBNumberRaw(infoTag, imdbNumber);
+    }
+
+    void InfoTagVideo::setDateAdded(const String& dateAdded)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setDateAddedRaw(infoTag, dateAdded);
+    }
+
+    void InfoTagVideo::setMediaType(const String& mediaType)
+    {
+      setMediaTypeRaw(infoTag, mediaType);
+    }
+
+    void InfoTagVideo::setShowLinks(std::vector<String> showLinks)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setShowLinksRaw(infoTag, std::move(showLinks));
+    }
+
+    void InfoTagVideo::setArtists(std::vector<String> artists)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setArtistsRaw(infoTag, std::move(artists));
+    }
+
+    void InfoTagVideo::setCast(std::vector<const Actor*> actors)
+    {
+      std::vector<SActorInfo> cast;
+      cast.reserve(actors.size());
+      for (const auto& actor : actors)
+        cast.push_back(actor->ToActorInfo());
+
+      {
+        XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+        setCastRaw(infoTag, std::move(cast));
+      }
+    }
+
+    void InfoTagVideo::setResumePoint(double time, double totalTime /* = 0.0 */)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setResumePointRaw(infoTag, time, totalTime);
+    }
+
+    void InfoTagVideo::addSeason(int number, std::string name /* = "" */)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      addSeasonRaw(infoTag, number, name);
+    }
+
+    void InfoTagVideo::addSeasons(std::vector<Tuple<int, std::string>> namedSeasons)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      addSeasonsRaw(infoTag, namedSeasons);
+    }
+
+    void InfoTagVideo::addVideoStream(const VideoStreamDetail* stream)
+    {
+      if (stream == nullptr)
+        return;
+
+      auto streamDetail = stream->ToStreamDetailVideo();
+      {
+        XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+        addStreamRaw(infoTag, streamDetail);
+      }
+    }
+
+    void InfoTagVideo::addAudioStream(const AudioStreamDetail* stream)
+    {
+      if (stream == nullptr)
+        return;
+
+      auto streamDetail = stream->ToStreamDetailAudio();
+      {
+        XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+        addStreamRaw(infoTag, streamDetail);
+      }
+    }
+
+    void InfoTagVideo::addSubtitleStream(const SubtitleStreamDetail* stream)
+    {
+      if (stream == nullptr)
+        return;
+
+      auto streamDetail = stream->ToStreamDetailSubtitle();
+      {
+        XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+        addStreamRaw(infoTag, streamDetail);
+      }
+    }
+
+    void InfoTagVideo::addAvailableArtwork(const std::string& url,
+                                           const std::string& art_type,
+                                           const std::string& preview,
+                                           const std::string& referrer,
+                                           const std::string& cache,
+                                           bool post,
+                                           bool isgz,
+                                           int season)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      addAvailableArtworkRaw(infoTag, url, art_type, preview, referrer, cache, post, isgz, season);
+    }
+
+    void InfoTagVideo::setDbIdRaw(CVideoInfoTag* infoTag, int dbId)
+    {
+      infoTag->m_iDbId = dbId;
+    }
+
+    void InfoTagVideo::setUniqueIDRaw(CVideoInfoTag* infoTag,
+                                      const String& uniqueID,
+                                      const String& type /* = "" */,
+                                      bool isDefault /* = false */)
+    {
+      infoTag->SetUniqueID(uniqueID, type, isDefault);
+    }
+
+    void InfoTagVideo::setUniqueIDsRaw(CVideoInfoTag* infoTag,
+                                       std::map<String, String> uniqueIDs,
+                                       const String& defaultUniqueID /* = "" */)
+    {
+      infoTag->SetUniqueIDs(uniqueIDs);
+      auto defaultUniqueIDEntry = uniqueIDs.find(defaultUniqueID);
+      if (defaultUniqueIDEntry != uniqueIDs.end())
+        infoTag->SetUniqueID(defaultUniqueIDEntry->second, defaultUniqueIDEntry->first, true);
+    }
+
+    void InfoTagVideo::setYearRaw(CVideoInfoTag* infoTag, int year)
+    {
+      infoTag->SetYear(year);
+    }
+
+    void InfoTagVideo::setEpisodeRaw(CVideoInfoTag* infoTag, int episode)
+    {
+      infoTag->m_iEpisode = episode;
+    }
+
+    void InfoTagVideo::setSeasonRaw(CVideoInfoTag* infoTag, int season)
+    {
+      infoTag->m_iSeason = season;
+    }
+
+    void InfoTagVideo::setSortEpisodeRaw(CVideoInfoTag* infoTag, int sortEpisode)
+    {
+      infoTag->m_iSpecialSortEpisode = sortEpisode;
+    }
+
+    void InfoTagVideo::setSortSeasonRaw(CVideoInfoTag* infoTag, int sortSeason)
+    {
+      infoTag->m_iSpecialSortSeason = sortSeason;
+    }
+
+    void InfoTagVideo::setEpisodeGuideRaw(CVideoInfoTag* infoTag, const String& episodeGuide)
+    {
+      infoTag->SetEpisodeGuide(episodeGuide);
+    }
+
+    void InfoTagVideo::setTop250Raw(CVideoInfoTag* infoTag, int top250)
+    {
+      infoTag->m_iTop250 = top250;
+    }
+
+    void InfoTagVideo::setSetIdRaw(CVideoInfoTag* infoTag, int setId)
+    {
+      infoTag->m_set.id = setId;
+    }
+
+    void InfoTagVideo::setTrackNumberRaw(CVideoInfoTag* infoTag, int trackNumber)
+    {
+      infoTag->m_iTrack = trackNumber;
+    }
+
+    void InfoTagVideo::setRatingRaw(CVideoInfoTag* infoTag,
+                                    float rating,
+                                    int votes /* = 0 */,
+                                    std::string type /* = "" */,
+                                    bool isDefault /* = false */)
+    {
+      infoTag->SetRating(rating, votes, type, isDefault);
+    }
+
+    void InfoTagVideo::setRatingsRaw(CVideoInfoTag* infoTag,
+                                     const std::map<String, Tuple<float, int>>& ratings,
+                                     const String& defaultRating /* = "" */)
+    {
+      RatingMap ratingMap;
+      for (const auto& rating : ratings)
+        ratingMap.emplace(rating.first, CRating{rating.second.first(), rating.second.second()});
+
+      infoTag->SetRatings(std::move(ratingMap), defaultRating);
+    }
+
+    void InfoTagVideo::setUserRatingRaw(CVideoInfoTag* infoTag, int userRating)
+    {
+      infoTag->m_iUserRating = userRating;
+    }
+
+    void InfoTagVideo::setPlaycountRaw(CVideoInfoTag* infoTag, int playcount)
+    {
+      infoTag->SetPlayCount(playcount);
+    }
+
+    void InfoTagVideo::setMpaaRaw(CVideoInfoTag* infoTag, const String& mpaa)
+    {
+      infoTag->SetMPAARating(mpaa);
+    }
+
+    void InfoTagVideo::setPlotRaw(CVideoInfoTag* infoTag, const String& plot)
+    {
+      infoTag->SetPlot(plot);
+    }
+
+    void InfoTagVideo::setPlotOutlineRaw(CVideoInfoTag* infoTag, const String& plotOutline)
+    {
+      infoTag->SetPlotOutline(plotOutline);
+    }
+
+    void InfoTagVideo::setTitleRaw(CVideoInfoTag* infoTag, const String& title)
+    {
+      infoTag->SetTitle(title);
+    }
+
+    void InfoTagVideo::setOriginalTitleRaw(CVideoInfoTag* infoTag, const String& originalTitle)
+    {
+      infoTag->SetOriginalTitle(originalTitle);
+    }
+
+    void InfoTagVideo::setSortTitleRaw(CVideoInfoTag* infoTag, const String& sortTitle)
+    {
+      infoTag->SetSortTitle(sortTitle);
+    }
+
+    void InfoTagVideo::setTagLineRaw(CVideoInfoTag* infoTag, const String& tagLine)
+    {
+      infoTag->SetTagLine(tagLine);
+    }
+
+    void InfoTagVideo::setTvShowTitleRaw(CVideoInfoTag* infoTag, const String& tvshowTitle)
+    {
+      infoTag->SetShowTitle(tvshowTitle);
+    }
+
+    void InfoTagVideo::setTvShowStatusRaw(CVideoInfoTag* infoTag, const String& tvshowStatus)
+    {
+      infoTag->SetStatus(tvshowStatus);
+    }
+
+    void InfoTagVideo::setGenresRaw(CVideoInfoTag* infoTag, std::vector<String> genre)
+    {
+      infoTag->SetGenre(std::move(genre));
+    }
+
+    void InfoTagVideo::setCountriesRaw(CVideoInfoTag* infoTag, std::vector<String> countries)
+    {
+      infoTag->SetCountry(std::move(countries));
+    }
+
+    void InfoTagVideo::setDirectorsRaw(CVideoInfoTag* infoTag, std::vector<String> directors)
+    {
+      infoTag->SetDirector(std::move(directors));
+    }
+
+    void InfoTagVideo::setStudiosRaw(CVideoInfoTag* infoTag, std::vector<String> studios)
+    {
+      infoTag->SetStudio(std::move(studios));
+    }
+
+    void InfoTagVideo::setWritersRaw(CVideoInfoTag* infoTag, std::vector<String> writers)
+    {
+      infoTag->SetWritingCredits(std::move(writers));
+    }
+
+    void InfoTagVideo::setDurationRaw(CVideoInfoTag* infoTag, int duration)
+    {
+      infoTag->SetDuration(duration);
+    }
+
+    void InfoTagVideo::setPremieredRaw(CVideoInfoTag* infoTag, const String& premiered)
+    {
+      CDateTime premieredDate;
+      premieredDate.SetFromDateString(premiered);
+      infoTag->SetPremiered(premieredDate);
+    }
+
+    void InfoTagVideo::setSetRaw(CVideoInfoTag* infoTag, const String& set)
+    {
+      infoTag->SetSet(set);
+    }
+
+    void InfoTagVideo::setSetOverviewRaw(CVideoInfoTag* infoTag, const String& setOverview)
+    {
+      infoTag->SetSetOverview(setOverview);
+    }
+
+    void InfoTagVideo::setTagsRaw(CVideoInfoTag* infoTag, std::vector<String> tags)
+    {
+      infoTag->SetTags(tags);
+    }
+
+    void InfoTagVideo::setProductionCodeRaw(CVideoInfoTag* infoTag, const String& productionCode)
+    {
+      infoTag->SetProductionCode(productionCode);
+    }
+
+    void InfoTagVideo::setFirstAiredRaw(CVideoInfoTag* infoTag, const String& firstAired)
+    {
+      CDateTime firstAiredDate;
+      firstAiredDate.SetFromDateString(firstAired);
+      infoTag->m_firstAired = std::move(firstAiredDate);
+    }
+
+    void InfoTagVideo::setLastPlayedRaw(CVideoInfoTag* infoTag, const String& lastPlayed)
+    {
+      CDateTime lastPlayedDate;
+      lastPlayedDate.SetFromDBDateTime(lastPlayed);
+      infoTag->m_lastPlayed = std::move(lastPlayedDate);
+    }
+
+    void InfoTagVideo::setAlbumRaw(CVideoInfoTag* infoTag, const String& album)
+    {
+      infoTag->SetAlbum(album);
+    }
+
+    void InfoTagVideo::setVotesRaw(CVideoInfoTag* infoTag, int votes)
+    {
+      infoTag->SetVotes(votes);
+    }
+
+    void InfoTagVideo::setTrailerRaw(CVideoInfoTag* infoTag, const String& trailer)
+    {
+      infoTag->SetTrailer(trailer);
+    }
+
+    void InfoTagVideo::setPathRaw(CVideoInfoTag* infoTag, const String& path)
+    {
+      infoTag->SetPath(path);
+    }
+
+    void InfoTagVideo::setFilenameAndPathRaw(CVideoInfoTag* infoTag, const String& filenameAndPath)
+    {
+      infoTag->SetFileNameAndPath(filenameAndPath);
+    }
+
+    void InfoTagVideo::setIMDBNumberRaw(CVideoInfoTag* infoTag, const String& imdbNumber)
+    {
+      infoTag->SetUniqueID(imdbNumber);
+    }
+
+    void InfoTagVideo::setDateAddedRaw(CVideoInfoTag* infoTag, const String& dateAdded)
+    {
+      CDateTime dateAddedDate;
+      dateAddedDate.SetFromDBDateTime(dateAdded);
+      infoTag->m_dateAdded = std::move(dateAddedDate);
+    }
+
+    void InfoTagVideo::setMediaTypeRaw(CVideoInfoTag* infoTag, const String& mediaType)
+    {
+      if (CMediaTypes::IsValidMediaType(mediaType))
+        infoTag->m_type = mediaType;
+    }
+
+    void InfoTagVideo::setShowLinksRaw(CVideoInfoTag* infoTag, std::vector<String> showLinks)
+    {
+      infoTag->SetShowLink(std::move(showLinks));
+    }
+
+    void InfoTagVideo::setArtistsRaw(CVideoInfoTag* infoTag, std::vector<String> artists)
+    {
+      infoTag->m_artist = std::move(artists);
+    }
+
+    void InfoTagVideo::setCastRaw(CVideoInfoTag* infoTag, std::vector<SActorInfo> cast)
+    {
+      infoTag->m_cast = std::move(cast);
+    }
+
+    void InfoTagVideo::setResumePointRaw(CVideoInfoTag* infoTag,
+                                         double time,
+                                         double totalTime /* = 0.0 */)
+    {
+      auto resumePoint = infoTag->GetResumePoint();
+      resumePoint.timeInSeconds = time;
+      if (totalTime > 0.0)
+        resumePoint.totalTimeInSeconds = totalTime;
+      infoTag->SetResumePoint(resumePoint);
+    }
+
+    void InfoTagVideo::addSeasonRaw(CVideoInfoTag* infoTag, int number, std::string name /* = "" */)
+    {
+      infoTag->m_namedSeasons[number] = std::move(name);
+    }
+
+    void InfoTagVideo::addSeasonsRaw(CVideoInfoTag* infoTag,
+                                     std::vector<Tuple<int, std::string>> namedSeasons)
+    {
+      for (const auto& season : namedSeasons)
+        addSeasonRaw(infoTag, season.first(), season.second());
+    }
+
+    void InfoTagVideo::addStreamRaw(CVideoInfoTag* infoTag, CStreamDetail* stream)
+    {
+      infoTag->m_streamDetails.AddStream(stream);
+    }
+
+    void InfoTagVideo::finalizeStreamsRaw(CVideoInfoTag* infoTag)
+    {
+      infoTag->m_streamDetails.DetermineBestStreams();
+    }
+
+    void InfoTagVideo::addAvailableArtworkRaw(CVideoInfoTag* infoTag,
+                                              const std::string& url,
+                                              const std::string& art_type,
+                                              const std::string& preview,
+                                              const std::string& referrer,
+                                              const std::string& cache,
+                                              bool post,
+                                              bool isgz,
+                                              int season)
+    {
+      infoTag->m_strPictureURL.AddParsedUrl(url, art_type, preview, referrer, cache, post, isgz,
+                                            season);
     }
   }
 }

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -407,18 +407,27 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_InfoTagVideo
-      /// @brief \python_func{ getRating() }
+      /// @brief \python_func{ getRating([type]) }
       /// Get the video rating if present as float (double where supported).
+      ///
+      /// @param type           [opt] string - the type of the rating.
+      /// - Some rating type values (any string possible):
+      ///  | Label         | Type                                             |
+      ///  |---------------|--------------------------------------------------|
+      ///  | imdb          | string - type name
+      ///  | tvdb          | string - type name
+      ///  | tmdb          | string - type name
+      ///  | anidb         | string - type name
       ///
       /// @return [float] The rating of the video
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 Optional `type` parameter added.
       ///
-      ///
-      getRating();
+      getRating(type);
 #else
-      double getRating();
+      double getRating(const String& type = "");
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -608,6 +608,38 @@ namespace XBMCAddon
 #else
       unsigned int getDuration();
 #endif
+
+      // TODO(Montellese)
+      double getResumeTime();
+      double getResumeTimeTotal();
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getUniqueID(key) }
+      ///-----------------------------------------------------------------------
+      /// Get the unique ID of the given key.
+      /// A unique ID is an identifier used by a (online) video database used to
+      /// identify a video in its database.
+      ///
+      /// @param key            string - uniqueID name.
+      /// - Some default uniqueID values (any string possible):
+      ///  | Label         | Type                                             |
+      ///  |---------------|--------------------------------------------------|
+      ///  | imdb          | string - uniqueid name
+      ///  | tvdb          | string - uniqueid name
+      ///  | tmdb          | string - uniqueid name
+      ///  | anidb         | string - uniqueid name
+      ///
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getUniqueID(key);
+#else
+      String getUniqueID(const char* key);
+#endif
     };
   }
 }

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -24,7 +24,7 @@ namespace XBMCAddon
     ///
     /// \python_class{ xbmc.InfoTagVideo() }
     ///
-    /// To get video info tag data of a video item.
+    /// Access and / or modify the video metadata of a ListItem.
     ///
     ///
     ///-------------------------------------------------------------------------
@@ -43,10 +43,12 @@ namespace XBMCAddon
     {
     private:
       CVideoInfoTag* infoTag;
+      bool owned;
 
     public:
 #ifndef SWIG
-      explicit InfoTagVideo(const CVideoInfoTag& tag);
+      explicit InfoTagVideo(const CVideoInfoTag* tag);
+      explicit InfoTagVideo(CVideoInfoTag* tag);
 #endif
       InfoTagVideo();
       ~InfoTagVideo() override;

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -9,12 +9,784 @@
 #pragma once
 
 #include "AddonClass.h"
+#include "Tuple.h"
+#include "utils/StreamDetails.h"
 #include "video/VideoInfoTag.h"
 
 namespace XBMCAddon
 {
   namespace xbmc
   {
+    ///
+    /// \defgroup python_xbmc_actor Actor
+    /// \ingroup python_xbmc
+    /// @{
+    /// @brief **Actor class used in combination with InfoTagVideo.**
+    ///
+    /// \python_class{ xbmc.Actor([name, role, order, thumbnail]) }
+    ///
+    /// Represents a single actor in the cast of a video item wrapped by InfoTagVideo.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    /// @python_v20 New class added.
+    ///
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// actor = xbmc.Actor('Sean Connery', 'James Bond', order=1)
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
+    class Actor : public AddonClass
+    {
+    public:
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor Actor
+      /// @brief \python_func{ xbmc.Actor([name, role, order, thumbnail]) }
+      /// Creates a single actor for the cast of a video item wrapped by InfoTagVideo.
+      ///
+      /// @param name               [opt] string - Name of the actor.
+      /// @param role               [opt] string - Role of the actor in the specific video item.
+      /// @param order              [opt] integer - Order of the actor in the cast of the specific video item.
+      /// @param thumbnail          [opt] string - Path / URL to the thumbnail of the actor.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// actor = xbmc.Actor('Sean Connery', 'James Bond', order=1)
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      Actor(...);
+#else
+      explicit Actor(const String& name = emptyString,
+                     const String& role = emptyString,
+                     int order = -1,
+                     const String& thumbnail = emptyString);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ getName() }
+      /// Get the name of the actor.
+      ///
+      /// @return [string] Name of the actor
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getName();
+#else
+      String getName() const { return m_name; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ getRole() }
+      /// Get the role of the actor in the specific video item.
+      ///
+      /// @return [string] Role of the actor in the specific video item
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getRole();
+#else
+      String getRole() const { return m_role; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ getOrder() }
+      /// Get the order of the actor in the cast of the specific video item.
+      ///
+      /// @return [integer] Order of the actor in the cast of the specific video item
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getOrder();
+#else
+      int getOrder() const { return m_order; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ getThumbnail() }
+      /// Get the path / URL to the thumbnail of the actor.
+      ///
+      /// @return [string] Path / URL to the thumbnail of the actor
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getThumbnail();
+#else
+      String getThumbnail() const { return m_thumbnail; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ setName(name) }
+      /// Set the name of the actor.
+      ///
+      /// @param name               string - Name of the actor.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setName(...);
+#else
+      void setName(const String& name) { m_name = name; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ setRole(role) }
+      /// Set the role of the actor in the specific video item.
+      ///
+      /// @param role               string - Role of the actor in the specific video item.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setRole(...);
+#else
+      void setRole(const String& role) { m_role = role; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ setOrder(order) }
+      /// Set the order of the actor in the cast of the specific video item.
+      ///
+      /// @param order              integer - Order of the actor in the cast of the specific video item.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setOrder(...);
+#else
+      void setOrder(int order) { m_order = order; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_actor
+      /// @brief \python_func{ setThumbnail(thumbnail) }
+      /// Set the path / URL to the thumbnail of the actor.
+      ///
+      /// @param thumbnail          string - Path / URL to the thumbnail of the actor.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setThumbnail(...);
+#else
+      void setThumbnail(const String& thumbnail) { m_thumbnail = thumbnail; }
+#endif
+
+#ifndef SWIG
+      SActorInfo ToActorInfo() const;
+#endif
+
+    private:
+      String m_name;
+      String m_role;
+      int m_order;
+      String m_thumbnail;
+    };
+
+    ///
+    /// \defgroup python_xbmc_videostreamdetail VideoStreamDetail
+    /// \ingroup python_xbmc
+    /// @{
+    /// @brief **Video stream details class used in combination with InfoTagVideo.**
+    ///
+    /// \python_class{ xbmc.VideoStreamDetail([width, height, aspect, duration, codec, stereoMode, language]) }
+    ///
+    /// Represents a single selectable video stream for a video item wrapped by InfoTagVideo.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    /// @python_v20 New class added.
+    ///
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// videostream = xbmc.VideoStreamDetail(1920, 1080, language='English')
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
+    class VideoStreamDetail : public AddonClass
+    {
+    public:
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail VideoStreamDetail
+      /// @brief \python_func{ xbmc.VideoStreamDetail([width, height, aspect, duration, codec, stereoMode, language]) }
+      /// Creates a single video stream details class for a video item wrapped by InfoTagVideo.
+      ///
+      /// @param width              [opt] integer - Width of the video stream in pixel.
+      /// @param height             [opt] integer - Height of the video stream in pixel.
+      /// @param aspect             [opt] float - Aspect ratio of the video stream.
+      /// @param duration           [opt] integer - Duration of the video stream in seconds.
+      /// @param codec              [opt] string - Codec of the video stream.
+      /// @param stereoMode         [opt] string - Stereo mode of the video stream.
+      /// @param language           [opt] string - Language of the video stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// videostream = xbmc.VideoStreamDetail(1920, 1080, language='English')
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      VideoStreamDetail(...);
+#else
+      explicit VideoStreamDetail(int width = 0,
+                                 int height = 0,
+                                 float aspect = 0.0f,
+                                 int duration = 0,
+                                 const String& codec = emptyString,
+                                 const String& stereoMode = emptyString,
+                                 const String& language = emptyString);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ getWidth() }
+      /// Get the width of the video stream in pixel.
+      ///
+      /// @return [integer] Width of the video stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getWidth();
+#else
+      int getWidth() const { return m_width; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ getHeight() }
+      /// Get the height of the video stream in pixel.
+      ///
+      /// @return [integer] Height of the video stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getHeight();
+#else
+      int getHeight() const { return m_height; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ getAspect() }
+      /// Get the aspect ratio of the video stream.
+      ///
+      /// @return [float] Aspect ratio of the video stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getAspect();
+#else
+      float getAspect() const { return m_aspect; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ getDuration() }
+      /// Get the duration of the video stream in seconds.
+      ///
+      /// @return [float] Duration of the video stream in seconds
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getDuration();
+#else
+      int getDuration() const { return m_duration; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ getCodec() }
+      /// Get the codec of the stream.
+      ///
+      /// @return [string] Codec of the stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getCodec();
+#else
+      String getCodec() const { return m_codec; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ getStereoMode() }
+      /// Get the stereo mode of the video stream.
+      ///
+      /// @return [string] Stereo mode of the video stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getStereoMode();
+#else
+      String getStereoMode() const { return m_stereoMode; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ getLanguage() }
+      /// Get the language of the stream.
+      ///
+      /// @return [string] Language of the stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getLanguage();
+#else
+      String getLanguage() const { return m_language; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ setWidth(width) }
+      /// Set the width of the video stream in pixel.
+      ///
+      /// @param width              integer - Width of the video stream in pixel.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setWidth(...);
+#else
+      void setWidth(int width) { m_width = width; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ setHeight(height) }
+      /// Set the height of the video stream in pixel.
+      ///
+      /// @param height             integer - Height of the video stream in pixel.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setHeight(...);
+#else
+      void setHeight(int height) { m_height = height; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ setAspect(aspect) }
+      /// Set the aspect ratio of the video stream.
+      ///
+      /// @param aspect             float - Aspect ratio of the video stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setAspect(...);
+#else
+      void setAspect(float aspect) { m_aspect = aspect; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ setDuration(duration) }
+      /// Set the duration of the video stream in seconds.
+      ///
+      /// @param duration           integer - Duration of the video stream in seconds.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDuration(...);
+#else
+      void setDuration(int duration) { m_duration = duration; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ setCodec(codec) }
+      /// Set the codec of the stream.
+      ///
+      /// @param codec              string - Codec of the stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setCodec(...);
+#else
+      void setCodec(const String& codec) { m_codec = codec; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ setStereoMode(stereoMode) }
+      /// Set the stereo mode of the video stream.
+      ///
+      /// @param stereoMode         string - Stereo mode of the video stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setStereoMode(...);
+#else
+      void setStereoMode(const String& stereoMode) { m_stereoMode = stereoMode; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_videostreamdetail
+      /// @brief \python_func{ setLanguage(language) }
+      /// Set the language of the stream.
+      ///
+      /// @param language           string - Language of the stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setLanguage(...);
+#else
+      void setLanguage(const String& language) { m_language = language; }
+#endif
+
+#ifndef SWIG
+      CStreamDetailVideo* ToStreamDetailVideo() const;
+#endif
+
+    private:
+      int m_width;
+      int m_height;
+      float m_aspect;
+      int m_duration;
+      String m_codec;
+      String m_stereoMode;
+      String m_language;
+    };
+
+    ///
+    /// \defgroup python_xbmc_audiostreamdetail AudioStreamDetail
+    /// \ingroup python_xbmc
+    /// @{
+    /// @brief **Audio stream details class used in combination with InfoTagVideo.**
+    ///
+    /// \python_class{ xbmc.AudioStreamDetail([channels, codec, language]) }
+    ///
+    /// Represents a single selectable audio stream for a video item wrapped by InfoTagVideo.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    /// @python_v20 New class added.
+    ///
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// audiostream = xbmc.AudioStreamDetail(6, 'DTS', 'English')
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
+    class AudioStreamDetail : public AddonClass
+    {
+    public:
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_audiostreamdetail AudioStreamDetail
+      /// @brief \python_func{ xbmc.AudioStreamDetail([channels, codec, language]) }
+      /// Creates a single audio stream details class for a video item wrapped by InfoTagVideo.
+      ///
+      /// @param channels           [opt] integer - Number of channels in the audio stream.
+      /// @param codec              [opt] string - Codec of the audio stream.
+      /// @param language           [opt] string - Language of the audio stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// audiostream = xbmc.AudioStreamDetail(6, 'DTS', 'English')
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      AudioStreamDetail(...);
+#else
+      explicit AudioStreamDetail(int channels = -1,
+                                 const String& codec = emptyString,
+                                 const String& language = emptyString);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_audiostreamdetail
+      /// @brief \python_func{ getChannels() }
+      /// Get the number of channels in the stream.
+      ///
+      /// @return [integer] Number of channels in the stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getChannels();
+#else
+      int getChannels() const { return m_channels; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_audiostreamdetail
+      /// @brief \python_func{ getCodec() }
+      /// Get the codec of the stream.
+      ///
+      /// @return [string] Codec of the stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getCodec();
+#else
+      String getCodec() const { return m_codec; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_audiostreamdetail
+      /// @brief \python_func{ getLanguage() }
+      /// Get the language of the stream.
+      ///
+      /// @return [string] Language of the stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getLanguage();
+#else
+      String getLanguage() const { return m_language; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_audiostreamdetail
+      /// @brief \python_func{ setChannels(channels) }
+      /// Set the number of channels in the stream.
+      ///
+      /// @param channels           integer - Number of channels in the stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setChannels(...);
+#else
+      void setChannels(int channels) { m_channels = channels; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_audiostreamdetail
+      /// @brief \python_func{ setCodec(codec) }
+      /// Set the codec of the stream.
+      ///
+      /// @param codec              string - Codec of the stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setCodec(...);
+#else
+      void setCodec(const String& codec) { m_codec = codec; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_audiostreamdetail
+      /// @brief \python_func{ setLanguage(language) }
+      /// Set the language of the stream.
+      ///
+      /// @param language           string - Language of the stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setLanguage(...);
+#else
+      void setLanguage(const String& language) { m_language = language; }
+#endif
+
+#ifndef SWIG
+      CStreamDetailAudio* ToStreamDetailAudio() const;
+#endif
+
+    private:
+      int m_channels;
+      String m_codec;
+      String m_language;
+    };
+
+    ///
+    /// \defgroup python_xbmc_subtitlestreamdetail SubtitleStreamDetail
+    /// \ingroup python_xbmc
+    /// @{
+    /// @brief **Subtitle stream details class used in combination with InfoTagVideo.**
+    ///
+    /// \python_class{ xbmc.SubtitleStreamDetail([language]) }
+    ///
+    /// Represents a single selectable subtitle stream for a video item wrapped by InfoTagVideo.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    /// @python_v20 New class added.
+    ///
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// subtitlestream = xbmc.SubtitleStreamDetail('English')
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
+    class SubtitleStreamDetail : public AddonClass
+    {
+    public:
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_subtitlestreamdetail SubtitleStreamDetail
+      /// @brief \python_func{ xbmc.SubtitleStreamDetail([language]) }
+      /// Creates a single subtitle stream details class for a video item wrapped by InfoTagVideo.
+      ///
+      /// @param language           [opt] string - Language of the subtitle.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// subtitlestream = xbmc.SubtitleStreamDetail('English')
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      SubtitleStreamDetail(...);
+#else
+      explicit SubtitleStreamDetail(const String& language = emptyString);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_subtitlestreamdetail
+      /// @brief \python_func{ getLanguage() }
+      /// Get the language of the stream.
+      ///
+      /// @return [string] Language of the stream
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getLanguage();
+#else
+      String getLanguage() const { return m_language; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmc_subtitlestreamdetail
+      /// @brief \python_func{ setLanguage(language) }
+      /// Set the language of the stream.
+      ///
+      /// @param language           string - Language of the stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setLanguage(...);
+#else
+      void setLanguage(const String& language) { m_language = language; }
+#endif
+
+#ifndef SWIG
+      CStreamDetailSubtitle* ToStreamDetailSubtitle() const;
+#endif
+
+    private:
+      String m_language;
+    };
 
     ///
     /// \defgroup python_InfoTagVideo InfoTagVideo
@@ -117,11 +889,29 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getDirectors()** instead.
       ///
       getDirector();
 #else
       String getDirector();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getDirectors() }
+      /// Get a list of [film directors](https://en.wikipedia.org/wiki/Film_director)
+      /// who have made the film (if present).
+      ///
+      /// @return [list] List of film director names.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getDirectors();
+#else
+      std::vector<String> getDirectors();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -134,11 +924,28 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getWriters()** instead.
       ///
       getWritingCredits();
 #else
       String getWritingCredits();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getWriters() }
+      /// Get the list of writers (if present) from video info tag.
+      ///
+      /// @return [list] List of writers
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getWriters();
+#else
+      std::vector<String> getWriters();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -152,11 +959,29 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getGenres()** instead.
       ///
       getGenre();
 #else
       String getGenre();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getGenres() }
+      /// Get the list of [Video Genres](https://en.wikipedia.org/wiki/Film_genre)
+      /// if available.
+      ///
+      /// @return [list] List of genres
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getGenres();
+#else
+      std::vector<String> getGenres();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -341,11 +1166,28 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getActors()** instead.
       ///
       getCast();
 #else
       String getCast();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getActors() }
+      /// Get the cast of the video if available.
+      ///
+      /// @return [list] List of actors
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getActors();
+#else
+      std::vector<Actor*> getActors();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -733,9 +1575,39 @@ namespace XBMCAddon
       unsigned int getDuration();
 #endif
 
-      // TODO(Montellese)
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getResumeTime()) }
+      /// Gets the resume time of the video item.
+      ///
+      /// @return [double] Resume time
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getResumeTime(...);
+#else
       double getResumeTime();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getResumeTimeTotal()) }
+      /// Gets the total duration stored with the resume time of the video item.
+      ///
+      /// @return [double] Total duration stored with the resume time
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSortEpisode(...);
+#else
       double getResumeTimeTotal();
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -763,6 +1635,1094 @@ namespace XBMCAddon
       getUniqueID(key);
 #else
       String getUniqueID(const char* key);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setUniqueID(uniqueID, [type], [isDefault]) }
+      /// Set the given unique ID.
+      /// A unique ID is an identifier used by a (online) video database used to
+      /// identify a video in its database.
+      ///
+      /// @param uniqueID           string - value of the unique ID.
+      /// @param type               [opt] string - type / label of the unique ID.
+      /// @param isDefault          [opt] bool - whether the given unique ID is the default unique ID.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setUniqueID(...);
+#else
+      void setUniqueID(const String& uniqueID, const String& type = "", bool isDefault = false);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setUniqueIDs(values, defaultUniqueID) }
+      ///-----------------------------------------------------------------------
+      /// Set the given unique IDs.
+      /// A unique ID is an identifier used by a (online) video database used to
+      /// identify a video in its database.
+      ///
+      /// @param values             dictionary - pairs of `{ 'label': 'value' }`.
+      /// @param defaultUniqueID    [opt] string - the name of default uniqueID.
+      ///
+      ///  - Some example values (any string possible):
+      ///  | Label         | Type                                              |
+      ///  |:-------------:|:--------------------------------------------------|
+      ///  | imdb          | string - uniqueid name
+      ///  | tvdb          | string - uniqueid name
+      ///  | tmdb          | string - uniqueid name
+      ///  | anidb         | string - uniqueid name
+      ///
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setUniqueIDs(...);
+#else
+      void setUniqueIDs(const std::map<String, String>& uniqueIDs,
+                        const String& defaultUniqueID = "");
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setDbId(dbId) }
+      /// Set the database identifier of the video item.
+      ///
+      /// @param dbId               integer - Database identifier.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDbId(...);
+#else
+      void setDbId(int dbId);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setYear(year) }
+      /// Set the year of the video item.
+      ///
+      /// @param year               integer - Year.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setYear(...);
+#else
+      void setYear(int year);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setEpisode(episode) }
+      /// Set the episode number of the episode.
+      ///
+      /// @param episode            integer - Episode number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setEpisode(...);
+#else
+      void setEpisode(int episode);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setSeason(season) }
+      /// Set the season number of the video item.
+      ///
+      /// @param season             integer - Season number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSeason(...);
+#else
+      void setSeason(int season);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setSortEpisode(sortEpisode) }
+      /// Set the episode sort number of the episode.
+      ///
+      /// @param sortEpisode        integer - Episode sort number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSortEpisode(...);
+#else
+      void setSortEpisode(int sortEpisode);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setSortSeason(sortSeason) }
+      /// Set the season sort number of the season.
+      ///
+      /// @param sortSeason         integer - Season sort number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSortSeason(...);
+#else
+      void setSortSeason(int sortSeason);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setEpisodeGuide(episodeGuide) }
+      /// Set the episode guide of the video item.
+      ///
+      /// @param episodeGuide       string - Episode guide.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setEpisodeGuide(...);
+#else
+      void setEpisodeGuide(const String& episodeGuide);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTop250(top250) }
+      /// Set the top 250 number of the video item.
+      ///
+      /// @param top250             integer - Top 250 number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTop250(...);
+#else
+      void setTop250(int top250);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setSetId(setId) }
+      /// Set the movie set identifier of the video item.
+      ///
+      /// @param setId              integer - Set identifier.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSetId(...);
+#else
+      void setSetId(int setId);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTrackNumber(trackNumber) }
+      /// Set the track number of the music video item.
+      ///
+      /// @param trackNumber        integer - Track number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTrackNumber(...);
+#else
+      void setTrackNumber(int trackNumber);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setRating(rating, [votes], [type], [isDefault]) }
+      /// Set the rating of the video item.
+      ///
+      /// @param rating             float - Rating number.
+      /// @param votes              integer - Number of votes.
+      /// @param type               string - Type of the rating.
+      /// @param isDefault          bool - Whether the rating is the default or not.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setRating(...);
+#else
+      void setRating(float rating, int votes = 0, const String& type = "", bool isDefault = false);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setRatings(ratings, [defaultRating]) }
+      /// Set the ratings of the video item.
+      ///
+      /// @param ratings            dictionary - `{ 'type': (rating, votes) }`.
+      /// @param defaultRating      string - Type / Label of the default rating.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setRatings(...);
+#else
+      void setRatings(const std::map<String, Tuple<float, int>>& ratings,
+                      const String& defaultRating = "");
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setUserRating(userRating) }
+      /// Set the user rating of the video item.
+      ///
+      /// @param userRating         integer - User rating.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setUserRating(...);
+#else
+      void setUserRating(int userRating);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setPlaycount(playcount) }
+      /// Set the playcount of the video item.
+      ///
+      /// @param playcount          integer - Playcount.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setPlaycount(...);
+#else
+      void setPlaycount(int playcount);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setMpaa(mpaa) }
+      /// Set the MPAA rating of the video item.
+      ///
+      /// @param mpaa               string - MPAA rating.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMpaa(...);
+#else
+      void setMpaa(const String& mpaa);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setPlot(plot) }
+      /// Set the plot of the video item.
+      ///
+      /// @param plot               string - Plot.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setPlot(...);
+#else
+      void setPlot(const String& plot);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setPlotOutline(plotOutline) }
+      /// Set the plot outline of the video item.
+      ///
+      /// @param plotOutline        string - Plot outline.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setPlotOutline(...);
+#else
+      void setPlotOutline(const String& plotOutline);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTitle(title) }
+      /// Set the title of the video item.
+      ///
+      /// @param title              string - Title.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTitle(...);
+#else
+      void setTitle(const String& title);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setOriginalTitle(originalTitle) }
+      /// Set the original title of the video item.
+      ///
+      /// @param originalTitle      string - Original title.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setOriginalTitle(...);
+#else
+      void setOriginalTitle(const String& originalTitle);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setSortTitle(sortTitle) }
+      /// Set the sort title of the video item.
+      ///
+      /// @param sortTitle          string - Sort title.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSortTitle(...);
+#else
+      void setSortTitle(const String& sortTitle);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTagLine(tagLine) }
+      /// Set the tagline of the video item.
+      ///
+      /// @param tagLine            string - Tagline.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTagLine(...);
+#else
+      void setTagLine(const String& tagLine);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTvShowTitle(tvshowTitle) }
+      /// Set the TV show title of the video item.
+      ///
+      /// @param tvshowTitle        string - TV show title.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTvShowTitle(...);
+#else
+      void setTvShowTitle(const String& tvshowTitle);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTvShowStatus(tvshowStatus) }
+      /// Set the TV show status of the video item.
+      ///
+      /// @param tvshowStatus       string - TV show status.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTvShowStatus(...);
+#else
+      void setTvShowStatus(const String& tvshowStatus);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setGenres(genre) }
+      /// Set the genres of the video item.
+      ///
+      /// @param genre              list - Genres.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setGenres(...);
+#else
+      void setGenres(std::vector<String> genre);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setCountries(countries) }
+      /// Set the countries of the video item.
+      ///
+      /// @param countries          list - Countries.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setCountries(...);
+#else
+      void setCountries(std::vector<String> countries);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setDirectors(directors) }
+      /// Set the directors of the video item.
+      ///
+      /// @param directors          list - Directors.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDirectors(...);
+#else
+      void setDirectors(std::vector<String> directors);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setStudios(studios) }
+      /// Set the studios of the video item.
+      ///
+      /// @param studios            list - Studios.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setStudios(...);
+#else
+      void setStudios(std::vector<String> studios);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setWriters(writers) }
+      /// Set the writers of the video item.
+      ///
+      /// @param writers            list - Writers.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setWriters(...);
+#else
+      void setWriters(std::vector<String> writers);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setDuration(duration) }
+      /// Set the duration of the video item.
+      ///
+      /// @param duration           integer - Duration in seconds.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDuration(...);
+#else
+      void setDuration(int duration);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setPremiered(premiered) }
+      /// Set the premiere date of the video item.
+      ///
+      /// @param premiered          string - Premiere date.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setPremiered(...);
+#else
+      void setPremiered(const String& premiered);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setSet(set) }
+      /// Set the movie set (name) of the video item.
+      ///
+      /// @param set                string - Movie set (name).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSet(...);
+#else
+      void setSet(const String& set);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setSetOverview(setOverview) }
+      /// Set the movie set overview of the video item.
+      ///
+      /// @param setOverview        string - Movie set overview.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setSetOverview(...);
+#else
+      void setSetOverview(const String& setOverview);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTags(tags) }
+      /// Set the tags of the video item.
+      ///
+      /// @param tags               list - Tags.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTags(...);
+#else
+      void setTags(std::vector<String> tags);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setProductionCode(const String& productionCode) }
+      /// Set the production code of the video item.
+      ///
+      /// @param productionCode     string - Production code.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setProductionCode(...);
+#else
+      void setProductionCode(const String& productionCode);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setFirstAired(firstAired) }
+      /// Set the first aired date of the video item.
+      ///
+      /// @param firstAired         string - First aired date.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setFirstAired(...);
+#else
+      void setFirstAired(const String& firstAired);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setLastPlayed(lastPlayed) }
+      /// Set the last played date of the video item.
+      ///
+      /// @param lastPlayed         string - Last played date (YYYY-MM-DD HH:MM:SS).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setLastPlayed(...);
+#else
+      void setLastPlayed(const String& lastPlayed);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setAlbum(album) }
+      /// Set the album of the video item.
+      ///
+      /// @param album              string - Album.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setAlbum(...);
+#else
+      void setAlbum(const String& album);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setVotes(votes) }
+      /// Set the number of votes of the video item.
+      ///
+      /// @param votes              integer - Number of votes.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setVotes(...);
+#else
+      void setVotes(int votes);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setTrailer(trailer) }
+      /// Set the trailer of the video item.
+      ///
+      /// @param trailer            string - Trailer.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setTrailer(...);
+#else
+      void setTrailer(const String& trailer);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setPath(path) }
+      /// Set the path of the video item.
+      ///
+      /// @param path               string - Path.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setPath(...);
+#else
+      void setPath(const String& path);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setFilenameAndPath(filenameAndPath) }
+      /// Set the filename and path of the video item.
+      ///
+      /// @param filenameAndPath   string - Filename and path.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setFilenameAndPath(...);
+#else
+      void setFilenameAndPath(const String& filenameAndPath);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setIMDBNumber(imdbNumber) }
+      /// Set the IMDb number of the video item.
+      ///
+      /// @param imdbNumber         string - IMDb number.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setIMDBNumber(...);
+#else
+      void setIMDBNumber(const String& imdbNumber);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setDateAdded(dateAdded) }
+      /// Set the date added of the video item.
+      ///
+      /// @param dateAdded          string - Date added (YYYY-MM-DD HH:MM:SS).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setDateAdded(...);
+#else
+      void setDateAdded(const String& dateAdded);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setMediaType(mediaType) }
+      /// Set the media type of the video item.
+      ///
+      /// @param mediaType          string - Media type.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMediaType(...);
+#else
+      void setMediaType(const String& mediaType);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setShowLinks(showLinks) }
+      /// Set the TV show links of the movie.
+      ///
+      /// @param showLinks          list - TV show links.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setShowLinks(...);
+#else
+      void setShowLinks(std::vector<String> showLinks);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setArtists(artists) }
+      /// Set the artists of the music video item.
+      ///
+      /// @param artists            list - Artists.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setArtists(...);
+#else
+      void setArtists(std::vector<String> artists);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setCast(actors) }
+      /// Set the cast / actors of the video item.
+      ///
+      /// @param actors             list - Cast / Actors.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setCast(...);
+#else
+      void setCast(std::vector<const Actor*> actors);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setResumePoint(time, [totalTime]) }
+      /// Set the resume point of the video item.
+      ///
+      /// @param time               float - Resume point in seconds.
+      /// @param totalTime          float - Total duration in seconds.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setResumePoint(...);
+#else
+      void setResumePoint(double time, double totalTime = 0.0);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ addSeason(number, [name]) }
+      /// Add a season with name. It needs at least the season number.
+      ///
+      /// @param number     int - the number of the season.
+      /// @param name       string - the name of the season. Default "".
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      ///
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// # addSeason(number, name))
+      /// infotagvideo.addSeason(1, "Murder House")
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      addSeason(...);
+#else
+      void addSeason(int number, std::string name = "");
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ addSeasons(namedSeasons) }
+      /// Add named seasons to the TV show.
+      ///
+      /// @param namedSeasons       list - `[ (season, name) ]`.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      addSeasons(...);
+#else
+      void addSeasons(std::vector<Tuple<int, std::string>> namedSeasons);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ addVideoStream(stream) }
+      /// Add a video stream to the video item.
+      ///
+      /// @param stream             VideoStreamDetail - Video stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      addVideoStream(...);
+#else
+      void addVideoStream(const VideoStreamDetail* stream);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ addAudioStream(stream) }
+      /// Add an audio stream to the video item.
+      ///
+      /// @param stream             AudioStreamDetail - Audio stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      addAudioStream(...);
+#else
+      void addAudioStream(const AudioStreamDetail* stream);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ addSubtitleStream(stream) }
+      /// Add a subtitle stream to the video item.
+      ///
+      /// @param stream             SubtitleStreamDetail - Subtitle stream.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      addSubtitleStream(...);
+#else
+      void addSubtitleStream(const SubtitleStreamDetail* stream);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ addAvailableArtwork(images) }
+      /// Add an image to available artworks (needed for video scrapers)
+      ///
+      /// @param url            string - image path url
+      /// @param art_type       string - image type
+      /// @param preview        [opt] string - image preview path url
+      /// @param referrer       [opt] string - referrer url
+      /// @param cache          [opt] string - filename in cache
+      /// @param post           [opt] bool - use post to retrieve the image (default false)
+      /// @param isgz           [opt] bool - use gzip to retrieve the image (default false)
+      /// @param season         [opt] integer - number of season in case of season thumb
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// infotagvideo.addAvailableArtwork(path_to_image_1, "thumb")
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      addAvailableArtwork(...);
+#else
+      void addAvailableArtwork(const std::string& url,
+        const std::string& art_type = "",
+        const std::string& preview = "",
+        const std::string& referrer = "",
+        const std::string& cache = "",
+        bool post = false,
+        bool isgz = false,
+        int season = -1);
+#endif
+
+#ifndef SWIG
+      static void setDbIdRaw(CVideoInfoTag* infoTag, int dbId);
+      static void setUniqueIDRaw(CVideoInfoTag* infoTag,
+                                 const String& uniqueID,
+                                 const String& type = "",
+                                 bool isDefault = false);
+      static void setUniqueIDsRaw(CVideoInfoTag* infoTag,
+                                  std::map<String, String> uniqueIDs,
+                                  const String& defaultUniqueID = "");
+      static void setYearRaw(CVideoInfoTag* infoTag, int year);
+      static void setEpisodeRaw(CVideoInfoTag* infoTag, int episode);
+      static void setSeasonRaw(CVideoInfoTag* infoTag, int season);
+      static void setSortEpisodeRaw(CVideoInfoTag* infoTag, int sortEpisode);
+      static void setSortSeasonRaw(CVideoInfoTag* infoTag, int sortSeason);
+      static void setEpisodeGuideRaw(CVideoInfoTag* infoTag, const String& episodeGuide);
+      static void setTop250Raw(CVideoInfoTag* infoTag, int top250);
+      static void setSetIdRaw(CVideoInfoTag* infoTag, int setId);
+      static void setTrackNumberRaw(CVideoInfoTag* infoTag, int trackNumber);
+      static void setRatingRaw(CVideoInfoTag* infoTag,
+                               float rating,
+                               int votes = 0,
+                               std::string type = "",
+                               bool isDefault = false);
+      static void setRatingsRaw(CVideoInfoTag* infoTag,
+                                const std::map<String, Tuple<float, int>>& ratings,
+                                const String& defaultRating = "");
+      static void setUserRatingRaw(CVideoInfoTag* infoTag, int userRating);
+      static void setPlaycountRaw(CVideoInfoTag* infoTag, int playcount);
+      static void setMpaaRaw(CVideoInfoTag* infoTag, const String& mpaa);
+      static void setPlotRaw(CVideoInfoTag* infoTag, const String& plot);
+      static void setPlotOutlineRaw(CVideoInfoTag* infoTag, const String& plotOutline);
+      static void setTitleRaw(CVideoInfoTag* infoTag, const String& title);
+      static void setOriginalTitleRaw(CVideoInfoTag* infoTag, const String& originalTitle);
+      static void setSortTitleRaw(CVideoInfoTag* infoTag, const String& sortTitle);
+      static void setTagLineRaw(CVideoInfoTag* infoTag, const String& tagLine);
+      static void setTvShowTitleRaw(CVideoInfoTag* infoTag, const String& tvshowTitle);
+      static void setTvShowStatusRaw(CVideoInfoTag* infoTag, const String& tvshowStatus);
+      static void setGenresRaw(CVideoInfoTag* infoTag, std::vector<String> genre);
+      static void setCountriesRaw(CVideoInfoTag* infoTag, std::vector<String> countries);
+      static void setDirectorsRaw(CVideoInfoTag* infoTag, std::vector<String> directors);
+      static void setStudiosRaw(CVideoInfoTag* infoTag, std::vector<String> studios);
+      static void setWritersRaw(CVideoInfoTag* infoTag, std::vector<String> writers);
+      static void setDurationRaw(CVideoInfoTag* infoTag, int duration);
+      static void setPremieredRaw(CVideoInfoTag* infoTag, const String& premiered);
+      static void setSetRaw(CVideoInfoTag* infoTag, const String& set);
+      static void setSetOverviewRaw(CVideoInfoTag* infoTag, const String& setOverview);
+      static void setTagsRaw(CVideoInfoTag* infoTag, std::vector<String> tags);
+      static void setProductionCodeRaw(CVideoInfoTag* infoTag, const String& productionCode);
+      static void setFirstAiredRaw(CVideoInfoTag* infoTag, const String& firstAired);
+      static void setLastPlayedRaw(CVideoInfoTag* infoTag, const String& lastPlayed);
+      static void setAlbumRaw(CVideoInfoTag* infoTag, const String& album);
+      static void setVotesRaw(CVideoInfoTag* infoTag, int votes);
+      static void setTrailerRaw(CVideoInfoTag* infoTag, const String& trailer);
+      static void setPathRaw(CVideoInfoTag* infoTag, const String& path);
+      static void setFilenameAndPathRaw(CVideoInfoTag* infoTag, const String& filenameAndPath);
+      static void setIMDBNumberRaw(CVideoInfoTag* infoTag, const String& imdbNumber);
+      static void setDateAddedRaw(CVideoInfoTag* infoTag, const String& dateAdded);
+      static void setMediaTypeRaw(CVideoInfoTag* infoTag, const String& mediaType);
+      static void setShowLinksRaw(CVideoInfoTag* infoTag, std::vector<String> showLinks);
+      static void setArtistsRaw(CVideoInfoTag* infoTag, std::vector<String> artists);
+      static void setCastRaw(CVideoInfoTag* infoTag, std::vector<SActorInfo> cast);
+      static void setResumePointRaw(CVideoInfoTag* infoTag, double time, double totalTime = 0.0);
+
+      static void addSeasonRaw(CVideoInfoTag* infoTag, int number, std::string name = "");
+      static void addSeasonsRaw(CVideoInfoTag* infoTag,
+                                std::vector<Tuple<int, std::string>> namedSeasons);
+
+      static void addStreamRaw(CVideoInfoTag* infoTag, CStreamDetail* stream);
+      static void finalizeStreamsRaw(CVideoInfoTag* infoTag);
+
+      static void addAvailableArtworkRaw(CVideoInfoTag* infoTag,
+                                         const std::string& url,
+                                         const std::string& art_type = "",
+                                         const std::string& preview = "",
+                                         const std::string& referrer = "",
+                                         const std::string& cache = "",
+                                         bool post = false,
+                                         bool isgz = false,
+                                         int season = -1);
 #endif
     };
   }

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -260,11 +260,37 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getVotesAsInt()** instead.
       ///
       getVotes();
 #else
       String getVotes();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getVotesAsInt([type]) }
+      /// Get the votes of the rating (if available) as an integer.
+      ///
+      /// @param type           [opt] string - the type of the rating.
+      /// - Some rating type values (any string possible):
+      ///  | Label         | Type                                             |
+      ///  |---------------|--------------------------------------------------|
+      ///  | imdb          | string - type name
+      ///  | tvdb          | string - type name
+      ///  | tmdb          | string - type name
+      ///  | anidb         | string - type name
+      ///
+      /// @return [integer] Votes
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getVotesAsInt(type);
+#else
+      int getVotesAsInt(const String& type = "");
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -474,11 +500,28 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getLastPlayedAsW3C()** instead.
       ///
       getLastPlayed();
 #else
       String getLastPlayed();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getLastPlayedAsW3C() }
+      /// Get last played datetime as string in W3C format (YYYY-MM-DDThh:mm:ssTZD).
+      ///
+      /// @return [string] Last played datetime (W3C)
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getLastPlayedAsW3C();
+#else
+      String getLastPlayedAsW3C();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -509,11 +552,28 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getPremieredAsW3C()** instead.
       ///
       getPremiered();
 #else
       String getPremiered();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getPremieredAsW3C() }
+      /// Get [premiered](https://en.wikipedia.org/wiki/Premiere) date as string in W3C format (YYYY-MM-DD).
+      ///
+      /// @return [string] Premiered date (W3C)
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getPremieredAsW3C();
+#else
+      String getPremieredAsW3C();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -526,11 +586,28 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      ///
+      /// @python_v20 Deprecated. Use **getFirstAiredAsW3C()** instead.
       ///
       getFirstAired();
 #else
       String getFirstAired();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getFirstAiredAsW3C() }
+      /// Get first aired date as string in W3C format (YYYY-MM-DD).
+      ///
+      /// @return [string] First aired date (W3C)
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getFirstAiredAsW3C();
+#else
+      String getFirstAiredAsW3C();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -22,7 +22,7 @@ namespace XBMCAddon
     /// @{
     /// @brief **Kodi's video info tag class.**
     ///
-    /// \python_class{ xbmc.InfoTagVideo() }
+    /// \python_class{ xbmc.InfoTagVideo([offscreen]) }
     ///
     /// Access and / or modify the video metadata of a ListItem.
     ///
@@ -43,14 +43,50 @@ namespace XBMCAddon
     {
     private:
       CVideoInfoTag* infoTag;
+      bool offscreen;
       bool owned;
 
     public:
 #ifndef SWIG
       explicit InfoTagVideo(const CVideoInfoTag* tag);
-      explicit InfoTagVideo(CVideoInfoTag* tag);
+      explicit InfoTagVideo(CVideoInfoTag* tag, bool offscreen = false);
 #endif
-      InfoTagVideo();
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ xbmc.InfoTagVideo([offscreen]) }
+      /// Create a video info tag.
+      ///
+      /// @param offscreen            [opt] bool (default `False`) - if GUI based locks should be
+      ///                                          avoided. Most of the times listitems are created
+      ///                                          offscreen and added later to a container
+      ///                                          for display (e.g. plugins) or they are not
+      ///                                          even displayed (e.g. python scrapers).
+      ///                                          In such cases, there is no need to lock the
+      ///                                          GUI when creating the items (increasing your addon
+      ///                                          performance).
+      ///                                          Note however, that if you are creating listitems
+      ///                                          and managing the container itself (e.g using
+      ///                                          WindowXML or WindowXMLDialog classes) subsquent
+      ///                                          modifications to the item will require locking.
+      ///                                          Thus, in such cases, use the default value (`False`).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 Added **offscreen** argument.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// videoinfo = xbmc.InfoTagVideo(offscreen=False)
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      InfoTagVideo(...);
+#else
+      explicit InfoTagVideo(bool offscreen = false);
+#endif
       ~InfoTagVideo() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -22,11 +22,9 @@ namespace XBMCAddon
     /// @{
     /// @brief **Kodi's video info tag class.**
     ///
-    /// \python_class{ InfoTagVideo() }
+    /// \python_class{ xbmc.InfoTagVideo() }
     ///
-    /// To get video info tag data of currently played source.
-    ///
-    /// @note Info tag load is only be possible from present player class.
+    /// To get video info tag data of a video item.
     ///
     ///
     ///-------------------------------------------------------------------------

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -888,7 +888,7 @@ namespace XBMCAddon
     xbmc::InfoTagMusic* ListItem::getMusicInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      return new xbmc::InfoTagMusic(item->GetMusicInfoTag());
+      return new xbmc::InfoTagMusic(item->GetMusicInfoTag(), m_offscreen);
     }
 
     xbmc::InfoTagPicture* ListItem::getPictureInfoTag()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -312,6 +312,10 @@ namespace XBMCAddon
 
     int ListItem::getVotes(const char* key)
     {
+      CLog::Log(LOGWARNING,
+                "ListItem.getVotes() is deprecated and might be removed in future Kodi versions. "
+                "Please use InfoTagVideo.getVotesAsInt().");
+
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
       return GetVideoInfoTag()->GetRating(key).votes;
     }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -236,7 +236,7 @@ namespace XBMCAddon
 
     void ListItem::setProperties(const Properties& dictionary)
     {
-      for (const auto& it: dictionary)
+      for (const auto& it : dictionary)
         setProperty(it.first.c_str(), it.second);
     }
 
@@ -324,11 +324,9 @@ namespace XBMCAddon
       if (StringUtils::CompareNoCase(type, "video") == 0)
       {
         auto& videotag = *GetVideoInfoTag();
-        for (const auto& it: infoLabels)
+        for (const auto& it : infoLabels)
         {
-          String key = it.first;
-          StringUtils::ToLower(key);
-
+          const auto key = StringUtils::ToLower(it.first);
           const InfoLabelValue& alt = it.second;
           const String value(alt.which() == first ? alt.former() : emptyString);
 
@@ -378,7 +376,7 @@ namespace XBMCAddon
               throw WrongTypeException("When using \"cast\" or \"castandrole\" you need to supply a list of tuples for the value in the dictionary");
 
             videotag.m_cast.clear();
-            for (const auto& castEntry: alt.later())
+            for (const auto& castEntry : alt.later())
             {
               // castEntry can be a string meaning it's the actor or it can be a tuple meaning it's the
               //  actor and the role.
@@ -396,8 +394,7 @@ namespace XBMCAddon
               throw WrongTypeException("When using \"artist\" you need to supply a list of strings for the value in the dictionary");
 
             videotag.m_artist.clear();
-
-            for (const auto& castEntry: alt.later())
+            for (const auto& castEntry : alt.later())
             {
               const String& actor = castEntry.which() == first ? castEntry.former() : castEntry.later().first();
               videotag.m_artist.push_back(actor);
@@ -483,9 +480,8 @@ namespace XBMCAddon
         std::string type;
         for (auto it = infoLabels.begin(); it != infoLabels.end(); ++it)
         {
-          String key = it->first;
-          StringUtils::ToLower(key);
-          const InfoLabelValue& alt = it->second;
+          const auto key = StringUtils::ToLower(it->first);
+          const auto& alt = it->second;
           const String value(alt.which() == first ? alt.former() : emptyString);
 
           if (key == "mediatype")
@@ -502,10 +498,8 @@ namespace XBMCAddon
         auto& musictag = *item->GetMusicInfoTag();
         for (const auto& it : infoLabels)
         {
-          String key = it.first;
-          StringUtils::ToLower(key);
-
-          const InfoLabelValue& alt = it.second;
+          const auto key = StringUtils::ToLower(it.first);
+          const auto& alt = it.second;
           const String value(alt.which() == first ? alt.former() : emptyString);
 
           //! @todo add the rest of the infolabels
@@ -565,12 +559,10 @@ namespace XBMCAddon
       }
       else if (StringUtils::CompareNoCase(type, "pictures") == 0)
       {
-        for (const auto& it: infoLabels)
+        for (const auto& it : infoLabels)
         {
-          String key = it.first;
-          StringUtils::ToLower(key);
-
-          const InfoLabelValue& alt = it.second;
+          const auto key = StringUtils::ToLower(it.first);
+          const auto& alt = it.second;
           const String value(alt.which() == first ? alt.former() : emptyString);
 
           if (key == "count")
@@ -596,12 +588,10 @@ namespace XBMCAddon
       else if (StringUtils::EqualsNoCase(type, "game"))
       {
         auto& gametag = *item->GetGameInfoTag();
-        for (const auto& it: infoLabels)
+        for (const auto& it : infoLabels)
         {
-          String key = it.first;
-          StringUtils::ToLower(key);
-
-          const InfoLabelValue& alt = it.second;
+          const auto key = StringUtils::ToLower(it.first);
+          const auto& alt = it.second;
           const String value(alt.which() == first ? alt.former() : emptyString);
 
           if (key == "title")
@@ -618,7 +608,7 @@ namespace XBMCAddon
 
             std::vector<std::string> genres;
 
-            for (const auto& genreEntry: alt.later())
+            for (const auto& genreEntry : alt.later())
             {
               const String& genre = genreEntry.which() == first ? genreEntry.former() : genreEntry.later().first();
               genres.emplace_back(genre);
@@ -638,13 +628,15 @@ namespace XBMCAddon
             gametag.SetGameClient(value);
         }
       }
+      else
+        CLog::Log(LOGWARNING, "ListItem.setInfo: unknown \"type\" parameter value: {}", type);
     } // end ListItem::setInfo
 
     void ListItem::setCast(const std::vector<Properties>& actors)
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
       GetVideoInfoTag()->m_cast.clear();
-      for (const auto& dictionary: actors)
+      for (const auto& dictionary : actors)
       {
         SActorInfo info;
         for (auto it = dictionary.begin(); it != dictionary.end(); ++it)
@@ -677,7 +669,7 @@ namespace XBMCAddon
         std::string image;
         std::string preview;
         std::string colors;
-        for (const auto& it: dictionary)
+        for (const auto& it : dictionary)
         {
           const String& key = it.first;
           const String& value = it.second;
@@ -714,7 +706,7 @@ namespace XBMCAddon
       if (StringUtils::CompareNoCase(cType, "video") == 0)
       {
         CStreamDetailVideo* video = new CStreamDetailVideo;
-        for (const auto& it: dictionary)
+        for (const auto& it : dictionary)
         {
           const String& key = it.first;
           const String value(it.second.c_str());
@@ -739,7 +731,7 @@ namespace XBMCAddon
       else if (StringUtils::CompareNoCase(cType, "audio") == 0)
       {
         CStreamDetailAudio* audio = new CStreamDetailAudio;
-        for (const auto& it: dictionary)
+        for (const auto& it : dictionary)
         {
           const String& key = it.first;
           const String& value = it.second;
@@ -756,7 +748,7 @@ namespace XBMCAddon
       else if (StringUtils::CompareNoCase(cType, "subtitle") == 0)
       {
         CStreamDetailSubtitle* subtitle = new CStreamDetailSubtitle;
-        for (const auto& it: dictionary)
+        for (const auto& it : dictionary)
         {
           const String& key = it.first;
           const String& value = it.second;

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -888,9 +888,7 @@ namespace XBMCAddon
     xbmc::InfoTagMusic* ListItem::getMusicInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      if (item->HasMusicInfoTag())
-        return new xbmc::InfoTagMusic(*item->GetMusicInfoTag());
-      return new xbmc::InfoTagMusic();
+      return new xbmc::InfoTagMusic(item->GetMusicInfoTag());
     }
 
     xbmc::InfoTagPicture* ListItem::getPictureInfoTag()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -673,7 +673,7 @@ namespace XBMCAddon
       }
       else if (StringUtils::EqualsNoCase(type, "game"))
       {
-        auto& gametag = *item->GetGameInfoTag();
+        auto gametag = item->GetGameInfoTag();
         for (const auto& it : infoLabels)
         {
           const auto key = StringUtils::ToLower(it.first);
@@ -683,35 +683,30 @@ namespace XBMCAddon
           if (key == "title")
           {
             setTitleRaw(value);
-            gametag.SetTitle(value);
+            xbmc::InfoTagGame::setTitleRaw(gametag, value);
           }
           else if (key == "platform")
-            gametag.SetPlatform(value);
+            xbmc::InfoTagGame::setPlatformRaw(gametag, value);
           else if (key == "genres")
-          {
-            if (alt.which() != second)
-              throw WrongTypeException("When using \"genres\" you need to supply a list of strings for the value in the dictionary");
-
-            std::vector<std::string> genres;
-
-            for (const auto& genreEntry : alt.later())
-            {
-              const String& genre = genreEntry.which() == first ? genreEntry.former() : genreEntry.later().first();
-              genres.emplace_back(genre);
-            }
-
-            gametag.SetGenres(genres);
-          }
+            xbmc::InfoTagGame::setGenresRaw(gametag, getStringArray(alt, key, value, ","));
           else if (key == "publisher")
-            gametag.SetPublisher(value);
+            xbmc::InfoTagGame::setPublisherRaw(gametag, value);
           else if (key == "developer")
-            gametag.SetDeveloper(value);
+            xbmc::InfoTagGame::setDeveloperRaw(gametag, value);
           else if (key == "overview")
-            gametag.SetOverview(value);
+            xbmc::InfoTagGame::setOverviewRaw(gametag, value);
           else if (key == "year")
-            gametag.SetYear(strtol(value.c_str(), nullptr, 10));
+            xbmc::InfoTagGame::setYearRaw(gametag, strtoul(value.c_str(), nullptr, 10));
           else if (key == "gameclient")
-            gametag.SetGameClient(value);
+            xbmc::InfoTagGame::setGameClientRaw(gametag, value);
+        }
+
+        if (!infoLabels.empty())
+        {
+          CLog::Log(
+              LOGWARNING,
+              "Setting game properties through ListItem.setInfo() is deprecated and might be "
+              "removed in future Kodi versions. Please use the respective setter in InfoTagGame.");
         }
       }
       else
@@ -902,8 +897,16 @@ namespace XBMCAddon
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
       if (item->HasPictureInfoTag())
-        return new xbmc::InfoTagPicture(*item->GetPictureInfoTag(), m_offscreen);
+        return new xbmc::InfoTagPicture(item->GetPictureInfoTag(), m_offscreen);
       return new xbmc::InfoTagPicture();
+    }
+
+    xbmc::InfoTagGame* ListItem::getGameInfoTag()
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+      if (item->HasGameInfoTag())
+        return new xbmc::InfoTagGame(item->GetGameInfoTag(), m_offscreen);
+      return new xbmc::InfoTagGame();
     }
 
     std::vector<std::string> ListItem::getStringArray(const InfoLabelValue& alt,

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -811,9 +811,7 @@ namespace XBMCAddon
     xbmc::InfoTagVideo* ListItem::getVideoInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      if (item->HasVideoInfoTag())
-        return new xbmc::InfoTagVideo(*GetVideoInfoTag());
-      return new xbmc::InfoTagVideo();
+      return new xbmc::InfoTagVideo(GetVideoInfoTag());
     }
 
     xbmc::InfoTagMusic* ListItem::getMusicInfoTag()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -302,6 +302,10 @@ namespace XBMCAddon
 
     float ListItem::getRating(const char* key)
     {
+      CLog::Log(LOGWARNING,
+                "ListItem.getRating() is deprecated and might be removed in future Kodi versions. "
+                "Please use InfoTagVideo.getRating().");
+
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
       return GetVideoInfoTag()->GetRating(key).rating;
     }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -811,7 +811,7 @@ namespace XBMCAddon
     xbmc::InfoTagVideo* ListItem::getVideoInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      return new xbmc::InfoTagVideo(GetVideoInfoTag());
+      return new xbmc::InfoTagVideo(GetVideoInfoTag(), m_offscreen);
     }
 
     xbmc::InfoTagMusic* ListItem::getMusicInfoTag()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -252,9 +252,23 @@ namespace XBMCAddon
         value = StringUtils::Format("{:f}", CUtil::ConvertMilliSecsToSecs(item->m_lStartOffset));
       }
       else if (lowerKey == "totaltime")
+      {
+        CLog::Log(LOGWARNING,
+                  "\"{}\" in ListItem.getProperty() is deprecated and might be removed in future "
+                  "Kodi versions. Please use InfoTagVideo.getResumeTimeTotal().",
+                  lowerKey);
+
         value = StringUtils::Format("{:f}", GetVideoInfoTag()->GetResumePoint().totalTimeInSeconds);
+      }
       else if (lowerKey == "resumetime")
+      {
+        CLog::Log(LOGWARNING,
+                  "\"{}\" in ListItem.getProperty() is deprecated and might be removed in future "
+                  "Kodi versions. Please use InfoTagVideo.getResumeTime().",
+                  lowerKey);
+
         value = StringUtils::Format("{:f}", GetVideoInfoTag()->GetResumePoint().timeInSeconds);
+      }
       else if (lowerKey == "fanart_image")
         value = item->GetArt("fanart");
       else
@@ -277,6 +291,11 @@ namespace XBMCAddon
 
     String ListItem::getUniqueID(const char* key)
     {
+      CLog::Log(
+          LOGWARNING,
+          "ListItem.getUniqueID() is deprecated and might be removed in future Kodi versions. "
+          "Please use InfoTagVideo.getUniqueID().");
+
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
       return GetVideoInfoTag()->GetUniqueID(key);
     }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -510,6 +510,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 Deprecated. Use **InfoTagVideo.getUniqueID()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1051,6 +1052,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 **ResumeTime** and **TotalTime** deprecated. Use **InfoTagVideo.getResumeTime()** and **InfoTagVideo.getResumeTimeTotal()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -574,6 +574,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 Deprecated. Use **InfoTagVideo.getVotesAsInt()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -689,7 +689,7 @@ namespace XBMCAddon
       /// | tracknumber   | integer (3)
       /// | rating        | float (6.4) - range is 0..10
       /// | userrating    | integer (9) - range is 1..10 (0 to reset)
-      /// | watched       | depreciated - use playcount instead
+      /// | watched       | deprecated - use playcount instead
       /// | playcount     | integer (2) - number of times this item has been played
       /// | overlay       | integer (2) - range is `0..7`.  See \ref kodi_guilib_listitem_iconoverlay "Overlay icon types" for values
       /// | cast          | list (["Michal C. Hall","Jennifer Carpenter"]) - if provided a list of tuples cast will be interpreted as castandrole

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -542,6 +542,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 Deprecated. Use **InfoTagVideo.getRating()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -14,6 +14,7 @@
 #include "Dictionary.h"
 #include "FileItem.h"
 #include "InfoTagMusic.h"
+#include "InfoTagPicture.h"
 #include "InfoTagVideo.h"
 #include "ListItem.h"
 #include "Tuple.h"
@@ -780,7 +781,7 @@ namespace XBMCAddon
       /// @python_v18 Added new **game** type and associated infolabels.
       /// Added labels **dbid** (music), **setoverview**, **tag**, **sortepisode**, **sortseason**, **episodeguide**, **showlink**.
       /// Extended labels **genre**, **country**, **director**, **studio**, **writer**, **tag**, **credits** to also use a list of strings.
-      /// @python_v20 Partially deprecated. Use explicit setters in **InfoTagVideo** instead.
+      /// @python_v20 Partially deprecated. Use explicit setters in **InfoTagVideo** or **InfoTagPicture** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1214,6 +1215,23 @@ namespace XBMCAddon
       xbmc::InfoTagMusic* getMusicInfoTag();
 #endif
 
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ getPictureInfoTag() }
+      /// Returns the InfoTagPicture for this item.
+      ///
+      /// @return     picture info tag
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getPictureInfoTag();
+#else
+      xbmc::InfoTagPicture* getPictureInfoTag();
+#endif
+
 private:
       std::vector<std::string> getStringArray(const InfoLabelValue& alt,
                                               const std::string& tag,
@@ -1226,6 +1244,8 @@ private:
       CVideoInfoTag* GetVideoInfoTag();
       const CVideoInfoTag* GetVideoInfoTag() const;
 
+      void setTitleRaw(std::string title);
+      void setPathRaw(std::string path);
       void setCountRaw(int count);
       void setSizeRaw(int64_t size);
       void setDateTimeRaw(const std::string& dateTime);

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -359,6 +359,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 Deprecated. Use **InfoTagVideo.setUniqueIDs()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -394,6 +395,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 Deprecated. Use **InfoTagVideo.setRating()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -421,6 +423,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       ///
       /// @python_v18 New function added.
+      /// @python_v20 Deprecated. Use **InfoTagVideo.addSeason()** or **InfoTagVideo.addSeasons()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -777,6 +780,7 @@ namespace XBMCAddon
       /// @python_v18 Added new **game** type and associated infolabels.
       /// Added labels **dbid** (music), **setoverview**, **tag**, **sortepisode**, **sortseason**, **episodeguide**, **showlink**.
       /// Extended labels **genre**, **country**, **director**, **studio**, **writer**, **tag**, **credits** to also use a list of strings.
+      /// @python_v20 Partially deprecated. Use explicit setters in **InfoTagVideo** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -809,6 +813,7 @@ namespace XBMCAddon
       ///
       ///-----------------------------------------------------------------------
       /// @python_v17 New function added.
+      /// @python_v20 Deprecated. Use **InfoTagVideo.setCast()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -874,6 +879,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18 New function added.
       /// @python_v19 New param added (preview).
+      /// @python_v20 Deprecated. Use **InfoTagVideo.addAvailableArtwork()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -927,6 +933,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 Deprecated. Use **InfoTagVideo.addVideoStream()**, **InfoTagVideo.addAudioStream()** or **InfoTagVideo.addSubtitleStream()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1002,6 +1009,7 @@ namespace XBMCAddon
       ///
       ///-----------------------------------------------------------------------
       /// @python_v20 OverrideInfotag property added
+      /// @python_v20 **ResumeTime** and **TotalTime** deprecated. Use **InfoTagVideo.setResumePoint()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1207,7 +1215,13 @@ namespace XBMCAddon
 #endif
 
 private:
-      std::vector<std::string> getStringArray(const InfoLabelValue& alt, const std::string& tag, std::string value = "");
+      std::vector<std::string> getStringArray(const InfoLabelValue& alt,
+                                              const std::string& tag,
+                                              std::string value,
+                                              const std::string& separator);
+      std::vector<std::string> getVideoStringArray(const InfoLabelValue& alt,
+                                                   const std::string& tag,
+                                                   std::string value = "");
 
       CVideoInfoTag* GetVideoInfoTag();
       const CVideoInfoTag* GetVideoInfoTag() const;

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -13,6 +13,7 @@
 #include "Alternative.h"
 #include "Dictionary.h"
 #include "FileItem.h"
+#include "InfoTagGame.h"
 #include "InfoTagMusic.h"
 #include "InfoTagPicture.h"
 #include "InfoTagVideo.h"
@@ -781,7 +782,7 @@ namespace XBMCAddon
       /// @python_v18 Added new **game** type and associated infolabels.
       /// Added labels **dbid** (music), **setoverview**, **tag**, **sortepisode**, **sortseason**, **episodeguide**, **showlink**.
       /// Extended labels **genre**, **country**, **director**, **studio**, **writer**, **tag**, **credits** to also use a list of strings.
-      /// @python_v20 Partially deprecated. Use explicit setters in **InfoTagVideo** or **InfoTagPicture** instead.
+      /// @python_v20 Partially deprecated. Use explicit setters in **InfoTagVideo**, **InfoTagPicture** or **InfoTagGame** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1230,6 +1231,23 @@ namespace XBMCAddon
       getPictureInfoTag();
 #else
       xbmc::InfoTagPicture* getPictureInfoTag();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ getGameInfoTag() }
+      /// Returns the InfoTagGame for this item.
+      ///
+      /// @return     game info tag
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getGameInfoTag();
+#else
+      xbmc::InfoTagGame* getGameInfoTag();
 #endif
 
 private:

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -641,7 +641,7 @@ namespace XBMCAddon
       /// @brief \python_func{ setInfo(type, infoLabels) }
       /// Sets the listitem's infoLabels.
       ///
-      /// @param type               string - type of
+      /// @param type               string - type of info labels
       /// @param infoLabels         dictionary - pairs of `{ label: value }`
       ///
       /// __Available types__
@@ -1207,6 +1207,18 @@ private:
 
       CVideoInfoTag* GetVideoInfoTag();
       const CVideoInfoTag* GetVideoInfoTag() const;
+
+      void setCountRaw(int count);
+      void setSizeRaw(int64_t size);
+      void setDateTimeRaw(const std::string& dateTime);
+      void setIsFolderRaw(bool isFolder);
+      void setStartOffsetRaw(double startOffset);
+      void setMimeTypeRaw(const std::string& mimetype);
+      void setSpecialSortRaw(std::string specialSort);
+      void setContentLookupRaw(bool enable);
+      void addArtRaw(std::string type, std::string url);
+      void addPropertyRaw(std::string type, CVariant value);
+      void addSubtitlesRaw(const std::vector<std::string>& subtitles);
     };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -782,7 +782,7 @@ namespace XBMCAddon
       /// @python_v18 Added new **game** type and associated infolabels.
       /// Added labels **dbid** (music), **setoverview**, **tag**, **sortepisode**, **sortseason**, **episodeguide**, **showlink**.
       /// Extended labels **genre**, **country**, **director**, **studio**, **writer**, **tag**, **credits** to also use a list of strings.
-      /// @python_v20 Partially deprecated. Use explicit setters in **InfoTagVideo**, **InfoTagPicture** or **InfoTagGame** instead.
+      /// @python_v20 Partially deprecated. Use explicit setters in **InfoTagVideo**, **InfoTagMusic**, **InfoTagPicture** or **InfoTagGame** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1258,9 +1258,15 @@ private:
       std::vector<std::string> getVideoStringArray(const InfoLabelValue& alt,
                                                    const std::string& tag,
                                                    std::string value = "");
+      std::vector<std::string> getMusicStringArray(const InfoLabelValue& alt,
+                                                   const std::string& tag,
+                                                   std::string value = "");
 
       CVideoInfoTag* GetVideoInfoTag();
       const CVideoInfoTag* GetVideoInfoTag() const;
+
+      MUSIC_INFO::CMusicInfoTag* GetMusicInfoTag();
+      const MUSIC_INFO::CMusicInfoTag* GetMusicInfoTag() const;
 
       void setTitleRaw(std::string title);
       void setPathRaw(std::string path);

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -368,7 +368,7 @@ namespace XBMCAddon
 
       const CVideoInfoTag* movie = CServiceBroker::GetGUI()->GetInfoManager().GetCurrentMovieTag();
       if (movie)
-        return new InfoTagVideo(*movie);
+        return new InfoTagVideo(movie);
 
       return new InfoTagVideo();
     }

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -383,7 +383,7 @@ namespace XBMCAddon
       if (tag)
         return new InfoTagMusic(tag);
 
-      return new InfoTagMusic();
+      return new InfoTagMusic(true);
     }
 
     void Player::updateInfoTag(const XBMCAddon::xbmcgui::ListItem* item)

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -370,7 +370,7 @@ namespace XBMCAddon
       if (movie)
         return new InfoTagVideo(movie);
 
-      return new InfoTagVideo();
+      return new InfoTagVideo(true);
     }
 
     InfoTagMusic* Player::getMusicInfoTag()

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -381,7 +381,7 @@ namespace XBMCAddon
 
       const MUSIC_INFO::CMusicInfoTag* tag = CServiceBroker::GetGUI()->GetInfoManager().GetCurrentSongTag();
       if (tag)
-        return new InfoTagMusic(*tag);
+        return new InfoTagMusic(tag);
 
       return new InfoTagMusic();
     }

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -36,6 +36,7 @@ using namespace xbmc;
 
 %include "interfaces/legacy/AddonString.h"
 %include "interfaces/legacy/ModuleXbmc.h"
+%include "interfaces/legacy/Dictionary.h"
 
 %feature("director") Player;
 

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -48,6 +48,7 @@ using namespace xbmc;
 
 %include "interfaces/legacy/RenderCapture.h"
 
+%include "interfaces/legacy/InfoTagGame.h"
 %include "interfaces/legacy/InfoTagMusic.h"
 %include "interfaces/legacy/InfoTagPicture.h"
 %include "interfaces/legacy/InfoTagRadioRDS.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -49,6 +49,7 @@ using namespace xbmc;
 %include "interfaces/legacy/RenderCapture.h"
 
 %include "interfaces/legacy/InfoTagMusic.h"
+%include "interfaces/legacy/InfoTagPicture.h"
 %include "interfaces/legacy/InfoTagRadioRDS.h"
 %include "interfaces/legacy/InfoTagVideo.h"
 %include "interfaces/legacy/Keyboard.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -36,7 +36,7 @@ using namespace xbmcgui;
 // not part of what swig parses.
 %feature("knownbasetypes") XBMCAddon::xbmcgui "AddonClass,AddonCallback"
 
-%feature("knownapitypes") XBMCAddon::xbmcgui "XBMCAddon::xbmc::InfoTagVideo,xbmc::InfoTagMusic,xbmc::InfoTagPicture"
+%feature("knownapitypes") XBMCAddon::xbmcgui "XBMCAddon::xbmc::InfoTagVideo,xbmc::InfoTagMusic,xbmc::InfoTagPicture,xbmc::InfoTagGame"
 
 %include "interfaces/legacy/swighelper.h"
 %include "interfaces/legacy/AddonString.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -36,7 +36,7 @@ using namespace xbmcgui;
 // not part of what swig parses.
 %feature("knownbasetypes") XBMCAddon::xbmcgui "AddonClass,AddonCallback"
 
-%feature("knownapitypes") XBMCAddon::xbmcgui "XBMCAddon::xbmc::InfoTagVideo,xbmc::InfoTagMusic"
+%feature("knownapitypes") XBMCAddon::xbmcgui "XBMCAddon::xbmc::InfoTagVideo,xbmc::InfoTagMusic,xbmc::InfoTagPicture"
 
 %include "interfaces/legacy/swighelper.h"
 %include "interfaces/legacy/AddonString.h"

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -336,24 +336,58 @@ wchar_t toupperUnicode(const wchar_t& c)
   return c;
 }
 
+template<typename Str, typename Fn>
+void transformString(const Str& input, Str& output, Fn fn)
+{
+  std::transform(input.begin(), input.end(), output.begin(), fn);
+}
+
+std::string StringUtils::ToUpper(const std::string& str)
+{
+  std::string result(str.size(), '\0');
+  transformString(str, result, ::toupper);
+  return result;
+}
+
+std::wstring StringUtils::ToUpper(const std::wstring& str)
+{
+  std::wstring result(str.size(), '\0');
+  transformString(str, result, toupperUnicode);
+  return result;
+}
+
 void StringUtils::ToUpper(std::string &str)
 {
-  std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+  transformString(str, str, ::toupper);
 }
 
 void StringUtils::ToUpper(std::wstring &str)
 {
-  transform(str.begin(), str.end(), str.begin(), toupperUnicode);
+  transformString(str, str, toupperUnicode);
+}
+
+std::string StringUtils::ToLower(const std::string& str)
+{
+  std::string result(str.size(), '\0');
+  transformString(str, result, ::tolower);
+  return result;
+}
+
+std::wstring StringUtils::ToLower(const std::wstring& str)
+{
+  std::wstring result(str.size(), '\0');
+  transformString(str, result, tolowerUnicode);
+  return result;
 }
 
 void StringUtils::ToLower(std::string &str)
 {
-  transform(str.begin(), str.end(), str.begin(), ::tolower);
+  transformString(str, str, ::tolower);
 }
 
 void StringUtils::ToLower(std::wstring &str)
 {
-  transform(str.begin(), str.end(), str.begin(), tolowerUnicode);
+  transformString(str, str, tolowerUnicode);
 }
 
 void StringUtils::ToCapitalize(std::string &str)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -104,8 +104,12 @@ public:
 
   static std::string FormatV(PRINTF_FORMAT_STRING const char *fmt, va_list args);
   static std::wstring FormatV(PRINTF_FORMAT_STRING const wchar_t *fmt, va_list args);
+  static std::string ToUpper(const std::string& str);
+  static std::wstring ToUpper(const std::wstring& str);
   static void ToUpper(std::string &str);
   static void ToUpper(std::wstring &str);
+  static std::string ToLower(const std::string& str);
+  static std::wstring ToLower(const std::wstring& str);
   static void ToLower(std::string &str);
   static void ToLower(std::wstring &str);
   static void ToCapitalize(std::string &str);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1530,9 +1530,12 @@ void CVideoInfoTag::RemoveRating(const std::string& type)
   }
 }
 
-void CVideoInfoTag::SetRatings(RatingMap ratings)
+void CVideoInfoTag::SetRatings(RatingMap ratings, const std::string& defaultRating /* = "" */)
 {
   m_ratings = std::move(ratings);
+
+  if (!defaultRating.empty() && m_ratings.find(defaultRating) != m_ratings.end())
+    m_strDefaultRating = defaultRating;
 }
 
 void CVideoInfoTag::SetVotes(int votes, const std::string& type /* = "" */)

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -135,7 +135,7 @@ public:
   void SetRating(CRating rating, const std::string& type = "", bool def = false);
   void SetRating(float rating, const std::string& type = "", bool def = false);
   void RemoveRating(const std::string& type);
-  void SetRatings(RatingMap ratings);
+  void SetRatings(RatingMap ratings, const std::string& defaultRating = "");
   void SetVotes(int votes, const std::string& type = "");
   void SetUniqueIDs(std::map<std::string, std::string> uniqueIDs);
   void SetPremiered(const CDateTime& premiered);


### PR DESCRIPTION
## Description
As part of my media import work I'm currently looking into ways to improve the performance of creating, filling and passing `ListItem` objects from Python add-ons into Kodi core. My profiling has shown that most of the time is spent in calls like `ListItem.setInfo()`, `ListItem.setCast()`, `ListItem.setProperties()` etc. The problem seems to be that - due to backwards compatibility - the interface of these methods is very odd. It has to support parameters which are either string or integer or lists of strings or integers or even worse. That leads to a lot of type checking and exception handling in the glue code between Python and C++.

Therefore I've tried to come up with alternative approaches:
* serialize the Python dictionary into JSON and passing the JSON string to a new method I temporarily called `ListItem.setInfoFromJson()` which then deserializes the JSON string into a `CVariant` and uses the expected type information to extract the necessary data. This approach is approximately 20 - 30% faster than using `ListItem.setInfo()`.
* I added a new method I temporarily called `ListItem.setInfoFromDict()` which directly expects a `CVariant` (instead of a JSON string). I also added a new python typemap to convert (restricted) Python `dict`s into `CVariant`s. This approach is 50 - 60% faster than using `ListItem.setInfo()`.

Obviously the disadvantage of these alternative approaches is that the interface is not as well defined as with `ListItem.setInfo()` but IMO its interface is horrible as well. This disadvantage could be resolved by providing a pure Python module which provides a wrapper around `ListItem` with explicit getters / setters and internally creates the proper Python `dict` to turn the wrapper into a proper `ListItem`.

So now my question is: would something like this be considered for mainline? Which approach would be preferred and should we provide the proposed pure Python wrapper?

And while we're at it should we split setting all these `ListItem` details into `InfoTagVideo` et al. instead of putting everything into one huge setter method?

## TODOs
- [x] `InfoTagVideo.getDirector()` returns a concatenated string of all directories instead of a list of strings. --> **`InfoTagVideo.getDirectors()`**
- [x] `InfoTagVideo.getWritingCredits()` returns a concatenated string of all writers instead of a list of strings. --> **`InfoTagVideo.getWriters()`**
- [x] `InfoTagVideo.getGenre()` returns a concatenated string of all genres instead of a list of strings. --> **`InfoTagVideo.getGenres()`**
- [x] `InfoTagVideo.getVotes()` returns the votes as a string instead of an integer. Furthermore it only support returning the default votes. `ListItem.getVotes()` returns an integer and support specifying the rating key for which to return the votes. --> **`InfoTagVideo.getVotesAsInt()`**
- [x] `InfoTagVideo.getCast()` returns a concatenated string of all actors instead of a list of strings / actor objects. --> **`InfoTagVideo.getActors()`**
- [x] `InfoTagVideo.getLastPlayed()` / `InfoTagVideo.getPremiered()` / `InfoTagVideo.getFirstAired()` / `InfoTagMusic.getLastPlayed()` return the date in a localized format which is stupid because the python add-on has no idea about what the localized format is (because it can be configured in the Kodi settings). Furthermore the localized format is missing any timezone information. --> **`InfoTagVideo|Music.getFooAsW3C()`**
- [x] `InfoTagMusic.getGenre()` returns a concatenated string of all genres instead of a list of strings. --> **`InfoTagMusic.getGenres()`**
- [x] document new methods in `InfoTagVideo`
- [x] document new methods in `InfoTagPicture`
- [x] document new methods in `InfoTagGame`
- [x] document new methods in `InfoTagMusic`

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
