### PR TITLE
DXVA2: Fix green screen on some DVD's menus

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -818,6 +818,9 @@ void CVideoBufferCopy::Initialize(CDecoder* decoder)
     // copy decoder surface on decoder device
     m_pDeviceContext->CopySubresourceRegion(m_copyRes.Get(), 0, 0, 0, 0, m_pResource.Get(),
                                             CVideoBuffer::GetIdx(), nullptr);
+
+    if (decoder->m_DVDWorkaround) // DVDs menus/stills need extra Flush()
+      m_pDeviceContext->Flush();
   }
 }
 
@@ -1133,6 +1136,10 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
 {
   if (!CheckCompatibility(avctx))
     return false;
+
+  // DVDs menus/stills need extra Flush() after copy texture
+  if (avctx->codec_id == AV_CODEC_ID_MPEG2VIDEO && avctx->height <= 576)
+    m_DVDWorkaround = true;
 
   CSingleLock lock(m_section);
   Close();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -255,6 +255,7 @@ protected:
   unsigned int m_surface_alignment = 0;
   HANDLE m_sharedHandle = INVALID_HANDLE_VALUE;
   D3D11_VIDEO_DECODER_DESC m_format = {};
+  bool m_DVDWorkaround = false;
 };
 
 } // namespace DXVA


### PR DESCRIPTION
## Description
DXVA2: Fix green screen on some DVD's menus

Fixes https://github.com/xbmc/xbmc/issues/19560

~Also renames PCI_Vendors ID from ATI to AMD~

## Motivation and Context
Some users have reported this issue only on the DVD menu (movie playback is fine). 
See: https://github.com/xbmc/xbmc/issues/19560 and original forum report: https://forum.kodi.tv/showthread.php?tid=358755

Disabling DXVA2 makes the issue go away. Intel seems unaffected by this.

~The fix consist on disable shared textures only in case of MPEG2 480-576p/i content and only for Nvidia and AMD. 
DXVA2 is still used without shared textures.~

The fix consist on introduce extra Flush() after texture copy only in case of MPEG2 480-576p/i content. This code path is used by Nvidia and AMD only so Intel is not affected by this.


## How Has This Been Tested?
**Update:** Tested with physical DVD disc "The Game" & "Los Otros"

Two forum users have confirmed that the changes made fix the issue in AMD 3200g and 3000g and Nvidia GT1030:

https://forum.kodi.tv/showthread.php?tid=358755&pid=3030072#pid3030072
https://forum.kodi.tv/showthread.php?tid=358755&pid=3030182#pid3030182


## Screenshots (if appropriate):
Before
![screenshot00006](https://user-images.githubusercontent.com/58434170/115011657-2e688800-9eaf-11eb-8256-5cce448acdf7.png)

After
![screenshot00005](https://user-images.githubusercontent.com/58434170/115011680-345e6900-9eaf-11eb-9ca2-1d1c4bff5080.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
