### PR TITLE
Fixed issues detected by Coverity

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -219,7 +219,7 @@ bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, 
   m_trayIcon.cbSize = sizeof(m_trayIcon);
   m_trayIcon.hWnd = m_hWnd;
   m_trayIcon.hIcon = m_hIcon;
-  wcsncpy(m_trayIcon.szTip, nameW.c_str(), sizeof(m_trayIcon.szTip));
+  wcsncpy(m_trayIcon.szTip, nameW.c_str(), sizeof(m_trayIcon.szTip) / sizeof(WCHAR));
   m_trayIcon.uCallbackMessage = TRAY_ICON_NOTIFY;
   m_trayIcon.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;  
 

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -192,8 +192,8 @@ protected:
   bool m_bFirstResChange = true;
   std::unique_ptr<CIRServerSuite> m_irss;
   std::vector<MONITOR_DETAILS> m_displays;
-  
-  NOTIFYICONDATA m_trayIcon;  
+
+  NOTIFYICONDATA m_trayIcon = {};
 };
 
 extern HWND g_hWnd;


### PR DESCRIPTION
## Description
Fixed issues detected by Coverity that were introduced when [adding the ability to minimize to system tray](https://github.com/xbmc/xbmc/pull/19379).

## Motivation and Context
Coverity detected problems that were missed during development and review.

```
*** CID 220471:  Memory - corruptions  (OVERRUN)
/xbmc/windowing/windows/WinSystemWin32.cpp: 222 in CWinSystemWin32::CreateNewWindow(const std::basic_string<char, std::char_traits<char>, std::allocator<char>>&, bool, RESOLUTION_INFO &)()
216       UpdateWindow( m_hWnd );
217       
218       // Configure the tray icon.
219       m_trayIcon.cbSize = sizeof(m_trayIcon);
220       m_trayIcon.hWnd = m_hWnd;
221       m_trayIcon.hIcon = m_hIcon;
>>>     CID 220471:  Memory - corruptions  (OVERRUN)
>>>     Overrunning array "this->m_trayIcon.szTip" of 128 2-byte elements by passing it to a function which accesses it at element index 255 (byte offset 511) using argument "256ULL".
222       wcsncpy(m_trayIcon.szTip, nameW.c_str(), sizeof(m_trayIcon.szTip));
223       m_trayIcon.uCallbackMessage = TRAY_ICON_NOTIFY;
224       m_trayIcon.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE; 
225     
226       return true;
227     }
```

```
*** CID 77646:  Uninitialized members  (UNINIT_CTOR)
/xbmc/windowing/windows/WinSystemWin32.cpp: 83 in CWinSystemWin32::CWinSystemWin32()()
77       if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bScanIRServer)
78       {
79         m_irss.reset(new CIRServerSuite());
80         m_irss->Initialize();
81       }
82       m_dpms = std::make_shared<CWin32DPMSSupport>();
>>>     CID 77646:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member field "m_trayIcon.hBalloonIcon" is not initialized in this constructor nor in any functions that it calls.
83     }
84     
85     CWinSystemWin32::~CWinSystemWin32()
86     {
87       if (m_hIcon)
88       {
```

## How Has This Been Tested?
Applied this to the Leia branch and compiled for Windows x64 then ensured the system tray still worked.
If it is possible for me to run Coverity to verify I actually did address the issues, please let me know.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
