### PR TITLE
[Windows] Fix: black screen with render method Software and without DXVA2 hardware acceleration

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -51,7 +51,10 @@ void CRendererDXVA::GetWeight(std::map<RenderMethod, int>& weights, const VideoP
 
     ComPtr<ID3D11Device> pDevice = DX::DeviceResources::Get()->GetD3DDevice();
     if (FAILED(pDevice->CreateTexture2D(&texDesc, nullptr, nullptr)))
+    {
+      CLog::LogF(LOGWARNING, "Texture format {} is not supported.", dxgi_format);
       return;
+    }
 
     if (av_pixel_format == AV_PIX_FMT_NV12 ||
         av_pixel_format == AV_PIX_FMT_P010 ||

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
@@ -181,10 +181,19 @@ void CRendererSoftware::CRenderBufferImpl::ReleasePicture()
 
 bool CRendererSoftware::CRenderBufferImpl::UploadBuffer()
 {
+  if (!videoBuffer)
+    return false;
+
+  if (videoBuffer->GetFormat() != AV_PIX_FMT_D3D11VA_VLD)
+  {
+    m_bLoaded = true;
+    return true;
+  }
+
   if (!m_staging)
     return false;
 
-  if (videoBuffer->GetFormat() == AV_PIX_FMT_D3D11VA_VLD && m_msr.pData == nullptr)
+  if (m_msr.pData == nullptr)
   {
     // map will finish copying data from GPU to CPU
     m_bLoaded = SUCCEEDED(DX::DeviceResources::Get()->GetImmediateContext()->Map(


### PR DESCRIPTION
## Description
- Fix: black screen with render method Software and without DXVA2 hardware acceleration.
- Fixes https://github.com/xbmc/xbmc/issues/19480
- Also helps mitigate https://github.com/xbmc/xbmc/issues/18902 when DXVA and PS rendering methods are not available for whatever reason.

## Motivation and Context
See: https://github.com/xbmc/xbmc/issues/19480

Render Software with DXVA2=off does not need to use "staging texture" because both video decoding and rendering is processed in CPU. Then `m_staging` is always nullptr and `UploadBuffer()` retuns always false:

https://github.com/xbmc/xbmc/blob/5f8667f1e5b3d45cc0750129252e191674b7b559/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp#L182-L195


This causes `CRendererBase::Render()` returns without rendering (L229):

https://github.com/xbmc/xbmc/blob/5f8667f1e5b3d45cc0750129252e191674b7b559/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp#L220-L232


The fix consists on return true when pixel format is not `AV_PIX_FMT_D3D11VA_VLD`:
```c++
    m_bLoaded = true;
    return true;
```
Also is added `videoBuffer` nullptr check because I experimented some crash debugging this as `videoBuffer` is accessed before it's initialized on some circumstances.

The log line added to `RendererDXVA.cpp` has no direct relationship with this patch, although it helps a lot to understand when the software rendering method is chosen because DXVA is not available.


## How Has This Been Tested?
Runtime tested.
Also tested with DXVA2 decoding enabled to verify that it still works as before.
Original bug reporter also confirmed issue is fixed with this patch: https://github.com/xbmc/xbmc/issues/19480#issuecomment-809382928


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
