### PR TITLE
File manager: Locate and browse the samba servers in Linux

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBDirectory.h
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.h
@@ -29,5 +29,6 @@ public:
 
 private:
   int OpenDir(const CURL &url, std::string& strAuth);
+  bool GetServerList(CFileItemList& items);
 };
 }


### PR DESCRIPTION
## Description
This patch tries to recover the functionality of the File manager to **find the samba servers** in a local network and **browse through** their shared folders and subfolders.

This functionality is limited to protocol versions less than or equal to ```SMBv3```. Later on, we should look at how to incorporate ```WS-Discovery``` software.

The patch is based on the command line tool```nmblookup``` to locate servers on a local network.

## How Has This Been Tested?
Ubuntu 20.10
Kodi > File manager > Add source > Browse > Windows network (SMB):
Shows the IP of the two samba servers (a NAS and a RPi) in the local network and I can browse through their shared folders and subfolders.
Add the selected new source.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
