### PR TITLE
[Android] StorageProvider Fixes

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=ee5cc102101d9cb04ab4dbfd7a65db1c52345faf
+VERSION=2b24db871a55a72897e3fedc354e1396ad01defd
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -28,7 +28,7 @@
 #include <androidjni/Environment.h>
 #include <androidjni/StorageManager.h>
 
-static const char * typeWL[] = { "vfat", "exfat", "sdcardfs", "fuse", "ntfs", "fat32", "ext3", "ext4", "esdfs" };
+static const char * typeWL[] = { "vfat", "exfat", "sdcardfs", "fuse", "ntfs", "fat32", "ext3", "ext4", "esdfs", "cifs" };
 static const char * mountWL[] = { "/mnt", "/Removable", "/storage" };
 static const char * mountBL[] = {
   "/mnt/secure",
@@ -44,7 +44,8 @@ static const char * mountBL[] = {
 static const char * deviceWL[] = {
   "/dev/block/vold",
   "/dev/fuse",
-  "/mnt/media_rw"
+  "/mnt/media_rw",
+  "//" // SMB
 };
 
 IStorageProvider* IStorageProvider::CreateInstance()

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -27,6 +27,7 @@
 #include <androidjni/Context.h>
 #include <androidjni/Environment.h>
 #include <androidjni/StorageManager.h>
+#include <androidjni/StorageVolume.h>
 
 static const char * typeWL[] = { "vfat", "exfat", "sdcardfs", "fuse", "ntfs", "fat32", "ext3", "ext4", "esdfs", "cifs" };
 static const char * mountWL[] = { "/mnt", "/Removable", "/storage" };
@@ -118,13 +119,13 @@ void CAndroidStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
 
 void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 {
-  // Uses non-public API: be extra carefull
   bool inError = false;
   VECSOURCES droidDrives;
 
   CJNIStorageManager manager(CJNIContext::getSystemService("storage"));
   if (xbmc_jnienv()->ExceptionCheck())
   {
+    xbmc_jnienv()->ExceptionDescribe();
     xbmc_jnienv()->ExceptionClear();
     inError = true;
   }
@@ -134,25 +135,31 @@ void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
     CJNIStorageVolumes vols = manager.getStorageVolumes();
     if (xbmc_jnienv()->ExceptionCheck())
     {
+      xbmc_jnienv()->ExceptionDescribe();
       xbmc_jnienv()->ExceptionClear();
       inError = true;
     }
 
     if (!inError)
     {
-      for (auto vol : vols)
+      for (int i = 0; i < vols.size(); ++i)
       {
+        CJNIStorageVolume vol = vols.get(i);
 //        CLog::Log(LOGDEBUG, "-- Volume: %s(%s) -- %s", vol.getPath().c_str(), vol.getUserLabel().c_str(), vol.getState().c_str());
+
         bool removable = vol.isRemovable();
         if (xbmc_jnienv()->ExceptionCheck())
         {
+          xbmc_jnienv()->ExceptionDescribe();
           xbmc_jnienv()->ExceptionClear();
           inError = true;
           break;
         }
+
         std::string state = vol.getState();
         if (xbmc_jnienv()->ExceptionCheck())
         {
+          xbmc_jnienv()->ExceptionDescribe();
           xbmc_jnienv()->ExceptionClear();
           inError = true;
           break;
@@ -161,23 +168,29 @@ void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
         if (removable && state == CJNIEnvironment::MEDIA_MOUNTED)
         {
           CMediaSource share;
+
           share.strPath = vol.getPath();
           if (xbmc_jnienv()->ExceptionCheck())
           {
+            xbmc_jnienv()->ExceptionDescribe();
             xbmc_jnienv()->ExceptionClear();
             inError = true;
             break;
           }
+
           share.strName = vol.getUserLabel();
           if (xbmc_jnienv()->ExceptionCheck())
           {
+            xbmc_jnienv()->ExceptionDescribe();
             xbmc_jnienv()->ExceptionClear();
             inError = true;
             break;
           }
+
           StringUtils::Trim(share.strName);
           if (share.strName.empty() || share.strName == "?" || StringUtils::EqualsNoCase(share.strName, "null"))
             share.strName = URIUtils::GetFileName(share.strPath);
+
           share.m_ignore = true;
           droidDrives.push_back(share);
         }


### PR DESCRIPTION
Fixes: #19023 #19307

~~DISCLAIMER: I’m not an Android dev, and it might be not the best fix or even nonsense, but for me it definitely fixes the problem of SMB shares mounted on the NVidia Shield TV at system level not appearing in the list of removable drives of Kodi.~~

DISCLAIMER: I’m not an Android dev, but with the help of @koying I was able to track down and fix the problems
* #19023 : SMB shares mounted on the NVidia Shield TV at system level not appearing in Kodi
* #19307 : Removable volumes labeled with UID instead of the actual volume label

Some details I found out while debugging:

* On Android, removable volumes are obtained using `CAndroidStorageProvider::GetRemovableDrives`
* This method first tries to obtain the volumes using JNI: `CJNIStorageManager::getStorageVolumes` eventually calls Java `StorageManager.getStorageVolumes`. 
* This call fails (Java throws an exception) on current master/Matrix branches, at least on my Shield, but the code has a fallback to obtain the volumes the Linux way using `/proc/mounts`.
* This seems to work; the Samba shares are reported by Android, but the current filter for valid devices does not include a proper entry to detect SMB devices (starting with a double slash) and the fstype filter is missing (cifs).

First commit fixes the fallback to support SMB mounts.
Second commit fixes the non working primary code path, fixing both SMB mounts not appearing and volume labels.

I runtime-tested the changes on my Shields, with both SMB mounts and USB sticks.

@koying by any chance, if you are around, does this fix make any sense to you?