### PR TITLE
CTimeUtils: make initial frametime from current timestamp

### DIFF
--- a/xbmc/utils/TimeUtils.cpp
+++ b/xbmc/utils/TimeUtils.cpp
@@ -52,7 +52,7 @@ int64_t CurrentHostFrequency(void)
 #endif
 }
 
-unsigned int CTimeUtils::frameTime = 0;
+unsigned int CTimeUtils::frameTime = XbmcThreads::SystemClockMillis();
 
 void CTimeUtils::UpdateFrameTime(bool flip)
 {


### PR DESCRIPTION
fix after #18783

#18783 changed the time reference from from when the app started `time 0` to `time since epoch`. This made it wait until `frametime > currenttime` (since epoch). see:
https://github.com/xbmc/xbmc/blob/0795c4be6a6836568c8308d0d3c29b5ddce2b0d1/xbmc/utils/TimeUtils.cpp#L59-L61

We may see more issues like this come about if we measure from time reference `0`.

I didn't want to revert #18783 because likely would run into this issue in the future anyways. I'm not sure how I missed this or if something changed but oh well lesson learned.

