### PR TITLE
CNetworkBase: add static method to get platform implementation

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -974,7 +974,7 @@ void CApplication::StartServices()
 
 void CApplication::StopServices()
 {
-  m_ServiceManager->GetNetwork().NetworkMessage(CNetwork::SERVICES_DOWN, 0);
+  m_ServiceManager->GetNetwork().NetworkMessage(CNetworkBase::SERVICES_DOWN, 0);
 
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
   CLog::Log(LOGINFO, "stop dvd detect media");
@@ -2201,7 +2201,8 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   break;
 
   case TMSG_NETWORKMESSAGE:
-    m_ServiceManager->GetNetwork().NetworkMessage((CNetwork::EMESSAGE)pMsg->param1, pMsg->param2);
+    m_ServiceManager->GetNetwork().NetworkMessage(static_cast<CNetworkBase::EMESSAGE>(pMsg->param1),
+                                                  pMsg->param2);
     break;
 
   case TMSG_SETLANGUAGE:

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -50,7 +50,7 @@ CServiceManager::~CServiceManager()
 
 bool CServiceManager::InitForTesting()
 {
-  m_network.reset(new CNetwork());
+  m_network = CNetworkBase::GetNetwork();
 
   m_databaseManager.reset(new CDatabaseManager);
 
@@ -91,7 +91,7 @@ bool CServiceManager::InitStageOne()
 
   m_playlistPlayer.reset(new PLAYLIST::CPlayListPlayer());
 
-  m_network.reset(new CNetwork());
+  m_network = CNetworkBase::GetNetwork();
 
   init_level = 1;
   return true;

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -46,52 +46,57 @@ public:
     SERVICES_DOWN
   };
 
-   CNetworkBase();
-   virtual ~CNetworkBase();
+  static std::unique_ptr<CNetworkBase> GetNetwork();
 
-   // Get network services
-   CNetworkServices& GetServices() { return *m_services; }
+  CNetworkBase();
+  virtual ~CNetworkBase();
 
-   // Return our hostname
-   virtual bool GetHostName(std::string& hostname);
+  // Get network services
+  CNetworkServices& GetServices() { return *m_services; }
 
-   // Return the list of interfaces
-   virtual std::vector<CNetworkInterface*>& GetInterfaceList(void) = 0;
+  // Return our hostname
+  virtual bool GetHostName(std::string& hostname);
 
-   // Return the first interface which is active
-   virtual CNetworkInterface* GetFirstConnectedInterface(void);
+  // Return the list of interfaces
+  virtual std::vector<CNetworkInterface*>& GetInterfaceList(void) = 0;
 
-   // Return true if there is a interface for the same network as address
-   bool HasInterfaceForIP(unsigned long address);
+  // Return the first interface which is active
+  virtual CNetworkInterface* GetFirstConnectedInterface(void);
 
-   // Return true if there's at least one defined network interface
-   bool IsAvailable(void);
+  // Return true if there is a interface for the same network as address
+  bool HasInterfaceForIP(unsigned long address);
 
-   // Return true if there's at least one interface which is connected
-   bool IsConnected(void);
+  // Return true if there's at least one defined network interface
+  bool IsAvailable(void);
 
-   // Return true if the magic packet was send
-   bool WakeOnLan(const char *mac);
+  // Return true if there's at least one interface which is connected
+  bool IsConnected(void);
 
-   // Return true if host replies to ping
-   bool PingHost(unsigned long host, unsigned short port, unsigned int timeout_ms = 2000, bool readability_check = false);
-   virtual bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) = 0;
+  // Return true if the magic packet was send
+  bool WakeOnLan(const char* mac);
 
-   // Get/set the nameserver(s)
-   virtual std::vector<std::string> GetNameServers(void) = 0;
+  // Return true if host replies to ping
+  bool PingHost(unsigned long host,
+                unsigned short port,
+                unsigned int timeout_ms = 2000,
+                bool readability_check = false);
+  virtual bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) = 0;
 
-   // callback from application controlled thread to handle any setup
-   void NetworkMessage(EMESSAGE message, int param);
+  // Get/set the nameserver(s)
+  virtual std::vector<std::string> GetNameServers(void) = 0;
 
-   static int ParseHex(char *str, unsigned char *addr);
+  // callback from application controlled thread to handle any setup
+  void NetworkMessage(EMESSAGE message, int param);
 
-   // Return true if given name or ip address corresponds to localhost
-   bool IsLocalHost(const std::string& hostname);
+  static int ParseHex(char* str, unsigned char* addr);
 
-   // Waits for the first network interface to become available
-   void WaitForNet();
+  // Return true if given name or ip address corresponds to localhost
+  bool IsLocalHost(const std::string& hostname);
 
-   /*!
+  // Waits for the first network interface to become available
+  void WaitForNet();
+
+  /*!
     \brief  IPv6/IPv4 compatible conversion of host IP address
     \param  struct sockaddr
     \return Function converts binary structure sockaddr to std::string.
@@ -100,31 +105,17 @@ public:
             IPv6 address is returned in it's canonised form.
             On error (or no IPv6/v4 valid input) empty string is returned.
     */
-   static std::string GetIpStr(const sockaddr* sa);
+  static std::string GetIpStr(const sockaddr* sa);
 
-   /*!
+  /*!
     \brief  convert prefix length of IPv4 address to IP mask representation
     \param  prefix length
     \return
    */
-   static std::string GetMaskByPrefixLength(uint8_t prefixLength);
+  static std::string GetMaskByPrefixLength(uint8_t prefixLength);
 
   std::unique_ptr<CNetworkServices> m_services;
 };
-
-#if defined(TARGET_ANDROID)
-#include "platform/android/network/NetworkAndroid.h"
-#elif defined(HAS_POSIX_NETWORK)
-#include "platform/posix/network/NetworkPosix.h"
-#elif defined(HAS_WIN32_NETWORK)
-#include "platform/win32/network/NetworkWin32.h"
-#elif defined(HAS_WIN10_NETWORK)
-#include "platform/win10/network/NetworkWin10.h"
-#elif defined(HAS_IOS_NETWORK)
-#include "platform/darwin/ios-common/network/NetworkIOS.h"
-#else
-using CNetwork = CNetworkBase;
-#endif
 
 //creates, binds and listens tcp sockets on the desired port. Set bindLocal to
 //true to bind to localhost only.

--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -228,6 +228,11 @@ std::string CNetworkInterfaceAndroid::GetHostName()
 
 /*************************/
 
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkAndroid>();
+}
+
 CNetworkAndroid::CNetworkAndroid()
  : CNetworkBase()
 {

--- a/xbmc/platform/android/network/NetworkAndroid.h
+++ b/xbmc/platform/android/network/NetworkAndroid.h
@@ -73,5 +73,3 @@ protected:
   std::vector<CNetworkInterface*> m_oldInterfaces;
   CCriticalSection m_refreshMutex;
 };
-
-using CNetwork = CNetworkAndroid;

--- a/xbmc/platform/darwin/ios-common/network/NetworkIOS.h
+++ b/xbmc/platform/darwin/ios-common/network/NetworkIOS.h
@@ -64,5 +64,3 @@ private:
   std::vector<CNetworkInterfaceIOS*> m_interfaces;
   int m_sock;
 };
-
-using CNetwork = CNetworkIOS;

--- a/xbmc/platform/darwin/ios-common/network/NetworkIOS.mm
+++ b/xbmc/platform/darwin/ios-common/network/NetworkIOS.mm
@@ -264,6 +264,10 @@ std::string CNetworkInterfaceIOS::GetCurrentDefaultGateway() const
   return gateway;
 }
 
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkIOS>();
+}
 
 CNetworkIOS::CNetworkIOS() : CNetworkBase()
 {

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
@@ -102,6 +102,11 @@ bool CNetworkInterfaceOsx::GetHostMacAddress(unsigned long host_ip, std::string&
   return ret;
 }
 
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkOsx>();
+}
+
 CNetworkOsx::CNetworkOsx() : CNetworkPosix()
 {
   queryInterfaceList();

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.h
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.h
@@ -38,5 +38,3 @@ private:
   void GetMacAddress(const std::string& interfaceName, char macAddrRaw[6]) override;
   void queryInterfaceList() override;
 };
-
-using CNetwork = CNetworkOsx;

--- a/xbmc/platform/freebsd/network/NetworkFreebsd.cpp
+++ b/xbmc/platform/freebsd/network/NetworkFreebsd.cpp
@@ -134,6 +134,11 @@ bool CNetworkInterfaceFreebsd::GetHostMacAddress(unsigned long host_ip, std::str
   return ret;
 }
 
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkFreebsd>();
+}
+
 CNetworkFreebsd::CNetworkFreebsd() : CNetworkPosix()
 {
   queryInterfaceList();

--- a/xbmc/platform/freebsd/network/NetworkFreebsd.h
+++ b/xbmc/platform/freebsd/network/NetworkFreebsd.h
@@ -38,5 +38,3 @@ private:
   void GetMacAddress(const std::string& interfaceName, char macAddrRaw[6]) override;
   void queryInterfaceList() override;
 };
-
-using CNetwork = CNetworkFreebsd;

--- a/xbmc/platform/linux/network/NetworkLinux.cpp
+++ b/xbmc/platform/linux/network/NetworkLinux.cpp
@@ -116,6 +116,11 @@ bool CNetworkInterfaceLinux::GetHostMacAddress(unsigned long host_ip, std::strin
   return false;
 }
 
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkLinux>();
+}
+
 CNetworkLinux::CNetworkLinux() : CNetworkPosix()
 {
   queryInterfaceList();

--- a/xbmc/platform/linux/network/NetworkLinux.h
+++ b/xbmc/platform/linux/network/NetworkLinux.h
@@ -38,5 +38,3 @@ private:
   void GetMacAddress(const std::string& interfaceName, char macAddrRaw[6]) override;
   void queryInterfaceList() override;
 };
-
-using CNetwork = CNetworkLinux;

--- a/xbmc/platform/posix/network/NetworkPosix.h
+++ b/xbmc/platform/posix/network/NetworkPosix.h
@@ -43,7 +43,6 @@ private:
 class CNetworkPosix : public CNetworkBase
 {
 public:
-  CNetworkPosix();
   virtual ~CNetworkPosix() override;
 
   std::vector<CNetworkInterface*>& GetInterfaceList() override;
@@ -52,6 +51,7 @@ public:
   int GetSocket() { return m_sock; }
 
 protected:
+  CNetworkPosix();
   std::vector<CNetworkInterface*> m_interfaces;
 
 private:
@@ -59,11 +59,3 @@ private:
   virtual void queryInterfaceList() = 0;
   int m_sock;
 };
-
-#if defined(HAS_LINUX_NETWORK)
-#include "platform/linux/network/NetworkLinux.h"
-#elif defined(HAS_FREEBSD_NETWORK)
-#include "platform/freebsd/network/NetworkFreebsd.h"
-#elif defined(HAS_OSX_NETWORK)
-#include "platform/darwin/osx/network/NetworkOsx.h"
-#endif

--- a/xbmc/platform/win10/network/NetworkWin10.cpp
+++ b/xbmc/platform/win10/network/NetworkWin10.cpp
@@ -193,7 +193,12 @@ CNetworkInterface* CNetworkWin10::GetFirstConnectedInterface()
   }
 
   // fallback to default
-  return CNetwork::GetFirstConnectedInterface();
+  return CNetworkBase::GetFirstConnectedInterface();
+}
+
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkWin10>();
 }
 
 void CNetworkWin10::queryInterfaceList()

--- a/xbmc/platform/win10/network/NetworkWin10.h
+++ b/xbmc/platform/win10/network/NetworkWin10.h
@@ -68,5 +68,3 @@ private:
     PIP_ADAPTER_ADDRESSES m_adapterAddresses;
 };
 
-using CNetwork = CNetworkWin10;
-

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -75,6 +75,11 @@ std::string CNetworkInterfaceWin32::GetCurrentDefaultGateway(void) const
   return m_adapter.FirstGatewayAddress != nullptr ? CNetworkBase::GetIpStr(m_adapter.FirstGatewayAddress->Address.lpSockaddr) : "";
 }
 
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkWin32>();
+}
+
 CNetworkWin32::CNetworkWin32()
  : CNetworkBase()
 {

--- a/xbmc/platform/win32/network/NetworkWin32.h
+++ b/xbmc/platform/win32/network/NetworkWin32.h
@@ -72,5 +72,3 @@ private:
    CCriticalSection m_critSection;
 };
 
-using CNetwork = CNetworkWin32;
-

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -267,7 +267,7 @@ void CProfileManager::PrepareLoadProfile(unsigned int profileIndex)
   pvrManager.Stop();
 
   if (profileIndex != 0 || !IsMasterProfile())
-    networkManager.NetworkMessage(CNetwork::SERVICES_DOWN, 1);
+    networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
 }
 
 bool CProfileManager::LoadProfile(unsigned int index)
@@ -447,7 +447,7 @@ void CProfileManager::LogOff()
   // Stop PVR services
   CServiceBroker::GetPVRManager().Stop();
 
-  networkManager.NetworkMessage(CNetwork::SERVICES_DOWN, 1);
+  networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
 
   LoadMasterProfileForLogin();
 


### PR DESCRIPTION
This improves the `CNetwork` classes to use proper inheritance. I've added a static getter to create the platform specific `CNetwork` implementation (as there can only be one anyways).

clang-format had a bit of a go at `xbmc/network/Network.h` because the indentation was wrong. I can split that out if needed.