### PR TITLE
FFmpeg update to 4.4

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -33,15 +33,14 @@
 #
 
 # required ffmpeg library versions
-set(REQUIRED_FFMPEG_VERSION 4.3)
-set(_avcodec_ver ">=58.91.100")
-set(_avfilter_ver ">=7.85.100")
-set(_avformat_ver ">=58.45.100")
-set(_avutil_ver ">=56.51.100")
-set(_swscale_ver ">=5.7.100")
-set(_swresample_ver ">=3.7.100")
-set(_postproc_ver ">=55.7.100")
-
+set(REQUIRED_FFMPEG_VERSION 4.4)
+set(_avcodec_ver ">=58.134.100")
+set(_avfilter_ver ">=7.110.100")
+set(_avformat_ver ">=58.76.100")
+set(_avutil_ver ">=56.70.100")
+set(_swscale_ver ">=5.9.100")
+set(_swresample_ver ">=3.9.100")
+set(_postproc_ver ">=55.9.100")
 
 # Allows building with external ffmpeg not found in system paths,
 # without library version checks

--- a/tools/buildsteps/windows/patches/0001-ffmpeg-windows-configure-detect-openssl.patch
+++ b/tools/buildsteps/windows/patches/0001-ffmpeg-windows-configure-detect-openssl.patch
@@ -1,8 +1,17 @@
+From 08ae41e824e04ab48eafde763c72d1ff3e878a41 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Sat, 10 Apr 2021 08:16:11 -0700
+Subject: [PATCH 1/4] ffmpeg: windows: configure: detect openssl
+
+---
+ configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/configure b/configure
-index 8569a60bf8..42f5a3ada4 100755
+index d7a3f507e8..4b85e881b1 100755
 --- a/configure
 +++ b/configure
-@@ -6468,6 +6468,8 @@ enabled openssl           && { check_pkg_config openssl openssl openssl/ssl.h OP
+@@ -6529,6 +6529,8 @@ enabled openssl           && { check_pkg_config openssl openssl openssl/ssl.h OP
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
@@ -11,3 +20,6 @@ index 8569a60bf8..42f5a3ada4 100755
                                 die "ERROR: openssl not found"; }
  enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
  enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/rk_mpi.h mpp_create &&
+-- 
+2.29.2
+

--- a/tools/buildsteps/windows/patches/0002-ffmpeg-windows-configure-fix-zlib-conflict.patch
+++ b/tools/buildsteps/windows/patches/0002-ffmpeg-windows-configure-fix-zlib-conflict.patch
@@ -1,8 +1,17 @@
+From 1e57e7f49f1a74ee11d3c8dd5d407f35eecd5167 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Sat, 10 Apr 2021 08:16:48 -0700
+Subject: [PATCH 2/4] ffmpeg: windows: configure: fix zlib conflict
+
+---
+ configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
 diff --git a/configure b/configure
-index 8569a60bf8..2091cea243 100755
+index 4b85e881b1..da457705d1 100755
 --- a/configure
 +++ b/configure
-@@ -7553,6 +7553,9 @@ print_config CONFIG_ "$config_files" $CONFIG_LIST       \
+@@ -7627,6 +7627,9 @@ print_config CONFIG_ "$config_files" $CONFIG_LIST       \
                                       $CONFIG_EXTRA      \
                                       $ALL_COMPONENTS    \
  
@@ -12,3 +21,6 @@ index 8569a60bf8..2091cea243 100755
  echo "#endif /* FFMPEG_CONFIG_H */" >> $TMPH
  echo "endif # FFMPEG_CONFIG_MAK" >> ffbuild/config.mak
  
+-- 
+2.29.2
+

--- a/tools/buildsteps/windows/patches/0003-ffmpeg-windows-configure-allow-building-static.patch
+++ b/tools/buildsteps/windows/patches/0003-ffmpeg-windows-configure-allow-building-static.patch
@@ -1,8 +1,17 @@
+From efb771d944e96bcbb24635bcae99a43dffab262e Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Sat, 10 Apr 2021 08:17:11 -0700
+Subject: [PATCH 3/4] ffmpeg: windows: configure: allow building static
+
+---
+ configure | 4 ++++
+ 1 file changed, 4 insertions(+)
+
 diff --git a/configure b/configure
-index 8569a60bf8..afca15141e 100755
+index da457705d1..e3a8f45ff4 100755
 --- a/configure
 +++ b/configure
-@@ -5401,6 +5401,8 @@ case $target_os in
+@@ -5439,6 +5439,8 @@ case $target_os in
          enabled shared && ! enabled small && test_cmd $windres --version && enable gnu_windres
          enabled x86_32 && check_ldflags -Wl,--large-address-aware
          shlibdir_default="$bindir_default"
@@ -11,7 +20,7 @@ index 8569a60bf8..afca15141e 100755
          SLIBPREF=""
          SLIBSUF=".dll"
          SLIBNAME_WITH_VERSION='$(SLIBPREF)$(FULLNAME)-$(LIBVERSION)$(SLIBSUF)'
-@@ -5450,6 +5452,8 @@ case $target_os in
+@@ -5488,6 +5490,8 @@ case $target_os in
          fi
          enabled x86_32 && check_ldflags -LARGEADDRESSAWARE
          shlibdir_default="$bindir_default"
@@ -20,3 +29,6 @@ index 8569a60bf8..afca15141e 100755
          SLIBPREF=""
          SLIBSUF=".dll"
          SLIBNAME_WITH_VERSION='$(SLIBPREF)$(FULLNAME)-$(LIBVERSION)$(SLIBSUF)'
+-- 
+2.29.2
+

--- a/tools/buildsteps/windows/patches/0004-ffmpeg-windows-configure-detect-libdav1d.patch
+++ b/tools/buildsteps/windows/patches/0004-ffmpeg-windows-configure-detect-libdav1d.patch
@@ -1,13 +1,25 @@
+From d475edac8c6890fbaea5ca20d552c60aead0f04a Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Sat, 10 Apr 2021 08:19:27 -0700
+Subject: [PATCH 4/4] ffmpeg: windows: configure: detect libdav1d
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/configure b/configure
-index 8569a60bf8..a368cc65b6 100755
+index e3a8f45ff4..983d7e1078 100755
 --- a/configure
 +++ b/configure
-@@ -6295,7 +6295,7 @@ enabled libcelt           && require libcelt celt/celt.h celt_decode -lcelt0 &&
+@@ -6357,7 +6357,7 @@ enabled libcelt           && require libcelt celt/celt.h celt_decode -lcelt0 &&
                                 die "ERROR: libcelt must be installed and version must be >= 0.11.0."; }
  enabled libcaca           && require_pkg_config libcaca caca caca.h caca_create_canvas
  enabled libcodec2         && require libcodec2 codec2/codec2.h codec2_create -lcodec2
--enabled libdav1d          && require_pkg_config libdav1d "dav1d >= 0.4.0" "dav1d/dav1d.h" dav1d_version
+-enabled libdav1d          && require_pkg_config libdav1d "dav1d >= 0.5.0" "dav1d/dav1d.h" dav1d_version
 +enabled libdav1d          && require libdav1d dav1d/dav1d.h dav1d_version -llibdav1d
  enabled libdavs2          && require_pkg_config libdavs2 "davs2 >= 1.6.0" davs2.h davs2_decoder_open
  enabled libdc1394         && require_pkg_config libdc1394 libdc1394-2 dc1394/dc1394.h dc1394_new
  enabled libdrm            && require_pkg_config libdrm libdrm xf86drm.h drmGetVersion
+-- 
+2.29.2
+

--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=4.3.2-Matrix-19.1
+VERSION=4.4-N-Alpha1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz

--- a/xbmc/cdrip/EncoderFFmpeg.h
+++ b/xbmc/cdrip/EncoderFFmpeg.h
@@ -31,7 +31,6 @@ private:
   AVCodecContext   *m_CodecCtx;
   SwrContext       *m_SwrCtx;
   AVStream         *m_Stream;
-  AVPacket          m_Pkt;
   AVSampleFormat    m_InFormat;
   AVSampleFormat    m_OutFormat;
   /* From libavformat/avio.h:

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -18,9 +18,7 @@
 #include <string.h>
 #include <cassert>
 
-CAEEncoderFFmpeg::CAEEncoderFFmpeg():
-  m_CodecCtx      (NULL ),
-  m_SwrCtx        (NULL )
+CAEEncoderFFmpeg::CAEEncoderFFmpeg() : m_CodecCtx(NULL), m_SwrCtx(NULL)
 {
 }
 
@@ -263,26 +261,34 @@ int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_siz
                     in, in_size, 0);
 
   /* initialize the output packet */
-  av_init_packet(&m_Pkt);
-  m_Pkt.size = out_size;
-  m_Pkt.data = out;
+  AVPacket* pkt = av_packet_alloc();
+  if (!pkt)
+  {
+    CLog::Log(LOGERROR, "CAEEncoderFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
+              strerror(errno));
+    av_frame_free(&frame);
+    return 0;
+  }
+
+  pkt->size = out_size;
+  pkt->data = out;
 
   /* encode it */
-  int ret = avcodec_encode_audio2(m_CodecCtx, &m_Pkt, frame, &got_output);
+  int ret = avcodec_encode_audio2(m_CodecCtx, pkt, frame, &got_output);
+
+  int size = pkt->size;
 
   /* free temporary data */
   av_frame_free(&frame);
+
+  /* free the packet */
+  av_packet_free(&pkt);
 
   if (ret < 0 || !got_output)
   {
     CLog::Log(LOGERROR, "CAEEncoderFFmpeg::Encode - Encoding failed");
     return 0;
   }
-
-  int size = m_Pkt.size;
-
-  /* free the packet */
-  av_packet_unref(&m_Pkt);
 
   /* return the number of frames used */
   return size;

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
@@ -44,7 +44,6 @@ private:
   AVCodecContext *m_CodecCtx;
   SwrContext *m_SwrCtx;
   CAEChannelInfo m_Layout;
-  AVPacket m_Pkt;
   uint8_t m_Buffer[8 + AV_INPUT_BUFFER_MIN_SIZE];
   int m_BufferSize = 0;
   int m_OutputSize = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -69,7 +69,6 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   if (!m_pCodecContext)
     return false;
 
-  m_pCodecContext->debug_mv = 0;
   m_pCodecContext->debug = 0;
   m_pCodecContext->workaround_bugs = 1;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -143,16 +143,32 @@ bool CDVDAudioCodecFFmpeg::AddData(const DemuxPacket &packet)
     Reset();
   }
 
-  AVPacket avpkt;
-  av_init_packet(&avpkt);
-  avpkt.data = packet.pData;
-  avpkt.size = packet.iSize;
-  avpkt.dts = (packet.dts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
-  avpkt.pts = (packet.pts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
-  avpkt.side_data = static_cast<AVPacketSideData*>(packet.pSideData);
-  avpkt.side_data_elems = packet.iSideDataElems;
+  AVPacket* avpkt = av_packet_alloc();
+  if (!avpkt)
+  {
+    CLog::Log(LOGERROR, "CDVDAudioCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
+              strerror(errno));
+    return false;
+  }
 
-  int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
+  avpkt->data = packet.pData;
+  avpkt->size = packet.iSize;
+  avpkt->dts = (packet.dts == DVD_NOPTS_VALUE)
+                   ? AV_NOPTS_VALUE
+                   : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
+  avpkt->pts = (packet.pts == DVD_NOPTS_VALUE)
+                   ? AV_NOPTS_VALUE
+                   : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
+  avpkt->side_data = static_cast<AVPacketSideData*>(packet.pSideData);
+  avpkt->side_data_elems = packet.iSideDataElems;
+
+  int ret = avcodec_send_packet(m_pCodecContext, avpkt);
+
+  //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+  // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
+  // and storing our own AVPacket. This will require some extensive changes.
+  av_buffer_unref(&avpkt->buf);
+  av_free(avpkt);
 
   // try again
   if (ret == AVERROR(EAGAIN))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -50,7 +50,6 @@ bool CDVDOverlayCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &optio
   if (!m_pCodecContext)
     return false;
 
-  m_pCodecContext->debug_mv = 0;
   m_pCodecContext->debug = 0;
   m_pCodecContext->workaround_bugs = FF_BUG_AUTODETECT;
   m_pCodecContext->codec_tag = hints.codec_tag;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -128,14 +128,24 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
 
   avsubtitle_free(&m_Subtitle);
 
-  AVPacket avpkt;
-  av_init_packet(&avpkt);
-  avpkt.data = pPacket->pData;
-  avpkt.size = pPacket->iSize;
-  avpkt.pts = pPacket->pts == DVD_NOPTS_VALUE ? AV_NOPTS_VALUE : (int64_t)pPacket->pts;
-  avpkt.dts = pPacket->dts == DVD_NOPTS_VALUE ? AV_NOPTS_VALUE : (int64_t)pPacket->dts;
+  AVPacket* avpkt = av_packet_alloc();
+  if (!avpkt)
+  {
+    CLog::Log(LOGERROR, "CDVDOverlayCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
+              strerror(errno));
+    return OC_ERROR;
+  }
 
-  len = avcodec_decode_subtitle2(m_pCodecContext, &m_Subtitle, &gotsub, &avpkt);
+  avpkt->data = pPacket->pData;
+  avpkt->size = pPacket->iSize;
+  avpkt->pts = pPacket->pts == DVD_NOPTS_VALUE ? AV_NOPTS_VALUE : (int64_t)pPacket->pts;
+  avpkt->dts = pPacket->dts == DVD_NOPTS_VALUE ? AV_NOPTS_VALUE : (int64_t)pPacket->dts;
+
+  len = avcodec_decode_subtitle2(m_pCodecContext, &m_Subtitle, &gotsub, avpkt);
+
+  int size = avpkt->size;
+
+  av_packet_free(&avpkt);
 
   if (len < 0)
   {
@@ -144,7 +154,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
     return OC_ERROR;
   }
 
-  if (len != avpkt.size)
+  if (len != size)
     CLog::Log(LOGWARNING, "%s - avcodec_decode_subtitle didn't consume the full packet", __FUNCTION__);
 
   if (!gotsub)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -313,7 +313,6 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   m_pCodecContext->bits_per_coded_sample = hints.bitsperpixel;
   m_pCodecContext->time_base.num = 1;
   m_pCodecContext->time_base.den = DVD_TIME_BASE;
-  m_pCodecContext->thread_safe_callbacks = 1;
   m_pCodecContext->thread_count = CServiceBroker::GetCPUInfo()->GetCPUCount();
 
   if (hints.extradata && hints.extrasize > 0)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -368,20 +368,33 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
   if (!packet.pData)
     return true;
 
-  AVPacket avpkt;
-  av_init_packet(&avpkt);
-  avpkt.data = packet.pData;
-  avpkt.size = packet.iSize;
-  avpkt.dts = (packet.dts == DVD_NOPTS_VALUE)
-                  ? AV_NOPTS_VALUE
-                  : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
-  avpkt.pts = (packet.pts == DVD_NOPTS_VALUE)
-                  ? AV_NOPTS_VALUE
-                  : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
-  avpkt.side_data = static_cast<AVPacketSideData*>(packet.pSideData);
-  avpkt.side_data_elems = packet.iSideDataElems;
+  AVPacket* avpkt = av_packet_alloc();
+  if (!avpkt)
+  {
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - av_packet_alloc failed: {}", __FUNCTION__,
+              strerror(errno));
+    return false;
+  }
 
-  int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
+  avpkt->data = packet.pData;
+  avpkt->size = packet.iSize;
+  avpkt->dts = (packet.dts == DVD_NOPTS_VALUE)
+                   ? AV_NOPTS_VALUE
+                   : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
+  avpkt->pts = (packet.pts == DVD_NOPTS_VALUE)
+                   ? AV_NOPTS_VALUE
+                   : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
+  avpkt->side_data = static_cast<AVPacketSideData*>(packet.pSideData);
+  avpkt->side_data_elems = packet.iSideDataElems;
+
+  int ret = avcodec_send_packet(m_pCodecContext, avpkt);
+
+  //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+  // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
+  // and storing our own AVPacket. This will require some extensive changes.
+  av_buffer_unref(&avpkt->buf);
+  av_free(avpkt);
+
   if (ret == AVERROR(EAGAIN))
     return false;
   else if (ret)
@@ -427,11 +440,18 @@ void CDVDVideoCodecDRMPRIME::Reset()
 
 void CDVDVideoCodecDRMPRIME::Drain()
 {
-  AVPacket avpkt;
-  av_init_packet(&avpkt);
-  avpkt.data = nullptr;
-  avpkt.size = 0;
-  int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
+  AVPacket* avpkt = av_packet_alloc();
+  if (!avpkt)
+  {
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - av_packet_alloc failed: {}", __FUNCTION__,
+              strerror(errno));
+    return;
+  }
+
+  avpkt->data = nullptr;
+  avpkt->size = 0;
+
+  int ret = avcodec_send_packet(m_pCodecContext, avpkt);
   if (ret && ret != AVERROR_EOF)
   {
     char err[AV_ERROR_MAX_STRING_SIZE] = {};
@@ -439,6 +459,8 @@ void CDVDVideoCodecDRMPRIME::Drain()
     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed: {} ({})", __FUNCTION__,
               err, ret);
   }
+
+  av_packet_free(&avpkt);
 }
 
 void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -354,7 +354,6 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
     return false;
 
   m_pCodecContext->opaque = static_cast<ICallbackHWAccel*>(this);
-  m_pCodecContext->debug_mv = 0;
   m_pCodecContext->debug = 0;
   m_pCodecContext->workaround_bugs = FF_BUG_AUTODETECT;
   m_pCodecContext->get_format = GetFormat;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -561,16 +561,32 @@ bool CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
   m_dts = packet.dts;
   m_pCodecContext->reordered_opaque = pts_dtoi(packet.pts);
 
-  AVPacket avpkt;
-  av_init_packet(&avpkt);
-  avpkt.data = packet.pData;
-  avpkt.size = packet.iSize;
-  avpkt.dts = (packet.dts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
-  avpkt.pts = (packet.pts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
-  avpkt.side_data = static_cast<AVPacketSideData*>(packet.pSideData);
-  avpkt.side_data_elems = packet.iSideDataElems;
+  AVPacket* avpkt = av_packet_alloc();
+  if (!avpkt)
+  {
+    CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
+              strerror(errno));
+    return false;
+  }
 
-  int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
+  avpkt->data = packet.pData;
+  avpkt->size = packet.iSize;
+  avpkt->dts = (packet.dts == DVD_NOPTS_VALUE)
+                   ? AV_NOPTS_VALUE
+                   : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
+  avpkt->pts = (packet.pts == DVD_NOPTS_VALUE)
+                   ? AV_NOPTS_VALUE
+                   : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
+  avpkt->side_data = static_cast<AVPacketSideData*>(packet.pSideData);
+  avpkt->side_data_elems = packet.iSideDataElems;
+
+  int ret = avcodec_send_packet(m_pCodecContext, avpkt);
+
+  //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+  // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
+  // and storing our own AVPacket. This will require some extensive changes.
+  av_buffer_unref(&avpkt->buf);
+  av_free(avpkt);
 
   // try again
   if (ret == AVERROR(EAGAIN))
@@ -649,13 +665,20 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
   // process ffmpeg
   if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
   {
-    AVPacket avpkt;
-    av_init_packet(&avpkt);
-    avpkt.data = nullptr;
-    avpkt.size = 0;
-    avpkt.dts = AV_NOPTS_VALUE;
-    avpkt.pts = AV_NOPTS_VALUE;
-    avcodec_send_packet(m_pCodecContext, &avpkt);
+    AVPacket* avpkt = av_packet_alloc();
+    if (!avpkt)
+    {
+      CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
+                strerror(errno));
+      return VC_ERROR;
+    }
+    avpkt->data = nullptr;
+    avpkt->size = 0;
+    avpkt->dts = AV_NOPTS_VALUE;
+    avpkt->pts = AV_NOPTS_VALUE;
+    avcodec_send_packet(m_pCodecContext, avpkt);
+
+    av_packet_free(&avpkt);
   }
 
   int ret = avcodec_receive_frame(m_pCodecContext, m_pDecodedFrame);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -372,7 +372,6 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
       int num_threads = CServiceBroker::GetCPUInfo()->GetCPUCount() * 3 / 2;
       num_threads = std::max(1, std::min(num_threads, 16));
       m_pCodecContext->thread_count = num_threads;
-      m_pCodecContext->thread_safe_callbacks = 1;
       m_decoderState = STATE_SW_MULTI;
       CLog::Log(LOGDEBUG, "CDVDVideoCodecFFmpeg - open frame threaded with %d threads", num_threads);
     }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -171,13 +171,19 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
       // Allow ffmpeg to transport codec information to stream->m_context
       if (!avcodec_open2(stream->m_context, stream->m_context->codec, nullptr))
       {
-        AVPacket avpkt;
-        av_init_packet(&avpkt);
-        avpkt.data = pkt->pData;
-        avpkt.size = pkt->iSize;
-        avpkt.dts = avpkt.pts = AV_NOPTS_VALUE;
-        avcodec_send_packet(stream->m_context, &avpkt);
+        AVPacket* avpkt = av_packet_alloc();
+        if (!avpkt)
+        {
+          CLog::Log(LOGERROR, "CDVDDemuxClient::{} - av_packet_alloc failed: {}", __FUNCTION__,
+                    strerror(errno));
+          return false;
+        }
+        avpkt->data = pkt->pData;
+        avpkt->size = pkt->iSize;
+        avpkt->dts = avpkt->pts = AV_NOPTS_VALUE;
+        avcodec_send_packet(stream->m_context, avpkt);
         avcodec_close(stream->m_context);
+        av_packet_free(&avpkt);
       }
     }
   }


### PR DESCRIPTION
This one has a pretty significant change so let's handle it early. The deprecation of `av_init_packet` is quite significant as our usage of AVPacket is interesting.

I've commented inline with `todo's` as we should properly fix the usage in the future. I don't know about the history of the `DemuxPacket` struct but we should probably replace it's usage with a wrapper to `AVPacket`. 

Regarding the changes:
1) I've updated FFmpeg to `4.4-N-Alpha1` (we don't have a v20 release name yet)
2) I've refreshed the windows patches
3) I've removed our usage of `av_init_packet`
4) I've removed usage of `AVCodecContext::thread_safe_callbacks`
5) I've removed usage of `AVCodecContext::debug_mv`
6) I've tried to remove usage of `av_frame_get_qp_table` but I'm not sure if it's acceptable, if not I can drop it for now.

clang-format seems to have had a go a messing up some formatting. It is what it is.

