### PR TITLE
Fix for #19479: put display to sleep when idle, prevent firing events…

### DIFF
--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -312,6 +312,12 @@ bool CWinEventsX11::MessagePump()
       if (xevent.xgeneric.serial == serial)
         continue;
 
+      if (g_application.IsDPMSActive())
+      {
+        CLog::Log(LOGDEBUG,"CWinEventsX11::MessagePump - skip XRRNotifyEvent since DPMS is active");
+        continue;
+      }
+
       XRRNotifyEvent* rrEvent = reinterpret_cast<XRRNotifyEvent*>(&xevent);
       if (rrEvent->subtype == RRNotify_OutputChange)
       {


### PR DESCRIPTION
… in DPMS state

## Description
The NotifyXRREvent won't be fired anymore if display is in DPMS state. 

## Motivation and Context
The reason for this change is issue #19479. Displays which are connected via displayport cable send two XRROutputChangeNotifyEvents if they are going to sleep (suspend). First event is of subtype RR_Disconnected. It is followed by an event of subtype RR_Connected. The second event caused that Kodi turns display on again.

I have seen this behaviour on my own display and also other kodi.log files of users who reported this problem which started with Kodi 18.x.

Displays connected via HDMI don't send any events if they are going to sleep.   
 
## How Has This Been Tested?
This fix has been tested on my computer which was connected via displayport. But it was also tested with a connection via HDMI. 

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
