### PR TITLE
[windows] remove mediafoundation library requirement

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -73,7 +73,7 @@ link_directories(${DEPENDENCIES_DIR}/lib)
 # Additional libraries
 list(APPEND DEPLIBS bcrypt.lib d3d11.lib DInput8.lib DSound.lib winmm.lib Mpr.lib Iphlpapi.lib WS2_32.lib
                     PowrProf.lib setupapi.lib Shlwapi.lib dwmapi.lib dxguid.lib DelayImp.lib version.lib
-                    crypt32.lib Mfplat.lib Mfuuid.lib Strmiids.lib)
+                    crypt32.lib)
 
 # NODEFAULTLIB option
 set(_nodefaultlibs_RELEASE libcmt)

--- a/cmake/scripts/windowsstore/ArchSetup.cmake
+++ b/cmake/scripts/windowsstore/ArchSetup.cmake
@@ -91,8 +91,7 @@ set(gtest_force_shared_crt ON CACHE STRING "" FORCE)
 link_directories(${MINGW_LIBS_DIR}/lib
                  ${DEPENDENCIES_DIR}/lib)
 
-list(APPEND DEPLIBS bcrypt.lib d3d11.lib WS2_32.lib dxguid.lib dloadhelper.lib WindowsApp.lib
-                    Mfplat.lib Mfuuid.lib Strmiids.lib)
+list(APPEND DEPLIBS bcrypt.lib d3d11.lib WS2_32.lib dxguid.lib dloadhelper.lib WindowsApp.lib)
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WINMD:NO")
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:msvcrt /DEBUG:FASTLINK /OPT:NOREF /OPT:NOICF")

--- a/tools/buildsteps/windows/buildffmpeg.sh
+++ b/tools/buildsteps/windows/buildffmpeg.sh
@@ -84,6 +84,7 @@ do_addOption "--disable-gnutls"
 do_addOption "--enable-openssl"
 do_addOption "--enable-nonfree"
 do_addOption "--toolchain=msvc"
+do_addOption "--disable-mediafoundation"
 
 if [ "$ARCH" == "x86_64" ]; then
   FFMPEG_TARGET_OS=win64


### PR DESCRIPTION
This should fix #19075

I'll have to wait till jenkins builds this to see if the other libs are still needed.