### PR TITLE
CPPCheck: fix Shadow variable warnings

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -336,14 +336,14 @@ void CLangInfo::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
   {
     if (!SetLanguage(std::static_pointer_cast<const CSettingString>(setting)->GetValue()))
     {
-      auto setting = settings->GetSetting(CSettings::SETTING_LOCALE_LANGUAGE);
-      if (!setting)
+      auto langsetting = settings->GetSetting(CSettings::SETTING_LOCALE_LANGUAGE);
+      if (!langsetting)
       {
         CLog::Log(LOGERROR, "Failed to load setting for: {}", CSettings::SETTING_LOCALE_LANGUAGE);
         return;
       }
 
-      std::static_pointer_cast<CSettingString>(setting)->Reset();
+      std::static_pointer_cast<CSettingString>(langsetting)->Reset();
     }
   }
   else if (settingId == CSettings::SETTING_LOCALE_COUNTRY)

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -221,8 +221,8 @@ void CGUIDialogVideoSettings::OnSettingAction(const std::shared_ptr<const CSetti
     if (!settings)
       return;
 
-    auto setting = settings->GetSetting(CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION);
-    if (!setting)
+    auto calibsetting = settings->GetSetting(CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION);
+    if (!calibsetting)
     {
       CLog::Log(LOGERROR, "Failed to load setting for: {}",
                 CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION);
@@ -231,7 +231,7 @@ void CGUIDialogVideoSettings::OnSettingAction(const std::shared_ptr<const CSetti
 
     // launch calibration window
     if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-        g_passwordManager.CheckSettingLevelLock(setting->GetLevel()))
+        g_passwordManager.CheckSettingLevelLock(calibsetting->GetLevel()))
       return;
 
     CServiceBroker::GetGUI()->GetWindowManager().ForceActivateWindow(WINDOW_SCREEN_CALIBRATION);


### PR DESCRIPTION
## Description
Fixes two warnings flagged via cppcheck regarding "shadow variables".

## Motivation and Context
Fix CPPCheck warnings

https://jenkins.kodi.tv/view/Linux/job/LINUX-64-GL-Static-Analysis/lastSuccessfulBuild/cppcheck/new/type.-331146243/folder.3672576/source.1c555b8b-910b-4a29-9c83-cad672ee3233/#339
https://jenkins.kodi.tv/view/Linux/job/LINUX-64-GL-Static-Analysis/lastSuccessfulBuild/cppcheck/new/type.-331146243/folder.-1454317368/source.17be25d6-57b8-4d22-a851-6056daf736a5/#224

## How Has This Been Tested?
osx

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
