### PR TITLE
[Plugin] Fix - Regression of CVideoInfoTag::Merge

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -84,7 +84,13 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
     resultItem.SetDynPath(newDir.m_fileResult->GetPath());
     resultItem.SetMimeType(newDir.m_fileResult->GetMimeType());
     resultItem.SetContentLookup(newDir.m_fileResult->ContentLookup());
-    resultItem.MergeInfo(*newDir.m_fileResult);
+
+    if (resultItem.HasProperty("OverrideInfotag") &&
+        resultItem.GetProperty("OverrideInfotag").asBoolean())
+      resultItem.UpdateInfo(*newDir.m_fileResult);
+    else
+      resultItem.MergeInfo(*newDir.m_fileResult);
+
     if (newDir.m_fileResult->HasVideoInfoTag() && newDir.m_fileResult->GetVideoInfoTag()->GetResumePoint().IsSet())
       resultItem.m_lStartOffset = STARTOFFSET_RESUME; // resume point set in the resume item, so force resume
   }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -995,8 +995,10 @@ namespace XBMCAddon
       /// | StartPercent  | float (15.0) - Set the percentage at which to start playback of the item
       /// | StationName   | string ("My Station Name") - Used to enforce/override MusicPlayer.StationName infolabel from addons (e.g. in radio addons)
       /// | TotalTime     | float (7848.0) - Set the total time of the item in seconds
+      /// | OverrideInfotag | string - "true", "false" - When true will override all info from previous listitem
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v20 OverrideInfotag property added
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1212,5 +1214,3 @@ private:
 #endif
   }
 }
-
-

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -324,151 +324,153 @@ bool CVideoInfoTag::Load(const TiXmlElement *element, bool append, bool prioriti
 
 void CVideoInfoTag::Merge(CVideoInfoTag& other)
 {
-  if (m_director.empty())
+  if (!other.m_director.empty())
     m_director = other.m_director;
-  if (m_writingCredits.empty())
+  if (!other.m_writingCredits.empty())
     m_writingCredits = other.m_writingCredits;
-  if (m_genre.empty())
+  if (!other.m_genre.empty())
     m_genre = other.m_genre;
-  if (m_country.empty())
+  if (!other.m_country.empty())
     m_country = other.m_country;
-  if (m_strTagLine.empty())
+  if (!other.m_strTagLine.empty())
     m_strTagLine = other.m_strTagLine;
-  if (m_strPlotOutline.empty())
+  if (!other.m_strPlotOutline.empty())
     m_strPlotOutline = other.m_strPlotOutline;
-  if (m_strPlot.empty())
+  if (!other.m_strPlot.empty())
     m_strPlot = other.m_strPlot;
-  if (!m_strPictureURL.HasData())
+  if (other.m_strPictureURL.HasData())
     m_strPictureURL = other.m_strPictureURL;
-  if (m_strTitle.empty())
+  if (!other.m_strTitle.empty())
     m_strTitle = other.m_strTitle;
-  if (m_strShowTitle.empty())
+  if (!other.m_strShowTitle.empty())
     m_strShowTitle = other.m_strShowTitle;
-  if (m_strOriginalTitle.empty())
+  if (!other.m_strOriginalTitle.empty())
     m_strOriginalTitle = other.m_strOriginalTitle;
-  if (m_strSortTitle.empty())
+  if (!other.m_strSortTitle.empty())
     m_strSortTitle = other.m_strSortTitle;
-  if (!m_cast.size())
+  if (other.m_cast.size())
     m_cast = other.m_cast;
 
-  if (m_set.title.empty())
+  if (!other.m_set.title.empty())
     m_set.title = other.m_set.title;
-  if (!m_set.id)
+  if (other.m_set.id)
     m_set.id = other.m_set.id;
-  if (m_set.overview.empty())
+  if (!other.m_set.overview.empty())
     m_set.overview = other.m_set.overview;
-  if (m_tags.empty())
+  if (!other.m_tags.empty())
     m_tags = other.m_tags;
 
-  if (m_strFile.empty())
+  if (!other.m_strFile.empty())
     m_strFile = other.m_strFile;
-  if (m_strPath.empty())
+  if (!other.m_strPath.empty())
     m_strPath = other.m_strPath;
 
-  if (m_strMPAARating.empty())
+  if (!other.m_strMPAARating.empty())
     m_strMPAARating = other.m_strMPAARating;
-  if (m_strFileNameAndPath.empty())
+  if (!other.m_strFileNameAndPath.empty())
       m_strFileNameAndPath = other.m_strFileNameAndPath;
 
-  if (!m_premiered.IsValid() && other.m_premiered.IsValid())
+  if (other.m_premiered.IsValid())
     SetPremiered(other.GetPremiered());
 
-  if (m_strStatus.empty())
+  if (!other.m_strStatus.empty())
     m_strStatus = other.m_strStatus;
-  if (m_strProductionCode.empty())
+  if (!other.m_strProductionCode.empty())
     m_strProductionCode = other.m_strProductionCode;
 
-  if (!m_firstAired.IsValid())
+  if (other.m_firstAired.IsValid())
     m_firstAired = other.m_firstAired;
-  if (m_studio.empty())
+  if (!other.m_studio.empty())
     m_studio = other.m_studio;
-  if (m_strAlbum.empty())
+  if (!other.m_strAlbum.empty())
     m_strAlbum = other.m_strAlbum;
-  if (m_artist.empty())
+  if (!other.m_artist.empty())
     m_artist = other.m_artist;
-  if (m_strTrailer.empty())
+  if (!other.m_strTrailer.empty())
     m_strTrailer = other.m_strTrailer;
-  if (!m_iTop250)
+  if (other.m_iTop250)
     m_iTop250 = other.m_iTop250;
-  if (m_iSeason == -1)
+  if (other.m_iSeason != -1)
     m_iSeason = other.m_iSeason;
-  if (m_iEpisode == -1)
+  if (other.m_iEpisode != -1)
     m_iEpisode = other.m_iEpisode;
 
-  if (m_iIdUniqueID == -1)
+  if (other.m_iIdUniqueID != -1)
     m_iIdUniqueID = other.m_iIdUniqueID;
-  if (!m_uniqueIDs.size() && other.m_uniqueIDs.size())
+  if (other.m_uniqueIDs.size())
   {
     m_uniqueIDs = other.m_uniqueIDs;
     m_strDefaultUniqueID = other.m_strDefaultUniqueID;
   };
-  if (m_iSpecialSortSeason == -1)
+  if (other.m_iSpecialSortSeason != -1)
     m_iSpecialSortSeason = other.m_iSpecialSortSeason;
-  if (m_iSpecialSortEpisode == -1)
+  if (other.m_iSpecialSortEpisode != -1)
     m_iSpecialSortEpisode = other.m_iSpecialSortEpisode;
 
-  if (m_ratings.empty() && !other.m_ratings.empty())
+  if (!other.m_ratings.empty())
   {
     m_ratings = other.m_ratings;
     m_strDefaultRating = other.m_strDefaultRating;
   };
-  if (m_iIdRating == -1)
+  if (other.m_iIdRating != -1)
     m_iIdRating = other.m_iIdRating;
-  if (!m_iUserRating)
+  if (other.m_iUserRating)
     m_iUserRating = other.m_iUserRating;
 
-  if (m_iDbId == -1)
+  if (other.m_iDbId != -1)
     m_iDbId = other.m_iDbId;
-  if (m_iFileId == -1)
+  if (other.m_iFileId != -1)
     m_iFileId = other.m_iFileId;
-  if (m_iBookmarkId == -1)
+  if (other.m_iBookmarkId != -1)
     m_iBookmarkId = other.m_iBookmarkId;
-  if (m_iTrack == -1)
+  if (other.m_iTrack != -1)
     m_iTrack = other.m_iTrack;
 
-  if (!m_fanart.GetNumFanarts())
+  if (other.m_fanart.GetNumFanarts())
     m_fanart = other.m_fanart;
 
-  if (!m_duration)
+  if (other.m_duration)
     m_duration = other.m_duration;
-  if (!m_lastPlayed.IsValid())
+  if (other.m_lastPlayed.IsValid())
     m_lastPlayed = other.m_lastPlayed;
 
-  if (m_showLink.empty())
+  if (!other.m_showLink.empty())
     m_showLink = other.m_showLink;
-  if (!m_namedSeasons.size())
+  if (other.m_namedSeasons.size())
     m_namedSeasons = other.m_namedSeasons;
-  if (!m_streamDetails.HasItems())
+  if (other.m_streamDetails.HasItems())
     m_streamDetails = other.m_streamDetails;
-  if (!IsPlayCountSet() && other.IsPlayCountSet())
+  if (other.IsPlayCountSet())
     SetPlayCount(other.GetPlayCount());
 
-  if (!m_EpBookmark.IsSet() && other.m_EpBookmark.IsSet())
+  if (other.m_EpBookmark.IsSet())
     m_EpBookmark = other.m_EpBookmark;
 
-  if (m_basePath.empty())
+  if (!other.m_basePath.empty())
     m_basePath = other.m_basePath;
-  if (m_parentPathID == -1)
+  if (other.m_parentPathID != -1)
     m_parentPathID = other.m_parentPathID;
-  if (!GetResumePoint().IsSet() && other.GetResumePoint().IsSet())
+  if (other.GetResumePoint().IsSet())
     SetResumePoint(other.GetResumePoint());
-  if (m_iIdShow == -1)
+  if (other.m_iIdShow != -1)
     m_iIdShow = other.m_iIdShow;
-  if (m_iIdSeason == -1)
+  if (other.m_iIdSeason != -1)
     m_iIdSeason = other.m_iIdSeason;
 
-  if (!m_dateAdded.IsValid())
+  if (other.m_dateAdded.IsValid())
     m_dateAdded = other.m_dateAdded;
 
-  if (m_type.empty())
+  if (!other.m_type.empty())
     m_type = other.m_type;
 
-  if (m_relevance == -1)
+  if (other.m_relevance != -1)
     m_relevance = other.m_relevance;
-  if (!m_parsedDetails)
+  if (other.m_parsedDetails)
     m_parsedDetails = other.m_parsedDetails;
-  if (!m_coverArt.size())
+  if (other.m_coverArt.size())
     m_coverArt = other.m_coverArt;
+  if (other.m_year != -1)
+    m_year = other.m_year;
 }
 
 void CVideoInfoTag::Archive(CArchive& ar)


### PR DESCRIPTION
## Description
In Kodi 18, the 2nd resolved list items information overwrites the initial listed list item.
In Kodi 19, it is not possible to overwrite existing 1st list items information

This is due to changes made here: https://github.com/xbmc/xbmc/pull/17993

**This PR is just changing the behavior from
If item 1 property is empty - then set it to item 2 property
to
If item 2 property is not empty - then set item 1 property to it**

It also adds in the missing 'year' property so that is now set correctly.

This doesn't affect the intention of the original PR.
But it does allow more functionality by overriding if required with the 2nd items data.

This should also backport to 19 as it is a regression? (I have a PR ready)
Matrix backport PR :https://github.com/xbmc/xbmc/pull/19538

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I have a few add-ons that get more data on the call for playback.
eg. HBO Max - their api doesn't return the year or plot in the main api call to list all videos.
But when starting playback, this data is available and is set to the list item.
This allows things like trakt to identify the movie correctly.

I also use this for linear live channels.
The plugin will list the channel with what is currently playing in the plot and title.
But when playing back the channel, it will change this to the channel name / logo etc.
That way - it doesn't become out of date when the next program plays

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
**Using this test add-on: [test.addon.zip](https://github.com/xbmc/xbmc/files/6263222/test.addon.zip)
In Leia without original PR - resume won't work. plot / year are updated. all other info is wiped.
In Matrix with original PR - resume works but plot / year isn't updated.
With this PR - resume works and plot / year are updated.**

Also tested with HBO Max add-on.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
