### PR TITLE
[python][addons] Request setResolvedUrl callback even when previously resolved

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2586,17 +2586,8 @@ void CApplication::Stop(int exitCode)
 
 bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPlaylist)
 {
-  // If item is a plugin, expand out
-  for (int i=0; URIUtils::IsPlugin(item.GetDynPath()) && i<5; ++i)
-  {
-    bool resume = item.m_lStartOffset == STARTOFFSET_RESUME;
-
-    if (!XFILE::CPluginDirectory::GetPluginResult(item.GetDynPath(), item, resume) ||
-        item.GetDynPath() == item.GetPath()) // GetPluginResult resolved to an empty path
-      return false;
-  }
-  // if after the 5 resolution attempts the item is still a plugin just return, it isn't playable
-  if (URIUtils::IsPlugin(item.GetDynPath()))
+  // if the item is a plugin we need to resolve the plugin paths
+  if (URIUtils::HasPluginPath(item) && !XFILE::CPluginDirectory::GetResolvedPluginResult(item))
     return false;
 
   if (item.IsSmartPlayList())
@@ -2726,16 +2717,8 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   if (item.IsPlayList())
     return false;
 
-  for (int i=0; URIUtils::IsPlugin(item.GetDynPath()) && i<5; ++i)
-  { // we modify the item so that it becomes a real URL
-    bool resume = item.m_lStartOffset == STARTOFFSET_RESUME;
-
-    if (!XFILE::CPluginDirectory::GetPluginResult(item.GetDynPath(), item, resume) ||
-        item.GetDynPath() == item.GetPath()) // GetPluginResult resolved to an empty path
-      return false;
-  }
-  // if after the 5 resolution attempts the item is still a plugin just return, it isn't playable
-  if (URIUtils::IsPlugin(item.GetDynPath()))
+  // if the item is a plugin we need to resolve the plugin paths
+  if (URIUtils::HasPluginPath(item) && !XFILE::CPluginDirectory::GetResolvedPluginResult(item))
     return false;
 
 #ifdef HAS_UPNP

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -913,11 +913,10 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
         {
           CFileItemPtr item = (*list)[0];
           // if the item is a plugin we need to resolve the URL to ensure the infotags are filled.
-          // resolve only for a maximum of 5 times to avoid deadlocks (plugin:// paths can resolve to plugin:// paths)
-          for (int i = 0; URIUtils::IsPlugin(item->GetDynPath()) && i < 5; ++i)
+          if (URIUtils::HasPluginPath(*item) &&
+              !XFILE::CPluginDirectory::GetResolvedPluginResult(*item))
           {
-            if (!XFILE::CPluginDirectory::GetPluginResult(item->GetDynPath(), *item, true))
-              return;
+            return;
           }
           if (item->IsAudio() || item->IsVideo())
             Play(item, pMsg->strParam);

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -34,6 +34,13 @@ public:
   float GetProgress() const override;
   void CancelDirectory() override;
   static bool RunScriptWithParams(const std::string& strPath, bool resume);
+
+  /*! \brief Get a reproducible CFileItem by trying to recursively resolve the plugin paths
+  up to a maximum allowed limit. If no plugin paths exist it will be ignored.
+  \param resultItem the CFileItem with plugin paths to be resolved.
+  \return false if the plugin path cannot be resolved, true otherwise.
+  */
+  static bool GetResolvedPluginResult(CFileItem& resultItem);
   static bool GetPluginResult(const std::string& strPath, CFileItem &resultItem, bool resume);
 
   /*! \brief Check whether a plugin supports media library scanning.

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -1008,10 +1008,12 @@ namespace XBMCAddon
       /// | StationName   | string ("My Station Name") - Used to enforce/override MusicPlayer.StationName infolabel from addons (e.g. in radio addons)
       /// | TotalTime     | float (7848.0) - Set the total time of the item in seconds
       /// | OverrideInfotag | string - "true", "false" - When true will override all info from previous listitem
+      /// | ForceResolvePlugin | string - "true", "false" - When true ensures that a plugin will always receive callbacks to resolve paths (useful for playlist cases)
       ///
       ///-----------------------------------------------------------------------
       /// @python_v20 OverrideInfotag property added
       /// @python_v20 **ResumeTime** and **TotalTime** deprecated. Use **InfoTagVideo.setResumePoint()** instead.
+      /// @python_v20 ForceResolvePlugin property added
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -66,6 +66,11 @@ std::string URIUtils::GetExtension(const std::string& strFileName)
   return strFileName.substr(period);
 }
 
+bool URIUtils::HasPluginPath(const CFileItem& item)
+{
+  return IsPlugin(item.GetPath()) || IsPlugin(item.GetDynPath());
+}
+
 bool URIUtils::HasExtension(const std::string& strFileName)
 {
   if (IsURL(strFileName))

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -13,6 +13,7 @@
 
 class CURL;
 class CAdvancedSettings;
+class CFileItem;
 
 class URIUtils
 {
@@ -27,6 +28,13 @@ public:
 
   static std::string GetExtension(const CURL& url);
   static std::string GetExtension(const std::string& strFileName);
+
+
+  /*! \brief Check if the CFileItem has a plugin path.
+   \param item The CFileItem.
+   \return true if there is a plugin path, false otherwise.
+  */
+  static bool HasPluginPath(const CFileItem& item);
 
   /*!
    \brief Check if there is a file extension


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Allow Kodi to request setResolvedUrl callback also if the addon listitem was previously resolved

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When we play addon videos from playlist, and we try to play a video previously played
Kodi avoid to call again the addon to resolve the ListItem,
this is correct, but at today the video addons use this callback not only to provide the ListItem to play with `xbmcplugin.setResolvedUrl` but also to execute code (needed before or after Kodi full execute the video) or/and to keep track of some things when a user play a video.

This is to solve issue #19529
if it's good i ask for backport permission

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On the add-on play callback:

```python
list_item = xbmcgui.ListItem(offscreen=True)
...
list_item.setProperty('ForceResolvePlugin', 'true')
xbmcplugin.setResolvedUrl(PLUGIN_HANDLE, succeeded=True, listitem=list_item)
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
