### PR TITLE
[addons] minor cleanups for readability and style

### DIFF
--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -47,7 +47,8 @@ struct CAddonWithUpdate
 class CAddonRepos
 {
 public:
-  CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr){};
+  CAddonRepos() = delete;
+  explicit CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr){};
 
   /*!
    * \brief Load the map of all available addon versions in any installed repository

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -790,8 +790,7 @@ void CGUIDialogAddonInfo::BuildDependencyList()
         (addonAvailable && addonAvailable->MainType() != ADDON_SCRIPT_MODULE) ||
         (!addonAvailable && !addonInstalled))
     {
-      m_depsInstalledWithAvailable.emplace_back(
-          CInstalledWithAvailable{dep, addonInstalled, addonAvailable});
+      m_depsInstalledWithAvailable.emplace_back(dep, addonInstalled, addonAvailable);
     }
 
     // sort optional add-ons to top of the list

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -615,7 +615,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
       if (infoAddon)
       {
         if (entryPoint != EntryPoint::UPDATE ||
-            (entryPoint == EntryPoint::UPDATE && !it.m_isInstalledUpToDate()))
+            (entryPoint == EntryPoint::UPDATE && !it.IsInstalledUpToDate()))
         {
           const CFileItemPtr item = std::make_shared<CFileItem>(infoAddon->Name());
           int messageId = 24180; // minversion only
@@ -642,7 +642,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
           {
             messageId = 24182; // => installed
 
-            if (!it.m_isInstalledUpToDate())
+            if (!it.IsInstalledUpToDate())
             {
               messageId = 24183; // => update to
             }
@@ -799,4 +799,17 @@ void CGUIDialogAddonInfo::BuildDependencyList()
         m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
         [](const auto& a, const auto& b) { return a.m_depInfo.optional > b.m_depInfo.optional; });
   }
+}
+
+bool CInstalledWithAvailable::IsInstalledUpToDate() const
+{
+  if (m_installed)
+  {
+    if (!m_available || m_available->Version() == m_installed->Version())
+    {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -44,14 +44,15 @@ struct CInstalledWithAvailable
   {
   }
 
+  /*!
+   * @brief Returns true if the currently installed dependency version is up to date
+   * or the dependency is not available from a repository
+   */
+  bool IsInstalledUpToDate() const;
+
   ADDON::DependencyInfo m_depInfo;
   std::shared_ptr<ADDON::IAddon> m_installed;
   std::shared_ptr<ADDON::IAddon> m_available;
-  bool m_isInstalledUpToDate() const
-  {
-    return ((m_installed && m_available) && (m_installed->Version() == m_available->Version())) ||
-           (m_installed && !m_available);
-  };
 };
 
 class CGUIDialogAddonInfo : public CGUIDialog

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -37,6 +37,13 @@ enum class EntryPoint
 
 struct CInstalledWithAvailable
 {
+  CInstalledWithAvailable(const ADDON::DependencyInfo& depInfo,
+                          std::shared_ptr<ADDON::IAddon> installed,
+                          std::shared_ptr<ADDON::IAddon> available)
+    : m_depInfo(depInfo), m_installed(installed), m_available(available)
+  {
+  }
+
   ADDON::DependencyInfo m_depInfo;
   std::shared_ptr<ADDON::IAddon> m_installed;
   std::shared_ptr<ADDON::IAddon> m_available;


### PR DESCRIPTION
## Description
**no functional changes involved here. just wanted to clean some mess after me**

1. don't aggregate initialize `CInstalledWithAvailable` and pass the temporary to `vector.emplace_back()` but provide it with a matching constructor. should save us one copy (i believe)

2. rename `m_isInstalledUpToDate` to `IsInstalledUpToDate` as that is a member function, not a data member and implement it a bit simpler.

3. read that you should _always_ declare any ctor that takes a single argument as `explicit`, so do this for `CAddonRepos`. the default constructor is implicitly deleted anyways.

## How Has This Been Tested?
debian buster

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
