### PR TITLE
[Application] move SwitchToFullScreen to windowing

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -14,6 +14,7 @@
 #include "GUIInfoManager.h"
 #include "GUIPassword.h"
 #include "GUITexture.h"
+#include "WindowIDs.h"
 #include "addons/Skin.h"
 #include "addons/gui/GUIWindowAddonBrowser.h"
 #include "addons/interfaces/gui/Window.h"
@@ -881,6 +882,66 @@ void CGUIWindowManager::CloseInternalModalDialogs(bool forceClose) const
     if (window->IsModalDialog() && !IsAddonWindow(window->GetID()) && !IsPythonWindow(window->GetID()))
       window->Close(forceClose);
   }
+}
+
+// SwitchToFullScreen() returns true if a switch is made, else returns false
+bool CGUIWindowManager::SwitchToFullScreen(bool force /* = false */)
+{
+  // don't switch if the slideshow is active
+  if (IsWindowActive(WINDOW_SLIDESHOW))
+    return false;
+
+  // if playing from the video info window, close it first!
+  if (IsModalDialogTopmost(WINDOW_DIALOG_VIDEO_INFO))
+  {
+    CGUIDialogVideoInfo* pDialog = GetWindow<CGUIDialogVideoInfo>(WINDOW_DIALOG_VIDEO_INFO);
+    if (pDialog)
+      pDialog->Close(true);
+  }
+
+  // if playing from the album info window, close it first!
+  if (IsModalDialogTopmost(WINDOW_DIALOG_MUSIC_INFO))
+  {
+    CGUIDialogVideoInfo* pDialog = GetWindow<CGUIDialogVideoInfo>(WINDOW_DIALOG_MUSIC_INFO);
+    if (pDialog)
+      pDialog->Close(true);
+  }
+
+  // if playing from the song info window, close it first!
+  if (IsModalDialogTopmost(WINDOW_DIALOG_SONG_INFO))
+  {
+    CGUIDialogVideoInfo* pDialog = GetWindow<CGUIDialogVideoInfo>(WINDOW_DIALOG_SONG_INFO);
+    if (pDialog)
+      pDialog->Close(true);
+  }
+
+  const int activeWindowID = GetActiveWindow();
+  int windowID = WINDOW_INVALID;
+
+  // See if we're playing a game
+  if (activeWindowID != WINDOW_FULLSCREEN_GAME && g_application.GetAppPlayer().IsPlayingGame())
+    windowID = WINDOW_FULLSCREEN_GAME;
+
+  // See if we're playing a video
+  else if (activeWindowID != WINDOW_FULLSCREEN_VIDEO &&
+           g_application.GetAppPlayer().IsPlayingVideo())
+    windowID = WINDOW_FULLSCREEN_VIDEO;
+
+  // See if we're playing an audio song
+  if (activeWindowID != WINDOW_VISUALISATION && g_application.GetAppPlayer().IsPlayingAudio())
+    windowID = WINDOW_VISUALISATION;
+
+  if (windowID != WINDOW_INVALID && (force || windowID != activeWindowID))
+  {
+    if (force)
+      ForceActivateWindow(windowID);
+    else
+      ActivateWindow(windowID);
+
+    return true;
+  }
+
+  return false;
 }
 
 void CGUIWindowManager::OnApplicationMessage(ThreadMessage* pMsg)

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -67,6 +67,14 @@ public:
   void ActivateWindow(int iWindowID, const std::vector<std::string>& params, bool swappingWindows = false, bool force = false);
   void PreviousWindow();
 
+  /**
+   * \brief Switch window to fullscreen
+   *
+   * \param force enforce fullscreen switch
+   * \return True if switch is made to fullscreen, otherwise False
+   */
+  bool SwitchToFullScreen(bool force = false);
+
   void CloseDialogs(bool forceClose = false) const;
   void CloseInternalModalDialogs(bool forceClose = false) const;
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -74,6 +74,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/VideoDatabaseFile.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "input/Key.h"
 #include "input/mouse/MouseStat.h"
@@ -283,7 +284,13 @@ void CXBMCApp::onPause()
   }
 
   if (m_hasReqVisible)
-    g_application.SwitchToFullScreen(true);
+  {
+    CGUIComponent* gui = CServiceBroker::GetGUI();
+    if (gui)
+    {
+      gui->GetWindowManager().SwitchToFullScreen(true);
+    }
+  }
 
   EnableWakeLock(false);
   m_hasReqVisible = false;

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -43,7 +43,10 @@ bool CGUIWindowHome::OnAction(const CAction &action)
       action.GetHoldTime() < min_hold_time &&
       g_application.GetAppPlayer().IsPlaying())
   {
-    g_application.SwitchToFullScreen();
+    CGUIComponent* gui = CServiceBroker::GetGUI();
+    if (gui)
+      gui->GetWindowManager().SwitchToFullScreen();
+
     return true;
   }
   return CGUIWindow::OnAction(action);


### PR DESCRIPTION
## Description
~~Definitely more a RFC on this one.~~
Seems odd to have a windowing function just littered in CApplication. The PR relocates this from CApplication into CGUIWindowManager.

~~The question i have is, does this make the design worse? It pulls in GUILIB stuff into windowing~~

## Motivation and Context
Cleanup/Streamline Application.h/cpp

## How Has This Been Tested?
osx

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
