### PR TITLE
[addons] fixup: pass arguments by const reference

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -38,8 +38,8 @@ enum class EntryPoint
 struct CInstalledWithAvailable
 {
   CInstalledWithAvailable(const ADDON::DependencyInfo& depInfo,
-                          std::shared_ptr<ADDON::IAddon> installed,
-                          std::shared_ptr<ADDON::IAddon> available)
+                          const std::shared_ptr<ADDON::IAddon>& installed,
+                          const std::shared_ptr<ADDON::IAddon>& available)
     : m_depInfo(depInfo), m_installed(installed), m_available(available)
   {
   }


### PR DESCRIPTION
## Description
in https://github.com/xbmc/xbmc/pull/19574 we should pass arguments by const reference. thanks for pointing @ksooo 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
