### PR TITLE
CPUInfoLinux: add alternative cpu revision and serial locations

### DIFF
--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -81,6 +81,14 @@ CCPUInfoLinux::CCPUInfoLinux()
   if (socPath.Exists())
     m_cpuSoC += " " + socPath.Get<std::string>();
 
+  CSysfsPath revisionPath{"/sys/bus/soc/devices/soc0/revision"};
+  if (revisionPath.Exists())
+    m_cpuRevision += revisionPath.Get<std::string>();
+
+  CSysfsPath serialPath{"/sys/bus/soc/devices/soc0/serial_number"};
+  if (serialPath.Exists())
+    m_cpuSerial += serialPath.Get<std::string>();
+
   const std::string freqStr{"/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"};
   CSysfsPath freqPath{freqStr};
   if (freqPath.Exists())

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -242,19 +242,34 @@ CCPUInfoLinux::CCPUInfoLinux()
         std::ssub_match value = match[1];
 
         if (line.find("model name") != std::string::npos)
-          m_cpuModel = value.str();
+        {
+          if (m_cpuModel.empty())
+            m_cpuModel = value.str();
+        }
 
         if (line.find("BogoMIPS") != std::string::npos)
-          m_cpuBogoMips = value.str();
+        {
+          if (m_cpuBogoMips.empty())
+            m_cpuBogoMips = value.str();
+        }
 
         if (line.find("Hardware") != std::string::npos)
-          m_cpuHardware = value.str();
+        {
+          if (m_cpuHardware.empty())
+            m_cpuHardware = value.str();
+        }
 
         if (line.find("Serial") != std::string::npos)
-          m_cpuSerial = value.str();
+        {
+          if (m_cpuSerial.empty())
+            m_cpuSerial = value.str();
+        }
 
         if (line.find("Revision") != std::string::npos)
-          m_cpuRevision = value.str();
+        {
+          if (m_cpuRevision.empty())
+            m_cpuRevision = value.str();
+        }
       }
     }
   }


### PR DESCRIPTION
This adds the locations of cpu revision and cpu serial values using the soc sysfs interface.

I've also added a commit to add guards so that values aren't set if previously set by the soc sysfs interface.