### PR TITLE
Move Music/Video LibraryScan methods out of CApplication

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4831,7 +4831,8 @@ void CApplication::UpdateLibraries()
   if (settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_UPDATEONSTARTUP))
   {
     CLog::LogF(LOGINFO, "Starting video library startup scan");
-    StartVideoScan("", !settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_BACKGROUNDUPDATE));
+    CVideoLibraryQueue::GetInstance().ScanLibrary(
+        "", false, !settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_BACKGROUNDUPDATE));
   }
 
   if (settings->GetBool(CSettings::SETTING_MUSICLIBRARY_UPDATEONSTARTUP))
@@ -4894,11 +4895,6 @@ void CApplication::StartVideoCleanup(bool userInitiated /* = true */,
     CVideoLibraryQueue::GetInstance().CleanLibraryModal(paths);
   else
     CVideoLibraryQueue::GetInstance().CleanLibrary(paths, true);
-}
-
-void CApplication::StartVideoScan(const std::string &strDirectory, bool userInitiated /* = true */, bool scanAll /* = false */)
-{
-  CVideoLibraryQueue::GetInstance().ScanLibrary(strDirectory, scanAll, userInitiated);
 }
 
 bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlayList& playlist, int iPlaylist, int track)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4863,11 +4863,6 @@ bool CApplication::IsMusicScanning() const
   return CMusicLibraryQueue::GetInstance().IsScanningLibrary();
 }
 
-void CApplication::StopMusicScan()
-{
-  CMusicLibraryQueue::GetInstance().StopLibraryScanning();
-}
-
 void CApplication::StartVideoCleanup(bool userInitiated /* = true */,
                                      const std::string& content /* = "" */,
                                      const std::string& strDirectory /* = "" */)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4932,14 +4932,6 @@ void CApplication::StartMusicScan(const std::string &strDirectory, bool userInit
   CMusicLibraryQueue::GetInstance().ScanLibrary(strDirectory, flags, !(flags & CMusicInfoScanner::SCAN_BACKGROUND));
 }
 
-void CApplication::StartMusicAlbumScan(const std::string& strDirectory, bool refresh)
-{
-  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
-    return;
-
-  CMusicLibraryQueue::GetInstance().StartAlbumScan(strDirectory, refresh);
-}
-
 bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlayList& playlist, int iPlaylist, int track)
 {
   CLog::Log(LOGDEBUG,"CApplication::ProcessAndStartPlaylist(%s, %i)",strPlayList.c_str(), iPlaylist);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4837,7 +4837,9 @@ void CApplication::UpdateLibraries()
   if (settings->GetBool(CSettings::SETTING_MUSICLIBRARY_UPDATEONSTARTUP))
   {
     CLog::LogF(LOGINFO, "Starting music library startup scan");
-    StartMusicScan("", !settings->GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE));
+    CMusicLibraryQueue::GetInstance().ScanLibrary(
+        "", MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL,
+        !settings->GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE));
   }
 }
 
@@ -4913,23 +4915,6 @@ void CApplication::StartMusicCleanup(bool userInitiated /* = true */)
     CMusicLibraryQueue::GetInstance().CleanLibrary(true);
   else
     CMusicLibraryQueue::GetInstance().CleanLibrary(false);
-}
-
-void CApplication::StartMusicScan(const std::string &strDirectory, bool userInitiated /* = true */, int flags /* = 0 */)
-{
-  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
-    return;
-
-  // Setup default flags
-  if (!flags)
-  { // Online scraping of additional info during scanning
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO))
-      flags |= CMusicInfoScanner::SCAN_ONLINE;
-  }
-  if (!userInitiated || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
-    flags |= CMusicInfoScanner::SCAN_BACKGROUND;
-
-  CMusicLibraryQueue::GetInstance().ScanLibrary(strDirectory, flags, !(flags & CMusicInfoScanner::SCAN_BACKGROUND));
 }
 
 bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlayList& playlist, int iPlaylist, int track)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4853,11 +4853,6 @@ void CApplication::UpdateCurrentPlayArt()
   CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(*m_itemCurrentFile);
 }
 
-bool CApplication::IsMusicScanning() const
-{
-  return CMusicLibraryQueue::GetInstance().IsScanningLibrary();
-}
-
 void CApplication::StartVideoCleanup(bool userInitiated /* = true */,
                                      const std::string& content /* = "" */,
                                      const std::string& strDirectory /* = "" */)
@@ -4922,7 +4917,7 @@ void CApplication::StartMusicCleanup(bool userInitiated /* = true */)
 
 void CApplication::StartMusicScan(const std::string &strDirectory, bool userInitiated /* = true */, int flags /* = 0 */)
 {
-  if (IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     return;
 
   // Setup default flags
@@ -4939,7 +4934,7 @@ void CApplication::StartMusicScan(const std::string &strDirectory, bool userInit
 
 void CApplication::StartMusicAlbumScan(const std::string& strDirectory, bool refresh)
 {
-  if (IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     return;
 
   CMusicLibraryQueue::GetInstance().StartAlbumScan(strDirectory, refresh);
@@ -4948,7 +4943,7 @@ void CApplication::StartMusicAlbumScan(const std::string& strDirectory, bool ref
 void CApplication::StartMusicArtistScan(const std::string& strDirectory,
                                         bool refresh)
 {
-  if (IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     return;
 
   CMusicLibraryQueue::GetInstance().StartArtistScan(strDirectory, refresh);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4856,47 +4856,6 @@ void CApplication::UpdateCurrentPlayArt()
   CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(*m_itemCurrentFile);
 }
 
-void CApplication::StartVideoCleanup(bool userInitiated /* = true */,
-                                     const std::string& content /* = "" */,
-                                     const std::string& strDirectory /* = "" */)
-{
-  if (userInitiated && CVideoLibraryQueue::GetInstance().IsRunning())
-    return;
-
-  std::set<int> paths;
-  if (!content.empty() || !strDirectory.empty())
-  {
-    CVideoDatabase db;
-    std::set<std::string> contentPaths;
-    if (db.Open())
-    {
-      if (!strDirectory.empty())
-        contentPaths.insert(strDirectory);
-      else
-        db.GetPaths(contentPaths);
-      for (const std::string& path : contentPaths)
-      {
-        if (db.GetContentForPath(path) == content)
-        {
-          paths.insert(db.GetPathId(path));
-          std::vector<std::pair<int, std::string>> sub;
-          if (db.GetSubPaths(path, sub))
-          {
-            for (const auto& it : sub)
-              paths.insert(it.first);
-          }
-        }
-      }
-    }
-    if (paths.empty())
-      return;
-  }
-  if (userInitiated)
-    CVideoLibraryQueue::GetInstance().CleanLibraryModal(paths);
-  else
-    CVideoLibraryQueue::GetInstance().CleanLibrary(paths, true);
-}
-
 bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlayList& playlist, int iPlaylist, int track)
 {
   CLog::Log(LOGDEBUG,"CApplication::ProcessAndStartPlaylist(%s, %i)",strPlayList.c_str(), iPlaylist);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4940,15 +4940,6 @@ void CApplication::StartMusicAlbumScan(const std::string& strDirectory, bool ref
   CMusicLibraryQueue::GetInstance().StartAlbumScan(strDirectory, refresh);
 }
 
-void CApplication::StartMusicArtistScan(const std::string& strDirectory,
-                                        bool refresh)
-{
-  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
-    return;
-
-  CMusicLibraryQueue::GetInstance().StartArtistScan(strDirectory, refresh);
-}
-
 bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlayList& playlist, int iPlaylist, int track)
 {
   CLog::Log(LOGDEBUG,"CApplication::ProcessAndStartPlaylist(%s, %i)",strPlayList.c_str(), iPlaylist);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4853,11 +4853,6 @@ void CApplication::UpdateCurrentPlayArt()
   CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(*m_itemCurrentFile);
 }
 
-bool CApplication::IsVideoScanning() const
-{
-  return CVideoLibraryQueue::GetInstance().IsScanningLibrary();
-}
-
 bool CApplication::IsMusicScanning() const
 {
   return CMusicLibraryQueue::GetInstance().IsScanningLibrary();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4901,22 +4901,6 @@ void CApplication::StartVideoScan(const std::string &strDirectory, bool userInit
   CVideoLibraryQueue::GetInstance().ScanLibrary(strDirectory, scanAll, userInitiated);
 }
 
-void CApplication::StartMusicCleanup(bool userInitiated /* = true */)
-{
-  if (userInitiated && CMusicLibraryQueue::GetInstance().IsRunning())
-    return;
-
-  if (userInitiated)
-    /*
-     CMusicLibraryQueue::GetInstance().CleanLibraryModal();
-     As cleaning is non-granular and does not offer many opportunities to update progress
-     dialog rendering, do asynchronously with model dialog
-    */
-    CMusicLibraryQueue::GetInstance().CleanLibrary(true);
-  else
-    CMusicLibraryQueue::GetInstance().CleanLibrary(false);
-}
-
 bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlayList& playlist, int iPlaylist, int track)
 {
   CLog::Log(LOGDEBUG,"CApplication::ProcessAndStartPlaylist(%s, %i)",strPlayList.c_str(), iPlaylist);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4863,11 +4863,6 @@ bool CApplication::IsMusicScanning() const
   return CMusicLibraryQueue::GetInstance().IsScanningLibrary();
 }
 
-void CApplication::StopVideoScan()
-{
-  CVideoLibraryQueue::GetInstance().StopLibraryScanning();
-}
-
 void CApplication::StopMusicScan()
 {
   CMusicLibraryQueue::GetInstance().StopLibraryScanning();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -251,7 +251,6 @@ public:
   void StopShutdownTimer();
   void ResetShutdownTimers();
 
-  void StopMusicScan();
   bool IsMusicScanning() const;
   bool IsVideoScanning() const;
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -251,7 +251,6 @@ public:
   void StopShutdownTimer();
   void ResetShutdownTimers();
 
-  void StopVideoScan();
   void StopMusicScan();
   bool IsMusicScanning() const;
   bool IsVideoScanning() const;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -281,7 +281,6 @@ public:
    */
   void StartMusicScan(const std::string &path, bool userInitiated = true, int flags = 0);
   void StartMusicAlbumScan(const std::string& strDirectory, bool refresh = false);
-  void StartMusicArtistScan(const std::string& strDirectory, bool refresh = false);
 
   void UpdateLibraries();
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -251,8 +251,6 @@ public:
   void StopShutdownTimer();
   void ResetShutdownTimers();
 
-  bool IsMusicScanning() const;
-
   /*!
    \brief Starts a video library cleanup.
    \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -267,12 +267,6 @@ public:
    */
   void StartVideoScan(const std::string &path, bool userInitiated = true, bool scanAll = false);
 
-  /*!
-  \brief Starts a music library cleanup.
-  \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
-  */
-  void StartMusicCleanup(bool userInitiated = true);
-
   void UpdateLibraries();
 
   void UpdateCurrentPlayArt();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -252,7 +252,6 @@ public:
   void ResetShutdownTimers();
 
   bool IsMusicScanning() const;
-  bool IsVideoScanning() const;
 
   /*!
    \brief Starts a video library cleanup.

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -259,14 +259,6 @@ public:
    */
   void StartVideoCleanup(bool userInitiated = true, const std::string& content = "", const std::string& strDirectory = "");
 
-  /*!
-   \brief Starts a video library update.
-   \param path The path to scan or "" (empty string) for a global scan.
-   \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
-   \param scanAll Whether to scan everything not already scanned (regardless of whether the user normally doesn't want a folder scanned).
-   */
-  void StartVideoScan(const std::string &path, bool userInitiated = true, bool scanAll = false);
-
   void UpdateLibraries();
 
   void UpdateCurrentPlayArt();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -251,14 +251,6 @@ public:
   void StopShutdownTimer();
   void ResetShutdownTimers();
 
-  /*!
-   \brief Starts a video library cleanup.
-   \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
-   \param content Content type to clean, blank for everything
-   \param strDirectory The path to clean or "" (empty string) for a global clean.
-   */
-  void StartVideoCleanup(bool userInitiated = true, const std::string& content = "", const std::string& strDirectory = "");
-
   void UpdateLibraries();
 
   void UpdateCurrentPlayArt();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -280,7 +280,6 @@ public:
    \param flags Flags for controlling the scanning process.  See xbmc/music/infoscanner/MusicInfoScanner.h for possible values.
    */
   void StartMusicScan(const std::string &path, bool userInitiated = true, int flags = 0);
-  void StartMusicAlbumScan(const std::string& strDirectory, bool refresh = false);
 
   void UpdateLibraries();
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -273,14 +273,6 @@ public:
   */
   void StartMusicCleanup(bool userInitiated = true);
 
-  /*!
-   \brief Starts a music library update.
-   \param path The path to scan or "" (empty string) for a global scan.
-   \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
-   \param flags Flags for controlling the scanning process.  See xbmc/music/infoscanner/MusicInfoScanner.h for possible values.
-   */
-  void StartMusicScan(const std::string &path, bool userInitiated = true, int flags = 0);
-
   void UpdateLibraries();
 
   void UpdateCurrentPlayArt();

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -19,6 +19,8 @@
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicLibraryQueue.h"
+#include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "settings/AdvancedSettings.h"
@@ -296,7 +298,9 @@ void CCDDARipper::OnJobComplete(unsigned int jobID, bool success, CJob* job)
       CMusicDatabase database;
       database.Open();
       if (source>=0 && database.InsideScannedPath(dir))
-        g_application.StartMusicScan(dir, false);
+        CMusicLibraryQueue::GetInstance().ScanLibrary(
+            dir, MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL, false);
+
       database.Close();
     }
     return CJobQueue::OnJobComplete(jobID, success, job);

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -20,6 +20,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoLibraryQueue.h"
 
 using namespace KODI::GUILIB::GUIINFO;
 
@@ -267,12 +268,13 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
     }
     case LIBRARY_IS_SCANNING:
     {
-      value = (g_application.IsMusicScanning() || g_application.IsVideoScanning());
+      value = (g_application.IsMusicScanning() ||
+               CVideoLibraryQueue::GetInstance().IsScanningLibrary());
       return true;
     }
     case LIBRARY_IS_SCANNING_VIDEO:
     {
-      value = g_application.IsVideoScanning();
+      value = CVideoLibraryQueue::GetInstance().IsScanningLibrary();
       return true;
     }
     case LIBRARY_IS_SCANNING_MUSIC:

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -15,6 +15,7 @@
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicLibraryQueue.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -268,7 +269,7 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
     }
     case LIBRARY_IS_SCANNING:
     {
-      value = (g_application.IsMusicScanning() ||
+      value = (CMusicLibraryQueue::GetInstance().IsScanningLibrary() ||
                CVideoLibraryQueue::GetInstance().IsScanningLibrary());
       return true;
     }
@@ -279,7 +280,7 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
     }
     case LIBRARY_IS_SCANNING_MUSIC:
     {
-      value = g_application.IsMusicScanning();
+      value = CMusicLibraryQueue::GetInstance().IsScanningLibrary();
       return true;
     }
   }

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -56,7 +56,10 @@ static int CleanLibrary(const std::vector<std::string>& params)
   else if (StringUtils::EqualsNoCase(params[0], "music"))
   {
     if (!CMusicLibraryQueue::GetInstance().IsScanningLibrary())
-      g_application.StartMusicCleanup(userInitiated);
+    {
+      if (!(userInitiated && CMusicLibraryQueue::GetInstance().IsRunning()))
+        CMusicLibraryQueue::GetInstance().CleanLibrary(userInitiated);
+    }
     else
       CLog::Log(LOGERROR, "CleanLibrary is not possible while scanning for media info");
   }

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -272,7 +272,7 @@ static int UpdateLibrary(const std::vector<std::string>& params)
   if (StringUtils::EqualsNoCase(params[0], "music"))
   {
     if (g_application.IsMusicScanning())
-      g_application.StopMusicScan();
+      CMusicLibraryQueue::GetInstance().StopLibraryScanning();
     else
       g_application.StartMusicScan(params.size() > 1 ? params[1] : "", userInitiated);
   }

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -19,6 +19,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "music/MusicLibraryQueue.h"
+#include "music/infoscanner/MusicInfoScanner.h"
 #include "settings/LibExportSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -274,7 +275,9 @@ static int UpdateLibrary(const std::vector<std::string>& params)
     if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
       CMusicLibraryQueue::GetInstance().StopLibraryScanning();
     else
-      g_application.StartMusicScan(params.size() > 1 ? params[1] : "", userInitiated);
+      CMusicLibraryQueue::GetInstance().ScanLibrary(params.size() > 1 ? params[1] : "",
+                                                    MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL,
+                                                    userInitiated);
   }
   else if (StringUtils::EqualsNoCase(params[0], "video"))
   {

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -54,7 +54,7 @@ static int CleanLibrary(const std::vector<std::string>& params)
   }
   else if (StringUtils::EqualsNoCase(params[0], "music"))
   {
-    if (!g_application.IsMusicScanning())
+    if (!CMusicLibraryQueue::GetInstance().IsScanningLibrary())
       g_application.StartMusicCleanup(userInitiated);
     else
       CLog::Log(LOGERROR, "CleanLibrary is not possible while scanning for media info");
@@ -271,7 +271,7 @@ static int UpdateLibrary(const std::vector<std::string>& params)
     userInitiated = StringUtils::EqualsNoCase(params[2], "true");
   if (StringUtils::EqualsNoCase(params[0], "music"))
   {
-    if (g_application.IsMusicScanning())
+    if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
       CMusicLibraryQueue::GetInstance().StopLibraryScanning();
     else
       g_application.StartMusicScan(params.size() > 1 ? params[1] : "", userInitiated);

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -287,7 +287,8 @@ static int UpdateLibrary(const std::vector<std::string>& params)
     if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
       CVideoLibraryQueue::GetInstance().StopLibraryScanning();
     else
-      g_application.StartVideoScan(params.size() > 1 ? params[1] : "", userInitiated);
+      CVideoLibraryQueue::GetInstance().ScanLibrary(params.size() > 1 ? params[1] : "", false,
+                                                    userInitiated);
   }
 
   return 0;

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -26,6 +26,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoLibraryQueue.h"
 
 using namespace KODI::MESSAGING;
 
@@ -278,7 +279,7 @@ static int UpdateLibrary(const std::vector<std::string>& params)
   else if (StringUtils::EqualsNoCase(params[0], "video"))
   {
     if (g_application.IsVideoScanning())
-      g_application.StopVideoScan();
+      CVideoLibraryQueue::GetInstance().StopLibraryScanning();
     else
       g_application.StartVideoScan(params.size() > 1 ? params[1] : "", userInitiated);
   }

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -44,7 +44,7 @@ static int CleanLibrary(const std::vector<std::string>& params)
                      || StringUtils::EqualsNoCase(params[0], "tvshows")
                      || StringUtils::EqualsNoCase(params[0], "musicvideos"))
   {
-    if (!g_application.IsVideoScanning())
+    if (!CVideoLibraryQueue::GetInstance().IsScanningLibrary())
     {
       const std::string content = (params.empty() || params[0] == "video") ? "" : params[0];
       g_application.StartVideoCleanup(userInitiated, content, params.size() > 2 ? params[2] : "");
@@ -278,7 +278,7 @@ static int UpdateLibrary(const std::vector<std::string>& params)
   }
   else if (StringUtils::EqualsNoCase(params[0], "video"))
   {
-    if (g_application.IsVideoScanning())
+    if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
       CVideoLibraryQueue::GetInstance().StopLibraryScanning();
     else
       g_application.StartVideoScan(params.size() > 1 ? params[1] : "", userInitiated);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -40,6 +40,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "music/MusicLibraryQueue.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/Network.h"
 #include "network/cddb.h"
@@ -83,7 +84,7 @@ static void AnnounceRemove(const std::string& content, int id)
   CVariant data;
   data["type"] = content;
   data["id"] = id;
-  if (g_application.IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     data["transaction"] = true;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnRemove", data);
 }
@@ -93,7 +94,7 @@ static void AnnounceUpdate(const std::string& content, int id, bool added = fals
   CVariant data;
   data["type"] = content;
   data["id"] = id;
-  if (g_application.IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     data["transaction"] = true;
   if (added)
     data["added"] = true;
@@ -4464,7 +4465,7 @@ void CMusicDatabase::Clean()
 {
   // If we are scanning for music info in the background,
   // other writing access to the database is prohibited.
-  if (g_application.IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
   {
     HELPERS::ShowOKDialogText(CVariant{189}, CVariant{14057});
     return;

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -14,11 +14,14 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "music/infoscanner/MusicInfoScanner.h"
 #include "music/jobs/MusicLibraryCleaningJob.h"
 #include "music/jobs/MusicLibraryExportJob.h"
 #include "music/jobs/MusicLibraryImportJob.h"
 #include "music/jobs/MusicLibraryJob.h"
 #include "music/jobs/MusicLibraryScanningJob.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "utils/Variant.h"
 
@@ -117,8 +120,21 @@ void CMusicLibraryQueue::ImportLibrary(const std::string& xmlFile, bool showDial
   }
 }
 
-void CMusicLibraryQueue::ScanLibrary(const std::string& strDirectory, int flags /* = 0 */, bool showProgress /* = true */)
+void CMusicLibraryQueue::ScanLibrary(const std::string& strDirectory,
+                                     int flags /* = 0 */,
+                                     bool showProgress /* = true */)
 {
+  if (flags == MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL)
+  {
+    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+            CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO))
+      flags |= MUSIC_INFO::CMusicInfoScanner::SCAN_ONLINE;
+  }
+
+  if (!showProgress || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                           CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
+    flags |= MUSIC_INFO::CMusicInfoScanner::SCAN_BACKGROUND;
+
   AddJob(new CMusicLibraryScanningJob(strDirectory, flags, showProgress));
 }
 

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -27,6 +27,7 @@
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicLibraryQueue.h"
 #include "music/MusicThumbLoader.h"
 #include "music/MusicUtils.h"
 #include "music/dialogs/GUIDialogSongInfo.h"
@@ -576,7 +577,7 @@ void CGUIDialogMusicInfo::RefreshInfo()
     return;
 
   // Check if scanning
-  if (g_application.IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
   {
     HELPERS::ShowOKDialogText(CVariant{ 189 }, CVariant{ 14057 });
     return;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1150,7 +1150,7 @@ void CGUIWindowMusicBase::DoScan(const std::string &strPath, bool bRescan /*= fa
 {
   if (g_application.IsMusicScanning())
   {
-    g_application.StopMusicScan();
+    CMusicLibraryQueue::GetInstance().StopLibraryScanning();
     return;
   }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -271,7 +271,12 @@ void CGUIWindowMusicBase::OnItemInfoAll(const std::string& strPath, bool refresh
   if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "albums"))
     g_application.StartMusicAlbumScan(strPath, refresh);
   else if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "artists"))
-    g_application.StartMusicArtistScan(strPath, refresh);
+  {
+    if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
+      return;
+
+    CMusicLibraryQueue::GetInstance().StartArtistScan(strPath, refresh);
+  }
 }
 
 void CGUIWindowMusicBase::OnItemInfo(int iItem)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1121,7 +1121,9 @@ void CGUIWindowMusicBase::OnInitWindow()
         if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO))
           if (CGUIDialogYesNo::ShowAndGetInput(CVariant{799}, CVariant{38061}))
             flags |= CMusicInfoScanner::SCAN_ONLINE;
-        g_application.StartMusicScan("", true, flags);
+
+        CMusicLibraryQueue::GetInstance().ScanLibrary("", flags, true);
+
         m_musicdatabase.SetMusicTagScanVersion(); // once is enough (user may interrupt, but that's up to them)
       }
     }
@@ -1178,7 +1180,9 @@ void CGUIWindowMusicBase::DoScan(const std::string &strPath, bool bRescan /*= fa
     flags = CMusicInfoScanner::SCAN_RESCAN;
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO))
     flags |= CMusicInfoScanner::SCAN_ONLINE;
-  g_application.StartMusicScan(strPath, true, flags);
+
+  CMusicLibraryQueue::GetInstance().ScanLibrary(strPath, flags, true);
+
   SET_CONTROL_FOCUS(iControl, 0);
   UpdateButtons();
 }
@@ -1235,7 +1239,7 @@ void CGUIWindowMusicBase::OnAssignContent(const std::string& oldName, const CMed
       CGUIDialogInfoProviderSettings::Show();
   }
   if (rep == DialogResponse::YES)
-    g_application.StartMusicScan(source.strPath, true);
-
+    CMusicLibraryQueue::GetInstance().ScanLibrary(source.strPath,
+                                                  MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL, true);
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -269,7 +269,12 @@ bool CGUIWindowMusicBase::OnAction(const CAction &action)
 void CGUIWindowMusicBase::OnItemInfoAll(const std::string& strPath, bool refresh)
 {
   if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "albums"))
-    g_application.StartMusicAlbumScan(strPath, refresh);
+  {
+    if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
+      return;
+
+    CMusicLibraryQueue::GetInstance().StartAlbumScan(strPath, refresh);
+  }
   else if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "artists"))
   {
     if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -29,6 +29,7 @@
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "music/MusicLibraryQueue.h"
 #include "music/dialogs/GUIDialogInfoProviderSettings.h"
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayList.h"
@@ -166,7 +167,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_UPDATE_LIBRARY)
       {
-        if (!g_application.IsMusicScanning())
+        if (!CMusicLibraryQueue::GetInstance().IsScanningLibrary())
           g_application.StartMusicScan("");
         else
           CMusicLibraryQueue::GetInstance().StopLibraryScanning();

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -168,7 +168,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_UPDATE_LIBRARY)
       {
         if (!CMusicLibraryQueue::GetInstance().IsScanningLibrary())
-          g_application.StartMusicScan("");
+          CMusicLibraryQueue::GetInstance().ScanLibrary("");
         else
           CMusicLibraryQueue::GetInstance().StopLibraryScanning();
         return true;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -169,7 +169,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
         if (!g_application.IsMusicScanning())
           g_application.StartMusicScan("");
         else
-          g_application.StopMusicScan();
+          CMusicLibraryQueue::GetInstance().StopLibraryScanning();
         return true;
       }
     }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -37,6 +37,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoLibraryQueue.h"
 #include "video/VideoThumbLoader.h"
 #include "view/GUIViewState.h"
 #include "xbmc/interfaces/AnnouncementManager.h"
@@ -67,7 +68,8 @@ const char* video_containers[] = { "library://video/movies/titles.xml/", "librar
 CUPnPServer::CUPnPServer(const char* friendly_name, const char* uuid /*= NULL*/, int port /*= 0*/)
   : PLT_MediaConnect(friendly_name, false, uuid, port),
     PLT_FileMediaConnectDelegate("/", "/"),
-    m_scanning(g_application.IsMusicScanning() || g_application.IsVideoScanning()),
+    m_scanning(g_application.IsMusicScanning() ||
+               CVideoLibraryQueue::GetInstance().IsScanningLibrary()),
     m_logger(CServiceBroker::GetLogging().GetLogger(
         StringUtils::Format("CUPnPServer[{}]", friendly_name)))
 {

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -24,6 +24,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicLibraryQueue.h"
 #include "music/MusicThumbLoader.h"
 #include "music/tags/MusicInfoTag.h"
 #include "settings/Settings.h"
@@ -68,7 +69,7 @@ const char* video_containers[] = { "library://video/movies/titles.xml/", "librar
 CUPnPServer::CUPnPServer(const char* friendly_name, const char* uuid /*= NULL*/, int port /*= 0*/)
   : PLT_MediaConnect(friendly_name, false, uuid, port),
     PLT_FileMediaConnectDelegate("/", "/"),
-    m_scanning(g_application.IsMusicScanning() ||
+    m_scanning(CMusicLibraryQueue::GetInstance().IsScanningLibrary() ||
                CVideoLibraryQueue::GetInstance().IsScanningLibrary()),
     m_logger(CServiceBroker::GetLogging().GetLogger(
         StringUtils::Format("CUPnPServer[{}]", friendly_name)))

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -6,11 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include <algorithm>
-#include <string>
-#include <vector>
-
 #include "ProfileManager.h"
+
 #include "DatabaseManager.h"
 #include "FileItem.h"
 #include "GUIInfoManager.h"
@@ -31,9 +28,14 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/InputManager.h"
+#include "music/MusicLibraryQueue.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
 #include "storage/DetectDVDType.h"
 #endif
@@ -438,7 +440,7 @@ void CProfileManager::LogOff()
 
   g_application.StopPlaying();
 
-  if (g_application.IsMusicScanning())
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     CMusicLibraryQueue::GetInstance().StopLibraryScanning();
 
   if (CVideoLibraryQueue::GetInstance().IsRunning())

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -439,7 +439,7 @@ void CProfileManager::LogOff()
   g_application.StopPlaying();
 
   if (g_application.IsMusicScanning())
-    g_application.StopMusicScan();
+    CMusicLibraryQueue::GetInstance().StopLibraryScanning();
 
   if (CVideoLibraryQueue::GetInstance().IsRunning())
     CVideoLibraryQueue::GetInstance().CancelAllJobs();

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -301,7 +301,10 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   if (settingId == CSettings::SETTING_MUSICLIBRARY_CLEANUP)
   {
     if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
-      g_application.StartMusicCleanup(true);
+    {
+      if (!CMusicLibraryQueue::GetInstance().IsRunning())
+        CMusicLibraryQueue::GetInstance().CleanLibrary(true);
+    }
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT)
   {

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -29,6 +29,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoLibraryQueue.h"
 
 #include <limits.h>
 #include <string>
@@ -332,7 +333,10 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_CLEANUP)
   {
     if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
-      g_application.StartVideoCleanup(true);
+    {
+      if (!CVideoLibraryQueue::GetInstance().IsRunning())
+        CVideoLibraryQueue::GetInstance().CleanLibraryModal();
+    }
   }
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_EXPORT)
     CBuiltins::GetInstance().Execute("exportlibrary(video)");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -55,6 +55,7 @@
 #include "utils/log.h"
 #include "video/VideoDbUrl.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoLibraryQueue.h"
 #include "video/windows/GUIWindowVideoBase.h"
 
 #include <algorithm>
@@ -6007,7 +6008,7 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
     if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId > 0)
     {
       CVariant data;
-      if (g_application.IsVideoScanning())
+      if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
         data["transaction"] = true;
       // Only provide the "playcount" value if it has actually changed
       if (item.GetVideoInfoTag()->GetPlayCount() != count)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -447,7 +447,7 @@ void CVideoDatabase::CreateViews()
                                      "    uniqueid.uniqueid_id=tvshow.c%02d ",
                                      VIDEODB_ID_TV_RATING_ID, VIDEODB_ID_TV_IDENT_ID);
   m_pDS->exec(tvshowview);
-  
+
   CLog::Log(LOGINFO, "create season_view");
   std::string seasonview = PrepareSQL("CREATE VIEW season_view AS SELECT "
                                      "  seasons.idSeason AS idSeason,"
@@ -4150,7 +4150,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
     return details;
 
   details = GetBasicDetailsForEpisode(record);
-  
+
   unsigned int time = XbmcThreads::SystemClockMillis();
 
   details.m_strPath = record->at(VIDEODB_DETAILS_EPISODE_PATH).get_asString();
@@ -4164,7 +4164,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
   details.m_genre = StringUtils::Split(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_GENRE).get_asString(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
   details.m_studio = StringUtils::Split(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_STUDIO).get_asString(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
   details.SetPremieredFromDBDate(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_AIRED).get_asString());
-  
+
   details.SetResumePoint(record->at(VIDEODB_DETAILS_EPISODE_RESUME_TIME).get_asInt(),
                          record->at(VIDEODB_DETAILS_EPISODE_TOTAL_TIME).get_asInt(),
                          record->at(VIDEODB_DETAILS_EPISODE_PLAYER_STATE).get_asString());
@@ -6470,7 +6470,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
     extFilter.AppendJoin(PrepareSQL("JOIN actor ON actor.actor_id = actor_link.actor_id"));
     extFilter.fields += ", path.strPath";
     extFilter.AppendJoin("join files on files.idFile = musicvideo_view.idFile join path on path.idPath = files.idPath");
-    
+
     if (StringUtils::EndsWith(strBaseDir,"albums/"))
       extFilter.AppendWhere(PrepareSQL("musicvideo_view.c%02d != ''", VIDEODB_ID_MUSICVIDEO_ALBUM));
 
@@ -6503,7 +6503,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
     */
     if (iRowsFound <= 0)
       return iRowsFound == 0;
-    
+
     std::string strArtist;
     if (idArtist> -1)
       strArtist = m_pDS->fv("actor.name").get_asString();
@@ -8751,7 +8751,7 @@ void CVideoDatabase::GetMoviesByName(const std::string& strSearch, CFileItemList
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT movie.idMovie, movie.c%02d, path.strPath, movie.idSet FROM movie "
                           "INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON "
-                          "path.idPath=files.idPath " 
+                          "path.idPath=files.idPath "
                           "WHERE movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%'",
                           VIDEODB_ID_TITLE, VIDEODB_ID_TITLE, strSearch.c_str(),
                           VIDEODB_ID_ORIGINALTITLE, strSearch.c_str());

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -51,6 +51,7 @@
 #include "utils/Variant.h"
 #include "video/VideoInfoScanner.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoLibraryQueue.h"
 #include "video/VideoThumbLoader.h"
 #include "video/tags/VideoTagLoaderFFmpeg.h"
 #include "video/windows/GUIWindowVideoNav.h"
@@ -1402,7 +1403,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const CFileItemPtr &pItem)
     return false;
 
   // dont allow update while scanning
-  if (g_application.IsVideoScanning())
+  if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
   {
     HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
     return false;
@@ -1494,7 +1495,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
     return false;
 
   // dont allow update while scanning
-  if (g_application.IsVideoScanning())
+  if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
   {
     HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
     return false;
@@ -2244,7 +2245,7 @@ std::string CGUIDialogVideoInfo::GetLocalizedVideoType(const std::string &strTyp
 bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const CFileItemPtr &pItem)
 {
   // dont allow update while scanning
-  if (g_application.IsVideoScanning())
+  if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
   {
     HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
     return false;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -408,7 +408,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
   if (!info)
     return false;
 
-  if (g_application.IsVideoScanning())
+  if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
   {
     HELPERS::ShowOKDialogText(CVariant{13346}, CVariant{14057});
     return false;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1550,7 +1550,7 @@ int CGUIWindowVideoBase::GetScraperForItem(CFileItem *item, ADDON::ScraperPtr &i
 
 void CGUIWindowVideoBase::OnScan(const std::string& strPath, bool scanAll)
 {
-    g_application.StartVideoScan(strPath, true, scanAll);
+  CVideoLibraryQueue::GetInstance().ScanLibrary(strPath, scanAll, true);
 }
 
 std::string CGUIWindowVideoBase::GetStartFolder(const std::string &dir)
@@ -1631,6 +1631,6 @@ void CGUIWindowVideoBase::OnAssignContent(const std::string &path)
 
   if (bScan)
   {
-    g_application.StartVideoScan(path, true, true);
+    CVideoLibraryQueue::GetInstance().ScanLibrary(path, true, true);
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -230,7 +230,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
         if (!g_application.IsVideoScanning())
           OnScan("");
         else
-          g_application.StopVideoScan();
+          CVideoLibraryQueue::GetInstance().StopLibraryScanning();
         return true;
       }
     }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -227,7 +227,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_UPDATE_LIBRARY)
       {
-        if (!g_application.IsVideoScanning())
+        if (!CVideoLibraryQueue::GetInstance().IsScanningLibrary())
           OnScan("");
         else
           CVideoLibraryQueue::GetInstance().StopLibraryScanning();
@@ -940,14 +940,15 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       // can we update the database?
       if (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
       {
-        if (!g_application.IsVideoScanning() && item->IsVideoDb() && item->HasVideoInfoTag() &&
-           (item->GetVideoInfoTag()->m_type == MediaTypeMovie ||          // movies
-            item->GetVideoInfoTag()->m_type == MediaTypeTvShow ||         // tvshows
-            item->GetVideoInfoTag()->m_type == MediaTypeSeason ||         // seasons
-            item->GetVideoInfoTag()->m_type == MediaTypeEpisode ||        // episodes
-            item->GetVideoInfoTag()->m_type == MediaTypeMusicVideo ||     // musicvideos
-            item->GetVideoInfoTag()->m_type == "tag" ||                   // tags
-            item->GetVideoInfoTag()->m_type == MediaTypeVideoCollection)) // sets
+        if (!CVideoLibraryQueue::GetInstance().IsScanningLibrary() && item->IsVideoDb() &&
+            item->HasVideoInfoTag() &&
+            (item->GetVideoInfoTag()->m_type == MediaTypeMovie || // movies
+             item->GetVideoInfoTag()->m_type == MediaTypeTvShow || // tvshows
+             item->GetVideoInfoTag()->m_type == MediaTypeSeason || // seasons
+             item->GetVideoInfoTag()->m_type == MediaTypeEpisode || // episodes
+             item->GetVideoInfoTag()->m_type == MediaTypeMusicVideo || // musicvideos
+             item->GetVideoInfoTag()->m_type == "tag" || // tags
+             item->GetVideoInfoTag()->m_type == MediaTypeVideoCollection)) // sets
         {
           buttons.Add(CONTEXT_BUTTON_EDIT, 16106);
         }
@@ -1116,7 +1117,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
   else if (StringUtils::StartsWithNoCase(item->GetPath(), "newtag://"))
   {
     // dont allow update while scanning
-    if (g_application.IsVideoScanning())
+    if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
     {
       HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
       return true;


### PR DESCRIPTION
I'm not really sure why these exist here, likely just legacy. We don't need `CApplication` to act as a wrapper for most of these methods so lets just call the methods directly.

Most methods were straight forward but a couple required a little extra logic, so please look carefully that I didn't change any behaviour.

@DaveTBlake you need to use an IDE that removes extra spaces dude!
