### PR TITLE
[mysql] handle conversion of mysql-type bigint correctly

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1648,6 +1648,15 @@ bool MysqlDataset::query(const std::string &query) {
       switch (fields[i].type)
       {
         case MYSQL_TYPE_LONGLONG:
+          if (row[i] != nullptr)
+          {
+            v.set_asInt64(strtoll(row[i], nullptr, 10));
+          }
+          else
+          {
+            v.set_asInt64(0);
+          }
+          break;
         case MYSQL_TYPE_DECIMAL:
         case MYSQL_TYPE_NEWDECIMAL:
         case MYSQL_TYPE_TINY:


### PR DESCRIPTION
## Description
follow up to https://github.com/xbmc/xbmc/pull/19586

read and conversion of mysql **bigint** fields were not handled correctly, which caused overflows `Undefined MySQL error: Code (1264)` for PVR ChannelGroups. it could happen for any field that gets fetched from MySQL using `get_asInt64()`

before this pr:
```
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 18446744073355491325 WHERE idGroup = 1
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 18446744073355491325 WHERE idGroup = 1
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848619558 WHERE idGroup = 1
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 18446744073355492779 WHERE idGroup = 8
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 18446744073355492779 WHERE idGroup = 8
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848620990 WHERE idGroup = 8
```

after:
```
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848619558 WHERE idGroup = 1
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848619558 WHERE idGroup = 1
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848861288 WHERE idGroup = 1
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848620990 WHERE idGroup = 8
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848620990 WHERE idGroup = 8
INFO <general>: ExecuteQuery UPDATE channelgroups SET iLastOpened = 1618848862777 WHERE idGroup = 8
```

with this change a `BIGINT` field would be sufficient, but oh well: it is BIGINT UNSIGNED now.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
