### PR TITLE
Windows: update wget and remove --quiet from wget command

### DIFF
--- a/project/BuildDependencies/bin/wget.exe.sha256
+++ b/project/BuildDependencies/bin/wget.exe.sha256
@@ -1,0 +1,1 @@
+bc8a2eabcb5598b66ea8c4a385a8135887a5688d9ad5dd33d2d3d6716c9332e7  project/BuildDependencies/bin/wget.exe

--- a/project/BuildDependencies/bin/wget.exe.url
+++ b/project/BuildDependencies/bin/wget.exe.url
@@ -1,0 +1,1 @@
+https://eternallybored.org/misc/wget/1.21.1/64/wget.exe

--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -64,7 +64,7 @@ IF EXIST %1 (
 ) ELSE (
   CALL :setSubStageName Downloading %1...
   SET DOWNLOAD_URL=%KODI_MIRROR%/build-deps/win32/%1
-  %WGET% --quiet --tries=5 --retry-connrefused --waitretry=2 --show-progress "!DOWNLOAD_URL!" 2>&1
+  %WGET% --tries=5 --retry-connrefused --waitretry=2 --show-progress "!DOWNLOAD_URL!" 2>&1
   REM Apparently there's a quirk in cmd so this means if error level => 1
   IF ERRORLEVEL 1 (
     ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST%


### PR DESCRIPTION
It seems to be non stop problems with windows builds these days so this is my attempt to solve them.

I've updated wget to the only version I could find (no idea if this source is trustworthy or not :wink:).

I've also removed the `--quiet` switch so we can actually see what happened if a download failed.

I've tested running the download-dependencies.bat on the Azure builder a few times with success.

@phunkyfish can you see if this solves the download issues you were having when doing windows builds?