### PR TITLE
[Windows] Add video, HDR metadata, shader and swapchain infos to debug info OSD

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -365,6 +365,7 @@
       <i>Info</i>
       <o>PlayerProcessInfo</o>
       <o mod="ctrl,shift">PlayerDebug</o>
+      <o mod="alt">PlayerDebugVideo</o>
       <z>AspectRatio</z>
       <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -68,6 +68,8 @@ public:
   bool hasLightMetadata = false;
   AVContentLightMetadata lightMetadata;
 
+  AVPixelFormat pixelFormat; //< source pixel format
+
   unsigned int iWidth;
   unsigned int iHeight;
   unsigned int iDisplayWidth;           //< width of the picture without black bars

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -969,6 +969,8 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
     pVideoPicture->iFlags |= DVP_FLAG_DROPPED;
   }
 
+  pVideoPicture->pixelFormat = m_pCodecContext->sw_pix_fmt;
+
   pVideoPicture->chroma_position = m_pCodecContext->chroma_sample_location;
   pVideoPicture->color_primaries = m_pCodecContext->color_primaries == AVCOL_PRI_UNSPECIFIED ? m_hints.colorPrimaries : m_pCodecContext->color_primaries;
   pVideoPicture->color_transfer = m_pCodecContext->color_trc == AVCOL_TRC_UNSPECIFIED ? m_hints.colorTransferCharacteristic : m_pCodecContext->color_trc;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4340,6 +4340,9 @@ bool CVideoPlayer::OnAction(const CAction &action)
     case ACTION_PLAYER_DEBUG:
       m_renderManager.ToggleDebug();
       break;
+    case ACTION_PLAYER_DEBUG_VIDEO:
+      m_renderManager.ToggleDebugVideo();
+      break;
 
     case ACTION_PLAYER_PROCESS_INFO:
       if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_DIALOG_PLAYER_PROCESS_INFO)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "DebugInfo.h"
 #include "RenderInfo.h"
 #include "VideoShaders/ShaderFormats.h"
 #include "cores/IPlayer.h"
@@ -91,6 +92,9 @@ public:
                                                 void* data);
 
   void SetVideoSettings(const CVideoSettings &settings);
+
+  // Gets debug info from render buffer
+  virtual DEBUG_INFO_VIDEO GetDebugInfo(int idx) { return {}; };
 
 protected:
   void CalcNormalRenderRect(float offsetX, float offsetY, float width, float height,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES BaseRenderer.cpp
 
 set(HEADERS BaseRenderer.h
             ColorManager.h
+            DebugInfo.h
             OverlayRenderer.h
             OverlayRendererGUI.h
             OverlayRendererUtil.h

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugInfo.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugInfo.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+struct DEBUG_INFO_PLAYER
+{
+  std::string audio;
+  std::string video;
+  std::string player;
+  std::string vsync;
+};
+
+struct DEBUG_INFO_VIDEO
+{
+  std::string videoSource;
+  std::string metaPrim;
+  std::string metaLight;
+  std::string shader;
+};
+
+struct DEBUG_INFO_RENDER
+{
+  std::string renderFlags;
+  std::string videoOutput;
+};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -17,7 +17,7 @@ using namespace OVERLAY;
 
 CDebugRenderer::CDebugRenderer()
 {
-  for (int i=0; i<4; i++)
+  for (int i = 0; i < 6; i++)
   {
     m_overlay[i] = nullptr;
     m_strDebug[i] = " ";
@@ -33,50 +33,105 @@ CDebugRenderer::~CDebugRenderer()
   }
 }
 
-void CDebugRenderer::SetInfo(std::string &info1, std::string &info2, std::string &info3, std::string &info4)
+void CDebugRenderer::SetInfo(DEBUG_INFO_PLAYER& info)
 {
   m_overlayRenderer.Release(0);
 
-  if (info1 != m_strDebug[0])
+  if (info.audio != m_strDebug[0])
   {
-    m_strDebug[0] = info1;
+    m_strDebug[0] = info.audio;
     if (m_overlay[0])
       m_overlay[0]->Release();
     m_overlay[0] = new CDVDOverlayText();
     m_overlay[0]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[0]));
   }
-  if (info2 != m_strDebug[1])
+  if (info.video != m_strDebug[1])
   {
-    m_strDebug[1] = info2;
+    m_strDebug[1] = info.video;
     if (m_overlay[1])
       m_overlay[1]->Release();
     m_overlay[1] = new CDVDOverlayText();
     m_overlay[1]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[1]));
   }
-  if (info3 != m_strDebug[2])
+  if (info.player != m_strDebug[2])
   {
-    m_strDebug[2] = info3;
+    m_strDebug[2] = info.player;
     if (m_overlay[2])
       m_overlay[2]->Release();
     m_overlay[2] = new CDVDOverlayText();
     m_overlay[2]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[2]));
   }
-  if (info4 != m_strDebug[3])
+  if (info.vsync != m_strDebug[3])
   {
-    m_strDebug[3] = info4;
+    m_strDebug[3] = info.vsync;
     if (m_overlay[3])
       m_overlay[3]->Release();
     m_overlay[3] = new CDVDOverlayText();
     m_overlay[3]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[3]));
   }
 
-  m_overlayRenderer.AddOverlay(m_overlay[0], 0, 0);
-  m_overlayRenderer.AddOverlay(m_overlay[1], 0, 0);
-  m_overlayRenderer.AddOverlay(m_overlay[2], 0, 0);
-  m_overlayRenderer.AddOverlay(m_overlay[3], 0, 0);
+  for (int i = 0; i < 4; i++)
+    m_overlayRenderer.AddOverlay(m_overlay[i], 0, 0);
 }
 
-void CDebugRenderer::Render(CRect &src, CRect &dst, CRect &view)
+void CDebugRenderer::SetInfo(DEBUG_INFO_VIDEO& video, DEBUG_INFO_RENDER& render)
+{
+  m_overlayRenderer.Release(0);
+
+  if (video.videoSource != m_strDebug[0])
+  {
+    m_strDebug[0] = video.videoSource;
+    if (m_overlay[0])
+      m_overlay[0]->Release();
+    m_overlay[0] = new CDVDOverlayText();
+    m_overlay[0]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[0]));
+  }
+  if (video.metaPrim != m_strDebug[1])
+  {
+    m_strDebug[1] = video.metaPrim;
+    if (m_overlay[1])
+      m_overlay[1]->Release();
+    m_overlay[1] = new CDVDOverlayText();
+    m_overlay[1]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[1]));
+  }
+  if (video.metaLight != m_strDebug[2])
+  {
+    m_strDebug[2] = video.metaLight;
+    if (m_overlay[2])
+      m_overlay[2]->Release();
+    m_overlay[2] = new CDVDOverlayText();
+    m_overlay[2]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[2]));
+  }
+  if (video.shader != m_strDebug[3])
+  {
+    m_strDebug[3] = video.shader;
+    if (m_overlay[3])
+      m_overlay[3]->Release();
+    m_overlay[3] = new CDVDOverlayText();
+    m_overlay[3]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[3]));
+  }
+  if (render.renderFlags != m_strDebug[4])
+  {
+    m_strDebug[4] = render.renderFlags;
+    if (m_overlay[4])
+      m_overlay[4]->Release();
+    m_overlay[4] = new CDVDOverlayText();
+    m_overlay[4]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[4]));
+  }
+  if (render.videoOutput != m_strDebug[5])
+  {
+    m_strDebug[5] = render.videoOutput;
+    if (m_overlay[5])
+      m_overlay[5]->Release();
+    m_overlay[5] = new CDVDOverlayText();
+    m_overlay[5]->AddElement(new CDVDOverlayText::CElementText(m_strDebug[5]));
+  }
+
+  for (int i = 0; i < 6; i++)
+    m_overlayRenderer.AddOverlay(m_overlay[i], 0, 0);
+}
+
+void CDebugRenderer::Render(CRect& src, CRect& dst, CRect& view)
 {
   m_overlayRenderer.SetVideoRect(src, dst, view);
   m_overlayRenderer.Render(0);
@@ -110,7 +165,8 @@ void CDebugRenderer::CRenderer::Render(int idx)
 
     COverlayText *text = dynamic_cast<COverlayText*>(o);
     if (text)
-      text->PrepareRender("arial.ttf", 1, 100, 16, 0, m_font, m_fontBorder, UTILS::COLOR::NONE, m_rv);
+      text->PrepareRender("arial.ttf", 1, 100, 15, 0, m_font, m_fontBorder, UTILS::COLOR::NONE,
+                          m_rv);
 
     RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "DebugInfo.h"
 #include "OverlayRenderer.h"
 
 #include <string>
@@ -19,8 +20,9 @@ class CDebugRenderer
 public:
   CDebugRenderer();
   virtual ~CDebugRenderer();
-  void SetInfo(std::string &info1, std::string &info2, std::string &info3, std::string &info4);
-  void Render(CRect &src, CRect &dst, CRect &view);
+  void SetInfo(DEBUG_INFO_PLAYER& info);
+  void SetInfo(DEBUG_INFO_VIDEO& video, DEBUG_INFO_RENDER& render);
+  void Render(CRect& src, CRect& dst, CRect& view);
   void Flush();
 
 protected:
@@ -32,7 +34,7 @@ protected:
     void Render(int idx) override;
   };
 
-  std::string m_strDebug[4];
-  CDVDOverlayText *m_overlay[4];
+  std::string m_strDebug[6];
+  CDVDOverlayText* m_overlay[6];
   CRenderer m_overlayRenderer;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -72,6 +72,7 @@ public:
   bool Flush(bool wait, bool saveBuffers);
   bool IsConfigured() const;
   void ToggleDebug();
+  void ToggleDebugVideo();
 
   unsigned int AllocRenderCapture();
   void ReleaseRenderCapture(unsigned int captureId);
@@ -141,6 +142,7 @@ protected:
   bool m_bRenderGUI = true;
   bool m_renderedOverlay = false;
   bool m_renderDebug = false;
+  bool m_renderDebugVideo = false;
   XbmcThreads::EndTime m_debugTimer;
   std::atomic_bool m_showVideo = {false};
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -69,6 +69,7 @@ public:
   void SetDisplayMetadata(bool hasDisplayMetadata, AVMasteringDisplayMetadata displayMetadata,
                           bool hasLightMetadata, AVContentLightMetadata lightMetadata);
   void SetToneMapParam(int method, float param);
+  std::string GetDebugInfo();
 
   static bool CreateLUTView(int lutSize, uint16_t* lutData, bool isRGB, ID3D11ShaderResourceView** ppLUTView);
 
@@ -98,6 +99,7 @@ private:
   int m_ditherDepth = 0;
   int m_toneMappingMethod = 0;
   float m_toneMappingParam = 1.0f;
+  float m_toneMappingDebug = .0f;
 
   CRect m_sourceRect = {};
   CPoint m_destPoints[4] = {};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -333,3 +333,11 @@ bool CWinRenderer::NeedBuffer(int idx)
 
   return m_renderer->NeedBuffer(idx);
 }
+
+DEBUG_INFO_VIDEO CWinRenderer::GetDebugInfo(int idx)
+{
+  if (!m_bConfigured)
+    return {};
+
+  return m_renderer->GetDebugInfo(idx);
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -46,6 +46,9 @@ public:
   bool WantsDoublePass() override;
   bool ConfigChanged(const VideoPicture& picture) override;
 
+  // Debug info video
+  DEBUG_INFO_VIDEO GetDebugInfo(int idx) override;
+
 protected:
   void PreInit();
   int NextBuffer() const;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -35,6 +35,7 @@ void CRenderBuffer::AppendPicture(const VideoPicture& picture)
   full_range = picture.color_range == 1;
   bits = picture.colorBits;
   stereoMode = picture.stereoMode;
+  pixelFormat = picture.pixelFormat;
 
   hasDisplayMetadata = picture.hasDisplayMetadata;
   displayMetadata = picture.displayMetadata;
@@ -636,4 +637,83 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
         DX::Windowing()->ToggleHDR(); // Toggle display HDR OFF
     }
   }
+}
+
+DEBUG_INFO_VIDEO CRendererBase::GetDebugInfo(int idx)
+{
+  CRenderBuffer* rb = m_renderBuffers[idx];
+
+  const char* px = av_get_pix_fmt_name(rb->pixelFormat);
+  const char* pr = av_color_primaries_name(rb->primaries);
+  const char* tr = av_color_transfer_name(rb->color_transfer);
+
+  const std::string pixel = px ? px : "unknown";
+  const std::string prim = pr ? pr : "unknown";
+  const std::string trans = tr ? tr : "unknown";
+
+  const int max = static_cast<int>(std::exp2(rb->bits));
+  const int range_min = rb->full_range ? 0 : (max * 16) / 256;
+  const int range_max = rb->full_range ? max - 1 : (max * 235) / 256;
+
+  DEBUG_INFO_VIDEO info;
+
+  info.videoSource = StringUtils::Format(
+      "Source: {}x{}{}, fr: {:.3f}, pixel: {} {}-bit, range: {}-{}, matx: {}, trc: {}",
+      m_sourceWidth, m_sourceHeight, (rb->pictureFlags & DVP_FLAG_INTERLACED) ? "i" : "p", m_fps,
+      pixel, rb->bits, range_min, range_max, prim, trans);
+
+  info.metaPrim = "Primaries (meta): ";
+  info.metaLight = "HDR light (meta): ";
+
+  if (rb->hasDisplayMetadata && rb->displayMetadata.has_primaries &&
+      rb->displayMetadata.display_primaries[0][0].num)
+  {
+    double prim[3][2];
+    double wp[2];
+
+    for (int i = 0; i < 3; i++)
+    {
+      for (int j = 0; j < 2; j++)
+        prim[i][j] = static_cast<double>(rb->displayMetadata.display_primaries[i][j].num) /
+                     static_cast<double>(rb->displayMetadata.display_primaries[i][j].den);
+    }
+
+    for (int j = 0; j < 2; j++)
+      wp[j] = static_cast<double>(rb->displayMetadata.white_point[j].num) /
+              static_cast<double>(rb->displayMetadata.white_point[j].den);
+
+    info.metaPrim += StringUtils::Format(
+        "R({:.3f} {:.3f}), G({:.3f} {:.3f}), B({:.3f} {:.3f}), WP({:.3f} {:.3f})", prim[0][0],
+        prim[0][1], prim[1][0], prim[1][1], prim[2][0], prim[2][1], wp[0], wp[1]);
+  }
+  else
+  {
+    info.metaPrim += "none";
+  }
+
+  if (rb->hasDisplayMetadata && rb->displayMetadata.has_luminance &&
+      rb->displayMetadata.max_luminance.num)
+  {
+    double maxML = static_cast<double>(rb->displayMetadata.max_luminance.num) /
+                   static_cast<double>(rb->displayMetadata.max_luminance.den);
+    double minML = static_cast<double>(rb->displayMetadata.min_luminance.num) /
+                   static_cast<double>(rb->displayMetadata.min_luminance.den);
+
+    info.metaLight += StringUtils::Format("max ML: {:.0f}, min ML: {:.4f}", maxML, minML);
+
+    if (rb->hasLightMetadata && rb->lightMetadata.MaxCLL)
+    {
+      info.metaLight += StringUtils::Format(", max CLL: {}, max FALL: {}", rb->lightMetadata.MaxCLL,
+                                            rb->lightMetadata.MaxFALL);
+    }
+  }
+  else
+  {
+    info.metaLight += "none";
+  }
+
+  if (m_outputShader)
+    info.shader = m_outputShader->GetDebugInfo();
+
+  return info;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "VideoRenderers/ColorManager.h"
+#include "VideoRenderers/DebugInfo.h"
 #include "VideoRenderers/RenderInfo.h"
 #include "VideoRenderers/VideoShaders/WinVideoFilter.h"
 #include "cores/VideoSettings.h"
@@ -19,6 +20,7 @@
 #include <dxgi1_5.h>
 extern "C" {
 #include <libavutil/mastering_display_metadata.h>
+#include <libavutil/pixdesc.h>
 }
 
 struct VideoPicture;
@@ -79,7 +81,7 @@ public:
   bool full_range = false;
   int bits = 8;
   uint8_t texBits = 8;
-
+  AVPixelFormat pixelFormat = AV_PIX_FMT_NONE; // source pixel format
   bool hasDisplayMetadata = false;
   bool hasLightMetadata = false;
   AVMasteringDisplayMetadata displayMetadata = {};
@@ -126,6 +128,8 @@ public:
   void ReleaseBuffer(int idx);
   bool Flush(bool saveBuffers);
   void SetBufferSize(int numBuffers) { m_iBuffersRequired = numBuffers; }
+
+  DEBUG_INFO_VIDEO GetDebugInfo(int idx);
 
   static DXGI_FORMAT GetDXGIFormat(const VideoPicture &picture);
   static DXGI_FORMAT GetDXGIFormat(CVideoBuffer* videoBuffer);

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -432,6 +432,9 @@
 
 #define ACTION_CYCLE_TONEMAP_METHOD 261 //!< Switch to next tonemap method
 
+//! Show debug info for video (source format, metadata, shaders, render flags and output format)
+#define ACTION_PLAYER_DEBUG_VIDEO 262
+
 // Voice actions
 #define ACTION_VOICE_RECOGNIZE 300
 

--- a/xbmc/input/actions/ActionTranslator.cpp
+++ b/xbmc/input/actions/ActionTranslator.cpp
@@ -53,6 +53,7 @@ static const std::map<ActionName, ActionID> ActionMappings = {
     {"browsesubtitle", ACTION_BROWSE_SUBTITLE},
     {"cyclesubtitle", ACTION_CYCLE_SUBTITLE},
     {"playerdebug", ACTION_PLAYER_DEBUG},
+    {"playerdebugvideo", ACTION_PLAYER_DEBUG_VIDEO},
     {"codecinfo", ACTION_PLAYER_PROCESS_INFO},
     {"playerprocessinfo", ACTION_PLAYER_PROCESS_INFO},
     {"playerprogramselect", ACTION_PLAYER_PROGRAM_SELECT},

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -21,6 +21,7 @@
 #include <wrl/client.h>
 
 struct RESOLUTION_INFO;
+struct DEBUG_INFO_RENDER;
 
 namespace DX
 {
@@ -108,6 +109,9 @@ namespace DX
     void SetWindowPos(winrt::Windows::Foundation::Rect rect);
 #endif // TARGET_WINDOWS_STORE
     bool IsNV12SharedTexturesSupported() const { return m_NV12SharedTexturesSupport; }
+
+    // Gets debug info from swapchain
+    DEBUG_INFO_RENDER GetDebugInfo() const;
 
   private:
     class CBackBuffer : public CD3DTexture

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -13,6 +13,7 @@
 #include "Resolution.h"
 #include "VideoSync.h"
 #include "WinEvents.h"
+#include "cores/VideoPlayer/VideoRenderers/DebugInfo.h"
 #include "guilib/DispResource.h"
 
 #include <memory>
@@ -166,6 +167,9 @@ public:
   virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; };
 
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
+
+  // Gets debug info from video renderer
+  virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; };
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -196,3 +196,8 @@ void CWinSystemWin10DX::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace)
 {
   m_deviceResources->SetHdrColorSpace(colorSpace);
 }
+
+DEBUG_INFO_RENDER CWinSystemWin10DX::GetDebugInfo()
+{
+  return m_deviceResources->GetDebugInfo();
+}

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -77,6 +77,9 @@ public:
   void SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const;
   void SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace) const;
 
+  // Get debug info from swapchain
+  DEBUG_INFO_RENDER GetDebugInfo() override;
+
 protected:
   void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) override;
   void ReleaseBackBuffer() override;

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -421,3 +421,8 @@ void CWinSystemWin32DX::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace)
 {
   m_deviceResources->SetHdrColorSpace(colorSpace);
 }
+
+DEBUG_INFO_RENDER CWinSystemWin32DX::GetDebugInfo()
+{
+  return m_deviceResources->GetDebugInfo();
+}

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -79,6 +79,9 @@ public:
   void SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const;
   void SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace) const;
 
+  // Get debug info from swapchain
+  DEBUG_INFO_RENDER GetDebugInfo() override;
+
 protected:
   void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) override;
   void ReleaseBackBuffer() override;


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/19126 for Matrix


## Motivation and Context
Adds debugging information related to the new HDR passthrough and tone mapping features in Matrix. This should have been included before but could not be finished in time for v19.0. Now it can be included as it is totally stable and has been tested in Matrix builds for months:

https://forum.kodi.tv/showthread.php?tid=359964


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
