### PR TITLE
[Subtitles][ASS] Log libass version

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -52,6 +52,7 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   //Setting the font directory to the temp dir(where mkv fonts are extracted to)
   std::string strPath = "special://temp/fonts/";
 
+  CLog::Log(LOGINFO, "CDVDSubtitlesLibass: Using libass version {0:x}", ass_library_version());
   CLog::Log(LOGINFO, "CDVDSubtitlesLibass: Creating ASS library structure");
   m_library = ass_library_init();
   if(!m_library)


### PR DESCRIPTION
## Description
This PR only logs the libass version being used

## Motivation and Context
Useful for debugging

## How Has This Been Tested?
Runtime tested

```
2021-04-08 13:07:31.544 T:12371    INFO <general>: Opening stream: 2 source: 256
2021-04-08 13:07:31.544 T:12371    INFO <general>: CDVDSubtitlesLibass: Using libass version 1500000
2021-04-08 13:07:31.544 T:12371    INFO <general>: CDVDSubtitlesLibass: Creating ASS library structure
2021-04-08 13:07:31.544 T:12371    INFO <general>: CDVDSubtitlesLibass: Initializing ASS library font settings
2021-04-08 13:07:31.544 T:12371    INFO <general>: CDVDSubtitlesLibass: Initializing ASS Renderer
2021-04-08 13:07:31.544 T:12371   DEBUG <general>: CDVDSubtitlesLibass: [ass] Shaper: FriBidi 1.0.10 (SIMPLE) HarfBuzz-ng 2.8.0 (COMPLEX)

```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
