### PR TITLE
[pvr] fix: modify db field to unsigned bigint for mysql

### DIFF
--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -61,7 +61,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 37; }
+    int GetSchemaVersion() const override { return 38; }
 
     /*!
      * @brief Get the default sqlite database filename.


### PR DESCRIPTION
## Description
TVDatabase field `channelgroups.iLastOpened` needs to be set to `BIGINT UNSIGNED` for mysql. turns out that only BIGINT is not sufficient for my testcase.

The unsigned range is 0 to 18446744073709551615.

maybe we should consider backporting to matrix

## Motivation and Context
```
ERROR <general>: SQL: [MyTv37] Undefined MySQL error: Code (1264)
     Query: REPLACE INTO channelgroups (idGroup, bIsRadio, iGroupType,
                                        sName, iLastWatched, bIsHidden, iPosition, iLastOpened)
            VALUES (5, 0, 1, 'Toutes les chaînes', 1617570032, 0, 0, 1617630866016)
```

## How Has This Been Tested?
debian buster, mariadb, pvr.hts

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
