### PR TITLE
[rendering] Fix OverlayRenderer alpha blending

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -368,7 +368,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glEnable(GL_BLEND);
 
   glBindTexture(GL_TEXTURE_2D, m_texture);
-  glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
@@ -488,9 +488,9 @@ void COverlayTextureGL::Render(SRenderState& state)
 
   glBindTexture(GL_TEXTURE_2D, m_texture);
   if(m_pma)
-    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
   else
-    glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);


### PR DESCRIPTION
If `glBlendFunc` is used, it sets the blend mode for RGB as well as
the alpha channel. Using GL_SRC_ALPHA and GL_ONE_MINUS_SRC_ALPHA for
the alpha channel leads to the equation

Alpha out = Overlay alpha * Overlay alpha +
            (1 - Overlay alpha) * Destination alpha

This sort of blending does not make much sense for the alpha channel and
means that the alpha of the framebuffer can become < 1 even if it was
completely opaque (destination alpha = 1 everywhere) before.

On Wayland, we promise the compositor that our surface is opaque. If
alpha is not 1.0 at some pixel, display artifacts may occur, so the
incorrect alpha channel leads to incorrect display.

To fix this problem, the alpha equation is changed to:

Alpha out = Overlay alpha + (1 - Overlay alpha) * Destination alpha

This removes the squaring of the overlay alpha and guarantees that
alpha out == 1 if destination alpha == 1.

@lrusak Please test if this doesn't break GBM

@lrusak and @sarbes Please review if this is the correct solution

@enen92 Please test if it fixes your ASS issues