### PR TITLE
[PVR] Guide window: Fix playing archived programme not selected on window init.

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRGuideControls.xml
+++ b/addons/skin.estuary/xml/DialogPVRGuideControls.xml
@@ -124,7 +124,7 @@
 							</include>
 							<animation effect="rotate" start="0" end="-90" center="auto" condition="true">Conditional</animation>
 							<onclick>PVR.EpgGridControl(PlayingChannel)</onclick>
-							<visible>PVR.IsPlayingTV | PVR.IsPlayingRadio</visible>
+							<visible>PVR.IsPlayingTV | PVR.IsPlayingRadio | PVR.IsPlayingEpgTag</visible>
 						</control>
 						<control type="radiobutton" id="70042">
 							<include content="OSDButton">

--- a/xbmc/interfaces/builtins/PVRBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PVRBuiltins.cpp
@@ -120,7 +120,7 @@ int EpgGridControl(const std::vector<std::string>& params)
   }
   else if (param == "currentprogramme")
   {
-    guideWindow->GotoNow();
+    guideWindow->GotoCurrentProgramme();
   }
   else if (param == "selectdate")
   {

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -404,6 +404,20 @@ std::shared_ptr<CPVRChannelGroup> CPVRPlaybackState::GetPlayingGroup(bool bRadio
   return CServiceBroker::GetPVRManager().ChannelGroups()->GetSelectedGroup(bRadio);
 }
 
+CDateTime CPVRPlaybackState::GetPlaybackTime(int iClientID, int iUniqueChannelID) const
+{
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = GetPlayingEpgTag();
+  if (epgTag && iClientID == epgTag->ClientID() && iUniqueChannelID == epgTag->UniqueChannelID())
+  {
+    // playing an epg tag on requested channel
+    return epgTag->StartAsUTC() +
+           CDateTimeSpan(0, 0, 0, CServiceBroker::GetDataCacheCore().GetPlayTime() / 1000);
+  }
+
+  // not playing / playing live / playing timeshifted
+  return GetChannelPlaybackTime(iClientID, iUniqueChannelID);
+}
+
 CDateTime CPVRPlaybackState::GetChannelPlaybackTime(int iClientID, int iUniqueChannelID) const
 {
   if (IsPlayingChannel(iClientID, iUniqueChannelID))

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -204,6 +204,15 @@ public:
   std::shared_ptr<CPVRChannelGroup> GetPlayingGroup(bool bRadio) const;
 
   /*!
+   * @brief Get current playback time for the given channel, taking timeshifting and playing
+   * epg tags into account.
+   * @param iClientID The client id.
+   * @param iUniqueChannelID The channel uid.
+   * @return The playback time or 'now' if not playing.
+   */
+  CDateTime GetPlaybackTime(int iClientID, int iUniqueChannelID) const;
+
+  /*!
    * @brief Get current playback time for the given channel, taking timeshifting into account.
    * @param iClientID The client id.
    * @param iUniqueChannelID The channel uid.

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1678,6 +1678,12 @@ void CGUIEPGGridContainer::JumpToNow()
   GoToNow();
 }
 
+void CGUIEPGGridContainer::JumpToDate(const CDateTime& date)
+{
+  m_bEnableProgrammeScrolling = false;
+  GoToDate(date);
+}
+
 void CGUIEPGGridContainer::GoToBegin()
 {
   ScrollToBlockOffset(0);
@@ -1692,15 +1698,26 @@ void CGUIEPGGridContainer::GoToEnd()
 
 void CGUIEPGGridContainer::GoToNow()
 {
-  ScrollToBlockOffset(m_gridModel->GetNowBlock());
-  SetBlock(m_gridModel->GetPageNowOffset());
+  GoToDate(CDateTime::GetUTCDateTime());
 }
 
 void CGUIEPGGridContainer::GoToDate(const CDateTime& date)
 {
   unsigned int offset = m_gridModel->GetPageNowOffset();
   ScrollToBlockOffset(m_gridModel->GetBlock(date) - offset);
-  SetBlock(offset);
+
+  // ensure we're selecting the active event, not its predecessor.
+  const int iChannel = m_channelOffset + m_channelCursor;
+  const int iBlock = m_blockOffset + offset;
+  if (iChannel >= m_gridModel->ChannelItemsSize() || iBlock >= m_gridModel->GridItemsSize() ||
+      m_gridModel->GetGridItemEndTime(iChannel, iBlock) > date)
+  {
+    SetBlock(offset);
+  }
+  else
+  {
+    SetBlock(offset + 1);
+  }
 }
 
 void CGUIEPGGridContainer::GoToFirstChannel()

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -85,6 +85,7 @@ namespace PVR
     void SetRenderOffset(const CPoint& offset);
 
     void JumpToNow();
+    void JumpToDate(const CDateTime& date);
 
     void GoToBegin();
     void GoToEnd();

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -450,6 +450,11 @@ int CGUIEPGGridContainerModel::GetGridItemEndBlock(int iChannel, int iBlock) con
   return GetGridItemPtr(iChannel, iBlock)->endBlock;
 }
 
+CDateTime CGUIEPGGridContainerModel::GetGridItemEndTime(int iChannel, int iBlock) const
+{
+  return GetGridItemPtr(iChannel, iBlock)->item->GetEPGInfoTag()->EndAsUTC();
+}
+
 float CGUIEPGGridContainerModel::GetGridItemWidth(int iChannel, int iBlock) const
 {
   return GetGridItemPtr(iChannel, iBlock)->width;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -89,6 +89,7 @@ namespace PVR
     std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
     int GetGridItemStartBlock(int iChannel, int iBlock) const;
     int GetGridItemEndBlock(int iChannel, int iBlock) const;
+    CDateTime GetGridItemEndTime(int iChannel, int iBlock) const;
     float GetGridItemWidth(int iChannel, int iBlock) const;
     float GetGridItemOriginWidth(int iChannel, int iBlock) const;
     void DecreaseGridItemWidth(int iChannel, int iBlock, float fSize);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -54,7 +54,7 @@ namespace PVR
 
     bool GotoBegin();
     bool GotoEnd();
-    bool GotoNow();
+    bool GotoCurrentProgramme();
     bool GotoDate(int deltaHours);
     bool OpenDateSelectionDialog();
     bool Go12HoursBack();


### PR DESCRIPTION
Reported in the Forum: https://forum.kodi.tv/showthread.php?tid=361676&pid=3026881#pid3026881

With this PR, if an archived programme is playing when the Guide window is opened, this programme will be selected in the EPG grid. If no programme is playing, the EPG grid will focus 'now', like it does without this PR.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish when you find some time for a code review... 