### PR TITLE
CApplication: move StartServer method to CNetworkServices

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -790,56 +790,6 @@ bool CApplication::Initialize()
   return true;
 }
 
-bool CApplication::StartServer(enum ESERVERS eServer, bool bStart, bool bWait/* = false*/)
-{
-  bool ret = false;
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  switch(eServer)
-  {
-    case ES_WEBSERVER:
-      // the callback will take care of starting/stopping webserver
-      ret = settings->SetBool(CSettings::SETTING_SERVICES_WEBSERVER, bStart);
-      break;
-
-    case ES_AIRPLAYSERVER:
-      // the callback will take care of starting/stopping airplay
-      ret = settings->SetBool(CSettings::SETTING_SERVICES_AIRPLAY, bStart);
-      break;
-
-    case ES_JSONRPCSERVER:
-      // the callback will take care of starting/stopping jsonrpc server
-      ret = settings->SetBool(CSettings::SETTING_SERVICES_ESENABLED, bStart);
-      break;
-
-    case ES_UPNPSERVER:
-      // the callback will take care of starting/stopping upnp server
-      ret = settings->SetBool(CSettings::SETTING_SERVICES_UPNPSERVER, bStart);
-      break;
-
-    case ES_UPNPRENDERER:
-      // the callback will take care of starting/stopping upnp renderer
-      ret = settings->SetBool(CSettings::SETTING_SERVICES_UPNPRENDERER, bStart);
-      break;
-
-    case ES_EVENTSERVER:
-      // the callback will take care of starting/stopping event server
-      ret = settings->SetBool(CSettings::SETTING_SERVICES_ESENABLED, bStart);
-      break;
-
-    case ES_ZEROCONF:
-      // the callback will take care of starting/stopping zeroconf
-      ret = settings->SetBool(CSettings::SETTING_SERVICES_ZEROCONF, bStart);
-      break;
-
-    default:
-      ret = false;
-      break;
-  }
-  settings->Save();
-
-  return ret;
-}
-
 void CApplication::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
   if (setting == NULL)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -122,17 +122,6 @@ public:
   // of currently playing item, otherwise it will seek to start of the previous item in playlist
   static const unsigned int ACTION_PREV_ITEM_THRESHOLD = 3; // seconds;
 
-  enum ESERVERS
-  {
-    ES_WEBSERVER = 1,
-    ES_AIRPLAYSERVER,
-    ES_JSONRPCSERVER,
-    ES_UPNPRENDERER,
-    ES_UPNPSERVER,
-    ES_EVENTSERVER,
-    ES_ZEROCONF
-  };
-
   CApplication(void);
   ~CApplication(void) override;
   bool Initialize() override;
@@ -146,8 +135,6 @@ public:
 
   bool CreateGUI();
   bool InitWindow(RESOLUTION res = RES_INVALID);
-
-  bool StartServer(enum ESERVERS eServer, bool bStart, bool bWait = false);
 
   bool IsCurrentThread() const;
   void Stop(int exitCode);

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -29,6 +29,7 @@
 #include "input/WindowTranslator.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
+#include "network/NetworkServices.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -466,11 +467,12 @@ namespace XBMCAddon
     }
 
 
-    bool startServer(int iTyp, bool bStart, bool bWait)
+    bool startServer(int iTyp, bool bStart)
     {
       XBMC_TRACE;
       DelayedCallGuard dg;
-      return g_application.StartServer((CApplication::ESERVERS)iTyp, bStart != 0, bWait != 0);
+      return CServiceBroker::GetNetwork().GetServices().StartServer(
+          static_cast<CNetworkServices::ESERVERS>(iTyp), bStart != 0);
     }
 
     void audioSuspend()
@@ -520,13 +522,34 @@ namespace XBMCAddon
       return CSysInfo::GetUserAgent();
     }
 
-    int getSERVER_WEBSERVER() { return CApplication::ES_WEBSERVER; }
-    int getSERVER_AIRPLAYSERVER() { return CApplication::ES_AIRPLAYSERVER; }
-    int getSERVER_UPNPSERVER() { return CApplication::ES_UPNPSERVER; }
-    int getSERVER_UPNPRENDERER() { return CApplication::ES_UPNPRENDERER; }
-    int getSERVER_EVENTSERVER() { return CApplication::ES_EVENTSERVER; }
-    int getSERVER_JSONRPCSERVER() { return CApplication::ES_JSONRPCSERVER; }
-    int getSERVER_ZEROCONF() { return CApplication::ES_ZEROCONF; }
+    int getSERVER_WEBSERVER()
+    {
+      return CNetworkServices::ES_WEBSERVER;
+    }
+    int getSERVER_AIRPLAYSERVER()
+    {
+      return CNetworkServices::ES_AIRPLAYSERVER;
+    }
+    int getSERVER_UPNPSERVER()
+    {
+      return CNetworkServices::ES_UPNPSERVER;
+    }
+    int getSERVER_UPNPRENDERER()
+    {
+      return CNetworkServices::ES_UPNPRENDERER;
+    }
+    int getSERVER_EVENTSERVER()
+    {
+      return CNetworkServices::ES_EVENTSERVER;
+    }
+    int getSERVER_JSONRPCSERVER()
+    {
+      return CNetworkServices::ES_JSONRPCSERVER;
+    }
+    int getSERVER_ZEROCONF()
+    {
+      return CNetworkServices::ES_ZEROCONF;
+    }
 
     int getPLAYLIST_MUSIC() { return PLAYLIST_MUSIC; }
     int getPLAYLIST_VIDEO() { return PLAYLIST_VIDEO; }

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -744,11 +744,11 @@ namespace XBMCAddon
     /// | xbmc.SERVER_EVENTSERVER   | [Set eventServer part that accepts remote device input on all platforms](http://kodi.wiki/view/EventServer)
     /// | xbmc.SERVER_ZEROCONF      | [Control Kodi's Avahi Zeroconf](http://kodi.wiki/view/Zeroconf)
     /// @param bStart               bool - start (True) or stop (False) a server
-    /// @param bWait                [opt] bool - wait on stop before returning (not supported by all servers)
     /// @return                     bool - True or False
     ///
     ///
     /// ------------------------------------------------------------------------
+    /// @python_v20 Removed option **bWait**.
     ///
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}
@@ -759,7 +759,7 @@ namespace XBMCAddon
     ///
     startServer(...);
 #else
-    bool startServer(int iTyp, bool bStart, bool bWait = false);
+    bool startServer(int iTyp, bool bStart);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -576,6 +576,63 @@ void CNetworkServices::Stop(bool bWait)
   StopAirTunesServer(bWait);
 }
 
+bool CNetworkServices::StartServer(enum ESERVERS server, bool start)
+{
+  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return false;
+
+  auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  if (!settings)
+    return false;
+
+  bool ret = false;
+  switch (server)
+  {
+    case ES_WEBSERVER:
+      // the callback will take care of starting/stopping webserver
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_WEBSERVER, start);
+      break;
+
+    case ES_AIRPLAYSERVER:
+      // the callback will take care of starting/stopping airplay
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_AIRPLAY, start);
+      break;
+
+    case ES_JSONRPCSERVER:
+      // the callback will take care of starting/stopping jsonrpc server
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_ESENABLED, start);
+      break;
+
+    case ES_UPNPSERVER:
+      // the callback will take care of starting/stopping upnp server
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_UPNPSERVER, start);
+      break;
+
+    case ES_UPNPRENDERER:
+      // the callback will take care of starting/stopping upnp renderer
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_UPNPRENDERER, start);
+      break;
+
+    case ES_EVENTSERVER:
+      // the callback will take care of starting/stopping event server
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_ESENABLED, start);
+      break;
+
+    case ES_ZEROCONF:
+      // the callback will take care of starting/stopping zeroconf
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_ZEROCONF, start);
+      break;
+
+    default:
+      ret = false;
+      break;
+  }
+  settings->Save();
+
+  return ret;
+}
+
 bool CNetworkServices::StartWebserver()
 {
 #ifdef HAS_WEB_SERVER

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -41,6 +41,19 @@ public:
   void Start();
   void Stop(bool bWait);
 
+  enum ESERVERS
+  {
+    ES_WEBSERVER = 1,
+    ES_AIRPLAYSERVER,
+    ES_JSONRPCSERVER,
+    ES_UPNPRENDERER,
+    ES_UPNPSERVER,
+    ES_EVENTSERVER,
+    ES_ZEROCONF
+  };
+
+  bool StartServer(enum ESERVERS server, bool start);
+
   bool StartWebserver();
   bool IsWebserverRunning();
   bool StopWebserver();


### PR DESCRIPTION
This method has no business in CApplication so let's move it to where it's relevant.

I've also cleaned up the method a bit and remove the unused bWait param

@enen92 for the python and doxygen changes