### PR TITLE
[iOS/tvOS] Improve Now Playing info in live TV case

### DIFF
--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -17,6 +17,8 @@
 #include "music/MusicDatabase.h"
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayList.h"
+#include "pvr/channels/PVRChannel.h"
+#include "pvr/epg/EpgInfoTag.h"
 #include "utils/Variant.h"
 
 #import "platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.h"
@@ -131,18 +133,10 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
   {
     NSMutableDictionary* item = dict[@"item"];
     NSDictionary* player = dict[@"player"];
+
+    // Common properties
     item[@"speed"] = player[@"speed"];
     std::string thumb = g_application.CurrentFileItem().GetArt("thumb");
-    if (!thumb.empty())
-    {
-      bool needsRecaching;
-      std::string cachedThumb(CTextureCache::GetInstance().CheckCachedImage(thumb, needsRecaching));
-      if (!cachedThumb.empty())
-      {
-        std::string thumbRealPath = CSpecialProtocol::TranslatePath(cachedThumb);
-        item[@"thumb"] = @(thumbRealPath.c_str());
-      }
-    }
     double duration = g_application.GetTotalTime();
     if (duration > 0)
       item[@"duration"] = @(duration);
@@ -155,6 +149,8 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
                              .GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist())
                              .size());
     }
+
+    // Music properties
     if (g_application.CurrentFileItem().HasMusicInfoTag())
     {
       const auto& genre = g_application.CurrentFileItem().GetMusicInfoTag()->GetGenre();
@@ -168,6 +164,36 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
         item[@"genre"] = genreArray;
       }
     }
+
+    // Live TV properties
+    if (g_application.CurrentFileItem().IsPVRChannel())
+    {
+      auto epg_now = g_application.CurrentFileItem().GetPVRChannelInfoTag()->GetEPGNow();
+      auto epg_title = epg_now->Title();
+      if (!epg_title.empty())
+      {
+        // If we have the TV show name then use artist property
+        // to put the channel name and title field for the TV show name.
+        item[@"artist"] = @[item[@"title"]];
+        item[@"title"] = @(epg_title.c_str());
+      }
+      auto epg_icon = epg_now->Icon();
+      if (!epg_icon.empty())
+      {
+        // If we have the TV show icon, use it instead of the channel logo.
+        thumb = epg_icon;
+      }
+    }
+
+    // Thumb cache process
+    bool needsRecaching;
+    std::string cachedIcon(CTextureCache::GetInstance().CheckCachedImage(thumb, needsRecaching));
+    if (cachedIcon.empty())
+    {
+      cachedIcon = CTextureCache::GetInstance().CacheImage(thumb);
+    }
+    std::string iconRealPath = CSpecialProtocol::TranslatePath(cachedIcon);
+    item[@"thumb"] = @(iconRealPath.c_str());
 
     dispatch_async(dispatch_get_main_queue(), ^{
       [g_xbmcController.MPNPInfoManager onPlay:item];


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When using Kodi on iOS or tvOS devices we can provide informations about current playing media so that others Apple devices in the house can see that in the Now Playing widget.

This PR improves the Now Playing integration of Kodi by displaying more informations when the current playing media is a Live TV channel with EPG data.

This is what this PR changes:

* If we have the current TV show icon in the EPG we use it instead of the TV channel logo
* If we have the current TV show title in the EPG we use it instead of the TV channel name and we put the TV channel name above by using another field.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve the user experience in an Apple ecosystem.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On iPhone 7 with HDHomeRun PVR add-on.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Best informations in the iOS/tvOS Now Playing widget.

## Screenshots (if appropriate):

### Before / After

<img src=https://user-images.githubusercontent.com/11562279/115152973-d3cc5900-a073-11eb-8fa0-f47bb4bf1087.PNG  width="400"> <img src=https://user-images.githubusercontent.com/11562279/115152979-dd55c100-a073-11eb-98b5-230ae270a02d.PNG  width="400">

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
