### PR TITLE
[Clean-up]Apply cosmetic code style guidelines to the music database

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -112,7 +112,8 @@ CMusicDatabase::~CMusicDatabase(void)
 
 bool CMusicDatabase::Open()
 {
-  return CDatabase::Open(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic);
+  return CDatabase::Open(
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic);
 }
 
 void CMusicDatabase::CreateTables()
@@ -131,10 +132,11 @@ void CMusicDatabase::CreateTables()
               " idInfoSetting INTEGER NOT NULL DEFAULT 0, "
               " dateAdded TEXT, dateNew TEXT, dateModified TEXT)");
   // Create missing artist tag artist [Missing].
-  std::string strSQL = PrepareSQL("INSERT INTO artist (idArtist, strArtist, strSortName, strMusicBrainzArtistID) "
-     "VALUES( %i, '%s', '%s', '%s' )",
-    BLANKARTIST_ID, BLANKARTIST_NAME.c_str(),
-    BLANKARTIST_NAME.c_str(), BLANKARTIST_FAKEMUSICBRAINZID.c_str());
+  std::string strSQL =
+      PrepareSQL("INSERT INTO artist (idArtist, strArtist, strSortName, strMusicBrainzArtistID) "
+                 "VALUES( %i, '%s', '%s', '%s' )",
+                 BLANKARTIST_ID, BLANKARTIST_NAME.c_str(), BLANKARTIST_NAME.c_str(),
+                 BLANKARTIST_FAKEMUSICBRAINZID.c_str());
   m_pDS->exec(strSQL);
 
   CLog::Log(LOGINFO, "create album table");
@@ -167,7 +169,8 @@ void CMusicDatabase::CreateTables()
               " dateAdded varchar (20) default NULL)");
 
   CLog::Log(LOGINFO, "create album_artist table");
-  m_pDS->exec("CREATE TABLE album_artist (idArtist integer, idAlbum integer, iOrder integer, strArtist text)");
+  m_pDS->exec("CREATE TABLE album_artist (idArtist integer, idAlbum integer, iOrder integer, "
+              "strArtist text)");
 
   CLog::Log(LOGINFO, "create album_source table");
   m_pDS->exec("CREATE TABLE album_source (idSource INTEGER, idAlbum INTEGER)");
@@ -179,7 +182,8 @@ void CMusicDatabase::CreateTables()
   m_pDS->exec("CREATE TABLE path (idPath integer primary key, strPath varchar(512), strHash text)");
 
   CLog::Log(LOGINFO, "create source table");
-  m_pDS->exec("CREATE TABLE source (idSource INTEGER PRIMARY KEY, strName TEXT, strMultipath TEXT)");
+  m_pDS->exec(
+      "CREATE TABLE source (idSource INTEGER PRIMARY KEY, strName TEXT, strMultipath TEXT)");
 
   CLog::Log(LOGINFO, "create source_path table");
   m_pDS->exec("CREATE TABLE source_path (idSource INTEGER, idPath INTEGER, strPath varchar(512))");
@@ -201,26 +205,30 @@ void CMusicDatabase::CreateTables()
               " strReplayGain text, "
               " dateAdded TEXT, dateNew TEXT, dateModified TEXT)");
   CLog::Log(LOGINFO, "create song_artist table");
-  m_pDS->exec("CREATE TABLE song_artist (idArtist integer, idSong integer, idRole integer, iOrder integer, strArtist text)");
+  m_pDS->exec("CREATE TABLE song_artist (idArtist integer, idSong integer, idRole integer, iOrder "
+              "integer, strArtist text)");
   CLog::Log(LOGINFO, "create song_genre table");
   m_pDS->exec("CREATE TABLE song_genre (idGenre integer, idSong integer, iOrder integer)");
 
   CLog::Log(LOGINFO, "create role table");
   m_pDS->exec("CREATE TABLE role (idRole integer primary key, strRole text)");
-  m_pDS->exec("INSERT INTO role(idRole, strRole) VALUES (1, 'Artist')");   //Default role
+  m_pDS->exec("INSERT INTO role(idRole, strRole) VALUES (1, 'Artist')"); //Default role
 
   CLog::Log(LOGINFO, "create infosetting table");
-  m_pDS->exec("CREATE TABLE infosetting (idSetting INTEGER PRIMARY KEY, strScraperPath TEXT, strSettings TEXT)");
+  m_pDS->exec("CREATE TABLE infosetting (idSetting INTEGER PRIMARY KEY, "
+              "strScraperPath TEXT, strSettings TEXT)");
 
   CLog::Log(LOGINFO, "create discography table");
   m_pDS->exec("CREATE TABLE discography (idArtist integer, strAlbum text, strYear text, "
               "strReleaseGroupMBID TEXT)");
 
   CLog::Log(LOGINFO, "create art table");
-  m_pDS->exec("CREATE TABLE art(art_id INTEGER PRIMARY KEY, media_id INTEGER, media_type TEXT, type TEXT, url TEXT)");
+  m_pDS->exec("CREATE TABLE art(art_id INTEGER PRIMARY KEY, "
+              "media_id INTEGER, media_type TEXT, type TEXT, url TEXT)");
 
   CLog::Log(LOGINFO, "create versiontagscan table");
-  m_pDS->exec("CREATE TABLE versiontagscan (idVersion INTEGER, iNeedsScan INTEGER, "
+  m_pDS->exec("CREATE TABLE versiontagscan "
+              "(idVersion INTEGER, iNeedsScan INTEGER, "
               "lastscanned VARCHAR(20), "
               "lastcleaned VARCHAR(20), "
               "artistlinksupdated VARCHAR(20), "
@@ -230,7 +238,6 @@ void CMusicDatabase::CreateTables()
 
   CLog::Log(LOGINFO, "create removed_link table");
   m_pDS->exec("CREATE TABLE removed_link (idArtist INTEGER, idMedia INTEGER, idRole INTEGER)");
-
 }
 
 void CMusicDatabase::CreateAnalytics()
@@ -376,7 +383,7 @@ void CMusicDatabase::CreateAnalytics()
                 " UPDATE versiontagscan SET genresupdated = now()");
   }
 
-    // Triggers to maintain recent changes to album and song artist links in removed_link table
+  // Triggers to maintain recent changes to album and song artist links in removed_link table
   m_pDS->exec("CREATE TRIGGER tgrInsertSongArtist AFTER INSERT ON song_artist FOR EACH ROW BEGIN "
               "DELETE FROM removed_link "
               "WHERE idArtist = NEW.idArtist AND idMedia = NEW.idSong AND idRole = NEW.idRole; "
@@ -457,38 +464,39 @@ void CMusicDatabase::CreateViews()
 
   CLog::Log(LOGINFO, "create album view");
   m_pDS->exec("CREATE VIEW albumview AS SELECT "
-              "        album.idAlbum AS idAlbum, "
-              "        strAlbum, "
-              "        strMusicBrainzAlbumID, "
-              "        strReleaseGroupMBID, "
-              "        album.strArtistDisp AS strArtists, "
-              "        album.strArtistSort AS strArtistSort, "
-              "        album.strGenres AS strGenres, "
-              "        album.strReleaseDate as strReleaseDate, "
-              "        album.strOrigReleaseDate as strOrigReleaseDate, "
-              "        album.bBoxedSet AS bBoxedSet, "
-              "        album.strMoods AS strMoods, "
-              "        album.strStyles AS strStyles, "
-              "        strThemes, "
-              "        strReview, "
-              "        strLabel, "
-              "        strType, "
-              "        strReleaseStatus, "
-              "        album.strImage as strImage, "
-              "        album.fRating, "
-              "        album.iUserrating, "
-              "        album.iVotes, "
-              "        bCompilation, "
-              "        bScrapedMBID,"
-              "        lastScraped,"
-              "        dateAdded, dateNew, dateModified, "
-              "        (SELECT ROUND(AVG(song.iTimesPlayed)) FROM song WHERE song.idAlbum = album.idAlbum) AS iTimesPlayed, "
-              "        strReleaseType, "
-              "        iDiscTotal, "
-              "        (SELECT MAX(song.lastplayed) FROM song WHERE song.idAlbum = album.idAlbum) AS lastplayed, "
-              "        iAlbumDuration "
-              "FROM album"
-              );
+              "album.idAlbum AS idAlbum, "
+              "strAlbum, "
+              "strMusicBrainzAlbumID, "
+              "strReleaseGroupMBID, "
+              "album.strArtistDisp AS strArtists, "
+              "album.strArtistSort AS strArtistSort, "
+              "album.strGenres AS strGenres, "
+              "album.strReleaseDate as strReleaseDate, "
+              "album.strOrigReleaseDate as strOrigReleaseDate, "
+              "album.bBoxedSet AS bBoxedSet, "
+              "album.strMoods AS strMoods, "
+              "album.strStyles AS strStyles, "
+              "strThemes, "
+              "strReview, "
+              "strLabel, "
+              "strType, "
+              "strReleaseStatus, "
+              "album.strImage as strImage, "
+              "album.fRating, "
+              "album.iUserrating, "
+              "album.iVotes, "
+              "bCompilation, "
+              "bScrapedMBID,"
+              "lastScraped,"
+              "dateAdded, dateNew, dateModified, "
+              "(SELECT ROUND(AVG(song.iTimesPlayed)) FROM song "
+              "WHERE song.idAlbum = album.idAlbum) AS iTimesPlayed, "
+              "strReleaseType, "
+              "iDiscTotal, "
+              "(SELECT MAX(song.lastplayed) FROM song "
+              "WHERE song.idAlbum = album.idAlbum) AS lastplayed, "
+              "iAlbumDuration "
+              "FROM album");
 
   CLog::Log(LOGINFO, "create artist view");
   m_pDS->exec("CREATE VIEW artistview AS SELECT"
@@ -648,7 +656,9 @@ void CMusicDatabase::CreateNativeDBFunctions()
   // clang-format on
 }
 
-void CMusicDatabase::SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName)
+void CMusicDatabase::SplitPath(const std::string& strFileNameAndPath,
+                               std::string& strPath,
+                               std::string& strFileName)
 {
   URIUtils::Split(strFileNameAndPath, strPath, strFileName);
   // Keep protocol options as part of the path
@@ -665,66 +675,80 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
   BeginTransaction();
   SetLibraryLastUpdated();
 
-  album.idAlbum = AddAlbum(album.strAlbum,
-                           album.strMusicBrainzAlbumID,
-                           album.strReleaseGroupMBID,
-                           album.GetAlbumArtistString(),
-                           album.GetAlbumArtistSort(),
-                           album.GetGenreString(),
-                           album.strReleaseDate, album.strOrigReleaseDate,
-                           album.bBoxedSet,
-                           album.strLabel, album.strType, album.strReleaseStatus,
-                           album.bCompilation, album.releaseType);
+  album.idAlbum = AddAlbum(album.strAlbum, //
+                           album.strMusicBrainzAlbumID, //
+                           album.strReleaseGroupMBID, //
+                           album.GetAlbumArtistString(), //
+                           album.GetAlbumArtistSort(), //
+                           album.GetGenreString(), //
+                           album.strReleaseDate, //
+                           album.strOrigReleaseDate, //
+                           album.bBoxedSet, //
+                           album.strLabel, //
+                           album.strType, //
+                           album.strReleaseStatus, //
+                           album.bCompilation, //
+                           album.releaseType);
 
   // Add the album artists
+  // Album must have at least one artist so set artist to [Missing]
   if (album.artistCredits.empty())
-    AddAlbumArtist(BLANKARTIST_ID, album.idAlbum, BLANKARTIST_NAME, 0); // Album must have at least one artist so set artist to [Missing]
-  for (auto artistCredit = album.artistCredits.begin(); artistCredit != album.artistCredits.end(); ++artistCredit)
+    AddAlbumArtist(BLANKARTIST_ID, album.idAlbum, BLANKARTIST_NAME, 0);
+  for (auto artistCredit = album.artistCredits.begin(); artistCredit != album.artistCredits.end();
+       ++artistCredit)
   {
-    artistCredit->idArtist = AddArtist(artistCredit->GetArtist(), artistCredit->GetMusicBrainzArtistID(), artistCredit->GetSortName());
-    AddAlbumArtist(artistCredit->idArtist,
-                   album.idAlbum,
-                   artistCredit->GetArtist(),
+    artistCredit->idArtist =
+        AddArtist(artistCredit->GetArtist(), artistCredit->GetMusicBrainzArtistID(),
+                  artistCredit->GetSortName());
+    AddAlbumArtist(artistCredit->idArtist, album.idAlbum, artistCredit->GetArtist(),
                    static_cast<int>(std::distance(album.artistCredits.begin(), artistCredit)));
   }
 
+  // Add songs
   for (auto song = album.songs.begin(); song != album.songs.end(); ++song)
   {
     song->idAlbum = album.idAlbum;
 
-    song->idSong = AddSong(song->idSong, song->dateNew,
-                           song->idAlbum,
-                           song->strTitle, song->strMusicBrainzTrackID,
-                           song->strFileName, song->strComment,
-                           song->strMood, song->strThumb,
-                           song->GetArtistString(),
-                           song->GetArtistSort(),
-                           song->genre,
-                           song->iTrack, song->iDuration, 
-                           song->strReleaseDate, song->strOrigReleaseDate,
-                           song->strDiscSubtitle,
-                           song->iTimesPlayed, song->iStartOffset,
-                           song->iEndOffset,
-                           song->lastPlayed,
-                           song->rating,
-                           song->userrating,
-                           song->votes,
-                           song->iBPM, song->iBitRate, song->iSampleRate, song->iChannels,
+    song->idSong = AddSong(song->idSong, //
+                           song->dateNew, //
+                           song->idAlbum, //
+                           song->strTitle, //
+                           song->strMusicBrainzTrackID, //
+                           song->strFileName, //
+                           song->strComment, //
+                           song->strMood, //
+                           song->strThumb, //
+                           song->GetArtistString(), //
+                           song->GetArtistSort(), //
+                           song->genre, //
+                           song->iTrack, //
+                           song->iDuration, //
+                           song->strReleaseDate, //
+                           song->strOrigReleaseDate, //
+                           song->strDiscSubtitle, //
+                           song->iTimesPlayed, //
+                           song->iStartOffset, song->iEndOffset, //
+                           song->lastPlayed, //
+                           song->rating, //
+                           song->userrating, //
+                           song->votes, //
+                           song->iBPM, song->iBitRate, song->iSampleRate, song->iChannels, //
                            song->replayGain);
 
+    // Song must have at least one artist so set artist to [Missing]
     if (song->artistCredits.empty())
-      AddSongArtist(BLANKARTIST_ID, song->idSong, ROLE_ARTIST, BLANKARTIST_NAME, 0); // Song must have at least one artist so set artist to [Missing]
+      AddSongArtist(BLANKARTIST_ID, song->idSong, ROLE_ARTIST, BLANKARTIST_NAME, 0);
 
-    for (auto artistCredit = song->artistCredits.begin(); artistCredit != song->artistCredits.end(); ++artistCredit)
+    for (auto artistCredit = song->artistCredits.begin(); artistCredit != song->artistCredits.end();
+         ++artistCredit)
     {
-      artistCredit->idArtist = AddArtist(artistCredit->GetArtist(),
-                                         artistCredit->GetMusicBrainzArtistID(),
-                                         artistCredit->GetSortName());
-      AddSongArtist(artistCredit->idArtist,
-                    song->idSong,
-                    ROLE_ARTIST,
-                    artistCredit->GetArtist(), // we don't have song artist breakdowns from scrapers, yet
-                    static_cast<int>(std::distance(song->artistCredits.begin(), artistCredit)));
+      artistCredit->idArtist =
+          AddArtist(artistCredit->GetArtist(), artistCredit->GetMusicBrainzArtistID(),
+                    artistCredit->GetSortName());
+      AddSongArtist(
+          artistCredit->idArtist, song->idSong, ROLE_ARTIST,
+          artistCredit->GetArtist(), // we don't have song artist breakdowns from scrapers, yet
+          static_cast<int>(std::distance(song->artistCredits.begin(), artistCredit)));
     }
     // Having added artist credits (maybe with MBID) add the other contributing artists (no MBID)
     // and use COMPOSERSORT tag data to provide sort names for artists that are composers
@@ -748,7 +772,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
     AddAlbumSources(album.idAlbum, album.strPath);
   }
 
-  for (const auto &albumArt : album.art)
+  for (const auto& albumArt : album.art)
     SetArtForItem(album.idAlbum, MediaTypeAlbum, albumArt.first, albumArt.second);
 
   // Set album disc total
@@ -763,7 +787,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
     strSQL = PrepareSQL("SELECT COUNT(DISTINCT strDiscSubtitle) FROM song WHERE song.idAlbum = %i",
                         album.idAlbum);
     int numTitles = GetSingleValueInt(strSQL);
-    if (numTitles >=3)
+    if (numTitles >= 3)
     {
       strSQL = PrepareSQL("UPDATE album SET bBoxedSet=1 WHERE album.idAlbum=%i", album.idAlbum);
       m_pDS->exec(strSQL);
@@ -772,9 +796,10 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
   m_pDS->exec(PrepareSQL("UPDATE album SET strReleaseDate = (SELECT DISTINCT strReleaseDate "
                          "FROM song WHERE song.idAlbum = album.idAlbum LIMIT 1) WHERE idAlbum = %i",
                          album.idAlbum));
-  m_pDS->exec(PrepareSQL("UPDATE album SET strOrigReleaseDate = (SELECT DISTINCT strOrigReleaseDate "
-                         "FROM song WHERE song.idAlbum = album.idAlbum LIMIT 1) WHERE idAlbum = %i",
-                         album.idAlbum));
+  m_pDS->exec(
+      PrepareSQL("UPDATE album SET strOrigReleaseDate = (SELECT DISTINCT strOrigReleaseDate "
+                 "FROM song WHERE song.idAlbum = album.idAlbum LIMIT 1) WHERE idAlbum = %i",
+                 album.idAlbum));
 
   std::string albumdateadded =
       GetSingleValue("song", "MAX(dateAdded)", PrepareSQL("idAlbum = %i", album.idAlbum));
@@ -805,7 +830,8 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
   BeginTransaction();
   SetLibraryLastUpdated();
 
-  const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  const std::string itemSeparator =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
   bool isBoxset = false;
   bool canBeBoxset = false;
 
@@ -847,43 +873,47 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
       }
     }
   }
-  UpdateAlbum(album.idAlbum,
-              album.strAlbum, album.strMusicBrainzAlbumID,
-              album.strReleaseGroupMBID,
-              album.GetAlbumArtistString(), album.GetAlbumArtistSort(),
-              album.GetGenreString(),
-              StringUtils::Join(album.moods, itemSeparator),
-              StringUtils::Join(album.styles, itemSeparator),
-              StringUtils::Join(album.themes, itemSeparator),
-              album.strReview,
-              album.thumbURL.GetData(),
-              album.strLabel, album.strType, album.strReleaseStatus,
-              album.fRating, album.iUserrating, album.iVotes, 
-              album.strReleaseDate, album.strOrigReleaseDate,
-              album.bBoxedSet,
-              album.bCompilation, album.releaseType,
+  UpdateAlbum(album.idAlbum, album.strAlbum, album.strMusicBrainzAlbumID, //
+              album.strReleaseGroupMBID, //
+              album.GetAlbumArtistString(), album.GetAlbumArtistSort(), //
+              album.GetGenreString(), //
+              StringUtils::Join(album.moods, itemSeparator), //
+              StringUtils::Join(album.styles, itemSeparator), //
+              StringUtils::Join(album.themes, itemSeparator), //
+              album.strReview, //
+              album.thumbURL.GetData(), //
+              album.strLabel, //
+              album.strType, //
+              album.strReleaseStatus, //
+              album.fRating, album.iUserrating, album.iVotes, //
+              album.strReleaseDate, //
+              album.strOrigReleaseDate, //
+              album.bBoxedSet, //
+              album.bCompilation, //
+              album.releaseType, //
               album.bScrapedMBID);
 
   if (!album.bArtistSongMerge)
   {
     // Album artist(s) already exist and names are not changing, but may have scraped Musicbrainz ids to add
-    for (const auto &artistCredit : album.artistCredits)
+    for (const auto& artistCredit : album.artistCredits)
       UpdateArtistScrapedMBID(artistCredit.GetArtistId(), artistCredit.GetMusicBrainzArtistID());
   }
   else
   {
     // Replace the album artists with those scraped or set by JSON
     DeleteAlbumArtistsByAlbum(album.idAlbum);
+    // Album must have at least one artist so set artist to [Missing]
     if (album.artistCredits.empty())
-      AddAlbumArtist(BLANKARTIST_ID, album.idAlbum, BLANKARTIST_NAME, 0); // Album must have at least one artist so set artist to [Missing]
-    for (auto artistCredit = album.artistCredits.begin(); artistCredit != album.artistCredits.end(); ++artistCredit)
+      AddAlbumArtist(BLANKARTIST_ID, album.idAlbum, BLANKARTIST_NAME, 0);
+    for (auto artistCredit = album.artistCredits.begin(); artistCredit != album.artistCredits.end();
+         ++artistCredit)
     {
-      artistCredit->idArtist = AddArtist(artistCredit->GetArtist(),
-        artistCredit->GetMusicBrainzArtistID(), artistCredit->GetSortName(), true);
-      AddAlbumArtist(artistCredit->idArtist,
-        album.idAlbum,
-        artistCredit->GetArtist(),
-        static_cast<int>(std::distance(album.artistCredits.begin(), artistCredit)));
+      artistCredit->idArtist =
+          AddArtist(artistCredit->GetArtist(), artistCredit->GetMusicBrainzArtistID(),
+                    artistCredit->GetSortName(), true);
+      AddAlbumArtist(artistCredit->idArtist, album.idAlbum, artistCredit->GetArtist(),
+                     static_cast<int>(std::distance(album.artistCredits.begin(), artistCredit)));
     }
     /* Replace the songs with those scraped or imported, but if new songs is empty
        (such as when called from JSON) do not remove the original ones
@@ -891,7 +921,7 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
        Do not check for artist link changes, that is done later for all songs and album
     */
     int albumDuration = 0;
-    for (auto &song : album.songs)
+    for (auto& song : album.songs)
     {
       UpdateSong(song);
       albumDuration += song.iDuration;
@@ -914,7 +944,7 @@ void CMusicDatabase::NormaliseSongDates(std::string& strRelease, std::string& st
 {
   // Validate we have ISO8601 format date strings YYYY, YYYY-MM, or YYYY-MM-DD
   int iDate;
-   iDate = StringUtils::DateStringToYYYYMMDD(strRelease);
+  iDate = StringUtils::DateStringToYYYYMMDD(strRelease);
   if (iDate < 0)
     strRelease.clear();
   iDate = StringUtils::DateStringToYYYYMMDD(strOriginal);
@@ -927,20 +957,34 @@ void CMusicDatabase::NormaliseSongDates(std::string& strRelease, std::string& st
     strRelease = strOriginal;
 }
 
-int CMusicDatabase::AddSong(const int idSong, const CDateTime& dtDateNew,
+int CMusicDatabase::AddSong(const int idSong,
+                            const CDateTime& dtDateNew,
                             const int idAlbum,
-                            const std::string& strTitle, const std::string& strMusicBrainzTrackID,
-                            const std::string& strPathAndFileName, const std::string& strComment,
-                            const std::string& strMood, const std::string& strThumb,
-                            const std::string &artistDisp, const std::string &artistSort,
+                            const std::string& strTitle,
+                            const std::string& strMusicBrainzTrackID,
+                            const std::string& strPathAndFileName,
+                            const std::string& strComment,
+                            const std::string& strMood,
+                            const std::string& strThumb,
+                            const std::string& artistDisp,
+                            const std::string& artistSort,
                             const std::vector<std::string>& genres,
-                            int iTrack, int iDuration, 
-                            const std::string& strReleaseDate, 
+                            int iTrack,
+                            int iDuration,
+                            const std::string& strReleaseDate,
                             const std::string& strOrigReleaseDate,
                             std::string& strDiscSubtitle,
-                            const int iTimesPlayed, int iStartOffset, int iEndOffset,
-                            const CDateTime& dtLastPlayed, float rating, int userrating, int votes,
-                            int iBPM, int iBitRate, int iSampleRate, int iChannels,
+                            const int iTimesPlayed,
+                            int iStartOffset,
+                            int iEndOffset,
+                            const CDateTime& dtLastPlayed,
+                            float rating,
+                            int userrating,
+                            int votes,
+                            int iBPM,
+                            int iBitRate,
+                            int iSampleRate,
+                            int iChannels,
                             const ReplayGain& replayGain)
 {
   int idNew = -1;
@@ -964,18 +1008,13 @@ int CMusicDatabase::AddSong(const int idSong, const CDateTime& dtDateNew,
     {
       if (!strMusicBrainzTrackID.empty())
         strSQL = PrepareSQL("SELECT idSong FROM song WHERE "
-          "idAlbum = %i AND iTrack=%i AND strMusicBrainzTrackID = '%s'",
-          idAlbum,
-          iTrack,
-          strMusicBrainzTrackID.c_str());
+                            "idAlbum = %i AND iTrack=%i AND strMusicBrainzTrackID = '%s'",
+                            idAlbum, iTrack, strMusicBrainzTrackID.c_str());
       else
         strSQL = PrepareSQL("SELECT idSong FROM song WHERE "
-          "idAlbum=%i AND strFileName='%s' AND strTitle='%s' AND iTrack=%i "
-          "AND strMusicBrainzTrackID IS NULL",
-          idAlbum,
-          strFileName.c_str(),
-          strTitle.c_str(),
-          iTrack);
+                            "idAlbum=%i AND strFileName='%s' AND strTitle='%s' AND iTrack=%i "
+                            "AND strMusicBrainzTrackID IS NULL",
+                            idAlbum, strFileName.c_str(), strTitle.c_str(), iTrack);
 
       if (!m_pDS->query(strSQL))
         return -1;
@@ -1001,14 +1040,14 @@ int CMusicDatabase::AddSong(const int idSong, const CDateTime& dtDateNew,
       std::string strDateMedia = GetMediaDateFromFile(strPathAndFileName);
 
       strSQL = "INSERT INTO song ("
-        "idSong, dateNew, idAlbum, idPath, strArtistDisp, "
-        "strTitle, iTrack, iDuration, "
-        "strReleaseDate, strOrigReleaseDate, iBPM, "
-        "iBitrate, iSampleRate, iChannels, "
-        "strDiscSubtitle, strFileName, dateAdded,  "
-        "strMusicBrainzTrackID, strArtistSort, "
-        "iTimesPlayed, iStartOffset, iEndOffset, "
-        "lastplayed, rating, userrating, votes, comment, mood, strReplayGain) ";
+               "idSong, dateNew, idAlbum, idPath, strArtistDisp, "
+               "strTitle, iTrack, iDuration, "
+               "strReleaseDate, strOrigReleaseDate, iBPM, "
+               "iBitrate, iSampleRate, iChannels, "
+               "strDiscSubtitle, strFileName, dateAdded,  "
+               "strMusicBrainzTrackID, strArtistSort, "
+               "iTimesPlayed, iStartOffset, iEndOffset, "
+               "lastplayed, rating, userrating, votes, comment, mood, strReplayGain) ";
 
       if (idSong <= 0)
         // Song ID is autoincremented and dateNew set by trigger
@@ -1033,13 +1072,15 @@ int CMusicDatabase::AddSong(const int idSong, const CDateTime& dtDateNew,
         strSQL += PrepareSQL(",'%s'", artistSort.c_str());
 
       if (dtLastPlayed.IsValid())
-        strSQL += PrepareSQL(",%i,%i,%i,'%s', %.1f, %i, %i, '%s','%s', '%s')", iTimesPlayed,
-                             iStartOffset, iEndOffset, dtLastPlayed.GetAsDBDateTime().c_str(),
-                             rating, userrating, votes, strComment.c_str(), strMood.c_str(),
-                             replayGain.Get().c_str());
+        strSQL += PrepareSQL(",%i,%i,%i,'%s', %.1f, %i, %i, '%s','%s', '%s')", //
+                             iTimesPlayed, iStartOffset, iEndOffset,
+                             dtLastPlayed.GetAsDBDateTime().c_str(), //
+                             rating, userrating, votes, //
+                             strComment.c_str(), strMood.c_str(), replayGain.Get().c_str());
       else
-        strSQL += PrepareSQL(",%i,%i,%i,NULL, %.1f, %i, %i,'%s', '%s', '%s')", iTimesPlayed,
-                             iStartOffset, iEndOffset, rating, userrating, votes,
+        strSQL += PrepareSQL(",%i,%i,%i,NULL, %.1f, %i, %i,'%s', '%s', '%s')", //
+                             iTimesPlayed, iStartOffset, iEndOffset, //
+                             rating, userrating, votes, //
                              strComment.c_str(), strMood.c_str(), replayGain.Get().c_str());
       m_pDS->exec(strSQL);
       if (idSong <= 0)
@@ -1051,10 +1092,26 @@ int CMusicDatabase::AddSong(const int idSong, const CDateTime& dtDateNew,
     {
       idNew = m_pDS->fv("idSong").get_asInt();
       m_pDS->close();
-      UpdateSong(idNew, strTitle, strMusicBrainzTrackID, strPathAndFileName, strComment, strMood,
-                 strThumb, artistDisp, artistSort, genres, iTrack, iDuration, 
-                 strReleaseDate, strOrigReleaseDate, strDiscSubtitle, iTimesPlayed,
-                 iStartOffset, iEndOffset, dtLastPlayed, rating, userrating, votes, replayGain,
+      UpdateSong(idNew, //
+                 strTitle, //
+                 strMusicBrainzTrackID, //
+                 strPathAndFileName, //
+                 strComment, //
+                 strMood, //
+                 strThumb, //
+                 artistDisp, //
+                 artistSort, //
+                 genres, //
+                 iTrack, //
+                 iDuration, //
+                 strReleaseDate, //
+                 strOrigReleaseDate, //
+                 strDiscSubtitle, //
+                 iTimesPlayed, //
+                 iStartOffset, iEndOffset, //
+                 dtLastPlayed, //
+                 rating, userrating, votes, //
+                 replayGain, //
                  iBPM, iBitRate, iSampleRate, iChannels);
     }
     if (!strThumb.empty())
@@ -1083,12 +1140,15 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL=PrepareSQL("SELECT songview.*,songartistview.* FROM songview "
-                                 " JOIN songartistview ON songview.idSong = songartistview.idSong "
-                                 " WHERE songview.idSong = %i "
-                                 " ORDER BY songartistview.idRole, songartistview.iOrder", idSong);
+    std::string strSQL =
+        PrepareSQL("SELECT songview.*,songartistview.* FROM songview "
+                   " JOIN songartistview ON songview.idSong = songartistview.idSong "
+                   " WHERE songview.idSong = %i "
+                   " ORDER BY songartistview.idRole, songartistview.iOrder",
+                   idSong);
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -1122,34 +1182,29 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
   return false;
 }
 
-bool CMusicDatabase::UpdateSong(CSong& song,
-                                bool bArtists /*= true*/,
-                                bool bArtistLinks /*= true*/)
+bool CMusicDatabase::UpdateSong(CSong& song, bool bArtists /*= true*/, bool bArtistLinks /*= true*/)
 {
   int result = UpdateSong(song.idSong,
-                    song.strTitle,
-                    song.strMusicBrainzTrackID,
-                    song.strFileName,
-                    song.strComment,
-                    song.strMood,
-                    song.strThumb,
-                    song.GetArtistString(),
-                    song.GetArtistSort(),
-                    song.genre,
-                    song.iTrack,
-                    song.iDuration,
-                    song.strReleaseDate,
-                    song.strOrigReleaseDate,
-                    song.strDiscSubtitle,
-                    song.iTimesPlayed,
-                    song.iStartOffset,
-                    song.iEndOffset,
-                    song.lastPlayed,
-                    song.rating,
-                    song.userrating,
-                    song.votes,
-                    song.replayGain,
-                    song.iBPM, song.iBitRate, song.iSampleRate, song.iChannels);
+                          song.strTitle, //
+                          song.strMusicBrainzTrackID, //
+                          song.strFileName, //
+                          song.strComment, //
+                          song.strMood, //
+                          song.strThumb, //
+                          song.GetArtistString(), //
+                          song.GetArtistSort(), //
+                          song.genre, //
+                          song.iTrack, //
+                          song.iDuration, //
+                          song.strReleaseDate, //
+                          song.strOrigReleaseDate, //
+                          song.strDiscSubtitle, //
+                          song.iTimesPlayed, //
+                          song.iStartOffset, song.iEndOffset, //
+                          song.lastPlayed, //
+                          song.rating, song.userrating, song.votes, //
+                          song.replayGain, //
+                          song.iBPM, song.iBitRate, song.iSampleRate, song.iChannels);
   if (result < 0)
     return false;
 
@@ -1159,17 +1214,17 @@ bool CMusicDatabase::UpdateSong(CSong& song,
   {
     //Replace song artists and contributors
     DeleteSongArtistsBySong(song.idSong);
+    // Song must have at least one artist so set artist to [Missing]
     if (song.artistCredits.empty())
-      AddSongArtist(BLANKARTIST_ID, song.idSong, ROLE_ARTIST, BLANKARTIST_NAME, 0); // Song must have at least one artist so set artist to [Missing]
-    for (auto artistCredit = song.artistCredits.begin(); artistCredit != song.artistCredits.end(); ++artistCredit)
+      AddSongArtist(BLANKARTIST_ID, song.idSong, ROLE_ARTIST, BLANKARTIST_NAME, 0);
+    for (auto artistCredit = song.artistCredits.begin(); artistCredit != song.artistCredits.end();
+         ++artistCredit)
     {
-      artistCredit->idArtist = AddArtist(artistCredit->GetArtist(),
-        artistCredit->GetMusicBrainzArtistID(), artistCredit->GetSortName());
-      AddSongArtist(artistCredit->idArtist,
-        song.idSong,
-        ROLE_ARTIST,
-        artistCredit->GetArtist(),
-        static_cast<int>(std::distance(song.artistCredits.begin(), artistCredit)));
+      artistCredit->idArtist =
+          AddArtist(artistCredit->GetArtist(), artistCredit->GetMusicBrainzArtistID(),
+                    artistCredit->GetSortName());
+      AddSongArtist(artistCredit->idArtist, song.idSong, ROLE_ARTIST, artistCredit->GetArtist(),
+                    static_cast<int>(std::distance(song.artistCredits.begin(), artistCredit)));
     }
     // Having added artist credits (maybe with MBID) add the other contributing artists (MBID unknown)
     // and use COMPOSERSORT tag data to provide sort names for artists that are composers
@@ -1183,18 +1238,30 @@ bool CMusicDatabase::UpdateSong(CSong& song,
 }
 
 int CMusicDatabase::UpdateSong(int idSong,
-                               const std::string& strTitle, const std::string& strMusicBrainzTrackID,
-                               const std::string& strPathAndFileName, const std::string& strComment,
-                               const std::string& strMood, const std::string& strThumb,
-                               const std::string &artistDisp, const std::string &artistSort,
+                               const std::string& strTitle,
+                               const std::string& strMusicBrainzTrackID,
+                               const std::string& strPathAndFileName,
+                               const std::string& strComment,
+                               const std::string& strMood,
+                               const std::string& strThumb,
+                               const std::string& artistDisp,
+                               const std::string& artistSort,
                                const std::vector<std::string>& genres,
-                               int iTrack, int iDuration, 
+                               int iTrack,
+                               int iDuration,
                                const std::string& strReleaseDate,
                                const std::string& strOrigReleaseDate,
                                const std::string& strDiscSubtitle,
-                               int iTimesPlayed, int iStartOffset, int iEndOffset,
-                               const CDateTime& dtLastPlayed, float rating, int userrating, int votes,
-                               const ReplayGain& replayGain, int iBPM, int iBitRate,
+                               int iTimesPlayed,
+                               int iStartOffset,
+                               int iEndOffset,
+                               const CDateTime& dtLastPlayed,
+                               float rating,
+                               int userrating,
+                               int votes,
+                               const ReplayGain& replayGain,
+                               int iBPM,
+                               int iBitRate,
                                int iSampleRate,
                                int iChannels)
 {
@@ -1258,15 +1325,20 @@ int CMusicDatabase::UpdateSong(int idSong,
   return idSong;
 }
 
-int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
+int CMusicDatabase::AddAlbum(const std::string& strAlbum,
+                             const std::string& strMusicBrainzAlbumID,
                              const std::string& strReleaseGroupMBID,
-                             const std::string& strArtist, const std::string& strArtistSort,
-                             const std::string& strGenre, 
-                             const std::string& strReleaseDate, const std::string& strOrigReleaseDate,
+                             const std::string& strArtist,
+                             const std::string& strArtistSort,
+                             const std::string& strGenre,
+                             const std::string& strReleaseDate,
+                             const std::string& strOrigReleaseDate,
                              bool bBoxedSet,
-                             const std::string& strRecordLabel, const std::string& strType,
+                             const std::string& strRecordLabel,
+                             const std::string& strType,
                              const std::string& strReleaseStatus,
-                             bool bCompilation, CAlbum::ReleaseType releaseType)
+                             bool bCompilation,
+                             CAlbum::ReleaseType releaseType)
 {
   std::string strSQL;
   try
@@ -1278,11 +1350,12 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
 
     if (!strMusicBrainzAlbumID.empty())
       strSQL = PrepareSQL("SELECT * FROM album WHERE strMusicBrainzAlbumID = '%s'",
-                        strMusicBrainzAlbumID.c_str());
+                          strMusicBrainzAlbumID.c_str());
     else
-      strSQL = PrepareSQL("SELECT * FROM album WHERE strArtistDisp LIKE '%s' AND strAlbum LIKE '%s' AND strMusicBrainzAlbumID IS NULL",
-                          strArtist.c_str(),
-                          strAlbum.c_str());
+      strSQL = PrepareSQL("SELECT * FROM album "
+                          "WHERE strArtistDisp LIKE '%s' AND strAlbum LIKE '%s' "
+                          "AND strMusicBrainzAlbumID IS NULL",
+                          strArtist.c_str(), strAlbum.c_str());
     m_pDS->query(strSQL);
     std::string strCheckFlag = strType;
     StringUtils::ToLower(strCheckFlag);
@@ -1292,17 +1365,17 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
     {
       m_pDS->close();
       // Does not exist, add it
-      strSQL = PrepareSQL(
-          "INSERT INTO album (idAlbum, strAlbum, strArtistDisp, strGenres, "
-          "strReleaseDate, strOrigReleaseDate, bBoxedSet, "
-          "strLabel, strType, strReleaseStatus, bCompilation, strReleaseType,  "
-          "strMusicBrainzAlbumID, "
-          "strReleaseGroupMBID, strArtistSort) "
-          "values(NULL, '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', '%s', %i, '%s'",
-          strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(), 
-          strReleaseDate.c_str(), strOrigReleaseDate.c_str(), bBoxedSet,
-          strRecordLabel.c_str(), strType.c_str(), strReleaseStatus.c_str(), bCompilation,
-          CAlbum::ReleaseTypeToString(releaseType).c_str());
+      strSQL =
+          PrepareSQL("INSERT INTO album (idAlbum, strAlbum, strArtistDisp, strGenres, "
+                     "strReleaseDate, strOrigReleaseDate, bBoxedSet, "
+                     "strLabel, strType, strReleaseStatus, bCompilation, strReleaseType,  "
+                     "strMusicBrainzAlbumID, "
+                     "strReleaseGroupMBID, strArtistSort) "
+                     "values(NULL, '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', '%s', %i, '%s'",
+                     strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(), //
+                     strReleaseDate.c_str(), strOrigReleaseDate.c_str(), bBoxedSet, //
+                     strRecordLabel.c_str(), strType.c_str(), strReleaseStatus.c_str(), //
+                     bCompilation, CAlbum::ReleaseTypeToString(releaseType).c_str());
 
       if (strMusicBrainzAlbumID.empty())
         strSQL += PrepareSQL(", NULL");
@@ -1337,7 +1410,8 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
 
       strSQL = "UPDATE album SET ";
       if (!strMusicBrainzAlbumID.empty())
-        strSQL += PrepareSQL("strAlbum = '%s', strArtistDisp = '%s', ", strAlbum.c_str(), strArtist.c_str());
+        strSQL += PrepareSQL("strAlbum = '%s', strArtistDisp = '%s', ", //
+                             strAlbum.c_str(), strArtist.c_str());
       if (strReleaseGroupMBID.empty())
         strSQL += PrepareSQL(" strReleaseGroupMBID = NULL,");
       else
@@ -1353,9 +1427,9 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
                      "bCompilation=%i, strReleaseType = '%s', "
                      "lastScraped = NULL "
                      "WHERE idAlbum=%i",
-                     strGenre.c_str(), strReleaseDate.c_str(), strOrigReleaseDate.c_str(), 
+                     strGenre.c_str(), strReleaseDate.c_str(), strOrigReleaseDate.c_str(), //
                      bBoxedSet, strRecordLabel.c_str(), strType.c_str(), strReleaseStatus.c_str(),
-                     bCompilation, CAlbum::ReleaseTypeToString(releaseType).c_str(), 
+                     bCompilation, CAlbum::ReleaseTypeToString(releaseType).c_str(), //
                      idAlbum);
       m_pDS->exec(strSQL);
       DeleteAlbumArtistsByAlbum(idAlbum);
@@ -1406,7 +1480,7 @@ int CMusicDatabase::UpdateAlbum(int idAlbum,
           CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic.type,
           "mysql"))
     TrimImageURLs(strImageURLs, 65535);
-    
+
   std::string strSQL;
   strSQL = PrepareSQL("UPDATE album SET "
                       " strAlbum = '%s', strArtistDisp = '%s', strGenres = '%s', "
@@ -1417,16 +1491,14 @@ int CMusicDatabase::UpdateAlbum(int idAlbum,
                       " bBoxedSet = %i, bCompilation = %i,"
                       " strReleaseType = '%s', strReleaseStatus = '%s', "
                       " lastScraped = '%s', bScrapedMBID = %i",
-                      strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(),
-                      strMoods.c_str(), strStyles.c_str(), strThemes.c_str(),
-                      strReview.c_str(), strImageURLs.c_str(), strLabel.c_str(),
-                      strType.c_str(), fRating, iUserrating, iVotes,
-                      strReleaseDate.c_str(), strOrigReleaseDate.c_str(),
-                      bBoxedSet, bCompilation,
-                      CAlbum::ReleaseTypeToString(releaseType).c_str(),
-                      strReleaseStatus.c_str(),
-                      CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(),
-                      bScrapedMBID);
+                      strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(), //
+                      strMoods.c_str(), strStyles.c_str(), strThemes.c_str(), //
+                      strReview.c_str(), strImageURLs.c_str(), strLabel.c_str(), //
+                      strType.c_str(), fRating, iUserrating, iVotes, //
+                      strReleaseDate.c_str(), strOrigReleaseDate.c_str(), //
+                      bBoxedSet, bCompilation, //
+                      CAlbum::ReleaseTypeToString(releaseType).c_str(), strReleaseStatus.c_str(), //
+                      CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(), bScrapedMBID);
   if (strMusicBrainzAlbumID.empty())
     strSQL += PrepareSQL(", strMusicBrainzAlbumID = NULL");
   else
@@ -1465,13 +1537,15 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
     //Get album data
     std::string sql;
     sql = PrepareSQL("SELECT albumview.*,albumartistview.* "
-      " FROM albumview "
-      " JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
-      " WHERE albumview.idAlbum = %ld "
-      " ORDER BY albumartistview.iOrder", idAlbum);
+                     " FROM albumview "
+                     " JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
+                     " WHERE albumview.idAlbum = %ld "
+                     " ORDER BY albumartistview.iOrder",
+                     idAlbum);
 
     CLog::Log(LOGDEBUG, "%s", sql.c_str());
-    if (!m_pDS->query(sql)) return false;
+    if (!m_pDS->query(sql))
+      return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -1480,7 +1554,8 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
 
     int albumArtistOffset = album_enumCount;
 
-    album = GetAlbumFromDataset(m_pDS->get_sql_record(), 0, true); // true to grab and parse the imageURL
+    album = GetAlbumFromDataset(m_pDS->get_sql_record(), 0,
+                                true); // true to grab and parse the imageURL
     while (!m_pDS->eof())
     {
       const dbiplus::sql_record* const record = m_pDS->get_sql_record();
@@ -1497,14 +1572,16 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
     if (getSongs)
     {
       sql = PrepareSQL("SELECT songview.*, songartistview.*"
-        " FROM songview "
-        " JOIN songartistview ON songview.idSong = songartistview.idSong "
-        " WHERE songview.idAlbum = %ld "
-        " ORDER BY songview.iTrack, songartistview.idRole, songartistview.iOrder", idAlbum);
+                       " FROM songview "
+                       " JOIN songartistview ON songview.idSong = songartistview.idSong "
+                       " WHERE songview.idAlbum = %ld "
+                       " ORDER BY songview.iTrack, songartistview.idRole, songartistview.iOrder",
+                       idAlbum);
 
       CLog::Log(LOGDEBUG, "%s", sql.c_str());
-      if (!m_pDS->query(sql)) return false;
-      if (m_pDS->num_rows() == 0)  //Album with no songs
+      if (!m_pDS->query(sql))
+        return false;
+      if (m_pDS->num_rows() == 0) //Album with no songs
       {
         m_pDS->close();
         return false;
@@ -1516,7 +1593,7 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
       {
         const dbiplus::sql_record* const record = m_pDS->get_sql_record();
 
-        int idSong = record->at(song_idSong).get_asInt();  //Same as songartist.idSong by join
+        int idSong = record->at(song_idSong).get_asInt(); //Same as songartist.idSong by join
         if (songs.find(idSong) == songs.end())
         {
           album.songs.emplace_back(GetSongFromDataset(record));
@@ -1526,7 +1603,8 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
         int idSongArtistRole = record->at(songArtistOffset + artistCredit_idRole).get_asInt();
         //By query order song is the last one appended to the album song vector.
         if (idSongArtistRole == ROLE_ARTIST)
-          album.songs.back().artistCredits.emplace_back(GetArtistCreditFromDataset(record, songArtistOffset));
+          album.songs.back().artistCredits.emplace_back(
+              GetArtistCreditFromDataset(record, songArtistOffset));
         else
           album.songs.back().AppendArtistRole(GetArtistRoleFromDataset(record, songArtistOffset));
 
@@ -1547,13 +1625,15 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
 
 bool CMusicDatabase::ClearAlbumLastScrapedTime(int idAlbum)
 {
-  std::string strSQL = PrepareSQL("UPDATE album SET lastScraped = NULL WHERE idAlbum = %i", idAlbum);
+  std::string strSQL =
+      PrepareSQL("UPDATE album SET lastScraped = NULL WHERE idAlbum = %i", idAlbum);
   return ExecuteQuery(strSQL);
 }
 
 bool CMusicDatabase::HasAlbumBeenScraped(int idAlbum)
 {
-  std::string strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE idAlbum = %i AND lastScraped IS NULL", idAlbum);
+  std::string strSQL =
+      PrepareSQL("SELECT idAlbum FROM album WHERE idAlbum = %i AND lastScraped IS NULL", idAlbum);
   return GetSingleValue(strSQL).empty();
 }
 
@@ -1565,7 +1645,7 @@ int CMusicDatabase::AddGenre(std::string& strGenre)
     StringUtils::Trim(strGenre);
 
     if (strGenre.empty())
-      strGenre=g_localizeStrings.Get(13205); // Unknown
+      strGenre = g_localizeStrings.Get(13205); // Unknown
 
     if (nullptr == m_pDB)
       return -1;
@@ -1577,13 +1657,15 @@ int CMusicDatabase::AddGenre(std::string& strGenre)
       return it->second;
 
 
-    strSQL=PrepareSQL("SELECT idGenre, strGenre FROM genre WHERE strGenre LIKE '%s'", strGenre.c_str());
+    strSQL = PrepareSQL("SELECT idGenre, strGenre FROM genre WHERE strGenre LIKE '%s'",
+                        strGenre.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesn't exists, add it
-      strSQL=PrepareSQL("INSERT INTO genre (idGenre, strGenre) values( NULL, '%s' )", strGenre.c_str());
+      strSQL = PrepareSQL("INSERT INTO genre (idGenre, strGenre) values( NULL, '%s' )",
+                          strGenre.c_str());
       m_pDS->exec(strSQL);
 
       int idGenre = (int)m_pDS->lastinsertid();
@@ -1611,24 +1693,31 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
 {
   SetLibraryLastUpdated();
 
-  const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  const std::string itemSeparator =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
 
-  UpdateArtist(artist.idArtist,
-               artist.strArtist, artist.strSortName,
-               artist.strMusicBrainzArtistID, artist.bScrapedMBID,
-               artist.strType, artist.strGender, artist.strDisambiguation,
-               artist.strBorn, artist.strFormed,
-               StringUtils::Join(artist.genre, itemSeparator),
-               StringUtils::Join(artist.moods, itemSeparator),
-               StringUtils::Join(artist.styles, itemSeparator),
-               StringUtils::Join(artist.instruments, itemSeparator),
-               artist.strBiography, artist.strDied,
-               artist.strDisbanded,
-               StringUtils::Join(artist.yearsActive, itemSeparator).c_str(),
+  UpdateArtist(artist.idArtist, //
+               artist.strArtist, //
+               artist.strSortName, //
+               artist.strMusicBrainzArtistID, //
+               artist.bScrapedMBID, //
+               artist.strType, //
+               artist.strGender, //
+               artist.strDisambiguation, //
+               artist.strBorn, //
+               artist.strFormed, //
+               StringUtils::Join(artist.genre, itemSeparator), //
+               StringUtils::Join(artist.moods, itemSeparator), //
+               StringUtils::Join(artist.styles, itemSeparator), //
+               StringUtils::Join(artist.instruments, itemSeparator), //
+               artist.strBiography, //
+               artist.strDied, //
+               artist.strDisbanded, //
+               StringUtils::Join(artist.yearsActive, itemSeparator).c_str(), //
                artist.thumbURL.GetData());
 
   DeleteArtistDiscography(artist.idArtist);
-  for (const auto &disc : artist.discography)
+  for (const auto& disc : artist.discography)
   {
     AddArtistDiscography(artist.idArtist, disc);
   }
@@ -1640,7 +1729,10 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
   return true;
 }
 
-int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, const std::string& strSortName, bool bScrapedMBID /* = false*/)
+int CMusicDatabase::AddArtist(const std::string& strArtist,
+                              const std::string& strMusicBrainzArtistID,
+                              const std::string& strSortName,
+                              bool bScrapedMBID /* = false*/)
 {
   std::string strSQL;
   int idArtist = AddArtist(strArtist, strMusicBrainzArtistID, bScrapedMBID);
@@ -1674,13 +1766,12 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
     if (!strArtistSort.empty())
     {
       if (strSortName.compare(strArtistName) == 0)
-        m_pDS->exec(PrepareSQL(
-            "UPDATE artist SET strSortName = NULL WHERE idArtist = %i", idArtist));
+        m_pDS->exec(
+            PrepareSQL("UPDATE artist SET strSortName = NULL WHERE idArtist = %i", idArtist));
     }
     else if (strSortName.compare(strArtistName) != 0)
-      m_pDS->exec(PrepareSQL(
-          "UPDATE artist SET strSortName = '%s' WHERE idArtist = %i",
-          strSortName.c_str(), idArtist));
+      m_pDS->exec(PrepareSQL("UPDATE artist SET strSortName = '%s' WHERE idArtist = %i",
+                             strSortName.c_str(), idArtist));
 
     return idArtist;
   }
@@ -1693,7 +1784,9 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
   return -1;
 }
 
-int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, bool bScrapedMBID /* = false*/)
+int CMusicDatabase::AddArtist(const std::string& strArtist,
+                              const std::string& strMusicBrainzArtistID,
+                              bool bScrapedMBID /* = false*/)
 {
   std::string strSQL;
   try
@@ -1707,8 +1800,9 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
     if (!strMusicBrainzArtistID.empty())
     {
       // 1.a) Match on a MusicBrainz ID
-      strSQL = PrepareSQL("SELECT idArtist, strArtist FROM artist WHERE strMusicBrainzArtistID = '%s'",
-        strMusicBrainzArtistID.c_str());
+      strSQL =
+          PrepareSQL("SELECT idArtist, strArtist FROM artist WHERE strMusicBrainzArtistID = '%s'",
+                     strMusicBrainzArtistID.c_str());
       m_pDS->query(strSQL);
       if (m_pDS->num_rows() > 0)
       {
@@ -1718,7 +1812,8 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
         if (update)
         {
           strSQL = PrepareSQL("UPDATE artist SET strArtist = '%s' "
-            "WHERE idArtist = %i", strArtist.c_str(), idArtist);
+                              "WHERE idArtist = %i",
+                              strArtist.c_str(), idArtist);
           m_pDS->exec(strSQL);
           m_pDS->close();
         }
@@ -1729,19 +1824,19 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
 
       // 1.b) No match on MusicBrainz ID. Look for a previously added artist with no MusicBrainz ID
       //     and update that if it exists.
-      strSQL = PrepareSQL("SELECT idArtist FROM artist WHERE strArtist LIKE '%s' AND strMusicBrainzArtistID IS NULL", strArtist.c_str());
+      strSQL = PrepareSQL("SELECT idArtist FROM artist "
+                          "WHERE strArtist LIKE '%s' AND strMusicBrainzArtistID IS NULL",
+                          strArtist.c_str());
       m_pDS->query(strSQL);
       if (m_pDS->num_rows() > 0)
       {
         int idArtist = m_pDS->fv("idArtist").get_asInt();
         m_pDS->close();
         // 1.b.a) We found an artist by name but with no MusicBrainz ID set, update it and assume it is our artist, flag when mbid scraped
-        strSQL = PrepareSQL("UPDATE artist SET strArtist = '%s', strMusicBrainzArtistID = '%s', "
-          "bScrapedMBID = %i WHERE idArtist = %i",
-          strArtist.c_str(),
-          strMusicBrainzArtistID.c_str(),
-          bScrapedMBID,
-          idArtist);
+        strSQL =
+            PrepareSQL("UPDATE artist SET strArtist = '%s', strMusicBrainzArtistID = '%s', "
+                       "bScrapedMBID = %i WHERE idArtist = %i",
+                       strArtist.c_str(), strMusicBrainzArtistID.c_str(), bScrapedMBID, idArtist);
         m_pDS->exec(strSQL);
         return idArtist;
       }
@@ -1752,8 +1847,8 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
     }
     else
     {
-      strSQL = PrepareSQL("SELECT idArtist FROM artist WHERE strArtist LIKE '%s'",
-        strArtist.c_str());
+      strSQL =
+          PrepareSQL("SELECT idArtist FROM artist WHERE strArtist LIKE '%s'", strArtist.c_str());
 
       m_pDS->query(strSQL);
       if (m_pDS->num_rows() > 0)
@@ -1768,15 +1863,14 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
     // 3) No artist exists at all - add it, flagging when has scraped mbid
     if (strMusicBrainzArtistID.empty())
       strSQL = PrepareSQL("INSERT INTO artist "
-        "(idArtist, strArtist, strMusicBrainzArtistID) "
-        "VALUES( NULL, '%s', NULL)",
-        strArtist.c_str());
+                          "(idArtist, strArtist, strMusicBrainzArtistID) "
+                          "VALUES( NULL, '%s', NULL)",
+                          strArtist.c_str());
     else
       strSQL = PrepareSQL("INSERT INTO artist (idArtist, strArtist, strMusicBrainzArtistID, "
-        "bScrapedMBID) "
-        "VALUES( NULL, '%s', '%s', %i )",
-        strArtist.c_str(),
-        strMusicBrainzArtistID.c_str(), bScrapedMBID);
+                          "bScrapedMBID) "
+                          "VALUES( NULL, '%s', '%s', %i )",
+                          strArtist.c_str(), strMusicBrainzArtistID.c_str(), bScrapedMBID);
 
     m_pDS->exec(strSQL);
     int idArtist = (int)m_pDS->lastinsertid();
@@ -1790,17 +1884,25 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
   return -1;
 }
 
-int  CMusicDatabase::UpdateArtist(int idArtist,
-                                  const std::string& strArtist, const std::string& strSortName,
-                                  const std::string& strMusicBrainzArtistID, const bool bScrapedMBID,
-                                  const std::string& strType, const std::string& strGender,
-                                  const std::string& strDisambiguation,
-                                  const std::string& strBorn, const std::string& strFormed,
-                                  const std::string& strGenres, const std::string& strMoods,
-                                  const std::string& strStyles, const std::string& strInstruments,
-                                  const std::string& strBiography, const std::string& strDied,
-                                  const std::string& strDisbanded, const std::string& strYearsActive,
-                                  const std::string& strImage)
+int CMusicDatabase::UpdateArtist(int idArtist,
+                                 const std::string& strArtist,
+                                 const std::string& strSortName,
+                                 const std::string& strMusicBrainzArtistID,
+                                 const bool bScrapedMBID,
+                                 const std::string& strType,
+                                 const std::string& strGender,
+                                 const std::string& strDisambiguation,
+                                 const std::string& strBorn,
+                                 const std::string& strFormed,
+                                 const std::string& strGenres,
+                                 const std::string& strMoods,
+                                 const std::string& strStyles,
+                                 const std::string& strInstruments,
+                                 const std::string& strBiography,
+                                 const std::string& strDied,
+                                 const std::string& strDisbanded,
+                                 const std::string& strYearsActive,
+                                 const std::string& strImage)
 {
   if (idArtist < 0)
     return -1;
@@ -1813,8 +1915,8 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
   if (idArtistMbid > 0 && idArtistMbid != idArtist)
   {
     CLog::Log(LOGDEBUG, "{0}: Updating {4} (Id: {5}) mbid {1} already assigned to {2} (Id: {3})",
-      __FUNCTION__, strMusicBrainzArtistID.c_str(), artistname.c_str(), idArtistMbid,
-      strArtist.c_str(), idArtist);
+              __FUNCTION__, strMusicBrainzArtistID.c_str(), artistname.c_str(), idArtistMbid,
+              strArtist.c_str(), idArtist);
     useMBIDNull = true;
     isScrapedMBID = false;
   }
@@ -1823,8 +1925,8 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
   // Truncate value cleaning up xml when URLs exceeds this
   std::string strImageURLs = strImage;
   if (StringUtils::EqualsNoCase(
-    CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic.type,
-    "mysql"))
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic.type,
+          "mysql"))
     TrimImageURLs(strImageURLs, 65535);
 
   std::string strSQL;
@@ -1839,11 +1941,11 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                       strArtist.c_str(),
                       /* strSortName.c_str(),*/
                       /* strMusicBrainzArtistID.c_str(), */
-                      strType.c_str(), strGender.c_str(), strDisambiguation.c_str(),
-                      strBorn.c_str(), strFormed.c_str(), strGenres.c_str(),
-                      strMoods.c_str(), strStyles.c_str(), strInstruments.c_str(),
-                      strBiography.c_str(), strDied.c_str(), strDisbanded.c_str(),
-                      strYearsActive.c_str(), strImageURLs.c_str(),
+                      strType.c_str(), strGender.c_str(), strDisambiguation.c_str(), //
+                      strBorn.c_str(), strFormed.c_str(), strGenres.c_str(), //
+                      strMoods.c_str(), strStyles.c_str(), strInstruments.c_str(), //
+                      strBiography.c_str(), strDied.c_str(), strDisbanded.c_str(), //
+                      strYearsActive.c_str(), strImageURLs.c_str(), //
                       CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(), isScrapedMBID);
   if (useMBIDNull)
     strSQL += PrepareSQL(", strMusicBrainzArtistID = NULL");
@@ -1862,7 +1964,8 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
   return idArtist;
 }
 
-bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist, const std::string& strMusicBrainzArtistID)
+bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist,
+                                             const std::string& strMusicBrainzArtistID)
 {
   if (strMusicBrainzArtistID.empty() || idArtist < 0)
     return false;
@@ -1880,8 +1983,8 @@ bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist, const std::string& st
   // Set scraped artist Musicbrainz ID for a previously added artist with no MusicBrainz ID
   std::string strSQL;
   strSQL = PrepareSQL("UPDATE artist SET strMusicBrainzArtistID = '%s', bScrapedMBID = 1 "
-    "WHERE idArtist = %i AND strMusicBrainzArtistID IS NULL",
-    strMusicBrainzArtistID.c_str(), idArtist);
+                      "WHERE idArtist = %i AND strMusicBrainzArtistID IS NULL",
+                      strMusicBrainzArtistID.c_str(), idArtist);
 
   bool status = ExecuteQuery(strSQL);
   if (status)
@@ -1892,7 +1995,7 @@ bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist, const std::string& st
   return false;
 }
 
-bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* = false */)
+bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* = false */)
 {
   try
   {
@@ -1907,11 +2010,15 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* =
 
     std::string strSQL;
     if (fetchAll)
-      strSQL = PrepareSQL("SELECT * FROM artistview LEFT JOIN discography ON artistview.idArtist = discography.idArtist WHERE artistview.idArtist = %i", idArtist);
+      strSQL = PrepareSQL("SELECT * FROM artistview "
+                          "LEFT JOIN discography ON artistview.idArtist = discography.idArtist "
+                          "WHERE artistview.idArtist = %i",
+                          idArtist);
     else
       strSQL = PrepareSQL("SELECT * FROM artistview WHERE artistview.idArtist = %i", idArtist);
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -1935,7 +2042,8 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* =
       }
     }
     m_pDS->close(); // cleanup recordset data
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{0}({1}) - took {2} ms", __FUNCTION__, strSQL, XbmcThreads::SystemClockMillis() - time);
+    CLog::Log(LOGDEBUG, LOGDATABASE, "{0}({1}) - took {2} ms", __FUNCTION__, strSQL,
+              XbmcThreads::SystemClockMillis() - time);
     return true;
   }
   catch (...)
@@ -1955,9 +2063,11 @@ bool CMusicDatabase::GetArtistExists(int idArtist)
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL = PrepareSQL("SELECT 1 FROM artist WHERE artist.idArtist = %i LIMIT 1", idArtist);
+    std::string strSQL =
+        PrepareSQL("SELECT 1 FROM artist WHERE artist.idArtist = %i LIMIT 1", idArtist);
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -1979,7 +2089,7 @@ int CMusicDatabase::GetLastArtist()
   std::string strSQL = "SELECT MAX(idArtist) FROM artist";
   std::string lastArtist = GetSingleValue(strSQL);
   if (lastArtist.empty())
-      return -1;
+    return -1;
 
   return static_cast<int>(strtol(lastArtist.c_str(), NULL, 10));
 }
@@ -2020,13 +2130,15 @@ int CMusicDatabase::GetArtistFromMBID(const std::string& strMusicBrainzArtistID,
 
 bool CMusicDatabase::HasArtistBeenScraped(int idArtist)
 {
-  std::string strSQL = PrepareSQL("SELECT idArtist FROM artist WHERE idArtist = %i AND lastScraped IS NULL", idArtist);
+  std::string strSQL = PrepareSQL(
+      "SELECT idArtist FROM artist WHERE idArtist = %i AND lastScraped IS NULL", idArtist);
   return GetSingleValue(strSQL).empty();
 }
 
 bool CMusicDatabase::ClearArtistLastScrapedTime(int idArtist)
 {
-  std::string strSQL = PrepareSQL("UPDATE artist SET lastScraped = NULL WHERE idArtist = %i", idArtist);
+  std::string strSQL =
+      PrepareSQL("UPDATE artist SET lastScraped = NULL WHERE idArtist = %i", idArtist);
   return ExecuteQuery(strSQL);
 }
 
@@ -2131,10 +2243,10 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
       std::string strAlbum = m_pDS->fv("strAlbum").get_asString();
       if (!strAlbum.empty())
       {
-          CFileItemPtr pItem(new CFileItem(strAlbum));
-          pItem->SetLabel2(m_pDS->fv("iYear").get_asString());
-          pItem->GetMusicInfoTag()->SetDatabaseId(idAlbum, MediaTypeAlbum);
-          items.Add(pItem);
+        CFileItemPtr pItem(new CFileItem(strAlbum));
+        pItem->SetLabel2(m_pDS->fv("iYear").get_asString());
+        pItem->GetMusicInfoTag()->SetDatabaseId(idAlbum, MediaTypeAlbum);
+        items.Add(pItem);
       }
       m_pDS->next();
     }
@@ -2153,7 +2265,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
   return false;
 }
 
-int CMusicDatabase::AddRole(const std::string &strRole)
+int CMusicDatabase::AddRole(const std::string& strRole)
 {
   int idRole = -1;
   std::string strSQL;
@@ -2185,21 +2297,27 @@ int CMusicDatabase::AddRole(const std::string &strRole)
   return idRole;
 }
 
-bool CMusicDatabase::AddSongArtist(int idArtist, int idSong, const std::string& strRole, const std::string& strArtist, int iOrder)
+bool CMusicDatabase::AddSongArtist(
+    int idArtist, int idSong, const std::string& strRole, const std::string& strArtist, int iOrder)
 {
   int idRole = AddRole(strRole);
   return AddSongArtist(idArtist, idSong, idRole, strArtist, iOrder);
 }
 
-bool CMusicDatabase::AddSongArtist(int idArtist, int idSong, int idRole, const std::string& strArtist, int iOrder)
+bool CMusicDatabase::AddSongArtist(
+    int idArtist, int idSong, int idRole, const std::string& strArtist, int iOrder)
 {
   std::string strSQL;
-  strSQL = PrepareSQL("replace into song_artist (idArtist, idSong, idRole, strArtist, iOrder) values(%i,%i,%i,'%s',%i)",
-    idArtist, idSong, idRole, strArtist.c_str(), iOrder);
+  strSQL = PrepareSQL("REPLACE INTO song_artist (idArtist, idSong, idRole, strArtist, iOrder) "
+                      "VALUES(%i, %i, %i,'%s', %i)",
+                      idArtist, idSong, idRole, strArtist.c_str(), iOrder);
   return ExecuteQuery(strSQL);
 }
 
-int CMusicDatabase::AddSongContributor(int idSong, const std::string& strRole, const std::string& strArtist, const std::string &strSort)
+int CMusicDatabase::AddSongContributor(int idSong,
+                                       const std::string& strRole,
+                                       const std::string& strArtist,
+                                       const std::string& strSort)
 {
   if (strArtist.empty())
     return -1;
@@ -2215,7 +2333,9 @@ int CMusicDatabase::AddSongContributor(int idSong, const std::string& strRole, c
     int idArtist = -1;
     // Add artist. As we only have name (no MBID) first try to identify artist from song
     // as they may have already been added with a different role (including MBID).
-    strSQL = PrepareSQL("SELECT idArtist FROM song_artist WHERE idSong = %i AND strArtist LIKE '%s' ", idSong, strArtist.c_str());
+    strSQL =
+        PrepareSQL("SELECT idArtist FROM song_artist WHERE idSong = %i AND strArtist LIKE '%s' ",
+                   idSong, strArtist.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() > 0)
       idArtist = m_pDS->fv("idArtist").get_asInt();
@@ -2237,16 +2357,20 @@ int CMusicDatabase::AddSongContributor(int idSong, const std::string& strRole, c
   return -1;
 }
 
-void CMusicDatabase::AddSongContributors(int idSong, const VECMUSICROLES& contributors, const std::string &strSort)
+void CMusicDatabase::AddSongContributors(int idSong,
+                                         const VECMUSICROLES& contributors,
+                                         const std::string& strSort)
 {
   std::vector<std::string> composerSort;
   size_t countComposer = 0;
   if (!strSort.empty())
   {
-    composerSort = StringUtils::Split(strSort, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+    composerSort = StringUtils::Split(
+        strSort,
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
   }
 
-  for (const auto &credit : contributors)
+  for (const auto& credit : contributors)
   {
     std::string strSortName;
     //Identify composer sort name if we have it
@@ -2274,7 +2398,8 @@ int CMusicDatabase::GetRoleByName(const std::string& strRole)
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idRole FROM role WHERE strRole like '%s'", strRole.c_str());
     // run query
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -2288,15 +2413,17 @@ int CMusicDatabase::GetRoleByName(const std::string& strRole)
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
   }
   return -1;
-
 }
 
 bool CMusicDatabase::GetRolesByArtist(int idArtist, CFileItem* item)
 {
   try
   {
-    std::string strSQL = PrepareSQL("SELECT DISTINCT song_artist.idRole, Role.strRole FROM song_artist JOIN role ON "
-                                    " song_artist.idRole = role.idRole WHERE idArtist = %i ORDER BY song_artist.idRole ASC", idArtist);
+    std::string strSQL =
+        PrepareSQL("SELECT DISTINCT song_artist.idRole, Role.strRole "
+                   "FROM song_artist JOIN role ON song_artist.idRole = role.idRole "
+                   "WHERE idArtist = %i ORDER BY song_artist.idRole ASC",
+                   idArtist);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
@@ -2338,8 +2465,9 @@ bool CMusicDatabase::AddAlbumArtist(int idArtist,
                                     int iOrder)
 {
   std::string strSQL;
-  strSQL = PrepareSQL("replace into album_artist (idArtist, idAlbum, strArtist, iOrder) values(%i,%i,'%s',%i)",
-    idArtist, idAlbum, strArtist.c_str(), iOrder);
+  strSQL = PrepareSQL("REPLACE INTO album_artist (idArtist, idAlbum, strArtist, iOrder) "
+                      "VALUES(%i,%i,'%s',%i)",
+                      idArtist, idAlbum, strArtist.c_str(), iOrder);
   return ExecuteQuery(strSQL);
 }
 
@@ -2362,17 +2490,20 @@ bool CMusicDatabase::AddSongGenres(int idSong, const std::vector<std::string>& g
       return false;
     unsigned int index = 0;
     std::vector<std::string> modgenres = genres;
-    for (auto &strGenre : modgenres)
+    for (auto& strGenre : modgenres)
     {
       int idGenre = AddGenre(strGenre); // Genre string trimed and matched case insensitively
       strSQL = PrepareSQL("INSERT INTO song_genre (idGenre, idSong, iOrder) VALUES(%i,%i,%i)",
-        idGenre, idSong, index++);
+                          idGenre, idSong, index++);
       if (!ExecuteQuery(strSQL))
         return false;
     }
     // Update concatenated genre string from the standardised genre values
-    std::string strGenres = StringUtils::Join(modgenres, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
-    strSQL = PrepareSQL("UPDATE song SET strGenres = '%s' WHERE idSong = %i", strGenres.c_str(), idSong);
+    std::string strGenres = StringUtils::Join(
+        modgenres,
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+    strSQL = PrepareSQL("UPDATE song SET strGenres = '%s' WHERE idSong = %i", //
+                        strGenres.c_str(), idSong);
     if (!ExecuteQuery(strSQL))
       return false;
 
@@ -2385,7 +2516,7 @@ bool CMusicDatabase::AddSongGenres(int idSong, const std::vector<std::string>& g
   return false;
 }
 
-bool CMusicDatabase::GetAlbumsByArtist(int idArtist, std::vector<int> &albums)
+bool CMusicDatabase::GetAlbumsByArtist(int idArtist, std::vector<int>& albums)
 {
   try
   {
@@ -2443,7 +2574,7 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, CFileItem* item)
     std::vector<std::string> musicBrainzID;
     std::vector<std::string> albumartists;
     CVariant artistidObj(CVariant::VariantTypeArray);
-    for (const auto &artistCredit : artistCredits)
+    for (const auto& artistCredit : artistCredits)
     {
       artistidObj.push_back(artistCredit.GetArtistId());
       albumartists.emplace_back(artistCredit.GetArtist());
@@ -2471,11 +2602,12 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, std::vector<std::string>& ar
     std::string strSQL;
     // Get distinct song and album artist IDs for this album, no other roles
     // Allow for artists that are only album artists and not song artists
-    strSQL = PrepareSQL("SELECT DISTINCT idArtist FROM album_artist WHERE album_artist.idAlbum = %i \n"
-      "UNION \n"
-      "SELECT DISTINCT idArtist FROM song_artist JOIN song ON song.idSong = song_artist.idSong "
-      "WHERE song_artist.idRole = 1 AND song.idAlbum = %i ",
-      idAlbum, idAlbum);
+    strSQL = PrepareSQL(
+        "SELECT DISTINCT idArtist FROM album_artist WHERE album_artist.idAlbum = %i \n"
+        "UNION \n"
+        "SELECT DISTINCT idArtist FROM song_artist JOIN song ON song.idSong = song_artist.idSong "
+        "WHERE song_artist.idRole = 1 AND song.idAlbum = %i ",
+        idAlbum, idAlbum);
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -2500,13 +2632,14 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, std::vector<std::string>& ar
   return false;
 };
 
-bool CMusicDatabase::GetSongsByArtist(int idArtist, std::vector<int> &songs)
+bool CMusicDatabase::GetSongsByArtist(int idArtist, std::vector<int>& songs)
 {
   try
   {
     std::string strSQL;
     //Restrict to Artists only, no other roles
-    strSQL = PrepareSQL("SELECT idSong FROM song_artist WHERE idArtist = %i AND idRole = 1", idArtist);
+    strSQL = PrepareSQL("SELECT idSong FROM song_artist WHERE idArtist = %i AND idRole = 1", //
+                        idArtist);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
@@ -2530,13 +2663,14 @@ bool CMusicDatabase::GetSongsByArtist(int idArtist, std::vector<int> &songs)
   return false;
 };
 
-bool CMusicDatabase::GetArtistsBySong(int idSong, std::vector<int> &artists)
+bool CMusicDatabase::GetArtistsBySong(int idSong, std::vector<int>& artists)
 {
   try
   {
     std::string strSQL;
     //Restrict to Artists only, no other roles
-    strSQL = PrepareSQL("SELECT idArtist FROM song_artist WHERE idSong = %i AND idRole = 1", idSong);
+    strSQL = PrepareSQL("SELECT idArtist FROM song_artist WHERE idSong = %i AND idRole = 1", //
+                        idSong);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
@@ -2565,12 +2699,14 @@ bool CMusicDatabase::GetGenresByArtist(int idArtist, CFileItem* item)
   try
   {
     std::string strSQL;
-    strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre FROM "
-      "album_artist JOIN song ON album_artist.idAlbum = song.idAlbum "
-      "JOIN song_genre ON song.idSong = song_genre.idSong "
-      "JOIN genre ON song_genre.idGenre = genre.idGenre "
-      "WHERE album_artist.idArtist = %i "
-      "ORDER BY song_genre.idGenre", idArtist);
+    strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre "
+                        "FROM album_artist "
+                        "JOIN song ON album_artist.idAlbum = song.idAlbum "
+                        "JOIN song_genre ON song.idSong = song_genre.idSong "
+                        "JOIN genre ON song_genre.idGenre = genre.idGenre "
+                        "WHERE album_artist.idArtist = %i "
+                        "ORDER BY song_genre.idGenre",
+                        idArtist);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
@@ -2578,11 +2714,13 @@ bool CMusicDatabase::GetGenresByArtist(int idArtist, CFileItem* item)
       // Artist does have any song genres via albums may not be an album artist.
       // Check via songs artist to fetch song genres from compilations or where they are guest artist
       m_pDS->close();
-      strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre FROM "
-        "song_artist JOIN song_genre ON song_artist.idSong = song_genre.idSong "
-        "JOIN genre ON song_genre.idGenre = genre.idGenre "
-        "WHERE song_artist.idArtist = %i "
-        "ORDER BY song_genre.idGenre", idArtist);
+      strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre "
+                          "FROM song_artist "
+                          "JOIN song_genre ON song_artist.idSong = song_genre.idSong "
+                          "JOIN genre ON song_genre.idGenre = genre.idGenre "
+                          "WHERE song_artist.idArtist = %i "
+                          "ORDER BY song_genre.idGenre",
+                          idArtist);
       if (!m_pDS->query(strSQL))
         return false;
       if (m_pDS->num_rows() == 0)
@@ -2621,10 +2759,11 @@ bool CMusicDatabase::GetGenresByAlbum(int idAlbum, CFileItem* item)
   {
     std::string strSQL;
     strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre FROM "
-      "song JOIN song_genre ON song.idSong = song_genre.idSong "
-      "JOIN genre ON song_genre.idGenre = genre.idGenre "
-      "WHERE song.idAlbum = %i "
-      "ORDER BY song_genre.idSong, song_genre.iOrder", idAlbum);
+                        "song JOIN song_genre ON song.idSong = song_genre.idSong "
+                        "JOIN genre ON song_genre.idGenre = genre.idGenre "
+                        "WHERE song.idAlbum = %i "
+                        "ORDER BY song_genre.idSong, song_genre.iOrder",
+                        idAlbum);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
@@ -2660,7 +2799,9 @@ bool CMusicDatabase::GetGenresBySong(int idSong, std::vector<int>& genres)
 {
   try
   {
-    std::string strSQL = PrepareSQL("select idGenre from song_genre where idSong = %i ORDER BY iOrder ASC", idSong);
+    std::string strSQL = PrepareSQL("SELECT idGenre FROM song_genre "
+                                    "WHERE idSong = %i ORDER BY iOrder ASC",
+                                    idSong);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
@@ -2689,7 +2830,8 @@ bool CMusicDatabase::GetIsAlbumArtist(int idArtist, CFileItem* item)
 {
   try
   {
-    int countalbum = GetSingleValueInt("album_artist", "count(idArtist)", PrepareSQL("idArtist=%i", idArtist));
+    int countalbum =
+        GetSingleValueInt("album_artist", "count(idArtist)", PrepareSQL("idArtist=%i", idArtist));
     CVariant IsAlbumArtistObj(CVariant::VariantTypeBoolean);
     IsAlbumArtistObj = (countalbum > 0);
     item->SetProperty("isalbumartist", IsAlbumArtistObj);
@@ -2721,13 +2863,15 @@ int CMusicDatabase::AddPath(const std::string& strPath1)
     if (it != m_pathCache.end())
       return it->second;
 
-    strSQL=PrepareSQL( "select * from path where strPath='%s'", strPath.c_str());
+    strSQL = PrepareSQL("SELECT * FROM path WHERE strPath='%s'", strPath.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesn't exists, add it
-      strSQL=PrepareSQL("insert into path (idPath, strPath) values( NULL, '%s' )", strPath.c_str());
+      strSQL = PrepareSQL("INSERT INTO path (idPath, strPath) "
+                          "VALUES(NULL, '%s')",
+                          strPath.c_str());
       m_pDS->exec(strSQL);
 
       int idPath = (int)m_pDS->lastinsertid();
@@ -2755,7 +2899,8 @@ CSong CMusicDatabase::GetSongFromDataset()
   return GetSongFromDataset(m_pDS->get_sql_record());
 }
 
-CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record, int offset /* = 0 */)
+CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record,
+                                         int offset /* = 0 */)
 {
   CSong song;
   song.idSong = record->at(offset + song_idSong).get_asInt();
@@ -2764,12 +2909,14 @@ CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record
   song.strArtistDesc = record->at(offset + song_strArtists).get_asString();
   song.strArtistSort = record->at(offset + song_strArtistSort).get_asString();
   // Get the full genre string
-  song.genre = StringUtils::Split(record->at(offset + song_strGenres).get_asString(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+  song.genre = StringUtils::Split(
+      record->at(offset + song_strGenres).get_asString(),
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
   // and the rest...
   song.strAlbum = record->at(offset + song_strAlbum).get_asString();
   song.idAlbum = record->at(offset + song_idAlbum).get_asInt();
-  song.iTrack = record->at(offset + song_iTrack).get_asInt() ;
-  song.iDuration = record->at(offset + song_iDuration).get_asInt() ;
+  song.iTrack = record->at(offset + song_iTrack).get_asInt();
+  song.iDuration = record->at(offset + song_iDuration).get_asInt();
   song.strReleaseDate = record->at(offset + song_strReleaseDate).get_asString();
   song.strOrigReleaseDate = record->at(offset + song_strOrigReleaseDate).get_asString();
   song.strTitle = record->at(offset + song_strTitle).get_asString();
@@ -2791,7 +2938,9 @@ CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record
   // Replay gain data (needed for songs from cuesheets, both separate .cue files and embedded metadata)
   song.replayGain.Set(record->at(offset + song_strReplayGain).get_asString());
   // Get filename with full path
-  song.strFileName = URIUtils::AddFileToFolder(record->at(offset + song_strPath).get_asString(), record->at(offset + song_strFileName).get_asString());
+  song.strFileName =
+      URIUtils::AddFileToFolder(record->at(offset + song_strPath).get_asString(),
+                                record->at(offset + song_strFileName).get_asString());
   song.iBPM = record->at(offset + song_iBPM).get_asInt();
   song.iBitRate = record->at(offset + song_iBitRate).get_asInt();
   song.iSampleRate = record->at(offset + song_iSampleRate).get_asInt();
@@ -2799,12 +2948,14 @@ CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record
   return song;
 }
 
-void CMusicDatabase::GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl &baseUrl)
+void CMusicDatabase::GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl& baseUrl)
 {
   GetFileItemFromDataset(m_pDS->get_sql_record(), item, baseUrl);
 }
 
-void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CMusicDbUrl &baseUrl)
+void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const record,
+                                            CFileItem* item,
+                                            const CMusicDbUrl& baseUrl)
 {
   // get the artist string from songview (not the song_artist and artist tables)
   item->GetMusicInfoTag()->SetArtistDesc(record->at(song_strArtists).get_asString());
@@ -2826,7 +2977,8 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   item->m_lStartOffset = record->at(song_iStartOffset).get_asInt64();
   item->SetProperty("item_start", item->m_lStartOffset);
   item->m_lEndOffset = record->at(song_iEndOffset).get_asInt64();
-  item->GetMusicInfoTag()->SetMusicBrainzTrackID(record->at(song_strMusicBrainzTrackID).get_asString());
+  item->GetMusicInfoTag()->SetMusicBrainzTrackID(
+      record->at(song_strMusicBrainzTrackID).get_asString());
   item->GetMusicInfoTag()->SetRating(record->at(song_rating).get_asFloat());
   item->GetMusicInfoTag()->SetUserrating(record->at(song_userrating).get_asInt());
   item->GetMusicInfoTag()->SetVotes(record->at(song_votes).get_asInt());
@@ -2835,15 +2987,17 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   item->GetMusicInfoTag()->SetPlayCount(record->at(song_iTimesPlayed).get_asInt());
   item->GetMusicInfoTag()->SetLastPlayed(record->at(song_lastplayed).get_asString());
   item->GetMusicInfoTag()->SetDateAdded(record->at(song_dateAdded).get_asString());
-  item->GetMusicInfoTag()->SetDateNew(record->at(song_dateNew).get_asString());  
+  item->GetMusicInfoTag()->SetDateNew(record->at(song_dateNew).get_asString());
   item->GetMusicInfoTag()->SetDateUpdated(record->at(song_dateModified).get_asString());
-  std::string strRealPath = URIUtils::AddFileToFolder(record->at(song_strPath).get_asString(), record->at(song_strFileName).get_asString());
+  std::string strRealPath = URIUtils::AddFileToFolder(record->at(song_strPath).get_asString(),
+                                                      record->at(song_strFileName).get_asString());
   item->GetMusicInfoTag()->SetURL(strRealPath);
   item->GetMusicInfoTag()->SetCompilation(record->at(song_bCompilation).get_asInt() == 1);
   item->GetMusicInfoTag()->SetBoxset(record->at(song_bBoxedSet).get_asInt() == 1);
   // get the album artist string from songview (not the album_artist and artist tables)
   item->GetMusicInfoTag()->SetAlbumArtist(record->at(song_strAlbumArtists).get_asString());
-  item->GetMusicInfoTag()->SetAlbumReleaseType(CAlbum::ReleaseTypeFromString(record->at(song_strAlbumReleaseType).get_asString()));
+  item->GetMusicInfoTag()->SetAlbumReleaseType(
+      CAlbum::ReleaseTypeFromString(record->at(song_strAlbumReleaseType).get_asString()));
   item->GetMusicInfoTag()->SetBPM(record->at(song_iBPM).get_asInt());
   item->GetMusicInfoTag()->SetBitRate(record->at(song_iBitRate).get_asInt());
   item->GetMusicInfoTag()->SetSampleRate(record->at(song_iSampleRate).get_asInt());
@@ -2863,7 +3017,8 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
     CMusicDbUrl itemUrl = baseUrl;
     std::string strFileName = record->at(song_strFileName).get_asString();
     std::string strExt = URIUtils::GetExtension(strFileName);
-    std::string path = StringUtils::Format("%i%s", record->at(song_idSong).get_asInt(), strExt.c_str());
+    std::string path =
+        StringUtils::Format("%i%s", record->at(song_idSong).get_asInt(), strExt.c_str());
     itemUrl.AppendPath(path);
     item->SetPath(itemUrl.ToString());
     item->SetDynPath(strRealPath);
@@ -2885,7 +3040,7 @@ void CMusicDatabase::GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredit
   }
   else
   {
-    for (const auto &artistCredit : artistCredits)
+    for (const auto& artistCredit : artistCredits)
     {
       artistidObj.push_back(artistCredit.GetArtistId());
       songartists.push_back(artistCredit.GetArtist());
@@ -2893,20 +3048,26 @@ void CMusicDatabase::GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredit
         musicBrainzID.push_back(artistCredit.GetMusicBrainzArtistID());
     }
   }
-  item->GetMusicInfoTag()->SetArtist(songartists); // Also sets ArtistDesc if empty from song.strArtist field
+  // Also sets ArtistDesc if empty from song.strArtist field
+  item->GetMusicInfoTag()->SetArtist(songartists);
   item->GetMusicInfoTag()->SetMusicBrainzArtistID(musicBrainzID);
   // Add album artistIds as separate property as not part of CMusicInfoTag
   item->SetProperty("artistid", artistidObj);
 }
 
-CAlbum CMusicDatabase::GetAlbumFromDataset(dbiplus::Dataset* pDS, int offset /* = 0 */, bool imageURL /* = false*/)
+CAlbum CMusicDatabase::GetAlbumFromDataset(dbiplus::Dataset* pDS,
+                                           int offset /* = 0 */,
+                                           bool imageURL /* = false*/)
 {
   return GetAlbumFromDataset(pDS->get_sql_record(), offset, imageURL);
 }
 
-CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const record, int offset /* = 0 */, bool imageURL /* = false*/)
+CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const record,
+                                           int offset /* = 0 */,
+                                           bool imageURL /* = false*/)
 {
-  const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  const std::string itemSeparator =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
 
   CAlbum album;
   album.idAlbum = record->at(offset + album_idAlbum).get_asInt();
@@ -2917,7 +3078,8 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const reco
   album.strReleaseGroupMBID = record->at(offset + album_strReleaseGroupMBID).get_asString();
   album.strArtistDesc = record->at(offset + album_strArtists).get_asString();
   album.strArtistSort = record->at(offset + album_strArtistSort).get_asString();
-  album.genre = StringUtils::Split(record->at(offset + album_strGenres).get_asString(), itemSeparator);
+  album.genre =
+      StringUtils::Split(record->at(offset + album_strGenres).get_asString(), itemSeparator);
   album.strReleaseDate = record->at(offset + album_strReleaseDate).get_asString();
   album.strOrigReleaseDate = record->at(offset + album_strOrigReleaseDate).get_asString();
   album.bBoxedSet = record->at(offset + album_bBoxedSet).get_asInt() == 1;
@@ -2927,9 +3089,12 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const reco
   album.iUserrating = record->at(offset + album_iUserrating).get_asInt();
   album.iVotes = record->at(offset + album_iVotes).get_asInt();
   album.strReview = record->at(offset + album_strReview).get_asString();
-  album.styles = StringUtils::Split(record->at(offset + album_strStyles).get_asString(), itemSeparator);
-  album.moods = StringUtils::Split(record->at(offset + album_strMoods).get_asString(), itemSeparator);
-  album.themes = StringUtils::Split(record->at(offset + album_strThemes).get_asString(), itemSeparator);
+  album.styles =
+      StringUtils::Split(record->at(offset + album_strStyles).get_asString(), itemSeparator);
+  album.moods =
+      StringUtils::Split(record->at(offset + album_strMoods).get_asString(), itemSeparator);
+  album.themes =
+      StringUtils::Split(record->at(offset + album_strThemes).get_asString(), itemSeparator);
   album.strLabel = record->at(offset + album_strLabel).get_asString();
   album.strType = record->at(offset + album_strType).get_asString();
   album.strReleaseStatus = record->at(offset + album_strReleaseStatus).get_asString();
@@ -2947,7 +3112,8 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const reco
   return album;
 }
 
-CArtistCredit CMusicDatabase::GetArtistCreditFromDataset(const dbiplus::sql_record* const record, int offset /* = 0 */)
+CArtistCredit CMusicDatabase::GetArtistCreditFromDataset(const dbiplus::sql_record* const record,
+                                                         int offset /* = 0 */)
 {
   CArtistCredit artistCredit;
   artistCredit.idArtist = record->at(offset + artistCredit_idArtist).get_asInt();
@@ -2956,12 +3122,14 @@ CArtistCredit CMusicDatabase::GetArtistCreditFromDataset(const dbiplus::sql_reco
   else
   {
     artistCredit.m_strArtist = record->at(offset + artistCredit_strArtist).get_asString();
-    artistCredit.m_strMusicBrainzArtistID = record->at(offset + artistCredit_strMusicBrainzArtistID).get_asString();
+    artistCredit.m_strMusicBrainzArtistID =
+        record->at(offset + artistCredit_strMusicBrainzArtistID).get_asString();
   }
   return artistCredit;
 }
 
-CMusicRole CMusicDatabase::GetArtistRoleFromDataset(const dbiplus::sql_record* const record, int offset /* = 0 */)
+CMusicRole CMusicDatabase::GetArtistRoleFromDataset(const dbiplus::sql_record* const record,
+                                                    int offset /* = 0 */)
 {
   CMusicRole ArtistRole(record->at(offset + artistCredit_idRole).get_asInt(),
                         record->at(offset + artistCredit_strRole).get_asString(),
@@ -2970,19 +3138,24 @@ CMusicRole CMusicDatabase::GetArtistRoleFromDataset(const dbiplus::sql_record* c
   return ArtistRole;
 }
 
-CArtist CMusicDatabase::GetArtistFromDataset(dbiplus::Dataset* pDS, int offset /* = 0 */, bool needThumb /* = true */)
+CArtist CMusicDatabase::GetArtistFromDataset(dbiplus::Dataset* pDS,
+                                             int offset /* = 0 */,
+                                             bool needThumb /* = true */)
 {
   return GetArtistFromDataset(pDS->get_sql_record(), offset, needThumb);
 }
 
-CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const record, int offset /* = 0 */, bool needThumb /* = true */)
+CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const record,
+                                             int offset /* = 0 */,
+                                             bool needThumb /* = true */)
 {
-  const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  const std::string itemSeparator =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
 
   CArtist artist;
   artist.idArtist = record->at(offset + artist_idArtist).get_asInt();
   if (artist.idArtist == BLANKARTIST_ID && m_translateBlankArtist)
-    artist.strArtist = g_localizeStrings.Get(38042);  //Missing artist tag in current language
+    artist.strArtist = g_localizeStrings.Get(38042); //Missing artist tag in current language
   else
     artist.strArtist = record->at(offset + artist_strArtist).get_asString();
   artist.strSortName = record->at(offset + artist_strSortName).get_asString();
@@ -2990,16 +3163,21 @@ CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const re
   artist.strType = record->at(offset + artist_strType).get_asString();
   artist.strGender = record->at(offset + artist_strGender).get_asString();
   artist.strDisambiguation = record->at(offset + artist_strDisambiguation).get_asString();
-  artist.genre = StringUtils::Split(record->at(offset + artist_strGenres).get_asString(), itemSeparator);
+  artist.genre =
+      StringUtils::Split(record->at(offset + artist_strGenres).get_asString(), itemSeparator);
   artist.strBiography = record->at(offset + artist_strBiography).get_asString();
-  artist.styles = StringUtils::Split(record->at(offset + artist_strStyles).get_asString(), itemSeparator);
-  artist.moods = StringUtils::Split(record->at(offset + artist_strMoods).get_asString(), itemSeparator);
+  artist.styles =
+      StringUtils::Split(record->at(offset + artist_strStyles).get_asString(), itemSeparator);
+  artist.moods =
+      StringUtils::Split(record->at(offset + artist_strMoods).get_asString(), itemSeparator);
   artist.strBorn = record->at(offset + artist_strBorn).get_asString();
   artist.strFormed = record->at(offset + artist_strFormed).get_asString();
   artist.strDied = record->at(offset + artist_strDied).get_asString();
   artist.strDisbanded = record->at(offset + artist_strDisbanded).get_asString();
-  artist.yearsActive = StringUtils::Split(record->at(offset + artist_strYearsActive).get_asString(), itemSeparator);
-  artist.instruments = StringUtils::Split(record->at(offset + artist_strInstruments).get_asString(), itemSeparator);
+  artist.yearsActive =
+      StringUtils::Split(record->at(offset + artist_strYearsActive).get_asString(), itemSeparator);
+  artist.instruments =
+      StringUtils::Split(record->at(offset + artist_strInstruments).get_asString(), itemSeparator);
   artist.bScrapedMBID = record->at(offset + artist_bScrapedMBID).get_asInt() == 1;
   artist.strLastScraped = record->at(offset + artist_lastScraped).get_asString();
   artist.SetDateAdded(record->at(offset + artist_dateAdded).get_asString());
@@ -3014,7 +3192,9 @@ CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const re
   return artist;
 }
 
-bool CMusicDatabase::GetSongByFileName(const std::string& strFileNameAndPath, CSong& song, int64_t startOffset)
+bool CMusicDatabase::GetSongByFileName(const std::string& strFileNameAndPath,
+                                       CSong& song,
+                                       int64_t startOffset)
 {
   song.Clear();
   CURL url(strFileNameAndPath);
@@ -3035,9 +3215,9 @@ bool CMusicDatabase::GetSongByFileName(const std::string& strFileNameAndPath, CS
   SplitPath(strFileNameAndPath, strPath, strFileName);
   URIUtils::AddSlashAtEnd(strPath);
 
-  std::string strSQL = PrepareSQL("select idSong from songview "
-                                 "where strFileName='%s' and strPath='%s'",
-                                 strFileName.c_str(), strPath.c_str());
+  std::string strSQL = PrepareSQL("SELECT idSong FROM songview "
+                                  "WHERE strFileName='%s' AND strPath='%s'",
+                                  strFileName.c_str(), strPath.c_str());
   if (startOffset)
     strSQL += PrepareSQL(" AND iStartOffset=%" PRIi64, startOffset);
 
@@ -3057,9 +3237,13 @@ int CMusicDatabase::GetAlbumIdByPath(const std::string& strPath)
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL = PrepareSQL("SELECT DISTINCT idAlbum FROM song JOIN path ON song.idPath = path.idPath WHERE path.strPath='%s'", strPath.c_str());
+    std::string strSQL = PrepareSQL("SELECT DISTINCT idAlbum FROM song "
+                                    "JOIN path ON song.idPath = path.idPath "
+                                    "WHERE path.strPath='%s'",
+                                    strPath.c_str());
     // run query
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
 
     int idAlbum = -1; // If no album is found, or more than one album is found then -1 is returned
@@ -3078,15 +3262,19 @@ int CMusicDatabase::GetAlbumIdByPath(const std::string& strPath)
   return -1;
 }
 
-int CMusicDatabase::GetSongByArtistAndAlbumAndTitle(const std::string& strArtist, const std::string& strAlbum, const std::string& strTitle)
+int CMusicDatabase::GetSongByArtistAndAlbumAndTitle(const std::string& strArtist,
+                                                    const std::string& strAlbum,
+                                                    const std::string& strTitle)
 {
   try
   {
-    std::string strSQL=PrepareSQL("select idSong from songview "
-                                "where strArtists like '%s' and strAlbum like '%s' and "
-                                "strTitle like '%s'",strArtist.c_str(),strAlbum.c_str(),strTitle.c_str());
+    std::string strSQL =
+        PrepareSQL("SELECT idSong FROM songview "
+                   "WHERE strArtists LIKE '%s' AND strAlbum LIKE '%s' AND strTitle LIKE '%s'",
+                   strArtist.c_str(), strAlbum.c_str(), strTitle.c_str());
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3099,13 +3287,14 @@ int CMusicDatabase::GetSongByArtistAndAlbumAndTitle(const std::string& strArtist
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s (%s,%s,%s) failed", __FUNCTION__, strArtist.c_str(),strAlbum.c_str(),strTitle.c_str());
+    CLog::Log(LOGERROR, "%s (%s,%s,%s) failed", __FUNCTION__, strArtist.c_str(), strAlbum.c_str(),
+              strTitle.c_str());
   }
 
   return -1;
 }
 
-bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList &artists)
+bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& artists)
 {
   try
   {
@@ -3117,15 +3306,17 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList &art
     std::string strVariousArtists = g_localizeStrings.Get(340).c_str();
     std::string strSQL;
     if (search.size() >= MIN_FULL_SEARCH_LENGTH)
-      strSQL=PrepareSQL("select * from artist "
-                                "where (strArtist like '%s%%' or strArtist like '%% %s%%') and strArtist <> '%s' "
-                                , search.c_str(), search.c_str(), strVariousArtists.c_str() );
+      strSQL = PrepareSQL("SELECT * FROM artist "
+                          "WHERE (strArtist LIKE '%s%%' OR strArtist LIKE '%% %s%%') "
+                          "AND strArtist <> '%s' ",
+                          search.c_str(), search.c_str(), strVariousArtists.c_str());
     else
-      strSQL=PrepareSQL("select * from artist "
-                                "where strArtist like '%s%%' and strArtist <> '%s' "
-                                , search.c_str(), strVariousArtists.c_str() );
+      strSQL = PrepareSQL("SELECT * FROM artist "
+                          "WHERE strArtist LIKE '%s%%' AND strArtist <> '%s' ",
+                          search.c_str(), strVariousArtists.c_str());
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -3137,9 +3328,11 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList &art
     {
       std::string path = StringUtils::Format("musicdb://artists/%i/", m_pDS->fv(0).get_asInt());
       CFileItemPtr pItem(new CFileItem(path, true));
-      std::string label = StringUtils::Format("[%s] %s", artistLabel.c_str(), m_pDS->fv(1).get_asString().c_str());
+      std::string label =
+          StringUtils::Format("[%s] %s", artistLabel.c_str(), m_pDS->fv(1).get_asString().c_str());
       pItem->SetLabel(label);
-      label = StringUtils::Format("A %s", m_pDS->fv(1).get_asString().c_str()); // sort label is stored in the title tag
+      // sort label is stored in the title tag
+      label = StringUtils::Format("A %s", m_pDS->fv(1).get_asString().c_str());
       pItem->GetMusicInfoTag()->SetTitle(label);
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv(0).get_asInt(), MediaTypeArtist);
       artists.Add(pItem);
@@ -3170,13 +3363,14 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
       return false;
 
-    std::string strSQL="select * from songview "
-                      "where iTimesPlayed>0 "
-                      "order by iTimesPlayed desc "
-                      "limit 100";
+    std::string strSQL = "SELECT * FROM songview "
+                         "WHERE iTimesPlayed>0 "
+                         "ORDER BY iTimesPlayed DESC "
+                         "LIMIT 100";
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3215,15 +3409,16 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
 
     // Get data from album and album_artist tables to fully populate albums
     std::string strSQL = "SELECT albumview.*, albumartistview.* FROM albumview "
-      "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
-      "WHERE albumartistview.idAlbum in "
-      "(SELECT albumview.idAlbum FROM albumview "
-      "WHERE albumview.strAlbum != '' AND albumview.iTimesPlayed>0 "
-      "ORDER BY albumview.iTimesPlayed DESC LIMIT 100) "
-      "ORDER BY albumview.iTimesPlayed DESC, albumartistview.iOrder";
+                         "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
+                         "WHERE albumartistview.idAlbum IN "
+                         "(SELECT albumview.idAlbum FROM albumview "
+                         "WHERE albumview.strAlbum != '' AND albumview.iTimesPlayed>0 "
+                         "ORDER BY albumview.iTimesPlayed DESC LIMIT 100) "
+                         "ORDER BY albumview.iTimesPlayed DESC, albumartistview.iOrder";
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3272,9 +3467,18 @@ bool CMusicDatabase::GetTop100AlbumSongs(const std::string& strBaseDir, CFileIte
     if (!strBaseDir.empty() && baseUrl.FromString(strBaseDir))
       return false;
 
-    std::string strSQL = StringUtils::Format("SELECT songview.*, albumview.* FROM songview JOIN albumview ON (songview.idAlbum = albumview.idAlbum) JOIN (SELECT song.idAlbum, SUM(song.iTimesPlayed) AS iTimesPlayedSum FROM song WHERE song.iTimesPlayed > 0 GROUP BY idAlbum ORDER BY iTimesPlayedSum DESC LIMIT 100) AS _albumlimit ON (songview.idAlbum = _albumlimit.idAlbum) ORDER BY _albumlimit.iTimesPlayedSum DESC");
-    CLog::Log(LOGDEBUG,"GetTop100AlbumSongs() query: %s", strSQL.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    std::string strSQL = StringUtils::Format(
+        "SELECT songview.*, albumview.* FROM songview"
+        "JOIN albumview ON (songview.idAlbum = albumview.idAlbum) "
+        "JOIN (SELECT song.idAlbum, SUM(song.iTimesPlayed) AS iTimesPlayedSum FROM song "
+        "WHERE song.iTimesPlayed > 0 "
+        "GROUP BY idAlbum "
+        "ORDER BY iTimesPlayedSum DESC LIMIT 100) AS _albumlimit "
+        "ON (songview.idAlbum = _albumlimit.idAlbum) "
+        "ORDER BY _albumlimit.iTimesPlayedSum DESC");
+    CLog::Log(LOGDEBUG, "GetTop100AlbumSongs() query: %s", strSQL.c_str());
+    if (!m_pDS->query(strSQL))
+      return false;
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -3318,18 +3522,20 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
     unsigned int time = XbmcThreads::SystemClockMillis();
 
     // Get data from album and album_artist tables to fully populate albums
-    std::string strSQL = PrepareSQL("SELECT albumview.*, albumartistview.* FROM "
-      "(SELECT idAlbum FROM albumview WHERE albumview.lastplayed IS NOT NULL "
-      "AND albumview.strReleaseType = '%s' "
-      "ORDER BY albumview.lastplayed DESC LIMIT %u) as playedalbums "
-      "JOIN albumview ON albumview.idAlbum = playedalbums.idAlbum "
-      "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
-      "ORDER BY albumview.lastplayed DESC, albumartistview.iorder ",
-      CAlbum::ReleaseTypeToString(CAlbum::Album).c_str(), RECENTLY_PLAYED_LIMIT);
+    std::string strSQL =
+        PrepareSQL("SELECT albumview.*, albumartistview.* "
+                   "FROM (SELECT idAlbum FROM albumview WHERE albumview.lastplayed IS NOT NULL "
+                   "AND albumview.strReleaseType = '%s' "
+                   "ORDER BY albumview.lastplayed DESC LIMIT %u) as playedalbums "
+                   "JOIN albumview ON albumview.idAlbum = playedalbums.idAlbum "
+                   "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
+                   "ORDER BY albumview.lastplayed DESC, albumartistview.iorder ",
+                   CAlbum::ReleaseTypeToString(CAlbum::Album).c_str(), RECENTLY_PLAYED_LIMIT);
 
     querytime = XbmcThreads::SystemClockMillis();
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     querytime = XbmcThreads::SystemClockMillis() - querytime;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -3356,8 +3562,8 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
     }
     m_pDS->close(); // cleanup recordset data
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with albums {1}ms query took {2}ms",
-      __FUNCTION__, XbmcThreads::SystemClockMillis() - time, querytime);
+    CLog::Log(LOGDEBUG, "{0}: Time to fill list with albums {1}ms query took {2}ms", __FUNCTION__,
+              XbmcThreads::SystemClockMillis() - time, querytime);
     return true;
   }
   catch (...)
@@ -3368,7 +3574,8 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
   return false;
 }
 
-bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, CFileItemList& items)
+bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir,
+                                                 CFileItemList& items)
 {
   try
   {
@@ -3381,15 +3588,21 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, 
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
       return false;
 
-    std::string strSQL = PrepareSQL("SELECT songview.*, songartistview.* FROM "
-      "(SELECT idAlbum, lastPlayed FROM albumview WHERE albumview.lastplayed IS NOT NULL "
-      "ORDER BY albumview.lastplayed DESC LIMIT %u) as playedalbums "
-      "JOIN songview ON songview.idAlbum = playedalbums.idAlbum "
-      "JOIN songartistview ON songview.idSong = songartistview.idSong "
-      "ORDER BY playedalbums.lastplayed DESC,songartistview.idsong, songartistview.idRole, songartistview.iOrder",
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iMusicLibraryRecentlyAddedItems);
-    CLog::Log(LOGDEBUG,"GetRecentlyPlayedAlbumSongs() query: %s", strSQL.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    std::string strSQL =
+        PrepareSQL("SELECT songview.*, songartistview.* "
+                   "FROM  (SELECT idAlbum, lastPlayed FROM albumview "
+                   "WHERE albumview.lastplayed IS NOT NULL "
+                   "ORDER BY albumview.lastplayed DESC LIMIT %u) as playedalbums "
+                   "JOIN songview ON songview.idAlbum = playedalbums.idAlbum "
+                   "JOIN songartistview ON songview.idSong = songartistview.idSong "
+                   "ORDER BY playedalbums.lastplayed DESC, "
+                   "songartistview.idsong, songartistview.idRole, songartistview.iOrder",
+                   CServiceBroker::GetSettingsComponent()
+                       ->GetAdvancedSettings()
+                       ->m_iMusicLibraryRecentlyAddedItems);
+    CLog::Log(LOGDEBUG, "GetRecentlyPlayedAlbumSongs() query: %s", strSQL.c_str());
+    if (!m_pDS->query(strSQL))
+      return false;
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -3426,7 +3639,8 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, 
       if (idSongArtistRole == ROLE_ARTIST)
         artistCredits.push_back(GetArtistCreditFromDataset(record, songArtistOffset));
       else
-        items[items.Size() - 1]->GetMusicInfoTag()->AppendArtistRole(GetArtistRoleFromDataset(record, songArtistOffset));
+        items[items.Size() - 1]->GetMusicInfoTag()->AppendArtistRole(
+            GetArtistRoleFromDataset(record, songArtistOffset));
 
       m_pDS->next();
     }
@@ -3461,16 +3675,21 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
     // Get data from album and album_artist tables to fully populate albums
     // Determine the recently added albums from dateAdded (usually derived from music file
     // timestamps, nothing to do with when albums added to library)
-    std::string strSQL = PrepareSQL("SELECT albumview.*, albumartistview.* FROM "
-      "(SELECT idAlbum FROM album WHERE strAlbum != '' "
-      "ORDER BY dateAdded DESC LIMIT %u) AS recentalbums "
-      "JOIN albumview ON albumview.idAlbum = recentalbums.idAlbum "
-      "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
-      "ORDER BY dateAdded DESC, albumview.idAlbum desc, albumartistview.iOrder ",
-       limit ? limit : CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iMusicLibraryRecentlyAddedItems);
+    std::string strSQL =
+        PrepareSQL("SELECT albumview.*, albumartistview.* "
+                   "FROM (SELECT idAlbum FROM album WHERE strAlbum != '' "
+                   "ORDER BY dateAdded DESC LIMIT %u) AS recentalbums "
+                   "JOIN albumview ON albumview.idAlbum = recentalbums.idAlbum "
+                   "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
+                   "ORDER BY dateAdded DESC, albumview.idAlbum desc, albumartistview.iOrder ",
+                   limit ? limit
+                         : CServiceBroker::GetSettingsComponent()
+                               ->GetAdvancedSettings()
+                               ->m_iMusicLibraryRecentlyAddedItems);
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3505,7 +3724,9 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
   return false;
 }
 
-bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, CFileItemList& items, unsigned int limit)
+bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir,
+                                                CFileItemList& items,
+                                                unsigned int limit)
 {
   try
   {
@@ -3522,15 +3743,20 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, C
     // Determine the recently added albums from dateAdded (usually derived from music file
     // timestamps, nothing to do with when albums added to library)
     std::string strSQL;
-    strSQL = PrepareSQL("SELECT songview.*, songartistview.* FROM "
-        "(SELECT idAlbum, dateAdded FROM album ORDER BY dateAdded DESC LIMIT %u) AS recentalbums "
-        "JOIN songview ON songview.idAlbum = recentalbums.idAlbum "
-        "JOIN songartistview ON songview.idSong = songartistview.idSong "
-        "ORDER BY recentalbums.dateAdded DESC, songview.idAlbum DESC, "
-        "songview.idSong, songartistview.idRole, songartistview.iOrder ",
-        limit ? limit : CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iMusicLibraryRecentlyAddedItems);
-    CLog::Log(LOGDEBUG,"GetRecentlyAddedAlbumSongs() query: %s", strSQL.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    strSQL = PrepareSQL("SELECT songview.*, songartistview.* "
+                        "FROM (SELECT idAlbum, dateAdded FROM album "
+                        "ORDER BY dateAdded DESC LIMIT %u) AS recentalbums "
+                        "JOIN songview ON songview.idAlbum = recentalbums.idAlbum "
+                        "JOIN songartistview ON songview.idSong = songartistview.idSong "
+                        "ORDER BY recentalbums.dateAdded DESC, songview.idAlbum DESC, "
+                        "songview.idSong, songartistview.idRole, songartistview.iOrder ",
+                        limit ? limit
+                              : CServiceBroker::GetSettingsComponent()
+                                    ->GetAdvancedSettings()
+                                    ->m_iMusicLibraryRecentlyAddedItems);
+    CLog::Log(LOGDEBUG, "GetRecentlyAddedAlbumSongs() query: %s", strSQL.c_str());
+    if (!m_pDS->query(strSQL))
+      return false;
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -3566,7 +3792,8 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, C
       if (idSongArtistRole == ROLE_ARTIST)
         artistCredits.push_back(GetArtistCreditFromDataset(record, songArtistOffset));
       else
-        items[items.Size() - 1]->GetMusicInfoTag()->AppendArtistRole(GetArtistRoleFromDataset(record, songArtistOffset));
+        items[items.Size() - 1]->GetMusicInfoTag()->AppendArtistRole(
+            GetArtistRoleFromDataset(record, songArtistOffset));
 
       m_pDS->next();
     }
@@ -3610,7 +3837,9 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
   }
 }
 
-bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songmap, bool bAppendToMap)
+bool CMusicDatabase::GetSongsByPath(const std::string& strPath1,
+                                    MAPSONGS& songmap,
+                                    bool bAppendToMap)
 {
   std::string strPath(strPath1);
   try
@@ -3628,11 +3857,13 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songm
 
     // Filename is not unique for a path as songs from a cuesheet have same filename.
     // Songs from cuesheets often have consecutive ID but not always e.g. more than one cuesheet
-    // in a folder and some edited and rescanned.    
+    // in a folder and some edited and rescanned.
     // Hence order by filename so these songs can be gathered together.
-    std::string strSQL =
-        PrepareSQL("SELECT * FROM songview WHERE strPath='%s' ORDER BY strFileName", strPath.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    std::string strSQL = PrepareSQL("SELECT * FROM songview "
+                                    "WHERE strPath='%s' ORDER BY strFileName",
+                                    strPath.c_str());
+    if (!m_pDS->query(strSQL))
+      return false;
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -3675,27 +3906,30 @@ void CMusicDatabase::EmptyCache()
   m_pathCache.erase(m_pathCache.begin(), m_pathCache.end());
 }
 
-bool CMusicDatabase::Search(const std::string& search, CFileItemList &items)
+bool CMusicDatabase::Search(const std::string& search, CFileItemList& items)
 {
   unsigned int time = XbmcThreads::SystemClockMillis();
   // first grab all the artists that match
   SearchArtists(search, items);
-  CLog::Log(LOGDEBUG, "%s Artist search in %i ms",
-            __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
+  CLog::Log(LOGDEBUG, "%s Artist search in %i ms", __FUNCTION__,
+            XbmcThreads::SystemClockMillis() - time);
+  time = XbmcThreads::SystemClockMillis();
 
   // then albums that match
   SearchAlbums(search, items);
-  CLog::Log(LOGDEBUG, "%s Album search in %i ms",
-            __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
+  CLog::Log(LOGDEBUG, "%s Album search in %i ms", __FUNCTION__,
+            XbmcThreads::SystemClockMillis() - time);
+  time = XbmcThreads::SystemClockMillis();
 
   // and finally songs
   SearchSongs(search, items);
-  CLog::Log(LOGDEBUG, "%s Songs search in %i ms",
-            __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
+  CLog::Log(LOGDEBUG, "%s Songs search in %i ms", __FUNCTION__,
+            XbmcThreads::SystemClockMillis() - time);
+  time = XbmcThreads::SystemClockMillis();
   return true;
 }
 
-bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList &items)
+bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList& items)
 {
   try
   {
@@ -3710,12 +3944,18 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList &items
 
     std::string strSQL;
     if (search.size() >= MIN_FULL_SEARCH_LENGTH)
-      strSQL=PrepareSQL("select * from songview where strTitle like '%s%%' or strTitle like '%% %s%%' limit 1000", search.c_str(), search.c_str());
+      strSQL = PrepareSQL("SELECT * FROM songview "
+                          "WHERE strTitle LIKE '%s%%' or strTitle LIKE '%% %s%%' LIMIT 1000",
+                          search.c_str(), search.c_str());
     else
-      strSQL=PrepareSQL("select * from songview where strTitle like '%s%%' limit 1000", search.c_str());
+      strSQL = PrepareSQL("SELECT * FROM songview "
+                          "WHERE strTitle LIKE '%s%%' LIMIT 1000",
+                          search.c_str());
 
-    if (!m_pDS->query(strSQL)) return false;
-    if (m_pDS->num_rows() == 0) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
+    if (m_pDS->num_rows() == 0)
+      return false;
 
     while (!m_pDS->eof())
     {
@@ -3736,7 +3976,7 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList &items
   return false;
 }
 
-bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList &albums)
+bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList& albums)
 {
   try
   {
@@ -3747,11 +3987,16 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList &albu
 
     std::string strSQL;
     if (search.size() >= MIN_FULL_SEARCH_LENGTH)
-      strSQL=PrepareSQL("select * from albumview where strAlbum like '%s%%' or strAlbum like '%% %s%%'", search.c_str(), search.c_str());
+      strSQL = PrepareSQL("SELECT * FROM albumview "
+                          "WHERE strAlbum LIKE '%s%%' OR strAlbum LIKE '%% %s%%'",
+                          search.c_str(), search.c_str());
     else
-      strSQL=PrepareSQL("select * from albumview where strAlbum like '%s%%'", search.c_str());
+      strSQL = PrepareSQL("SELECT * FROM albumview "
+                          "WHERE strAlbum LIKE '%s%%'",
+                          search.c_str());
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
 
     const std::string& albumLabel(g_localizeStrings.Get(558)); // Album
     while (!m_pDS->eof())
@@ -3759,9 +4004,11 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList &albu
       CAlbum album = GetAlbumFromDataset(m_pDS.get());
       std::string path = StringUtils::Format("musicdb://albums/%ld/", album.idAlbum);
       CFileItemPtr pItem(new CFileItem(path, album));
-      std::string label = StringUtils::Format("[%s] %s", albumLabel.c_str(), album.strAlbum.c_str());
+      std::string label =
+          StringUtils::Format("[%s] %s", albumLabel.c_str(), album.strAlbum.c_str());
       pItem->SetLabel(label);
-      label = StringUtils::Format("B %s", album.strAlbum.c_str()); // sort label is stored in the title tag
+      // sort label is stored in the title tag
+      label = StringUtils::Format("B %s", album.strAlbum.c_str());
       pItem->GetMusicInfoTag()->SetTitle(label);
       albums.Add(pItem);
       m_pDS->next();
@@ -3776,7 +4023,7 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList &albu
   return false;
 }
 
-bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
+bool CMusicDatabase::CleanupSongsByIds(const std::string& strSongIds)
 {
   try
   {
@@ -3785,8 +4032,11 @@ bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
     if (nullptr == m_pDS)
       return false;
     // ok, now find all idSong's
-    std::string strSQL=PrepareSQL("select * from song join path on song.idPath = path.idPath where song.idSong in %s", strSongIds.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+    std::string strSQL = PrepareSQL("SELECT * FROM song JOIN path ON song.idPath = path.idPath"
+                                    "WHERE song.idSong IN %s",
+                                    strSongIds.c_str());
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3796,7 +4046,8 @@ bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
     std::vector<std::string> songsToDelete;
     while (!m_pDS->eof())
     { // get the full song path
-      std::string strFileName = URIUtils::AddFileToFolder(m_pDS->fv("path.strPath").get_asString(), m_pDS->fv("song.strFileName").get_asString());
+      std::string strFileName = URIUtils::AddFileToFolder(
+          m_pDS->fv("path.strPath").get_asString(), m_pDS->fv("song.strFileName").get_asString());
 
       //  Special case for streams inside an ogg file. (oggstream)
       //  The last dir in the path is the ogg file that
@@ -3846,10 +4097,13 @@ bool CMusicDatabase::CleanupSongs(CGUIDialogProgress* progressDialog /*= nullptr
 
     // run through all songs and get all unique path ids
     int iLIMIT = 1000;
-    for (int i=0;;i+=iLIMIT)
+    for (int i = 0;; i += iLIMIT)
     {
-      std::string strSQL=PrepareSQL("select song.idSong from song order by song.idSong limit %i offset %i",iLIMIT,i);
-      if (!m_pDS->query(strSQL)) return false;
+      std::string strSQL = PrepareSQL("SELECT song.idSong FROM song "
+                                      "ORDER BY song.idSong LIMIT %i OFFSET %i",
+                                      iLIMIT, i);
+      if (!m_pDS->query(strSQL))
+        return false;
       int iRowsFound = m_pDS->num_rows();
       // keep going until no rows are left!
       if (iRowsFound == 0)
@@ -3866,7 +4120,7 @@ bool CMusicDatabase::CleanupSongs(CGUIDialogProgress* progressDialog /*= nullptr
       }
       m_pDS->close();
       std::string strSongIds = "(" + StringUtils::Join(songIds, ",") + ")";
-      CLog::Log(LOGDEBUG,"Checking songs from song ID list: %s",strSongIds.c_str());
+      CLog::Log(LOGDEBUG, "Checking songs from song ID list: %s", strSongIds.c_str());
       if (progressDialog)
       {
         int percentage = i * 100 / total;
@@ -3881,11 +4135,12 @@ bool CMusicDatabase::CleanupSongs(CGUIDialogProgress* progressDialog /*= nullptr
           return false;
         }
       }
-      if (!CleanupSongsByIds(strSongIds)) return false;
+      if (!CleanupSongsByIds(strSongIds))
+        return false;
     }
     return true;
   }
-  catch(...)
+  catch (...)
   {
     CLog::Log(LOGERROR, "Exception in CMusicDatabase::CleanupSongs()");
   }
@@ -3898,8 +4153,10 @@ bool CMusicDatabase::CleanupAlbums()
   {
     // This must be run AFTER songs have been cleaned up
     // delete albums with no reference to songs
-    std::string strSQL = "select * from album where album.idAlbum not in (select idAlbum from song)";
-    if (!m_pDS->query(strSQL)) return false;
+    std::string strSQL = "SELECT * FROM album "
+                         "WHERE album.idAlbum NOT IN (SELECT idAlbum FROM song)";
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3938,11 +4195,14 @@ bool CMusicDatabase::CleanupPaths()
 
     // first create a temporary table of song paths
     m_pDS->exec("CREATE TEMPORARY TABLE songpaths (idPath integer, strPath varchar(512))\n");
-    m_pDS->exec("INSERT INTO songpaths select idPath,strPath from path where idPath in (select idPath from song)\n");
+    m_pDS->exec("INSERT INTO songpaths "
+                "SELECT idPath, strPath FROM path "
+                "WHERE idPath IN (SELECT idPath FROM song)\n");
 
     // grab all paths that aren't immediately connected with a song
-    std::string sql = "select * from path where idPath not in (select idPath from song)";
-    if (!m_pDS->query(sql)) return false;
+    std::string sql = "SELECT * FROM path WHERE idPath NOT IN (SELECT idPath FROM song)";
+    if (!m_pDS->query(sql))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3955,7 +4215,9 @@ bool CMusicDatabase::CleanupPaths()
     {
       // anything that isn't a parent path of a song path is to be deleted
       std::string path = m_pDS->fv("strPath").get_asString();
-      std::string sql = PrepareSQL("select count(idPath) from songpaths where SUBSTR(strPath,1,%i)='%s'", StringUtils::utf8_strlen(path.c_str()), path.c_str());
+      std::string sql =
+          PrepareSQL("SELECT COUNT(idPath) FROM songpaths WHERE SUBSTR(strPath,1,%i)='%s'",
+                     StringUtils::utf8_strlen(path.c_str()), path.c_str());
       if (m_pDS2->query(sql) && m_pDS2->num_rows() == 1 && m_pDS2->fv(0).get_asInt() == 0)
         pathIds.push_back(m_pDS->fv("idPath").get_asString()); // nothing found, so delete
       m_pDS2->close();
@@ -3966,7 +4228,8 @@ bool CMusicDatabase::CleanupPaths()
     if (!pathIds.empty())
     {
       // do the deletion, and drop our temp table
-      std::string deleteSQL = "DELETE FROM path WHERE idPath IN (" + StringUtils::Join(pathIds, ",") + ")";
+      std::string deleteSQL =
+          "DELETE FROM path WHERE idPath IN (" + StringUtils::Join(pathIds, ",") + ")";
       m_pDS->exec(deleteSQL);
     }
     m_pDS->exec("drop table songpaths");
@@ -3981,7 +4244,8 @@ bool CMusicDatabase::CleanupPaths()
 
 bool CMusicDatabase::InsideScannedPath(const std::string& path)
 {
-  std::string sql = PrepareSQL("select idPath from path where SUBSTR(strPath,1,%i)='%s' LIMIT 1", path.size(), path.c_str());
+  std::string sql = PrepareSQL("SELECT idPath FROM path WHERE SUBSTR(strPath,1,%i)='%s' LIMIT 1",
+                               path.size(), path.c_str());
   return !GetSingleValue(sql).empty();
 }
 
@@ -4040,8 +4304,9 @@ bool CMusicDatabase::CleanupInfoSettings()
   {
     // Cleanup orphaned info settings (ie those that don't belong to an album or artist entry)
     // Must be executed AFTER the album and artist tables have been cleaned.
-    std::string strSQL = "DELETE FROM infosetting WHERE idSetting NOT IN (SELECT idInfoSetting FROM artist) "
-      "AND idSetting NOT IN (SELECT idInfoSetting FROM album)";
+    std::string strSQL = "DELETE FROM infosetting "
+                         "WHERE idSetting NOT IN (SELECT idInfoSetting FROM artist) "
+                         "AND idSetting NOT IN (SELECT idInfoSetting FROM album)";
     m_pDS->exec(strSQL);
     return true;
   }
@@ -4059,7 +4324,8 @@ bool CMusicDatabase::CleanupRoles()
     // Cleanup orphaned roles (ie those that don't belong to a song entry)
     // Must be executed AFTER the song, and song_artist tables have been cleaned.
     // Do not remove default role (ROLE_ARTIST)
-    std::string strSQL = "DELETE FROM role WHERE idRole > 1 AND idRole NOT IN (SELECT idRole FROM song_artist)";
+    std::string strSQL = "DELETE FROM role "
+                         "WHERE idRole > 1 AND idRole NOT IN (SELECT idRole FROM song_artist)";
     m_pDS->exec(strSQL);
     return true;
   }
@@ -4094,11 +4360,16 @@ bool CMusicDatabase::CleanupOrphanedItems()
   if (nullptr == m_pDS)
     return false;
   SetLibraryLastUpdated();
-  if (!CleanupAlbums()) return false;
-  if (!CleanupArtists()) return false;
-  if (!CleanupGenres()) return false;
-  if (!CleanupRoles()) return false;
-  if (!CleanupInfoSettings()) return false;
+  if (!CleanupAlbums())
+    return false;
+  if (!CleanupArtists())
+    return false;
+  if (!CleanupGenres())
+    return false;
+  if (!CleanupRoles())
+    return false;
+  if (!CleanupInfoSettings())
+    return false;
   return true;
 }
 
@@ -4234,7 +4505,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
     ret = ERROR_WRITING_CHANGES;
     goto error;
   }
-  
+
   // Recreate DELETE triggers on song_artist and album_artist
   CreateRemovedLinkTriggers();
 
@@ -4278,10 +4549,11 @@ bool CMusicDatabase::TrimImageURLs(std::string& strImage, const size_t space)
   return true;
 }
 
-bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
+bool CMusicDatabase::LookupCDDBInfo(bool bRequery /*=false*/)
 {
 #ifdef HAS_DVD_DRIVE
-  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_AUDIOCDS_USECDDB))
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_AUDIOCDS_USECDDB))
     return false;
 
   // check network connectivity
@@ -4312,11 +4584,17 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
   // Do we have to look for cddb information
   if (pCdInfo->HasCDDBInfo() && !cddb.isCDCached(pCdInfo))
   {
-    CGUIDialogProgress* pDialogProgress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
-    CGUIDialogSelect *pDlgSelect = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+    CGUIDialogProgress* pDialogProgress =
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(
+            WINDOW_DIALOG_PROGRESS);
+    CGUIDialogSelect* pDlgSelect =
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+            WINDOW_DIALOG_SELECT);
 
-    if (!pDialogProgress) return false;
-    if (!pDlgSelect) return false;
+    if (!pDialogProgress)
+      return false;
+    if (!pDlgSelect)
+      return false;
 
     // Show progress dialog if we have to connect to freedb.org
     pDialogProgress->SetHeading(CVariant{255}); //CDDB
@@ -4343,7 +4621,8 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
         while (true)
         {
           std::string strTitle = cddb.getInexactTitle(i);
-          if (strTitle == "") break;
+          if (strTitle == "")
+            break;
 
           const std::string& strArtist = cddb.getInexactArtist(i);
           if (!strArtist.empty())
@@ -4373,8 +4652,10 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
       {
         pCdInfo->SetNoCDDBInfo();
         // ..no, an error occurred, display it to the user
-        std::string strErrorText = StringUtils::Format("[%d] %s", cddb.getLastError(), cddb.getLastErrorText());
-        HELPERS::ShowOKDialogLines(CVariant{255}, CVariant{257}, CVariant{std::move(strErrorText)}, CVariant{0});
+        std::string strErrorText =
+            StringUtils::Format("[%d] %s", cddb.getLastError(), cddb.getLastErrorText());
+        HELPERS::ShowOKDialogLines(CVariant{255}, CVariant{257}, CVariant{std::move(strErrorText)},
+                                   CVariant{0});
       }
     } // if ( !cddb.queryCDinfo( pCdInfo ) )
     else
@@ -4393,13 +4674,15 @@ void CMusicDatabase::DeleteCDDBInfo()
 {
 #ifdef HAS_DVD_DRIVE
   CFileItemList items;
-  if (!CDirectory::GetDirectory(m_profileManager.GetCDDBFolder(), items, ".cddb", DIR_FLAG_NO_FILE_DIRS))
+  if (!CDirectory::GetDirectory(m_profileManager.GetCDDBFolder(), items, ".cddb",
+                                DIR_FLAG_NO_FILE_DIRS))
   {
     HELPERS::ShowOKDialogText(CVariant{313}, CVariant{426});
-    return ;
+    return;
   }
   // Show a selectdialog that the user can select the album to delete
-  CGUIDialogSelect *pDlg = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+  CGUIDialogSelect* pDlg = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+      WINDOW_DIALOG_SELECT);
   if (pDlg)
   {
     pDlg->SetHeading(CVariant{g_localizeStrings.Get(181)});
@@ -4442,15 +4725,15 @@ void CMusicDatabase::DeleteCDDBInfo()
     if (iSelectedAlbum < 0)
     {
       mapCDDBIds.erase(mapCDDBIds.begin(), mapCDDBIds.end());
-      return ;
+      return;
     }
 
     std::string strSelectedAlbum = pDlg->GetSelectedFileItem()->GetLabel();
-    for (const auto &i : mapCDDBIds)
+    for (const auto& i : mapCDDBIds)
     {
       if (i.second == strSelectedAlbum)
       {
-        std::string strFile = StringUtils::Format("%x.cddb", (unsigned int) i.first);
+        std::string strFile = StringUtils::Format("%x.cddb", (unsigned int)i.first);
         CFile::Delete(URIUtils::AddFileToFolder(m_profileManager.GetCDDBFolder(), strFile));
         break;
       }
@@ -4486,7 +4769,10 @@ void CMusicDatabase::Clean()
   }
 }
 
-bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir, CFileItemList& items, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
+                                  CFileItemList& items,
+                                  const Filter& filter /* = Filter() */,
+                                  bool countOnly /* = false */)
 {
   try
   {
@@ -4510,14 +4796,14 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir, CFileItemList& 
     {
       if (extFilter.where.find("artistview") != std::string::npos)
       {
-        extFilter.AppendJoin("JOIN song_genre ON song_genre.idGenre = genre.idGenre"); 
-        extFilter.AppendJoin("JOIN songview ON songview.idSong = song_genre.idSong"); 
-        extFilter.AppendJoin("JOIN song_artist ON song_artist.idSong = songview.idSong"); 
+        extFilter.AppendJoin("JOIN song_genre ON song_genre.idGenre = genre.idGenre");
+        extFilter.AppendJoin("JOIN songview ON songview.idSong = song_genre.idSong");
+        extFilter.AppendJoin("JOIN song_artist ON song_artist.idSong = songview.idSong");
         extFilter.AppendJoin("JOIN artistview ON artistview.idArtist = song_artist.idArtist");
       }
       else if (extFilter.where.find("songview") != std::string::npos)
       {
-        extFilter.AppendJoin("JOIN song_genre ON song_genre.idGenre = genre.idGenre"); 
+        extFilter.AppendJoin("JOIN song_genre ON song_genre.idGenre = genre.idGenre");
         extFilter.AppendJoin("JOIN songview ON songview.idSong = song_genre.idSong");
       }
       else if (extFilter.where.find("albumview") != std::string::npos)
@@ -4541,7 +4827,11 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir, CFileItemList& 
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
-    strSQL = PrepareSQL(strSQL.c_str(), !extFilter.fields.empty() && extFilter.fields.compare("*") != 0 ? extFilter.fields.c_str() : "genre.*") + strSQLExtra;
+    strSQL =
+        PrepareSQL(strSQL.c_str(), !extFilter.fields.empty() && extFilter.fields.compare("*") != 0
+                                       ? extFilter.fields.c_str()
+                                       : "genre.*") +
+        strSQLExtra;
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
@@ -4595,7 +4885,10 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir, CFileItemList& 
   return false;
 }
 
-bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir, CFileItemList& items, const Filter &filter /*= Filter()*/, bool countOnly /*= false*/)
+bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
+                                   CFileItemList& items,
+                                   const Filter& filter /*= Filter()*/,
+                                   bool countOnly /*= false*/)
 {
   try
   {
@@ -4652,7 +4945,11 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir, CFileItemList&
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
-    strSQL = PrepareSQL(strSQL.c_str(), !extFilter.fields.empty() && extFilter.fields.compare("*") != 0 ? extFilter.fields.c_str() : "source.*") + strSQLExtra;
+    strSQL =
+        PrepareSQL(strSQL.c_str(), !extFilter.fields.empty() && extFilter.fields.compare("*") != 0
+                                       ? extFilter.fields.c_str()
+                                       : "source.*") +
+        strSQLExtra;
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
@@ -4707,7 +5004,9 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir, CFileItemList&
   return false;
 }
 
-bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& items, const Filter& filter /* = Filter() */)
+bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
+                                 CFileItemList& items,
+                                 const Filter& filter /* = Filter() */)
 {
   try
   {
@@ -4788,7 +5087,9 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
   return false;
 }
 
-bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir, CFileItemList& items, const Filter &filter /* = Filter() */)
+bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
+                                 CFileItemList& items,
+                                 const Filter& filter /* = Filter() */)
 {
   try
   {
@@ -4865,7 +5166,12 @@ bool CMusicDatabase::GetAlbumsByYear(const std::string& strBaseDir, CFileItemLis
   return GetAlbumsByWhere(musicUrl.ToString(), filter, items);
 }
 
-bool CMusicDatabase::GetCommonNav(const std::string &strBaseDir, const std::string &table, const std::string &labelField, CFileItemList &items, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
+                                  const std::string& table,
+                                  const std::string& labelField,
+                                  CFileItemList& items,
+                                  const Filter& filter /* = Filter() */,
+                                  bool countOnly /* = false */)
 {
   if (nullptr == m_pDB)
     return false;
@@ -4891,7 +5197,8 @@ bool CMusicDatabase::GetCommonNav(const std::string &strBaseDir, const std::stri
 
     // Do prepare before add where as it could contain a LIKE statement with wild card that upsets format
     // e.g. LIKE '%symphony%' would be taken as a %s format argument
-    strSQL = PrepareSQL(strSQL, !extFilter.fields.empty() ? extFilter.fields.c_str() : labelField.c_str());
+    strSQL = PrepareSQL(strSQL,
+                        !extFilter.fields.empty() ? extFilter.fields.c_str() : labelField.c_str());
 
     CMusicDbUrl musicUrl;
     if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, musicUrl))
@@ -4950,17 +5257,31 @@ bool CMusicDatabase::GetCommonNav(const std::string &strBaseDir, const std::stri
   return false;
 }
 
-bool CMusicDatabase::GetAlbumTypesNav(const std::string &strBaseDir, CFileItemList &items, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetAlbumTypesNav(const std::string& strBaseDir,
+                                      CFileItemList& items,
+                                      const Filter& filter /* = Filter() */,
+                                      bool countOnly /* = false */)
 {
   return GetCommonNav(strBaseDir, "albumview", "albumview.strType", items, filter, countOnly);
 }
 
-bool CMusicDatabase::GetMusicLabelsNav(const std::string &strBaseDir, CFileItemList &items, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetMusicLabelsNav(const std::string& strBaseDir,
+                                       CFileItemList& items,
+                                       const Filter& filter /* = Filter() */,
+                                       bool countOnly /* = false */)
 {
   return GetCommonNav(strBaseDir, "albumview", "albumview.strLabel", items, filter, countOnly);
 }
 
-bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir, CFileItemList& items, bool albumArtistsOnly /* = false */, int idGenre /* = -1 */, int idAlbum /* = -1 */, int idSong /* = -1 */, const Filter &filter /* = Filter() */, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir,
+                                   CFileItemList& items,
+                                   bool albumArtistsOnly /* = false */,
+                                   int idGenre /* = -1 */,
+                                   int idAlbum /* = -1 */,
+                                   int idSong /* = -1 */,
+                                   const Filter& filter /* = Filter() */,
+                                   const SortDescription& sortDescription /* = SortDescription() */,
+                                   bool countOnly /* = false */)
 {
   if (nullptr == m_pDB)
     return false;
@@ -4996,7 +5317,12 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir, CFileItemList&
   return false;
 }
 
-bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetArtistsByWhere(
+    const std::string& strBaseDir,
+    const Filter& filter,
+    CFileItemList& items,
+    const SortDescription& sortDescription /* = SortDescription() */,
+    bool countOnly /* = false */)
 {
   if (nullptr == m_pDB)
     return false;
@@ -5016,8 +5342,7 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
       return false;
 
     bool extended = false;
-    bool limitedInSQL =
-      extFilter.limit.empty() && (sorting.limitStart > 0 || sorting.limitEnd > 0);
+    bool limitedInSQL = extFilter.limit.empty() && (sorting.limitStart > 0 || sorting.limitEnd > 0);
 
     // if there are extra WHERE conditions (from media filter dialog) we might
     // need access to songview or albumview for these conditions
@@ -5026,12 +5351,14 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
       if (extFilter.where.find("songview") != std::string::npos)
       {
         extended = true;
-        extFilter.AppendJoin("JOIN song_artist ON song_artist.idArtist = artistview.idArtist JOIN songview ON songview.idSong = song_artist.idSong");
+        extFilter.AppendJoin("JOIN song_artist ON song_artist.idArtist = artistview.idArtist "
+                             "JOIN songview ON songview.idSong = song_artist.idSong");
       }
       else if (extFilter.where.find("albumview") != std::string::npos)
       {
         extended = true;
-        extFilter.AppendJoin("JOIN album_artist ON album_artist.idArtist = artistview.idArtist JOIN albumview ON albumview.idAlbum = album_artist.idAlbum");
+        extFilter.AppendJoin("JOIN album_artist ON album_artist.idArtist = artistview.idArtist "
+                             "JOIN albumview ON albumview.idAlbum = album_artist.idAlbum");
       }
       if (extended)
         extFilter.AppendGroup("artistview.idArtist"); // Only one row per artist despite joins
@@ -5097,7 +5424,7 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     querytime = XbmcThreads::SystemClockMillis();
-    if (!m_pDS->query(strSQL)) 
+    if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -5124,8 +5451,8 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
 
     // Get Artists from returned rows
     items.Reserve(results.size());
-    const dbiplus::query_data &data = m_pDS->get_result_set().records;
-    for (const auto &i : results)
+    const dbiplus::query_data& data = m_pDS->get_result_set().records;
+    for (const auto& i : results)
     {
       unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
       const dbiplus::sql_record* const record = data.at(targetRow);
@@ -5151,14 +5478,15 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "%s - out of memory getting listing (got %i)", __FUNCTION__, items.Size());
+        CLog::Log(LOGERROR, "%s - out of memory getting listing (got %i)", __FUNCTION__,
+                  items.Size());
       }
     }
     // cleanup
     m_pDS->close();
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with artists {1}ms query took {2}ms",
-      __FUNCTION__, XbmcThreads::SystemClockMillis() - time, querytime);
+    CLog::Log(LOGDEBUG, "{0}: Time to fill list with artists {1}ms query took {2}ms", __FUNCTION__,
+              XbmcThreads::SystemClockMillis() - time, querytime);
     return true;
   }
   catch (...)
@@ -5169,7 +5497,7 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
   return false;
 }
 
-bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
+bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum& album)
 {
   try
   {
@@ -5178,8 +5506,12 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL = PrepareSQL("select albumview.* from song join albumview on song.idAlbum = albumview.idAlbum where song.idSong='%i'", idSong);
-    if (!m_pDS->query(strSQL)) return false;
+    std::string strSQL = PrepareSQL("SELECT albumview.* FROM song"
+                                    "JOIN albumview on song.idAlbum = albumview.idAlbum "
+                                    "WHERE song.idSong='%i'",
+                                    idSong);
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -5191,7 +5523,6 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
 
     m_pDS->close();
     return true;
-
   }
   catch (...)
   {
@@ -5200,7 +5531,13 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
   return false;
 }
 
-bool CMusicDatabase::GetAlbumsNav(const std::string& strBaseDir, CFileItemList& items, int idGenre /* = -1 */, int idArtist /* = -1 */, const Filter &filter /* = Filter() */, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetAlbumsNav(const std::string& strBaseDir,
+                                  CFileItemList& items,
+                                  int idGenre /* = -1 */,
+                                  int idArtist /* = -1 */,
+                                  const Filter& filter /* = Filter() */,
+                                  const SortDescription& sortDescription /* = SortDescription() */,
+                                  bool countOnly /* = false */)
 {
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString(strBaseDir))
@@ -5216,7 +5553,12 @@ bool CMusicDatabase::GetAlbumsNav(const std::string& strBaseDir, CFileItemList& 
   return GetAlbumsByWhere(musicUrl.ToString(), filter, items, sortDescription, countOnly);
 }
 
-bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
+bool CMusicDatabase::GetAlbumsByWhere(
+    const std::string& baseDir,
+    const Filter& filter,
+    CFileItemList& items,
+    const SortDescription& sortDescription /* = SortDescription() */,
+    bool countOnly /* = false */)
 {
   if (m_pDB == nullptr || m_pDS == nullptr)
     return false;
@@ -5234,8 +5576,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
       return false;
 
     bool extended = false;
-    bool limitedInSQL =
-      extFilter.limit.empty() && (sorting.limitStart > 0 || sorting.limitEnd > 0);
+    bool limitedInSQL = extFilter.limit.empty() && (sorting.limitStart > 0 || sorting.limitEnd > 0);
 
     // If there are extra WHERE conditions (from media filter dialog) we might
     // need access to songview for these conditions
@@ -5281,8 +5622,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
     // Apply any limiting directly in SQL
     if (limitedInSQL)
     {
-      extFilter.limit =
-          DatabaseUtils::BuildLimitClauseOnly(sorting.limitEnd, sorting.limitStart);
+      extFilter.limit = DatabaseUtils::BuildLimitClauseOnly(sorting.limitEnd, sorting.limitStart);
     }
 
     // Apply sort in SQL
@@ -5313,7 +5653,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     querytime = XbmcThreads::SystemClockMillis();
-    if (!m_pDS->query(strSQL)) 
+    if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -5340,8 +5680,8 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
 
     // Get albums from returned rows
     items.Reserve(results.size());
-    const dbiplus::query_data &data = m_pDS->get_result_set().records;
-    for (const auto &i : results)
+    const dbiplus::query_data& data = m_pDS->get_result_set().records;
+    for (const auto& i : results)
     {
       unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
       const dbiplus::sql_record* const record = data.at(targetRow);
@@ -5361,14 +5701,15 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "%s - out of memory getting listing (got %i)", __FUNCTION__, items.Size());
+        CLog::Log(LOGERROR, "%s - out of memory getting listing (got %i)", __FUNCTION__,
+                  items.Size());
       }
     }
     // cleanup
     m_pDS->close();
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with albums {1}ms query took {2}ms",
-      __FUNCTION__, XbmcThreads::SystemClockMillis() - time, querytime);
+    CLog::Log(LOGDEBUG, "{0}: Time to fill list with albums {1}ms query took {2}ms", __FUNCTION__,
+              XbmcThreads::SystemClockMillis() - time, querytime);
     return true;
   }
   catch (...)
@@ -5379,8 +5720,12 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
   return false;
 }
 
-bool CMusicDatabase::GetDiscsNav(const std::string& strBaseDir, CFileItemList& items, int idAlbum,
-  const Filter& filter, const SortDescription& sortDescription, bool countOnly)
+bool CMusicDatabase::GetDiscsNav(const std::string& strBaseDir,
+                                 CFileItemList& items,
+                                 int idAlbum,
+                                 const Filter& filter,
+                                 const SortDescription& sortDescription,
+                                 bool countOnly)
 {
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString(strBaseDir))
@@ -5444,12 +5789,12 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
     // Apply any limiting directly in SQL if there is either no special sorting or random sort
     // When limited, random sort is also applied in SQL
     bool limitedInSQL = extFilter.limit.empty() &&
-      (sorting.sortBy == SortByNone || sorting.sortBy == SortByRandom) &&
-      (sorting.limitStart > 0 || sorting.limitEnd > 0);
+                        (sorting.sortBy == SortByNone || sorting.sortBy == SortByRandom) &&
+                        (sorting.limitStart > 0 || sorting.limitEnd > 0);
 
     if (countOnly || limitedInSQL)
     {
-      // Count number of discs that satisfy selection criteria 
+      // Count number of discs that satisfy selection criteria
       // (when fetching all records get total from row count of results dataset)
       // Count not allow for same non-null title discs to be grouped together
       strSQL = "SELECT iTrack >> 16 AS iDisc FROM albumview JOIN song on song.idAlbum = "
@@ -5468,14 +5813,14 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
     {
       if (sorting.sortBy == SortByRandom)
         strSQLExtra += PrepareSQL(" ORDER BY RANDOM()");
-      strSQLExtra +=
-          DatabaseUtils::BuildLimitClause(sorting.limitEnd, sorting.limitStart);
+      strSQLExtra += DatabaseUtils::BuildLimitClause(sorting.limitEnd, sorting.limitStart);
     }
     else
       strSQLExtra += PrepareSQL(" ORDER BY albumview.idAlbum, iDisc");
 
     strSQL = "SELECT iTrack >> 16 AS iDisc, strDiscSubtitle, albumview.* "
-      "FROM albumview JOIN song on song.idAlbum = albumview.idAlbum " + strSQLExtra;
+             "FROM albumview JOIN song on song.idAlbum = albumview.idAlbum " +
+             strSQLExtra;
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
@@ -5573,12 +5918,11 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
 
     // Finally do any sorting in items list we have not been able to do before in SQL or dataset,
     // that is when have join with songartistview and sorting other than random with limit
-    if (sorting.sortBy != SortByNone &&
-        !(limitedInSQL && sorting.sortBy == SortByRandom))
+    if (sorting.sortBy != SortByNone && !(limitedInSQL && sorting.sortBy == SortByRandom))
       items.Sort(sorting);
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with discs {1}ms query took {2}ms",
-      __FUNCTION__, XbmcThreads::SystemClockMillis() - time, querytime);
+    CLog::Log(LOGDEBUG, "{0}: Time to fill list with discs {1}ms query took {2}ms", __FUNCTION__,
+              XbmcThreads::SystemClockMillis() - time, querytime);
     return true;
   }
   catch (...)
@@ -5598,7 +5942,12 @@ int CMusicDatabase::GetDiscsCount(const std::string& baseDir, const Filter& filt
   return iDiscTotal;
 }
 
-bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool artistData /* = false*/)
+bool CMusicDatabase::GetSongsFullByWhere(
+    const std::string& baseDir,
+    const Filter& filter,
+    CFileItemList& items,
+    const SortDescription& sortDescription /* = SortDescription() */,
+    bool artistData /* = false*/)
 {
   if (m_pDB == nullptr || m_pDS == nullptr)
     return false;
@@ -5653,8 +6002,7 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
     // Apply any limiting directly in SQL
     if (limitedInSQL)
     {
-      extFilter.limit =
-          DatabaseUtils::BuildLimitClauseOnly(sorting.limitEnd, sorting.limitStart);
+      extFilter.limit = DatabaseUtils::BuildLimitClauseOnly(sorting.limitEnd, sorting.limitStart);
     }
 
     // Apply sort in SQL
@@ -5759,9 +6107,9 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
     int songArtistOffset = song_enumCount;
     int songId = -1;
     VECARTISTCREDITS artistCredits;
-    const dbiplus::query_data &data = m_pDS->get_result_set().records;
+    const dbiplus::query_data& data = m_pDS->get_result_set().records;
     int count = 0;
-    for (const auto &i : results)
+    for (const auto& i : results)
     {
       unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
       const dbiplus::sql_record* const record = data.at(targetRow);
@@ -5773,7 +6121,7 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
           if (songId > 0 && !artistCredits.empty())
           {
             //Store artist credits for previous song
-            GetFileItemFromArtistCredits(artistCredits, items[items.Size()-1].get());
+            GetFileItemFromArtistCredits(artistCredits, items[items.Size() - 1].get());
             artistCredits.clear();
           }
           songId = record->at(song_idSong).get_asInt();
@@ -5793,13 +6141,15 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
           if (idSongArtistRole == ROLE_ARTIST)
             artistCredits.push_back(GetArtistCreditFromDataset(record, songArtistOffset));
           else
-            items[items.Size() - 1]->GetMusicInfoTag()->AppendArtistRole(GetArtistRoleFromDataset(record, songArtistOffset));
+            items[items.Size() - 1]->GetMusicInfoTag()->AppendArtistRole(
+                GetArtistRoleFromDataset(record, songArtistOffset));
         }
       }
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__, filter.where.c_str());
+        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__,
+                  filter.where.c_str());
         return (items.Size() > 0);
       }
     }
@@ -5834,7 +6184,11 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
   return false;
 }
 
-bool CMusicDatabase::GetSongsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetSongsByWhere(
+    const std::string& baseDir,
+    const Filter& filter,
+    CFileItemList& items,
+    const SortDescription& sortDescription /* = SortDescription() */)
 {
   if (m_pDB == nullptr || m_pDS == nullptr)
     return false;
@@ -5864,15 +6218,17 @@ bool CMusicDatabase::GetSongsByWhere(const std::string &baseDir, const Filter &f
       return false;
 
     // Apply the limiting directly here if there's no special sorting but limiting
-    if (extFilter.limit.empty() &&
-        sorting.sortBy == SortByNone &&
-       (sorting.limitStart > 0 || sorting.limitEnd > 0))
+    if (extFilter.limit.empty() && sorting.sortBy == SortByNone &&
+        (sorting.limitStart > 0 || sorting.limitEnd > 0))
     {
       total = GetSingleValueInt(PrepareSQL(strSQL, "COUNT(1)") + strSQLExtra, m_pDS);
       strSQLExtra += DatabaseUtils::BuildLimitClause(sorting.limitEnd, sorting.limitStart);
     }
 
-    strSQL = PrepareSQL(strSQL, !filter.fields.empty() && filter.fields.compare("*") != 0 ? filter.fields.c_str() : "songview.*") + strSQLExtra;
+    strSQL = PrepareSQL(strSQL, !filter.fields.empty() && filter.fields.compare("*") != 0
+                                    ? filter.fields.c_str()
+                                    : "songview.*") +
+             strSQLExtra;
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
@@ -5898,9 +6254,9 @@ bool CMusicDatabase::GetSongsByWhere(const std::string &baseDir, const Filter &f
 
     // get data from returned rows
     items.Reserve(results.size());
-    const dbiplus::query_data &data = m_pDS->get_result_set().records;
+    const dbiplus::query_data& data = m_pDS->get_result_set().records;
     int count = 0;
-    for (const auto &i : results)
+    for (const auto& i : results)
     {
       unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
       const dbiplus::sql_record* const record = data.at(targetRow);
@@ -5916,7 +6272,8 @@ bool CMusicDatabase::GetSongsByWhere(const std::string &baseDir, const Filter &f
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__, filter.where.c_str());
+        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__,
+                  filter.where.c_str());
         return (items.Size() > 0);
       }
     }
@@ -5946,7 +6303,12 @@ bool CMusicDatabase::GetSongsByYear(const std::string& baseDir, CFileItemList& i
   return GetSongsFullByWhere(baseDir, filter, items, SortDescription(), true);
 }
 
-bool CMusicDatabase::GetSongsNav(const std::string& strBaseDir, CFileItemList& items, int idGenre, int idArtist, int idAlbum, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetSongsNav(const std::string& strBaseDir,
+                                 CFileItemList& items,
+                                 int idGenre,
+                                 int idArtist,
+                                 int idAlbum,
+                                 const SortDescription& sortDescription /* = SortDescription() */)
 {
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString(strBaseDir))
@@ -6015,20 +6377,22 @@ static const translateJSONField JSONtoDBArtist[] = {
   { "isalbumartist",               "bool", false, "",                       "" },
   { "thumbnail",                 "string", false, "",                       "" },
   { "fanart",                    "string", false, "",                       "" }
-  // clang-format on
   /*
-  Sources and genre are related via album, and so the dataset only contains source
-  and genre pairs that exist, rather than all the genres being repeated for every
-  source. We can not only look at genres for the first source, and genre can be
-  out of order.
-  */
-
+    Sources and genre are related via album, and so the dataset only contains source and genre
+    pairs that exist, rather than all the genres being repeated for every source. We can not only
+    look at genres for the first source, and genre can be out of order.
+   */
 };
+// clang-format on
 
 static const size_t NUM_ARTIST_FIELDS = sizeof(JSONtoDBArtist) / sizeof(translateJSONField);
 
-bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, const std::string &baseDir,
-  CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetArtistsByWhereJSON(
+    const std::set<std::string>& fields,
+    const std::string& baseDir,
+    CVariant& result,
+    int& total,
+    const SortDescription& sortDescription /* = SortDescription() */)
 {
   if (nullptr == m_pDB)
     return false;
@@ -6055,7 +6419,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
-    // Count number of artists that satisfy selection criteria 
+    // Count number of artists that satisfy selection criteria
     //(includes xsp limits from filter, but not sort limits)
     total = GetSingleValueInt("SELECT COUNT(1) FROM artist " + strSQLExtra, m_pDS);
     resultcount = static_cast<size_t>(total);
@@ -6097,7 +6461,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     std::string strSQL;
 
     // Setup fields to query, and album field number mapping
-    // Find first join field (isSong) in JSONtoDBArtist for offset 
+    // Find first join field (isSong) in JSONtoDBArtist for offset
     int index_firstjoin = -1;
     for (unsigned int i = 0; i < NUM_ARTIST_FIELDS; i++)
     {
@@ -6111,7 +6475,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     Filter albumArtistFilter;
     Filter songArtistFilter;
     DatasetLayout joinLayout(static_cast<size_t>(joinToArtist_enumCount));
-    extFilter.AppendField("artist.idArtist");  // ID "artistid" in JSON
+    extFilter.AppendField("artist.idArtist"); // ID "artistid" in JSON
     std::vector<int> dbfieldindex;
     // JSON "label" field is strArtist which is also output as "artist", query field once output twice
     extFilter.AppendField(JSONtoDBArtist[0].fieldDB);
@@ -6124,7 +6488,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
       if (JSONtoDBArtist[i].bSimple)
       {
         // Check for non-join fields in order too.
-        // Query these in inline view (but not output) so can ref in outer order 
+        // Query these in inline view (but not output) so can ref in outer order
         bool foundOrderby(false);
         if (!foundJSON)
           foundOrderby = extFilter.order.find(JSONtoDBArtist[i].fieldDB) != std::string::npos;
@@ -6161,13 +6525,13 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
       return false;
 
     // Add any LIMIT clause to strSQLExtra
-    if (extFilter.limit.empty() &&
-      (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    if (extFilter.limit.empty() && (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
-      strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+      strSQLExtra +=
+          DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
       resultcount = std::min(
-        DatabaseUtils::GetLimitCount(sortDescription.limitEnd, sortDescription.limitStart),
-        resultcount);
+          DatabaseUtils::GetLimitCount(sortDescription.limitEnd, sortDescription.limitStart),
+          resultcount);
     }
 
     // Setup multivalue JOINs, GROUP BY and ORDER BY
@@ -6182,12 +6546,12 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     }
     else
       joinFilter.AppendOrder("a1.idArtist");
-    joinFilter.AppendGroup("a1.idArtist"); 
+    joinFilter.AppendGroup("a1.idArtist");
     // Album artists and song artists
     if ((joinLayout.GetFetch(joinToArtist_isalbumartist) && !albumArtistsOnly) ||
-      joinLayout.GetFetch(joinToArtist_idSourceAlbum) ||
-      joinLayout.GetFetch(joinToArtist_idSongGenreAlbum) ||
-      joinLayout.GetFetch(joinToArtist_strRole))
+        joinLayout.GetFetch(joinToArtist_idSourceAlbum) ||
+        joinLayout.GetFetch(joinToArtist_idSongGenreAlbum) ||
+        joinLayout.GetFetch(joinToArtist_strRole))
     {
       bJoinAlbumArtist = true;
       albumArtistFilter.AppendField("album_artist.idArtist AS id");
@@ -6197,7 +6561,8 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
         songArtistFilter.AppendField("song_artist.idArtist AS id");
         songArtistFilter.AppendField("1 AS isSong");
         albumArtistFilter.AppendField("0 AS isSong");
-        joinLayout.SetField(joinToArtist_isSong, JSONtoDBArtist[index_firstjoin + joinToArtist_isSong].fieldDB);
+        joinLayout.SetField(joinToArtist_isSong,
+                            JSONtoDBArtist[index_firstjoin + joinToArtist_isSong].fieldDB);
         joinFilter.AppendGroup(JSONtoDBArtist[index_firstjoin + joinToArtist_isSong].fieldDB);
         joinFilter.AppendOrder(JSONtoDBArtist[index_firstjoin + joinToArtist_isSong].fieldDB);
       }
@@ -6205,32 +6570,40 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     else if (joinLayout.GetFetch(joinToArtist_isalbumartist))
     {
       // Filtering album artists only and isalbumartist requested but not source, songgenres or roles,
-      // so no need for join to album_artist table. Set fetching fetch false so that 
-      // joinLayout.HasFilterFields() is false 
+      // so no need for join to album_artist table. Set fetching fetch false so that
+      // joinLayout.HasFilterFields() is false
       joinLayout.SetFetch(joinToArtist_isalbumartist, false);
     }
 
     // Sources
     if (joinLayout.GetFetch(joinToArtist_idSourceAlbum))
-    { // Left join as source may have been removed but leaving lib entries      
-      albumArtistFilter.AppendJoin("LEFT JOIN album_source ON album_source.idAlbum = album_artist.idAlbum");
-      albumArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].SQL);
+    { // Left join as source may have been removed but leaving lib entries
+      albumArtistFilter.AppendJoin(
+          "LEFT JOIN album_source ON album_source.idAlbum = album_artist.idAlbum");
+      albumArtistFilter.AppendField(
+          JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].SQL);
       joinFilter.AppendGroup(JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].fieldDB);
       joinFilter.AppendOrder(JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].fieldDB);
       if (bJoinSongArtist)
       {
         songArtistFilter.AppendJoin("JOIN song ON song.idSong = song_artist.idSong");
-        songArtistFilter.AppendJoin("LEFT JOIN album_source ON album_source.idAlbum = song.idAlbum");
-        songArtistFilter.AppendField("-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].fieldDB);
-        songArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].SQL);
-        albumArtistFilter.AppendField("-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].fieldDB);
-        joinLayout.SetField(joinToArtist_idSourceSong, JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].fieldDB);
+        songArtistFilter.AppendJoin(
+            "LEFT JOIN album_source ON album_source.idAlbum = song.idAlbum");
+        songArtistFilter.AppendField(
+            "-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].fieldDB);
+        songArtistFilter.AppendField(
+            JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].SQL);
+        albumArtistFilter.AppendField(
+            "-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].fieldDB);
+        joinLayout.SetField(joinToArtist_idSourceSong,
+                            JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].fieldDB);
         joinFilter.AppendGroup(JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].fieldDB);
         joinFilter.AppendOrder(JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceSong].fieldDB);
       }
       else
       {
-        joinLayout.SetField(joinToArtist_idSourceAlbum, JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].SQL, true);
+        joinLayout.SetField(joinToArtist_idSourceAlbum,
+                            JSONtoDBArtist[index_firstjoin + joinToArtist_idSourceAlbum].SQL, true);
       }
     }
 
@@ -6240,47 +6613,68 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
       albumArtistFilter.AppendJoin("JOIN song ON song.idAlbum = album_artist.idAlbum");
       albumArtistFilter.AppendJoin("LEFT JOIN song_genre ON song_genre.idSong = song.idSong");
       albumArtistFilter.AppendJoin("LEFT JOIN genre ON genre.idGenre = song_genre.idGenre");
-      albumArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].SQL);
-      albumArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].SQL);
-      joinLayout.SetField(joinToArtist_strSongGenreAlbum, JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].fieldDB);
-      joinFilter.AppendGroup(JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].fieldDB);
-      joinFilter.AppendOrder(JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].fieldDB);
+      albumArtistFilter.AppendField(
+          JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].SQL);
+      albumArtistFilter.AppendField(
+          JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].SQL);
+      joinLayout.SetField(joinToArtist_strSongGenreAlbum,
+                          JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].fieldDB);
+      joinFilter.AppendGroup(
+          JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].fieldDB);
+      joinFilter.AppendOrder(
+          JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].fieldDB);
       if (bJoinSongArtist)
       { // Left join genre as songs may not have genre
-        songArtistFilter.AppendJoin("LEFT JOIN song_genre ON song_genre.idSong = song_artist.idSong");
+        songArtistFilter.AppendJoin(
+            "LEFT JOIN song_genre ON song_genre.idSong = song_artist.idSong");
         songArtistFilter.AppendJoin("LEFT JOIN genre ON genre.idGenre = song_genre.idGenre");
-        songArtistFilter.AppendField("-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].fieldDB);
-        songArtistFilter.AppendField("'' AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].fieldDB);
-        songArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].SQL);
-        songArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreSong].SQL);
-        albumArtistFilter.AppendField("-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
-        albumArtistFilter.AppendField("'' AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreSong].fieldDB);
-        joinLayout.SetField(joinToArtist_idSongGenreSong, JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
-        joinLayout.SetField(joinToArtist_strSongGenreSong, JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreSong].fieldDB);
-        joinFilter.AppendGroup(JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
-        joinFilter.AppendOrder(JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
+        songArtistFilter.AppendField(
+            "-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].fieldDB);
+        songArtistFilter.AppendField(
+            "'' AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].fieldDB);
+        songArtistFilter.AppendField(
+            JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].SQL);
+        songArtistFilter.AppendField(
+            JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreSong].SQL);
+        albumArtistFilter.AppendField(
+            "-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
+        albumArtistFilter.AppendField(
+            "'' AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreSong].fieldDB);
+        joinLayout.SetField(joinToArtist_idSongGenreSong,
+                            JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
+        joinLayout.SetField(
+            joinToArtist_strSongGenreSong,
+            JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreSong].fieldDB);
+        joinFilter.AppendGroup(
+            JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
+        joinFilter.AppendOrder(
+            JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreSong].fieldDB);
       }
       else
-      {  // Define field alias names in join layout
-        joinLayout.SetField(joinToArtist_idSongGenreAlbum, JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].SQL, true);
-        joinLayout.SetField(joinToArtist_strSongGenreAlbum, JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].SQL);
+      { // Define field alias names in join layout
+        joinLayout.SetField(joinToArtist_idSongGenreAlbum,
+                            JSONtoDBArtist[index_firstjoin + joinToArtist_idSongGenreAlbum].SQL,
+                            true);
+        joinLayout.SetField(joinToArtist_strSongGenreAlbum,
+                            JSONtoDBArtist[index_firstjoin + joinToArtist_strSongGenreAlbum].SQL);
       }
     }
 
     // Roles
     if (roleidfilter == 1 && !joinLayout.GetFetch(joinToArtist_strRole))
-      // Only looking at album and song artists not other roles (default), 
-      // so filter dataset rows likewise. 
+      // Only looking at album and song artists not other roles (default),
+      // so filter dataset rows likewise.
       songArtistFilter.AppendWhere("song_artist.idRole = 1");
-    else if (joinLayout.GetFetch(joinToArtist_strRole) ||  // "roles" field
-             (bJoinSongArtist &&
-             (joinLayout.GetFetch(joinToArtist_idSourceAlbum) ||
-             joinLayout.GetFetch(joinToArtist_idSongGenreAlbum))))
+    else if (joinLayout.GetFetch(joinToArtist_strRole) || // "roles" field
+             (bJoinSongArtist && (joinLayout.GetFetch(joinToArtist_idSourceAlbum) ||
+                                  joinLayout.GetFetch(joinToArtist_idSongGenreAlbum))))
     { // Rows from many roles so fetch roleid for "roles", source and genre processing
       songArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_idRole].SQL);
       // Add fake column to album_artist query
-      albumArtistFilter.AppendField("-1 AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_idRole].fieldDB);
-      joinLayout.SetField(joinToArtist_idRole, JSONtoDBArtist[index_firstjoin + joinToArtist_idRole].fieldDB);
+      albumArtistFilter.AppendField("-1 AS " +
+                                    JSONtoDBArtist[index_firstjoin + joinToArtist_idRole].fieldDB);
+      joinLayout.SetField(joinToArtist_idRole,
+                          JSONtoDBArtist[index_firstjoin + joinToArtist_idRole].fieldDB);
       joinFilter.AppendGroup(JSONtoDBArtist[index_firstjoin + joinToArtist_idRole].fieldDB);
       joinFilter.AppendOrder(JSONtoDBArtist[index_firstjoin + joinToArtist_idRole].fieldDB);
     }
@@ -6289,7 +6683,8 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
       songArtistFilter.AppendJoin("JOIN role ON role.idRole = song_artist.idRole");
       songArtistFilter.AppendField(JSONtoDBArtist[index_firstjoin + joinToArtist_strRole].SQL);
       // Add fake column to album_artist query
-      albumArtistFilter.AppendField("'albumartist' AS " + JSONtoDBArtist[index_firstjoin + joinToArtist_strRole].fieldDB);
+      albumArtistFilter.AppendField("'albumartist' AS " +
+                                    JSONtoDBArtist[index_firstjoin + joinToArtist_strRole].fieldDB);
     }
 
     // Build source, genre and roles part of query
@@ -6307,7 +6702,8 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
           return false;
         strSongSQL = "SELECT " + songArtistFilter.fields + " FROM song_artist " + strSongSQL;
 
-        joinFilter.AppendJoin("JOIN (" + strAlbumSQL + " UNION " + strSongSQL + ") AS albumSong ON id = a1.idArtist");
+        joinFilter.AppendJoin("JOIN (" + strAlbumSQL + " UNION " + strSongSQL +
+                              ") AS albumSong ON id = a1.idArtist");
       }
       else
       { //Only join album_artist, so move filter elements to join filter
@@ -6319,15 +6715,19 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     //Art
     bool bJoinArt(false);
     bJoinArt = joinLayout.GetOutput(joinToArtist_idArt) ||
-      joinLayout.GetOutput(joinToArtist_thumbnail) ||
-      joinLayout.GetOutput(joinToArtist_fanart);
+               joinLayout.GetOutput(joinToArtist_thumbnail) ||
+               joinLayout.GetOutput(joinToArtist_fanart);
     if (bJoinArt)
     { // Left join as artist may not have any art
-      joinFilter.AppendJoin("LEFT JOIN art ON art.media_id = a1.idArtist AND art.media_type = 'artist'");
-      joinLayout.SetField(joinToArtist_idArt, JSONtoDBArtist[index_firstjoin + joinToArtist_idArt].SQL,
-        joinLayout.GetOutput(joinToArtist_idArt));
-      joinLayout.SetField(joinToArtist_artType, JSONtoDBArtist[index_firstjoin + joinToArtist_artType].SQL);
-      joinLayout.SetField(joinToArtist_artURL, JSONtoDBArtist[index_firstjoin + joinToArtist_artURL].SQL);
+      joinFilter.AppendJoin(
+          "LEFT JOIN art ON art.media_id = a1.idArtist AND art.media_type = 'artist'");
+      joinLayout.SetField(joinToArtist_idArt,
+                          JSONtoDBArtist[index_firstjoin + joinToArtist_idArt].SQL,
+                          joinLayout.GetOutput(joinToArtist_idArt));
+      joinLayout.SetField(joinToArtist_artType,
+                          JSONtoDBArtist[index_firstjoin + joinToArtist_artType].SQL);
+      joinLayout.SetField(joinToArtist_artURL,
+                          JSONtoDBArtist[index_firstjoin + joinToArtist_artURL].SQL);
       joinFilter.AppendGroup("art.art_id");
       joinFilter.AppendOrder("arttype");
       if (!joinLayout.GetOutput(joinToArtist_idArt))
@@ -6351,15 +6751,15 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
 
     // Adjust where in the results record the join fields are allowing for the
     // inline view fields (Quicker than finding field by name every time)
-    // idArtist + other artist fields    
+    // idArtist + other artist fields
     joinLayout.AdjustRecordNumbers(static_cast<int>(1 + dbfieldindex.size()));
 
     // Build full query
     // When have multiple value joins e.g. song genres, use inline view
-    // SELECT a1.*, <join fields> FROM 
-    //   (SELECT <artist fields> FROM artist <where> + <order by> +  <limits> ) AS a1 
+    // SELECT a1.*, <join fields> FROM
+    //   (SELECT <artist fields> FROM artist <where> + <order by> +  <limits> ) AS a1
     //   <joins> <group by> <order by> + <joins order by>
-    // Don't use prepareSQL - confuses  arttype = 'thumb' filter 
+    // Don't use prepareSQL - confuses  arttype = 'thumb' filter
 
     strSQL = "SELECT " + extFilter.fields + " FROM artist " + strSQLExtra;
     if (joinLayout.HasFilterFields())
@@ -6373,8 +6773,8 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     unsigned int time = XbmcThreads::SystemClockMillis();
     if (!m_pDS->query(strSQL))
       return false;
-    CLog::Log(LOGDEBUG, "%s - query took %i ms",
-      __FUNCTION__, XbmcThreads::SystemClockMillis() - time);
+    CLog::Log(LOGDEBUG, "%s - query took %i ms", __FUNCTION__,
+              XbmcThreads::SystemClockMillis() - time);
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -6441,7 +6841,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
           bArtDone = false;
         }
         if (m_pDS->eof())
-          continue;  // Having saved the last artist stop
+          continue; // Having saved the last artist stop
 
         // New artist
         artistId = record->at(0).get_asInt();
@@ -6449,7 +6849,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
         artistObj["artistid"] = artistId;
         artistObj["label"] = record->at(1).get_asString();
         artistObj["artist"] = record->at(1).get_asString(); // Always have "artist"
-        bIsAlbumArtist = true;  //Album artist by default
+        bIsAlbumArtist = true; //Album artist by default
         if (joinLayout.GetOutput(joinToArtist_isalbumartist))
         {
           // Not album artist when fetching song artists too and first row for artist isSong=true
@@ -6463,14 +6863,18 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
             if (JSONtoDBArtist[dbfieldindex[i]].formatJSON == "integer")
               artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asInt();
             else if (JSONtoDBArtist[dbfieldindex[i]].formatJSON == "float")
-              artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asFloat();
-            else if (JSONtoDBArtist[dbfieldindex[i]].formatJSON == "array")
               artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] =
-              StringUtils::Split(record->at(1 + i).get_asString(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+                  record->at(1 + i).get_asFloat();
+            else if (JSONtoDBArtist[dbfieldindex[i]].formatJSON == "array")
+              artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] = StringUtils::Split(
+                  record->at(1 + i).get_asString(), CServiceBroker::GetSettingsComponent()
+                                                        ->GetAdvancedSettings()
+                                                        ->m_musicItemSeparator);
             else if (JSONtoDBArtist[dbfieldindex[i]].formatJSON == "boolean")
               artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asBool();
             else
-              artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asString();
+              artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] =
+                  record->at(1 + i).get_asString();
           }
       }
       if (bJoinAlbumArtist)
@@ -6481,23 +6885,24 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
         {
           bAlbumArtistRow = !record->at(joinLayout.GetRecNo(joinToArtist_isSong)).get_asBool();
           if (joinLayout.GetRecNo(joinToArtist_idRole) > -1 &&
-            !record->at(joinLayout.GetRecNo(joinToArtist_idRole)).get_isNull())
+              !record->at(joinLayout.GetRecNo(joinToArtist_idRole)).get_isNull())
           {
             idRoleRow = record->at(joinLayout.GetRecNo(joinToArtist_idRole)).get_asInt();
           }
         }
 
-        // Sources - gathered via both album_artist and song_artist (with role = 1)       
+        // Sources - gathered via both album_artist and song_artist (with role = 1)
         if (joinLayout.GetFetch(joinToArtist_idSourceAlbum))
         {
           if ((bAlbumArtistRow && joinLayout.GetRecNo(joinToArtist_idSourceAlbum) > -1 &&
-            !record->at(joinLayout.GetRecNo(joinToArtist_idSourceAlbum)).get_isNull() &&
-            sourceId != record->at(joinLayout.GetRecNo(joinToArtist_idSourceAlbum)).get_asInt()) ||
-            (!bAlbumArtistRow && joinLayout.GetRecNo(joinToArtist_idSourceSong) > -1 &&
-              !record->at(joinLayout.GetRecNo(joinToArtist_idSourceSong)).get_isNull() &&
-              sourceId != record->at(joinLayout.GetRecNo(joinToArtist_idSourceSong)).get_asInt()))
+               !record->at(joinLayout.GetRecNo(joinToArtist_idSourceAlbum)).get_isNull() &&
+               sourceId !=
+                   record->at(joinLayout.GetRecNo(joinToArtist_idSourceAlbum)).get_asInt()) ||
+              (!bAlbumArtistRow && joinLayout.GetRecNo(joinToArtist_idSourceSong) > -1 &&
+               !record->at(joinLayout.GetRecNo(joinToArtist_idSourceSong)).get_isNull() &&
+               sourceId != record->at(joinLayout.GetRecNo(joinToArtist_idSourceSong)).get_asInt()))
           {
-            bArtDone = bArtDone || (sourceId > 0);  // Not first source, skip art repeats
+            bArtDone = bArtDone || (sourceId > 0); // Not first source, skip art repeats
             bool found(false);
             sourceId = record->at(joinLayout.GetRecNo(joinToArtist_idSourceAlbum)).get_asInt();
             if (!bAlbumArtistRow)
@@ -6511,7 +6916,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
               {
                 sourceId = record->at(joinLayout.GetRecNo(joinToArtist_idSourceSong)).get_asInt();
                 // Song artist row may repeat sources found via album artist
-                // Already have that source? 
+                // Already have that source?
                 for (const auto& i : sourceidlist)
                   if (i == sourceId)
                   {
@@ -6540,28 +6945,31 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
           std::string strGenre;
           bool newgenre(false);
           if (bAlbumArtistRow && joinLayout.GetRecNo(joinToArtist_idSongGenreAlbum) > -1 &&
-            !record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreAlbum)).get_isNull() &&
-            genreId != record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreAlbum)).get_asInt())
+              !record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreAlbum)).get_isNull() &&
+              genreId != record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreAlbum)).get_asInt())
           {
-            bArtDone = bArtDone || (genreId > 0);  // Not first genre, skip art repeats
+            bArtDone = bArtDone || (genreId > 0); // Not first genre, skip art repeats
             newgenre = true;
             genreId = record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreAlbum)).get_asInt();
-            strGenre = record->at(joinLayout.GetRecNo(joinToArtist_strSongGenreAlbum)).get_asString();
+            strGenre =
+                record->at(joinLayout.GetRecNo(joinToArtist_strSongGenreAlbum)).get_asString();
           }
           else if (!bAlbumArtistRow && !bGenreFoundViaAlbum &&
-            joinLayout.GetRecNo(joinToArtist_idSongGenreSong) > -1 &&
-            !record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreSong)).get_isNull() &&
-            genreId != record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreSong)).get_asInt())
+                   joinLayout.GetRecNo(joinToArtist_idSongGenreSong) > -1 &&
+                   !record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreSong)).get_isNull() &&
+                   genreId !=
+                       record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreSong)).get_asInt())
           {
-            bArtDone = bArtDone || (genreId > 0);  // Not first genre, skip art repeats
+            bArtDone = bArtDone || (genreId > 0); // Not first genre, skip art repeats
             newgenre = idRoleRow <= 1; // Skip other roles (when fetching them)
             genreId = record->at(joinLayout.GetRecNo(joinToArtist_idSongGenreSong)).get_asInt();
-            strGenre = record->at(joinLayout.GetRecNo(joinToArtist_strSongGenreSong)).get_asString();
+            strGenre =
+                record->at(joinLayout.GetRecNo(joinToArtist_strSongGenreSong)).get_asString();
           }
           bool found(false);
           if (newgenre)
           {
-            // Already have that genre? 
+            // Already have that genre?
             for (const auto& i : genreidlist)
               if (i == genreId)
               {
@@ -6579,16 +6987,16 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
             }
           }
         }
-        // Roles - gathered via song_artist roleid rows 
+        // Roles - gathered via song_artist roleid rows
         if (joinLayout.GetFetch(joinToArtist_idRole))
         {
           if (!bAlbumArtistRow && roleId != idRoleRow)
           {
-            bArtDone = bArtDone || (roleId > 0);  // Not first role, skip art repeats
+            bArtDone = bArtDone || (roleId > 0); // Not first role, skip art repeats
             roleId = idRoleRow;
             if (joinLayout.GetOutput(joinToArtist_strRole))
             {
-              // Already have that role? 
+              // Already have that role?
               bool found(false);
               for (const auto& i : roleidlist)
                 if (i == roleId)
@@ -6601,7 +7009,8 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
                 roleidlist.emplace_back(roleId);
                 CVariant roleObj;
                 roleObj["roleid"] = roleId;
-                roleObj["role"] = record->at(joinLayout.GetRecNo(joinToArtist_strRole)).get_asString();
+                roleObj["role"] =
+                    record->at(joinLayout.GetRecNo(joinToArtist_strRole)).get_asString();
                 artistObj["roles"].append(roleObj);
               }
             }
@@ -6609,26 +7018,29 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
         }
       }
       // Art
-      if (bJoinArt && !bArtDone && 
-        !record->at(joinLayout.GetRecNo(joinToArtist_idArt)).get_isNull() &&
-        record->at(joinLayout.GetRecNo(joinToArtist_idArt)).get_asInt() > 0 && 
-        artId != record->at(joinLayout.GetRecNo(joinToArtist_idArt)).get_asInt())
+      if (bJoinArt && !bArtDone &&
+          !record->at(joinLayout.GetRecNo(joinToArtist_idArt)).get_isNull() &&
+          record->at(joinLayout.GetRecNo(joinToArtist_idArt)).get_asInt() > 0 &&
+          artId != record->at(joinLayout.GetRecNo(joinToArtist_idArt)).get_asInt())
       {
         artId = record->at(joinLayout.GetRecNo(joinToArtist_idArt)).get_asInt();
         if (joinLayout.GetOutput(joinToArtist_idArt))
         {
           artistObj["art"][record->at(joinLayout.GetRecNo(joinToArtist_artType)).get_asString()] =
-            CTextureUtils::GetWrappedImageURL(record->at(joinLayout.GetRecNo(joinToArtist_artURL)).get_asString());
+              CTextureUtils::GetWrappedImageURL(
+                  record->at(joinLayout.GetRecNo(joinToArtist_artURL)).get_asString());
         }
         if (joinLayout.GetOutput(joinToArtist_thumbnail) &&
-          record->at(joinLayout.GetRecNo(joinToArtist_artType)).get_asString() == "thumb")
+            record->at(joinLayout.GetRecNo(joinToArtist_artType)).get_asString() == "thumb")
         {
-          artistObj["thumbnail"] = CTextureUtils::GetWrappedImageURL(record->at(joinLayout.GetRecNo(joinToArtist_artURL)).get_asString());
+          artistObj["thumbnail"] = CTextureUtils::GetWrappedImageURL(
+              record->at(joinLayout.GetRecNo(joinToArtist_artURL)).get_asString());
         }
         if (joinLayout.GetOutput(joinToArtist_fanart) &&
-          record->at(joinLayout.GetRecNo(joinToArtist_artType)).get_asString() == "fanart")
+            record->at(joinLayout.GetRecNo(joinToArtist_artType)).get_asString() == "fanart")
         {
-          artistObj["fanart"] = CTextureUtils::GetWrappedImageURL(record->at(joinLayout.GetRecNo(joinToArtist_artURL)).get_asString());
+          artistObj["fanart"] = CTextureUtils::GetWrappedImageURL(
+              record->at(joinLayout.GetRecNo(joinToArtist_artURL)).get_asString());
         }
       }
 
@@ -6708,8 +7120,12 @@ static const translateJSONField JSONtoDBAlbum[] = {
 
 static const size_t NUM_ALBUM_FIELDS = sizeof(JSONtoDBAlbum) / sizeof(translateJSONField);
 
-bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, const std::string &baseDir,  
-  CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetAlbumsByWhereJSON(
+    const std::set<std::string>& fields,
+    const std::string& baseDir,
+    CVariant& result,
+    int& total,
+    const SortDescription& sortDescription /* = SortDescription() */)
 {
 
   if (nullptr == m_pDB)
@@ -6754,7 +7170,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
     std::string strSQL;
 
     // Setup fields to query, and album field number mapping
-    // Find idArtist in JSONtoDBAlbum, offset of first join field 
+    // Find idArtist in JSONtoDBAlbum, offset of first join field
     int index_idArtist = -1;
     for (unsigned int i = 0; i < NUM_ALBUM_FIELDS; i++)
     {
@@ -6763,10 +7179,10 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
         index_idArtist = i;
         break;
       }
-    }   
+    }
     Filter joinFilter;
     DatasetLayout joinLayout(static_cast<size_t>(joinToAlbum_enumCount));
-    extFilter.AppendField("albumview.idAlbum");  // ID "albumid" in JSON
+    extFilter.AppendField("albumview.idAlbum"); // ID "albumid" in JSON
     std::vector<int> dbfieldindex;
     // JSON "label" field is strAlbum which may also be requested as "title", query field once output twice
     extFilter.AppendField(JSONtoDBAlbum[0].fieldDB);
@@ -6817,7 +7233,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
     if (extFilter.fields.find("art.") != std::string::npos)
     { // Left join as not all albums have art, but only have one thumb at most
       extFilter.AppendJoin("LEFT JOIN art ON art.media_id = idAlbum "
-        "AND art.media_type = 'album' AND art.type = 'thumb'");
+                           "AND art.media_type = 'album' AND art.type = 'thumb'");
     }
 
     // Build JOIN, WHERE, ORDER BY and LIMIT for inline view
@@ -6826,10 +7242,10 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
       return false;
 
     // Add any LIMIT clause to strSQLExtra
-    if (extFilter.limit.empty() &&
-      (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    if (extFilter.limit.empty() && (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
-      strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+      strSQLExtra +=
+          DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
       resultcount = std::min(
           DatabaseUtils::GetLimitCount(sortDescription.limitEnd, sortDescription.limitStart),
           resultcount);
@@ -6848,21 +7264,22 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
       joinFilter.AppendOrder("a1.idAlbum");
     joinFilter.AppendGroup("a1.idAlbum");
     // Album artists
-    if (joinLayout.GetFetch(joinToAlbum_idArtist) ||
-        joinLayout.GetFetch(joinToAlbum_strArtist) ||
+    if (joinLayout.GetFetch(joinToAlbum_idArtist) || joinLayout.GetFetch(joinToAlbum_strArtist) ||
         joinLayout.GetFetch(joinToAlbum_strArtistMBID))
     { // All albums have at least one artist so inner join sufficient
       bJoinAlbumArtist = true;
       joinFilter.AppendJoin("JOIN album_artist ON album_artist.idAlbum = a1.idAlbum");
       joinFilter.AppendGroup("album_artist.idArtist");
       joinFilter.AppendOrder("album_artist.iOrder");
-      // Ensure idArtist is queried 
+      // Ensure idArtist is queried
       if (!joinLayout.GetFetch(joinToAlbum_idArtist))
-        joinLayout.SetField(joinToAlbum_idArtist, JSONtoDBAlbum[index_idArtist + joinToAlbum_idArtist].SQL);
+        joinLayout.SetField(joinToAlbum_idArtist,
+                            JSONtoDBAlbum[index_idArtist + joinToAlbum_idArtist].SQL);
     }
-    // artist table needed for strArtist or MBID 
-    // (album_artist.strArtist can be an alias or spelling variation) 
-    if (joinLayout.GetFetch(joinToAlbum_strArtist) || joinLayout.GetFetch(joinToAlbum_strArtistMBID))
+    // artist table needed for strArtist or MBID
+    // (album_artist.strArtist can be an alias or spelling variation)
+    if (joinLayout.GetFetch(joinToAlbum_strArtist) ||
+        joinLayout.GetFetch(joinToAlbum_strArtistMBID))
       joinFilter.AppendJoin("JOIN artist ON artist.idArtist = album_artist.idArtist");
 
     // Build JOIN part of query (if we have one)
@@ -6870,16 +7287,16 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
     if (joinLayout.HasFilterFields())
       if (!BuildSQL(strSQLJoin, joinFilter, strSQLJoin))
         return false;
-        
+
     // Adjust where in the results record the join fields are allowing for the
     // inline view fields (Quicker than finding field by name every time)
-    // idAlbum + other album fields    
+    // idAlbum + other album fields
     joinLayout.AdjustRecordNumbers(static_cast<int>(1 + dbfieldindex.size()));
-    
+
     // Build full query
     // When have multiple value joins (artists or song genres) use inline view
-    // SELECT a1.*, <join fields> FROM 
-    //   (SELECT <album fields> FROM albumview <where> + <order by> +  <limits> ) AS a1 
+    // SELECT a1.*, <join fields> FROM
+    //   (SELECT <album fields> FROM albumview <where> + <order by> +  <limits> ) AS a1
     //   <joins> <group by> <order by> <joins order by>
     // Don't use prepareSQL - confuses  releasetype = 'album' filter and group_concat separator
 
@@ -6889,10 +7306,10 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
       strSQL = "(" + strSQL + ") AS a1 ";
       strSQL = "SELECT a1.*, " + joinLayout.GetFields() + " FROM " + strSQL + strSQLJoin;
     }
-        
+
     // Modify query to use correct year field
     if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-      CSettings::SETTING_MUSICLIBRARY_USEORIGINALDATE))
+            CSettings::SETTING_MUSICLIBRARY_USEORIGINALDATE))
       StringUtils::Replace(strSQL, "<datefield>", "strReleaseDate");
     else
       StringUtils::Replace(strSQL, "<datefield>", "strOrigReleaseDate");
@@ -6902,8 +7319,8 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
     unsigned int time = XbmcThreads::SystemClockMillis();
     if (!m_pDS->query(strSQL))
       return false;
-    CLog::Log(LOGDEBUG, "%s - query took %i ms",
-      __FUNCTION__, XbmcThreads::SystemClockMillis() - time);
+    CLog::Log(LOGDEBUG, "%s - query took %i ms", __FUNCTION__,
+              XbmcThreads::SystemClockMillis() - time);
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -6922,20 +7339,21 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
       const dbiplus::sql_record* const record = m_pDS->get_sql_record();
 
       if (m_pDS->eof() || albumId != record->at(0).get_asInt())
-      { 
+      {
         // Store previous or last album
         if (!albumObj.empty())
         {
           // Split sources string into int array
           if (albumObj.isMember("sourceid"))
           {
-            std::vector<std::string> sources = StringUtils::Split(albumObj["sourceid"].asString(), ";");
+            std::vector<std::string> sources =
+                StringUtils::Split(albumObj["sourceid"].asString(), ";");
             albumObj["sourceid"] = CVariant(CVariant::VariantTypeArray);
             for (size_t i = 0; i < sources.size(); i++)
               albumObj["sourceid"].append(atoi(sources[i].c_str()));
           }
           result["albums"].append(albumObj);
-          albumObj.clear();          
+          albumObj.clear();
           artistId = -1;
         }
         if (m_pDS->eof())
@@ -6974,12 +7392,16 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "integer")
               albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asInt();
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "unsigned")
-              albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = std::max(record->at(1 + i).get_asInt(), 0);
+              albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] =
+                  std::max(record->at(1 + i).get_asInt(), 0);
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "float")
-              albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = std::max(record->at(1 + i).get_asFloat(), 0.f);
+              albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] =
+                  std::max(record->at(1 + i).get_asFloat(), 0.f);
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "array")
-              albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = StringUtils::Split(record->at(1 + i).get_asString(),
-                CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+              albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = StringUtils::Split(
+                  record->at(1 + i).get_asString(), CServiceBroker::GetSettingsComponent()
+                                                        ->GetAdvancedSettings()
+                                                        ->m_musicItemSeparator);
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "boolean")
               albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asBool();
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "image")
@@ -7009,12 +7431,16 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
           }
           else
           {
-            if (joinLayout.GetOutput(joinToAlbum_strArtist) && joinLayout.GetRecNo(joinToAlbum_strArtist) > -1)
-              albumObj["artist"].append(record->at(joinLayout.GetRecNo(joinToAlbum_strArtist)).get_asString());
-            if (joinLayout.GetOutput(joinToAlbum_strArtistMBID) && joinLayout.GetRecNo(joinToAlbum_strArtistMBID) > -1)
-              albumObj["musicbrainzalbumartistid"].append(record->at(joinLayout.GetRecNo(joinToAlbum_strArtistMBID)).get_asString());
+            if (joinLayout.GetOutput(joinToAlbum_strArtist) &&
+                joinLayout.GetRecNo(joinToAlbum_strArtist) > -1)
+              albumObj["artist"].append(
+                  record->at(joinLayout.GetRecNo(joinToAlbum_strArtist)).get_asString());
+            if (joinLayout.GetOutput(joinToAlbum_strArtistMBID) &&
+                joinLayout.GetRecNo(joinToAlbum_strArtistMBID) > -1)
+              albumObj["musicbrainzalbumartistid"].append(
+                  record->at(joinLayout.GetRecNo(joinToAlbum_strArtistMBID)).get_asString());
           }
-        }        
+        }
       }
       m_pDS->next();
     }
@@ -7117,8 +7543,12 @@ static const translateJSONField JSONtoDBSong[] = {
 
 static const size_t NUM_SONG_FIELDS = sizeof(JSONtoDBSong) / sizeof(translateJSONField);
 
-bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, const std::string &baseDir,
-  CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetSongsByWhereJSON(
+    const std::set<std::string>& fields,
+    const std::string& baseDir,
+    CVariant& result,
+    int& total,
+    const SortDescription& sortDescription /* = SortDescription() */)
 {
 
   if (nullptr == m_pDB)
@@ -7149,7 +7579,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
 
     // JOIN album and path tables needed by filter rules in where clause
     if (extFilter.where.find("album.") != std::string::npos ||
-      extFilter.where.find("strAlbum") != std::string::npos)
+        extFilter.where.find("strAlbum") != std::string::npos)
     { // All songs have one album so inner join sufficient
       extFilter.AppendJoin("JOIN album ON album.idAlbum = song.idAlbum");
     }
@@ -7163,7 +7593,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
-    // Count number of songs that satisfy selection criteria 
+    // Count number of songs that satisfy selection criteria
     // (includes xsp limits from filter, but not sort limits)
     total = GetSingleValueInt("SELECT COUNT(1) FROM song " + strSQLExtra, m_pDS);
     resultcount = static_cast<size_t>(total);
@@ -7193,7 +7623,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     std::string strSQL;
 
     // Setup fields to query, and song field number mapping
-    // Find idAlbumArtist in JSONtoDBSong, offset of first join field 
+    // Find idAlbumArtist in JSONtoDBSong, offset of first join field
     int index_idAlbumArtist = -1;
     for (unsigned int i = 0; i < NUM_SONG_FIELDS; i++)
     {
@@ -7202,10 +7632,10 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
         index_idAlbumArtist = i;
         break;
       }
-    }    
+    }
     Filter joinFilter;
     DatasetLayout joinLayout(static_cast<size_t>(joinToSongs_enumCount));
-    extFilter.AppendField("song.idSong");  // ID "songid" in JSON
+    extFilter.AppendField("song.idSong"); // ID "songid" in JSON
     std::vector<int> dbfieldindex;
     // JSON "label" field is strTitle which may also be requested as "title", query field once output twice
     extFilter.AppendField(JSONtoDBSong[0].fieldDB);
@@ -7222,7 +7652,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
       if (JSONtoDBSong[i].bSimple)
       {
         // Check for non-join fields in order too.
-        // Query these in inline view (but not output) so can ref in outer order 
+        // Query these in inline view (but not output) so can ref in outer order
         bool foundOrderby(false);
         if (!foundJSON)
           foundOrderby = extFilter.order.find(JSONtoDBSong[i].fieldDB) != std::string::npos;
@@ -7260,7 +7690,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     for (int i = 0; i < iAddedFields; i++)
       dbfieldindex.emplace_back(-1); // columns in dataset
 
-    // Build matching list of role id for "displaycomposer", "displayconductor", 
+    // Build matching list of role id for "displaycomposer", "displayconductor",
     // "displayorchestra", "displaylyricist"
     if (!rolefieldlist.empty())
     {
@@ -7286,22 +7716,22 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     { // All songs have one path so inner join sufficient
       extFilter.AppendJoin("JOIN path ON path.idPath = song.idPath");
     }
-    
+
     // Build JOIN, WHERE, ORDER BY and LIMIT for inline view
     strSQLExtra = "";
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
     // Add any LIMIT clause to strSQLExtra
-    if (extFilter.limit.empty() &&
-      (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    if (extFilter.limit.empty() && (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
-      strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+      strSQLExtra +=
+          DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
       resultcount = std::min(
-        DatabaseUtils::GetLimitCount(sortDescription.limitEnd, sortDescription.limitStart),
-        resultcount);
+          DatabaseUtils::GetLimitCount(sortDescription.limitEnd, sortDescription.limitStart),
+          resultcount);
     }
-    
+
     // Setup multivalue JOINs, GROUP BY and ORDER BY
     bool bJoinSongArtist(false);
     bool bJoinAlbumArtist(false);
@@ -7318,7 +7748,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     else
       joinFilter.AppendOrder("sv.idSong");
     joinFilter.AppendGroup("sv.idSong");
-    
+
     // Album artists
     if (joinLayout.GetFetch(joinToSongs_idAlbumArtist) ||
         joinLayout.GetFetch(joinToSongs_strAlbumArtist) ||
@@ -7331,19 +7761,21 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
       // Ensure idAlbumArtist is queried for processing repeats
       if (!joinLayout.GetFetch(joinToSongs_idAlbumArtist))
       {
-        joinLayout.SetField(joinToSongs_idAlbumArtist, 
-          JSONtoDBSong[index_idAlbumArtist + joinToSongs_idAlbumArtist].SQL);
-      }      
+        joinLayout.SetField(joinToSongs_idAlbumArtist,
+                            JSONtoDBSong[index_idAlbumArtist + joinToSongs_idAlbumArtist].SQL);
+      }
       // Ensure song.IdAlbum is field of the inline view for join
       if (fields.find("albumid") == fields.end())
       {
         extFilter.AppendField("song.idAlbum"); //Prefer lookup JSONtoDBSong[XXX].dbField);
         dbfieldindex.emplace_back(-1);
       }
-      // artist table needed for strArtist or MBID 
-      // (album_artist.strArtist can be an alias or spelling variation) 
-      if (joinLayout.GetFetch(joinToSongs_strAlbumArtistMBID) || joinLayout.GetFetch(joinToSongs_strAlbumArtist))
-        joinFilter.AppendJoin("JOIN artist AS albumartist ON albumartist.idArtist = album_artist.idArtist");
+      // artist table needed for strArtist or MBID
+      // (album_artist.strArtist can be an alias or spelling variation)
+      if (joinLayout.GetFetch(joinToSongs_strAlbumArtistMBID) ||
+          joinLayout.GetFetch(joinToSongs_strAlbumArtist))
+        joinFilter.AppendJoin(
+            "JOIN artist AS albumartist ON albumartist.idArtist = album_artist.idArtist");
     }
 
     /*
@@ -7351,31 +7783,30 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
      JSON schema "artist", "artistid", "musicbrainzartistid", "contributors",
      "displaycomposer", "displayconductor", "displayorchestra", "displaylyricist",
     */
-    if (joinLayout.GetFetch(joinToSongs_idArtist) ||
-        joinLayout.GetFetch(joinToSongs_strArtist) ||
-        joinLayout.GetFetch(joinToSongs_strArtistMBID) ||
-        !rolefieldlist.empty())
+    if (joinLayout.GetFetch(joinToSongs_idArtist) || joinLayout.GetFetch(joinToSongs_strArtist) ||
+        joinLayout.GetFetch(joinToSongs_strArtistMBID) || !rolefieldlist.empty())
     { // All songs have at least one artist (idRole = 1) so inner join sufficient
       bJoinSongArtist = true;
       if (rolefieldlist.empty())
       { // song artists only, no other roles needed
-        joinFilter.AppendJoin("JOIN song_artist ON song_artist.idSong = sv.idSong AND song_artist.idRole = 1");
+        joinFilter.AppendJoin(
+            "JOIN song_artist ON song_artist.idSong = sv.idSong AND song_artist.idRole = 1");
         joinFilter.AppendGroup("song_artist.idArtist");
         joinFilter.AppendOrder("song_artist.iOrder");
       }
-      else 
+      else
       {
         // Ensure idRole is queried
         if (!joinLayout.GetFetch(joinToSongs_idRole))
         {
           joinLayout.SetField(joinToSongs_idRole,
-            JSONtoDBSong[index_idAlbumArtist + joinToSongs_idRole].SQL);
+                              JSONtoDBSong[index_idAlbumArtist + joinToSongs_idRole].SQL);
         }
         // Ensure strArtist is queried
         if (!joinLayout.GetFetch(joinToSongs_strArtist))
         {
           joinLayout.SetField(joinToSongs_strArtist,
-            JSONtoDBSong[index_idAlbumArtist + joinToSongs_strArtist].SQL);
+                              JSONtoDBSong[index_idAlbumArtist + joinToSongs_strArtist].SQL);
         }
         if (fields.find("contributors") != fields.end())
         { // all roles
@@ -7391,7 +7822,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
         { // Get just roles for  "displaycomposer", "displayconductor" etc.
           std::string where;
           for (size_t i = 0; i < roleidlist.size(); i++)
-          {          
+          {
             int idRole = roleidlist[i];
             if (idRole <= 1)
               continue;
@@ -7411,18 +7842,20 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
       if (!joinLayout.GetFetch(joinToSongs_idArtist))
       {
         joinLayout.SetField(joinToSongs_idArtist,
-          JSONtoDBSong[index_idAlbumArtist + joinToSongs_idArtist].SQL);
+                            JSONtoDBSong[index_idAlbumArtist + joinToSongs_idArtist].SQL);
       }
-      // artist table needed for strArtist or MBID 
-      // (song_artist.strArtist can be an alias or spelling variation) 
-      if (joinLayout.GetFetch(joinToSongs_strArtistMBID) || joinLayout.GetFetch(joinToSongs_strArtist))
-        joinFilter.AppendJoin("JOIN artist AS songartist ON songartist.idArtist = song_artist.idArtist");
-    }    
+      // artist table needed for strArtist or MBID
+      // (song_artist.strArtist can be an alias or spelling variation)
+      if (joinLayout.GetFetch(joinToSongs_strArtistMBID) ||
+          joinLayout.GetFetch(joinToSongs_strArtist))
+        joinFilter.AppendJoin(
+            "JOIN artist AS songartist ON songartist.idArtist = song_artist.idArtist");
+    }
 
     // Genre ids
     if (joinLayout.GetFetch(joinToSongs_idGenre))
     { // song genre ids (strGenre demormalised in song table)
-      // Left join as songs may not have genre      
+      // Left join as songs may not have genre
       joinFilter.AppendJoin("LEFT JOIN song_genre ON song_genre.idSong = sv.idSong");
       joinFilter.AppendGroup("song_genre.idGenre");
       joinFilter.AppendOrder("song_genre.iOrder");
@@ -7441,21 +7874,21 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
 
     // Build full query
     // When have multiple value joins use inline view
-    // SELECT sv.*, <join fields> FROM 
-    //   (SELECT <song fields> FROM song <JOIN album> <where> + <order by> +  <limits> ) AS sv 
+    // SELECT sv.*, <join fields> FROM
+    //   (SELECT <song fields> FROM song <JOIN album> <where> + <order by> +  <limits> ) AS sv
     //   <joins> <group by>
     //   <order by> + <joins order by>
     // Don't use prepareSQL - confuses  releasetype = 'album' filter and group_concat separator
     strSQL = "SELECT " + extFilter.fields + " FROM song " + strSQLExtra;
     if (joinLayout.HasFilterFields())
     {
-      strSQL = "("+ strSQL + ") AS sv ";
+      strSQL = "(" + strSQL + ") AS sv ";
       strSQL = "SELECT sv.*, " + joinLayout.GetFields() + " FROM " + strSQL + strSQLJoin;
     }
-    
+
     // Modify query to use correct year field
     if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-      CSettings::SETTING_MUSICLIBRARY_USEORIGINALDATE))
+            CSettings::SETTING_MUSICLIBRARY_USEORIGINALDATE))
       StringUtils::Replace(strSQL, "<datefield>", "song.strReleaseDate");
     else
       StringUtils::Replace(strSQL, "<datefield>", "song.strOrigReleaseDate");
@@ -7466,8 +7899,8 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     unsigned int time = XbmcThreads::SystemClockMillis();
     if (!m_pDS->query(strSQL))
       return false;
-    CLog::Log(LOGDEBUG, "%s - query took %i ms",
-      __FUNCTION__, XbmcThreads::SystemClockMillis() - time);
+    CLog::Log(LOGDEBUG, "%s - query took %i ms", __FUNCTION__,
+              XbmcThreads::SystemClockMillis() - time);
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -7532,7 +7965,8 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
         {
           // Initialise fields, ensure those with possible null values are set to correct empty variant type
           if (joinLayout.GetOutput(joinToSongs_idGenre))
-            songObj["genreid"] = CVariant(CVariant::VariantTypeArray); //"genre" set [] by split of array
+            songObj["genreid"] =
+                CVariant(CVariant::VariantTypeArray); //"genre" set [] by split of array
 
           albumartistId = -1;
           artistId = -1;
@@ -7541,7 +7975,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
           bSongArtistDone = false;
         }
         if (m_pDS->eof())
-          continue;  // Having saved the last song stop
+          continue; // Having saved the last song stop
 
         // New song
         songId = record->at(0).get_asInt();
@@ -7554,11 +7988,16 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
             if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "integer")
               songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asInt();
             else if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "unsigned")
-              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = std::max(record->at(1 + i).get_asInt(), 0);
+              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] =
+                  std::max(record->at(1 + i).get_asInt(), 0);
             else if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "float")
-              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = std::max(record->at(1 + i).get_asFloat(), 0.f);
+              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] =
+                  std::max(record->at(1 + i).get_asFloat(), 0.f);
             else if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "array")
-              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = StringUtils::Split(record->at(1 + i).get_asString(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = StringUtils::Split(
+                  record->at(1 + i).get_asString(), CServiceBroker::GetSettingsComponent()
+                                                        ->GetAdvancedSettings()
+                                                        ->m_musicItemSeparator);
             else if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "boolean")
               songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asBool();
             else
@@ -7568,7 +8007,8 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
         // Split sources string into int array
         if (songObj.isMember("sourceid"))
         {
-          std::vector<std::string> sources = StringUtils::Split(songObj["sourceid"].asString(), ";");
+          std::vector<std::string> sources =
+              StringUtils::Split(songObj["sourceid"].asString(), ";");
           songObj["sourceid"] = CVariant(CVariant::VariantTypeArray);
           for (size_t i = 0; i < sources.size(); i++)
             songObj["sourceid"].append(atoi(sources[i].c_str()));
@@ -7579,8 +8019,10 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
       {
         if (albumartistId != record->at(joinLayout.GetRecNo(joinToSongs_idAlbumArtist)).get_asInt())
         {
-          bSongGenreDone = bSongGenreDone || (albumartistId > 0);  // Not first album artist, skip genre
-          bSongArtistDone = bSongArtistDone || (albumartistId > 0);  // Not first album artist, skip song artists
+          bSongGenreDone =
+              bSongGenreDone || (albumartistId > 0); // Not first album artist, skip genre
+          bSongArtistDone =
+              bSongArtistDone || (albumartistId > 0); // Not first album artist, skip song artists
           albumartistId = record->at(joinLayout.GetRecNo(joinToSongs_idAlbumArtist)).get_asInt();
           if (joinLayout.GetOutput(joinToSongs_idAlbumArtist))
             songObj["albumartistid"].append(albumartistId);
@@ -7596,9 +8038,11 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
             if (joinLayout.GetOutput(joinToSongs_idAlbumArtist))
               songObj["albumartistid"].append(albumartistId);
             if (joinLayout.GetOutput(joinToSongs_strAlbumArtist))
-              songObj["albumartist"].append(record->at(joinLayout.GetRecNo(joinToSongs_strAlbumArtist)).get_asString());
+              songObj["albumartist"].append(
+                  record->at(joinLayout.GetRecNo(joinToSongs_strAlbumArtist)).get_asString());
             if (joinLayout.GetOutput(joinToSongs_strAlbumArtistMBID))
-              songObj["musicbrainzalbumartistid"].append(record->at(joinLayout.GetRecNo(joinToSongs_strAlbumArtistMBID)).get_asString());
+              songObj["musicbrainzalbumartistid"].append(
+                  record->at(joinLayout.GetRecNo(joinToSongs_strAlbumArtistMBID)).get_asString());
           }
         }
       }
@@ -7606,7 +8050,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
       {
         if (artistId != record->at(joinLayout.GetRecNo(joinToSongs_idArtist)).get_asInt())
         {
-          bSongGenreDone = bSongGenreDone || (artistId > 0);  // Not first artist, skip genre
+          bSongGenreDone = bSongGenreDone || (artistId > 0); // Not first artist, skip genre
           roleId = -1; // Allow for many artists same role
           artistId = record->at(joinLayout.GetRecNo(joinToSongs_idArtist)).get_asInt();
           if (joinLayout.GetRecNo(joinToSongs_idRole) < 0 ||
@@ -7624,34 +8068,40 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
             else
             {
               if (joinLayout.GetOutput(joinToSongs_strArtist))
-                songObj["artist"].append(record->at(joinLayout.GetRecNo(joinToSongs_strArtist)).get_asString());
+                songObj["artist"].append(
+                    record->at(joinLayout.GetRecNo(joinToSongs_strArtist)).get_asString());
               if (joinLayout.GetOutput(joinToSongs_strArtistMBID))
-                songObj["musicbrainzartistid"].append(record->at(joinLayout.GetRecNo(joinToSongs_strArtistMBID)).get_asString());
+                songObj["musicbrainzartistid"].append(
+                    record->at(joinLayout.GetRecNo(joinToSongs_strArtistMBID)).get_asString());
             }
           }
         }
         if (joinLayout.GetRecNo(joinToSongs_idRole) > 0 &&
             roleId != record->at(joinLayout.GetRecNo(joinToSongs_idRole)).get_asInt())
         {
-          bSongGenreDone = bSongGenreDone || (roleId > 0);  // Not first role, skip genre
+          bSongGenreDone = bSongGenreDone || (roleId > 0); // Not first role, skip genre
           roleId = record->at(joinLayout.GetRecNo(joinToSongs_idRole)).get_asInt();
           if (roleId > 1)
           {
             if (bJoinRole)
-            {  //Contributors
-               CVariant contributor;
-               contributor["name"] = record->at(joinLayout.GetRecNo(joinToSongs_strArtist)).get_asString();
-               contributor["role"] = record->at(joinLayout.GetRecNo(joinToSongs_strRole)).get_asString();
-               contributor["roleid"] = roleId;
-               contributor["artistid"] = record->at(joinLayout.GetRecNo(joinToSongs_idArtist)).get_asInt();
-               songObj["contributors"].append(contributor);               
+            { //Contributors
+              CVariant contributor;
+              contributor["name"] =
+                  record->at(joinLayout.GetRecNo(joinToSongs_strArtist)).get_asString();
+              contributor["role"] =
+                  record->at(joinLayout.GetRecNo(joinToSongs_strRole)).get_asString();
+              contributor["roleid"] = roleId;
+              contributor["artistid"] =
+                  record->at(joinLayout.GetRecNo(joinToSongs_idArtist)).get_asInt();
+              songObj["contributors"].append(contributor);
             }
             // "displaycomposer", "displayconductor" etc.
             for (size_t i = 0; i < roleidlist.size(); i++)
             {
               if (roleidlist[i] == roleId)
               {
-                songObj[rolefieldlist[i]].append(record->at(joinLayout.GetRecNo(joinToSongs_strArtist)).get_asString());
+                songObj[rolefieldlist[i]].append(
+                    record->at(joinLayout.GetRecNo(joinToSongs_strArtist)).get_asString());
                 continue;
               }
             }
@@ -7702,7 +8152,7 @@ std::string CMusicDatabase::GetIgnoreArticleSQL(const std::string& strField)
       if (!strWhen.empty())
       {
         if (!sortclause.empty())
-           sortclause += " ";
+          sortclause += " ";
         std::string strThen = PrepareSQL(" THEN SUBSTR(%s, %i)", strField.c_str(), tokenlength + 1);
         sortclause += "WHEN " + strWhen + strThen;
         strWhen.clear();
@@ -7718,13 +8168,13 @@ std::string CMusicDatabase::GetIgnoreArticleSQL(const std::string& strField)
     if (token.find('_') != std::string::npos)
       tokenclause += " ESCAPE '_'";
     if (!strWhen.empty())
-       strWhen += " OR ";
+      strWhen += " OR ";
     strWhen += tokenclause;
   }
   if (!strWhen.empty())
   {
     if (!sortclause.empty())
-       sortclause += " ";
+      sortclause += " ";
     std::string strThen = PrepareSQL(" THEN SUBSTR(%s, %i)", strField.c_str(), tokenlength + 1);
     sortclause += "WHEN " + strWhen + strThen;
   }
@@ -7766,7 +8216,8 @@ std::string CMusicDatabase::SortnameBuildSQL(const std::string& strAlias,
   return sortSQL;
 }
 
-std::string CMusicDatabase::AlphanumericSortSQL(const std::string& strField, const SortOrder& sortOrder)
+std::string CMusicDatabase::AlphanumericSortSQL(const std::string& strField,
+                                                const SortOrder& sortOrder)
 {
   /*
   Use custom collation ALPHANUM in SQLite. This handles natural number order, case sensitivity
@@ -7800,8 +8251,18 @@ void CMusicDatabase::UpdateTables(int version)
   {
     m_pDS->exec("ALTER TABLE artist ADD strMusicBrainzArtistID text\n");
     m_pDS->exec("ALTER TABLE album ADD strMusicBrainzAlbumID text\n");
-    m_pDS->exec("CREATE TABLE song_new ( idSong integer primary key, idAlbum integer, idPath integer, strArtists text, strGenres text, strTitle varchar(512), iTrack integer, iDuration integer, iYear integer, dwFileNameCRC text, strFileName text, strMusicBrainzTrackID text, iTimesPlayed integer, iStartOffset integer, iEndOffset integer, idThumb integer, lastplayed varchar(20) default NULL, rating char default '0', comment text)\n");
-    m_pDS->exec("INSERT INTO song_new ( idSong, idAlbum, idPath, strArtists, strTitle, iTrack, iDuration, iYear, dwFileNameCRC, strFileName, strMusicBrainzTrackID, iTimesPlayed, iStartOffset, iEndOffset, idThumb, lastplayed, rating, comment) SELECT idSong, idAlbum, idPath, strArtists, strTitle, iTrack, iDuration, iYear, dwFileNameCRC, strFileName, strMusicBrainzTrackID, iTimesPlayed, iStartOffset, iEndOffset, idThumb, lastplayed, rating, comment FROM song");
+    m_pDS->exec(
+        "CREATE TABLE song_new ( idSong integer primary key, idAlbum integer, idPath integer, "
+        "strArtists text, strGenres text, strTitle varchar(512), iTrack integer, iDuration "
+        "integer, iYear integer, dwFileNameCRC text, strFileName text, strMusicBrainzTrackID text, "
+        "iTimesPlayed integer, iStartOffset integer, iEndOffset integer, idThumb integer, "
+        "lastplayed varchar(20) default NULL, rating char default '0', comment text)\n");
+    m_pDS->exec("INSERT INTO song_new ( idSong, idAlbum, idPath, strArtists, strTitle, iTrack, "
+                "iDuration, iYear, dwFileNameCRC, strFileName, strMusicBrainzTrackID, "
+                "iTimesPlayed, iStartOffset, iEndOffset, idThumb, lastplayed, rating, comment) "
+                "SELECT idSong, idAlbum, idPath, strArtists, strTitle, iTrack, iDuration, iYear, "
+                "dwFileNameCRC, strFileName, strMusicBrainzTrackID, iTimesPlayed, iStartOffset, "
+                "iEndOffset, idThumb, lastplayed, rating, comment FROM song");
 
     m_pDS->exec("DROP TABLE song");
     m_pDS->exec("ALTER TABLE song_new RENAME TO song");
@@ -7822,10 +8283,11 @@ void CMusicDatabase::UpdateTables(int version)
       }
       m_pDS->close();
 
-      for (const auto &originalPath : contentPaths)
+      for (const auto& originalPath : contentPaths)
       {
         std::string path = CLegacyPathTranslation::TranslateMusicDbPath(originalPath);
-        m_pDS->exec(PrepareSQL("UPDATE content SET strPath='%s' WHERE strPath='%s'", path.c_str(), originalPath.c_str()));
+        m_pDS->exec(PrepareSQL("UPDATE content SET strPath='%s' WHERE strPath='%s'", path.c_str(),
+                               originalPath.c_str()));
       }
     }
   }
@@ -7864,8 +8326,11 @@ void CMusicDatabase::UpdateTables(int version)
                 " strReview, strImage, strLabel, "
                 " strType, iRating "
                 " FROM album LEFT JOIN albuminfo ON album.idAlbum = albuminfo.idAlbum");
-    m_pDS->exec("UPDATE albuminfosong SET idAlbumInfo = (SELECT idAlbum FROM albuminfo WHERE albuminfo.idAlbumInfo = albuminfosong.idAlbumInfo)");
-    m_pDS->exec(PrepareSQL("UPDATE album_new SET lastScraped='%s' WHERE idAlbum IN (SELECT idAlbum FROM albuminfo)", CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str()));
+    m_pDS->exec("UPDATE albuminfosong SET idAlbumInfo = (SELECT idAlbum FROM albuminfo WHERE "
+                "albuminfo.idAlbumInfo = albuminfosong.idAlbumInfo)");
+    m_pDS->exec(PrepareSQL(
+        "UPDATE album_new SET lastScraped='%s' WHERE idAlbum IN (SELECT idAlbum FROM albuminfo)",
+        CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str()));
     m_pDS->exec("DROP TABLE album");
     m_pDS->exec("DROP TABLE albuminfo");
     m_pDS->exec("ALTER TABLE album_new RENAME TO album");
@@ -7895,7 +8360,9 @@ void CMusicDatabase::UpdateTables(int version)
                 " strImage, strFanart "
                 " FROM artist "
                 " LEFT JOIN artistinfo ON artist.idArtist = artistinfo.idArtist");
-    m_pDS->exec(PrepareSQL("UPDATE artist_new SET lastScraped='%s' WHERE idArtist IN (SELECT idArtist FROM artistinfo)", CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str()));
+    m_pDS->exec(PrepareSQL("UPDATE artist_new SET lastScraped='%s' WHERE idArtist IN (SELECT "
+                           "idArtist FROM artistinfo)",
+                           CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str()));
     m_pDS->exec("DROP TABLE artist");
     m_pDS->exec("DROP TABLE artistinfo");
     m_pDS->exec("ALTER TABLE artist_new RENAME TO artist");
@@ -7909,8 +8376,10 @@ void CMusicDatabase::UpdateTables(int version)
     m_pDS->query(sql);
     while (!m_pDS->eof())
     {
-      m_pDS2->exec(PrepareSQL("UPDATE song_artist SET strArtist='%s' where idArtist=%i", m_pDS->fv(1).get_asString().c_str(), m_pDS->fv(0).get_asInt()));
-      m_pDS2->exec(PrepareSQL("UPDATE album_artist SET strArtist='%s' where idArtist=%i", m_pDS->fv(1).get_asString().c_str(), m_pDS->fv(0).get_asInt()));
+      m_pDS2->exec(PrepareSQL("UPDATE song_artist SET strArtist='%s' where idArtist=%i",
+                              m_pDS->fv(1).get_asString().c_str(), m_pDS->fv(0).get_asInt()));
+      m_pDS2->exec(PrepareSQL("UPDATE album_artist SET strArtist='%s' where idArtist=%i",
+                              m_pDS->fv(1).get_asString().c_str(), m_pDS->fv(0).get_asInt()));
       m_pDS->next();
     }
   }
@@ -7929,8 +8398,12 @@ void CMusicDatabase::UpdateTables(int version)
     m_pDS->exec("ALTER TABLE album ADD strReleaseType text\n");
 
     // set strReleaseType based on album name
-    m_pDS->exec(PrepareSQL("UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NOT NULL AND strAlbum <> ''", CAlbum::ReleaseTypeToString(CAlbum::Album).c_str()));
-    m_pDS->exec(PrepareSQL("UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NULL OR strAlbum = ''", CAlbum::ReleaseTypeToString(CAlbum::Single).c_str()));
+    m_pDS->exec(PrepareSQL(
+        "UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NOT NULL AND strAlbum <> ''",
+        CAlbum::ReleaseTypeToString(CAlbum::Album).c_str()));
+    m_pDS->exec(
+        PrepareSQL("UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NULL OR strAlbum = ''",
+                   CAlbum::ReleaseTypeToString(CAlbum::Single).c_str()));
   }
   if (version < 51)
   {
@@ -7942,168 +8415,168 @@ void CMusicDatabase::UpdateTables(int version)
   }
   if (version < 54)
   {
-      //Remove dateAdded from artist table
-      m_pDS->exec("CREATE TABLE artist_new ( idArtist integer primary key, "
-              " strArtist varchar(256), strMusicBrainzArtistID text, "
-              " strBorn text, strFormed text, strGenres text, strMoods text, "
-              " strStyles text, strInstruments text, strBiography text, "
-              " strDied text, strDisbanded text, strYearsActive text, "
-              " strImage text, strFanart text, "
-              " lastScraped varchar(20) default NULL)");
-      m_pDS->exec("INSERT INTO artist_new "
-          "(idArtist, strArtist, strMusicBrainzArtistID, "
-          " strBorn, strFormed, strGenres, strMoods, "
-          " strStyles , strInstruments , strBiography , "
-          " strDied, strDisbanded, strYearsActive, "
-          " strImage, strFanart, lastScraped) "
-          " SELECT "
-          " idArtist, "
-          " strArtist, strMusicBrainzArtistID, "
-          " strBorn, strFormed, strGenres, strMoods, "
-          " strStyles, strInstruments, strBiography, "
-          " strDied, strDisbanded, strYearsActive, "
-          " strImage, strFanart, lastScraped "
-          " FROM artist");
-      m_pDS->exec("DROP TABLE artist");
-      m_pDS->exec("ALTER TABLE artist_new RENAME TO artist");
+    //Remove dateAdded from artist table
+    m_pDS->exec("CREATE TABLE artist_new ( idArtist integer primary key, "
+                " strArtist varchar(256), strMusicBrainzArtistID text, "
+                " strBorn text, strFormed text, strGenres text, strMoods text, "
+                " strStyles text, strInstruments text, strBiography text, "
+                " strDied text, strDisbanded text, strYearsActive text, "
+                " strImage text, strFanart text, "
+                " lastScraped varchar(20) default NULL)");
+    m_pDS->exec("INSERT INTO artist_new "
+                "(idArtist, strArtist, strMusicBrainzArtistID, "
+                " strBorn, strFormed, strGenres, strMoods, "
+                " strStyles , strInstruments , strBiography , "
+                " strDied, strDisbanded, strYearsActive, "
+                " strImage, strFanart, lastScraped) "
+                " SELECT "
+                " idArtist, "
+                " strArtist, strMusicBrainzArtistID, "
+                " strBorn, strFormed, strGenres, strMoods, "
+                " strStyles, strInstruments, strBiography, "
+                " strDied, strDisbanded, strYearsActive, "
+                " strImage, strFanart, lastScraped "
+                " FROM artist");
+    m_pDS->exec("DROP TABLE artist");
+    m_pDS->exec("ALTER TABLE artist_new RENAME TO artist");
 
-      //Remove dateAdded from album table
-      m_pDS->exec("CREATE TABLE album_new (idAlbum integer primary key, "
-              " strAlbum varchar(256), strMusicBrainzAlbumID text, "
-              " strArtists text, strGenres text, "
-              " iYear integer, idThumb integer, "
-              " bCompilation integer not null default '0', "
-              " strMoods text, strStyles text, strThemes text, "
-              " strReview text, strImage text, strLabel text, "
-              " strType text, "
-              " iRating integer, "
-              " lastScraped varchar(20) default NULL, "
-              " strReleaseType text)");
-      m_pDS->exec("INSERT INTO album_new "
-          "(idAlbum, "
-          " strAlbum, strMusicBrainzAlbumID, "
-          " strArtists, strGenres, "
-          " iYear, idThumb, "
-          " bCompilation, "
-          " strMoods, strStyles, strThemes, "
-          " strReview, strImage, strLabel, "
-          " strType, iRating, lastScraped, "
-          " strReleaseType) "
-          " SELECT "
-          " album.idAlbum, "
-          " strAlbum, strMusicBrainzAlbumID, "
-          " strArtists, strGenres, "
-          " iYear, idThumb, "
-          " bCompilation, "
-          " strMoods, strStyles, strThemes, "
-          " strReview, strImage, strLabel, "
-          " strType, iRating, lastScraped, "
-          " strReleaseType"
-          " FROM album");
-      m_pDS->exec("DROP TABLE album");
-      m_pDS->exec("ALTER TABLE album_new RENAME TO album");
-   }
-   if (version < 55)
-   {
-     m_pDS->exec("DROP TABLE karaokedata");
-   }
-   if (version < 57)
-   {
-     m_pDS->exec("ALTER TABLE song ADD userrating INTEGER NOT NULL DEFAULT 0");
-     m_pDS->exec("UPDATE song SET rating = 0 WHERE rating < 0 or rating IS NULL");
-     m_pDS->exec("UPDATE song SET userrating = rating * 2");
-     m_pDS->exec("UPDATE song SET rating = 0");
-     m_pDS->exec("CREATE TABLE song_new (idSong INTEGER PRIMARY KEY, "
-       " idAlbum INTEGER, idPath INTEGER, "
-       " strArtists TEXT, strGenres TEXT, strTitle VARCHAR(512), "
-       " iTrack INTEGER, iDuration INTEGER, iYear INTEGER, "
-       " dwFileNameCRC TEXT, "
-       " strFileName TEXT, strMusicBrainzTrackID TEXT, "
-       " iTimesPlayed INTEGER, iStartOffset INTEGER, iEndOffset INTEGER, "
-       " idThumb INTEGER, "
-       " lastplayed VARCHAR(20) DEFAULT NULL, "
-       " rating FLOAT DEFAULT 0, "
-       " userrating INTEGER DEFAULT 0, "
-       " comment TEXT, mood TEXT, dateAdded TEXT)");
-     m_pDS->exec("INSERT INTO song_new "
-       "(idSong, "
-       " idAlbum, idPath, "
-       " strArtists, strGenres, strTitle, "
-       " iTrack, iDuration, iYear, "
-       " dwFileNameCRC, "
-       " strFileName, strMusicBrainzTrackID, "
-       " iTimesPlayed, iStartOffset, iEndOffset, "
-       " idThumb, "
-       " lastplayed,"
-       " rating, userrating, "
-       " comment, mood, dateAdded)"
-       " SELECT "
-       " idSong, "
-       " idAlbum, idPath, "
-       " strArtists, strGenres, strTitle, "
-       " iTrack, iDuration, iYear, "
-       " dwFileNameCRC, "
-       " strFileName, strMusicBrainzTrackID, "
-       " iTimesPlayed, iStartOffset, iEndOffset, "
-       " idThumb, "
-       " lastplayed,"
-       " rating, "
-       " userrating, "
-       " comment, mood, dateAdded"
-       " FROM song");
-     m_pDS->exec("DROP TABLE song");
-     m_pDS->exec("ALTER TABLE song_new RENAME TO song");
+    //Remove dateAdded from album table
+    m_pDS->exec("CREATE TABLE album_new (idAlbum integer primary key, "
+                " strAlbum varchar(256), strMusicBrainzAlbumID text, "
+                " strArtists text, strGenres text, "
+                " iYear integer, idThumb integer, "
+                " bCompilation integer not null default '0', "
+                " strMoods text, strStyles text, strThemes text, "
+                " strReview text, strImage text, strLabel text, "
+                " strType text, "
+                " iRating integer, "
+                " lastScraped varchar(20) default NULL, "
+                " strReleaseType text)");
+    m_pDS->exec("INSERT INTO album_new "
+                "(idAlbum, "
+                " strAlbum, strMusicBrainzAlbumID, "
+                " strArtists, strGenres, "
+                " iYear, idThumb, "
+                " bCompilation, "
+                " strMoods, strStyles, strThemes, "
+                " strReview, strImage, strLabel, "
+                " strType, iRating, lastScraped, "
+                " strReleaseType) "
+                " SELECT "
+                " album.idAlbum, "
+                " strAlbum, strMusicBrainzAlbumID, "
+                " strArtists, strGenres, "
+                " iYear, idThumb, "
+                " bCompilation, "
+                " strMoods, strStyles, strThemes, "
+                " strReview, strImage, strLabel, "
+                " strType, iRating, lastScraped, "
+                " strReleaseType"
+                " FROM album");
+    m_pDS->exec("DROP TABLE album");
+    m_pDS->exec("ALTER TABLE album_new RENAME TO album");
+  }
+  if (version < 55)
+  {
+    m_pDS->exec("DROP TABLE karaokedata");
+  }
+  if (version < 57)
+  {
+    m_pDS->exec("ALTER TABLE song ADD userrating INTEGER NOT NULL DEFAULT 0");
+    m_pDS->exec("UPDATE song SET rating = 0 WHERE rating < 0 or rating IS NULL");
+    m_pDS->exec("UPDATE song SET userrating = rating * 2");
+    m_pDS->exec("UPDATE song SET rating = 0");
+    m_pDS->exec("CREATE TABLE song_new (idSong INTEGER PRIMARY KEY, "
+                " idAlbum INTEGER, idPath INTEGER, "
+                " strArtists TEXT, strGenres TEXT, strTitle VARCHAR(512), "
+                " iTrack INTEGER, iDuration INTEGER, iYear INTEGER, "
+                " dwFileNameCRC TEXT, "
+                " strFileName TEXT, strMusicBrainzTrackID TEXT, "
+                " iTimesPlayed INTEGER, iStartOffset INTEGER, iEndOffset INTEGER, "
+                " idThumb INTEGER, "
+                " lastplayed VARCHAR(20) DEFAULT NULL, "
+                " rating FLOAT DEFAULT 0, "
+                " userrating INTEGER DEFAULT 0, "
+                " comment TEXT, mood TEXT, dateAdded TEXT)");
+    m_pDS->exec("INSERT INTO song_new "
+                "(idSong, "
+                " idAlbum, idPath, "
+                " strArtists, strGenres, strTitle, "
+                " iTrack, iDuration, iYear, "
+                " dwFileNameCRC, "
+                " strFileName, strMusicBrainzTrackID, "
+                " iTimesPlayed, iStartOffset, iEndOffset, "
+                " idThumb, "
+                " lastplayed,"
+                " rating, userrating, "
+                " comment, mood, dateAdded)"
+                " SELECT "
+                " idSong, "
+                " idAlbum, idPath, "
+                " strArtists, strGenres, strTitle, "
+                " iTrack, iDuration, iYear, "
+                " dwFileNameCRC, "
+                " strFileName, strMusicBrainzTrackID, "
+                " iTimesPlayed, iStartOffset, iEndOffset, "
+                " idThumb, "
+                " lastplayed,"
+                " rating, "
+                " userrating, "
+                " comment, mood, dateAdded"
+                " FROM song");
+    m_pDS->exec("DROP TABLE song");
+    m_pDS->exec("ALTER TABLE song_new RENAME TO song");
 
-     m_pDS->exec("ALTER TABLE album ADD iUserrating INTEGER NOT NULL DEFAULT 0");
-     m_pDS->exec("UPDATE album SET iRating = 0 WHERE iRating < 0 or iRating IS NULL");
-     m_pDS->exec("CREATE TABLE album_new (idAlbum INTEGER PRIMARY KEY, "
-       " strAlbum VARCHAR(256), strMusicBrainzAlbumID TEXT, "
-       " strArtists TEXT, strGenres TEXT, "
-       " iYear INTEGER, idThumb INTEGER, "
-       " bCompilation INTEGER NOT NULL DEFAULT '0', "
-       " strMoods TEXT, strStyles TEXT, strThemes TEXT, "
-       " strReview TEXT, strImage TEXT, strLabel TEXT, "
-       " strType TEXT, "
-       " fRating FLOAT NOT NULL DEFAULT 0, "
-       " iUserrating INTEGER NOT NULL DEFAULT 0, "
-       " lastScraped VARCHAR(20) DEFAULT NULL, "
-       " strReleaseType TEXT)");
-     m_pDS->exec("INSERT INTO album_new "
-       "(idAlbum, "
-       " strAlbum, strMusicBrainzAlbumID, "
-       " strArtists, strGenres, "
-       " iYear, idThumb, "
-       " bCompilation, "
-       " strMoods, strStyles, strThemes, "
-       " strReview, strImage, strLabel, "
-       " strType, "
-       " fRating, "
-       " iUserrating, "
-       " lastScraped, "
-       " strReleaseType)"
-       " SELECT "
-       " idAlbum, "
-       " strAlbum, strMusicBrainzAlbumID, "
-       " strArtists, strGenres, "
-       " iYear, idThumb, "
-       " bCompilation, "
-       " strMoods, strStyles, strThemes, "
-       " strReview, strImage, strLabel, "
-       " strType, "
-       " iRating, "
-       " iUserrating, "
-       " lastScraped, "
-       " strReleaseType"
-       " FROM album");
-     m_pDS->exec("DROP TABLE album");
-     m_pDS->exec("ALTER TABLE album_new RENAME TO album");
+    m_pDS->exec("ALTER TABLE album ADD iUserrating INTEGER NOT NULL DEFAULT 0");
+    m_pDS->exec("UPDATE album SET iRating = 0 WHERE iRating < 0 or iRating IS NULL");
+    m_pDS->exec("CREATE TABLE album_new (idAlbum INTEGER PRIMARY KEY, "
+                " strAlbum VARCHAR(256), strMusicBrainzAlbumID TEXT, "
+                " strArtists TEXT, strGenres TEXT, "
+                " iYear INTEGER, idThumb INTEGER, "
+                " bCompilation INTEGER NOT NULL DEFAULT '0', "
+                " strMoods TEXT, strStyles TEXT, strThemes TEXT, "
+                " strReview TEXT, strImage TEXT, strLabel TEXT, "
+                " strType TEXT, "
+                " fRating FLOAT NOT NULL DEFAULT 0, "
+                " iUserrating INTEGER NOT NULL DEFAULT 0, "
+                " lastScraped VARCHAR(20) DEFAULT NULL, "
+                " strReleaseType TEXT)");
+    m_pDS->exec("INSERT INTO album_new "
+                "(idAlbum, "
+                " strAlbum, strMusicBrainzAlbumID, "
+                " strArtists, strGenres, "
+                " iYear, idThumb, "
+                " bCompilation, "
+                " strMoods, strStyles, strThemes, "
+                " strReview, strImage, strLabel, "
+                " strType, "
+                " fRating, "
+                " iUserrating, "
+                " lastScraped, "
+                " strReleaseType)"
+                " SELECT "
+                " idAlbum, "
+                " strAlbum, strMusicBrainzAlbumID, "
+                " strArtists, strGenres, "
+                " iYear, idThumb, "
+                " bCompilation, "
+                " strMoods, strStyles, strThemes, "
+                " strReview, strImage, strLabel, "
+                " strType, "
+                " iRating, "
+                " iUserrating, "
+                " lastScraped, "
+                " strReleaseType"
+                " FROM album");
+    m_pDS->exec("DROP TABLE album");
+    m_pDS->exec("ALTER TABLE album_new RENAME TO album");
 
-     m_pDS->exec("ALTER TABLE album ADD iVotes INTEGER NOT NULL DEFAULT 0");
-     m_pDS->exec("ALTER TABLE song ADD votes INTEGER NOT NULL DEFAULT 0");
-   }
+    m_pDS->exec("ALTER TABLE album ADD iVotes INTEGER NOT NULL DEFAULT 0");
+    m_pDS->exec("ALTER TABLE song ADD votes INTEGER NOT NULL DEFAULT 0");
+  }
   if (version < 58)
   {
-     m_pDS->exec("UPDATE album SET fRating = fRating * 2");
+    m_pDS->exec("UPDATE album SET fRating = fRating * 2");
   }
   if (version < 59)
   {
@@ -8111,16 +8584,18 @@ void CMusicDatabase::UpdateTables(int version)
     m_pDS->exec("INSERT INTO role(idRole, strRole) VALUES (1, 'Artist')"); //Default Role
 
     //Remove strJoinPhrase, boolFeatured from song_artist table and add idRole
-    m_pDS->exec("CREATE TABLE song_artist_new (idArtist integer, idSong integer, idRole integer, iOrder integer, strArtist text)");
+    m_pDS->exec("CREATE TABLE song_artist_new (idArtist integer, idSong integer, idRole integer, "
+                "iOrder integer, strArtist text)");
     m_pDS->exec("INSERT INTO song_artist_new (idArtist, idSong, idRole, iOrder, strArtist) "
-      "SELECT idArtist, idSong, 1 as idRole, iOrder, strArtist FROM song_artist");
+                "SELECT idArtist, idSong, 1 as idRole, iOrder, strArtist FROM song_artist");
     m_pDS->exec("DROP TABLE song_artist");
     m_pDS->exec("ALTER TABLE song_artist_new RENAME TO song_artist");
 
     //Remove strJoinPhrase, boolFeatured from album_artist table
-    m_pDS->exec("CREATE TABLE album_artist_new (idArtist integer, idAlbum integer, iOrder integer, strArtist text)");
+    m_pDS->exec("CREATE TABLE album_artist_new (idArtist integer, idAlbum integer, iOrder integer, "
+                "strArtist text)");
     m_pDS->exec("INSERT INTO album_artist_new (idArtist, idAlbum, iOrder, strArtist) "
-      "SELECT idArtist, idAlbum, iOrder, strArtist FROM album_artist");
+                "SELECT idArtist, idAlbum, iOrder, strArtist FROM album_artist");
     m_pDS->exec("DROP TABLE album_artist");
     m_pDS->exec("ALTER TABLE album_artist_new RENAME TO album_artist");
   }
@@ -8135,12 +8610,13 @@ void CMusicDatabase::UpdateTables(int version)
       try
       { //No mbid index yet, so can have record for artist twice even with mbid
         strSQL = PrepareSQL("INSERT INTO artist SELECT null, "
-          "strArtist, strMusicBrainzArtistID, "
-          "strBorn, strFormed, strGenres, strMoods, "
-          "strStyles, strInstruments, strBiography, "
-          "strDied, strDisbanded, strYearsActive, "
-          "strImage, strFanart, lastScraped "
-          "FROM artist WHERE artist.idArtist = %i", BLANKARTIST_ID);
+                            "strArtist, strMusicBrainzArtistID, "
+                            "strBorn, strFormed, strGenres, strMoods, "
+                            "strStyles, strInstruments, strBiography, "
+                            "strDied, strDisbanded, strYearsActive, "
+                            "strImage, strFanart, lastScraped "
+                            "FROM artist WHERE artist.idArtist = %i",
+                            BLANKARTIST_ID);
         m_pDS->exec(strSQL);
         int idArtist = (int)m_pDS->lastinsertid();
         //No triggers, so can delete artist without effecting other tables.
@@ -8153,13 +8629,18 @@ void CMusicDatabase::UpdateTables(int version)
         m_pDS->exec("CREATE INDEX idxAlbumArtist2 ON album_artist ( idArtist )");
         m_pDS->exec("CREATE INDEX idxDiscography ON discography ( idArtist )");
         m_pDS->exec("CREATE INDEX ix_art ON art ( media_id, media_type(20) )");
-        strSQL = PrepareSQL("UPDATE song_artist SET idArtist = %i WHERE idArtist = %i", idArtist, BLANKARTIST_ID);
+        strSQL = PrepareSQL("UPDATE song_artist SET idArtist = %i WHERE idArtist = %i", idArtist,
+                            BLANKARTIST_ID);
         m_pDS->exec(strSQL);
-        strSQL = PrepareSQL("UPDATE album_artist SET idArtist = %i WHERE idArtist = %i", idArtist, BLANKARTIST_ID);
+        strSQL = PrepareSQL("UPDATE album_artist SET idArtist = %i WHERE idArtist = %i", idArtist,
+                            BLANKARTIST_ID);
         m_pDS->exec(strSQL);
-        strSQL = PrepareSQL("UPDATE art SET media_id = %i WHERE media_id = %i AND media_type='artist'", idArtist, BLANKARTIST_ID);
+        strSQL =
+            PrepareSQL("UPDATE art SET media_id = %i WHERE media_id = %i AND media_type='artist'",
+                       idArtist, BLANKARTIST_ID);
         m_pDS->exec(strSQL);
-        strSQL = PrepareSQL("UPDATE discography SET idArtist = %i WHERE idArtist = %i", idArtist, BLANKARTIST_ID);
+        strSQL = PrepareSQL("UPDATE discography SET idArtist = %i WHERE idArtist = %i", idArtist,
+                            BLANKARTIST_ID);
         m_pDS->exec(strSQL);
         // Drop temp indices
         m_pDS->exec("DROP INDEX idxSongArtist2 ON song_artist");
@@ -8175,8 +8656,9 @@ void CMusicDatabase::UpdateTables(int version)
 
     // Create missing artist tag artist [Missing].
     // Fake MusicbrainzId assures uniqueness and avoids updates from scanned songs
-    strSQL = PrepareSQL("INSERT INTO artist (idArtist, strArtist, strMusicBrainzArtistID) VALUES( %i, '%s', '%s' )",
-      BLANKARTIST_ID, BLANKARTIST_NAME.c_str(), BLANKARTIST_FAKEMUSICBRAINZID.c_str());
+    strSQL = PrepareSQL(
+        "INSERT INTO artist (idArtist, strArtist, strMusicBrainzArtistID) VALUES( %i, '%s', '%s' )",
+        BLANKARTIST_ID, BLANKARTIST_NAME.c_str(), BLANKARTIST_FAKEMUSICBRAINZID.c_str());
     m_pDS->exec(strSQL);
 
     // Indices have been dropped making transactions very slow, so create temp index
@@ -8195,10 +8677,10 @@ void CMusicDatabase::UpdateTables(int version)
       try
       {
         strSQL = PrepareSQL("INSERT INTO song_artist(idArtist, idSong, idRole, strArtist, iOrder) "
-          "SELECT %i, idSong, %i, '%s', 0 FROM song "
-          "WHERE NOT EXISTS(SELECT idSong FROM song_artist "
-          "WHERE song_artist.idsong = song.idsong AND song_artist.idRole = %i)",
-          BLANKARTIST_ID, ROLE_ARTIST, BLANKARTIST_NAME.c_str(), ROLE_ARTIST);
+                            "SELECT %i, idSong, %i, '%s', 0 FROM song "
+                            "WHERE NOT EXISTS(SELECT idSong FROM song_artist "
+                            "WHERE song_artist.idsong = song.idsong AND song_artist.idRole = %i)",
+                            BLANKARTIST_ID, ROLE_ARTIST, BLANKARTIST_NAME.c_str(), ROLE_ARTIST);
         ExecuteQuery(strSQL);
       }
       catch (...)
@@ -8209,8 +8691,8 @@ void CMusicDatabase::UpdateTables(int version)
 
     // Ensure all albums have at least one artist, set those without to [Missing]
     strSQL = "SELECT count(idAlbum) FROM album "
-      "WHERE NOT EXISTS(SELECT idAlbum FROM album_artist "
-      "WHERE album_artist.idAlbum = album.idAlbum)";
+             "WHERE NOT EXISTS(SELECT idAlbum FROM album_artist "
+             "WHERE album_artist.idAlbum = album.idAlbum)";
     int numalbums = GetSingleValueInt(strSQL);
     if (numalbums > 0)
     {
@@ -8219,10 +8701,10 @@ void CMusicDatabase::UpdateTables(int version)
       try
       {
         strSQL = PrepareSQL("INSERT INTO album_artist(idArtist, idAlbum, strArtist, iOrder) "
-          "SELECT %i, idAlbum, '%s', 0 FROM album "
-          "WHERE NOT EXISTS(SELECT idAlbum FROM album_artist "
-          "WHERE album_artist.idAlbum = album.idAlbum)",
-          BLANKARTIST_ID, BLANKARTIST_NAME.c_str());
+                            "SELECT %i, idAlbum, '%s', 0 FROM album "
+                            "WHERE NOT EXISTS(SELECT idAlbum FROM album_artist "
+                            "WHERE album_artist.idAlbum = album.idAlbum)",
+                            BLANKARTIST_ID, BLANKARTIST_NAME.c_str());
         ExecuteQuery(strSQL);
       }
       catch (...)
@@ -8244,9 +8726,9 @@ void CMusicDatabase::UpdateTables(int version)
   {
     CLog::Log(LOGINFO, "create audiobook table");
     m_pDS->exec("CREATE TABLE audiobook (idBook integer primary key, "
-        " strBook varchar(256), strAuthor text,"
-        " bookmark integer, file text,"
-        " dateAdded varchar (20) default NULL)");
+                " strBook varchar(256), strAuthor text,"
+                " bookmark integer, file text,"
+                " dateAdded varchar (20) default NULL)");
   }
   if (version < 63)
   {
@@ -8255,75 +8737,75 @@ void CMusicDatabase::UpdateTables(int version)
 
     //Remove idThumb (column unused since v47), rename strArtists and add strArtistSort to album table
     m_pDS->exec("CREATE TABLE album_new (idAlbum integer primary key, "
-      " strAlbum varchar(256), strMusicBrainzAlbumID text, "
-      " strArtistDisp text, strArtistSort text, strGenres text, "
-      " iYear integer, bCompilation integer not null default '0', "
-      " strMoods text, strStyles text, strThemes text, "
-      " strReview text, strImage text, strLabel text, "
-      " strType text, "
-      " fRating FLOAT NOT NULL DEFAULT 0, "
-      " iUserrating INTEGER NOT NULL DEFAULT 0, "
-      " lastScraped varchar(20) default NULL, "
-      " strReleaseType text, "
-      " iVotes INTEGER NOT NULL DEFAULT 0)");
+                " strAlbum varchar(256), strMusicBrainzAlbumID text, "
+                " strArtistDisp text, strArtistSort text, strGenres text, "
+                " iYear integer, bCompilation integer not null default '0', "
+                " strMoods text, strStyles text, strThemes text, "
+                " strReview text, strImage text, strLabel text, "
+                " strType text, "
+                " fRating FLOAT NOT NULL DEFAULT 0, "
+                " iUserrating INTEGER NOT NULL DEFAULT 0, "
+                " lastScraped varchar(20) default NULL, "
+                " strReleaseType text, "
+                " iVotes INTEGER NOT NULL DEFAULT 0)");
     m_pDS->exec("INSERT INTO album_new "
-      "(idAlbum, "
-      " strAlbum, strMusicBrainzAlbumID, "
-      " strArtistDisp, strArtistSort, strGenres, "
-      " iYear, bCompilation, "
-      " strMoods, strStyles, strThemes, "
-      " strReview, strImage, strLabel, "
-      " strType, "
-      " fRating, iUserrating, iVotes, "
-      " lastScraped, "
-      " strReleaseType)"
-      " SELECT "
-      " idAlbum, "
-      " strAlbum, strMusicBrainzAlbumID, "
-      " strArtists, NULL, strGenres, "
-      " iYear, bCompilation, "
-      " strMoods, strStyles, strThemes, "
-      " strReview, strImage, strLabel, "
-      " strType, "
-      " fRating, iUserrating, iVotes, "
-      " lastScraped, "
-      " strReleaseType"
-      " FROM album");
+                "(idAlbum, "
+                " strAlbum, strMusicBrainzAlbumID, "
+                " strArtistDisp, strArtistSort, strGenres, "
+                " iYear, bCompilation, "
+                " strMoods, strStyles, strThemes, "
+                " strReview, strImage, strLabel, "
+                " strType, "
+                " fRating, iUserrating, iVotes, "
+                " lastScraped, "
+                " strReleaseType)"
+                " SELECT "
+                " idAlbum, "
+                " strAlbum, strMusicBrainzAlbumID, "
+                " strArtists, NULL, strGenres, "
+                " iYear, bCompilation, "
+                " strMoods, strStyles, strThemes, "
+                " strReview, strImage, strLabel, "
+                " strType, "
+                " fRating, iUserrating, iVotes, "
+                " lastScraped, "
+                " strReleaseType"
+                " FROM album");
     m_pDS->exec("DROP TABLE album");
     m_pDS->exec("ALTER TABLE album_new RENAME TO album");
 
     //Remove dwFileNameCRC, idThumb (columns unused since v47), rename strArtists and add strArtistSort to song table
     m_pDS->exec("CREATE TABLE song_new (idSong INTEGER PRIMARY KEY, "
-      " idAlbum INTEGER, idPath INTEGER, "
-      " strArtistDisp TEXT, strArtistSort TEXT, strGenres TEXT, strTitle VARCHAR(512), "
-      " iTrack INTEGER, iDuration INTEGER, iYear INTEGER, "
-      " strFileName TEXT, strMusicBrainzTrackID TEXT, "
-      " iTimesPlayed INTEGER, iStartOffset INTEGER, iEndOffset INTEGER, "
-      " lastplayed VARCHAR(20) DEFAULT NULL, "
-      " rating FLOAT NOT NULL DEFAULT 0, votes INTEGER NOT NULL DEFAULT 0, "
-      " userrating INTEGER NOT NULL DEFAULT 0, "
-      " comment TEXT, mood TEXT, dateAdded TEXT)");
+                " idAlbum INTEGER, idPath INTEGER, "
+                " strArtistDisp TEXT, strArtistSort TEXT, strGenres TEXT, strTitle VARCHAR(512), "
+                " iTrack INTEGER, iDuration INTEGER, iYear INTEGER, "
+                " strFileName TEXT, strMusicBrainzTrackID TEXT, "
+                " iTimesPlayed INTEGER, iStartOffset INTEGER, iEndOffset INTEGER, "
+                " lastplayed VARCHAR(20) DEFAULT NULL, "
+                " rating FLOAT NOT NULL DEFAULT 0, votes INTEGER NOT NULL DEFAULT 0, "
+                " userrating INTEGER NOT NULL DEFAULT 0, "
+                " comment TEXT, mood TEXT, dateAdded TEXT)");
     m_pDS->exec("INSERT INTO song_new "
-      "(idSong, "
-      " idAlbum, idPath, "
-      " strArtistDisp, strArtistSort, strGenres, strTitle, "
-      " iTrack, iDuration, iYear, "
-      " strFileName, strMusicBrainzTrackID, "
-      " iTimesPlayed, iStartOffset, iEndOffset, "
-      " lastplayed,"
-      " rating, userrating, votes, "
-      " comment, mood, dateAdded)"
-      " SELECT "
-      " idSong, "
-      " idAlbum, idPath, "
-      " strArtists, NULL, strGenres, strTitle, "
-      " iTrack, iDuration, iYear, "
-      " strFileName, strMusicBrainzTrackID, "
-      " iTimesPlayed, iStartOffset, iEndOffset, "
-      " lastplayed,"
-      " rating, userrating, votes, "
-      " comment, mood, dateAdded"
-      " FROM song");
+                "(idSong, "
+                " idAlbum, idPath, "
+                " strArtistDisp, strArtistSort, strGenres, strTitle, "
+                " iTrack, iDuration, iYear, "
+                " strFileName, strMusicBrainzTrackID, "
+                " iTimesPlayed, iStartOffset, iEndOffset, "
+                " lastplayed,"
+                " rating, userrating, votes, "
+                " comment, mood, dateAdded)"
+                " SELECT "
+                " idSong, "
+                " idAlbum, idPath, "
+                " strArtists, NULL, strGenres, strTitle, "
+                " iTrack, iDuration, iYear, "
+                " strFileName, strMusicBrainzTrackID, "
+                " iTimesPlayed, iStartOffset, iEndOffset, "
+                " lastplayed,"
+                " rating, userrating, votes, "
+                " comment, mood, dateAdded"
+                " FROM song");
     m_pDS->exec("DROP TABLE song");
     m_pDS->exec("ALTER TABLE song_new RENAME TO song");
   }
@@ -8345,50 +8827,60 @@ void CMusicDatabase::UpdateTables(int version)
   if (version < 67)
   {
     // Add infosetting table
-    m_pDS->exec("CREATE TABLE infosetting (idSetting INTEGER PRIMARY KEY, strScraperPath TEXT, strSettings TEXT)");
+    m_pDS->exec("CREATE TABLE infosetting (idSetting INTEGER PRIMARY KEY, strScraperPath TEXT, "
+                "strSettings TEXT)");
     // Add a new column for setting to album and artist tables
     m_pDS->exec("ALTER TABLE artist ADD idInfoSetting INTEGER NOT NULL DEFAULT 0\n");
     m_pDS->exec("ALTER TABLE album ADD idInfoSetting INTEGER NOT NULL DEFAULT 0\n");
 
     // Attempt to get album and artist specific scraper settings from the content table, extracting ids from path
-    m_pDS->exec("CREATE TABLE content_temp(id INTEGER PRIMARY KEY, idItem INTEGER, strContent text, "
-      "strScraperPath text, strSettings text)");
+    m_pDS->exec(
+        "CREATE TABLE content_temp(id INTEGER PRIMARY KEY, idItem INTEGER, strContent text, "
+        "strScraperPath text, strSettings text)");
     try
     {
       m_pDS->exec("INSERT INTO content_temp(idItem, strContent, strScraperPath, strSettings) "
-        "SELECT SUBSTR(strPath, 19, LENGTH(strPath) - 19) + 0 AS idItem, strContent, strScraperPath, strSettings "
-        "FROM content WHERE strContent = 'artists' AND strPath LIKE 'musicdb://artists/_%/' ORDER BY idItem"
-        );
+                  "SELECT SUBSTR(strPath, 19, LENGTH(strPath) - 19) + 0 AS idItem, strContent, "
+                  "strScraperPath, strSettings "
+                  "FROM content WHERE strContent = 'artists' AND strPath LIKE "
+                  "'musicdb://artists/_%/' ORDER BY idItem");
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "Migrating specific artist scraper settings has failed, settings not transferred");
+      CLog::Log(LOGERROR,
+                "Migrating specific artist scraper settings has failed, settings not transferred");
     }
     try
     {
       m_pDS->exec("INSERT INTO content_temp (idItem, strContent, strScraperPath, strSettings ) "
-        "SELECT SUBSTR(strPath, 18, LENGTH(strPath) - 18) + 0 AS idItem, strContent, strScraperPath, strSettings "
-        "FROM content WHERE strContent = 'albums' AND strPath LIKE 'musicdb://albums/_%/' ORDER BY idItem"
-      );
+                  "SELECT SUBSTR(strPath, 18, LENGTH(strPath) - 18) + 0 AS idItem, strContent, "
+                  "strScraperPath, strSettings "
+                  "FROM content WHERE strContent = 'albums' AND strPath LIKE "
+                  "'musicdb://albums/_%/' ORDER BY idItem");
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "Migrating specific album scraper settings has failed, settings not transferred");
+      CLog::Log(LOGERROR,
+                "Migrating specific album scraper settings has failed, settings not transferred");
     }
     try
     {
       m_pDS->exec("INSERT INTO infosetting(idSetting, strScraperPath, strSettings) "
-        "SELECT id, strScraperPath, strSettings FROM content_temp");
-      m_pDS->exec("UPDATE artist SET idInfoSetting = "
-        "(SELECT id FROM content_temp WHERE strContent = 'artists' AND idItem = idArtist) "
-        "WHERE EXISTS(SELECT 1 FROM content_temp WHERE strContent = 'artists' AND idItem = idArtist) ");
+                  "SELECT id, strScraperPath, strSettings FROM content_temp");
+      m_pDS->exec(
+          "UPDATE artist SET idInfoSetting = "
+          "(SELECT id FROM content_temp WHERE strContent = 'artists' AND idItem = idArtist) "
+          "WHERE EXISTS(SELECT 1 FROM content_temp WHERE strContent = 'artists' AND idItem = "
+          "idArtist) ");
       m_pDS->exec("UPDATE album SET idInfoSetting = "
-        "(SELECT id FROM content_temp WHERE strContent = 'albums' AND idItem = idAlbum) "
-        "WHERE EXISTS(SELECT 1 FROM content_temp WHERE strContent = 'albums' AND idItem = idAlbum) ");
+                  "(SELECT id FROM content_temp WHERE strContent = 'albums' AND idItem = idAlbum) "
+                  "WHERE EXISTS(SELECT 1 FROM content_temp WHERE strContent = 'albums' AND idItem "
+                  "= idAlbum) ");
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "Migrating album and artist scraper settings has failed, settings not transferred");
+      CLog::Log(LOGERROR,
+                "Migrating album and artist scraper settings has failed, settings not transferred");
     }
     m_pDS->exec("DROP TABLE content_temp");
 
@@ -8412,21 +8904,25 @@ void CMusicDatabase::UpdateTables(int version)
   if (version < 70)
   {
     // Update all songs iStartOffset and iEndOffset to milliseconds instead of frames (* 1000 / 75)
-    m_pDS->exec("UPDATE song SET iStartOffset = iStartOffset * 40 / 3, iEndOffset = iEndOffset * 40 / 3 \n");
+    m_pDS->exec("UPDATE song SET iStartOffset = iStartOffset * 40 / 3, iEndOffset = iEndOffset * "
+                "40 / 3 \n");
   }
   if (version < 71)
   {
     // Add lastscanned to versiontagscan table
     m_pDS->exec("ALTER TABLE versiontagscan ADD lastscanned VARCHAR(20)\n");
     CDateTime dateAdded = CDateTime::GetCurrentDateTime();
-    m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET lastscanned = '%s'", dateAdded.GetAsDBDateTime().c_str()));
+    m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET lastscanned = '%s'",
+                           dateAdded.GetAsDBDateTime().c_str()));
   }
   if (version < 72)
   {
     // Create source table
-    m_pDS->exec("CREATE TABLE source (idSource INTEGER PRIMARY KEY, strName TEXT, strMultipath TEXT)");
+    m_pDS->exec(
+        "CREATE TABLE source (idSource INTEGER PRIMARY KEY, strName TEXT, strMultipath TEXT)");
     // Create source_path table
-    m_pDS->exec("CREATE TABLE source_path (idSource INTEGER, idPath INTEGER, strPath varchar(512))");
+    m_pDS->exec(
+        "CREATE TABLE source_path (idSource INTEGER, idPath INTEGER, strPath varchar(512))");
     // Create album_source table
     m_pDS->exec("CREATE TABLE album_source (idSource INTEGER, idAlbum INTEGER)");
     // Populate source and source_path tables from sources.xml
@@ -8470,71 +8966,72 @@ void CMusicDatabase::UpdateTables(int version)
                 "iDiscTotal INTEGER NOT NULL DEFAULT 0, "
                 "idInfoSetting INTEGER NOT NULL DEFAULT 0)");
     // Prepare as MySQL has different CAST datatypes
-    m_pDS->exec(PrepareSQL("INSERT INTO album_new "
-                "(idalbum, strAlbum, "
-                "strMusicBrainzAlbumID, strReleaseGroupMBID, "
-                "strArtistDisp, strArtistSort, strGenres, "
-                "strReleaseDate, strOrigReleaseDate, "
-                "bBoxedSet, bCompilation, strMoods, strStyles, strThemes, "
-                "strReview, strImage, strLabel, strType, "
-                "fRating, iVotes, iUserrating, "
-                "lastScraped, bScrapedMBID, strReleaseType, "
-                "iDiscTotal, idInfoSetting) "
-                "SELECT "
-                "idAlbum, strAlbum, "
-                "strMusicBrainzAlbumID, strReleaseGroupMBID, "
-                "strArtistDisp, strArtistSort, strGenres, "
-                "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
-                "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
-                // bBoxedSet could be null if v72 not rescanned and that is invalid, tidy up now
-                "CASE WHEN bBoxedSet IS NULL THEN 0 ELSE bBoxedSet END, "
-                "bCompilation, strMoods, strStyles, strThemes, "
-                "strReview, strImage, strLabel, strType, "
-                "fRating, iVotes, iUserrating, "
-                "lastScraped, bScrapedMBID, strReleaseType, "
-                "iDiscTotal, idInfoSetting "
-                "FROM album"));
+    m_pDS->exec(
+        PrepareSQL("INSERT INTO album_new "
+                   "(idalbum, strAlbum, "
+                   "strMusicBrainzAlbumID, strReleaseGroupMBID, "
+                   "strArtistDisp, strArtistSort, strGenres, "
+                   "strReleaseDate, strOrigReleaseDate, "
+                   "bBoxedSet, bCompilation, strMoods, strStyles, strThemes, "
+                   "strReview, strImage, strLabel, strType, "
+                   "fRating, iVotes, iUserrating, "
+                   "lastScraped, bScrapedMBID, strReleaseType, "
+                   "iDiscTotal, idInfoSetting) "
+                   "SELECT "
+                   "idAlbum, strAlbum, "
+                   "strMusicBrainzAlbumID, strReleaseGroupMBID, "
+                   "strArtistDisp, strArtistSort, strGenres, "
+                   "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
+                   "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
+                   // bBoxedSet could be null if v72 not rescanned and that is invalid, tidy up now
+                   "CASE WHEN bBoxedSet IS NULL THEN 0 ELSE bBoxedSet END, "
+                   "bCompilation, strMoods, strStyles, strThemes, "
+                   "strReview, strImage, strLabel, strType, "
+                   "fRating, iVotes, iUserrating, "
+                   "lastScraped, bScrapedMBID, strReleaseType, "
+                   "iDiscTotal, idInfoSetting "
+                   "FROM album"));
     m_pDS->exec("DROP TABLE album");
     m_pDS->exec("ALTER TABLE album_new RENAME TO album");
-   
+
     //Remove iYear and add stReleaseDate, strOrigReleaseDate and iBPM columns to song table
     m_pDS->exec("CREATE TABLE song_new (idSong INTEGER PRIMARY KEY, "
-      "idAlbum INTEGER, idPath INTEGER, "
-      "strArtistDisp TEXT, strArtistSort TEXT, strGenres TEXT, strTitle VARCHAR(512), "
-      "iTrack INTEGER, iDuration INTEGER, "
-      "strReleaseDate TEXT, strOrigReleaseDate TEXT, "
-      "strDiscSubtitle TEXT, strFileName TEXT, strMusicBrainzTrackID TEXT, "
-      "iTimesPlayed INTEGER, iStartOffset INTEGER, iEndOffset INTEGER, "
-      "lastplayed VARCHAR(20) DEFAULT NULL, "
-      "rating FLOAT NOT NULL DEFAULT 0, votes INTEGER NOT NULL DEFAULT 0, "
-      "userrating INTEGER NOT NULL DEFAULT 0, "
-      "comment TEXT, mood TEXT, iBPM INTEGER NOT NULL DEFAULT 0, strReplayGain TEXT, "
-      "dateAdded TEXT)");
+                "idAlbum INTEGER, idPath INTEGER, "
+                "strArtistDisp TEXT, strArtistSort TEXT, strGenres TEXT, strTitle VARCHAR(512), "
+                "iTrack INTEGER, iDuration INTEGER, "
+                "strReleaseDate TEXT, strOrigReleaseDate TEXT, "
+                "strDiscSubtitle TEXT, strFileName TEXT, strMusicBrainzTrackID TEXT, "
+                "iTimesPlayed INTEGER, iStartOffset INTEGER, iEndOffset INTEGER, "
+                "lastplayed VARCHAR(20) DEFAULT NULL, "
+                "rating FLOAT NOT NULL DEFAULT 0, votes INTEGER NOT NULL DEFAULT 0, "
+                "userrating INTEGER NOT NULL DEFAULT 0, "
+                "comment TEXT, mood TEXT, iBPM INTEGER NOT NULL DEFAULT 0, strReplayGain TEXT, "
+                "dateAdded TEXT)");
     // Prepare as MySQL has different CAST datatypes
     m_pDS->exec(PrepareSQL("INSERT INTO song_new "
-      "(idSong, "
-      "idAlbum, idPath, "
-      "strArtistDisp, strArtistSort, strGenres, strTitle, "
-      "iTrack, iDuration, "
-      "strReleaseDate, strOrigReleaseDate, "
-      "strDiscSubtitle, strFileName, strMusicBrainzTrackID, "
-      "iTimesPlayed, iStartOffset, iEndOffset, "
-      "lastplayed, "
-      "rating, userrating, votes, "
-      "comment, mood, strReplayGain, dateAdded) "
-      "SELECT "
-      "idSong, "
-      "idAlbum, idPath, "
-      "strArtistDisp, strArtistSort, strGenres, strTitle, "
-      "iTrack, iDuration, "
-      "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
-      "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
-      "strDiscSubtitle, strFileName, strMusicBrainzTrackID, "
-      "iTimesPlayed, iStartOffset, iEndOffset, "
-      "lastplayed, "
-      "rating, userrating, votes, "
-      "comment, mood, strReplayGain, dateAdded "
-      "FROM song"));
+                           "(idSong, "
+                           "idAlbum, idPath, "
+                           "strArtistDisp, strArtistSort, strGenres, strTitle, "
+                           "iTrack, iDuration, "
+                           "strReleaseDate, strOrigReleaseDate, "
+                           "strDiscSubtitle, strFileName, strMusicBrainzTrackID, "
+                           "iTimesPlayed, iStartOffset, iEndOffset, "
+                           "lastplayed, "
+                           "rating, userrating, votes, "
+                           "comment, mood, strReplayGain, dateAdded) "
+                           "SELECT "
+                           "idSong, "
+                           "idAlbum, idPath, "
+                           "strArtistDisp, strArtistSort, strGenres, strTitle, "
+                           "iTrack, iDuration, "
+                           "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
+                           "CASE WHEN iYear > 0 THEN CAST(iYear AS TEXT) ELSE NULL END, "
+                           "strDiscSubtitle, strFileName, strMusicBrainzTrackID, "
+                           "iTimesPlayed, iStartOffset, iEndOffset, "
+                           "lastplayed, "
+                           "rating, userrating, votes, "
+                           "comment, mood, strReplayGain, dateAdded "
+                           "FROM song"));
     m_pDS->exec("DROP TABLE song");
     m_pDS->exec("ALTER TABLE song_new RENAME TO song");
   }
@@ -8571,8 +9068,8 @@ void CMusicDatabase::UpdateTables(int version)
     // Set new to dateAdded and modified to lastplayed as estimates
     // Limit those local time values to now UTC, and modified is after new
     m_pDS->exec("UPDATE song SET dateNew = dateAdded, dateModified = lastplayed");
-    m_pDS->exec(PrepareSQL("UPDATE song SET dateNew = '%s' WHERE dateNew > '%s'",
-                           strUTCNow.c_str(), strUTCNow.c_str()));
+    m_pDS->exec(PrepareSQL("UPDATE song SET dateNew = '%s' WHERE dateNew > '%s'", strUTCNow.c_str(),
+                           strUTCNow.c_str()));
     m_pDS->exec("UPDATE song SET dateModified = dateNew WHERE dateModified IS NULL");
     m_pDS->exec(PrepareSQL("UPDATE song SET dateModified = '%s' WHERE dateModified > '%s'",
                            strUTCNow.c_str(), strUTCNow.c_str()));
@@ -8587,9 +9084,9 @@ void CMusicDatabase::UpdateTables(int version)
     // Indices have been dropped making subquery very slow, so create temp index
     m_pDS->exec("CREATE INDEX idxSong3 ON song(idAlbum)");
     m_pDS->exec("UPDATE album SET dateAdded = "
-      "(SELECT MAX(song.dateAdded) FROM song WHERE song.idAlbum = album.idAlbum)");
+                "(SELECT MAX(song.dateAdded) FROM song WHERE song.idAlbum = album.idAlbum)");
     m_pDS->exec("UPDATE album SET dateNew = "
-      "(SELECT MIN(song.dateNew) FROM song WHERE song.idAlbum = album.idAlbum)");
+                "(SELECT MIN(song.dateNew) FROM song WHERE song.idAlbum = album.idAlbum)");
     m_pDS->exec("UPDATE album SET dateModified = dateNew");
     m_pDS->exec("UPDATE album SET dateModified = lastscraped WHERE lastscraped > dateModified");
     m_pDS->exec(PrepareSQL("UPDATE album SET dateModified = '%s' WHERE dateModified > '%s'",
@@ -8736,7 +9233,8 @@ int CMusicDatabase::GetMusicNeedsTagScan()
       return -1;
 
     std::string sql = "SELECT * FROM versiontagscan";
-    if (!m_pDS->query(sql)) return -1;
+    if (!m_pDS->query(sql))
+      return -1;
 
     if (m_pDS->num_rows() != 1)
     {
@@ -8780,8 +9278,8 @@ std::string CMusicDatabase::GetLibraryLastUpdated()
 void CMusicDatabase::SetLibraryLastUpdated()
 {
   CDateTime dateUpdated = CDateTime::GetUTCDateTime();
-  m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET lastscanned = '%s'", 
-                          dateUpdated.GetAsDBDateTime().c_str()));
+  m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET lastscanned = '%s'",
+                         dateUpdated.GetAsDBDateTime().c_str()));
 }
 
 std::string CMusicDatabase::GetLibraryLastCleaned()
@@ -8792,8 +9290,7 @@ std::string CMusicDatabase::GetLibraryLastCleaned()
 void CMusicDatabase::SetLibraryLastCleaned()
 {
   std::string strUpdated = CDateTime::GetUTCDateTime().GetAsDBDateTime();
-  m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET lastcleaned  = '%s'",
-                         strUpdated.c_str()));
+  m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET lastcleaned  = '%s'", strUpdated.c_str()));
 }
 
 std::string CMusicDatabase::GetArtistLinksUpdated()
@@ -8804,8 +9301,8 @@ std::string CMusicDatabase::GetArtistLinksUpdated()
 void CMusicDatabase::SetArtistLinksUpdated()
 {
   std::string strUpdated = CDateTime::GetUTCDateTime().GetAsDBDateTime();
-  m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET artistlinksupdated = '%s'",
-                         strUpdated.c_str()));
+  m_pDS->exec(
+      PrepareSQL("UPDATE versiontagscan SET artistlinksupdated = '%s'", strUpdated.c_str()));
 }
 
 std::string CMusicDatabase::GetGenresLastAdded()
@@ -8843,7 +9340,8 @@ std::string CMusicDatabase::GetArtistsLastModified()
   return GetSingleValue("SELECT MAX(dateModified) FROM artist");
 }
 
-unsigned int CMusicDatabase::GetRandomSongIDs(const Filter &filter, std::vector<std::pair<int,int> > &songIDs)
+unsigned int CMusicDatabase::GetRandomSongIDs(const Filter& filter,
+                                              std::vector<std::pair<int, int>>& songIDs)
 {
   try
   {
@@ -8857,7 +9355,8 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter &filter, std::vector<
       return false;
     strSQL += PrepareSQL(" ORDER BY RANDOM()");
 
-    if (!m_pDS->query(strSQL)) return 0;
+    if (!m_pDS->query(strSQL))
+      return 0;
     songIDs.clear();
     if (m_pDS->num_rows() == 0)
     {
@@ -8867,9 +9366,9 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter &filter, std::vector<
     songIDs.reserve(m_pDS->num_rows());
     while (!m_pDS->eof())
     {
-      songIDs.push_back(std::make_pair<int,int>(1, m_pDS->fv(song_idSong).get_asInt()));
+      songIDs.push_back(std::make_pair<int, int>(1, m_pDS->fv(song_idSong).get_asInt()));
       m_pDS->next();
-    }    // cleanup
+    } // cleanup
     m_pDS->close();
     return static_cast<unsigned int>(songIDs.size());
   }
@@ -8880,7 +9379,7 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter &filter, std::vector<
   return 0;
 }
 
-int CMusicDatabase::GetSongsCount(const Filter &filter)
+int CMusicDatabase::GetSongsCount(const Filter& filter)
 {
   try
   {
@@ -8893,7 +9392,8 @@ int CMusicDatabase::GetSongsCount(const Filter &filter)
     if (!CDatabase::BuildSQL(strSQL, filter, strSQL))
       return false;
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -8948,10 +9448,11 @@ bool CMusicDatabase::GetAlbumPaths(int idAlbum, std::vector<std::pair<std::strin
     // deliberate file organisation, or (more likely) because of a tagging error in album name
     // or Musicbrainzalbumid. Thus it avoids finding somme generic music path.
     strSQL = PrepareSQL("SELECT DISTINCT strPath, song.idPath FROM song "
-      "JOIN path ON song.idPath = path.idPath "
-      "WHERE song.idAlbum = %ld "
-      "AND (SELECT COUNT(DISTINCT(idAlbum)) FROM song AS song2 "
-      "WHERE idPath = song.idPath) = 1", idAlbum);
+                        "JOIN path ON song.idPath = path.idPath "
+                        "WHERE song.idAlbum = %ld "
+                        "AND (SELECT COUNT(DISTINCT(idAlbum)) FROM song AS song2 "
+                        "WHERE idPath = song.idPath) = 1",
+                        idAlbum);
 
     if (!m_pDS2->query(strSQL))
       return false;
@@ -8964,7 +9465,8 @@ bool CMusicDatabase::GetAlbumPaths(int idAlbum, std::vector<std::pair<std::strin
 
     while (!m_pDS2->eof())
     {
-      paths.emplace_back(m_pDS2->fv("strPath").get_asString(), m_pDS2->fv("song.idPath").get_asInt());
+      paths.emplace_back(m_pDS2->fv("strPath").get_asString(),
+                         m_pDS2->fv("song.idPath").get_asInt());
       m_pDS2->next();
     }
     // Cleanup recordset data
@@ -8991,7 +9493,8 @@ int CMusicDatabase::GetDiscnumberForPathID(int idPath)
       return -1;
 
     strSQL = PrepareSQL("SELECT DISTINCT(song.iTrack >> 16) AS discnum FROM song "
-      "WHERE idPath = %i", idPath);
+                        "WHERE idPath = %i",
+                        idPath);
 
     if (!m_pDS2->query(strSQL))
       return -1;
@@ -9013,7 +9516,7 @@ int CMusicDatabase::GetDiscnumberForPathID(int idPath)
 // It is the path common to all albums by an (album) artist, but ensure it is unique
 // to that artist and not shared with other artists. Previously this caused incorrect nfo
 // and art to be applied to multiple artists.
-bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string &basePath)
+bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string& basePath)
 {
   basePath.clear();
   try
@@ -9025,14 +9528,15 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string &basePath)
 
     // find all albums from this artist, and all the paths to the songs from those albums
     std::string strSQL = PrepareSQL("SELECT strPath FROM album_artist "
-      "JOIN song ON album_artist.idAlbum = song.idAlbum "
-      "JOIN path ON song.idPath = path.idPath "
-      "WHERE album_artist.idArtist = %ld "
-      "GROUP BY song.idPath",
-      idArtist);
+                                    "JOIN song ON album_artist.idAlbum = song.idAlbum "
+                                    "JOIN path ON song.idPath = path.idPath "
+                                    "WHERE album_artist.idArtist = %ld "
+                                    "GROUP BY song.idPath",
+                                    idArtist);
 
     // run query
-    if (!m_pDS2->query(strSQL)) return false;
+    if (!m_pDS2->query(strSQL))
+      return false;
     int iRowsFound = m_pDS2->num_rows();
     if (iRowsFound == 0)
     {
@@ -9070,11 +9574,11 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string &basePath)
     if (!basePath.empty())
     {
       strSQL = PrepareSQL("SELECT COUNT(album_artist.idArtist) FROM album_artist "
-        "JOIN song ON album_artist.idAlbum = song.idAlbum "
-        "JOIN path ON song.idPath = path.idPath "
-        "WHERE album_artist.idArtist <> %ld "
-        "AND strPath LIKE '%s%%'",
-        idArtist, basePath.c_str());
+                          "JOIN song ON album_artist.idAlbum = song.idAlbum "
+                          "JOIN path ON song.idPath = path.idPath "
+                          "WHERE album_artist.idArtist <> %ld "
+                          "AND strPath LIKE '%s%%'",
+                          idArtist, basePath.c_str());
       std::string strValue = GetSingleValue(strSQL, m_pDS2);
       if (!strValue.empty())
       {
@@ -9092,24 +9596,27 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string &basePath)
   return false;
 }
 
-bool CMusicDatabase::GetArtistPath(const CArtist& artist, std::string &path)
+bool CMusicDatabase::GetArtistPath(const CArtist& artist, std::string& path)
 {
-   // Get path for artist in the artists folder
-  path = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER);
+  // Get path for artist in the artists folder
+  path = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+      CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER);
   if (path.empty())
     return false; // No Artists folder not set;
   // Get unique artist folder name
   std::string strFolder;
   if (GetArtistFolderName(artist, strFolder))
   {
-      path = URIUtils::AddFileToFolder(path, strFolder);
-      return true;
+    path = URIUtils::AddFileToFolder(path, strFolder);
+    return true;
   }
   path.clear();
   return false;
 }
 
-bool CMusicDatabase::GetAlbumFolder(const CAlbum& album, const std::string &strAlbumPath, std::string &strFolder)
+bool CMusicDatabase::GetAlbumFolder(const CAlbum& album,
+                                    const std::string& strAlbumPath,
+                                    std::string& strFolder)
 {
   strFolder.clear();
   // Get a name for the album folder that is unique for the artist to use when
@@ -9130,12 +9637,12 @@ bool CMusicDatabase::GetAlbumFolder(const CAlbum& album, const std::string &strA
       // the same name (but different mbid). Be over cautious and look for the
       // name any where in the music file paths
       std::string strSQL = PrepareSQL("SELECT DISTINCT album_artist.idAlbum FROM album_artist "
-        "JOIN song ON album_artist.idAlbum = song.idAlbum "
-        "JOIN path on path.idPath = song.idPath "
-        "WHERE album_artist.iOrder = 0 "
-        "AND album_artist.idArtist = %ld "
-        "AND path.strPath LIKE '%%\\%s\\%%'",
-        album.artistCredits[0].GetArtistId(), strFolder.c_str());
+                                      "JOIN song ON album_artist.idAlbum = song.idAlbum "
+                                      "JOIN path on path.idPath = song.idPath "
+                                      "WHERE album_artist.iOrder = 0 "
+                                      "AND album_artist.idArtist = %ld "
+                                      "AND path.strPath LIKE '%%\\%s\\%%'",
+                                      album.artistCredits[0].GetArtistId(), strFolder.c_str());
 
       if (!m_pDS2->query(strSQL))
         return false;
@@ -9156,11 +9663,11 @@ bool CMusicDatabase::GetAlbumFolder(const CAlbum& album, const std::string &strA
   // This will not handle names that only differ by reserved chars e.g. "a>album" and "a?name"
   // will be unique in db, but produce same folder name "a_name", but that kind of album and artist naming is very unlikely
   std::string strSQL = PrepareSQL("SELECT COUNT(album_artist.idAlbum) FROM album_artist "
-    "JOIN album ON album_artist.idAlbum = album.idAlbum "
-    "WHERE album_artist.iOrder = 0 "
-    "AND album_artist.idArtist = %ld "
-    "AND album.strAlbum LIKE '%s'  ",
-    album.artistCredits[0].GetArtistId(), album.strAlbum.c_str());
+                                  "JOIN album ON album_artist.idAlbum = album.idAlbum "
+                                  "WHERE album_artist.iOrder = 0 "
+                                  "AND album_artist.idArtist = %ld "
+                                  "AND album.strAlbum LIKE '%s'  ",
+                                  album.artistCredits[0].GetArtistId(), album.strAlbum.c_str());
   std::string strValue = GetSingleValue(strSQL, m_pDS2);
   if (strValue.empty())
     return false;
@@ -9172,13 +9679,14 @@ bool CMusicDatabase::GetAlbumFolder(const CAlbum& album, const std::string &strA
   return !strFolder.empty();
 }
 
-bool CMusicDatabase::GetArtistFolderName(const CArtist &artist, std::string &strFolder)
+bool CMusicDatabase::GetArtistFolderName(const CArtist& artist, std::string& strFolder)
 {
   return GetArtistFolderName(artist.strArtist, artist.strMusicBrainzArtistID, strFolder);
 }
 
-bool CMusicDatabase::GetArtistFolderName(const std::string &strArtist, const std::string &strMusicBrainzArtistID,
-  std::string &strFolder)
+bool CMusicDatabase::GetArtistFolderName(const std::string& strArtist,
+                                         const std::string& strMusicBrainzArtistID,
+                                         std::string& strFolder)
 {
   // Create a valid unique folder name for artist
   // @todo: Does UFT8 matter or need normalizing?
@@ -9190,7 +9698,8 @@ bool CMusicDatabase::GetArtistFolderName(const std::string &strArtist, const std
   // To have duplicate artist names there must both have mbids, so append start of mbid to folder.
   // This will not handle names that only differ by reserved chars e.g. "a>name" and "a?name"
   // will be unique in db, but produce same folder name "a_name", but that kind of artist naming is very unlikely
-  std::string strSQL = PrepareSQL("SELECT COUNT(1) FROM artist WHERE strArtist LIKE '%s'", strArtist.c_str());
+  std::string strSQL =
+      PrepareSQL("SELECT COUNT(1) FROM artist WHERE strArtist LIKE '%s'", strArtist.c_str());
   std::string strValue = GetSingleValue(strSQL, m_pDS2);
   if (strValue.empty())
     return false;
@@ -9200,7 +9709,10 @@ bool CMusicDatabase::GetArtistFolderName(const std::string &strArtist, const std
   return !strFolder.empty();
 }
 
-int CMusicDatabase::AddSource(const std::string& strName, const std::string& strMultipath, const std::vector<std::string>& vecPaths, int id /*= -1*/)
+int CMusicDatabase::AddSource(const std::string& strName,
+                              const std::string& strMultipath,
+                              const std::vector<std::string>& vecPaths,
+                              int id /*= -1*/)
 {
   int idSource = -1;
   std::string strSQL;
@@ -9218,11 +9730,13 @@ int CMusicDatabase::AddSource(const std::string& strName, const std::string& str
       BeginTransaction();
       // Add new source and source paths
       if (id > 0)
-        strSQL = PrepareSQL("INSERT INTO source (idSource, strName, strMultipath) VALUES(%i, '%s', '%s')",
-          id, strName.c_str(), strMultipath.c_str());
+        strSQL = PrepareSQL("INSERT INTO source (idSource, strName, strMultipath) "
+                            "VALUES(%i, '%s', '%s')",
+                            id, strName.c_str(), strMultipath.c_str());
       else
-        strSQL = PrepareSQL("INSERT INTO source (idSource, strName, strMultipath) VALUES(NULL, '%s', '%s')",
-          strName.c_str(), strMultipath.c_str());
+        strSQL = PrepareSQL("INSERT INTO source (idSource, strName, strMultipath) "
+                            "VALUES(NULL, '%s', '%s')",
+                            strName.c_str(), strMultipath.c_str());
       m_pDS->exec(strSQL);
 
       idSource = static_cast<int>(m_pDS->lastinsertid());
@@ -9230,8 +9744,9 @@ int CMusicDatabase::AddSource(const std::string& strName, const std::string& str
       int idPath = 1;
       for (const auto& path : vecPaths)
       {
-        strSQL = PrepareSQL("INSERT INTO source_path (idSource, idPath, strPath) values(%i,%i,'%s')",
-          idSource, idPath, path.c_str());
+        strSQL = PrepareSQL("INSERT INTO source_path (idSource, idPath, strPath) "
+                            "VALUES(%i,%i,'%s')",
+                            idSource, idPath, path.c_str());
         m_pDS->exec(strSQL);
         ++idPath;
       }
@@ -9262,8 +9777,9 @@ int CMusicDatabase::AddSource(const std::string& strName, const std::string& str
         // Add album_source for related albums
         for (auto idAlbum : albumIds)
         {
-          strSQL = PrepareSQL("INSERT INTO album_source (idSource, idAlbum) VALUES('%i', '%i')",
-            idSource, idAlbum);
+          strSQL = PrepareSQL("INSERT INTO album_source (idSource, idAlbum) "
+                              "VALUES('%i', '%i')",
+                              idSource, idAlbum);
           m_pDS->exec(strSQL);
         }
       }
@@ -9280,7 +9796,10 @@ int CMusicDatabase::AddSource(const std::string& strName, const std::string& str
   return -1;
 }
 
-int CMusicDatabase::UpdateSource(const std::string& strOldName, const std::string& strName, const std::string& strMultipath, const std::vector<std::string>& vecPaths)
+int CMusicDatabase::UpdateSource(const std::string& strOldName,
+                                 const std::string& strName,
+                                 const std::string& strMultipath,
+                                 const std::vector<std::string>& vecPaths)
 {
   int idSource = -1;
   std::string strSourceMultipath;
@@ -9292,11 +9811,11 @@ int CMusicDatabase::UpdateSource(const std::string& strOldName, const std::strin
     if (nullptr == m_pDS)
       return -1;
 
-    // Get details of named old source 
+    // Get details of named old source
     if (!strOldName.empty())
     {
-      strSQL = PrepareSQL("SELECT idSource, strMultipath FROM source WHERE strName LIKE '%s'", 
-        strOldName.c_str());
+      strSQL = PrepareSQL("SELECT idSource, strMultipath FROM source WHERE strName LIKE '%s'",
+                          strOldName.c_str());
       if (!m_pDS->query(strSQL))
         return -1;
       if (m_pDS->num_rows() > 0)
@@ -9322,8 +9841,9 @@ int CMusicDatabase::UpdateSource(const std::string& strOldName, const std::strin
       // Name changed? Could be that none of the values held in db changed
       if (strOldName.compare(strName) != 0)
       {
-        strSQL = PrepareSQL("UPDATE source SET strName = '%s' WHERE idSource = %i",
-          strName.c_str(), idSource);
+        strSQL = PrepareSQL("UPDATE source SET strName = '%s' "
+                            "WHERE idSource = %i",
+                            strName.c_str(), idSource);
         m_pDS->exec(strSQL);
       }
       return idSource;
@@ -9379,14 +9899,14 @@ int CMusicDatabase::GetSourceFromPath(const std::string& strPath1)
 
     // Check if path is a source path (of many) or a subfolder of a single source
     strSQL = PrepareSQL("SELECT DISTINCT idSource FROM source_path "
-      "WHERE SUBSTR('%s', 1, LENGTH(strPath)) = strPath", strPath.c_str());
+                        "WHERE SUBSTR('%s', 1, LENGTH(strPath)) = strPath",
+                        strPath.c_str());
     if (!m_pDS->query(strSQL))
       return -1;
     if (m_pDS->num_rows() == 1)
       idSource = m_pDS->fv("idSource").get_asInt();
     m_pDS->close();
     return idSource;
-
   }
   catch (...)
   {
@@ -9399,8 +9919,9 @@ int CMusicDatabase::GetSourceFromPath(const std::string& strPath1)
 bool CMusicDatabase::AddAlbumSource(int idAlbum, int idSource)
 {
   std::string strSQL;
-  strSQL = PrepareSQL("INSERT INTO album_source (idAlbum, idSource) values(%i, %i)",
-    idAlbum, idSource);
+  strSQL = PrepareSQL("INSERT INTO album_source (idAlbum, idSource) "
+                      "VALUES(%i, %i)",
+                      idAlbum, idSource);
   return ExecuteQuery(strSQL);
 }
 
@@ -9417,9 +9938,10 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
 
     if (!strPath.empty())
     {
-      // Find sources related to album using album path       
+      // Find sources related to album using album path
       strSQL = PrepareSQL("SELECT DISTINCT idSource FROM source_path "
-        "WHERE SUBSTR('%s', 1, LENGTH(strPath)) = strPath", strPath.c_str());
+                          "WHERE SUBSTR('%s', 1, LENGTH(strPath)) = strPath",
+                          strPath.c_str());
       if (!m_pDS->query(strSQL))
         return false;
       while (!m_pDS->eof())
@@ -9430,7 +9952,7 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
       m_pDS->close();
     }
     else
-    { 
+    {
       // Find sources using song paths, check each source path individually
       if (nullptr == m_pDS2)
         return false;
@@ -9441,8 +9963,9 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
       {
         std::string sourcepath = m_pDS->fv("strPath").get_asString();
         strSQL = PrepareSQL("SELECT 1 FROM song "
-          "JOIN path ON song.idPath = path.idPath "
-          "WHERE song.idAlbum = %i AND path.strPath LIKE '%s%%%%'", sourcepath.c_str());
+                            "JOIN path ON song.idPath = path.idPath "
+                            "WHERE song.idAlbum = %i AND path.strPath LIKE '%s%%%%'",
+                            sourcepath.c_str());
         if (!m_pDS2->query(strSQL))
           return false;
         if (m_pDS2->num_rows() > 0)
@@ -9459,7 +9982,7 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
     {
       AddAlbumSource(idAlbum, idSource);
     }
-    
+
     return true;
   }
   catch (...)
@@ -9501,7 +10024,8 @@ bool CMusicDatabase::CheckSources(VECSOURCES& sources)
     {
       // Check each source by name
       strSQL = PrepareSQL("SELECT idSource, strMultipath FROM source "
-        "WHERE strName LIKE '%s'", source.strName.c_str());
+                          "WHERE strName LIKE '%s'",
+                          source.strName.c_str());
       m_pDS->query(strSQL);
       if (!m_pDS->query(strSQL))
         return false;
@@ -9540,14 +10064,15 @@ bool CMusicDatabase::MigrateSources()
 
   std::string strSQL;
   try
-  {   
+  {
     // Fill source and source paths tables
     for (const auto& source : sources)
     {
       // AddSource(source.strName, source.strPath, source.vecPaths);
       // Add new source
-      strSQL = PrepareSQL("INSERT INTO source (idSource, strName, strMultipath) VALUES(NULL, '%s', '%s')",
-        source.strName.c_str(), source.strPath.c_str());
+      strSQL = PrepareSQL("INSERT INTO source (idSource, strName, strMultipath) "
+                          "VALUES(NULL, '%s', '%s')",
+                          source.strName.c_str(), source.strPath.c_str());
       m_pDS->exec(strSQL);
       int idSource = static_cast<int>(m_pDS->lastinsertid());
 
@@ -9555,11 +10080,12 @@ bool CMusicDatabase::MigrateSources()
       int idPath = 1;
       for (const auto& path : source.vecPaths)
       {
-        strSQL = PrepareSQL("INSERT INTO source_path (idSource, idPath, strPath) values(%i,%i,'%s')",
-          idSource, idPath, path.c_str());
+        strSQL = PrepareSQL("INSERT INTO source_path (idSource, idPath, strPath) "
+                            "VALUES(%i,%i,'%s')",
+                            idSource, idPath, path.c_str());
         m_pDS->exec(strSQL);
         ++idPath;
-      }  
+      }
     }
 
     return true;
@@ -9571,18 +10097,18 @@ bool CMusicDatabase::MigrateSources()
   return false;
 }
 
- bool CMusicDatabase::UpdateSources()
+bool CMusicDatabase::UpdateSources()
 {
   //Check library and xml sources match
   VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
   if (CheckSources(sources))
     return true;
-  
+
   try
-  {  
+  {
     // Empty sources table (related link tables removed by trigger);
     ExecuteQuery("DELETE FROM source");
-  
+
     // Fill source table, and album sources
     for (const auto& source : sources)
       AddSource(source.strName, source.strPath, source.vecPaths);
@@ -9606,9 +10132,10 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
       return false;
 
     // Get music sources and individual source paths (may not be scanned or have albums etc.)
-    std::string strSQL = "SELECT source.idSource, source.strName, source.strMultipath, source_path.strPath "
-      "FROM source JOIN source_path ON source.idSource = source_path.idSource "
-      "ORDER BY source.idSource, source_path.idPath";
+    std::string strSQL =
+        "SELECT source.idSource, source.strName, source.strMultipath, source_path.strPath "
+        "FROM source JOIN source_path ON source.idSource = source_path.idSource "
+        "ORDER BY source.idSource, source_path.idPath";
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     if (!m_pDS->query(strSQL))
@@ -9680,10 +10207,11 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
   {
     std::string strSQL;
     strSQL = PrepareSQL("SELECT DISTINCT album_source.idSource FROM artist "
-      "JOIN album_artist ON album_artist.idArtist = artist.idArtist "
-      "JOIN album_source ON album_source.idAlbum = album_artist.idAlbum "
-      "WHERE artist.idArtist = %i "
-      "ORDER BY album_source.idSource", idArtist);
+                        "JOIN album_artist ON album_artist.idArtist = artist.idArtist "
+                        "JOIN album_source ON album_source.idAlbum = album_artist.idAlbum "
+                        "WHERE artist.idArtist = %i "
+                        "ORDER BY album_source.idSource",
+                        idArtist);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
@@ -9692,10 +10220,11 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
       // Check via songs fetch sources from compilations or where they are guest artist
       m_pDS->close();
       strSQL = PrepareSQL("SELECT DISTINCT album_source.idSource, FROM song_artist "
-        "JOIN song ON song_artist.idSong = song.idSong "
-        "JOIN album_source ON album_source.idAlbum = song.idAlbum "
-        "WHERE song_artist.idArtist = %i AND song_artist.idRole = 1 "
-        "ORDER BY album_source.idSource", idArtist);
+                          "JOIN song ON song_artist.idSong = song.idSong "
+                          "JOIN album_source ON album_source.idAlbum = song.idAlbum "
+                          "WHERE song_artist.idArtist = %i AND song_artist.idRole = 1 "
+                          "ORDER BY album_source.idSource",
+                          idArtist);
       if (!m_pDS->query(strSQL))
         return false;
       if (m_pDS->num_rows() == 0)
@@ -9708,7 +10237,7 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
 
     CVariant artistSources(CVariant::VariantTypeArray);
     while (!m_pDS->eof())
-    {      
+    {
       artistSources.push_back(m_pDS->fv("idSource").get_asInt());
       m_pDS->next();
     }
@@ -9735,8 +10264,9 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
   {
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idSource FROM album_source "
-      "WHERE album_source.idAlbum = %i "
-      "ORDER BY idSource", idAlbum);
+                        "WHERE album_source.idAlbum = %i "
+                        "ORDER BY idSource",
+                        idAlbum);
     if (!m_pDS->query(strSQL))
       return false;
     CVariant albumSources(CVariant::VariantTypeArray);
@@ -9749,7 +10279,7 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
       }
       m_pDS->close();
     }
-    else 
+    else
     {
       //! @todo: handle singles, or don't waste time checking songs
       // Album does have any sources, may be a single??
@@ -9766,8 +10296,9 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
       {
         std::string sourcepath = m_pDS->fv("strPath").get_asString();
         strSQL = PrepareSQL("SELECT 1 FROM song "
-          "JOIN path ON song.idPath = path.idPath "
-          "WHERE song.idAlbum = %i AND path.strPath LIKE '%s%%%%'", idAlbum, sourcepath.c_str());
+                            "JOIN path ON song.idPath = path.idPath "
+                            "WHERE song.idAlbum = %i AND path.strPath LIKE '%s%%%%'",
+                            idAlbum, sourcepath.c_str());
         if (!m_pDS2->query(strSQL))
           return false;
         if (m_pDS2->num_rows() > 0)
@@ -9779,7 +10310,7 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
       m_pDS->close();
     }
 
-    
+
     item->SetProperty("sourceid", albumSources);
     return true;
   }
@@ -9801,9 +10332,10 @@ bool CMusicDatabase::GetSourcesBySong(int idSong, const std::string& strPath1, C
   {
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idSource FROM song "
-      "JOIN album_source ON album_source.idAlbum = song.idAlbum "
-      "WHERE song.idSong = %i "
-      "ORDER BY idSource", idSong);
+                        "JOIN album_source ON album_source.idAlbum = song.idAlbum "
+                        "WHERE song.idSong = %i "
+                        "ORDER BY idSource",
+                        idSong);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0 && !strPath1.empty())
@@ -9815,7 +10347,8 @@ bool CMusicDatabase::GetSourcesBySong(int idSong, const std::string& strPath1, C
         URIUtils::AddSlashAtEnd(strPath);
 
       strSQL = PrepareSQL("SELECT DISTINCT idSource FROM source_path "
-        "WHERE SUBSTR('%s', 1, LENGTH(strPath)) = strPath", strPath.c_str());
+                          "WHERE SUBSTR('%s', 1, LENGTH(strPath)) = strPath",
+                          strPath.c_str());
       if (!m_pDS->query(strSQL))
         return false;
     }
@@ -9849,7 +10382,8 @@ int CMusicDatabase::GetSourceByName(const std::string& strSource)
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idSource FROM source WHERE strName LIKE '%s'", strSource.c_str());
     // run query
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -9879,10 +10413,12 @@ int CMusicDatabase::GetArtistByName(const std::string& strArtist)
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL=PrepareSQL("select idArtist from artist where artist.strArtist like '%s'", strArtist.c_str());
+    std::string strSQL = PrepareSQL("SELECT idArtist FROM artist WHERE artist.strArtist LIKE '%s'",
+                                    strArtist.c_str());
 
     // run query
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -9909,13 +10445,16 @@ int CMusicDatabase::GetArtistByMatch(const CArtist& artist)
       return false;
     // Match on MusicBrainz ID, definitively unique
     if (!artist.strMusicBrainzArtistID.empty())
-      strSQL = PrepareSQL("SELECT idArtist FROM artist WHERE strMusicBrainzArtistID = '%s'",
-        artist.strMusicBrainzArtistID.c_str());
+      strSQL = PrepareSQL("SELECT idArtist FROM artist "
+                          "WHERE strMusicBrainzArtistID = '%s'",
+                          artist.strMusicBrainzArtistID.c_str());
     else
-    // No MusicBrainz ID, artist by name with no mbid
-    strSQL = PrepareSQL("SELECT idArtist FROM artist WHERE strArtist LIKE '%s' AND strMusicBrainzArtistID IS NULL",
-      artist.strArtist.c_str());
-    if (!m_pDS->query(strSQL)) return false;
+      // No MusicBrainz ID, artist by name with no mbid
+      strSQL = PrepareSQL("SELECT idArtist FROM artist "
+                          "WHERE strArtist LIKE '%s' AND strMusicBrainzArtistID IS NULL",
+                          artist.strArtist.c_str());
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -9934,7 +10473,7 @@ int CMusicDatabase::GetArtistByMatch(const CArtist& artist)
   return -1;
 }
 
-bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist &artist)
+bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist& artist)
 {
   try
   {
@@ -9944,11 +10483,12 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist &artist)
       return false;
 
     std::string strSQL = PrepareSQL(
-      "SELECT artistview.* FROM song_artist "
-      "JOIN artistview ON song_artist.idArtist = artistview.idArtist "
-      "WHERE song_artist.idSong= %i AND song_artist.idRole = 1 AND song_artist.iOrder = 0",
-      idSong);
-    if (!m_pDS->query(strSQL)) return false;
+        "SELECT artistview.* FROM song_artist "
+        "JOIN artistview ON song_artist.idArtist = artistview.idArtist "
+        "WHERE song_artist.idSong= %i AND song_artist.idRole = 1 AND song_artist.iOrder = 0",
+        idSong);
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -9960,7 +10500,6 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist &artist)
 
     m_pDS->close();
     return true;
-
   }
   catch (...)
   {
@@ -9971,20 +10510,19 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist &artist)
 
 bool CMusicDatabase::IsSongArtist(int idSong, int idArtist)
 {
-  std::string strSQL = PrepareSQL(
-    "SELECT 1 FROM song_artist "
-    "WHERE song_artist.idSong= %i AND "
-    "song_artist.idArtist = %i AND song_artist.idRole = 1",
-    idSong, idArtist);
+  std::string strSQL = PrepareSQL("SELECT 1 FROM song_artist "
+                                  "WHERE song_artist.idSong= %i AND "
+                                  "song_artist.idArtist = %i AND song_artist.idRole = 1",
+                                  idSong, idArtist);
   return GetSingleValue(strSQL).empty();
 }
 
 bool CMusicDatabase::IsSongAlbumArtist(int idSong, int idArtist)
 {
-  std::string strSQL = PrepareSQL(
-    "SELECT 1 FROM song JOIN album_artist ON song.idAlbum = album_artist.idAlbum "
-    "WHERE song.idSong = %i AND album_artist.idArtist = %i",
-    idSong, idArtist);
+  std::string strSQL =
+      PrepareSQL("SELECT 1 FROM song JOIN album_artist ON song.idAlbum = album_artist.idAlbum "
+                 "WHERE song.idSong = %i AND album_artist.idArtist = %i",
+                 idSong, idArtist);
   return GetSingleValue(strSQL).empty();
 }
 
@@ -10006,11 +10544,15 @@ int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::strin
 
     std::string strSQL;
     if (strArtist.empty())
-      strSQL=PrepareSQL("SELECT idAlbum FROM album WHERE album.strAlbum LIKE '%s'", strAlbum.c_str());
+      strSQL =
+          PrepareSQL("SELECT idAlbum FROM album WHERE album.strAlbum LIKE '%s'", strAlbum.c_str());
     else
-      strSQL=PrepareSQL("SELECT idAlbum FROM album WHERE album.strAlbum LIKE '%s' AND album.strArtistDisp LIKE '%s'", strAlbum.c_str(),strArtist.c_str());
+      strSQL = PrepareSQL("SELECT idAlbum FROM album "
+                          "WHERE album.strAlbum LIKE '%s' AND album.strArtistDisp LIKE '%s'",
+                          strAlbum.c_str(), strArtist.c_str());
     // run query
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -10046,14 +10588,12 @@ bool CMusicDatabase::GetMatchingMusicVideoAlbum(const std::string& strAlbum,
 
     std::string strSQL;
     if (strArtist.empty())
-      strSQL =
-          PrepareSQL("SELECT idAlbum, strReview FROM album WHERE album.strAlbum LIKE '%s'",
-                     strAlbum.c_str());
+      strSQL = PrepareSQL("SELECT idAlbum, strReview FROM album WHERE album.strAlbum LIKE '%s'",
+                          strAlbum.c_str());
     else
-      strSQL =
-          PrepareSQL("SELECT idAlbum, strReview FROM album WHERE album.strAlbum LIKE '%s' AND "
-                     "album.strArtistDisp LIKE '%s'",
-                     strAlbum.c_str(), strArtist.c_str());
+      strSQL = PrepareSQL("SELECT idAlbum, strReview FROM album "
+                          "WHERE album.strAlbum LIKE '%s' AND album.strArtistDisp LIKE '%s'",
+                          strAlbum.c_str(), strArtist.c_str());
     // run query
     if (!m_pDS->query(strSQL))
       return false;
@@ -10083,9 +10623,9 @@ bool CMusicDatabase::SearchAlbumsByArtistName(const std::string& strArtist, CFil
 
     std::string strSQL;
     strSQL = PrepareSQL("SELECT albumview.* FROM albumview "
-      "JOIN album_artist ON album_artist.idAlbum = albumview.idAlbum "
-      "WHERE  album_artist.strArtist LIKE '%s'",
-      strArtist.c_str());
+                        "JOIN album_artist ON album_artist.idAlbum = albumview.idAlbum "
+                        "WHERE  album_artist.strArtist LIKE '%s'",
+                        strArtist.c_str());
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -10096,7 +10636,7 @@ bool CMusicDatabase::SearchAlbumsByArtistName(const std::string& strArtist, CFil
       std::string path = StringUtils::Format("musicdb://albums/%ld/", album.idAlbum);
       CFileItemPtr pItem(new CFileItem(path, album));
       std::string label =
-        StringUtils::Format("%s (%i)", album.strAlbum, pItem->GetMusicInfoTag()->GetYear());
+          StringUtils::Format("%s (%i)", album.strAlbum, pItem->GetMusicInfoTag()->GetYear());
       pItem->SetLabel(label);
       items.Add(pItem);
       m_pDS->next();
@@ -10111,12 +10651,17 @@ bool CMusicDatabase::SearchAlbumsByArtistName(const std::string& strArtist, CFil
   return false;
 }
 
-int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::vector<std::string>& artist)
+int CMusicDatabase::GetAlbumByName(const std::string& strAlbum,
+                                   const std::vector<std::string>& artist)
 {
-  return GetAlbumByName(strAlbum, StringUtils::Join(artist, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator));
+  return GetAlbumByName(
+      strAlbum,
+      StringUtils::Join(
+          artist,
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator));
 }
 
-int CMusicDatabase::GetAlbumByMatch(const CAlbum &album)
+int CMusicDatabase::GetAlbumByMatch(const CAlbum& album)
 {
   std::string strSQL;
   try
@@ -10125,14 +10670,17 @@ int CMusicDatabase::GetAlbumByMatch(const CAlbum &album)
       return false;
     // Match on MusicBrainz ID, definitively unique
     if (!album.strMusicBrainzAlbumID.empty())
-      strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE strMusicBrainzAlbumID = '%s'", album.strMusicBrainzAlbumID.c_str());
+      strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE strMusicBrainzAlbumID = '%s'",
+                          album.strMusicBrainzAlbumID.c_str());
     else
       // No mbid, match on album title and album artist descriptive string, ignore those with mbid
-      strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE strArtistDisp LIKE '%s' AND strAlbum LIKE '%s' AND strMusicBrainzAlbumID IS NULL",
-        album.GetAlbumArtistString().c_str(),
-        album.strAlbum.c_str());
+      strSQL = PrepareSQL("SELECT idAlbum FROM album "
+                          "WHERE strArtistDisp LIKE '%s' AND strAlbum LIKE '%s' "
+                          "AND strMusicBrainzAlbumID IS NULL",
+                          album.GetAlbumArtistString().c_str(), album.strAlbum.c_str());
     m_pDS->query(strSQL);
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -10171,8 +10719,8 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
   // Propagate artist sort names into concatenated artist sort name string for songs and albums
   // Avoid updating records where sort same as strArtistDisp
   std::string strSQL;
- 
-  // MySQL syntax for GROUP_CONCAT with order is different from that in SQLite 
+
+  // MySQL syntax for GROUP_CONCAT with order is different from that in SQLite
   // (not handled by PrepareSQL)
   bool bisMySQL = StringUtils::EqualsNoCase(
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic.type, "mysql");
@@ -10197,10 +10745,13 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
 
   strSQL = "UPDATE album SET strArtistSort = " + strSQL +
            "WHERE (album.strArtistSort = '' OR album.strArtistSort IS NULL) "
-           "AND strArtistDisp <> " + strSQL;
+           "AND strArtistDisp <> " +
+           strSQL;
   if (idArtist > 0)
-    strSQL += PrepareSQL(" AND EXISTS (SELECT 1 FROM album_artist WHERE album_artist.idArtist = %ld "
-      "AND album_artist.idAlbum = album.idAlbum)", idArtist);
+    strSQL +=
+        PrepareSQL(" AND EXISTS (SELECT 1 FROM album_artist WHERE album_artist.idArtist = %ld "
+                   "AND album_artist.idAlbum = album.idAlbum)",
+                   idArtist);
   ExecuteQuery(strSQL);
   CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
 
@@ -10223,10 +10774,12 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
 
   strSQL = "UPDATE song SET strArtistSort = " + strSQL +
            "WHERE (song.strArtistSort = '' OR song.strArtistSort IS NULL) "
-           "AND strArtistDisp <> " + strSQL;
+           "AND strArtistDisp <> " +
+           strSQL;
   if (idArtist > 0)
     strSQL += PrepareSQL(" AND EXISTS (SELECT 1 FROM song_artist WHERE song_artist.idArtist = %ld "
-      "AND song_artist.idSong = song.idSong AND song_artist.idRole = 1)", idArtist);
+                         "AND song_artist.idSong = song.idSong AND song_artist.idRole = 1)",
+                         idArtist);
   ExecuteQuery(strSQL);
   CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
 
@@ -10252,9 +10805,12 @@ int CMusicDatabase::GetGenreByName(const std::string& strGenre)
       return false;
 
     std::string strSQL;
-    strSQL=PrepareSQL("select idGenre from genre where genre.strGenre like '%s'", strGenre.c_str());
+    strSQL = PrepareSQL("SELECT idGenre FROM genre "
+                        "WHERE genre.strGenre LIKE '%s'",
+                        strGenre.c_str());
     // run query
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -10294,13 +10850,13 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
       extFilter.AppendJoin("LEFT JOIN album_source on album_source.idAlbum = album.idAlbum");
       extFilter.AppendOrder("genre.strGenre");
       extFilter.AppendOrder("album_source.idSource");
-    }   
+    }
     extFilter.AppendWhere("genre.strGenre != ''");
 
     std::string strSQLExtra;
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
-   
+
     strSQL = PrepareSQL(strSQL.c_str(), extFilter.fields.c_str()) + strSQLExtra;
 
     // run query
@@ -10332,7 +10888,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
           items[items.Size() - 1].get()->SetProperty("sourceid", genreSources);
           genreSources.clear();
         }
-        idGenre = m_pDS->fv("genre.idGenre").get_asInt();       
+        idGenre = m_pDS->fv("genre.idGenre").get_asInt();
         std::string strGenre = m_pDS->fv("genre.strGenre").get_asString();
         CFileItemPtr pItem(new CFileItem(strGenre));
         pItem->GetMusicInfoTag()->SetTitle(strGenre);
@@ -10408,23 +10964,29 @@ int CMusicDatabase::GetCompilationAlbumsCount()
 
 int CMusicDatabase::GetSinglesCount()
 {
-  CDatabase::Filter filter(PrepareSQL("songview.idAlbum IN (SELECT idAlbum FROM album WHERE strReleaseType = '%s')", CAlbum::ReleaseTypeToString(CAlbum::Single).c_str()));
+  CDatabase::Filter filter(
+      PrepareSQL("songview.idAlbum IN (SELECT idAlbum FROM album WHERE strReleaseType = '%s')",
+                 CAlbum::ReleaseTypeToString(CAlbum::Single).c_str()));
   return GetSongsCount(filter);
 }
 
 int CMusicDatabase::GetArtistCountForRole(int role)
 {
-  std::string strSQL = PrepareSQL("SELECT COUNT(DISTINCT idartist) FROM song_artist WHERE song_artist.idRole = %i", role);
+  std::string strSQL = PrepareSQL(
+      "SELECT COUNT(DISTINCT idartist) FROM song_artist WHERE song_artist.idRole = %i", role);
   return GetSingleValueInt(strSQL);
 }
 
 int CMusicDatabase::GetArtistCountForRole(const std::string& strRole)
 {
-  std::string strSQL = PrepareSQL("SELECT COUNT(DISTINCT idartist) FROM song_artist JOIN role ON song_artist.idRole = role.idRole WHERE role.strRole LIKE '%s'", strRole.c_str());
+  std::string strSQL = PrepareSQL("SELECT COUNT(DISTINCT idartist) FROM song_artist "
+                                  "JOIN role ON song_artist.idRole = role.idRole "
+                                  "WHERE role.strRole LIKE '%s'",
+                                  strRole.c_str());
   return GetSingleValueInt(strSQL);
 }
 
-bool CMusicDatabase::SetPathHash(const std::string &path, const std::string &hash)
+bool CMusicDatabase::SetPathHash(const std::string& path, const std::string& hash)
 {
   try
   {
@@ -10440,9 +11002,11 @@ bool CMusicDatabase::SetPathHash(const std::string &path, const std::string &has
         return false;
     }
     int idPath = AddPath(path);
-    if (idPath < 0) return false;
+    if (idPath < 0)
+      return false;
 
-    std::string strSQL=PrepareSQL("update path set strHash='%s' where idPath=%ld", hash.c_str(), idPath);
+    std::string strSQL =
+        PrepareSQL("UPDATE path SET strHash='%s' WHERE idPath=%ld", hash.c_str(), idPath);
     m_pDS->exec(strSQL);
 
     return true;
@@ -10455,7 +11019,7 @@ bool CMusicDatabase::SetPathHash(const std::string &path, const std::string &has
   return false;
 }
 
-bool CMusicDatabase::GetPathHash(const std::string &path, std::string &hash)
+bool CMusicDatabase::GetPathHash(const std::string& path, std::string& hash)
 {
   try
   {
@@ -10464,7 +11028,7 @@ bool CMusicDatabase::GetPathHash(const std::string &path, std::string &hash)
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
+    std::string strSQL = PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
       return false;
@@ -10479,7 +11043,7 @@ bool CMusicDatabase::GetPathHash(const std::string &path, std::string &hash)
   return false;
 }
 
-bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& songmap, bool exact)
+bool CMusicDatabase::RemoveSongsFromPath(const std::string& path1, MAPSONGS& songmap, bool exact)
 {
   // We need to remove all songs from this path, as their tags are going
   // to be re-read.  We need to remove all songs from the song table + all links to them
@@ -10521,15 +11085,17 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& son
 
     // Filename is not unique for a path as songs from a cuesheet have same filename.
     // Songs from cuesheets often have consecutive ID but not always e.g. more than one cuesheet
-    // in a folder and some edited and rescanned.    
+    // in a folder and some edited and rescanned.
     // Hence order by filename so these songs can be gathered together.
     std::string where;
     if (exact)
-      where = PrepareSQL(" where strPath='%s'", path.c_str());
+      where = PrepareSQL(" WHERE strPath='%s'", path.c_str());
     else
-      where = PrepareSQL(" where SUBSTR(strPath,1,%i)='%s'", StringUtils::utf8_strlen(path.c_str()), path.c_str());
-    std::string sql = "select * from songview" + where + " ORDER BY strFileName";
-    if (!m_pDS->query(sql)) return false;
+      where = PrepareSQL(" WHERE SUBSTR(strPath,1,%i)='%s'", StringUtils::utf8_strlen(path.c_str()),
+                         path.c_str());
+    std::string sql = "SELECT * FROM songview" + where + " ORDER BY strFileName";
+    if (!m_pDS->query(sql))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound > 0)
     {
@@ -10554,7 +11120,7 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& son
         m_pDS->next();
       }
       m_pDS->close();
-      songmap.insert(std::make_pair(filename, songs));  // Save songs for last filename
+      songmap.insert(std::make_pair(filename, songs)); // Save songs for last filename
 
       //! @todo move this below the m_pDS->exec block, once UPnP doesn't rely on this anymore
       for (const auto& id : songIds)
@@ -10588,7 +11154,7 @@ void CMusicDatabase::CheckArtistLinksChanged()
   }
 }
 
-bool CMusicDatabase::GetPaths(std::set<std::string> &paths)
+bool CMusicDatabase::GetPaths(std::set<std::string>& paths)
 {
   try
   {
@@ -10600,7 +11166,8 @@ bool CMusicDatabase::GetPaths(std::set<std::string> &paths)
     paths.clear();
 
     // find all paths
-    if (!m_pDS->query("select strPath from path")) return false;
+    if (!m_pDS->query("SELECT strPath FROM path"))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -10622,18 +11189,20 @@ bool CMusicDatabase::GetPaths(std::set<std::string> &paths)
   return false;
 }
 
-bool CMusicDatabase::SetSongUserrating(const std::string &filePath, int userrating)
+bool CMusicDatabase::SetSongUserrating(const std::string& filePath, int userrating)
 {
   try
   {
-    if (filePath.empty()) return false;
+    if (filePath.empty())
+      return false;
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS)
       return false;
 
     int songID = GetSongIDFromPath(filePath);
-    if (-1 == songID) return false;
+    if (-1 == songID)
+      return false;
 
     return SetSongUserrating(songID, userrating);
   }
@@ -10674,7 +11243,8 @@ bool CMusicDatabase::SetAlbumUserrating(const int idAlbum, int userrating)
     if (nullptr == m_pDS)
       return false;
 
-    if (-1 == idAlbum) return false;
+    if (-1 == idAlbum)
+      return false;
     std::string sql =
         PrepareSQL("UPDATE album SET iUserrating='%i' WHERE idAlbum = %i", userrating, idAlbum);
     m_pDS->exec(sql);
@@ -10687,21 +11257,22 @@ bool CMusicDatabase::SetAlbumUserrating(const int idAlbum, int userrating)
   return false;
 }
 
-bool CMusicDatabase::SetSongVotes(const std::string &filePath, int votes)
+bool CMusicDatabase::SetSongVotes(const std::string& filePath, int votes)
 {
   try
   {
-    if (filePath.empty()) return false;
+    if (filePath.empty())
+      return false;
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS)
       return false;
 
     int songID = GetSongIDFromPath(filePath);
-    if (-1 == songID) return false;
+    if (-1 == songID)
+      return false;
 
-    std::string sql =
-      PrepareSQL("UPDATE song SET votes ='%i' WHERE idSong = %i", votes, songID);
+    std::string sql = PrepareSQL("UPDATE song SET votes ='%i' WHERE idSong = %i", votes, songID);
 
     m_pDS->exec(sql);
     return true;
@@ -10713,13 +11284,13 @@ bool CMusicDatabase::SetSongVotes(const std::string &filePath, int votes)
   return false;
 }
 
-int CMusicDatabase::GetSongIDFromPath(const std::string &filePath)
+int CMusicDatabase::GetSongIDFromPath(const std::string& filePath)
 {
   // grab the where string to identify the song id
   CURL url(filePath);
   if (url.IsProtocol("musicdb"))
   {
-    std::string strFile=URIUtils::GetFileName(filePath);
+    std::string strFile = URIUtils::GetFileName(filePath);
     URIUtils::RemoveExtension(strFile);
     return atoi(strFile.c_str());
   }
@@ -10735,8 +11306,11 @@ int CMusicDatabase::GetSongIDFromPath(const std::string &filePath)
     SplitPath(filePath, strPath, strFileName);
     URIUtils::AddSlashAtEnd(strPath);
 
-    std::string sql = PrepareSQL("select idSong from song join path on song.idPath = path.idPath where song.strFileName='%s' and path.strPath='%s'", strFileName.c_str(), strPath.c_str());
-    if (!m_pDS->query(sql)) return -1;
+    std::string sql = PrepareSQL("SELECT idSong FROM song JOIN path ON song.idPath = path.idPath "
+                                 "WHERE song.strFileName='%s' AND path.strPath='%s'",
+                                 strFileName.c_str(), strPath.c_str());
+    if (!m_pDS->query(sql))
+      return -1;
 
     if (m_pDS->num_rows() == 0)
     {
@@ -10762,7 +11336,8 @@ bool CMusicDatabase::CommitTransaction()
     CGUIComponent* gui = CServiceBroker::GetGUI();
     if (gui)
     {
-      gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().SetLibraryBool(LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
+      gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().SetLibraryBool(
+          LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
       return true;
     }
   }
@@ -10798,7 +11373,7 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
       content = CONTENT_ALBUMS;
     }
     else
-      return false;  //Only artists and albums have info settings
+      return false; //Only artists and albums have info settings
 
     std::string strSQLWhere;
     if (!BuildSQL(strSQLWhere, extFilter, strSQLWhere))
@@ -10885,9 +11460,11 @@ bool CMusicDatabase::SetScraper(int id,
       m_pDS->exec(strSQL);
     }
     else
-    {  // Update info setting
-      strSQL = "UPDATE infosetting SET strScraperPath = '%s', strSettings = '%s' WHERE idSetting = %i";
-      strSQL = PrepareSQL(strSQL, scraper->ID().c_str(), scraper->GetPathSettings().c_str(), idSetting);
+    { // Update info setting
+      strSQL = "UPDATE infosetting SET strScraperPath = '%s', strSettings = '%s' "
+               "WHERE idSetting = %i";
+      strSQL =
+          PrepareSQL(strSQL, scraper->ID().c_str(), scraper->GetPathSettings().c_str(), idSetting);
       m_pDS->exec(strSQL);
     }
     CommitTransaction();
@@ -10901,7 +11478,7 @@ bool CMusicDatabase::SetScraper(int id,
   return false;
 }
 
-bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE &content, ADDON::ScraperPtr& scraper)
+bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE& content, ADDON::ScraperPtr& scraper)
 {
   std::string scraperUUID;
   std::string strSettings;
@@ -10915,9 +11492,11 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE &content, ADDON::Scra
     std::string strSQL;
     strSQL = "SELECT strScraperPath, strSettings FROM infosetting JOIN ";
     if (content == CONTENT_ARTISTS)
-      strSQL = strSQL + "artist ON artist.idInfoSetting = infosetting.idSetting WHERE artist.idArtist = %i";
+      strSQL = strSQL + "artist ON artist.idInfoSetting = infosetting.idSetting "
+                        "WHERE artist.idArtist = %i";
     else
-      strSQL = strSQL + "album ON album.idInfoSetting = infosetting.idSetting WHERE album.idAlbum = %i";
+      strSQL = strSQL + "album ON album.idInfoSetting = infosetting.idSetting "
+                        "WHERE album.idAlbum = %i";
     strSQL = PrepareSQL(strSQL, id);
     m_pDS->query(strSQL);
     if (!m_pDS->eof())
@@ -10943,7 +11522,8 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE &content, ADDON::Scra
     if (!scraper)
     { // use default music scraper instead
       ADDON::AddonPtr addon;
-      if(ADDON::CAddonSystemSettings::GetInstance().GetActive(ADDON::ScraperTypeFromContent(content), addon))
+      if (ADDON::CAddonSystemSettings::GetInstance().GetActive(
+              ADDON::ScraperTypeFromContent(content), addon))
       {
         scraper = std::dynamic_pointer_cast<ADDON::CScraper>(addon);
         return scraper != NULL;
@@ -10956,12 +11536,13 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE &content, ADDON::Scra
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s -(%i, %s %s) failed", __FUNCTION__, id, scraperUUID.c_str(), strSettings.c_str());
+    CLog::Log(LOGERROR, "%s -(%i, %s %s) failed", __FUNCTION__, id, scraperUUID.c_str(),
+              strSettings.c_str());
   }
   return false;
 }
 
-bool CMusicDatabase::ScraperInUse(const std::string &scraperID) const
+bool CMusicDatabase::ScraperInUse(const std::string& scraperID) const
 {
   try
   {
@@ -10970,7 +11551,8 @@ bool CMusicDatabase::ScraperInUse(const std::string &scraperID) const
     if (nullptr == m_pDS)
       return false;
 
-    std::string sql = PrepareSQL("SELECT COUNT(1) FROM infosetting WHERE strScraperPath='%s'",scraperID.c_str());
+    std::string sql =
+        PrepareSQL("SELECT COUNT(1) FROM infosetting WHERE strScraperPath='%s'", scraperID.c_str());
     if (!m_pDS->query(sql) || m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -10987,7 +11569,10 @@ bool CMusicDatabase::ScraperInUse(const std::string &scraperID) const
   return false;
 }
 
-bool CMusicDatabase::GetItems(const std::string &strBaseDir, CFileItemList &items, const Filter &filter /* = Filter() */, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetItems(const std::string& strBaseDir,
+                              CFileItemList& items,
+                              const Filter& filter /* = Filter() */,
+                              const SortDescription& sortDescription /* = SortDescription() */)
 {
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString(strBaseDir))
@@ -10996,7 +11581,11 @@ bool CMusicDatabase::GetItems(const std::string &strBaseDir, CFileItemList &item
   return GetItems(strBaseDir, musicUrl.GetType(), items, filter, sortDescription);
 }
 
-bool CMusicDatabase::GetItems(const std::string &strBaseDir, const std::string &itemType, CFileItemList &items, const Filter &filter /* = Filter() */, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetItems(const std::string& strBaseDir,
+                              const std::string& itemType,
+                              CFileItemList& items,
+                              const Filter& filter /* = Filter() */,
+                              const SortDescription& sortDescription /* = SortDescription() */)
 {
   if (StringUtils::EqualsNoCase(itemType, "genres"))
     return GetGenresNav(strBaseDir, items, filter);
@@ -11007,7 +11596,10 @@ bool CMusicDatabase::GetItems(const std::string &strBaseDir, const std::string &
   else if (StringUtils::EqualsNoCase(itemType, "roles"))
     return GetRolesNav(strBaseDir, items, filter);
   else if (StringUtils::EqualsNoCase(itemType, "artists"))
-    return GetArtistsNav(strBaseDir, items, !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS), -1, -1, -1, filter, sortDescription);
+    return GetArtistsNav(strBaseDir, items,
+                         !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                             CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS),
+                         -1, -1, -1, filter, sortDescription);
   else if (StringUtils::EqualsNoCase(itemType, "albums"))
     return GetAlbumsByWhere(strBaseDir, filter, items, sortDescription);
   else if (StringUtils::EqualsNoCase(itemType, "discs"))
@@ -11018,7 +11610,7 @@ bool CMusicDatabase::GetItems(const std::string &strBaseDir, const std::string &
   return false;
 }
 
-std::string CMusicDatabase::GetItemById(const std::string &itemType, int id)
+std::string CMusicDatabase::GetItemById(const std::string& itemType, int id)
 {
   if (StringUtils::EqualsNoCase(itemType, "genres"))
     return GetGenreById(id);
@@ -11036,19 +11628,18 @@ std::string CMusicDatabase::GetItemById(const std::string &itemType, int id)
   return "";
 }
 
-void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialogProgress* progressDialog /*= nullptr*/)
+void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
+                                 CGUIDialogProgress* progressDialog /*= nullptr*/)
 {
   if (!settings.IsItemExported(ELIBEXPORT_ALBUMARTISTS) &&
       !settings.IsItemExported(ELIBEXPORT_SONGARTISTS) &&
       !settings.IsItemExported(ELIBEXPORT_OTHERARTISTS) &&
-      !settings.IsItemExported(ELIBEXPORT_ALBUMS) && 
-      !settings.IsItemExported(ELIBEXPORT_SONGS))
+      !settings.IsItemExported(ELIBEXPORT_ALBUMS) && !settings.IsItemExported(ELIBEXPORT_SONGS))
     return;
 
   // Exporting albums either art or NFO (or both) selected
-  if ((settings.IsToLibFolders() || settings.IsSeparateFiles()) &&
-       settings.m_skipnfo && !settings.m_artwork &&
-       settings.IsItemExported(ELIBEXPORT_ALBUMS))
+  if ((settings.IsToLibFolders() || settings.IsSeparateFiles()) && settings.m_skipnfo &&
+      !settings.m_artwork && settings.IsItemExported(ELIBEXPORT_ALBUMS))
     return;
 
   std::string strFolder;
@@ -11068,18 +11659,19 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
   else if (settings.IsArtistFoldersOnly() || (settings.IsToLibFolders() && settings.IsArtists()))
   {
     // Exporting artist folders only, or artist NFO or art to library folders
-    // need Artist Information Folder defined. 
+    // need Artist Information Folder defined.
     // (Album NFO and art goes to music folders)
-    strFolder = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER);
+    strFolder = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+        CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER);
     if (strFolder.empty())
       return;
   }
 
   //
-  bool artistfoldersonly; 
+  bool artistfoldersonly;
   artistfoldersonly = settings.IsArtistFoldersOnly() ||
-                      ((settings.IsToLibFolders() || settings.IsSeparateFiles()) && 
-                        settings.m_skipnfo && !settings.m_artwork);
+                      ((settings.IsToLibFolders() || settings.IsSeparateFiles()) &&
+                       settings.m_skipnfo && !settings.m_artwork);
 
   int iFailCount = 0;
   try
@@ -11095,7 +11687,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
     CXBMCTinyXML xmlDoc;
     TiXmlDeclaration decl("1.0", "UTF-8", "yes");
     xmlDoc.InsertEndChild(decl);
-    TiXmlNode *pMain = NULL;
+    TiXmlNode* pMain = NULL;
     if ((settings.IsToLibFolders() || settings.IsSeparateFiles()) && !artistfoldersonly)
       pMain = &xmlDoc;
     else if (settings.IsSingleFile())
@@ -11109,7 +11701,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
       // Find albums to export
       std::vector<int> albumIds;
       std::string strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE strReleaseType = '%s' ",
-        CAlbum::ReleaseTypeToString(CAlbum::Album).c_str());
+                                      CAlbum::ReleaseTypeToString(CAlbum::Album).c_str());
       if (!settings.m_unscraped)
         strSQL += "AND lastScraped IS NOT NULL";
       CLog::Log(LOGDEBUG, "CMusicDatabase::%s - %s", __FUNCTION__, strSQL.c_str());
@@ -11126,7 +11718,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
       }
       m_pDS->close();
 
-      for (const auto &albumId : albumIds)
+      for (const auto& albumId : albumIds)
       {
         CAlbum album;
         GetAlbum(albumId, album);
@@ -11149,11 +11741,14 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
             // Most albums are under a unique folder, but if songs from various albums are mixed then
             // avoid overwriting by not allow NFO and art to be exported
             if (strAlbumPath.empty())
-              CLog::Log(LOGDEBUG, "CMusicDatabase::%s - Not exporting album %s as unique path not found",
-                __FUNCTION__, album.strAlbum.c_str());
+              CLog::Log(LOGDEBUG,
+                        "CMusicDatabase::%s - Not exporting album %s as unique path not found",
+                        __FUNCTION__, album.strAlbum.c_str());
             else if (!CDirectory::Exists(strAlbumPath))
-              CLog::Log(LOGDEBUG, "CMusicDatabase::%s - Not exporting album %s as found path %s does not exist",
-                __FUNCTION__, album.strAlbum.c_str(), strAlbumPath.c_str());
+              CLog::Log(
+                  LOGDEBUG,
+                  "CMusicDatabase::%s - Not exporting album %s as found path %s does not exist",
+                  __FUNCTION__, album.strAlbum.c_str(), strAlbumPath.c_str());
             else
             {
               strPath = strAlbumPath;
@@ -11166,7 +11761,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
             // where <albumname> is either the same name as the album folder
             // containing the music files (if unique) or is created using the album name
             std::string strAlbumArtist;
-            pathfound = GetArtistFolderName(album.GetAlbumArtist()[0], album.GetMusicBrainzAlbumArtistID()[0], strAlbumArtist);
+            pathfound = GetArtistFolderName(album.GetAlbumArtist()[0],
+                                            album.GetMusicBrainzAlbumArtistID()[0], strAlbumArtist);
             if (pathfound)
             {
               strPath = URIUtils::AddFileToFolder(strFolder, strAlbumArtist);
@@ -11175,8 +11771,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
                 pathfound = CDirectory::Create(strPath);
             }
             if (!pathfound)
-              CLog::Log(LOGDEBUG, "CMusicDatabase::%s - Not exporting album %s as could not create %s",
-                __FUNCTION__, album.strAlbum.c_str(), strPath.c_str());
+              CLog::Log(LOGDEBUG,
+                        "CMusicDatabase::%s - Not exporting album %s as could not create %s",
+                        __FUNCTION__, album.strAlbum.c_str(), strPath.c_str());
             else
             {
               std::string strAlbumFolder;
@@ -11189,8 +11786,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
                   pathfound = CDirectory::Create(strPath);
               }
               if (!pathfound)
-                CLog::Log(LOGDEBUG, "CMusicDatabase::%s - Not exporting album %s as could not create %s",
-                  __FUNCTION__, album.strAlbum.c_str(), strPath.c_str());
+                CLog::Log(LOGDEBUG,
+                          "CMusicDatabase::%s - Not exporting album %s as could not create %s",
+                          __FUNCTION__, album.strAlbum.c_str(), strPath.c_str());
             }
           }
           if (pathfound)
@@ -11204,8 +11802,10 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
               {
                 if (!xmlDoc.SaveFile(nfoFile))
                 {
-                  CLog::Log(LOGERROR, "CMusicDatabase::%s: Album nfo export failed! ('%s')", __FUNCTION__, nfoFile.c_str());
-                  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
+                  CLog::Log(LOGERROR, "CMusicDatabase::%s: Album nfo export failed! ('%s')",
+                            __FUNCTION__, nfoFile.c_str());
+                  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
+                                                        g_localizeStrings.Get(20302), nfoFile);
                   iFailCount++;
                 }
               }
@@ -11218,13 +11818,14 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
               std::string savedArtfile;
               if (GetArtForItem(album.idAlbum, MediaTypeAlbum, artwork))
               {
-                for (const auto &art : artwork)
+                for (const auto& art : artwork)
                 {
                   if (art.first == "thumb")
                     savedArtfile = URIUtils::AddFileToFolder(strPath, "folder");
                   else
                     savedArtfile = URIUtils::AddFileToFolder(strPath, art.first);
-                  CTextureCache::GetInstance().Export(art.second, savedArtfile, settings.m_overwrite);
+                  CTextureCache::GetInstance().Export(art.second, savedArtfile,
+                                                      settings.m_overwrite);
                 }
               }
             }
@@ -11236,7 +11837,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
 
         if ((current % 50) == 0 && progressDialog)
         {
-          progressDialog->SetLine(1, CVariant{ album.strAlbum });
+          progressDialog->SetLine(1, CVariant{album.strAlbum});
           progressDialog->SetPercentage(current * 100 / total);
           if (progressDialog->IsCanceled())
             return;
@@ -11260,16 +11861,26 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
       Filter filter;
 
       if (settings.IsItemExported(ELIBEXPORT_ALBUMARTISTS))
-        filter.AppendWhere("EXISTS(SELECT 1 FROM album_artist WHERE album_artist.idArtist = artist.idArtist)", false);
+        filter.AppendWhere("EXISTS(SELECT 1 FROM album_artist "
+                           "WHERE album_artist.idArtist = artist.idArtist)",
+                           false);
       if (settings.IsItemExported(ELIBEXPORT_SONGARTISTS))
       {
         if (settings.IsItemExported(ELIBEXPORT_OTHERARTISTS))
-          filter.AppendWhere("EXISTS (SELECT 1 FROM song_artist WHERE song_artist.idArtist = artist.idArtist )", false);
+          filter.AppendWhere("EXISTS (SELECT 1 FROM song_artist "
+                             "WHERE song_artist.idArtist = artist.idArtist )",
+                             false);
         else
-          filter.AppendWhere("EXISTS (SELECT 1 FROM song_artist WHERE song_artist.idArtist = artist.idArtist AND song_artist.idRole = 1)", false);
+          filter.AppendWhere(
+              "EXISTS (SELECT 1 FROM song_artist "
+              "WHERE song_artist.idArtist = artist.idArtist AND song_artist.idRole = 1)",
+              false);
       }
       else if (settings.IsItemExported(ELIBEXPORT_OTHERARTISTS))
-        filter.AppendWhere("EXISTS (SELECT 1 FROM song_artist WHERE song_artist.idArtist = artist.idArtist AND song_artist.idRole > 1)", false);
+        filter.AppendWhere(
+            "EXISTS (SELECT 1 FROM song_artist "
+            "WHERE song_artist.idArtist = artist.idArtist AND song_artist.idRole > 1)",
+            false);
 
       if (!settings.m_unscraped && !artistfoldersonly)
         filter.AppendWhere("lastScraped IS NOT NULL", true);
@@ -11289,10 +11900,11 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
       }
       m_pDS->close();
 
-      for (const auto &artistId : artistIds)
+      for (const auto& artistId : artistIds)
       {
         CArtist artist;
-        GetArtist(artistId, artist, !artistfoldersonly); // include discography when not folders only
+        // Include discography when not folders only
+        GetArtist(artistId, artist, !artistfoldersonly);
         std::string strPath;
         std::map<std::string, std::string> artwork;
         if (settings.IsSingleFile())
@@ -11304,7 +11916,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
           if (GetArtForItem(artist.idArtist, MediaTypeArtist, artwork))
           { // append to the XML
             TiXmlElement additionalNode("art");
-            for (const auto &i : artwork)
+            for (const auto& i : artwork)
               XMLUtils::SetString(&additionalNode, i.first.c_str(), i.second);
             pMain->LastChild()->InsertEndChild(additionalNode);
           }
@@ -11321,8 +11933,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
               pathfound = CDirectory::Create(strPath);
           }
           if (!pathfound)
-            CLog::Log(LOGDEBUG, "CMusicDatabase::%s - Not exporting artist %s as could not create %s",
-              __FUNCTION__, artist.strArtist.c_str(), strPath.c_str());
+            CLog::Log(LOGDEBUG,
+                      "CMusicDatabase::%s - Not exporting artist %s as could not create %s",
+                      __FUNCTION__, artist.strArtist.c_str(), strPath.c_str());
           else
           {
             if (!artistfoldersonly)
@@ -11335,8 +11948,10 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
                 {
                   if (!xmlDoc.SaveFile(nfoFile))
                   {
-                    CLog::Log(LOGERROR, "CMusicDatabase::%s: Artist nfo export failed! ('%s')", __FUNCTION__, nfoFile.c_str());
-                    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
+                    CLog::Log(LOGERROR, "CMusicDatabase::%s: Artist nfo export failed! ('%s')",
+                              __FUNCTION__, nfoFile.c_str());
+                    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
+                                                          g_localizeStrings.Get(20302), nfoFile);
                     iFailCount++;
                   }
                 }
@@ -11346,13 +11961,14 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
                 std::string savedArtfile;
                 if (GetArtForItem(artist.idArtist, MediaTypeArtist, artwork))
                 {
-                  for (const auto &art : artwork)
+                  for (const auto& art : artwork)
                   {
                     if (art.first == "thumb")
                       savedArtfile = URIUtils::AddFileToFolder(strPath, "folder");
                     else
                       savedArtfile = URIUtils::AddFileToFolder(strPath, art.first);
-                    CTextureCache::GetInstance().Export(art.second, savedArtfile, settings.m_overwrite);
+                    CTextureCache::GetInstance().Export(art.second, savedArtfile,
+                                                        settings.m_overwrite);
                   }
                 }
               }
@@ -11364,7 +11980,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
         }
         if ((current % 50) == 0 && progressDialog)
         {
-          progressDialog->SetLine(1, CVariant{ artist.strArtist });
+          progressDialog->SetLine(1, CVariant{artist.strArtist});
           progressDialog->SetPercentage(current * 100 / total);
           if (progressDialog->IsCanceled())
             return;
@@ -11375,9 +11991,11 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
 
     if (settings.IsSingleFile())
     {
-      std::string xmlFile = URIUtils::AddFileToFolder(strFolder, "kodi_musicdb" + CDateTime::GetCurrentDateTime().GetAsDBDate() + ".xml");
+      std::string xmlFile = URIUtils::AddFileToFolder(
+          strFolder, "kodi_musicdb" + CDateTime::GetCurrentDateTime().GetAsDBDate() + ".xml");
       if (CFile::Exists(xmlFile))
-        xmlFile = URIUtils::AddFileToFolder(strFolder, "kodi_musicdb" + CDateTime::GetCurrentDateTime().GetAsSaveString() + ".xml");
+        xmlFile = URIUtils::AddFileToFolder(
+            strFolder, "kodi_musicdb" + CDateTime::GetCurrentDateTime().GetAsSaveString() + ".xml");
       xmlDoc.SaveFile(xmlFile);
 
       CVariant data;
@@ -11398,7 +12016,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
     progressDialog->Close();
 
   if (iFailCount > 0 && progressDialog)
-    HELPERS::ShowOKDialogLines(CVariant{20196}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
+    HELPERS::ShowOKDialogLines(
+        CVariant{20196},
+        CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
 }
 
 bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* progressDialog)
@@ -11406,12 +12026,13 @@ bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* pro
   try
   {
     // Export songs with some playback history
-    std::string strSQL = "SELECT idSong, song.idAlbum, "
-      "strAlbum, strMusicBrainzAlbumID, album.strArtistDisp AS strAlbumArtistDisp, "
-      "song.strArtistDisp, strTitle, iTrack, strFileName, strMusicBrainzTrackID, "
-      "iTimesPlayed, lastplayed, song.rating, song.votes, song.userrating "
-      "FROM song JOIN album on album.idAlbum = song.idAlbum "
-      "WHERE iTimesPlayed > 0 OR rating > 0 or userrating > 0";
+    std::string strSQL =
+        "SELECT idSong, song.idAlbum, "
+        "strAlbum, strMusicBrainzAlbumID, album.strArtistDisp AS strAlbumArtistDisp, "
+        "song.strArtistDisp, strTitle, iTrack, strFileName, strMusicBrainzTrackID, "
+        "iTimesPlayed, lastplayed, song.rating, song.votes, song.userrating "
+        "FROM song JOIN album on album.idAlbum = song.idAlbum "
+        "WHERE iTimesPlayed > 0 OR rating > 0 or userrating > 0";
 
     CLog::Log(LOGDEBUG, "{0} - {1}", __FUNCTION__, strSQL.c_str());
     m_pDS->query(strSQL);
@@ -11428,14 +12049,17 @@ bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* pro
       XMLUtils::SetString(song, "title", m_pDS->fv("strTitle").get_asString());
       XMLUtils::SetInt(song, "track", m_pDS->fv("iTrack").get_asInt());
       XMLUtils::SetString(song, "filename", m_pDS->fv("strFilename").get_asString());
-      XMLUtils::SetString(song, "musicbrainztrackid", m_pDS->fv("strMusicBrainzTrackID").get_asString());
+      XMLUtils::SetString(song, "musicbrainztrackid",
+                          m_pDS->fv("strMusicBrainzTrackID").get_asString());
       XMLUtils::SetInt(song, "idalbum", m_pDS->fv("idAlbum").get_asInt());
       XMLUtils::SetString(song, "albumtitle", m_pDS->fv("strAlbum").get_asString());
-      XMLUtils::SetString(song, "musicbrainzalbumid", m_pDS->fv("strMusicBrainzAlbumID").get_asString());
+      XMLUtils::SetString(song, "musicbrainzalbumid",
+                          m_pDS->fv("strMusicBrainzAlbumID").get_asString());
       XMLUtils::SetString(song, "albumartistdesc", m_pDS->fv("strAlbumArtistDisp").get_asString());
       XMLUtils::SetInt(song, "timesplayed", m_pDS->fv("iTimesplayed").get_asInt());
       XMLUtils::SetString(song, "lastplayed", m_pDS->fv("lastplayed").get_asString());
-      auto* rating = XMLUtils::SetString(song, "rating", StringUtils::FormatNumber(m_pDS->fv("rating").get_asFloat()));
+      auto* rating = XMLUtils::SetString(
+          song, "rating", StringUtils::FormatNumber(m_pDS->fv("rating").get_asFloat()));
       if (rating)
         rating->ToElement()->SetAttribute("max", 10);
       XMLUtils::SetInt(song, "votes", m_pDS->fv("votes").get_asInt());
@@ -11445,7 +12069,7 @@ bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* pro
 
       if ((current % 100) == 0 && progressDialog)
       {
-        progressDialog->SetLine(1, CVariant{ m_pDS->fv("strAlbum").get_asString() });
+        progressDialog->SetLine(1, CVariant{m_pDS->fv("strAlbum").get_asString()});
         progressDialog->SetPercentage(current * 100 / total);
         if (progressDialog->IsCanceled())
         {
@@ -11468,7 +12092,7 @@ bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* pro
 }
 
 void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgress* progressDialog)
-{  
+{
   try
   {
     if (nullptr == m_pDB)
@@ -11479,14 +12103,15 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
     CXBMCTinyXML xmlDoc;
     if (!xmlDoc.LoadFile(xmlFile) && progressDialog)
     {
-      HELPERS::ShowOKDialogLines(CVariant{ 20197 }, CVariant{ 38354 }); //"Unable to read xml file"
+      HELPERS::ShowOKDialogLines(CVariant{20197}, CVariant{38354}); //"Unable to read xml file"
       return;
     }
 
-    TiXmlElement *root = xmlDoc.RootElement();
-    if (!root) return;
+    TiXmlElement* root = xmlDoc.RootElement();
+    if (!root)
+      return;
 
-    TiXmlElement *entry = root->FirstChildElement();
+    TiXmlElement* entry = root->FirstChildElement();
     int current = 0;
     int total = 0;
     int songtotal = 0;
@@ -11523,7 +12148,8 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
           UpdateArtist(artist);
         }
         else
-          CLog::Log(LOGDEBUG, "%s - Not import additional artist data as %s not found", __FUNCTION__, importedArtist.strArtist.c_str());
+          CLog::Log(LOGDEBUG, "%s - Not import additional artist data as %s not found",
+                    __FUNCTION__, importedArtist.strArtist.c_str());
         current++;
       }
       else if (StringUtils::CompareNoCase(entry->Value(), "album", 5) == 0)
@@ -11541,11 +12167,12 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
           UpdateAlbum(album); //Will replace song artists if present in xml
         }
         else
-          CLog::Log(LOGDEBUG, "%s - Not import additional album data as %s not found", __FUNCTION__, importedAlbum.strAlbum.c_str());
+          CLog::Log(LOGDEBUG, "%s - Not import additional album data as %s not found", __FUNCTION__,
+                    importedAlbum.strAlbum.c_str());
 
         current++;
       }
-      entry = entry ->NextSiblingElement();
+      entry = entry->NextSiblingElement();
       if (progressDialog && total)
       {
         progressDialog->SetPercentage(current * 100 / total);
@@ -11578,8 +12205,10 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
     progressDialog->Close();
 }
 
-bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int total,  CGUIDialogProgress* progressDialog)
-{  
+bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
+                                       const int total,
+                                       CGUIDialogProgress* progressDialog)
+{
   bool bHistSongExists = false;
   try
   {
@@ -11588,21 +12217,21 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
       return false;
 
     TiXmlElement* root = xmlDoc.RootElement();
-    if (!root) 
+    if (!root)
       return false;
 
     TiXmlElement* entry = root->FirstChildElement();
     int current = 0;
-    
+
     if (progressDialog)
     {
       progressDialog->SetLine(1, CVariant{38350}); //"Importing song playback history"
-      progressDialog->SetLine(2, CVariant{ "" });
+      progressDialog->SetLine(2, CVariant{""});
     }
-   
+
     // As can be many songs do in db, not song at a time which would be slow
     // Convert xml entries into a SQL bulk insert statement
-    std::string strSQL;    
+    std::string strSQL;
     entry = root->FirstChildElement();
     while (entry)
     {
@@ -11621,7 +12250,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
       int iVotes;
       std::string strSQLSong;
       if (StringUtils::CompareNoCase(entry->Value(), "song", 4) == 0)
-      {      
+      {
         XMLUtils::GetString(entry, "artistdesc", strArtistDisp);
         XMLUtils::GetString(entry, "title", strTitle);
         XMLUtils::GetInt(entry, "track", iTrack);
@@ -11643,7 +12272,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
           if (rating > 10.f)
             rating = 10.f;
           fRating = rating;
-        }        
+        }
         XMLUtils::GetInt(entry, "votes", iVotes);
         const TiXmlElement* userrating = entry->FirstChildElement("userrating");
         if (userrating)
@@ -11651,7 +12280,8 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
           float rating = 0;
           float max_rating = 10;
           XMLUtils::GetFloat(entry, "userrating", rating);
-          if (userrating->QueryFloatAttribute("max", &max_rating) == TIXML_SUCCESS && max_rating >= 1)
+          if (userrating->QueryFloatAttribute("max", &max_rating) == TIXML_SUCCESS &&
+              max_rating >= 1)
             rating *= (10.f / max_rating); // Normalise the value to between 0 and 10
           if (rating > 10.f)
             rating = 10.f;
@@ -11659,7 +12289,8 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
         }
 
         strSQLSong = PrepareSQL("(%d, %d, ", current + 1, iTrack);
-        strSQLSong += PrepareSQL("'%s', '%s', '%s', ", strArtistDisp.c_str(), strTitle.c_str(), strFilename.c_str());
+        strSQLSong += PrepareSQL("'%s', '%s', '%s', ", strArtistDisp.c_str(), strTitle.c_str(),
+                                 strFilename.c_str());
         if (strMusicBrainzTrackID.empty())
           strSQLSong += PrepareSQL("NULL, ");
         else
@@ -11687,41 +12318,43 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
       if ((current % 100) == 0 && progressDialog)
       {
         progressDialog->SetPercentage(current * 100 / total);
-        progressDialog->SetLine(3, CVariant{ std::move(strTitle) });
+        progressDialog->SetLine(3, CVariant{std::move(strTitle)});
         progressDialog->Progress();
         if (progressDialog->IsCanceled())
           return false;
       }
     }
 
-    CLog::Log(LOGINFO, "{0}: Create temporary HistSong table and insert {1} records", __FUNCTION__, total);
+    CLog::Log(LOGINFO, "{0}: Create temporary HistSong table and insert {1} records", __FUNCTION__,
+              total);
     /* Can not use CREATE TEMPORARY TABLE as MySQL does not support updates of
        song table using correlated subqueries to a temp table. An updatable join
        to temp table would work in MySQL but SQLite not support updatable joins.
     */
     m_pDS->exec("CREATE TABLE HistSong ("
-      "idSongSrc INTEGER primary key, "
-      "strAlbum varchar(256), "
-      "strMusicBrainzAlbumID text, "
-      "strAlbumArtistDisp text, "
-      "strArtistDisp text, strTitle varchar(512), "
-      "iTrack INTEGER, strFileName text, strMusicBrainzTrackID text, "
-      "iTimesPlayed INTEGER, lastplayed varchar(20) default NULL, "
-      "rating FLOAT NOT NULL DEFAULT 0, votes INTEGER NOT NULL DEFAULT 0, "
-      "userrating INTEGER NOT NULL DEFAULT 0, "
-      "idAlbum INTEGER, idSong INTEGER)");
+                "idSongSrc INTEGER primary key, "
+                "strAlbum varchar(256), "
+                "strMusicBrainzAlbumID text, "
+                "strAlbumArtistDisp text, "
+                "strArtistDisp text, strTitle varchar(512), "
+                "iTrack INTEGER, strFileName text, strMusicBrainzTrackID text, "
+                "iTimesPlayed INTEGER, lastplayed varchar(20) default NULL, "
+                "rating FLOAT NOT NULL DEFAULT 0, votes INTEGER NOT NULL DEFAULT 0, "
+                "userrating INTEGER NOT NULL DEFAULT 0, "
+                "idAlbum INTEGER, idSong INTEGER)");
     bHistSongExists = true;
 
     strSQL = "INSERT INTO HistSong (idSongSrc, iTrack, strArtistDisp, strTitle, "
-      "strFileName, strMusicBrainzTrackID, "
-      "strAlbum, strAlbumArtistDisp, strMusicBrainzAlbumID, "
-      " iTimesPlayed, lastplayed, rating, votes, userrating, idAlbum, idSong) VALUES " + strSQL;
+             "strFileName, strMusicBrainzTrackID, "
+             "strAlbum, strAlbumArtistDisp, strMusicBrainzAlbumID, "
+             " iTimesPlayed, lastplayed, rating, votes, userrating, idAlbum, idSong) VALUES " +
+             strSQL;
     m_pDS->exec(strSQL);
 
     if (progressDialog)
     {
-      progressDialog->SetLine(2, CVariant{38351}); //"Matching data" 
-      progressDialog->SetLine(3, CVariant{ "" });
+      progressDialog->SetLine(2, CVariant{38351}); //"Matching data"
+      progressDialog->SetLine(3, CVariant{""});
       progressDialog->Progress();
       if (progressDialog->IsCanceled())
       {
@@ -11731,42 +12364,42 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
     }
 
     BeginTransaction();
-    // Match albums first on mbid then artist string and album title, setting idAlbum 
+    // Match albums first on mbid then artist string and album title, setting idAlbum
     // mbid is unique so subquery can only return one result at most
     strSQL = "UPDATE HistSong "
-      "SET idAlbum = (SELECT album.idAlbum FROM album "
-      "WHERE album.strMusicBrainzAlbumID = HistSong.strMusicBrainzAlbumID) "
-      "WHERE EXISTS(SELECT 1 FROM album "
-      "WHERE album.strMusicBrainzAlbumID = HistSong.strMusicBrainzAlbumID) AND idAlbum < 0";
+             "SET idAlbum = (SELECT album.idAlbum FROM album "
+             "WHERE album.strMusicBrainzAlbumID = HistSong.strMusicBrainzAlbumID) "
+             "WHERE EXISTS(SELECT 1 FROM album "
+             "WHERE album.strMusicBrainzAlbumID = HistSong.strMusicBrainzAlbumID) AND idAlbum < 0";
     m_pDS->exec(strSQL);
 
-    // Can only be one album with same title and artist(s) and no mbid. 
+    // Can only be one album with same title and artist(s) and no mbid.
     // But could have 2 releases one with and one without mbid, match up those without mbid
     strSQL = "UPDATE HistSong "
-      "SET idAlbum = (SELECT album.idAlbum FROM album "
-      "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
-      "AND HistSong.strAlbum = album.strAlbum "
-      "AND album.strMusicBrainzAlbumID IS NULL "
-      "AND HistSong.strMusicBrainzAlbumID IS NULL) "
-      "WHERE EXISTS(SELECT 1 FROM album "
-      "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
-      "AND HistSong.strAlbum = album.strAlbum "
-      "AND album.strMusicBrainzAlbumID IS NULL "
-      "AND HistSong.strMusicBrainzAlbumID IS NULL) "
-      "AND idAlbum < 0";
+             "SET idAlbum = (SELECT album.idAlbum FROM album "
+             "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
+             "AND HistSong.strAlbum = album.strAlbum "
+             "AND album.strMusicBrainzAlbumID IS NULL "
+             "AND HistSong.strMusicBrainzAlbumID IS NULL) "
+             "WHERE EXISTS(SELECT 1 FROM album "
+             "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
+             "AND HistSong.strAlbum = album.strAlbum "
+             "AND album.strMusicBrainzAlbumID IS NULL "
+             "AND HistSong.strMusicBrainzAlbumID IS NULL) "
+             "AND idAlbum < 0";
     m_pDS->exec(strSQL);
 
     // Try match rest by title and artist(s), prioritise one without mbid
     // Target could have multiple releases - with mbid (non-matching) or one without mbid
     strSQL = "UPDATE HistSong "
-      "SET idAlbum = (SELECT album.idAlbum FROM album "
-      "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
-      "AND HistSong.strAlbum = album.strAlbum "
-      "ORDER BY album.strMusicBrainzAlbumID LIMIT 1) "
-      "WHERE EXISTS(SELECT 1 FROM album "
-      "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
-      "AND HistSong.strAlbum = album.strAlbum) "
-      "AND idAlbum < 0";
+             "SET idAlbum = (SELECT album.idAlbum FROM album "
+             "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
+             "AND HistSong.strAlbum = album.strAlbum "
+             "ORDER BY album.strMusicBrainzAlbumID LIMIT 1) "
+             "WHERE EXISTS(SELECT 1 FROM album "
+             "WHERE HistSong.strAlbumArtistDisp = album.strArtistDisp "
+             "AND HistSong.strAlbum = album.strAlbum) "
+             "AND idAlbum < 0";
     m_pDS->exec(strSQL);
     if (progressDialog)
     {
@@ -11781,14 +12414,14 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
 
     // Match songs on first on idAlbum, track and mbid, then idAlbum, track and title, setting idSong
     strSQL = "UPDATE HistSong "
-      "SET idSong = (SELECT idsong FROM song "
-      "WHERE HistSong.idAlbum = song.idAlbum AND "
-      "HistSong.iTrack = song.iTrack AND "
-      "HistSong.strMusicBrainzTrackID = song.strMusicBrainzTrackID) "
-      "WHERE EXISTS(SELECT 1 FROM song "
-      "WHERE HistSong.idAlbum = song.idAlbum AND "
-      "HistSong.iTrack = song.iTrack AND "
-      "HistSong.strMusicBrainzTrackID = song.strMusicBrainzTrackID) AND idSong < 0";
+             "SET idSong = (SELECT idsong FROM song "
+             "WHERE HistSong.idAlbum = song.idAlbum AND "
+             "HistSong.iTrack = song.iTrack AND "
+             "HistSong.strMusicBrainzTrackID = song.strMusicBrainzTrackID) "
+             "WHERE EXISTS(SELECT 1 FROM song "
+             "WHERE HistSong.idAlbum = song.idAlbum AND "
+             "HistSong.iTrack = song.iTrack AND "
+             "HistSong.strMusicBrainzTrackID = song.strMusicBrainzTrackID) AND idSong < 0";
     m_pDS->exec(strSQL);
 
     // An album can have more than one song with same track and title (although idAlbum, track and
@@ -11796,12 +12429,12 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
     // history for renamed files. It is about song playback not file playback.
     // Pick the first
     strSQL = "UPDATE HistSong "
-      "SET idSong = (SELECT idsong FROM song "
-      "WHERE HistSong.idAlbum = song.idAlbum AND "
-      "HistSong.iTrack = song.iTrack AND HistSong.strTitle = song.strTitle LIMIT 1) "
-      "WHERE EXISTS(SELECT 1 FROM song "
-      "WHERE HistSong.idAlbum = song.idAlbum AND "
-      "HistSong.iTrack = song.iTrack AND HistSong.strTitle = song.strTitle) AND idSong < 0";
+             "SET idSong = (SELECT idsong FROM song "
+             "WHERE HistSong.idAlbum = song.idAlbum AND "
+             "HistSong.iTrack = song.iTrack AND HistSong.strTitle = song.strTitle LIMIT 1) "
+             "WHERE EXISTS(SELECT 1 FROM song "
+             "WHERE HistSong.idAlbum = song.idAlbum AND "
+             "HistSong.iTrack = song.iTrack AND HistSong.strTitle = song.strTitle) AND idSong < 0";
     m_pDS->exec(strSQL);
 
     CommitTransaction();
@@ -11820,7 +12453,8 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
 
     // Log how many songs matched
     int unmatched = GetSingleValueInt("SELECT COUNT(1) FROM HistSong WHERE idSong < 0", m_pDS);
-    CLog::Log(LOGINFO, "{0}: Importing song history {1} of {2} songs matched", __FUNCTION__, total - unmatched,  total);
+    CLog::Log(LOGINFO, "{0}: Importing song history {1} of {2} songs matched", __FUNCTION__,
+              total - unmatched, total);
 
     if (progressDialog)
     {
@@ -11841,27 +12475,27 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
     BeginTransaction();
     // Times played and last played date(when count is greater)
     strSQL = "UPDATE song SET iTimesPlayed = "
-      "(SELECT iTimesPlayed FROM HistSong WHERE HistSong.idSong = song.idSong), "
-      "lastplayed = "
-      "(SELECT lastplayed FROM HistSong WHERE HistSong.idSong = song.idSong) "
-      "WHERE EXISTS(SELECT 1 FROM HistSong WHERE "
-      "HistSong.idSong = song.idSong AND HistSong.iTimesPlayed > song.iTimesPlayed)";
+             "(SELECT iTimesPlayed FROM HistSong WHERE HistSong.idSong = song.idSong), "
+             "lastplayed = "
+             "(SELECT lastplayed FROM HistSong WHERE HistSong.idSong = song.idSong) "
+             "WHERE EXISTS(SELECT 1 FROM HistSong WHERE "
+             "HistSong.idSong = song.idSong AND HistSong.iTimesPlayed > song.iTimesPlayed)";
     m_pDS->exec(strSQL);
-    
+
     // User rating
     strSQL = "UPDATE song SET userrating = "
-      "(SELECT userrating FROM HistSong WHERE HistSong.idSong = song.idSong) "
-      "WHERE EXISTS(SELECT 1 FROM HistSong WHERE "
-      "HistSong.idSong = song.idSong AND HistSong.userrating > 0)";
+             "(SELECT userrating FROM HistSong WHERE HistSong.idSong = song.idSong) "
+             "WHERE EXISTS(SELECT 1 FROM HistSong WHERE "
+             "HistSong.idSong = song.idSong AND HistSong.userrating > 0)";
     m_pDS->exec(strSQL);
-    
+
     // Rating and votes
     strSQL = "UPDATE song SET rating = "
-      "(SELECT rating FROM HistSong WHERE HistSong.idSong = song.idSong), "
-      "votes = "
-      "(SELECT votes FROM HistSong WHERE HistSong.idSong = song.idSong) "
-      "WHERE  EXISTS(SELECT 1 FROM HistSong WHERE "
-      "HistSong.idSong = song.idSong AND HistSong.rating > 0)";
+             "(SELECT rating FROM HistSong WHERE HistSong.idSong = song.idSong), "
+             "votes = "
+             "(SELECT votes FROM HistSong WHERE HistSong.idSong = song.idSong) "
+             "WHERE  EXISTS(SELECT 1 FROM HistSong WHERE "
+             "HistSong.idSong = song.idSong AND HistSong.rating > 0)";
     m_pDS->exec(strSQL);
 
     if (progressDialog)
@@ -11881,16 +12515,17 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
     // Compact db to recover space as had to add/drop actual table
     if (progressDialog)
     {
-      progressDialog->SetLine(2, CVariant{ 331 });
+      progressDialog->SetLine(2, CVariant{331});
       progressDialog->Progress();
     }
-    Compress(false);    
+    Compress(false);
 
     // Write event log entry
     // "Importing song history {1} of {2} songs matched", total - unmatched, total)
-    std::string strLine = StringUtils::Format(g_localizeStrings.Get(38353).c_str(), total - unmatched, total);
+    std::string strLine =
+        StringUtils::Format(g_localizeStrings.Get(38353).c_str(), total - unmatched, total);
     CServiceBroker::GetEventLog().Add(
-      EventPtr(new CNotificationEvent(20197, strLine, EventLevel::Information)));
+        EventPtr(new CNotificationEvent(20197, strLine, EventLevel::Information)));
 
     return true;
   }
@@ -11906,7 +12541,8 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
 
 void CMusicDatabase::SetPropertiesFromArtist(CFileItem& item, const CArtist& artist)
 {
-  const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  const std::string itemSeparator =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
 
   item.SetProperty("artist_sortname", artist.strSortName);
   item.SetProperty("artist_type", artist.strType);
@@ -11931,7 +12567,8 @@ void CMusicDatabase::SetPropertiesFromArtist(CFileItem& item, const CArtist& art
 
 void CMusicDatabase::SetPropertiesFromAlbum(CFileItem& item, const CAlbum& album)
 {
-  const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  const std::string itemSeparator =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
 
   item.SetProperty("album_description", album.strReview);
   item.SetProperty("album_theme", StringUtils::Join(album.themes, itemSeparator));
@@ -11958,8 +12595,8 @@ void CMusicDatabase::SetPropertiesFromAlbum(CFileItem& item, const CAlbum& album
   item.SetProperty("album_totaldiscs", album.iTotalDiscs);
   item.SetProperty("album_releasetype", CAlbum::ReleaseTypeToString(album.releaseType));
   item.SetProperty("album_duration",
-                   StringUtils::SecondsToTimeString(
-                       album.iAlbumDuration, static_cast<TIME_FORMAT>(TIME_FORMAT_GUESS)));
+                   StringUtils::SecondsToTimeString(album.iAlbumDuration,
+                                                    static_cast<TIME_FORMAT>(TIME_FORMAT_GUESS)));
 }
 
 void CMusicDatabase::SetPropertiesForFileItem(CFileItem& item)
@@ -11981,7 +12618,7 @@ void CMusicDatabase::SetPropertiesForFileItem(CFileItem& item)
   {
     CArtist artist;
     if (GetArtist(idArtist, artist))
-      SetPropertiesFromArtist(item,artist);
+      SetPropertiesFromArtist(item, artist);
   }
   int idAlbum = item.GetMusicInfoTag()->GetAlbumId();
   if (idAlbum <= 0)
@@ -11991,7 +12628,7 @@ void CMusicDatabase::SetPropertiesForFileItem(CFileItem& item)
   {
     CAlbum album;
     if (GetAlbum(idAlbum, album, false))
-      SetPropertiesFromAlbum(item,album);
+      SetPropertiesFromAlbum(item, album);
   }
 }
 
@@ -12025,13 +12662,18 @@ void CMusicDatabase::SetItemUpdated(int mediaId, const std::string& mediaType)
   }
 }
 
-void CMusicDatabase::SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art)
+void CMusicDatabase::SetArtForItem(int mediaId,
+                                   const std::string& mediaType,
+                                   const std::map<std::string, std::string>& art)
 {
-  for (const auto &i : art)
+  for (const auto& i : art)
     SetArtForItem(mediaId, mediaType, i.first, i.second);
 }
 
-void CMusicDatabase::SetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType, const std::string &url)
+void CMusicDatabase::SetArtForItem(int mediaId,
+                                   const std::string& mediaType,
+                                   const std::string& artType,
+                                   const std::string& url)
 {
   try
   {
@@ -12044,7 +12686,9 @@ void CMusicDatabase::SetArtForItem(int mediaId, const std::string &mediaType, co
     if (artType.find('.') != std::string::npos)
       return;
 
-    std::string sql = PrepareSQL("SELECT art_id FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
+    std::string sql = PrepareSQL("SELECT art_id FROM art "
+                                 "WHERE media_id=%i AND media_type='%s' AND type='%s'",
+                                 mediaId, mediaType.c_str(), artType.c_str());
     m_pDS->query(sql);
     if (!m_pDS->eof())
     { // update
@@ -12056,22 +12700,27 @@ void CMusicDatabase::SetArtForItem(int mediaId, const std::string &mediaType, co
     else
     { // insert
       m_pDS->close();
-      sql = PrepareSQL("INSERT INTO art(media_id, media_type, type, url) VALUES (%d, '%s', '%s', '%s')", mediaId, mediaType.c_str(), artType.c_str(), url.c_str());
+      sql = PrepareSQL("INSERT INTO art(media_id, media_type, type, url) "
+                       "VALUES (%d, '%s', '%s', '%s')",
+                       mediaId, mediaType.c_str(), artType.c_str(), url.c_str());
       m_pDS->exec(sql);
     }
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s(%d, '%s', '%s', '%s') failed", __FUNCTION__, mediaId, mediaType.c_str(), artType.c_str(), url.c_str());
+    CLog::Log(LOGERROR, "%s(%d, '%s', '%s', '%s') failed", __FUNCTION__, mediaId, mediaType.c_str(),
+              artType.c_str(), url.c_str());
   }
 }
 
-bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool bPrimaryArtist, std::vector<ArtForThumbLoader> &art)
+bool CMusicDatabase::GetArtForItem(
+    int songId, int albumId, int artistId, bool bPrimaryArtist, std::vector<ArtForThumbLoader>& art)
 {
   std::string strSQL;
   try
   {
-    if (!(songId > 0 || albumId > 0 || artistId > 0)) return false;
+    if (!(songId > 0 || albumId > 0 || artistId > 0))
+      return false;
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS2)
@@ -12081,11 +12730,14 @@ bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool b
     if (songId > 0)
       filter.AppendWhere(PrepareSQL("media_id = %i AND media_type ='%s'", songId, MediaTypeSong));
     if (albumId > 0)
-      filter.AppendWhere(PrepareSQL("media_id = %i AND media_type ='%s'", albumId, MediaTypeAlbum), false);
+      filter.AppendWhere(PrepareSQL("media_id = %i AND media_type ='%s'", albumId, MediaTypeAlbum),
+                         false);
     if (artistId > 0)
-      filter.AppendWhere(PrepareSQL("media_id = %i AND media_type ='%s'", artistId, MediaTypeArtist), false);
+      filter.AppendWhere(
+          PrepareSQL("media_id = %i AND media_type ='%s'", artistId, MediaTypeArtist), false);
 
-    strSQL = "SELECT DISTINCT art_id, media_id, media_type, type, '' as prefix, url, 0 as iorder FROM art";
+    strSQL = "SELECT DISTINCT art_id, media_id, media_type, type, '' as prefix, url, 0 as iorder "
+             "FROM art";
     if (!BuildSQL(strSQL, filter, strSQL))
       return false;
 
@@ -12097,11 +12749,11 @@ bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool b
       {
         //Album ID known, so use it to look up album artist(s)
         strSQL2 = PrepareSQL(
-          "SELECT art_id, media_id, media_type, type, 'albumartist' as prefix, "
-          "url, album_artist.iOrder as iorder FROM art "
-          "JOIN album_artist ON art.media_id = album_artist.idArtist AND art.media_type ='%s' "
-          "WHERE album_artist.idAlbum = %i ",
-          MediaTypeArtist, albumId);
+            "SELECT art_id, media_id, media_type, type, 'albumartist' as prefix, "
+            "url, album_artist.iOrder as iorder FROM art "
+            "JOIN album_artist ON art.media_id = album_artist.idArtist AND art.media_type ='%s' "
+            "WHERE album_artist.idAlbum = %i ",
+            MediaTypeArtist, albumId);
         if (bPrimaryArtist)
           strSQL2 += "AND album_artist.iOrder = 0";
 
@@ -12113,12 +12765,12 @@ bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool b
         {
           //Album ID unknown, so get from song to look up album artist(s)
           strSQL2 = PrepareSQL(
-            "SELECT art_id, media_id, media_type, type, 'albumartist' as prefix, "
-            "url, album_artist.iOrder as iorder FROM art "
-            "JOIN album_artist ON art.media_id = album_artist.idArtist AND art.media_type ='%s' "
-            "JOIN song ON song.idAlbum = album_artist.idAlbum  "
-            "WHERE song.idSong = %i ",
-            MediaTypeArtist, songId);
+              "SELECT art_id, media_id, media_type, type, 'albumartist' as prefix, "
+              "url, album_artist.iOrder as iorder FROM art "
+              "JOIN album_artist ON art.media_id = album_artist.idArtist AND art.media_type ='%s' "
+              "JOIN song ON song.idAlbum = album_artist.idAlbum  "
+              "WHERE song.idSong = %i ",
+              MediaTypeArtist, songId);
           if (bPrimaryArtist)
             strSQL2 += "AND album_artist.iOrder = 0";
 
@@ -12127,27 +12779,26 @@ bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool b
 
         // Artist ID unknown, so lookup artist for songs (could be different from album artist)
         strSQL2 = PrepareSQL(
-          "SELECT art_id, media_id, media_type, type, 'artist' as prefix, "
-          "url, song_artist.iOrder as iorder FROM art "
-          "JOIN song_artist on art.media_id = song_artist.idArtist AND art.media_type = '%s' "
-          "WHERE song_artist.idsong = %i AND song_artist.idRole = %i ",
-          MediaTypeArtist, songId, ROLE_ARTIST);
+            "SELECT art_id, media_id, media_type, type, 'artist' as prefix, "
+            "url, song_artist.iOrder as iorder FROM art "
+            "JOIN song_artist on art.media_id = song_artist.idArtist AND art.media_type = '%s' "
+            "WHERE song_artist.idsong = %i AND song_artist.idRole = %i ",
+            MediaTypeArtist, songId, ROLE_ARTIST);
         if (bPrimaryArtist)
           strSQL2 += "AND song_artist.iOrder = 0";
 
-        strSQL = strSQL +  " UNION " + strSQL2;
+        strSQL = strSQL + " UNION " + strSQL2;
       }
     }
     if (songId > 0 && albumId < 0)
     {
       //Album ID unknown, so get from song to look up album art
       std::string strSQL2;
-      strSQL2 = PrepareSQL(
-        "SELECT art_id, media_id, media_type, type, '' as prefix, "
-        "url, 0 as iorder FROM art "
-        "JOIN song ON art.media_id = song.idAlbum AND art.media_type ='%s' "
-        "WHERE song.idSong = %i ",
-        MediaTypeAlbum, songId);
+      strSQL2 = PrepareSQL("SELECT art_id, media_id, media_type, type, '' as prefix, "
+                           "url, 0 as iorder FROM art "
+                           "JOIN song ON art.media_id = song.idAlbum AND art.media_type ='%s' "
+                           "WHERE song.idSong = %i ",
+                           MediaTypeAlbum, songId);
       strSQL = strSQL + " UNION " + strSQL2;
     }
 
@@ -12177,7 +12828,9 @@ bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool b
   return false;
 }
 
-bool CMusicDatabase::GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art)
+bool CMusicDatabase::GetArtForItem(int mediaId,
+                                   const std::string& mediaType,
+                                   std::map<std::string, std::string>& art)
 {
   try
   {
@@ -12186,7 +12839,8 @@ bool CMusicDatabase::GetArtForItem(int mediaId, const std::string &mediaType, st
     if (nullptr == m_pDS2)
       return false; // using dataset 2 as we're likely called in loops on dataset 1
 
-    std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
+    std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'",
+                                 mediaId, mediaType.c_str());
     m_pDS2->query(sql);
     while (!m_pDS2->eof())
     {
@@ -12203,27 +12857,37 @@ bool CMusicDatabase::GetArtForItem(int mediaId, const std::string &mediaType, st
   return false;
 }
 
-std::string CMusicDatabase::GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType)
+std::string CMusicDatabase::GetArtForItem(int mediaId,
+                                          const std::string& mediaType,
+                                          const std::string& artType)
 {
-  std::string query = PrepareSQL("SELECT url FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
+  std::string query = PrepareSQL("SELECT url FROM art "
+                                 "WHERE media_id=%i AND media_type='%s' AND type='%s'",
+                                 mediaId, mediaType.c_str(), artType.c_str());
   return GetSingleValue(query, m_pDS2);
 }
 
-bool CMusicDatabase::RemoveArtForItem(int mediaId, const MediaType & mediaType, const std::string & artType)
+bool CMusicDatabase::RemoveArtForItem(int mediaId,
+                                      const MediaType& mediaType,
+                                      const std::string& artType)
 {
-  return ExecuteQuery(PrepareSQL("DELETE FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str()));
+  return ExecuteQuery(PrepareSQL("DELETE FROM art "
+                                 "WHERE media_id=%i AND media_type='%s' AND type='%s'",
+                                 mediaId, mediaType.c_str(), artType.c_str()));
 }
 
-bool CMusicDatabase::RemoveArtForItem(int mediaId, const MediaType & mediaType, const std::set<std::string>& artTypes)
+bool CMusicDatabase::RemoveArtForItem(int mediaId,
+                                      const MediaType& mediaType,
+                                      const std::set<std::string>& artTypes)
 {
   bool result = true;
-  for (const auto &i : artTypes)
+  for (const auto& i : artTypes)
     result &= RemoveArtForItem(mediaId, mediaType, i);
 
   return result;
 }
 
-bool CMusicDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes)
+bool CMusicDatabase::GetArtTypes(const MediaType& mediaType, std::vector<std::string>& artTypes)
 {
   try
   {
@@ -12232,9 +12896,11 @@ bool CMusicDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL = PrepareSQL("SELECT DISTINCT type FROM art WHERE media_type='%s'", mediaType.c_str());
+    std::string strSQL =
+        PrepareSQL("SELECT DISTINCT type FROM art WHERE media_type='%s'", mediaType.c_str());
 
-    if (!m_pDS->query(strSQL)) return false;
+    if (!m_pDS->query(strSQL))
+      return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -12258,7 +12924,7 @@ bool CMusicDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
 }
 
 std::vector<std::string> CMusicDatabase::GetAvailableArtTypesForItem(int mediaId,
-  const MediaType& mediaType)
+                                                                     const MediaType& mediaType)
 {
   CScraperUrl thumbURL;
   if (mediaType == MediaTypeArtist)
@@ -12287,7 +12953,7 @@ std::vector<std::string> CMusicDatabase::GetAvailableArtTypesForItem(int mediaId
 }
 
 std::vector<CScraperUrl::SUrlEntry> CMusicDatabase::GetAvailableArtForItem(
-  int mediaId, const MediaType& mediaType, const std::string& artType)
+    int mediaId, const MediaType& mediaType, const std::string& artType)
 {
   CScraperUrl thumbURL;
   if (mediaType == MediaTypeArtist)
@@ -12386,7 +13052,7 @@ int CMusicDatabase::GetOrderFilter(const std::string& type,
   return iFieldsAdded;
 }
 
-bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription &sorting)
+bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription& sorting)
 {
   if (!musicUrl.IsValid())
     return false;
@@ -12407,7 +13073,8 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
     std::set<std::string> playlists;
     std::string xspWhere;
     xspWhere = xsp.GetWhereClause(*this, playlists);
-    hasRoleRules = xsp.GetType() == "artists" && xspWhere.find("song_artist.idRole = role.idRole") != xspWhere.npos;
+    hasRoleRules = xsp.GetType() == "artists" &&
+                   xspWhere.find("song_artist.idRole = role.idRole") != xspWhere.npos;
 
     // Check if the filter playlist matches the item type
     // Allow for grouping name like "originalyears" and type "years"
@@ -12421,7 +13088,8 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       if (xsp.GetOrder() != SortByNone)
         sorting.sortBy = xsp.GetOrder();
       sorting.sortOrder = xsp.GetOrderAscending() ? SortOrderAscending : SortOrderDescending;
-      if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
+      if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+              CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
         sorting.sortAttributes = SortAttributeIgnoreArticle;
     }
   }
@@ -12450,7 +13118,8 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
   }
 
   std::string strRoleSQL; //Role < 0 means all roles, otherwise filter by role
-  if(idRole > 0) strRoleSQL = PrepareSQL(" AND song_artist.idRole = %i ", idRole);
+  if (idRole > 0)
+    strRoleSQL = PrepareSQL(" AND song_artist.idRole = %i ", idRole);
 
   int idArtist = -1, idGenre = -1, idAlbum = -1, idSong = -1;
   int idDisc = -1;
@@ -12458,7 +13127,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
   bool albumArtistsOnly = false;
   bool useOriginalYear = false;
   std::string artistname;
-  
+
   // Process useoriginalyear option, setting overridden by option
   useOriginalYear = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
       CSettings::SETTING_MUSICLIBRARY_USEORIGINALDATE);
@@ -12515,7 +13184,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
     {
       idArtist = GetArtistByName(option->second.asString());
       if (idArtist == -1)
-      {// not found with that name, or more than one found as artist name is not unique
+      { // not found with that name, or more than one found as artist name is not unique
         artistname = option->second.asString();
       }
     }
@@ -12533,12 +13202,16 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       if (idArtist > 0)
         filter.AppendWhere(PrepareSQL("artistview.idArtist = %d", idArtist));
       else if (idAlbum > 0)
-        filter.AppendWhere(PrepareSQL("artistview.idArtist IN (SELECT album_artist.idArtist FROM album_artist "
-          "WHERE album_artist.idAlbum = %i)", idAlbum));
+        filter.AppendWhere(
+            PrepareSQL("artistview.idArtist IN (SELECT album_artist.idArtist FROM album_artist "
+                       "WHERE album_artist.idAlbum = %i)",
+                       idAlbum));
       else if (idSong > 0)
       {
-        filter.AppendWhere(PrepareSQL("artistview.idArtist IN (SELECT song_artist.idArtist FROM song_artist "
-          "WHERE song_artist.idSong = %i %s)", idSong, strRoleSQL.c_str()));
+        filter.AppendWhere(
+            PrepareSQL("artistview.idArtist IN (SELECT song_artist.idArtist FROM song_artist "
+                       "WHERE song_artist.idSong = %i %s)",
+                       idSong, strRoleSQL.c_str()));
       }
       else
       { /*
@@ -12556,29 +13229,35 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
            table is checked.
         c) When album artists only and role = 1 (an "artist") then only the album_artist
            table is checked.      
-        */        
+        */
         std::string albumArtistSQL, songArtistSQL;
-        ExistsSubQuery albumArtistSub("album_artist", "album_artist.idArtist = artistview.idArtist");
+        ExistsSubQuery albumArtistSub("album_artist",
+                                      "album_artist.idArtist = artistview.idArtist");
         // Prepare album artist subquery SQL
         if (idSource > 0)
         {
           if (idRole == 1 && idGenre < 0)
           {
-            albumArtistSub.AppendJoin("JOIN album_source ON album_source.idAlbum = album_artist.idAlbum");
+            albumArtistSub.AppendJoin(
+                "JOIN album_source ON album_source.idAlbum = album_artist.idAlbum");
             albumArtistSub.AppendWhere(PrepareSQL("album_source.idSource = %i", idSource));
           }
           else
           {
-            albumArtistSub.AppendWhere(PrepareSQL("EXISTS(SELECT 1 FROM album_source "
-              "WHERE album_source.idSource = %i "
-              "AND album_source.idAlbum = album_artist.idAlbum)", idSource));
-          }       
+            albumArtistSub.AppendWhere(
+                PrepareSQL("EXISTS(SELECT 1 FROM album_source "
+                           "WHERE album_source.idSource = %i "
+                           "AND album_source.idAlbum = album_artist.idAlbum)",
+                           idSource));
+          }
         }
         if (idRole <= 1 && idGenre > 0)
         { // Check genre of songs of album using nested subquery
-          std::string strGenre = PrepareSQL("EXISTS(SELECT 1 FROM song "
-            "JOIN song_genre ON song_genre.idSong = song.idSong "
-            "WHERE song.idAlbum = album_artist.idAlbum AND song_genre.idGenre = %i)", idGenre);
+          std::string strGenre =
+              PrepareSQL("EXISTS(SELECT 1 FROM song "
+                         "JOIN song_genre ON song_genre.idSong = song.idSong "
+                         "WHERE song.idAlbum = album_artist.idAlbum AND song_genre.idGenre = %i)",
+                         idGenre);
           albumArtistSub.AppendWhere(strGenre);
         }
 
@@ -12589,14 +13268,15 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
         if (idSource > 0 && idGenre > 0 && !albumArtistsOnly && idRole >= 1)
         {
           songArtistSub.AppendWhere(PrepareSQL("EXISTS(SELECT 1 FROM song "
-            "JOIN song_genre ON song_genre.idSong = song.idSong "
-            "WHERE song.idSong = song_artist.idSong "
-            "AND song_genre.idGenre = %i "
-            "AND EXISTS(SELECT 1 FROM album_source "
-            "WHERE album_source.idSource = %i "
-            "AND album_source.idAlbum = song.idAlbum))", idGenre, idSource));
+                                               "JOIN song_genre ON song_genre.idSong = song.idSong "
+                                               "WHERE song.idSong = song_artist.idSong "
+                                               "AND song_genre.idGenre = %i "
+                                               "AND EXISTS(SELECT 1 FROM album_source "
+                                               "WHERE album_source.idSource = %i "
+                                               "AND album_source.idAlbum = song.idAlbum))",
+                                               idGenre, idSource));
         }
-        else 
+        else
         {
           if (idGenre > 0)
           {
@@ -12615,7 +13295,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
             songArtistSub.AppendJoin("JOIN song ON song.idSong = song_artist.idSong");
             songArtistSub.param = "song_artist.idArtist = album_artist.idArtist";
             songArtistSub.AppendWhere("song.idAlbum = album_artist.idAlbum");
-          }         
+          }
         }
 
         // Build filter clause from subqueries
@@ -12658,14 +13338,15 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
     {
       if (!useOriginalYear)
         filter.AppendWhere(PrepareSQL("albumview.strReleaseDate LIKE '%s%%%%'",
-          option->second.asString().c_str()));
+                                      option->second.asString().c_str()));
       else
         filter.AppendWhere(PrepareSQL("albumview.strOrigReleaseDate LIKE '%s%%%%'",
-          option->second.asString().c_str()));
+                                      option->second.asString().c_str()));
     }
     option = options.find("compilation");
     if (option != options.end())
-      filter.AppendWhere(PrepareSQL("albumview.bCompilation = %i", option->second.asBoolean() ? 1 : 0));
+      filter.AppendWhere(
+          PrepareSQL("albumview.bCompilation = %i", option->second.asBoolean() ? 1 : 0));
 
     option = options.find("boxset");
     if (option != options.end())
@@ -12673,8 +13354,10 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
           PrepareSQL("albumview.bBoxedSet = %i", option->second.asBoolean() ? 1 : 0));
 
     if (idSource > 0)
-      filter.AppendWhere(PrepareSQL("EXISTS(SELECT 1 FROM album_source "
-        "WHERE album_source.idAlbum = albumview.idAlbum AND album_source.idSource = %i)", idSource));
+      filter.AppendWhere(PrepareSQL(
+          "EXISTS(SELECT 1 FROM album_source "
+          "WHERE album_source.idAlbum = albumview.idAlbum AND album_source.idSource = %i)",
+          idSource));
 
     // Process artist, role and genre options together as song subquery to filter those
     // albums that have songs with both that artist and genre
@@ -12715,13 +13398,13 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
         albumArtistSub.AppendWhere(genreSQL);
       }
       if (idRole > 1 && albumArtistsOnly)
-      {  // Album artists only with role, check AND in album_artist for same song
-         // using nested subquery correlated with album_artist
-         songArtistSub.param = "song.idAlbum = album_artist.idAlbum";
-         songArtistSub.BuildSQL(songArtistSQL);
-         albumArtistSub.AppendWhere(songArtistSQL);
-         albumArtistSub.BuildSQL(albumArtistSQL);
-         filter.AppendWhere(albumArtistSQL);
+      { // Album artists only with role, check AND in album_artist for same song
+        // using nested subquery correlated with album_artist
+        songArtistSub.param = "song.idAlbum = album_artist.idAlbum";
+        songArtistSub.BuildSQL(songArtistSQL);
+        albumArtistSub.AppendWhere(songArtistSQL);
+        albumArtistSub.BuildSQL(albumArtistSQL);
+        filter.AppendWhere(albumArtistSQL);
       }
       else
       {
@@ -12756,7 +13439,8 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       // This causes "albums"  media filter artist selection to only offer album artists
       option = options.find("show_singles");
       if (option == options.end() || !option->second.asBoolean())
-        filter.AppendWhere(PrepareSQL("albumview.strReleaseType = '%s'", CAlbum::ReleaseTypeToString(CAlbum::Album).c_str()));
+        filter.AppendWhere(PrepareSQL("albumview.strReleaseType = '%s'",
+                                      CAlbum::ReleaseTypeToString(CAlbum::Album).c_str()));
     }
   }
   else if (type == "discs")
@@ -12770,10 +13454,10 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       {
         if (!useOriginalYear)
           filter.AppendWhere(PrepareSQL("albumview.strReleaseDate LIKE '%s%%%%'",
-            option->second.asString().c_str()));
+                                        option->second.asString().c_str()));
         else
           filter.AppendWhere(PrepareSQL("albumview.strOrigReleaseDate LIKE '%s%%%%'",
-            option->second.asString().c_str()));
+                                        option->second.asString().c_str()));
       }
 
       option = options.find("compilation");
@@ -12787,8 +13471,10 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
             PrepareSQL("albumview.bBoxedSet = %i", option->second.asBoolean() ? 1 : 0));
 
       if (idSource > 0)
-        filter.AppendWhere(PrepareSQL("EXISTS(SELECT 1 FROM album_source "
-          "WHERE album_source.idAlbum = albumview.idAlbum AND album_source.idSource = %i)", idSource));
+        filter.AppendWhere(PrepareSQL(
+            "EXISTS(SELECT 1 FROM album_source "
+            "WHERE album_source.idAlbum = albumview.idAlbum AND album_source.idSource = %i)",
+            idSource));
     }
     option = options.find("discid");
     if (option != options.end())
@@ -12806,15 +13492,17 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
     std::string songArtistClause, albumArtistClause;
     if (idArtist > 0)
     {
-      songArtistClause = PrepareSQL("EXISTS (SELECT 1 FROM song_artist "
-        "WHERE song_artist.idSong = song.idSong AND song_artist.idArtist = %i %s)",
-        idArtist, strRoleSQL.c_str());
-      albumArtistClause = PrepareSQL("EXISTS (SELECT 1 FROM album_artist "
-        "WHERE album_artist.idAlbum = song.idAlbum AND album_artist.idArtist = %i)",
-        idArtist);
+      songArtistClause =
+          PrepareSQL("EXISTS (SELECT 1 FROM song_artist "
+                     "WHERE song_artist.idSong = song.idSong AND song_artist.idArtist = %i %s)",
+                     idArtist, strRoleSQL.c_str());
+      albumArtistClause =
+          PrepareSQL("EXISTS (SELECT 1 FROM album_artist "
+                     "WHERE album_artist.idAlbum = song.idAlbum AND album_artist.idArtist = %i)",
+                     idArtist);
     }
     else if (!artistname.empty())
-    {  // Artist name is not unique, so could get songs from more than one.
+    { // Artist name is not unique, so could get songs from more than one.
       songArtistClause = PrepareSQL(
           "EXISTS (SELECT 1 FROM song_artist JOIN artist ON artist.idArtist = song_artist.idArtist "
           "WHERE song_artist.idSong = song.idSong AND artist.strArtist like '%s' %s)",
@@ -12833,7 +13521,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
         filter.AppendWhere("(" + songArtistClause + " OR " + albumArtistClause + ")");
       else if (idRole > 1)
       {
-        if (albumArtistsOnly)  //Album artists only with role, check AND in album_artist for same song
+        if (albumArtistsOnly) //Album artists only with role, check AND in album_artist for same song
           filter.AppendWhere("(" + songArtistClause + " AND " + albumArtistClause + ")");
         else // songs where artist contributes that role.
           filter.AppendWhere(songArtistClause);
@@ -12851,13 +13539,14 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
   {
     option = options.find("singles");
     if (option != options.end())
-      filter.AppendWhere(PrepareSQL("songview.idAlbum %sIN (SELECT idAlbum FROM album WHERE strReleaseType = '%s')",
-                                    option->second.asBoolean() ? "" : "NOT ",
-                                    CAlbum::ReleaseTypeToString(CAlbum::Single).c_str()));
+      filter.AppendWhere(PrepareSQL(
+          "songview.idAlbum %sIN (SELECT idAlbum FROM album WHERE strReleaseType = '%s')",
+          option->second.asBoolean() ? "" : "NOT ",
+          CAlbum::ReleaseTypeToString(CAlbum::Single).c_str()));
 
     // When have idAlbum skip year, compilation, boxset criteria as already applied via album
     if (idAlbum < 0)
-    { 
+    {
       option = options.find("year");
       if (option != options.end())
       {
@@ -12899,30 +13588,40 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       filter.AppendWhere(PrepareSQL("songview.iTrack >> 16 = %i", idDisc));
 
     if (idGenre > 0)
-      filter.AppendWhere(PrepareSQL("songview.idSong IN (SELECT song_genre.idSong FROM song_genre WHERE song_genre.idGenre = %i)", idGenre));
+      filter.AppendWhere(PrepareSQL("songview.idSong IN (SELECT song_genre.idSong FROM song_genre "
+                                    "WHERE song_genre.idGenre = %i)",
+                                    idGenre));
 
     if (idSource > 0)
-      filter.AppendWhere(PrepareSQL("EXISTS(SELECT 1 FROM album_source "
-        "WHERE album_source.idAlbum = songview.idAlbum AND album_source.idSource = %i)", idSource));
+      filter.AppendWhere(PrepareSQL(
+          "EXISTS(SELECT 1 FROM album_source "
+          "WHERE album_source.idAlbum = songview.idAlbum AND album_source.idSource = %i)",
+          idSource));
 
     std::string songArtistClause, albumArtistClause;
     if (idArtist > 0)
     {
-      songArtistClause = PrepareSQL("EXISTS (SELECT 1 FROM song_artist "
-        "WHERE song_artist.idSong = songview.idSong AND song_artist.idArtist = %i %s)",
-        idArtist, strRoleSQL.c_str());
-      albumArtistClause = PrepareSQL("EXISTS (SELECT 1 FROM album_artist "
-        "WHERE album_artist.idAlbum = songview.idAlbum AND album_artist.idArtist = %i)",
-        idArtist);
+      songArtistClause =
+          PrepareSQL("EXISTS (SELECT 1 FROM song_artist "
+                     "WHERE song_artist.idSong = songview.idSong AND song_artist.idArtist = %i %s)",
+                     idArtist, strRoleSQL.c_str());
+      albumArtistClause = PrepareSQL(
+          "EXISTS (SELECT 1 FROM album_artist "
+          "WHERE album_artist.idAlbum = songview.idAlbum AND album_artist.idArtist = %i)",
+          idArtist);
     }
     else if (!artistname.empty())
-    {  // Artist name is not unique, so could get songs from more than one.
-      songArtistClause = PrepareSQL("EXISTS (SELECT 1 FROM song_artist JOIN artist ON artist.idArtist = song_artist.idArtist "
-        "WHERE song_artist.idSong = songview.idSong AND artist.strArtist like '%s' %s)",
-        artistname.c_str(), strRoleSQL.c_str());
-      albumArtistClause = PrepareSQL("EXISTS (SELECT 1 FROM album_artist JOIN artist ON artist.idArtist = album_artist.idArtist "
-        "WHERE album_artist.idAlbum = songview.idAlbum AND artist.strArtist like '%s')",
-        artistname.c_str());
+    { // Artist name is not unique, so could get songs from more than one.
+      songArtistClause = PrepareSQL(
+          "EXISTS (SELECT 1 FROM song_artist "
+          "JOIN artist ON artist.idArtist = song_artist.idArtist "
+          "WHERE song_artist.idSong = songview.idSong AND artist.strArtist like '%s' %s)",
+          artistname.c_str(), strRoleSQL.c_str());
+      albumArtistClause = PrepareSQL(
+          "EXISTS (SELECT 1 FROM album_artist "
+          "JOIN artist ON artist.idArtist = album_artist.idArtist "
+          "WHERE album_artist.idAlbum = songview.idAlbum AND artist.strArtist like '%s')",
+          artistname.c_str());
     }
 
     // Process artist name or id option
@@ -12932,7 +13631,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
         filter.AppendWhere("(" + songArtistClause + " OR " + albumArtistClause + ")");
       else if (idRole > 1)
       {
-        if (albumArtistsOnly)  //Album artists only with role, check AND in album_artist for same song
+        if (albumArtistsOnly) //Album artists only with role, check AND in album_artist for same song
           filter.AppendWhere("(" + songArtistClause + " AND " + albumArtistClause + ")");
         else // songs where artist contributes that role.
           filter.AppendWhere(songArtistClause);
@@ -12996,28 +13695,26 @@ bool CMusicDatabase::AddAudioBook(const CFileItem& item)
 {
   auto const& artists = item.GetMusicInfoTag()->GetArtist();
   std::string strSQL = PrepareSQL(
-    "INSERT INTO audiobook (idBook,strBook,strAuthor,bookmark,file,dateAdded) "
-    "VALUES (NULL,'%s','%s',%i,'%s','%s')",
-    item.GetMusicInfoTag()->GetAlbum().c_str(),
-    artists.empty() ? "" : artists[0].c_str(),
-    0,
-    item.GetDynPath().c_str(),
-    CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str()
-  );
+      "INSERT INTO audiobook (idBook,strBook,strAuthor,bookmark,file,dateAdded) "
+      "VALUES (NULL,'%s','%s',%i,'%s','%s')",
+      item.GetMusicInfoTag()->GetAlbum().c_str(), artists.empty() ? "" : artists[0].c_str(), 0,
+      item.GetDynPath().c_str(), CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str());
   return ExecuteQuery(strSQL);
 }
 
 bool CMusicDatabase::SetResumeBookmarkForAudioBook(const CFileItem& item, int bookmark)
 {
-  std::string strSQL = PrepareSQL("select bookmark from audiobook where file='%s'",
-                                 item.GetDynPath().c_str());
+  std::string strSQL = PrepareSQL("SELECT bookmark FROM audiobook "
+                                  "WHERE file='%s'",
+                                  item.GetDynPath().c_str());
   if (!m_pDS->query(strSQL.c_str()) || m_pDS->num_rows() == 0)
   {
     if (!AddAudioBook(item))
       return false;
   }
 
-  strSQL = PrepareSQL("UPDATE audiobook SET bookmark=%i WHERE file='%s'",
+  strSQL = PrepareSQL("UPDATE audiobook SET bookmark=%i "
+                      "WHERE file='%s'",
                       bookmark, item.GetDynPath().c_str());
 
   return ExecuteQuery(strSQL);
@@ -13025,8 +13722,8 @@ bool CMusicDatabase::SetResumeBookmarkForAudioBook(const CFileItem& item, int bo
 
 bool CMusicDatabase::GetResumeBookmarkForAudioBook(const CFileItem& item, int& bookmark)
 {
-  std::string strSQL = PrepareSQL("SELECT bookmark FROM audiobook WHERE file='%s'",
-                                 item.GetDynPath().c_str());
+  std::string strSQL =
+      PrepareSQL("SELECT bookmark FROM audiobook WHERE file='%s'", item.GetDynPath().c_str());
   if (!m_pDS->query(strSQL.c_str()) || m_pDS->num_rows() == 0)
     return false;
 

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -13,41 +13,41 @@
 \brief
 */
 
-#include <utility>
-#include <vector>
-
-#include "addons/Scraper.h"
 #include "Album.h"
-#include "dbwrappers/Database.h"
-#include "MusicDbUrl.h"
 #include "MediaSource.h"
+#include "MusicDbUrl.h"
+#include "addons/Scraper.h"
+#include "dbwrappers/Database.h"
 #include "settings/LibExportSettings.h"
 #include "utils/SortUtils.h"
+
+#include <utility>
+#include <vector>
 
 class CArtist;
 class CFileItem;
 
 namespace dbiplus
 {
-  class field_value;
-  typedef std::vector<field_value> sql_record;
-}
+class field_value;
+typedef std::vector<field_value> sql_record;
+} // namespace dbiplus
 
 #include <set>
 #include <string>
 
 // return codes of Cleaning up the Database
 // numbers are strings from strings.po
-#define ERROR_OK     317
-#define ERROR_CANCEL    0
-#define ERROR_DATABASE    315
-#define ERROR_REORG_SONGS   319
-#define ERROR_REORG_ARTIST   321
-#define ERROR_REORG_OTHER   323
-#define ERROR_REORG_PATH   325
-#define ERROR_REORG_ALBUM   327
-#define ERROR_WRITING_CHANGES  329
-#define ERROR_COMPRESSING   332
+#define ERROR_OK 317
+#define ERROR_CANCEL 0
+#define ERROR_DATABASE 315
+#define ERROR_REORG_SONGS 319
+#define ERROR_REORG_ARTIST 321
+#define ERROR_REORG_OTHER 323
+#define ERROR_REORG_PATH 325
+#define ERROR_REORG_ALBUM 327
+#define ERROR_WRITING_CHANGES 329
+#define ERROR_COMPRESSING 332
 
 #define NUM_SONGS_BEFORE_COMMIT 500
 
@@ -71,7 +71,8 @@ typedef std::set<std::string>::iterator ISETPATHS;
 \sa CMusicDatabase::GetArtForItem()
 */
 
-typedef struct {
+typedef struct
+{
   std::string mediaType;
   std::string artType;
   std::string prefix;
@@ -107,8 +108,8 @@ public:
   bool CommitTransaction() override;
   void EmptyCache();
   void Clean();
-  int  Cleanup(CGUIDialogProgress* progressDialog = nullptr);
-  bool LookupCDDBInfo(bool bRequery=false);
+  int Cleanup(CGUIDialogProgress* progressDialog = nullptr);
+  bool LookupCDDBInfo(bool bRequery = false);
   void DeleteCDDBInfo();
 
   /////////////////////////////////////////////////
@@ -142,7 +143,8 @@ public:
    \param replayGain [in] album and track replaygain and peak values
    \return the id of the song
    */
-  int AddSong(const int idSong, const CDateTime& dtDateNew,
+  int AddSong(const int idSong,
+              const CDateTime& dtDateNew,
               const int idAlbum,
               const std::string& strTitle,
               const std::string& strMusicBrainzTrackID,
@@ -150,19 +152,29 @@ public:
               const std::string& strComment,
               const std::string& strMood,
               const std::string& strThumb,
-              const std::string &artistDisp, const std::string &artistSort,
+              const std::string& artistDisp,
+              const std::string& artistSort,
               const std::vector<std::string>& genres,
-              int iTrack, int iDuration,
+              int iTrack,
+              int iDuration,
               const std::string& strReleaseDate,
               const std::string& strOrigReleaseDate,
               std::string& strDiscSubtitle,
-              const int iTimesPlayed, int iStartOffset, int iEndOffset,
-              const CDateTime& dtLastPlayed, float rating, int userrating, int votes,
-              int iBPM, int iBitRate, int iSampleRate, int iChannels,
+              const int iTimesPlayed,
+              int iStartOffset,
+              int iEndOffset,
+              const CDateTime& dtLastPlayed,
+              float rating,
+              int userrating,
+              int votes,
+              int iBPM,
+              int iBitRate,
+              int iSampleRate,
+              int iChannels,
               const ReplayGain& replayGain);
   bool GetSong(int idSong, CSong& song);
 
-   /*! \brief Update a song and all its nested entities (genres, artists, contributors)
+  /*! \brief Update a song and all its nested entities (genres, artists, contributors)
     \param song [in/out] the song to update, artist ids are returned in artist credits
     \param bArtists to update artist credits and contributors, default is true
     \param bArtists to check and log if artist links have changed, default is true
@@ -201,30 +213,45 @@ public:
    \return the id of the song
    */
   int UpdateSong(int idSong,
-                 const std::string& strTitle, const std::string& strMusicBrainzTrackID,
-                 const std::string& strPathAndFileName, const std::string& strComment,
-                 const std::string& strMood, const std::string& strThumb,
-                 const std::string& artistDisp, const std::string& artistSort,
+                 const std::string& strTitle,
+                 const std::string& strMusicBrainzTrackID,
+                 const std::string& strPathAndFileName,
+                 const std::string& strComment,
+                 const std::string& strMood,
+                 const std::string& strThumb,
+                 const std::string& artistDisp,
+                 const std::string& artistSort,
                  const std::vector<std::string>& genres,
-                 int iTrack, int iDuration,
+                 int iTrack,
+                 int iDuration,
                  const std::string& strReleaseDate,
                  const std::string& strOrigReleaseDate,
                  const std::string& strDiscSubtitle,
-                 int iTimesPlayed, int iStartOffset, int iEndOffset,
-                 const CDateTime& dtLastPlayed, float rating, int userrating, int votes,
+                 int iTimesPlayed,
+                 int iStartOffset,
+                 int iEndOffset,
+                 const CDateTime& dtLastPlayed,
+                 float rating,
+                 int userrating,
+                 int votes,
                  const ReplayGain& replayGain,
-                 int iBPM, int iBitRate, int iSampleRate, int iChannels);
+                 int iBPM,
+                 int iBitRate,
+                 int iSampleRate,
+                 int iChannels);
 
   //// Misc Song
   bool GetSongByFileName(const std::string& strFileName, CSong& song, int64_t startOffset = 0);
   bool GetSongsByPath(const std::string& strPath, MAPSONGS& songmap, bool bAppendToMap = false);
-  bool Search(const std::string& search, CFileItemList &items);
-  bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songmap, bool exact=true);
+  bool Search(const std::string& search, CFileItemList& items);
+  bool RemoveSongsFromPath(const std::string& path, MAPSONGS& songmap, bool exact = true);
   void CheckArtistLinksChanged();
-  bool SetSongUserrating(const std::string &filePath, int userrating);
+  bool SetSongUserrating(const std::string& filePath, int userrating);
   bool SetSongUserrating(int idSong, int userrating);
-  bool SetSongVotes(const std::string &filePath, int votes);
-  int  GetSongByArtistAndAlbumAndTitle(const std::string& strArtist, const std::string& strAlbum, const std::string& strTitle);
+  bool SetSongVotes(const std::string& filePath, int votes);
+  int GetSongByArtistAndAlbumAndTitle(const std::string& strArtist,
+                                      const std::string& strAlbum,
+                                      const std::string& strTitle);
 
   /////////////////////////////////////////////////
   // Album
@@ -258,15 +285,20 @@ public:
    \param releaseType "album" or "single"
    \return the id of the album
    */
-  int  AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
-                const std::string& strReleaseGroupMBID,
-                const std::string& strArtist, const std::string& strArtistSort,
-                const std::string& strGenre,
-                const std::string& strReleaseDate, const std::string& strOrigReleaseDate,
-                bool bBoxedSet,
-                const std::string& strRecordLabel, const std::string& strType,
-                const std::string& strReleaseStatus,
-                bool bCompilation, CAlbum::ReleaseType releaseType);
+  int AddAlbum(const std::string& strAlbum,
+               const std::string& strMusicBrainzAlbumID,
+               const std::string& strReleaseGroupMBID,
+               const std::string& strArtist,
+               const std::string& strArtistSort,
+               const std::string& strGenre,
+               const std::string& strReleaseDate,
+               const std::string& strOrigReleaseDate,
+               bool bBoxedSet,
+               const std::string& strRecordLabel,
+               const std::string& strType,
+               const std::string& strReleaseStatus,
+               bool bCompilation,
+               CAlbum::ReleaseType releaseType);
 
   /*! \brief retrieve an album, optionally with all songs.
    \param idAlbum the database id of the album.
@@ -275,22 +307,30 @@ public:
    \return true if the album is retrieved, false otherwise.
    */
   bool GetAlbum(int idAlbum, CAlbum& album, bool getSongs = true);
-  int  UpdateAlbum(int idAlbum,
-                   const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
-                   const std::string& strReleaseGroupMBID,
-                   const std::string& strArtist, const std::string& strArtistSort,
-                   const std::string& strGenre,
-                   const std::string& strMoods, const std::string& strStyles,
-                   const std::string& strThemes, const std::string& strReview,
-                   const std::string& strImage, const std::string& strLabel,
-                   const std::string& strType,
-                   const std::string& strReleaseStatus,
-                   float fRating, int iUserrating, int iVotes,
-                   const std::string& strReleaseDate, const std::string& strOrigReleaseDate,
-                   bool bBoxedSet,
-                   bool bCompilation,
-                   CAlbum::ReleaseType releaseType,
-                   bool bScrapedMBID);
+  int UpdateAlbum(int idAlbum,
+                  const std::string& strAlbum,
+                  const std::string& strMusicBrainzAlbumID,
+                  const std::string& strReleaseGroupMBID,
+                  const std::string& strArtist,
+                  const std::string& strArtistSort,
+                  const std::string& strGenre,
+                  const std::string& strMoods,
+                  const std::string& strStyles,
+                  const std::string& strThemes,
+                  const std::string& strReview,
+                  const std::string& strImage,
+                  const std::string& strLabel,
+                  const std::string& strType,
+                  const std::string& strReleaseStatus,
+                  float fRating,
+                  int iUserrating,
+                  int iVotes,
+                  const std::string& strReleaseDate,
+                  const std::string& strOrigReleaseDate,
+                  bool bBoxedSet,
+                  bool bCompilation,
+                  CAlbum::ReleaseType releaseType,
+                  bool bScrapedMBID);
   bool ClearAlbumLastScrapedTime(int idAlbum);
   bool HasAlbumBeenScraped(int idAlbum);
 
@@ -307,10 +347,10 @@ public:
   bool InsideScannedPath(const std::string& path);
 
   //// Misc Album
-  int  GetAlbumIdByPath(const std::string& path);
-  bool GetAlbumFromSong(int idSong, CAlbum &album);
-  int  GetAlbumByName(const std::string& strAlbum, const std::string& strArtist="");
-  int  GetAlbumByName(const std::string& strAlbum, const std::vector<std::string>& artist);
+  int GetAlbumIdByPath(const std::string& path);
+  bool GetAlbumFromSong(int idSong, CAlbum& album);
+  int GetAlbumByName(const std::string& strAlbum, const std::string& strArtist = "");
+  int GetAlbumByName(const std::string& strAlbum, const std::vector<std::string>& artist);
   bool GetMatchingMusicVideoAlbum(const std::string& strAlbum,
                                   const std::string& strArtist,
                                   int& idAlbum,
@@ -327,23 +367,36 @@ public:
   /////////////////////////////////////////////////
   bool UpdateArtist(const CArtist& artist);
 
-  int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, const std::string& strSortName, bool bScrapedMBID = false);
-  int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, bool bScrapedMBID = false);
+  int AddArtist(const std::string& strArtist,
+                const std::string& strMusicBrainzArtistID,
+                const std::string& strSortName,
+                bool bScrapedMBID = false);
+  int AddArtist(const std::string& strArtist,
+                const std::string& strMusicBrainzArtistID,
+                bool bScrapedMBID = false);
   bool GetArtist(int idArtist, CArtist& artist, bool fetchAll = false);
   bool GetArtistExists(int idArtist);
   int GetLastArtist();
   int GetArtistFromMBID(const std::string& strMusicBrainzArtistID, std::string& artistname);
-  int  UpdateArtist(int idArtist,
-                    const std::string& strArtist, const std::string& strSortName,
-                    const std::string& strMusicBrainzArtistID, bool bScrapedMBID,
-                    const std::string& strType, const std::string& strGender,
-                    const std::string& strDisambiguation,
-                    const std::string& strBorn, const std::string& strFormed,
-                    const std::string& strGenres, const std::string& strMoods,
-                    const std::string& strStyles, const std::string& strInstruments,
-                    const std::string& strBiography, const std::string& strDied,
-                    const std::string& strDisbanded, const std::string& strYearsActive,
-                    const std::string& strImage);
+  int UpdateArtist(int idArtist,
+                   const std::string& strArtist,
+                   const std::string& strSortName,
+                   const std::string& strMusicBrainzArtistID,
+                   bool bScrapedMBID,
+                   const std::string& strType,
+                   const std::string& strGender,
+                   const std::string& strDisambiguation,
+                   const std::string& strBorn,
+                   const std::string& strFormed,
+                   const std::string& strGenres,
+                   const std::string& strMoods,
+                   const std::string& strStyles,
+                   const std::string& strInstruments,
+                   const std::string& strBiography,
+                   const std::string& strDied,
+                   const std::string& strDisbanded,
+                   const std::string& strYearsActive,
+                   const std::string& strImage);
   bool UpdateArtistScrapedMBID(int idArtist, const std::string& strMusicBrainzArtistID);
   bool GetTranslateBlankArtist() { return m_translateBlankArtist; }
   void SetTranslateBlankArtist(bool translate) { m_translateBlankArtist = translate; }
@@ -356,7 +409,7 @@ public:
   std::string GetArtistById(int id);
   int GetArtistByName(const std::string& strArtist);
   int GetArtistByMatch(const CArtist& artist);
-  bool GetArtistFromSong(int idSong, CArtist &artist);
+  bool GetArtistFromSong(int idSong, CArtist& artist);
   bool IsSongArtist(int idSong, int idArtist);
   bool IsSongAlbumArtist(int idSong, int idArtist);
   std::string GetRoleById(int id);
@@ -372,28 +425,36 @@ public:
   /////////////////////////////////////////////////
   int AddPath(const std::string& strPath);
 
-  bool GetPaths(std::set<std::string> &paths);
-  bool SetPathHash(const std::string &path, const std::string &hash);
-  bool GetPathHash(const std::string &path, std::string &hash);
+  bool GetPaths(std::set<std::string>& paths);
+  bool SetPathHash(const std::string& path, const std::string& hash);
+  bool GetPathHash(const std::string& path, std::string& hash);
   bool GetAlbumPaths(int idAlbum, std::vector<std::pair<std::string, int>>& paths);
-  bool GetAlbumPath(int idAlbum, std::string &basePath);
+  bool GetAlbumPath(int idAlbum, std::string& basePath);
   int GetDiscnumberForPathID(int idPath);
-  bool GetOldArtistPath(int idArtist, std::string &path);
-  bool GetArtistPath(const CArtist& artist, std::string &path);
-  bool GetAlbumFolder(const CAlbum& album, const std::string &strAlbumPath, std::string &strFolder);
-  bool GetArtistFolderName(const CArtist& artist, std::string &strFolder);
-  bool GetArtistFolderName(const std::string &strArtist, const std::string &strMusicBrainzArtistID, std::string &strFolder);
+  bool GetOldArtistPath(int idArtist, std::string& path);
+  bool GetArtistPath(const CArtist& artist, std::string& path);
+  bool GetAlbumFolder(const CAlbum& album, const std::string& strAlbumPath, std::string& strFolder);
+  bool GetArtistFolderName(const CArtist& artist, std::string& strFolder);
+  bool GetArtistFolderName(const std::string& strArtist,
+                           const std::string& strMusicBrainzArtistID,
+                           std::string& strFolder);
 
   /////////////////////////////////////////////////
   // Sources
   /////////////////////////////////////////////////
   bool UpdateSources();
-  int AddSource(const std::string& strName, const std::string& strMultipath, const std::vector<std::string>& vecPaths, int id = -1);
-  int UpdateSource(const std::string& strOldName, const std::string& strName, const std::string& strMultipath, const std::vector<std::string>& vecPaths);
+  int AddSource(const std::string& strName,
+                const std::string& strMultipath,
+                const std::vector<std::string>& vecPaths,
+                int id = -1);
+  int UpdateSource(const std::string& strOldName,
+                   const std::string& strName,
+                   const std::string& strMultipath,
+                   const std::vector<std::string>& vecPaths);
   bool RemoveSource(const std::string& strName);
   int GetSourceFromPath(const std::string& strPath);
   bool AddAlbumSource(int idAlbum, int idSource);
-  bool AddAlbumSources(int idAlbum,  const std::string& strPath);
+  bool AddAlbumSources(int idAlbum, const std::string& strPath);
   bool DeleteAlbumSources(int idAlbum);
   bool GetSources(CFileItemList& items);
 
@@ -419,11 +480,21 @@ public:
   bool GetArtistsByAlbum(int idAlbum, std::vector<std::string>& artistIDs);
   bool DeleteAlbumArtistsByAlbum(int idAlbum);
 
-  int AddRole(const std::string &strRole);
-  bool AddSongArtist(int idArtist, int idSong, const std::string& strRole, const std::string& strArtist, int iOrder);
-  bool AddSongArtist(int idArtist, int idSong, int idRole, const std::string& strArtist, int iOrder);
-  int  AddSongContributor(int idSong, const std::string& strRole, const std::string& strArtist, const std::string &strSort);
-  void AddSongContributors(int idSong, const VECMUSICROLES& contributors, const std::string &strSort);
+  int AddRole(const std::string& strRole);
+  bool AddSongArtist(int idArtist,
+                     int idSong,
+                     const std::string& strRole,
+                     const std::string& strArtist,
+                     int iOrder);
+  bool AddSongArtist(
+      int idArtist, int idSong, int idRole, const std::string& strArtist, int iOrder);
+  int AddSongContributor(int idSong,
+                         const std::string& strRole,
+                         const std::string& strArtist,
+                         const std::string& strSort);
+  void AddSongContributors(int idSong,
+                           const VECMUSICROLES& contributors,
+                           const std::string& strSort);
   int GetRoleByName(const std::string& strRole);
   bool GetRolesByArtist(int idArtist, CFileItem* item);
   bool GetSongsByArtist(int idArtist, std::vector<int>& songs);
@@ -448,15 +519,17 @@ public:
   /////////////////////////////////////////////////
   // Recently added
   /////////////////////////////////////////////////
-  bool GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limit=0);
-  bool GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, CFileItemList& item, unsigned int limit=0);
+  bool GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limit = 0);
+  bool GetRecentlyAddedAlbumSongs(const std::string& strBaseDir,
+                                  CFileItemList& item,
+                                  unsigned int limit = 0);
   bool GetRecentlyPlayedAlbums(VECALBUMS& albums);
   bool GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, CFileItemList& item);
 
   /////////////////////////////////////////////////
   // Compilations
   /////////////////////////////////////////////////
-  int  GetCompilationAlbumsCount();
+  int GetCompilationAlbumsCount();
 
   ////////////////////////////////////////////////
   // Boxsets
@@ -473,21 +546,56 @@ public:
    Increments the playcount and updates the last played date
    \param item CFileItem to increment the playcount for
    */
-  void IncrementPlayCount(const CFileItem &item);
+  void IncrementPlayCount(const CFileItem& item);
   bool CleanupOrphanedItems();
 
   /////////////////////////////////////////////////
   // VIEWS
   /////////////////////////////////////////////////
-  bool GetGenresNav(const std::string& strBaseDir, CFileItemList& items, const Filter &filter = Filter(), bool countOnly = false);
-  bool GetSourcesNav(const std::string& strBaseDir, CFileItemList& items, const Filter &filter = Filter(), bool countOnly = false);
-  bool GetYearsNav(const std::string& strBaseDir, CFileItemList& items, const Filter &filter = Filter());
-  bool GetRolesNav(const std::string& strBaseDir, CFileItemList& items, const Filter &filter = Filter());
-  bool GetArtistsNav(const std::string& strBaseDir, CFileItemList& items, bool albumArtistsOnly = false, int idGenre = -1, int idAlbum = -1, int idSong = -1, const Filter &filter = Filter(), const SortDescription &sortDescription = SortDescription(), bool countOnly = false);
-  bool GetCommonNav(const std::string &strBaseDir, const std::string &table, const std::string &labelField, CFileItemList &items, const Filter &filter /* = Filter() */, bool countOnly /* = false */);
-  bool GetAlbumTypesNav(const std::string &strBaseDir, CFileItemList &items, const Filter &filter = Filter(), bool countOnly = false);
-  bool GetMusicLabelsNav(const std::string &strBaseDir, CFileItemList &items, const Filter &filter = Filter(), bool countOnly = false);
-  bool GetAlbumsNav(const std::string& strBaseDir, CFileItemList& items, int idGenre = -1, int idArtist = -1, const Filter &filter = Filter(), const SortDescription &sortDescription = SortDescription(), bool countOnly = false);
+  bool GetGenresNav(const std::string& strBaseDir,
+                    CFileItemList& items,
+                    const Filter& filter = Filter(),
+                    bool countOnly = false);
+  bool GetSourcesNav(const std::string& strBaseDir,
+                     CFileItemList& items,
+                     const Filter& filter = Filter(),
+                     bool countOnly = false);
+  bool GetYearsNav(const std::string& strBaseDir,
+                   CFileItemList& items,
+                   const Filter& filter = Filter());
+  bool GetRolesNav(const std::string& strBaseDir,
+                   CFileItemList& items,
+                   const Filter& filter = Filter());
+  bool GetArtistsNav(const std::string& strBaseDir,
+                     CFileItemList& items,
+                     bool albumArtistsOnly = false,
+                     int idGenre = -1,
+                     int idAlbum = -1,
+                     int idSong = -1,
+                     const Filter& filter = Filter(),
+                     const SortDescription& sortDescription = SortDescription(),
+                     bool countOnly = false);
+  bool GetCommonNav(const std::string& strBaseDir,
+                    const std::string& table,
+                    const std::string& labelField,
+                    CFileItemList& items,
+                    const Filter& filter /* = Filter() */,
+                    bool countOnly /* = false */);
+  bool GetAlbumTypesNav(const std::string& strBaseDir,
+                        CFileItemList& items,
+                        const Filter& filter = Filter(),
+                        bool countOnly = false);
+  bool GetMusicLabelsNav(const std::string& strBaseDir,
+                         CFileItemList& items,
+                         const Filter& filter = Filter(),
+                         bool countOnly = false);
+  bool GetAlbumsNav(const std::string& strBaseDir,
+                    CFileItemList& items,
+                    int idGenre = -1,
+                    int idArtist = -1,
+                    const Filter& filter = Filter(),
+                    const SortDescription& sortDescription = SortDescription(),
+                    bool countOnly = false);
   bool GetDiscsNav(const std::string& strBaseDir,
                    CFileItemList& items,
                    int idAlbum,
@@ -495,11 +603,27 @@ public:
                    const SortDescription& sortDescription = SortDescription(),
                    bool countOnly = false);
   bool GetAlbumsByYear(const std::string& strBaseDir, CFileItemList& items, int year);
-  bool GetSongsNav(const std::string& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription = SortDescription());
+  bool GetSongsNav(const std::string& strBaseDir,
+                   CFileItemList& items,
+                   int idGenre,
+                   int idArtist,
+                   int idAlbum,
+                   const SortDescription& sortDescription = SortDescription());
   bool GetSongsByYear(const std::string& baseDir, CFileItemList& items, int year);
-  bool GetSongsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
-  bool GetSongsFullByWhere(const std::string &baseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), bool artistData = false);
-  bool GetAlbumsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription = SortDescription(), bool countOnly = false);
+  bool GetSongsByWhere(const std::string& baseDir,
+                       const Filter& filter,
+                       CFileItemList& items,
+                       const SortDescription& sortDescription = SortDescription());
+  bool GetSongsFullByWhere(const std::string& baseDir,
+                           const Filter& filter,
+                           CFileItemList& items,
+                           const SortDescription& sortDescription = SortDescription(),
+                           bool artistData = false);
+  bool GetAlbumsByWhere(const std::string& baseDir,
+                        const Filter& filter,
+                        CFileItemList& items,
+                        const SortDescription& sortDescription = SortDescription(),
+                        bool countOnly = false);
   bool GetDiscsByWhere(const std::string& baseDir,
                        const Filter& filter,
                        CFileItemList& items,
@@ -510,10 +634,14 @@ public:
                        CFileItemList& items,
                        const SortDescription& sortDescription = SortDescription(),
                        bool countOnly = false);
-  bool GetArtistsByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), bool countOnly = false);
+  bool GetArtistsByWhere(const std::string& strBaseDir,
+                         const Filter& filter,
+                         CFileItemList& items,
+                         const SortDescription& sortDescription = SortDescription(),
+                         bool countOnly = false);
   int GetDiscsCount(const std::string& baseDir, const Filter& filter = Filter());
-  int GetSongsCount(const Filter &filter = Filter());
-  bool GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription &sorting) override;
+  int GetSongsCount(const Filter& filter = Filter());
+  bool GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription& sorting) override;
   int GetOrderFilter(const std::string& type, const SortDescription& sorting, Filter& filter);
 
   /////////////////////////////////////////////////
@@ -524,46 +652,65 @@ public:
   \param songIDs a vector of <1, id> pairs suited to party mode use
   \return count of song ids found.
   */
-  unsigned int GetRandomSongIDs(const Filter &filter, std::vector<std::pair<int, int> > &songIDs);
+  unsigned int GetRandomSongIDs(const Filter& filter, std::vector<std::pair<int, int>>& songIDs);
 
   /////////////////////////////////////////////////
-  // JSON-RPC 
+  // JSON-RPC
   /////////////////////////////////////////////////
   bool GetGenresJSON(CFileItemList& items, bool bSources = false);
-  bool GetArtistsByWhereJSON(const std::set<std::string>& fields, const std::string& baseDir,
-    CVariant& result, int& total, const SortDescription& sortDescription = SortDescription());
-  bool GetAlbumsByWhereJSON(const std::set<std::string>& fields, const std::string& baseDir,
-    CVariant& result, int& total, const SortDescription& sortDescription = SortDescription());
-  bool GetSongsByWhereJSON(const std::set<std::string>& fields, const std::string& baseDir,
-    CVariant& result, int& total, const SortDescription& sortDescription = SortDescription());
+  bool GetArtistsByWhereJSON(const std::set<std::string>& fields,
+                             const std::string& baseDir,
+                             CVariant& result,
+                             int& total,
+                             const SortDescription& sortDescription = SortDescription());
+  bool GetAlbumsByWhereJSON(const std::set<std::string>& fields,
+                            const std::string& baseDir,
+                            CVariant& result,
+                            int& total,
+                            const SortDescription& sortDescription = SortDescription());
+  bool GetSongsByWhereJSON(const std::set<std::string>& fields,
+                           const std::string& baseDir,
+                           CVariant& result,
+                           int& total,
+                           const SortDescription& sortDescription = SortDescription());
 
   /////////////////////////////////////////////////
   // Scraper
   /////////////////////////////////////////////////
   bool SetScraper(int id, const CONTENT_TYPE& content, const ADDON::ScraperPtr& scraper);
   bool SetScraperAll(const std::string& strBaseDir, const ADDON::ScraperPtr& scraper);
-  bool GetScraper(int id, const CONTENT_TYPE &content, ADDON::ScraperPtr& scraper);
+  bool GetScraper(int id, const CONTENT_TYPE& content, ADDON::ScraperPtr& scraper);
 
   /*! \brief Check whether a given scraper is in use.
    \param scraperID the scraper to check for.
    \return true if the scraper is in use, false otherwise.
    */
-  bool ScraperInUse(const std::string &scraperID) const;
+  bool ScraperInUse(const std::string& scraperID) const;
 
   /////////////////////////////////////////////////
   // Filters
   /////////////////////////////////////////////////
-  bool GetItems(const std::string &strBaseDir, CFileItemList &items, const Filter &filter = Filter(), const SortDescription &sortDescription = SortDescription());
-  bool GetItems(const std::string &strBaseDir, const std::string &itemType, CFileItemList &items, const Filter &filter = Filter(), const SortDescription &sortDescription = SortDescription());
-  std::string GetItemById(const std::string &itemType, int id);
+  bool GetItems(const std::string& strBaseDir,
+                CFileItemList& items,
+                const Filter& filter = Filter(),
+                const SortDescription& sortDescription = SortDescription());
+  bool GetItems(const std::string& strBaseDir,
+                const std::string& itemType,
+                CFileItemList& items,
+                const Filter& filter = Filter(),
+                const SortDescription& sortDescription = SortDescription());
+  std::string GetItemById(const std::string& itemType, int id);
 
   /////////////////////////////////////////////////
   // XML
   /////////////////////////////////////////////////
-  void ExportToXML(const CLibExportSettings& settings, CGUIDialogProgress* progressDialog = nullptr);
+  void ExportToXML(const CLibExportSettings& settings,
+                   CGUIDialogProgress* progressDialog = nullptr);
   bool ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* progressDialog = nullptr);
   void ImportFromXML(const std::string& xmlFile, CGUIDialogProgress* progressDialog = nullptr);
-  bool ImportSongHistory(const std::string& xmlFile, const int total, CGUIDialogProgress* progressDialog = nullptr);
+  bool ImportSongHistory(const std::string& xmlFile,
+                         const int total,
+                         CGUIDialogProgress* progressDialog = nullptr);
 
   /////////////////////////////////////////////////
   // Properties
@@ -584,7 +731,10 @@ public:
    \param url the url to the art (this is the original url, not a cached url).
    \sa GetArtForItem
    */
-  void SetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType, const std::string &url);
+  void SetArtForItem(int mediaId,
+                     const std::string& mediaType,
+                     const std::string& artType,
+                     const std::string& url);
 
   /*! \brief Sets art for a database item.
    Sets multiple pieces of art for a database item.
@@ -593,7 +743,9 @@ public:
    \param art a map of <type, url> where type is "thumb", "fanart", etc. and url is the original url of the art.
    \sa GetArtForItem
    */
-  void SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art);
+  void SetArtForItem(int mediaId,
+                     const std::string& mediaType,
+                     const std::map<std::string, std::string>& art);
 
 
   /*! \brief Fetch all related art for a database item.
@@ -613,7 +765,11 @@ public:
   \return true if art is retrieved, false if no art is found.
   \sa SetArtForItem
   */
-  bool GetArtForItem(int songId, int albumId, int artistId, bool bPrimaryArtist, std::vector<ArtForThumbLoader> &art);
+  bool GetArtForItem(int songId,
+                     int albumId,
+                     int artistId,
+                     bool bPrimaryArtist,
+                     std::vector<ArtForThumbLoader>& art);
 
   /*! \brief Fetch art for a database item.
    Fetches multiple pieces of art for a database item.
@@ -623,7 +779,9 @@ public:
    \return true if art is retrieved, false if no art is found.
    \sa SetArtForItem
    */
-  bool GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);
+  bool GetArtForItem(int mediaId,
+                     const std::string& mediaType,
+                     std::map<std::string, std::string>& art);
 
   /*! \brief Fetch art for a database item.
    Fetches a single piece of art for a database item.
@@ -633,7 +791,7 @@ public:
    \return the original URL to the piece of art, if available.
    \sa SetArtForItem
    */
-  std::string GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
+  std::string GetArtForItem(int mediaId, const std::string& mediaType, const std::string& artType);
 
   /*! \brief Remove art for a database item.
   Removes  a single piece of art for a database item.
@@ -643,7 +801,7 @@ public:
   \return true if art is removed, false if no art is found.
   \sa RemoveArtForItem
   */
-  bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
+  bool RemoveArtForItem(int mediaId, const MediaType& mediaType, const std::string& artType);
 
   /*! \brief Remove art for a database item.
   Removes multiple pieces of art for a database item.
@@ -653,14 +811,16 @@ public:
   \return true if art is removed, false if no art is found.
   \sa RemoveArtForItem
   */
-  bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);
+  bool RemoveArtForItem(int mediaId,
+                        const MediaType& mediaType,
+                        const std::set<std::string>& artTypes);
 
   /*! \brief Fetch the distinct types of art held in the database for a type of media.
   \param mediaType the type of media, which corresponds to the table the item resides in (song/artist/album).
   \param artTypes [out] the types of art e.g. "thumb", "fanart", etc.
   \return true if art is found, false if no art is found.
   */
-  bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
+  bool GetArtTypes(const MediaType& mediaType, std::vector<std::string>& artTypes);
 
   /*! \brief Fetch the distinct types of available-but-unassigned art held in the
   database for a specific media item.
@@ -677,8 +837,9 @@ public:
   \param artType e.g. "thumb", "fanart", etc.
   \return list of URLs
   */
-  std::vector<CScraperUrl::SUrlEntry> GetAvailableArtForItem(
-    int mediaId, const MediaType& mediaType, const std::string& artType);
+  std::vector<CScraperUrl::SUrlEntry> GetAvailableArtForItem(int mediaId,
+                                                             const MediaType& mediaType,
+                                                             const std::string& artType);
 
   /////////////////////////////////////////////////
   // Tag Scan Version
@@ -700,19 +861,19 @@ public:
   */
   void SetMusicTagScanVersion(int version = 0);
 
-std::string GetLibraryLastUpdated();
-void SetLibraryLastUpdated();
-std::string GetLibraryLastCleaned();
-void SetLibraryLastCleaned();
-std::string GetArtistLinksUpdated();
-void SetArtistLinksUpdated();
-std::string GetGenresLastAdded();
-std::string GetSongsLastAdded();
-std::string GetAlbumsLastAdded();
-std::string GetArtistsLastAdded();
-std::string GetSongsLastModified();
-std::string GetAlbumsLastModified();
-std::string GetArtistsLastModified();
+  std::string GetLibraryLastUpdated();
+  void SetLibraryLastUpdated();
+  std::string GetLibraryLastCleaned();
+  void SetLibraryLastCleaned();
+  std::string GetArtistLinksUpdated();
+  void SetArtistLinksUpdated();
+  std::string GetGenresLastAdded();
+  std::string GetSongsLastAdded();
+  std::string GetAlbumsLastAdded();
+  std::string GetArtistsLastAdded();
+  std::string GetSongsLastModified();
+  std::string GetAlbumsLastModified();
+  std::string GetArtistsLastModified();
 
 
 protected:
@@ -724,7 +885,7 @@ protected:
   int GetMinSchemaVersion() const override { return 32; }
   int GetSchemaVersion() const override;
 
-  const char *GetBaseDBName() const override { return "MyMusic"; };
+  const char* GetBaseDBName() const override { return "MyMusic"; };
 
 private:
   /*! \brief (Re)Create the generic database views for songs and albums
@@ -733,25 +894,33 @@ private:
   void CreateNativeDBFunctions();
   void CreateRemovedLinkTriggers();
 
-  void SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);
+  void SplitPath(const std::string& strFileNameAndPath,
+                 std::string& strPath,
+                 std::string& strFileName);
 
   CSong GetSongFromDataset();
   CSong GetSongFromDataset(const dbiplus::sql_record* const record, int offset = 0);
   CArtist GetArtistFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool needThumb = true);
-  CArtist GetArtistFromDataset(const dbiplus::sql_record* const record, int offset = 0, bool needThumb = true);
+  CArtist GetArtistFromDataset(const dbiplus::sql_record* const record,
+                               int offset = 0,
+                               bool needThumb = true);
   CAlbum GetAlbumFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool imageURL = false);
-  CAlbum GetAlbumFromDataset(const dbiplus::sql_record* const record, int offset = 0, bool imageURL = false);
+  CAlbum GetAlbumFromDataset(const dbiplus::sql_record* const record,
+                             int offset = 0,
+                             bool imageURL = false);
   CArtistCredit GetArtistCreditFromDataset(const dbiplus::sql_record* const record, int offset = 0);
   CMusicRole GetArtistRoleFromDataset(const dbiplus::sql_record* const record, int offset = 0);
   std::string GetMediaDateFromFile(const std::string& strFileNameAndPath);
-  void GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl &baseUrl);
-  void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CMusicDbUrl &baseUrl);
+  void GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl& baseUrl);
+  void GetFileItemFromDataset(const dbiplus::sql_record* const record,
+                              CFileItem* item,
+                              const CMusicDbUrl& baseUrl);
   void GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits, CFileItem* item);
-    
+
   bool DeleteRemovedLinks();
 
   bool CleanupSongs(CGUIDialogProgress* progressDialog = nullptr);
-  bool CleanupSongsByIds(const std::string &strSongIds);
+  bool CleanupSongsByIds(const std::string& strSongIds);
   bool CleanupPaths();
   bool CleanupAlbums();
   bool CleanupArtists();
@@ -759,10 +928,10 @@ private:
   bool CleanupInfoSettings();
   bool CleanupRoles();
   void UpdateTables(int version) override;
-  bool SearchArtists(const std::string& search, CFileItemList &artists);
-  bool SearchAlbums(const std::string& search, CFileItemList &albums);
-  bool SearchSongs(const std::string& strSearch, CFileItemList &songs);
-  int GetSongIDFromPath(const std::string &filePath);
+  bool SearchArtists(const std::string& search, CFileItemList& artists);
+  bool SearchAlbums(const std::string& search, CFileItemList& albums);
+  bool SearchSongs(const std::string& strSearch, CFileItemList& songs);
+  int GetSongIDFromPath(const std::string& filePath);
   void NormaliseSongDates(std::string& strRelease, std::string& strOriginal);
   bool TrimImageURLs(std::string& strImage, const size_t space);
 
@@ -783,8 +952,10 @@ private:
   ELSE strField
   END AS strAlias
   */
-  std::string SortnameBuildSQL(const std::string& strAlias, const SortAttribute& sortAttributes, 
-    const std::string& strField, const std::string& strSortField);
+  std::string SortnameBuildSQL(const std::string& strAlias,
+                               const SortAttribute& sortAttributes,
+                               const std::string& strField,
+                               const std::string& strSortField);
 
   /*! \brief Build SQL for sorting field naturally and case insensitvely (in SQLite).
   \param strField field name
@@ -810,9 +981,8 @@ private:
 
   // Fields should be ordered as they
   // appear in the songview
-  static enum _SongFields
-  {
-    song_idSong=0,
+  static enum _SongFields {
+    song_idSong = 0,
     song_strArtists,
     song_strArtistSort,
     song_strGenres,
@@ -857,9 +1027,8 @@ private:
 
   // Fields should be ordered as they
   // appear in the albumview
-  static enum _AlbumFields
-  {
-    album_idAlbum=0,
+  static enum _AlbumFields {
+    album_idAlbum = 0,
     album_strAlbum,
     album_strMusicBrainzAlbumID,
     album_strReleaseGroupMBID,
@@ -896,10 +1065,9 @@ private:
 
   // Fields should be ordered as they
   // appear in the songartistview/albumartistview
-  static enum _ArtistCreditFields
-  {
+  static enum _ArtistCreditFields {
     // used for GetAlbum to get the cascaded album/song artist credits
-    artistCredit_idEntity = 0,  // can be idSong or idAlbum depending on context
+    artistCredit_idEntity = 0, // can be idSong or idAlbum depending on context
     artistCredit_idArtist,
     artistCredit_idRole,
     artistCredit_strRole,
@@ -912,9 +1080,8 @@ private:
 
   // Fields should be ordered as they
   // appear in the artistview
-  static enum _ArtistFields
-  {
-    artist_idArtist=0,
+  static enum _ArtistFields {
+    artist_idArtist = 0,
     artist_strArtist,
     artist_strSortName,
     artist_strMusicBrainzArtistID,
@@ -941,8 +1108,7 @@ private:
   } ArtistFields;
 
   // Fields fetched by GetArtistsByWhereJSON,  order same as in JSONtoDBArtist
-  static enum _JoinToArtistFields
-  {
+  static enum _JoinToArtistFields {
     joinToArtist_isSong = 0,
     joinToArtist_idSourceAlbum,
     joinToArtist_idSourceSong,
@@ -963,8 +1129,7 @@ private:
   } JoinToArtistFields;
 
   // Fields fetched by GetAlbumsByWhereJSON,  order same as in JSONtoDBAlbum
-  static enum _JoinToAlbumFields
-  {
+  static enum _JoinToAlbumFields {
     joinToAlbum_idArtist = 0,
     joinToAlbum_strArtist,
     joinToAlbum_strArtistMBID,
@@ -972,9 +1137,8 @@ private:
   } JoinToAlbumFields;
 
   // Fields fetched by GetSongsByWhereJSON,  order same as in JSONtoDBSong
-  static enum _JoinToSongFields
-  {
-    // Used by GetSongsByWhereJSON 
+  static enum _JoinToSongFields {
+    // Used by GetSongsByWhereJSON
     joinToSongs_idAlbumArtist = 0,
     joinToSongs_strAlbumArtist,
     joinToSongs_strAlbumArtistMBID,
@@ -990,5 +1154,4 @@ private:
     joinToSongs_iOrderGenre,
     joinToSongs_enumCount // end of the enum, do not add past here
   } JoinToSongFields;
-
 };


### PR DESCRIPTION
Apply style guidelines using to the `CMusicDatabase` unit using clang-format.

The changes are all whitespace removeal and layout formating, all cosmetic,  nothing functional is altered in any way. I am hoping this can be  added to the default  git-blame ignore list.

This unit has many lines of code, much of it entails building SQL as text strings and so I have manually checked how the automated new line breaks introduced by Clang would have impacted the SQL readability and adjusted it before hand. This includes matching field layout in SQL to parameter layout  of  `PrepareSQL`  and 'Format' calls in some places. Similarly for calls to methods with many paramaters I have added empty comments `//` to preserve readable separated layout rather than block wrap around. 

The main thing is that running clang-format does not produce any further changes.
