### PR TITLE
[Windows] Implements WS-Discovery protocol and enables browse SMB shares

### DIFF
--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -18,6 +18,7 @@
 
 #include "platform/win32/CharsetConverter.h"
 #include "platform/win32/WIN32Util.h"
+#include "platform/win32/network/WSDiscoveryWin32.h"
 
 #include <Windows.h>
 #include <Winnetwk.h>
@@ -50,6 +51,7 @@ static inline bool worthTryToConnect(const DWORD lastErr)
 */
 static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, const std::string& urlPrefixForItems, CFileItemList& items, bool getShares);
 static bool localGetShares(const std::wstring& serverNameToScan, const std::string& urlPrefixForItems, CFileItemList& items);
+static bool localWSDiscovery(const std::string& urlPrefixForItems, CFileItemList& items);
 
 // check for empty string, remove trailing slash if any, convert to win32 form
 inline static std::wstring prepareWin32SMBDirectoryName(const CURL& url)
@@ -392,9 +394,18 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
     if (localGetShares(basePathToScanPtr->lpRemoteName, urlPrefixForItems, items))
       return true;
 
-    CLog::LogF(LOGINFO,
-               "Can't read shares for \"%ls\" by localGetShares(), fallback to standard method",
+    CLog::LogF(LOGWARNING,
+               "Can't read shares for \"%ls\" by localGetShares(), fallback to old method",
                FromW(basePathToScanPtr->lpRemoteName));
+  }
+
+  // Get servers using WS-Discovery protocol
+  if (!getShares)
+  {
+    if (localWSDiscovery(urlPrefixForItems, items))
+      return true;
+
+    CLog::LogF(LOGWARNING, "Can't locate servers by localWSDiscovery(), fallback to old method");
   }
 
   HANDLE netEnum;
@@ -616,6 +627,39 @@ static bool localGetShares(const std::wstring& serverNameToScan, const std::stri
 
   items.Append(locItems); // all shares loaded, store result
   return true;
+}
+
+// Get servers using WS-Discovery protocol
+static bool localWSDiscovery(const std::string& urlPrefixForItems, CFileItemList& items)
+{
+  CClientNotificationSink* sink = nullptr;
+
+  auto wsd = CWSDiscoverySupport::Get();
+
+  // Get servers immediately from daemon process
+  if (wsd && wsd->IsInitialized())
+  {
+    wsd->GetSink(&sink);
+
+    if (sink && sink->ThereAreServers())
+    {
+      for (const auto& ip : sink->GetServersIPs())
+      {
+        std::wstring hostname = wsd->ResolveHostName(ip);
+        std::string shareNameUtf8;
+        if (g_charsetConverter.wToUTF8(hostname, shareNameUtf8, true) && !shareNameUtf8.empty())
+        {
+          CFileItemPtr pItem = std::make_shared<CFileItem>(shareNameUtf8);
+          pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
+          pItem->m_bIsFolder = true;
+          items.Add(pItem);
+        }
+      }
+      return true;
+    }
+  }
+
+  return false;
 }
 
 bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCredential /*= false*/)

--- a/xbmc/platform/win32/network/CMakeLists.txt
+++ b/xbmc/platform/win32/network/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES NetworkWin32.cpp)
+set(SOURCES NetworkWin32.cpp
+            WSDiscoveryWin32.cpp)
 
-set(HEADERS NetworkWin32.h)
+set(HEADERS NetworkWin32.h
+            WSDiscoveryWin32.h)
 
 core_add_library(platform_win32_network)

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -1,0 +1,271 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WSDiscoveryWin32.h"
+
+#include "threads/SingleLock.h"
+#include "utils/log.h"
+
+#include "platform/win32/CharsetConverter.h"
+
+#include <windns.h>
+#pragma comment(lib, "dnsapi.lib")
+
+using KODI::PLATFORM::WINDOWS::FromW;
+
+
+HRESULT CClientNotificationSink::Create(CClientNotificationSink** sink)
+{
+  CClientNotificationSink* tempSink = nullptr;
+
+  if (!sink)
+    return E_POINTER;
+
+  tempSink = new CClientNotificationSink();
+
+  if (!tempSink)
+    return E_OUTOFMEMORY;
+
+  *sink = tempSink;
+  tempSink = nullptr;
+
+  return S_OK;
+}
+
+CClientNotificationSink::CClientNotificationSink() : m_cRef(1)
+{
+}
+
+CClientNotificationSink::~CClientNotificationSink()
+{
+}
+
+HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* service)
+{
+  if (!service)
+    return E_INVALIDARG;
+
+  CSingleLock lock(m_criticalSection);
+
+  WSD_NAME_LIST* list = nullptr;
+  service->GetTypes(&list);
+
+  LPCWSTR address = nullptr;
+  service->GetRemoteTransportAddress(&address);
+
+  if (list && address)
+  {
+    std::wstring type(list->Next->Element->LocalName);
+    std::wstring addr(address);
+
+    CLog::Log(LOGINFO,
+              "[WS-Discovery]: HELLO packet received: device type = '{}', device address = '{}'",
+              FromW(type), FromW(addr));
+
+    // filter Printers and other devices that are not "Computers"
+    if (type == L"Computer")
+    {
+      std::wstring addr(address);
+      const std::wstring ip = addr.substr(0, addr.find(L":", 0));
+
+      auto it = std::find(m_serversIPs.begin(), m_serversIPs.end(), ip);
+
+      // inserts server IP if not exist in list
+      if (it == m_serversIPs.end())
+      {
+        m_serversIPs.push_back(ip);
+        CLog::Log(LOGINFO, "[WS-Discovery]: IP '{}' has been inserted into the server list.",
+                  FromW(ip));
+      }
+    }
+  }
+
+  return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* service)
+{
+  if (!service)
+    return E_INVALIDARG;
+
+  CSingleLock lock(m_criticalSection);
+
+  LPCWSTR address = nullptr;
+  service->GetRemoteTransportAddress(&address);
+
+  if (address)
+  {
+    std::wstring addr(address);
+
+    CLog::Log(LOGINFO, "[WS-Discovery]: BYE packet received: device address = '{}'", FromW(addr));
+
+    const std::wstring ip = addr.substr(0, addr.find(L":", 0));
+    auto it = std::find(m_serversIPs.begin(), m_serversIPs.end(), ip);
+
+    // removes server IP from list
+    if (it != m_serversIPs.end())
+    {
+      m_serversIPs.erase(it);
+      CLog::Log(LOGINFO, "[WS-Discovery]: IP '{}' has been removed from the server list.",
+                FromW(ip));
+    }
+  }
+
+  return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchFailed(HRESULT hr, LPCWSTR tag)
+{
+  CSingleLock lock(m_criticalSection);
+
+  CLog::Log(LOGINFO,
+            "[WS-Discovery]: The initial search for servers has failed. No servers found.");
+
+  return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchComplete(LPCWSTR tag)
+{
+  CSingleLock lock(m_criticalSection);
+
+  CLog::Log(LOGINFO,
+            "[WS-Discovery]: The initial servers search has completed successfully with {} "
+            "server(s) found:",
+            m_serversIPs.size());
+
+  for (const auto& ip : GetServersIPs())
+    CLog::Log(LOGINFO, "    {}", FromW(ip));
+
+  return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CClientNotificationSink::QueryInterface(REFIID riid, void** object)
+{
+  if (!object)
+    return E_POINTER;
+
+  *object = nullptr;
+
+  if (__uuidof(IWSDiscoveryProviderNotify) == riid)
+    *object = static_cast<IWSDiscoveryProviderNotify*>(this);
+  else if (__uuidof(IUnknown) == riid)
+    *object = static_cast<IUnknown*>(this);
+  else
+    return E_NOINTERFACE;
+
+  ((LPUNKNOWN)*object)->AddRef();
+
+  return S_OK;
+}
+
+ULONG STDMETHODCALLTYPE CClientNotificationSink::AddRef()
+{
+  ULONG newRefCount = InterlockedIncrement(&m_cRef);
+
+  return newRefCount;
+}
+
+ULONG STDMETHODCALLTYPE CClientNotificationSink::Release()
+{
+  ULONG newRefCount = InterlockedDecrement(&m_cRef);
+
+  if (!newRefCount)
+    delete this;
+
+  return newRefCount;
+}
+
+//==================================================================================
+
+std::shared_ptr<CWSDiscoverySupport> CWSDiscoverySupport::Get()
+{
+  static std::shared_ptr<CWSDiscoverySupport> sWSD(new CWSDiscoverySupport);
+  return sWSD;
+}
+
+CWSDiscoverySupport::CWSDiscoverySupport()
+{
+  Initialize();
+}
+
+CWSDiscoverySupport::~CWSDiscoverySupport()
+{
+  Terminate();
+}
+
+bool CWSDiscoverySupport::Initialize()
+{
+  if (m_initialized)
+    return true;
+
+  if (S_OK == WSDCreateDiscoveryProvider(nullptr, &m_provider))
+  {
+    m_provider->SetAddressFamily(WSDAPI_ADDRESSFAMILY_IPV4);
+
+    if (S_OK == CClientNotificationSink::Create(&m_sink))
+    {
+      if (S_OK == m_provider->Attach(m_sink))
+      {
+        if (S_OK == m_provider->SearchByType(nullptr, nullptr, nullptr, nullptr))
+        {
+          m_initialized = true;
+          CLog::Log(LOGINFO, "[WS-Discovery]: Daemon initialized successfully. Now are listening "
+                             "HELLO and BYE packets from LAN.");
+          return true;
+        }
+      }
+    }
+  }
+
+  // if get here something has gone wrong
+  CLog::Log(LOGERROR, "[WS-Discovery]: Daemon initialization has failed.");
+
+  Terminate();
+
+  return false;
+}
+
+void CWSDiscoverySupport::Terminate()
+{
+  if (m_initialized)
+  {
+    CLog::Log(LOGINFO, "[WS-Discovery]: terminate...");
+    m_initialized = false;
+  }
+  if (m_provider)
+  {
+    m_provider->Detach();
+    m_provider->Release();
+    m_provider = nullptr;
+  }
+  if (m_sink)
+  {
+    m_sink->Release();
+    m_sink = nullptr;
+  }
+}
+
+std::wstring CWSDiscoverySupport::ResolveHostName(std::wstring server_ip)
+{
+  std::wstring hostname = server_ip;
+  std::vector<std::string> ip = StringUtils::Split(FromW(server_ip), '.', 4);
+  std::string reverse = StringUtils::Format("{}.{}.{}.{}.IN-ADDR.ARPA", ip[3], ip[2], ip[1], ip[0]);
+
+  PDNS_RECORD pDnsRecord = nullptr;
+
+  if (!DnsQuery_W(KODI::PLATFORM::WINDOWS::ToW(reverse).c_str(), DNS_TYPE_PTR, DNS_QUERY_STANDARD,
+                  nullptr, &pDnsRecord, nullptr) &&
+      pDnsRecord)
+  {
+    hostname = pDnsRecord->Data.PTR.pNameHost;
+  }
+
+  DnsRecordListFree(pDnsRecord, freetype);
+
+  return hostname;
+}

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.h
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.h
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+
+#include <wsdapi.h>
+#pragma comment(lib, "wsdapi.lib")
+
+#include <vector>
+
+
+class CClientNotificationSink : public IWSDiscoveryProviderNotify
+{
+public:
+  CClientNotificationSink();
+  virtual ~CClientNotificationSink();
+
+  static HRESULT Create(CClientNotificationSink** sink);
+
+  HRESULT STDMETHODCALLTYPE Add(IWSDiscoveredService* service);
+  HRESULT STDMETHODCALLTYPE Remove(IWSDiscoveredService* service);
+  HRESULT STDMETHODCALLTYPE SearchFailed(HRESULT hr, LPCWSTR tag);
+  HRESULT STDMETHODCALLTYPE SearchComplete(LPCWSTR tag);
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** object);
+  ULONG STDMETHODCALLTYPE AddRef();
+  ULONG STDMETHODCALLTYPE Release();
+
+  bool ThereAreServers() { return m_serversIPs.size(); };
+  std::vector<std::wstring> GetServersIPs() { return m_serversIPs; }
+
+private:
+  std::vector<std::wstring> m_serversIPs;
+  ULONG m_cRef;
+  CCriticalSection m_criticalSection;
+};
+
+class CWSDiscoverySupport
+{
+public:
+  CWSDiscoverySupport();
+  virtual ~CWSDiscoverySupport();
+
+  static std::shared_ptr<CWSDiscoverySupport> Get();
+
+  bool Initialize();
+  void Terminate();
+
+  bool IsInitialized() { return m_initialized; }
+  void GetSink(CClientNotificationSink** sink) { *sink = m_sink; };
+
+  static std::wstring ResolveHostName(std::wstring server_ip);
+
+private:
+  bool m_initialized = false;
+  IWSDiscoveryProvider* m_provider = nullptr;
+  CClientNotificationSink* m_sink = nullptr;
+};

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -34,6 +34,7 @@
 
 #include "platform/win32/CharsetConverter.h"
 #include "platform/win32/input/IRServerSuite.h"
+#include "platform/win32/network/WSDiscoveryWin32.h"
 
 #include <algorithm>
 
@@ -80,10 +81,14 @@ CWinSystemWin32::CWinSystemWin32()
     m_irss->Initialize();
   }
   m_dpms = std::make_shared<CWin32DPMSSupport>();
+
+  CWSDiscoverySupport::Get()->Initialize();
 }
 
 CWinSystemWin32::~CWinSystemWin32()
 {
+  CWSDiscoverySupport::Get()->Terminate();
+
   if (m_hIcon)
   {
     DestroyIcon(m_hIcon);


### PR DESCRIPTION
## Description
Implements WS-Discovery protocol and enables browse SMB shares.

## Motivation and Context
Since Windows 10 no longer supports SMBv1 (deprecated) it is not possible browse SMB shares from the file explorer or when adding media sources.

This PR enables this functionality again (Windows desktop only) using the WS-Discovery protocol.

WS-Discovery is enabled by default on all Windows 10 installations and is well supported from Windows 7:
https://en.wikipedia.org/wiki/WS-Discovery

## How Has This Been Tested?
Runtime tested with various devices in LAN.
Are detected all computers running Windows 10 as well network storage devices (NAS).
Is possible to open SMB shared folders and navigate directory tree.

## Screenshots (if appropriate):
![screenshot00000](https://user-images.githubusercontent.com/58434170/113333722-15929b00-9323-11eb-92e8-1feb2aae3dee.png)

![screenshot00001](https://user-images.githubusercontent.com/58434170/113333736-19beb880-9323-11eb-8eee-61fac8cbda88.png)

On NAS and similar devices it may be necessary to enable this option:
![Captura de pantalla 2021-04-02 132155](https://user-images.githubusercontent.com/58434170/113411753-e0378d00-93b6-11eb-9086-6d3d09833033.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
