### PR TITLE
[Estuary] Add All/Watched/Unwatched button to sidebar menu for Music …

### DIFF
--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -104,7 +104,7 @@
 						<include>MediaMenuItemsCommon</include>
 						<label>$LOCALIZE[20367]</label>
 						<label2>[B]$INFO[Container.NumItems][/B]</label2>
-						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.content(seasons) | Container.Content(episodes)</visible>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.content(seasons) | Container.Content(episodes) | Container.Content(MusicVideos)</visible>
 					</control>
 					<control type="label" id="203">
 						<include>MediaMenuLabelCommon</include>


### PR DESCRIPTION
Backport of #19505

Simple change that adds something that had no reason to be missing, so that sidebar menu for Music Videos is now aligned with all other video types. thus is a fix in my opinion and hence the backport.