### PR TITLE
[Backport][PVR][GUI] 'Next recording on ...' label time is not localized

### DIFF
--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -138,11 +138,11 @@ void CPVRGUITimerInfo::UpdateNextTimer()
     strNextRecordingChannelIcon = StringUtils::Format("%s", timer->ChannelIcon().c_str());
     strNextRecordingTime = StringUtils::Format("%s", timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
 
-    strNextTimerInfo = StringUtils::Format("%s %s %s %s",
-        g_localizeStrings.Get(19106).c_str(),
-        timer->StartAsLocalTime().GetAsLocalizedDate(true).c_str(),
-        g_localizeStrings.Get(19107).c_str(),
-        timer->StartAsLocalTime().GetAsLocalizedTime("HH:mm", false).c_str());
+    strNextTimerInfo =
+        StringUtils::Format("%s %s %s %s", g_localizeStrings.Get(19106).c_str(),
+                            timer->StartAsLocalTime().GetAsLocalizedDate(true).c_str(),
+                            g_localizeStrings.Get(19107).c_str(),
+                            timer->StartAsLocalTime().GetAsLocalizedTime("", false).c_str());
   }
 
   CSingleLock lock(m_critSection);


### PR DESCRIPTION
## Description

Backport of PR https://github.com/xbmc/xbmc/pull/19551 for Matrix branch

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
The "Next recording on..." label shown in the PVR Timers and PVR Timer Rules view does not localize the time portion of the label correctly:

![Untitled](https://user-images.githubusercontent.com/706055/114258584-824a0d00-9995-11eb-9aa2-5c431d773406.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
After a time consuming "deep" search, this concern has apparently existed since PVR was first implemented in Frodo via PR https://github.com/xbmc/xbmc/pull/1357.  I searched the current PVR implementation and did not find any additional instances where the localized date/time format is being ignored, and do not have any other suggested edits to resolve.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on Kodi master branch current as of 2021.04.09, on Windows x64 (Desktop), with:

-  Settings / Interface / Regional / Regional default format -> USA (12h)
-  Settings / Interface / Regional / Time format --> Regional (h:mm:ss xx)

## Screenshots (if appropriate):
Before the requested change, the time portion of the label shows as HH:mm on all platforms and regions:

![Untitled](https://user-images.githubusercontent.com/706055/114258696-7f9be780-9996-11eb-99cf-dfdf0d489c37.png)

After the requested change the time portion of the label is localized based on Settings as expected:

![Untitled2](https://user-images.githubusercontent.com/706055/114258968-80357d80-9998-11eb-8f79-3159d9e1ecdc.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
