### PR TITLE
[estuary] fix overlaps in Fanart / Widelist views

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -34,9 +34,12 @@
 	<constant name="dialogbuttons_itemgap">-20</constant>
 	<constant name="list_y_offset">0</constant>
 	<constant name="list_item_height">80</constant>
+	<constant name="widelist_offset_top">110</constant>
+	<constant name="widelist_offset_bottom">90</constant>
 	<expression name="infodialog_active">Window.IsActive(musicinformation) | Window.IsActive(songinformation) | Window.IsActive(movieinformation) | Window.IsActive(addoninformation) | Window.IsActive(pvrguideinfo) | Window.IsActive(pvrrecordinginfo) | Window.IsActive(pictureinfo) | Window.IsVisible(script-embuary-video.xml) | Window.IsVisible(script-embuary-person.xml) | Window.IsVisible(script-embuary-image.xml)</expression>
 	<expression name="sidebar_visible">ControlGroup(9000).HasFocus | Control.HasFocus(6130) | Control.HasFocus(6131)</expression>
 	<include name="CommonScrollbars">
+		<definition>
 		<control type="group">
 			<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="System.HasActiveModalDialog">Conditional</animation>
@@ -87,6 +90,7 @@
 				</control>
 			</control>
 		</control>
+		</definition>
 	</include>
 	<include name="HiddenObject">
 		<left>-3000</left>

--- a/addons/skin.estuary/xml/MyMusicNav.xml
+++ b/addons/skin.estuary/xml/MyMusicNav.xml
@@ -12,7 +12,12 @@
 			<include>View_52_IconWall</include>
 			<include>View_53_Shift</include>
 			<include>View_54_InfoWall</include>
-			<include>View_55_WideList</include>
+			<include content="View_55_WideList">
+				<param name="top">widelist_offset_top</param>
+				<param name="bottom">list_y_offset</param>
+				<param name="movement">5</param>
+				<param name="focusposition">5</param>
+			</include>
 			<include>View_500_Wall</include>
 			<include>CommonScrollbars</include>
 			<control type="group">

--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -13,10 +13,20 @@
 			<include>View_52_IconWall</include>
 			<include>View_53_Shift</include>
 			<include>View_54_InfoWall</include>
-			<include>View_55_WideList</include>
+			<include content="View_55_WideList">
+				<param name="top">widelist_offset_top</param>
+				<param name="bottom">widelist_offset_bottom</param>
+				<param name="movement">5</param>
+				<param name="focusposition">5</param>
+			</include>
 			<include>View_500_Wall</include>
 			<include>View_501_Banner</include>
-			<include>View_502_FanArt</include>
+			<include content="View_502_FanArt">
+				<param name="top">widelist_offset_top</param>
+				<param name="bottom">widelist_offset_bottom</param>
+				<param name="movement">5</param>
+				<param name="focusposition">5</param>
+			</include>
 			<control type="group">
 				<depth>DepthContentPanel</depth>
 				<include>OpenClose_Left</include>

--- a/addons/skin.estuary/xml/View_502_FanArt.xml
+++ b/addons/skin.estuary/xml/View_502_FanArt.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_502_FanArt">
+		<param name="top" default="list_y_offset"/>
+		<param name="bottom" default="list_y_offset"/>
+		<definition>
 		<control type="group">
 			<include>OpenClose_Left</include>
 			<visible>Control.IsVisible(502)</visible>
 			<include>Visible_Left</include>
 			<include content="ListContainer">
+				<param name="top" value="$PARAM[top]"/>
+		                <param name="bottom" value="$PARAM[bottom]"/>
 				<param name="left" value="-5" />
 				<param name="right" value="1195" />
 				<param name="list_id" value="502" />
 				<param name="viewtype_label" value="$LOCALIZE[20445]" />
+				<param name="focusposition" value="$PARAM[focusposition]"/>
+				<param name="movement" value="$PARAM[movement]"/>
 			</include>
 		</control>
 		<control type="group">
@@ -50,9 +57,9 @@
 				</control>
 				<control type="scrollbar" id="502600">
 					<left>20</left>
-					<top>list_y_offset</top>
+					<top>$PARAM[top]</top>
 					<width>12</width>
-					<bottom>list_y_offset</bottom>
+					<bottom>$PARAM[bottom]</bottom>
 					<onleft>502</onleft>
 					<onright>502</onright>
 					<orientation>vertical</orientation>
@@ -72,5 +79,6 @@
 				</control>
 			</control>
 		</control>
+		</definition>
 	</include>
 </includes>

--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -30,6 +30,9 @@
 		</control>
 	</include>
 	<include name="RightListPanel">
+		<param name="top" default="list_y_offset"/>
+		<param name="bottom" default="list_y_offset"/>
+		<definition>
 		<control type="group">
 			<depth>DepthContentPanel</depth>
 			<control type="group">
@@ -108,26 +111,31 @@
 		</control>
 		<control type="scrollbar" id="$PARAM[list_id]600">
 			<left>20</left>
-			<top>list_y_offset</top>
+			<top>$PARAM[top]</top>
 			<width>12</width>
-			<bottom>list_y_offset</bottom>
+			<bottom>$PARAM[bottom]</bottom>
 			<onleft>$PARAM[list_id]</onleft>
 			<onright>$PARAM[list_id]</onright>
 			<orientation>vertical</orientation>
 			<animation effect="zoom" end="50,100" time="300" tween="sine" center="20,0" easing="inout" condition="!Control.HasFocus($PARAM[list_id]600)">conditional</animation>
 		</control>
+		</definition>
 	</include>
 	<include name="ListContainer">
 		<param name="left">0</param>
 		<param name="right">0</param>
+		<param name="top">list_y_offset</param>
+		<param name="bottom">list_y_offset</param>
+		<param name="movement">4</param>
+		<param name="focusposition">6</param>
 		<definition>
 			<control type="fixedlist" id="$PARAM[list_id]">
 				<left>$PARAM[left]</left>
 				<right>$PARAM[right]</right>
-				<top>list_y_offset</top>
-				<bottom>list_y_offset</bottom>
-				<movement>4</movement>
-				<focusposition>6</focusposition>
+				<top>$PARAM[top]</top>
+				<bottom>$PARAM[bottom]</bottom>
+				<movement>$PARAM[movement]</movement>
+				<focusposition>$PARAM[focusposition]</focusposition>
 				<scrolltime tween="cubic" easing="out">500</scrolltime>
 				<orientation>vertical</orientation>
 				<pagecontrol>$PARAM[list_id]600</pagecontrol>

--- a/addons/skin.estuary/xml/View_55_WideList.xml
+++ b/addons/skin.estuary/xml/View_55_WideList.xml
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_55_WideList">
+		<param name="top" default="list_y_offset"/>
+		<param name="bottom" default="list_y_offset"/>
+		<param name="movement" default="5"/>
+		<param name="focusposition" default="6"/>
+		<definition>
 		<control type="group">
 			<include>OpenClose_Right</include>
 			<visible>Control.IsVisible(55)</visible>
 			<include>Visible_Right</include>
 			<control type="fixedlist" id="55">
 				<left>594</left>
-				<top>list_y_offset</top>
-				<bottom>list_y_offset</bottom>
+				<top>$PARAM[top]</top>
+				<bottom>$PARAM[bottom]</bottom>
 				<right>0</right>
 				<scrolltime tween="cubic" easing="out">500</scrolltime>
 				<orientation>vertical</orientation>
 				<pagecontrol>531</pagecontrol>
-				<movement>5</movement>
-				<focusposition>6</focusposition>
+				<movement>$PARAM[movement]</movement>
+				<focusposition>$PARAM[focusposition]</focusposition>
 				<onleft>9000</onleft>
 				<onright>531</onright>
 				<onup>55</onup>
@@ -198,6 +203,7 @@
 				<include>AddonsListLayout</include>
 			</control>
 		</control>
+		</definition>
 	</include>
 	<include name="SongsListLayout">
 		<focusedlayout height="80" condition="Container.Content(songs)">


### PR DESCRIPTION
## Description
attempt to bring Estuary more in line with the new PVR Views by @ksooo. the Fanart- and Widelist views are changed to _prevent unreadable overlaps_ with the top / bottom overlays, example Clock/Weather on top, Runtime labels etc. at the bottom.

i decided to keep the label height at `80px`, while pvr uses `100px`, to make it as less disruptive to the gui as possible.
changes apply to Movies, TV Shows and Music for now, there's `MyPlaylist`, `MyPics`, `AddonBrowser`, `MyGames` and `MyPrograms` left to do. but i want to see first if that route is fine. also a huge "tab correction" commit needs to follow because of the new `<definition>` tags in the skin files.

runtime tests very welcome

## Screenshots:

**Fanart view** (top and bottom overlays always readable)

![fanart](https://user-images.githubusercontent.com/58829855/113490552-1c5c1200-94cb-11eb-996a-99ac2669de05.png)

**Widelist view** (same for top and bottom overlays)

![widelist](https://user-images.githubusercontent.com/58829855/113490589-604f1700-94cb-11eb-803c-b6a576fdd6e8.png)

**Listview** (unchanged because we don't have top / bottom overlay labels in the middle)

![list](https://user-images.githubusercontent.com/58829855/113490614-8f658880-94cb-11eb-8d73-823bb9bf4cd5.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
