### PR TITLE
[Estuary] Rework PVR windows

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
@@ -9,162 +9,41 @@
 				<depth>DepthOSD</depth>
 				<include>OpenClose_Left</include>
 				<include content="ContentPanel">
-					<param name="width" value="941" />
+					<param name="width" value="1042" />
 				</include>
 				<control type="fixedlist" id="11">
 					<left>0</left>
-					<width>875</width>
-					<height>100%</height>
+					<top>100</top>
+					<width>970</width>
+					<bottom>0</bottom>
 					<onleft>PreviousChannelGroup</onleft>
 					<onright>60</onright>
 					<onup>11</onup>
 					<ondown>11</ondown>
-					<pagecontrol>60</pagecontrol>
 					<movement>4</movement>
-					<focusposition>5</focusposition>
+					<focusposition>4</focusposition>
+					<pagecontrol>60</pagecontrol>
 					<scrolltime tween="cubic" easing="out">500</scrolltime>
-					<focusedlayout height="90" width="875">
-						<control type="image">
-							<left>0</left>
-							<right>0</right>
-							<bottom>0</bottom>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.hasFocus(11)</visible>
-						</control>
-						<control type="image">
-							<right>20</right>
-							<top>10</top>
-							<width>80</width>
-							<height>70</height>
-							<aspectratio align="right">keep</aspectratio>
-							<texture>$INFO[listitem.icon]</texture>
-						</control>
-						<control type="progress">
-							<left>105</left>
-							<top>58</top>
-							<width>50</width>
-							<height>12</height>
-							<midtexture border="3">progress/texturebg_white.png</midtexture>
-							<visible>ListItem.HasEpg</visible>
-							<info>ListItem.Progress</info>
-						</control>
-						<control type="image">
-							<right>110</right>
-							<top>25</top>
-							<width>40</width>
-							<height>40</height>
-							<texture>$VAR[PVRStatusImageVar]</texture>
-						</control>
-						<control type="label">
-							<left>105</left>
-							<top>8</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font14</font>
-							<animation effect="slide" start="0,0" end="0,14" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
-							<label>$INFO[ListItem.Label]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>165</left>
-							<top>46</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>12</left>
-							<top>0</top>
-							<height>90</height>
-							<width>75</width>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font32_title</font>
-							<label>$INFO[ListItem.ChannelNumberLabel]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</focusedlayout>
-					<itemlayout height="90" width="875">
-						<control type="image">
-							<right>20</right>
-							<top>10</top>
-							<width>80</width>
-							<height>70</height>
-							<aspectratio align="right">keep</aspectratio>
-							<texture>$INFO[listitem.icon]</texture>
-						</control>
-						<control type="progress">
-							<left>105</left>
-							<top>58</top>
-							<width>50</width>
-							<height>12</height>
-							<colordiffuse>88FFFFFF</colordiffuse>
-							<visible>ListItem.HasEpg</visible>
-							<info>ListItem.Progress</info>
-						</control>
-						<control type="image">
-							<right>110</right>
-							<top>25</top>
-							<width>40</width>
-							<height>40</height>
-							<texture>$VAR[PVRStatusImageVar]</texture>
-						</control>
-						<control type="label">
-							<left>105</left>
-							<top>8</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font14</font>
-							<label>$INFO[ListItem.Label]</label>
-							<animation effect="slide" start="0,0" end="0,14" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>165</left>
-							<top>46</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-							<textcolor>grey</textcolor>
-						</control>
-						<control type="label">
-							<left>12</left>
-							<top>0</top>
-							<height>90</height>
-							<width>75</width>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font32_title</font>
-							<label>$INFO[ListItem.ChannelNumberLabel]</label>
-							<textcolor>grey</textcolor>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</itemlayout>
+					<include content="PVRListItemLayouts">
+						<param name="list_id" value="11" />
+						<param name="label1" value="$INFO[ListItem.Label]" />
+						<param name="has_status_icon" value="true" />
+					</include>
 				</control>
 				<control type="scrollbar" id="60">
-					<left>869</left>
+					<left>970</left>
+					<top>100</top>
 					<width>12</width>
-					<height>100%</height>
+					<bottom>0</bottom>
 					<onleft>11</onleft>
-					<texturesliderbackground />
 					<onright>NextChannelGroup</onright>
-					<ondown>61</ondown>
-					<onup>61</onup>
-					<animation effect="zoom" start="100,100" end="50,100" center="881,0" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(60)">conditional</animation>
-					<orientation>vertical</orientation>
+					<texturesliderbackground />
+					<animation effect="zoom" start="100,100" end="50,100" center="982,0" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(60)">conditional</animation>
 				</control>
 				<control type="image">
 					<left>0</left>
 					<bottom>0</bottom>
-					<width>880</width>
+					<width>970</width>
 					<height>115</height>
 					<texture flipy="true">frame/InfoBar.png</texture>
 				</control>
@@ -174,18 +53,18 @@
 				<include>Animation_TopSlide</include>
 				<control type="image">
 					<left>0</left>
-					<width>880</width>
+					<width>970</width>
 					<height>110</height>
 					<texture>frame/InfoBar.png</texture>
 				</control>
 				<control type="label" id="2">
 					<description>header label</description>
 					<textoffsetx>40</textoffsetx>
-					<width>830</width>
+					<width>970</width>
 					<height>70</height>
 					<font>font45</font>
 					<aligny>center</aligny>
-					<label>&lt; $INFO[VideoPlayer.ChannelGroup] &gt;</label>
+					<label>$VAR[BreadcrumbsPVRChannelsOSDVar]</label>
 					<shadowcolor>black</shadowcolor>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -1,5 +1,164 @@
 <?xml version="1.0" encoding="utf-8"?>
 <includes>
+	<expression name="listitem_has_episode_info">!String.IsEmpty(ListItem.Episode) | !String.IsEmpty(ListItem.EpisodeName) | !String.IsEmpty(ListItem.Season)</expression>
+	<expression name="listitem_has_epg_event_info">!String.IsEmpty(ListItem.EpgEventTitle) | $EXP[listitem_has_episode_info]</expression>
+	<include name="PVRListItemLayout">
+		<definition>
+			<control type="label">
+				<left>30</left>
+				<top>0</top>
+				<right>30</right>
+				<font>font36_title</font>
+				<aligny>center</aligny>
+				<visible>$PARAM[only_label_condition]</visible>
+				<label>$INFO[ListItem.Label]</label>
+			</control>
+			<control type="group">
+				<visible>!$PARAM[only_label_condition]</visible>
+				<animation effect="slide" start="0,0" end="0,16" time="0" condition="!$EXP[listitem_has_epg_event_info]">Conditional</animation>
+				<control type="image">
+					<left>29</left>
+					<top>17</top>
+					<width>32</width>
+					<height>32</height>
+					<aspectratio align="center">keep</aspectratio>
+					<visible>$PARAM[has_info_icon]</visible>
+					<texture>$PARAM[info_icon]</texture>
+				</control>
+				<control type="label">
+					<left>10</left>
+					<top>10</top>
+					<width>90</width>
+					<height>50</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font32_title</font>
+					<visible>!$PARAM[has_info_icon]</visible>
+					<label>$PARAM[label0]</label>
+				</control>
+				<control type="label">
+					<left>105</left>
+					<right>120</right>
+					<top>10</top>
+					<height>30</height>
+					<aligny>top</aligny>
+					<label>$PARAM[label1]</label>
+				</control>
+				<control type="label">
+					<left>105</left>
+					<right>120</right>
+					<top>10</top>
+					<height>30</height>
+					<align>right</align>
+					<aligny>top</aligny>
+					<label>$PARAM[label2]</label>
+				</control>
+			</control>
+			<control type="group">
+				<visible>!$PARAM[only_label_condition]</visible>
+				<control type="label">
+					<left>105</left>
+					<right>120</right>
+					<top>53</top>
+					<height>30</height>
+					<font>font12</font>
+					<aligny>top</aligny>
+					<label>$PARAM[label3]</label>
+				</control>
+				<control type="label">
+					<left>105</left>
+					<right>120</right>
+					<top>53</top>
+					<height>30</height>
+					<font>font12</font>
+					<align>right</align>
+					<aligny>top</aligny>
+					<label>$PARAM[label4]</label>
+				</control>
+			</control>
+			<control type="image">
+				<right>110</right>
+				<top>0</top>
+				<width>32</width>
+				<aligny>center</aligny>
+				<aspectratio align="center">keep</aspectratio>
+				<texture>$VAR[PVRStatusImageVar]</texture>
+				<visible>$PARAM[has_status_icon]</visible>
+			</control>
+			<control type="image">
+				<right>20</right>
+				<top>0</top>
+				<width>80</width>
+				<aligny>center</aligny>
+				<aspectratio align="center">keep</aspectratio>
+				<visible>!$PARAM[only_label_condition] | ListItem.IsParentFolder</visible>
+				<texture>$INFO[ListItem.ActualIcon]</texture>
+			</control>
+		</definition>
+	</include>
+	<include name="PVRListItemLayouts">
+		<param name="only_label_condition">false</param>
+		<param name="has_info_icon">false</param>
+		<param name="has_status_icon">false</param>
+		<definition>
+			<itemlayout height="100">
+				<control type="progress">
+					<left>20</left>
+					<top>66</top>
+					<width>70</width>
+					<height>12</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<colordiffuse>88FFFFFF</colordiffuse>
+					<visible>ListItem.HasEpg + !$PARAM[has_info_icon]</visible>
+					<info>ListItem.Progress</info>
+				</control>
+				<include content="PVRListItemLayout">
+					<param name="only_label_condition" value="$PARAM[only_label_condition]" />
+					<param name="info_icon" value="$PARAM[info_icon]" />
+					<param name="has_info_icon" value="$PARAM[has_info_icon]" />
+					<param name="has_status_icon" value="$PARAM[has_status_icon]" />
+					<param name="label0" value="[COLOR grey]$INFO[ListItem.ChannelNumberLabel][/COLOR]" />
+					<param name="label1" value="$PARAM[label1]" />
+					<param name="label2" value="$PARAM[label2]" />
+					<param name="label3" value="$VAR[PVRListItemSubLabel]" />
+					<param name="label4" value="[COLOR grey]$INFO[ListItem.Comment][/COLOR]" />
+				</include>
+			</itemlayout>
+			<focusedlayout height="100">
+				<control type="image">
+					<left>0</left>
+					<top>0</top>
+					<right>0</right>
+					<animation effect="fade" start="100" end="0" time="0">UnFocus</animation>
+					<texture colordiffuse="button_focus">lists/focus.png</texture>
+					<visible>Control.HasFocus($PARAM[list_id])</visible>
+				</control>
+				<control type="progress">
+					<left>20</left>
+					<top>66</top>
+					<width>70</width>
+					<height>12</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<midtexture border="3">progress/texturebg_white.png</midtexture>
+					<visible>ListItem.HasEpg + !$PARAM[has_info_icon]</visible>
+					<info>ListItem.Progress</info>
+				</control>
+				<include content="PVRListItemLayout">
+					<param name="only_label_condition" value="$PARAM[only_label_condition]" />
+					<param name="info_icon" value="$PARAM[info_icon]" />
+					<param name="has_info_icon" value="$PARAM[has_info_icon]" />
+					<param name="has_status_icon" value="$PARAM[has_status_icon]" />
+					<param name="label0" value="$INFO[ListItem.ChannelNumberLabel]" />
+					<param name="label1" value="$PARAM[label1]" />
+					<param name="label2" value="$PARAM[label2]" />
+					<param name="label3" value="$VAR[PVRListItemSubLabelFocused]" />
+					<param name="label4" value="$INFO[ListItem.Comment]" />
+				</include>
+			</focusedlayout>
+		</definition>
+	</include>
 	<include name="ChannelManagerList">
 		<control type="grouplist">
 			<orientation>horizontal</orientation>
@@ -197,8 +356,9 @@
 				<left>630</left>
 				<width>200</width>
 				<height>200</height>
-				<aspectratio align="center" aligny="top">keep</aspectratio>
+				<aspectratio align="center" aligny="center">keep</aspectratio>
 				<texture fallback="DefaultTVShows.png">$VAR[ChannelListEPGIconVar]</texture>
+				<visible>!String.IsEmpty(ListItem.ChannelName)</visible>
 				<fadetime>200</fadetime>
 			</control>
 			<control type="group">
@@ -213,26 +373,14 @@
 				<control type="label">
 					<top>60</top>
 					<height>200</height>
-					<wrapmultiline>true</wrapmultiline>
-					<label>$INFO[ListItem.TimerType,[COLOR grey]$LOCALIZE[803]:[/COLOR] ,[CR]]$VAR[DateDurationLabel]$VAR[ExpirationDateTimeLabel]$VAR[FlagLabel]</label>
+					<label>$VAR[PVRInfoPanelDateDurationLabel]</label>
 				</control>
-				<control type="group">
+				<control type="progress">
+					<top>200</top>
+					<height>12</height>
+					<colordiffuse>88FFFFFF</colordiffuse>
+					<info>ListItem.Progress</info>
 					<visible>Integer.IsGreater(ListItem.Progress,0)</visible>
-					<top>150</top>
-					<height>262</height>
-					<control type="label">
-						<label>$INFO[ListItem.StartTime]</label>
-					</control>
-					<control type="label">
-						<align>right</align>
-						<label>$INFO[ListItem.EndTime]</label>
-					</control>
-					<control type="progress">
-						<top>50</top>
-						<height>12</height>
-						<colordiffuse>88FFFFFF</colordiffuse>
-						<info>ListItem.Progress</info>
-					</control>
 				</control>
 				<control type="progress">
 					<top>200</top>
@@ -243,48 +391,41 @@
 				</control>
 			</control>
 			<control type="label">
-				<top>390</top>
+				<top>365</top>
 				<width>830</width>
 				<height>262</height>
 				<font>font36_title</font>
 				<label>$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
-				<visible>!PVR.HasEpg</visible>
+				<scroll>true</scroll>
+				<visible>!ListItem.HasEpg</visible>
 			</control>
 			<control type="label">
-				<top>390</top>
+				<top>365</top>
 				<width>830</width>
 				<height>262</height>
 				<font>font36_title</font>
 				<label>$INFO[ListItem.EpgEventTitle] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
-				<visible>PVR.HasEpg</visible>
+				<scroll>true</scroll>
+				<visible>ListItem.HasEpg</visible>
 			</control>
 			<control type="label">
-				<top>435</top>
+				<top>410</top>
 				<width>830</width>
 				<height>70</height>
+				<scroll>true</scroll>
 				<label>[I]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/I]</label>
 			</control>
 			<control type="textbox">
-				<top>490</top>
+				<top>465</top>
 				<width>830</width>
-				<bottom>75</bottom>
-				<label>$INFO[ListItem.Plot]</label>
+				<bottom>80</bottom>
+				<label>$VAR[FlagLabel,,[CR]]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ,[CR]]$INFO[ListItem.TimerType,[COLOR grey]$LOCALIZE[803]:[/COLOR] ,[CR]]$VAR[RecordingSizeLabel]$VAR[ExpirationDateTimeLabel]$INFO[ListItem.Plot,[CR]]</label>
 				<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
-			</control>
-			<control type="textbox">
-				<top>530</top>
-				<width>830</width>
-				<height>340</height>
-				<align>center</align>
-				<font>font27</font>
-				<textcolor>80FFFFFF</textcolor>
-				<label>$LOCALIZE[19055]</label>
-				<visible>String.IsEmpty(Listitem.Plot) + String.IsEmpty(Listitem.Genre)</visible>
 			</control>
 		</control>
 		<control type="group">
 			<visible>ListItem.IsFolder</visible>
-			<top>180</top>
+			<top>100</top>
 			<control type="label">
 				<top>10</top>
 				<width>830</width>

--- a/addons/skin.estuary/xml/MyPVRChannels.xml
+++ b/addons/skin.estuary/xml/MyPVRChannels.xml
@@ -12,222 +12,42 @@
 				<include>OpenClose_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<right>918</right>
-					<bottom>list_y_offset</bottom>
-					<movement>3</movement>
-					<focusposition>5</focusposition>
-					<scrolltime tween="cubic" easing="out">500</scrolltime>
-					<orientation>vertical</orientation>
+					<bottom>80</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
 					<onup>50</onup>
 					<ondown>50</ondown>
-					<viewtype label="535">list</viewtype>
-					<preloaditems>1</preloaditems>
+					<movement>4</movement>
+					<focusposition>4</focusposition>
 					<pagecontrol>73</pagecontrol>
-					<focusedlayout height="90">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<right>0</right>
-							<bottom>0</bottom>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.hasFocus(50)</visible>
-						</control>
-						<control type="image">
-							<right>20</right>
-							<top>10</top>
-							<width>80</width>
-							<height>70</height>
-							<aspectratio align="right">keep</aspectratio>
-							<texture>$INFO[listitem.icon]</texture>
-						</control>
-						<control type="progress">
-							<left>105</left>
-							<top>58</top>
-							<width>50</width>
-							<height>12</height>
-							<midtexture border="3">progress/texturebg_white.png</midtexture>
-							<visible>ListItem.HasEpg</visible>
-							<info>ListItem.Progress</info>
-						</control>
-						<control type="image">
-							<right>110</right>
-							<top>25</top>
-							<width>40</width>
-							<height>40</height>
-							<texture>$VAR[PVRStatusImageVar]</texture>
-						</control>
-						<control type="label">
-							<left>105</left>
-							<top>8</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font14</font>
-							<animation effect="slide" start="0,0" end="0,14" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
-							<label>$INFO[ListItem.Label]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>165</left>
-							<top>46</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>10</left>
-							<top>0</top>
-							<height>90</height>
-							<width>82</width>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font32_title</font>
-							<label>$INFO[ListItem.ChannelNumberLabel]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</focusedlayout>
-					<itemlayout height="90">
-						<control type="image">
-							<right>20</right>
-							<top>10</top>
-							<width>80</width>
-							<height>70</height>
-							<aspectratio align="right">keep</aspectratio>
-							<texture>$INFO[listitem.icon]</texture>
-						</control>
-						<control type="progress">
-							<left>105</left>
-							<top>58</top>
-							<width>50</width>
-							<height>12</height>
-							<colordiffuse>88FFFFFF</colordiffuse>
-							<visible>ListItem.HasEpg</visible>
-							<info>ListItem.Progress</info>
-						</control>
-						<control type="image">
-							<right>110</right>
-							<top>25</top>
-							<width>40</width>
-							<height>40</height>
-							<texture>$VAR[PVRStatusImageVar]</texture>
-						</control>
-						<control type="label">
-							<left>105</left>
-							<top>8</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font14</font>
-							<label>$INFO[ListItem.Label]</label>
-							<animation effect="slide" start="0,0" end="0,14" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>165</left>
-							<top>46</top>
-							<height>90</height>
-							<right>120</right>
-							<aligny>top</aligny>
-							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-							<textcolor>grey</textcolor>
-						</control>
-						<control type="label">
-							<left>10</left>
-							<top>0</top>
-							<height>90</height>
-							<width>82</width>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font32_title</font>
-							<label>$INFO[ListItem.ChannelNumberLabel]</label>
-							<textcolor>grey</textcolor>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</itemlayout>
+					<scrolltime tween="cubic" easing="out">500</scrolltime>
+					<viewtype label="535">list</viewtype>
+					<include content="PVRListItemLayouts">
+						<param name="list_id" value="50" />
+						<param name="label1" value="$INFO[ListItem.Label]" />
+						<param name="has_status_icon" value="true" />
+					</include>
 				</control>
 				<control type="fixedlist" id="51">
 					<left>0</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<right>920</right>
-					<bottom>list_y_offset</bottom>
+					<bottom>80</bottom>
 					<movement>4</movement>
-					<focusposition>6</focusposition>
+					<focusposition>4</focusposition>
 					<scrolltime tween="cubic" easing="out">500</scrolltime>
-					<orientation>vertical</orientation>
 					<onleft>9000</onleft>
 					<onright>73</onright>
 					<onup>51</onup>
 					<ondown>51</ondown>
 					<viewtype label="535">list</viewtype>
-					<preloaditems>1</preloaditems>
 					<pagecontrol>73</pagecontrol>
-					<focusedlayout height="70">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<right>0</right>
-							<bottom>0</bottom>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.hasFocus(51)</visible>
-						</control>
-						<control type="progress">
-							<right>10</right>
-							<top>25</top>
-							<width>50</width>
-							<height>12</height>
-							<colordiffuse>88FFFFFF</colordiffuse>
-							<midtexture border="3">progress/texturebg_white.png</midtexture>
-							<visible>ListItem.HasEpg + !ListItem.IsRecording</visible>
-							<info>ListItem.Progress</info>
-						</control>
-						<control type="image">
-							<right>15</right>
-							<top>9</top>
-							<width>40</width>
-							<height>40</height>
-							<texture>$VAR[PVRStatusImageVar]</texture>
-						</control>
-						<control type="label">
-							<left>105</left>
-							<top>0</top>
-							<bottom>0</bottom>
-							<right>90</right>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="label">
-							<left>320</left>
-							<top>0</top>
-							<bottom>0</bottom>
-							<right>90</right>
-							<aligny>center</aligny>
-							<align>right</align>
-							<label>$INFO[ListItem.Title]</label>
-						</control>
-						<control type="label">
-							<left>10</left>
-							<top>0</top>
-							<bottom>0</bottom>
-							<width>82</width>
-							<align>center</align>
-							<aligny>center</aligny>
-							<font>font32_title</font>
-							<label>$INFO[ListItem.ChannelNumberLabel]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</focusedlayout>
 					<itemlayout height="70">
 						<control type="progress">
 							<right>10</right>
-							<top>25</top>
+							<top>30</top>
 							<width>50</width>
 							<height>12</height>
 							<colordiffuse>88FFFFFF</colordiffuse>
@@ -274,6 +94,61 @@
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 					</itemlayout>
+					<focusedlayout height="70">
+						<control type="image">
+							<left>0</left>
+							<top>0</top>
+							<right>0</right>
+							<height>70</height>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<visible>Control.HasFocus(51)</visible>
+						</control>
+						<control type="progress">
+							<right>10</right>
+							<top>30</top>
+							<width>50</width>
+							<height>12</height>
+							<colordiffuse>88FFFFFF</colordiffuse>
+							<midtexture border="3">progress/texturebg_white.png</midtexture>
+							<visible>ListItem.HasEpg + !ListItem.IsRecording</visible>
+							<info>ListItem.Progress</info>
+						</control>
+						<control type="image">
+							<right>15</right>
+							<top>9</top>
+							<width>40</width>
+							<height>40</height>
+							<texture>$VAR[PVRStatusImageVar]</texture>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>90</right>
+							<aligny>center</aligny>
+							<label>$INFO[ListItem.Label]</label>
+						</control>
+						<control type="label">
+							<left>320</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>90</right>
+							<aligny>center</aligny>
+							<align>right</align>
+							<label>$INFO[ListItem.Title]</label>
+						</control>
+						<control type="label">
+							<left>10</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<width>82</width>
+							<align>center</align>
+							<aligny>center</aligny>
+							<font>font32_title</font>
+							<label>$INFO[ListItem.ChannelNumberLabel]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+					</focusedlayout>
 				</control>
 			</control>
 			<control type="group">
@@ -289,9 +164,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<width>12</width>
-					<bottom>list_y_offset</bottom>
+					<bottom>80</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>
@@ -311,8 +186,7 @@
 				<bottom>10</bottom>
 				<width>850</width>
 				<height>60</height>
-				<visible>!String.isempty(ListItem.NextTitle)</visible>
-				<label>[COLOR grey]$LOCALIZE[19031]:[/COLOR] $INFO[ListItem.NextStartTime]: $INFO[ListItem.NextTitle]</label>
+				<label>$VAR[PVRNextProgrammeLabel]</label>
 				<shadowcolor>black</shadowcolor>
 				<align>right</align>
 				<aligny>center</aligny>

--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -12,80 +12,24 @@
 				<include>OpenClose_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<right>918</right>
-					<bottom>list_y_offset</bottom>
+					<bottom>80</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
 					<onup>50</onup>
 					<ondown>50</ondown>
-					<movement>3</movement>
-					<focusposition>5</focusposition>
+					<movement>4</movement>
+					<focusposition>4</focusposition>
 					<pagecontrol>73</pagecontrol>
-					<scrolltime>200</scrolltime>
-					<focusedlayout height="80">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<right>0</right>
-							<height>80</height>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<animation effect="fade" start="100" end="0" time="0" condition="!Control.HasFocus(50)">Conditional</animation>
-						</control>
-						<control type="image">
-							<left>21</left>
-							<top>30</top>
-							<width>32</width>
-							<height>32</height>
-							<texture colordiffuse="white">$VAR[ListWatchedIconVar]</texture>
-						</control>
-						<control type="label">
-							<left>75</left>
-							<top>0</top>
-							<height>80</height>
-							<right>30</right>
-							<aligny>center</aligny>
-							<scroll>true</scroll>
-							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
-						</control>
-						<control type="label">
-							<left>15</left>
-							<top>0</top>
-							<height>80</height>
-							<right>20</right>
-							<align>right</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
-						</control>
-					</focusedlayout>
-					<itemlayout height="80">
-						<control type="image">
-							<left>21</left>
-							<top>30</top>
-							<width>32</width>
-							<height>32</height>
-							<texture>$VAR[ListWatchedIconVar]</texture>
-						</control>
-						<control type="label">
-							<left>75</left>
-							<top>0</top>
-							<height>80</height>
-							<right>30</right>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
-						</control>
-						<control type="label">
-							<left>15</left>
-							<top>0</top>
-							<height>80</height>
-							<right>20</right>
-							<align>right</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
-							<textcolor>grey</textcolor>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</itemlayout>
+					<scrolltime tween="cubic" easing="out">500</scrolltime>
+					<include content="PVRListItemLayouts">
+						<param name="list_id" value="50" />
+						<param name="info_icon" value="$VAR[ListPVRRecordingsIconVar]" />
+						<param name="has_info_icon" value="true" />
+						<param name="label1" value="$INFO[ListItem.Label]" />
+						<param name="label2" value="$INFO[ListItem.Label2]" />
+					</include>
 				</control>
 			</control>
 			<control type="group">
@@ -101,9 +45,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<width>12</width>
-					<bottom>list_y_offset</bottom>
+					<bottom>80</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/MyPVRSearch.xml
+++ b/addons/skin.estuary/xml/MyPVRSearch.xml
@@ -14,107 +14,23 @@
 				<include>Visible_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<right>918</right>
-					<bottom>list_y_offset</bottom>
-					<onup>50</onup>
-					<ondown>50</ondown>
+					<bottom>80</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
-					<movement>2</movement>
-					<focusposition>3</focusposition>
+					<onup>50</onup>
+					<ondown>50</ondown>
+					<movement>4</movement>
+					<focusposition>4</focusposition>
 					<pagecontrol>73</pagecontrol>
-					<scrolltime>200</scrolltime>
-					<itemlayout height="100">
-						<control type="label">
-							<visible>String.IsEmpty(ListItem.Date)</visible>
-							<left>120</left>
-							<top>0</top>
-							<right>30</right>
-							<height>100</height>
-							<font>font36_title</font>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="group">
-							<visible>!String.IsEmpty(ListItem.Date)</visible>
-							<control type="image">
-								<left>25</left>
-								<top>10</top>
-								<width>80</width>
-								<height>80</height>
-								<texture fallback="DefaultTVShows.png">$INFO[Listitem.ActualIcon]</texture>
-								<aspectratio>keep</aspectratio>
-								<visible>!String.IsEmpty(ListItem.ActualIcon)</visible>
-							</control>
-							<control type="label">
-								<left>120</left>
-								<top>10</top>
-								<right>30</right>
-								<height>100</height>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.ChannelName][COLOR grey]$INFO[ListItem.Label, - ][/COLOR]</label>
-							</control>
-							<control type="label">
-								<left>120</left>
-								<top>20</top>
-								<width>350</width>
-								<height>100</height>
-								<font>font12</font>
-								<aligny>center</aligny>
-								<label>$INFO[ListItem.Date]</label>
-							</control>
-						</control>
-					</itemlayout>
-					<focusedlayout height="100">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<right>0</right>
-							<height>101</height>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.HasFocus(50)</visible>
-						</control>
-						<control type="label">
-							<visible>String.IsEmpty(ListItem.Date)</visible>
-							<left>120</left>
-							<top>0</top>
-							<right>30</right>
-							<height>100</height>
-							<font>font36_title</font>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="group">
-							<visible>!String.IsEmpty(ListItem.Date)</visible>
-							<control type="image">
-								<left>25</left>
-								<top>10</top>
-								<width>80</width>
-								<height>80</height>
-								<texture fallback="DefaultTVShows.png">$INFO[Listitem.ActualIcon]</texture>
-								<aspectratio>keep</aspectratio>
-								<visible>!String.IsEmpty(ListItem.ActualIcon)</visible>
-							</control>
-							<control type="label">
-								<left>120</left>
-								<top>10</top>
-								<right>30</right>
-								<height>100</height>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.ChannelName]$INFO[ListItem.Label, - ]</label>
-							</control>
-							<control type="label">
-								<left>120</left>
-								<top>20</top>
-								<width>350</width>
-								<height>100</height>
-								<font>font12</font>
-								<aligny>center</aligny>
-								<label>$INFO[ListItem.Date]</label>
-							</control>
-						</control>
-					</focusedlayout>
+					<scrolltime tween="cubic" easing="out">500</scrolltime>
+					<include content="PVRListItemLayouts">
+						<param name="list_id" value="50" />
+						<param name="only_label_condition" value="String.IsEmpty(ListItem.Date)" />
+						<param name="label1" value="$INFO[ListItem.ChannelName]" />
+						<param name="label2" value="$INFO[ListItem.Date]" />
+					</include>
 				</control>
 			</control>
 			<control type="group">
@@ -130,9 +46,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<width>12</width>
-					<bottom>list_y_offset</bottom>
+					<bottom>80</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/MyPVRTimers.xml
+++ b/addons/skin.estuary/xml/MyPVRTimers.xml
@@ -11,165 +11,25 @@
 				<include>OpenClose_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<right>918</right>
-					<bottom>list_y_offset</bottom>
-					<onup>50</onup>
-					<ondown>50</ondown>
+					<bottom>80</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
-					<movement>3</movement>
+					<onup>50</onup>
+					<ondown>50</ondown>
+					<movement>4</movement>
 					<focusposition>4</focusposition>
 					<pagecontrol>73</pagecontrol>
-					<scrolltime>200</scrolltime>
-					<itemlayout height="100">
-						<control type="label">
-							<left>30</left>
-							<top>0</top>
-							<right>30</right>
-							<height>100</height>
-							<font>font36_title</font>
-							<aligny>center</aligny>
-							<visible>String.IsEmpty(ListItem.Date)</visible>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="group">
-							<visible>!String.IsEmpty(ListItem.Date)</visible>
-							<control type="image">
-								<left>10</left>
-								<top>18</top>
-								<width>40</width>
-								<height>30</height>
-								<aspectratio align="left">keep</aspectratio>
-								<texture>icons/pvr/timers/recording.png</texture>
-								<visible>!ListItem.HasReminder</visible>
-							</control>
-							<control type="image">
-								<left>10</left>
-								<top>18</top>
-								<width>40</width>
-								<height>30</height>
-								<aspectratio align="left">keep</aspectratio>
-								<texture>icons/pvr/timers/bell.png</texture>
-								<visible>ListItem.HasReminder</visible>
-							</control>
-							<control type="label">
-								<left>50</left>
-								<top>10</top>
-								<right>30</right>
-								<height>30</height>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.ChannelName][COLOR grey]$INFO[ListItem.Label, - ][/COLOR]</label>
-							</control>
-							<control type="label">
-								<left>50</left>
-								<top>53</top>
-								<width>680</width>
-								<height>30</height>
-								<font>font12</font>
-								<aligny>top</aligny>
-								<label>$VAR[TimersSubLabel]</label>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<top>13</top>
-								<width>900</width>
-								<height>70</height>
-								<font>font12</font>
-								<align>right</align>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.Comment]</label>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<top>53</top>
-								<width>900</width>
-								<height>75</height>
-								<font>font12</font>
-								<align>right</align>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.Date]</label>
-							</control>
-						</control>
-					</itemlayout>
-					<focusedlayout height="100">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<right>0</right>
-							<height>101</height>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.HasFocus(50)</visible>
-						</control>
-						<control type="label">
-							<left>30</left>
-							<top>0</top>
-							<right>30</right>
-							<height>100</height>
-							<font>font36_title</font>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-							<visible>String.IsEmpty(ListItem.Date)</visible>
-						</control>
-						<control type="group">
-							<visible>!String.IsEmpty(ListItem.Date)</visible>
-							<control type="image">
-								<left>10</left>
-								<top>18</top>
-								<width>40</width>
-								<height>30</height>
-								<aspectratio align="left">keep</aspectratio>
-								<texture>icons/pvr/timers/recording.png</texture>
-								<visible>!ListItem.HasReminder</visible>
-							</control>
-							<control type="image">
-								<left>10</left>
-								<top>18</top>
-								<width>40</width>
-								<height>30</height>
-								<aspectratio align="left">keep</aspectratio>
-								<texture>icons/pvr/timers/bell.png</texture>
-								<visible>ListItem.HasReminder</visible>
-							</control>
-							<control type="label">
-								<left>50</left>
-								<top>10</top>
-								<right>30</right>
-								<height>100</height>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.ChannelName]$INFO[ListItem.Label, - ]</label>
-							</control>
-							<control type="label">
-								<left>50</left>
-								<top>53</top>
-								<width>680</width>
-								<height>100</height>
-								<font>font12</font>
-								<aligny>top</aligny>
-								<label>$VAR[TimersSubLabel]</label>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<top>13</top>
-								<width>900</width>
-								<height>70</height>
-								<font>font12</font>
-								<align>right</align>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.Comment]</label>
-							</control>
-							<control type="label">
-								<right>20</right>
-								<top>53</top>
-								<width>900</width>
-								<height>75</height>
-								<font>font12</font>
-								<align>right</align>
-								<aligny>top</aligny>
-								<label>$INFO[ListItem.Date]</label>
-							</control>
-						</control>
-					</focusedlayout>
+					<scrolltime tween="cubic" easing="out">500</scrolltime>
+					<include content="PVRListItemLayouts">
+						<param name="list_id" value="50" />
+						<param name="only_label_condition" value="String.IsEmpty(ListItem.Date)" />
+						<param name="info_icon" value="$VAR[ListPVRTimersIconVar]" />
+						<param name="has_info_icon" value="true" />
+						<param name="label1" value="$INFO[ListItem.Label]" />
+						<param name="label2" value="$INFO[ListItem.Date]" />
+					</include>
 				</control>
 			</control>
 			<control type="group">
@@ -185,9 +45,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>list_y_offset</top>
+					<top>100</top>
 					<width>12</width>
-					<bottom>list_y_offset</bottom>
+					<bottom>80</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -4,6 +4,7 @@
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.HasTimer | ListItem.HasTimerSchedule">windows/pvr/timer.png</value>
 		<value condition="ListItem.HasArchive">windows/pvr/archive.png</value>
+		<value condition="ListItem.HasReminder">icons/pvr/timers/bell.png</value>
 	</variable>
 	<variable name="AutoCompletionContentVar">
 		<value condition="System.AddonIsEnabled(plugin.program.autocompletion) + !System.HasHiddenInput">plugin://plugin.program.autocompletion?info=autocomplete&amp;&amp;id=$INFO[Control.GetLabel(312).index(1)]&amp;&amp;limit=9</value>
@@ -399,6 +400,17 @@
 		<value condition="ListItem.HasArchive">windows/pvr/archive.png</value>
 		<value condition="Integer.IsGreater(ListItem.Playcount,0)">$INFO[ListItem.Overlay]</value>
 	</variable>
+	<variable name="ListPVRRecordingsIconVar">
+		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
+		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
+		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>
+		<value condition="!ListItem.IsParentFolder">OverlayUnwatched.png</value>
+	</variable>
+	<variable name="ListPVRTimersIconVar">
+		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
+		<value condition="ListItem.HasReminder">icons/pvr/timers/bell.png</value>
+		<value>icons/pvr/timers/recording.png</value>
+  </variable>
 	<!-- Breadcrumbs -->
 	<variable name="BreadcrumbsVideoVar">
 		<value condition="Container.Content(movies) | String.StartsWith(container.folderpath,library://video/movies/) | String.StartsWith(container.folderpath,videodb://movies)">$LOCALIZE[20342]</value>
@@ -520,11 +532,6 @@
 		<value condition="ListItem.IsNew + String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode) + String.IsEmpty(ListItem.EpisodeName)">[B][COLOR button_focus]$LOCALIZE[842][/COLOR][/B]</value>
 		<value condition="ListItem.IsNew">[B][COLOR button_focus]$LOCALIZE[842][/COLOR][/B] - </value>
 	</variable>
-	<variable name="DateDurationLabel">
-		<value condition="[Window.IsActive(tvrecordings) | Window.IsActive(radiorecordings)] + Container.SortMethod(3) + String.IsEmpty(ListItem.ExpirationDate)">$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ,[CR]]</value>
-		<value condition="[Window.IsActive(tvrecordings) | Window.IsActive(radiorecordings)] + [Container.SortMethod(3) | Container.SortMethod(9)]">$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]</value>
-		<value>$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ,[CR]]</value>
-	</variable>
 	<variable name="RecordingSizeLabel">
 		<value condition="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0 B)">$INFO[ListItem.Size,[COLOR grey]$LOCALIZE[22031]:[/COLOR] ,[CR]]</value>
 	</variable>
@@ -542,9 +549,25 @@
 	<variable name="AddonNewsVar">
 		<value condition="!String.IsEmpty(ListItem.AddonNews)">$LOCALIZE[31136]</value>
 	</variable>
-	<variable name="TimersSubLabel">
-		<value condition="[Window.IsActive(tvtimerrules) | Window.IsActive(radiotimerrules)] + !ListItem.HasTimerSchedule">$INFO[ListItem.Timertype]</value>
-		<value>$INFO[ListItem.EpisodeName]</value>
+	<variable name="PVRNextProgrammeLabel">
+		<value condition="!String.IsEmpty(ListItem.NextStartTime) + !String.IsEmpty(ListItem.NextTitle)">[COLOR grey]$LOCALIZE[19031]:[/COLOR] $INFO[ListItem.NextStartTime]: $INFO[ListItem.NextTitle]</value>
+		<value condition="!String.IsEmpty(ListItem.NextTitle)">[COLOR grey]$LOCALIZE[19031]:[/COLOR] $INFO[ListItem.NextTitle]</value>
+	</variable>
+	<variable name="PVRListItemSubLabel">
+		<value condition="ListItem.IsFolder">[COLOR grey]$INFO[ListItem.Timertype][/COLOR]</value>
+		<value condition="$EXP[listitem_has_episode_info] + !String.IsEmpty(ListItem.EpgEventTitle) + !String.StartsWith(ListItem.EpisodeName,ListItem.EpgEventTitle)">$INFO[ListItem.EpgEventTitle] | [COLOR grey]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/COLOR]</value>
+		<value condition="$EXP[listitem_has_episode_info]">[COLOR grey]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/COLOR]</value>
+		<value>$INFO[ListItem.EpgEventTitle]</value>
+	</variable>
+	<variable name="PVRListItemSubLabelFocused">
+		<value condition="ListItem.IsFolder">$INFO[ListItem.Timertype]</value>
+		<value condition="$EXP[listitem_has_episode_info] + !String.IsEmpty(ListItem.EpgEventTitle) + !String.StartsWith(ListItem.EpisodeName,ListItem.EpgEventTitle)">$INFO[ListItem.EpgEventTitle] | $VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName]</value>
+		<value condition="$EXP[listitem_has_episode_info]">$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName]</value>
+		<value>$INFO[ListItem.EpgEventTitle]</value>
+	</variable>
+	<variable name="PVRInfoPanelDateDurationLabel">
+		<value condition="!String.IsEmpty(ListItem.StartDate) + !String.IsEmpty(ListItem.StartTime)">$INFO[ListItem.StartDate,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.StartTime,[COLOR grey]$LOCALIZE[555]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ]</value>
+		<value>$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ]</value>
 	</variable>
 	<variable name="BackgroundOverlayTypeVar">
 		<value condition="String.IsEqual(Skin.String(background_overlay),0)">$LOCALIZE[231]</value>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -444,6 +444,11 @@
 		<value condition="Window.IsActive(TVSearch)">$LOCALIZE[19020] / $LOCALIZE[137]</value>
 		<value>$LOCALIZE[19021] / $LOCALIZE[137]</value>
 	</variable>
+	<variable name="BreadcrumbsPVRChannelsOSDVar">
+		<value condition="PVR.IsPlayingTV">$LOCALIZE[19020] / $LOCALIZE[19019] / $INFO[VideoPlayer.ChannelGroup]</value>
+		<value condition="PVR.IsPlayingRadio">$LOCALIZE[19021] / $LOCALIZE[19019] / $INFO[VideoPlayer.ChannelGroup]</value>
+		<value>$LOCALIZE[19019] / $INFO[VideoPlayer.ChannelGroup]</value>
+	</variable>
 	<variable name="BreadcrumbsGameVar">
 		<value>$LOCALIZE[15016]</value>
 	</variable>


### PR DESCRIPTION
This PR reworks PVR channels, recordings, timers, timer rules and search windows, plus the channels OSD dialog to share a common layout. Before, every window had its own implementation which led to smaller or larger visual inconsistencies.

Channels OSD dialog:
![screenshot00010](https://user-images.githubusercontent.com/3226626/112474271-af7ca580-8d6f-11eb-9d2e-1fd44d348e63.png)

Channels window:
![screenshot00004](https://user-images.githubusercontent.com/3226626/112474329-c4f1cf80-8d6f-11eb-91aa-72f64e7badeb.png)

Search results window:
![screenshot00009](https://user-images.githubusercontent.com/3226626/112474278-b3102c80-8d6f-11eb-9d88-12aebe2b8a2b.png)

Timer rules window:
![screenshot00008](https://user-images.githubusercontent.com/3226626/112474309-c28f7580-8d6f-11eb-90e6-4c2d9eadd2bc.png)

Timers window:
![screenshot00007](https://user-images.githubusercontent.com/3226626/112474316-c3280c00-8d6f-11eb-97da-87e2ff2eb44d.png)

Recordings window:
![screenshot00005](https://user-images.githubusercontent.com/3226626/112474325-c4593900-8d6f-11eb-9ddf-85bb559acd2e.png)

