### PR TITLE
[Estuary] Add All/Watched/Unwatched button to sidebar menu for Music Videos

### DIFF
--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -104,7 +104,7 @@
 						<include>MediaMenuItemsCommon</include>
 						<label>$LOCALIZE[20367]</label>
 						<label2>[B]$INFO[Container.NumItems][/B]</label2>
-						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.content(seasons) | Container.Content(episodes)</visible>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.content(seasons) | Container.Content(episodes) | Container.Content(MusicVideos)</visible>
 					</control>
 					<control type="label" id="203">
 						<include>MediaMenuLabelCommon</include>


### PR DESCRIPTION
## Description
Add the All/Watched/Unwatched button to Sidebar Menu for Music Videos to bring in line with of video media types.

## Motivation and Context
All/Watched/Unwatched button was available for Movies & TV shows but not Music Videos, this discrepancy was raised on the forum https://forum.kodi.tv/showthread.php?tid=361768

I view this as a fix as it seems likely that this menu item was just missed for music videos.

## How Has This Been Tested?

Before
![image](https://user-images.githubusercontent.com/5781142/113415382-fe9d8880-93b6-11eb-8d21-0d4f04e2a6f8.png)

After
![image](https://user-images.githubusercontent.com/5781142/113415389-02c9a600-93b7-11eb-8be4-6790f93f086a.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
