### PR TITLE
[Subtitles][ASS] Support both user defined fonts and extracted fonts

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -679,7 +679,7 @@ void CUtil::ClearSubtitles()
 
 void CUtil::ClearTempFonts()
 {
-  std::string searchPath = "special://temp/fonts/";
+  const std::string searchPath = "special://home/media/Fonts/";
 
   if (!CDirectory::Exists(searchPath))
     return;
@@ -691,7 +691,9 @@ void CUtil::ClearTempFonts()
   {
     if (item->m_bIsFolder)
       continue;
-    CFile::Delete(item->GetPath());
+
+    if (StringUtils::StartsWithNoCase(URIUtils::GetFileName(item->GetPath()), "tmp.font."))
+      CFile::Delete(item->GetPath());
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1708,7 +1708,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         if (pStream->codecpar->codec_id == AV_CODEC_ID_TTF ||
             pStream->codecpar->codec_id == AV_CODEC_ID_OTF || AttachmentIsFont(attachmentMimetype))
         {
-          std::string fileName = "special://temp/fonts/";
+          std::string fileName = "special://home/media/Fonts/";
           XFILE::CDirectory::Create(fileName);
           AVDictionaryEntry* nameTag = av_dict_get(pStream->metadata, "filename", NULL, 0);
           if (!nameTag)
@@ -1717,7 +1717,11 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           }
           else
           {
-            fileName += CUtil::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
+            // Note: libass only supports a single font directory to look for aditional fonts
+            // (c.f. ass_set_fonts_dir). To support both user defined fonts (those placed in
+            // special://home/media/Fonts/) and fonts extracted by the demuxer, make it extract
+            // fonts to the user directory with a known, easy to identify, prefix (tmp.font.*).
+            fileName += "tmp.font." + CUtil::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
             XFILE::CFile file;
             if (pStream->codecpar->extradata && file.OpenForWrite(fileName))
             {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -49,8 +49,9 @@ static void libass_log(int level, const char *fmt, va_list args, void *data)
 
 CDVDSubtitlesLibass::CDVDSubtitlesLibass()
 {
-  //Setting the font directory to the temp dir(where mkv fonts are extracted to)
-  std::string strPath = "special://temp/fonts/";
+  // Setting the font directory to the user font dir. This is the directory
+  // where user defined fonts are located (and where mkv fonts are extracted to)
+  const std::string strPath = "special://home/media/Fonts/";
 
   CLog::Log(LOGINFO, "CDVDSubtitlesLibass: Creating ASS library structure");
   m_library = ass_library_init();


### PR DESCRIPTION
## Description
This PR improves font handling for ASS subtitles. In kodi we allow users to add new fonts for subtitles (see 5.1 in https://kodi.wiki/view/Subtitles) by placing them into .kodi/media/Fonts. When using external subtitles that require the use of external fonts, the user should be able to place the fonts there for kodi/libass to find and use.

The main issue here is that libass only supports a single folder for storing additional fonts (see `ass_set_fonts_dir`) and we currently use the temp folder (.kodi/temp/Fonts) - the demuxer is configured to extract fonts to this directory (for muxed subs).

Due to the limitation, this PR changes the implementation and makes the demuxer extract subtitles to the user font directory by appending a known prefix to the files "tmp.font.*. This prefix is later used to cleanup temporary files, just like today (`ClearTempFonts`). This way we can support external fonts for subtitles and muxed fonts with libass.

## Motivation and Context
Improve font handling for ASS subtitles. Feature pairity between ASS and other subtitle formats (so that we can work towards a future conversion).
Fixes https://github.com/xbmc/xbmc/issues/16209

## How Has This Been Tested?
This was runtime tested on Linux, Android (TV), Windows and OSX with the samples available on the team ftp server. Furthermore, external subtitles (with missing fonts) were tested using the sample provided in https://forum.kodi.tv/showthread.php?tid=361545&pid=3024983#pid3024983

## Screenshots (if appropriate):

**Before (segoeprb.ttf in media/Fonts):**
![alt text](https://i.imgur.com/NKwmKh4.png "Before")

**After (segoeprb.ttf in media/Fonts)**
![alt text](https://i.imgur.com/JHTWFIn.png "After")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
