### PR TITLE
Fixed display sleep when idle if monitor is connected via displayport,…

### DIFF
--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -316,12 +316,19 @@ bool CWinEventsX11::MessagePump()
       if (rrEvent->subtype == RRNotify_OutputChange)
       {
         XRROutputChangeNotifyEvent* changeEvent = reinterpret_cast<XRROutputChangeNotifyEvent*>(&xevent);
-        if (changeEvent->connection == RR_Connected ||
-            changeEvent->connection == RR_Disconnected)
+        if (changeEvent->connection == RR_Connected || changeEvent->connection == RR_Disconnected)
         {
-          m_winSystem.NotifyXRREvent();
-          CServiceBroker::GetActiveAE()->DeviceChange();
+          if (m_xrrIgnoreConnectTimer.IsTimePast())
+          {
+            m_winSystem.NotifyXRREvent();
+            CServiceBroker::GetActiveAE()->DeviceChange();
+          }
+          else
+          {
+            CLog::Log(LOGDEBUG,"CWinEventsX11 - skip NotifyXRREvent since RR_Connected/RR_Disconnected handled recently");
+          }
           serial = xevent.xgeneric.serial;
+          m_xrrIgnoreConnectTimer.Set(10000);
         }
       }
 

--- a/xbmc/windowing/X11/WinEventsX11.h
+++ b/xbmc/windowing/X11/WinEventsX11.h
@@ -51,6 +51,7 @@ protected:
   bool m_structureChanged;
   int m_RREventBase;
   XbmcThreads::EndTime m_xrrFailSafeTimer;
+  XbmcThreads::EndTime m_xrrIgnoreConnectTimer;
   bool m_xrrEventPending;
   CWinSystemX11& m_winSystem;
 };


### PR DESCRIPTION
… issue #19479

## Description
The 'put display to sleep when idle' feature does not work as expected if monitor is connected to displayport. The display turns off. But after 3 seconds it turns on again and so on.

## Motivation and Context
This is caused since there are more XEvents fired if displays are connected via Displayport, especially there is another RR_Connected event even if display is going to sleep. 

For further describtion see #19479

## How Has This Been Tested?
Tested on my machine with display connected via Displayport. 

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
