### PR TITLE
Linux meminfo: use MemAvailable when possible

### DIFF
--- a/xbmc/platform/linux/MemUtils.cpp
+++ b/xbmc/platform/linux/MemUtils.cpp
@@ -44,6 +44,7 @@ void GetMemoryStatus(MemoryStatus* buffer)
   uint64_t free;
   uint64_t total;
   uint64_t reclaimable;
+  uint64_t available = 0;
 
   std::string token;
 
@@ -59,10 +60,13 @@ void GetMemoryStatus(MemoryStatus* buffer)
       file >> total;
     if (token == "SReclaimable:")
       file >> reclaimable;
+    if (token == "MemAvailable:")
+      file >> available;
   }
 
   buffer->totalPhys = total * 1024;
-  buffer->availPhys = (free + cached + reclaimable + buffers) * 1024;
+  buffer->availPhys =
+      available > 0 ? available * 1024 : (free + cached + reclaimable + buffers) * 1024;
 }
 
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Recent Linux kernels (well, since 3.2) do report the available memory in "MemAvailable:" of /proc/meminfo. Use it if possible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The is a bug report in LibreELEC forum: https://forum.libreelec.tv/thread/23014-kodi-system-info-summary-free-memory-value-too-optimistic/

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Using Matrix HEAD on my x86-64 desktop.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
