### PR TITLE
Add cmake-variants.yaml and cmake-kits.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ testMain
 # Created in vs2017 when using open folder with cmake tools
 CMakeSettings.json
 
+# Created in vscode when using cmake-tools
+cmake-variants.yaml
+cmake-kits.json
+
 # generated files etc
 .last_success_revision
 *.d


### PR DESCRIPTION
## Description
I am using vscode and cmake tools as the development environment for Kodi. In cmake-tools, a `cmake-variants.yaml` has to be created to group build options. As I believe this could be a common setup (and that I'll endup PRing my configs by mistake someday), let's add them to gitignore.

Refs: 
https://vector-of-bool.github.io/docs/vscode-cmake-tools/variants.html
https://vector-of-bool.github.io/docs/vscode-cmake-tools/kits.html

## Motivation and Context
Cosmetic
