### PR TITLE
Fix crash on android in CRunningScriptObserver

### DIFF
--- a/xbmc/interfaces/generic/RunningScriptObserver.cpp
+++ b/xbmc/interfaces/generic/RunningScriptObserver.cpp
@@ -11,12 +11,14 @@
 #include "interfaces/generic/ScriptInvocationManager.h"
 
 CRunningScriptObserver::CRunningScriptObserver(int scriptId, CEvent& evt)
-  : m_scriptId(scriptId),
-  m_event(evt),
-  m_thread(this, "ScriptObs"),
-  m_stopEvent(true)
+  : m_scriptId(scriptId), m_event(evt), m_stopEvent(true), m_thread(this, "ScriptObs")
 {
   m_thread.Create();
+}
+
+CRunningScriptObserver::~CRunningScriptObserver()
+{
+  Abort();
 }
 
 void CRunningScriptObserver::Run()
@@ -34,4 +36,5 @@ void CRunningScriptObserver::Run()
 void CRunningScriptObserver::Abort()
 {
   m_stopEvent.Set();
+  m_thread.StopThread();
 }

--- a/xbmc/interfaces/generic/RunningScriptObserver.h
+++ b/xbmc/interfaces/generic/RunningScriptObserver.h
@@ -18,7 +18,7 @@ class CRunningScriptObserver : public IRunnable
 {
 public:
   CRunningScriptObserver(int scriptId, CEvent& evt);
-  ~CRunningScriptObserver() = default;
+  ~CRunningScriptObserver();
 
   void Abort();
 
@@ -29,6 +29,6 @@ protected:
   int m_scriptId;
   CEvent& m_event;
 
-  CThread m_thread;
   CEvent m_stopEvent;
+  CThread m_thread;
 };


### PR DESCRIPTION
## Description
This should fix the crash on android introduced by #19310. Thanks to @Acidzero2020 for reporting the problem and for @Maven85 for pointing me in the right direction.

## Motivation and Context
`CRunningScriptObserver` is created in `CScriptRunner::WaitOnScriptResult()` as a local variable. Right before the local variable goes out of scope it calls `CRunningScriptObserver::Abort()`. I assumed that the destructor of `CRunningScriptObserver` would implicitly stop the thread because it would also execute the destructor of `m_thread` but due to the order of the declaration of `m_thread` and `m_stopEvent` in `CRunningScriptObserver` `m_stopEvent` is destroyed before `m_thread` so when the next loop in `CRunningScriptObserver::Run()` is executed `m_stopEvent` has become invalid which leads to a crash. Why this only happens on android I have no idea it might also happen on any other platform.

## How Has This Been Tested?
By @Maven85.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed