### PR TITLE
fix uptime calculation

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -8,7 +8,6 @@
 
 #include <limits.h>
 
-#include "threads/SystemClock.h"
 #include "SystemInfo.h"
 #ifndef TARGET_POSIX
 #include <conio.h>
@@ -78,6 +77,11 @@ using namespace winrt::Windows::System::Profile;
 /* Expand macro before stringify */
 #define STR_MACRO(x) #x
 #define XSTR_MACRO(x) STR_MACRO(x)
+
+namespace
+{
+auto startTime = std::chrono::steady_clock::now();
+}
 
 using namespace XFILE;
 
@@ -336,15 +340,18 @@ std::string CSysInfoJob::GetSystemUpTime(bool bTotalUptime)
   std::string strSystemUptime;
   int iInputMinutes, iMinutes,iHours,iDays;
 
+  auto now = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::minutes>(now - startTime);
+
   if(bTotalUptime)
   {
     //Total Uptime
-    iInputMinutes = g_sysinfo.GetTotalUptime() + ((int)(XbmcThreads::SystemClockMillis() / 60000));
+    iInputMinutes = g_sysinfo.GetTotalUptime() + duration.count();
   }
   else
   {
     //Current UpTime
-    iInputMinutes = (int)(XbmcThreads::SystemClockMillis() / 60000);
+    iInputMinutes = duration.count();
   }
 
   SystemUpTime(iInputMinutes,iMinutes, iHours, iDays);

--- a/xbmc/utils/TimeUtils.cpp
+++ b/xbmc/utils/TimeUtils.cpp
@@ -8,7 +8,6 @@
 
 #include "TimeUtils.h"
 #include "XBDateTime.h"
-#include "threads/SystemClock.h"
 #include "windowing/GraphicContext.h"
 
 #if   defined(TARGET_DARWIN)
@@ -19,6 +18,11 @@
 #else
 #include <time.h>
 #endif
+
+namespace
+{
+auto startTime = std::chrono::steady_clock::now();
+}
 
 int64_t CurrentHostCounter(void)
 {
@@ -52,11 +56,14 @@ int64_t CurrentHostFrequency(void)
 #endif
 }
 
-unsigned int CTimeUtils::frameTime = XbmcThreads::SystemClockMillis();
+unsigned int CTimeUtils::frameTime = 0;
 
 void CTimeUtils::UpdateFrameTime(bool flip)
 {
-  unsigned int currentTime = XbmcThreads::SystemClockMillis();
+  auto now = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - startTime);
+
+  unsigned int currentTime = duration.count();
   unsigned int last = frameTime;
   while (frameTime < currentTime)
   {


### PR DESCRIPTION
some more fallout after #18783

The calculation of uptime relied on the relative absolute calculation of time from time (0, start) to now. This fixes that by creating a timepoint reference and subtracting from that.

I've also converted the frametime calculation to use a similar calculation.

Whoops! I hope no one was tracking uptime!