### PR TITLE
[macOS] Fix macOS specific settings not loaded at launch

### DIFF
--- a/xbmc/platform/darwin/osx/PlatformDarwinOSX.cpp
+++ b/xbmc/platform/darwin/osx/PlatformDarwinOSX.cpp
@@ -10,7 +10,6 @@
 
 #include "windowing/osx/WinSystemOSXGL.h"
 
-#include "platform/darwin/osx/XBMCHelper.h"
 #include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
 
 CPlatform* CPlatform::CreateInstance()
@@ -22,9 +21,6 @@ bool CPlatformDarwinOSX::Init()
 {
   if (!CPlatformDarwin::Init())
     return false;
-
-  // Configure and possible manually start the helper.
-  XBMCHelper::GetInstance().Configure();
 
   CWinSystemOSXGL::Register();
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -739,6 +739,9 @@ bool CWinSystemOSX::InitWindowSystem()
     name:NSWindowDidChangeScreenNotification object:nil];
   m_impl->m_windowChangedScreen = windowDidChangeScreen;
 
+  // Configure and possible manually start the helper.
+  XBMCHelper::GetInstance().Configure();
+
   return true;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR fix a bug where macOS specific user settings are not loaded during Kodi launch, forcing user to manually unset/set setting to take it into account.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/xbmc/xbmc/pull/18435 introduced a bug because we moved `XBMCHelper::GetInstance().Configure()` in `m_Platform->InitStageOne()` BUT `XBMCHelper::GetInstance().Configure()` reads some user settings and `m_Platform->InitStageOne()` is executed BEFORE user settings are loaded.

By moving `XBMCHelper::GetInstance().Configure()` in `CWinSystemOSX::InitWindowSystem()` we are sure that user settings are already been loaded when we call this function.

We discussed this in https://github.com/xbmc/xbmc/pull/19460.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On macOS Big Sur / MacBook Pro.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
