### PR TITLE
[Estuary] Align top/bottom offsets to prevent info overlap

### DIFF
--- a/addons/skin.estuary/xml/AddonBrowser.xml
+++ b/addons/skin.estuary/xml/AddonBrowser.xml
@@ -10,8 +10,12 @@
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
 			<include>View_50_List</include>
 			<include>View_52_IconWall</include>
-			<include>View_55_WideList</include>
-			<include>CommonScrollbars</include>
+			<include content="View_55_WideList">
+				<param name="bottom_offset">list_bottom</param>
+			</include>
+			<include content="CommonScrollbars">
+				<param name="bottom_offset">list_bottom</param>
+			</include>
 			<control type="group">
 				<include>OpenClose_Left</include>
 				<visible>Control.IsVisible(55)</visible>

--- a/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
@@ -12,9 +12,9 @@
 				</include>
 				<control type="fixedlist" id="11">
 					<left>0</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<width>970</width>
-					<bottom>0</bottom>
+					<bottom>list_bottom</bottom>
 					<onleft>PreviousChannelGroup</onleft>
 					<onright>60</onright>
 					<onup>11</onup>
@@ -31,9 +31,9 @@
 				</control>
 				<control type="scrollbar" id="60">
 					<left>970</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<width>12</width>
-					<bottom>0</bottom>
+					<bottom>list_bottom</bottom>
 					<onleft>11</onleft>
 					<onright>NextChannelGroup</onright>
 					<texturesliderbackground />

--- a/addons/skin.estuary/xml/EventLog.xml
+++ b/addons/skin.estuary/xml/EventLog.xml
@@ -12,9 +12,9 @@
 				<include>OpenClose_Right</include>
 				<control type="fixedlist" id="50">
 					<left>490</left>
-					<top>list_y_offset</top>
+					<top>list_top_offset</top>
 					<right>0</right>
-					<bottom>list_y_offset</bottom>
+					<bottom>list_bottom</bottom>
 					<onleft>9000</onleft>
 					<onright>60</onright>
 					<onup>50</onup>
@@ -178,9 +178,9 @@
 			</control>
 			<control type="scrollbar" id="60">
 				<right>0</right>
-				<top>80</top>
+				<top>list_top_offset</top>
 				<width>12</width>
-				<bottom>80</bottom>
+				<bottom>list_bottom</bottom>
 				<onleft>50</onleft>
 				<onright>9000</onright>
 				<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/FileManager.xml
+++ b/addons/skin.estuary/xml/FileManager.xml
@@ -27,10 +27,10 @@
 				<param name="width" value="812" />
 			</include>
 			<control type="scrollbar" id="60">
-				<top>80</top>
+				<top>list_top_offset</top>
 				<left>0</left>
 				<width>12</width>
-				<bottom>80</bottom>
+				<bottom>list_bottom_offset</bottom>
 				<onleft>20</onleft>
 				<onright>20</onright>
 				<orientation>vertical</orientation>
@@ -57,9 +57,9 @@
 			<control type="scrollbar" id="61">
 				<left>800</left>
 				<animation effect="slide" end="5,0" time="0" condition="true">Conditional</animation>
-				<top>80</top>
+				<top>list_top_offset</top>
 				<width>12</width>
-				<bottom>80</bottom>
+				<bottom>list_bottom_offset</bottom>
 				<onleft>21</onleft>
 				<onright>21</onright>
 				<animation effect="zoom" end="50,100" time="300" tween="sine" center="812,0" easing="inout" condition="!Control.HasFocus(61)">conditional</animation>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -32,61 +32,66 @@
 	<constant name="DepthSideBlade">0.10</constant>
 	<constant name="bg_alpha">79</constant>
 	<constant name="dialogbuttons_itemgap">-20</constant>
-	<constant name="list_y_offset">0</constant>
-	<constant name="list_item_height">80</constant>
+	<constant name="list_bottom">0</constant>
+	<constant name="list_bottom_offset">80</constant>
+	<constant name="list_top_offset">100</constant>
+	<constant name="list_item_height">75</constant>
 	<expression name="infodialog_active">Window.IsActive(musicinformation) | Window.IsActive(songinformation) | Window.IsActive(movieinformation) | Window.IsActive(addoninformation) | Window.IsActive(pvrguideinfo) | Window.IsActive(pvrrecordinginfo) | Window.IsActive(pictureinfo) | Window.IsVisible(script-embuary-video.xml) | Window.IsVisible(script-embuary-person.xml) | Window.IsVisible(script-embuary-image.xml)</expression>
 	<expression name="sidebar_visible">ControlGroup(9000).HasFocus | Control.HasFocus(6130) | Control.HasFocus(6131)</expression>
 	<include name="CommonScrollbars">
-		<control type="group">
-			<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
-			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="System.HasActiveModalDialog">Conditional</animation>
-			<animation effect="fade" start="0" end="100" delay="300" time="320">WindowOpen</animation>
+		<param name="bottom_offset">list_bottom_offset</param>
+		<definition>
 			<control type="group">
-				<right>0</right>
-				<top>80</top>
-				<width>60</width>
-				<bottom>80</bottom>
-				<control type="scrollbar" id="531">
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
+				<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="System.HasActiveModalDialog">Conditional</animation>
+				<animation effect="fade" start="0" end="100" delay="300" time="320">WindowOpen</animation>
+				<control type="group">
 					<right>0</right>
-					<top>0</top>
-					<bottom>0</bottom>
-					<width>13</width>
-					<onleft condition="![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)]">50</onleft>
-					<onleft condition="Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)">55</onleft>
-					<onright condition="![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)]">50</onright>
-					<onright condition="Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)">55</onright>
-					<orientation>vertical</orientation>
-					<texturesliderbackground />
-					<animation effect="fade" start="0" end="100" time="200" delay="300">Visible</animation>
-					<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
-					<animation effect="slide" end="6,0" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(531)">conditional</animation>
-					<visible>Control.IsVisible(52) | Control.IsVisible(500) | Control.IsVisible(55) | Control.IsVisible(501) | Control.IsVisible(54)</visible>
+					<top>list_top_offset</top>
+					<width>60</width>
+					<bottom>$PARAM[bottom_offset]</bottom>
+					<control type="scrollbar" id="531">
+						<right>0</right>
+						<top>0</top>
+						<bottom>0</bottom>
+						<width>13</width>
+						<onleft condition="![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)]">50</onleft>
+						<onleft condition="Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)">55</onleft>
+						<onright condition="![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)]">50</onright>
+						<onright condition="Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)">55</onright>
+						<orientation>vertical</orientation>
+						<texturesliderbackground />
+						<animation effect="fade" start="0" end="100" time="200" delay="300">Visible</animation>
+						<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
+						<animation effect="slide" end="6,0" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(531)">conditional</animation>
+						<visible>Control.IsVisible(52) | Control.IsVisible(500) | Control.IsVisible(55) | Control.IsVisible(501) | Control.IsVisible(54)</visible>
+					</control>
 				</control>
-			</control>
-			<control type="group">
-				<left>0</left>
-				<right>0</right>
-				<bottom>0</bottom>
-				<width>100%</width>
-				<height>60</height>
-				<control type="scrollbar" id="5199">
+				<control type="group">
 					<left>0</left>
+					<right>0</right>
 					<bottom>0</bottom>
 					<width>100%</width>
-					<height>12</height>
-					<texturesliderbackground />
-					<onup>50</onup>
-					<ondown>50</ondown>
-					<orientation>horizontal</orientation>
-					<visible>Control.IsVisible(51) | Control.IsVisible(53)</visible>
-					<animation effect="slide" end="0,6" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(5199)">conditional</animation>
-					<animation effect="fade" start="0" end="100" time="200" delay="300">Visible</animation>
-					<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
-					<animation effect="slide" end="0,90" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>
-					<hitrect x="0" y="20" w="100%" h="40" />
+					<height>60</height>
+					<control type="scrollbar" id="5199">
+						<left>0</left>
+						<bottom>0</bottom>
+						<width>100%</width>
+						<height>12</height>
+						<texturesliderbackground />
+						<onup>50</onup>
+						<ondown>50</ondown>
+						<orientation>horizontal</orientation>
+						<visible>Control.IsVisible(51) | Control.IsVisible(53)</visible>
+						<animation effect="slide" end="0,6" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(5199)">conditional</animation>
+						<animation effect="fade" start="0" end="100" time="200" delay="300">Visible</animation>
+						<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
+						<animation effect="slide" end="0,90" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>
+						<hitrect x="0" y="20" w="100%" h="40" />
+					</control>
 				</control>
 			</control>
-		</control>
+		</definition>
 	</include>
 	<include name="HiddenObject">
 		<left>-3000</left>
@@ -459,8 +464,8 @@
 		<definition>
 			<control type="fixedlist" id="$PARAM[list_id]">
 				<left>0</left>
-				<top>list_y_offset</top>
-				<bottom>list_y_offset</bottom>
+				<top>list_top_offset</top>
+				<bottom>list_bottom_offset</bottom>
 				<right>$PARAM[right]</right>
 				<width>$PARAM[width]</width>
 				<focusposition>4</focusposition>

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -418,14 +418,14 @@
 			<control type="textbox">
 				<top>465</top>
 				<width>830</width>
-				<bottom>80</bottom>
+				<bottom>list_bottom_offset</bottom>
 				<label>$VAR[FlagLabel,,[CR]]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ,[CR]]$INFO[ListItem.TimerType,[COLOR grey]$LOCALIZE[803]:[/COLOR] ,[CR]]$VAR[RecordingSizeLabel]$VAR[ExpirationDateTimeLabel]$INFO[ListItem.Plot,[CR]]</label>
 				<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
 			</control>
 		</control>
 		<control type="group">
 			<visible>ListItem.IsFolder</visible>
-			<top>100</top>
+			<top>list_top_offset</top>
 			<control type="label">
 				<top>10</top>
 				<width>830</width>

--- a/addons/skin.estuary/xml/MyPVRChannels.xml
+++ b/addons/skin.estuary/xml/MyPVRChannels.xml
@@ -12,9 +12,9 @@
 				<include>OpenClose_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<right>918</right>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
 					<onup>50</onup>
@@ -32,9 +32,9 @@
 				</control>
 				<control type="fixedlist" id="51">
 					<left>0</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<right>920</right>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<movement>4</movement>
 					<focusposition>4</focusposition>
 					<scrolltime tween="cubic" easing="out">500</scrolltime>
@@ -164,9 +164,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<width>12</width>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -12,9 +12,9 @@
 				<include>OpenClose_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<right>918</right>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
 					<onup>50</onup>
@@ -45,9 +45,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<width>12</width>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/MyPVRSearch.xml
+++ b/addons/skin.estuary/xml/MyPVRSearch.xml
@@ -14,9 +14,9 @@
 				<include>Visible_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<right>918</right>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
 					<onup>50</onup>
@@ -46,9 +46,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<width>12</width>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/MyPVRTimers.xml
+++ b/addons/skin.estuary/xml/MyPVRTimers.xml
@@ -11,9 +11,9 @@
 				<include>OpenClose_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<right>918</right>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>9000</onleft>
 					<onright>73</onright>
 					<onup>50</onup>
@@ -45,9 +45,9 @@
 				</include>
 				<control type="scrollbar" id="73">
 					<left>-50</left>
-					<top>100</top>
+					<top>list_top_offset</top>
 					<width>12</width>
-					<bottom>80</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/View_502_FanArt.xml
+++ b/addons/skin.estuary/xml/View_502_FanArt.xml
@@ -50,9 +50,9 @@
 				</control>
 				<control type="scrollbar" id="502600">
 					<left>20</left>
-					<top>list_y_offset</top>
+					<top>list_top_offset</top>
 					<width>12</width>
-					<bottom>list_y_offset</bottom>
+					<bottom>list_bottom_offset</bottom>
 					<onleft>502</onleft>
 					<onright>502</onright>
 					<orientation>vertical</orientation>

--- a/addons/skin.estuary/xml/View_503_NowPlaying.xml
+++ b/addons/skin.estuary/xml/View_503_NowPlaying.xml
@@ -25,6 +25,16 @@
 					<include content="RightListPanel">
 						<param name="list_id" value="503" />
 					</include>
+					<control type="scrollbar" id="503600">
+						<left>20</left>
+						<top>list_top_offset</top>
+						<width>12</width>
+						<bottom>list_bottom_offset</bottom>
+						<onleft>503</onleft>
+						<onright>503</onright>
+						<orientation>vertical</orientation>
+						<animation effect="zoom" end="50,100" time="300" tween="sine" center="20,0" easing="inout" condition="!Control.HasFocus(503600)">conditional</animation>
+					</control>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -25,6 +25,16 @@
 					<include content="RightListPanel">
 						<param name="list_id" value="50" />
 					</include>
+					<control type="scrollbar" id="50600">
+						<left>20</left>
+						<top>list_top_offset</top>
+						<width>12</width>
+						<bottom>list_bottom_offset</bottom>
+						<onleft>50</onleft>
+						<onright>50</onright>
+						<orientation>vertical</orientation>
+						<animation effect="zoom" end="50,100" time="300" tween="sine" center="20,0" easing="inout" condition="!Control.HasFocus(50600)">conditional</animation>
+					</control>
 				</control>
 			</control>
 		</control>
@@ -106,16 +116,6 @@
 				</control>
 			</control>
 		</control>
-		<control type="scrollbar" id="$PARAM[list_id]600">
-			<left>20</left>
-			<top>list_y_offset</top>
-			<width>12</width>
-			<bottom>list_y_offset</bottom>
-			<onleft>$PARAM[list_id]</onleft>
-			<onright>$PARAM[list_id]</onright>
-			<orientation>vertical</orientation>
-			<animation effect="zoom" end="50,100" time="300" tween="sine" center="20,0" easing="inout" condition="!Control.HasFocus($PARAM[list_id]600)">conditional</animation>
-		</control>
 	</include>
 	<include name="ListContainer">
 		<param name="left">0</param>
@@ -124,10 +124,10 @@
 			<control type="fixedlist" id="$PARAM[list_id]">
 				<left>$PARAM[left]</left>
 				<right>$PARAM[right]</right>
-				<top>list_y_offset</top>
-				<bottom>list_y_offset</bottom>
-				<movement>4</movement>
-				<focusposition>6</focusposition>
+				<top>list_top_offset</top>
+				<bottom>list_bottom_offset</bottom>
+				<movement>6</movement>
+				<focusposition>5</focusposition>
 				<scrolltime tween="cubic" easing="out">500</scrolltime>
 				<orientation>vertical</orientation>
 				<pagecontrol>$PARAM[list_id]600</pagecontrol>

--- a/addons/skin.estuary/xml/View_55_WideList.xml
+++ b/addons/skin.estuary/xml/View_55_WideList.xml
@@ -1,216 +1,217 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_55_WideList">
-		<control type="group">
-			<include>OpenClose_Right</include>
-			<visible>Control.IsVisible(55)</visible>
-			<include>Visible_Right</include>
-			<control type="fixedlist" id="55">
-				<left>594</left>
-				<top>list_y_offset</top>
-				<bottom>list_y_offset</bottom>
-				<right>0</right>
-				<scrolltime tween="cubic" easing="out">500</scrolltime>
-				<orientation>vertical</orientation>
-				<pagecontrol>531</pagecontrol>
-				<movement>5</movement>
-				<focusposition>6</focusposition>
-				<onleft>9000</onleft>
-				<onright>531</onright>
-				<onup>55</onup>
-				<ondown>55</ondown>
-				<viewtype label="$LOCALIZE[31107]">list</viewtype>
-				<focusedlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games) | Window.IsActive(videoplaylist) | Window.IsActive(musicplaylist)">
-					<control type="image">
-						<left>0</left>
-						<right>0</right>
-						<bottom>0</bottom>
-						<texture colordiffuse="button_focus">lists/focus.png</texture>
-						<visible>Control.HasFocus(55)</visible>
-					</control>
-					<control type="image">
-						<left>35</left>
-						<centertop>50%</centertop>
-						<width>32</width>
-						<height>32</height>
-						<texture>$VAR[ListWatchedIconVar]</texture>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<aligny>center</aligny>
-						<scroll>true</scroll>
-						<label>$VAR[ListLabelVar]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$VAR[ListLabel2Var]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-				</focusedlayout>
-				<itemlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games) | Window.IsActive(videoplaylist) | Window.IsActive(musicplaylist)">
-					<control type="image">
-						<left>35</left>
-						<centertop>50%</centertop>
-						<width>32</width>
-						<height>32</height>
-						<texture colordiffuse="grey">$VAR[ListWatchedIconVar]</texture>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<aligny>center</aligny>
-						<label>$VAR[ListLabelVar]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$VAR[ListLabel2Var]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-				</itemlayout>
-				<focusedlayout height="list_item_height" condition="!Container.Content(songs) + !Container.Content(addons) + !Container.Content(playlists) + !Container.Content() + !Container.Content(tvshows) + !Container.Content(seasons) + !Container.Content(episodes) + !Container.Content(movies) + !Container.Content(musicvideos) + !Container.Content(videos)">
-					<control type="image">
-						<left>0</left>
-						<right>0</right>
-						<bottom>0</bottom>
-						<texture colordiffuse="button_focus">lists/focus.png</texture>
-						<visible>Control.HasFocus(55)</visible>
-					</control>
-					<control type="image">
-						<left>35</left>
-						<centertop>50%</centertop>
-						<width>32</width>
-						<height>32</height>
-						<texture>$VAR[ListWatchedIconVar]</texture>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<aligny>center</aligny>
-						<scroll>true</scroll>
-						<label>$INFO[ListItem.Label]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$VAR[ListLabel2Var]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-				</focusedlayout>
-				<itemlayout height="list_item_height" condition="!Container.Content(songs) + !Container.Content(addons) + !Container.Content(playlists) + !Container.Content() + !Container.Content(tvshows) + !Container.Content(seasons) + !Container.Content(episodes) + !Container.Content(movies) + !Container.Content(musicvideos) + !Container.Content(videos)">
-					<control type="image">
-						<left>35</left>
-						<centertop>50%</centertop>
-						<width>32</width>
-						<height>32</height>
-						<texture colordiffuse="grey">$VAR[ListWatchedIconVar]</texture>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<aligny>center</aligny>
-						<label>$VAR[ListLabelVar]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>40</right>
-						<align>right</align>
-						<aligny>center</aligny>
-						<label>$VAR[ListLabel2Var]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-				</itemlayout>
-				<focusedlayout height="list_item_height" condition="Container.Content(playlists) | Container.Content()">
-					<control type="image">
-						<left>0</left>
-						<right>0</right>
-						<bottom>0</bottom>
-						<texture colordiffuse="button_focus">lists/focus.png</texture>
-						<visible>Control.HasFocus(55)</visible>
-					</control>
-					<control type="image">
-						<left>20</left>
-						<top>10</top>
-						<width>60</width>
-						<bottom>10</bottom>
-						<aspectratio>keep</aspectratio>
-						<texture>$INFO[ListItem.Icon]</texture>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>100</right>
-						<aligny>center</aligny>
-						<scroll>true</scroll>
-						<label>$INFO[ListItem.Label]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-				</focusedlayout>
-				<itemlayout height="list_item_height" condition="Container.Content(playlists) | Container.Content()">
-					<control type="image">
-						<left>20</left>
-						<top>10</top>
-						<width>60</width>
-						<bottom>10</bottom>
-						<aspectratio>keep</aspectratio>
-						<texture colordiffuse="grey">$INFO[ListItem.Icon]</texture>
-					</control>
-					<control type="label">
-						<left>105</left>
-						<top>0</top>
-						<bottom>0</bottom>
-						<right>100</right>
-						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
-						<shadowcolor>text_shadow</shadowcolor>
-					</control>
-				</itemlayout>
-				<include condition="Window.IsActive(music)">SongsListLayout</include>
-				<include>AddonsListLayout</include>
+		<param name="bottom_offset">list_bottom_offset</param>
+		<definition>
+			<control type="group">
+				<include>OpenClose_Right</include>
+				<visible>Control.IsVisible(55)</visible>
+				<include>Visible_Right</include>
+				<control type="fixedlist" id="55">
+					<left>594</left>
+					<top>list_top_offset</top>
+					<bottom>$PARAM[bottom_offset]</bottom>
+					<right>0</right>
+					<scrolltime tween="cubic" easing="out">500</scrolltime>
+					<orientation>vertical</orientation>
+					<pagecontrol>531</pagecontrol>
+					<movement>6</movement>
+					<focusposition>5</focusposition>
+					<onleft>9000</onleft>
+					<onright>531</onright>
+					<onup>55</onup>
+					<ondown>55</ondown>
+					<viewtype label="$LOCALIZE[31107]">list</viewtype>
+					<focusedlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games) | Window.IsActive(videoplaylist) | Window.IsActive(musicplaylist)">
+						<control type="image">
+							<left>0</left>
+							<right>0</right>
+							<bottom>0</bottom>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<visible>Control.HasFocus(55)</visible>
+						</control>
+						<control type="image">
+							<left>35</left>
+							<centertop>50%</centertop>
+							<width>32</width>
+							<height>32</height>
+							<texture>$VAR[ListWatchedIconVar]</texture>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<aligny>center</aligny>
+							<scroll>true</scroll>
+							<label>$VAR[ListLabelVar]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<align>right</align>
+							<aligny>center</aligny>
+							<label>$VAR[ListLabel2Var]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+					</focusedlayout>
+					<itemlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games) | Window.IsActive(videoplaylist) | Window.IsActive(musicplaylist)">
+						<control type="image">
+							<left>35</left>
+							<centertop>50%</centertop>
+							<width>32</width>
+							<height>32</height>
+							<texture colordiffuse="grey">$VAR[ListWatchedIconVar]</texture>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<aligny>center</aligny>
+							<label>$VAR[ListLabelVar]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<align>right</align>
+							<aligny>center</aligny>
+							<label>$VAR[ListLabel2Var]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+					</itemlayout>
+					<focusedlayout height="list_item_height" condition="!Container.Content(songs) + !Container.Content(addons) + !Container.Content(playlists) + !Container.Content() + !Container.Content(tvshows) + !Container.Content(seasons) + !Container.Content(episodes) + !Container.Content(movies) + !Container.Content(musicvideos) + !Container.Content(videos)">
+						<control type="image">
+							<left>0</left>
+							<right>0</right>
+							<bottom>0</bottom>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<visible>Control.HasFocus(55)</visible>
+						</control>
+						<control type="image">
+							<left>35</left>
+							<centertop>50%</centertop>
+							<width>32</width>
+							<height>32</height>
+							<texture>$VAR[ListWatchedIconVar]</texture>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<aligny>center</aligny>
+							<scroll>true</scroll>
+							<label>$INFO[ListItem.Label]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<align>right</align>
+							<aligny>center</aligny>
+							<label>$VAR[ListLabel2Var]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+					</focusedlayout>
+					<itemlayout height="list_item_height" condition="!Container.Content(songs) + !Container.Content(addons) + !Container.Content(playlists) + !Container.Content() + !Container.Content(tvshows) + !Container.Content(seasons) + !Container.Content(episodes) + !Container.Content(movies) + !Container.Content(musicvideos) + !Container.Content(videos)">
+						<control type="image">
+							<left>35</left>
+							<centertop>50%</centertop>
+							<width>32</width>
+							<height>32</height>
+							<texture colordiffuse="grey">$VAR[ListWatchedIconVar]</texture>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<aligny>center</aligny>
+							<label>$VAR[ListLabelVar]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>40</right>
+							<align>right</align>
+							<aligny>center</aligny>
+							<label>$VAR[ListLabel2Var]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+					</itemlayout>
+					<focusedlayout height="list_item_height" condition="Container.Content(playlists) | Container.Content()">
+						<control type="image">
+							<left>0</left>
+							<right>0</right>
+							<bottom>0</bottom>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<visible>Control.HasFocus(55)</visible>
+						</control>
+						<control type="image">
+							<left>20</left>
+							<top>10</top>
+							<width>60</width>
+							<bottom>10</bottom>
+							<aspectratio>keep</aspectratio>
+							<texture>$INFO[ListItem.Icon]</texture>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>100</right>
+							<aligny>center</aligny>
+							<scroll>true</scroll>
+							<label>$INFO[ListItem.Label]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+					</focusedlayout>
+					<itemlayout height="list_item_height" condition="Container.Content(playlists) | Container.Content()">
+						<control type="image">
+							<left>20</left>
+							<top>10</top>
+							<width>60</width>
+							<bottom>10</bottom>
+							<aspectratio>keep</aspectratio>
+							<texture colordiffuse="grey">$INFO[ListItem.Icon]</texture>
+						</control>
+						<control type="label">
+							<left>105</left>
+							<top>0</top>
+							<bottom>0</bottom>
+							<right>100</right>
+							<aligny>center</aligny>
+							<label>$INFO[ListItem.Label]</label>
+							<shadowcolor>text_shadow</shadowcolor>
+						</control>
+					</itemlayout>
+					<include condition="Window.IsActive(music)">SongsListLayout</include>
+					<include>AddonsListLayout</include>
+				</control>
 			</control>
-		</control>
+		</definition>
 	</include>
 	<include name="SongsListLayout">
-		<focusedlayout height="80" condition="Container.Content(songs)">
+		<focusedlayout height="list_item_height" condition="Container.Content(songs)">
 			<control type="image">
 				<left>0</left>
 				<right>0</right>
-				<height>80</height>
 				<texture colordiffuse="button_focus">lists/focus.png</texture>
 				<visible>Control.hasFocus(55)</visible>
 			</control>
 			<control type="label">
 				<left>35</left>
-				<height>80</height>
 				<right>40</right>
 				<aligny>center</aligny>
 				<scroll>true</scroll>
@@ -219,7 +220,6 @@
 			</control>
 			<control type="label">
 				<left>35</left>
-				<height>80</height>
 				<right>40</right>
 				<align>right</align>
 				<aligny>center</aligny>
@@ -227,10 +227,9 @@
 				<shadowcolor>text_shadow</shadowcolor>
 			</control>
 		</focusedlayout>
-		<itemlayout height="80" condition="Container.Content(songs)">
+		<itemlayout height="list_item_height" condition="Container.Content(songs)">
 			<control type="label">
 				<left>35</left>
-				<height>80</height>
 				<right>40</right>
 				<aligny>center</aligny>
 				<label>$VAR[ListLabelVar]</label>
@@ -238,7 +237,6 @@
 			</control>
 			<control type="label">
 				<left>35</left>
-				<height>80</height>
 				<right>40</right>
 				<align>right</align>
 				<aligny>center</aligny>
@@ -249,11 +247,10 @@
 		</itemlayout>
 	</include>
 	<include name="AddonsListLayout">
-		<focusedlayout height="80" condition="Container.Content(addons)">
+		<focusedlayout height="list_item_height" condition="Container.Content(addons)">
 			<control type="image">
 				<left>0</left>
 				<right>0</right>
-				<height>80</height>
 				<texture colordiffuse="button_focus">lists/focus.png</texture>
 				<visible>Control.hasFocus(55)</visible>
 			</control>
@@ -266,7 +263,6 @@
 			</control>
 			<control type="label">
 				<left>75</left>
-				<height>80</height>
 				<right>40</right>
 				<aligny>center</aligny>
 				<scroll>true</scroll>
@@ -274,7 +270,6 @@
 			</control>
 			<control type="label">
 				<left>75</left>
-				<height>80</height>
 				<right>90</right>
 				<align>right</align>
 				<aligny>center</aligny>
@@ -291,7 +286,7 @@
 				<visible>!ListItem.IsFolder</visible>
 			</control>
 		</focusedlayout>
-		<itemlayout height="80" condition="Container.Content(addons)">
+		<itemlayout height="list_item_height" condition="Container.Content(addons)">
 			<control type="image">
 				<left>20</left>
 				<top>25</top>
@@ -301,14 +296,12 @@
 			</control>
 			<control type="label">
 				<left>75</left>
-				<height>80</height>
 				<right>40</right>
 				<aligny>center</aligny>
 				<label>$INFO[ListItem.Label]</label>
 			</control>
 			<control type="label">
 				<left>75</left>
-				<height>80</height>
 				<right>90</right>
 				<align>right</align>
 				<aligny>center</aligny>


### PR DESCRIPTION
## Description
Follow on from https://github.com/xbmc/xbmc/pull/19478 to realign all views that use lists to have common offsets for top/bottom. A more extensive alternative to @howie-f  https://github.com/xbmc/xbmc/pull/19512

## Motivation and Context
Restore consistency of look to all views.

## Screenshots (if appropriate):

**List view before**
Overlap of list with flags to the bottom
![image](https://user-images.githubusercontent.com/5781142/113509241-69cc9380-954c-11eb-93fd-6e344bbed4cc.png)

**List view after**
![image](https://user-images.githubusercontent.com/5781142/113509185-14908200-954c-11eb-9f90-0192076a5330.png)

**Widelist view before**
Overlap of list with TopBar info and flags to the bottom
![image](https://user-images.githubusercontent.com/5781142/113509253-823cae00-954c-11eb-8ab5-9bf9bb5c98f0.png)

**Widelist view after**
![image](https://user-images.githubusercontent.com/5781142/113509191-1c502680-954c-11eb-91e4-af4e5b50eafb.png)

**Fanart view before** 
Overlap of list with breadcrumb/sort info to the top
![image](https://user-images.githubusercontent.com/5781142/113509297-b6b06a00-954c-11eb-850a-80e1e739569d.png)

**Fanart view after**
![image](https://user-images.githubusercontent.com/5781142/113509195-25d98e80-954c-11eb-8be0-b9517c793183.png)

**Addon Browser view before**
Overlap of list with TopBar info
![image](https://user-images.githubusercontent.com/5781142/113509348-fd9e5f80-954c-11eb-9e2d-602a7d24e7bc.png)

**Addon Browser view after**
![image](https://user-images.githubusercontent.com/5781142/113509382-2888b380-954d-11eb-806a-eeca487b2540.png)

**File Manager view before**
Overlap of list with Breadcrumb and bottom text
![image](https://user-images.githubusercontent.com/5781142/113509393-35a5a280-954d-11eb-8997-2a3da1f8eddd.png)

**File Manager view after**
![image](https://user-images.githubusercontent.com/5781142/113509205-30942380-954c-11eb-9b10-34e46cc4aa96.png)

**Event Log view before**
Overlap of list with TopBar info 
![image](https://user-images.githubusercontent.com/5781142/113509511-f035a500-954d-11eb-89c1-aa76fc10e27e.png)

**Event Log view after**
![image](https://user-images.githubusercontent.com/5781142/113509207-3853c800-954c-11eb-8be5-b5f9df976936.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
