### PR TITLE
std::chrono cleanup (simple changes)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -444,7 +444,7 @@ bool CApplication::Create(const CAppParamParser &params)
 
   CUtil::InitRandomSeed();
 
-  m_lastRenderTime = XbmcThreads::SystemClockMillis();
+  m_lastRenderTime = std::chrono::steady_clock::now();
   return true;
 }
 
@@ -1438,7 +1438,7 @@ void CApplication::Render()
     // execute post rendering actions (finalize window closing)
     CServiceBroker::GetGUI()->GetWindowManager().AfterRender();
 
-    m_lastRenderTime = XbmcThreads::SystemClockMillis();
+    m_lastRenderTime = std::chrono::steady_clock::now();
   }
 
   // render video layer
@@ -2364,8 +2364,9 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     if (CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo() && !m_appPlayer.IsPausedPlayback() && m_appPlayer.IsRenderingVideoLayer())
       fps = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_LIMITGUIUPDATE);
 
-    unsigned int now = XbmcThreads::SystemClockMillis();
-    unsigned int frameTime = now - m_lastRenderTime;
+    auto now = std::chrono::steady_clock::now();
+
+    auto frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastRenderTime).count();
     if (fps > 0 && frameTime * fps < 1000)
       m_skipGuiRender = true;
     */

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -31,13 +31,14 @@
 #ifdef TARGET_WINDOWS
 #include "powermanagement/WinIdleTimer.h"
 #endif
+#include "ApplicationPlayer.h"
+#include "threads/SystemClock.h"
+#include "threads/Thread.h"
 #include "utils/Stopwatch.h"
 #include "windowing/OSScreenSaver.h"
 #include "windowing/XBMC_events.h"
-#include "threads/SystemClock.h"
-#include "threads/Thread.h"
 
-#include "ApplicationPlayer.h"
+#include <chrono>
 
 class CAction;
 class CFileItem;
@@ -396,7 +397,7 @@ protected:
 
   int m_nextPlaylistItem = -1;
 
-  unsigned int m_lastRenderTime = 0;
+  std::chrono::time_point<std::chrono::steady_clock> m_lastRenderTime;
   bool m_skipGuiRender = false;
 
   bool m_bStandalone = false;

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -11,7 +11,6 @@
 #include "TextureCache.h"
 #include "guilib/Texture.h"
 #include "threads/SingleLock.h"
-#include "threads/SystemClock.h"
 #include "utils/JobManager.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
@@ -48,13 +47,16 @@ bool CImageLoader::DoWork()
   if (!loadPath.empty())
   {
     // direct route - load the image
-    unsigned int start = XbmcThreads::SystemClockMillis();
+    auto start = std::chrono::steady_clock::now();
     m_texture =
         CTexture::LoadFromFile(loadPath, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
                                CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight());
 
-    if (XbmcThreads::SystemClockMillis() - start > 100)
-      CLog::Log(LOGDEBUG, "%s - took %u ms to load %s", __FUNCTION__, XbmcThreads::SystemClockMillis() - start, loadPath.c_str());
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    if (duration.count() > 100)
+      CLog::Log(LOGDEBUG, "{} - took {} ms to load {}", __FUNCTION__, duration.count(), loadPath);
 
     if (m_texture)
     {

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -24,7 +24,6 @@
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SystemClock.h"
 #include "utils/Random.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -96,8 +95,8 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
   std::string strCurrentFilterVideo;
   unsigned int songcount = 0;
   unsigned int videocount = 0;
-  unsigned int time = XbmcThreads::SystemClockMillis();
-  
+  auto start = std::chrono::steady_clock::now();
+
   if (StringUtils::EqualsNoCase(m_type, "songs") ||
       StringUtils::EqualsNoCase(m_type, "mixed"))
   {
@@ -169,7 +168,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
   // Songs and music videos are random from query, but need mixing together when have both
   if (songcount > 0 && videocount > 0 )
     KODI::UTILS::RandomShuffle(m_songIDCache.begin(), m_songIDCache.end());
- 
+
   CLog::Log(LOGINFO,"PARTY MODE MANAGER: Matching songs = {0}", m_iMatchingSongs);
   CLog::Log(LOGINFO,"PARTY MODE MANAGER: Party mode enabled!");
 
@@ -187,8 +186,10 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
     pDialog->Close();
     return false;
   }
-  CLog::Log(LOGDEBUG, "%s time for song fetch: %u",
-            __FUNCTION__, XbmcThreads::SystemClockMillis() - time);
+
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  CLog::Log(LOGDEBUG, "{} time for song fetch: {} ms", __FUNCTION__, duration.count());
 
   // start playing
   CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlaylist);
@@ -311,7 +312,7 @@ bool CPartyModeManager::AddRandomSongs()
   {
     // Limit songs fetched to remainder of songID cache
     iMissingSongs = std::min(iMissingSongs, static_cast<int>(m_songIDCache.size()) - m_iMatchingSongsPicked);
-      
+
     // Pick iMissingSongs from remaining songID cache
     std::string sqlWhereMusic = "songview.idSong IN (";
     std::string sqlWhereVideo = "idMVideo IN (";

--- a/xbmc/SectionLoader.h
+++ b/xbmc/SectionLoader.h
@@ -10,6 +10,7 @@
 
 #include "threads/CriticalSection.h"
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -25,7 +26,7 @@ public:
     std::string m_strDllName;
     long m_lReferenceCount;
     LibraryLoader *m_pDll;
-    unsigned int m_unloadDelayStartTick;
+    std::chrono::time_point<std::chrono::steady_clock> m_unloadDelayStartTick;
     bool m_bDelayUnload;
   };
   CSectionLoader(void);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "network/Network.h"
-#include "threads/SystemClock.h"
 #if defined(TARGET_DARWIN)
 #include <sys/param.h>
 #include <mach-o/dyld.h>
@@ -1983,7 +1982,7 @@ int CUtil::ScanArchiveForAssociatedItems(const std::string& strArchivePath,
 
 void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles)
 {
-  unsigned int startTimer = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   CFileItem item(strMovie, false);
   if ((item.IsInternetStream() && !URIUtils::IsOnLAN(item.GetDynPath()))
@@ -2072,7 +2071,10 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
       }
     }
   }
-  CLog::Log(LOGDEBUG, "%s: END (total time: %i ms)", __FUNCTION__, (int)(XbmcThreads::SystemClockMillis() - startTimer));
+
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  CLog::Log(LOGDEBUG, "{}: END (total time: {} ms)", __FUNCTION__, duration.count());
 }
 
 ExternalStreamInfo CUtil::GetExternalStreamDetailsFromFilename(const std::string& videoPath, const std::string& associatedFile)

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -13,7 +13,6 @@
 #include "PlayListPlayer.h"
 #include "commons/Exception.h"
 #include "messaging/ApplicationMessenger.h"
-#include "threads/SystemClock.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
@@ -41,8 +40,8 @@ int CXBApplicationEx::Run(const CAppParamParser &params)
 {
   CLog::Log(LOGINFO, "Running the application...");
 
-  unsigned int lastFrameTime = 0;
-  unsigned int frameTime = 0;
+  std::chrono::time_point<std::chrono::steady_clock> lastFrameTime;
+  std::chrono::milliseconds frameTime;
   const unsigned int noRenderFrameTime = 15;  // Simulates ~66fps
 
   if (params.GetPlaylist().Size() > 0)
@@ -59,7 +58,7 @@ int CXBApplicationEx::Run(const CAppParamParser &params)
     // Animate and render a frame
     //-----------------------------------------
 
-    lastFrameTime = XbmcThreads::SystemClockMillis();
+    lastFrameTime = std::chrono::steady_clock::now();
     Process();
 
     if (!m_bStop)
@@ -73,9 +72,10 @@ int CXBApplicationEx::Run(const CAppParamParser &params)
     }
     else if (!m_renderGUI)
     {
-      frameTime = XbmcThreads::SystemClockMillis() - lastFrameTime;
-      if(frameTime < noRenderFrameTime)
-        KODI::TIME::Sleep(noRenderFrameTime - frameTime);
+      auto now = std::chrono::steady_clock::now();
+      frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastFrameTime);
+      if (frameTime.count() < noRenderFrameTime)
+        KODI::TIME::Sleep(noRenderFrameTime - frameTime.count());
     }
 
   }

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -504,11 +504,13 @@ bool CAddonDatabase::SetLastUsed(const std::string& addonId, const CDateTime& da
     if (!m_pDS)
       return false;
 
-    auto start = XbmcThreads::SystemClockMillis();
+    auto start = std::chrono::steady_clock::now();
     m_pDS->exec(PrepareSQL("UPDATE installed SET lastUsed='%s' WHERE addonID='%s'",
         dateTime.GetAsDBDateTime().c_str(), addonId.c_str()));
 
-    CLog::Log(LOGDEBUG, "CAddonDatabase::SetLastUsed[%s] took %i ms", addonId.c_str(), XbmcThreads::SystemClockMillis() - start);
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    CLog::Log(LOGDEBUG, "CAddonDatabase::SetLastUsed[{}] took {} ms", addonId, duration.count());
     return true;
   }
   catch (...)
@@ -744,7 +746,7 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
     if (!m_pDS)
       return false;
 
-    auto start = XbmcThreads::SystemClockMillis();
+    auto start = std::chrono::steady_clock::now();
 
     // Ensure that the repositories we fetch from are enabled and valid.
     std::vector<std::string> repoIds;
@@ -766,7 +768,9 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
       }
     }
 
-    CLog::Log(LOGDEBUG, "CAddonDatabase: SELECT repo.id FROM repo .. took %d ms", XbmcThreads::SystemClockMillis() - start);
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    CLog::Log(LOGDEBUG, "CAddonDatabase: SELECT repo.id FROM repo .. took {} ms", duration.count());
 
     if (repoIds.empty())
     {
@@ -782,10 +786,13 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
                                    " ORDER BY repo.addonID, addons.addonID",
                                    StringUtils::Join(repoIds, ",").c_str());
 
-      auto start = XbmcThreads::SystemClockMillis();
+      start = std::chrono::steady_clock::now();
       m_pDS->query(sql);
-      CLog::Log(LOGDEBUG, "CAddonDatabase: query %s returned %d rows in %d ms", sql.c_str(),
-          m_pDS->num_rows(), XbmcThreads::SystemClockMillis() - start);
+
+      end = std::chrono::steady_clock::now();
+      duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+      CLog::Log(LOGDEBUG, "CAddonDatabase: query {} returned {} rows in {} ms", sql,
+                m_pDS->num_rows(), duration.count());
     }
 
     VECADDONS result;
@@ -815,7 +822,10 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
     m_pDS->close();
     addons = std::move(result);
 
-    CLog::Log(LOGDEBUG, "CAddonDatabase::GetAddons took %i ms", XbmcThreads::SystemClockMillis() - start);
+    end = std::chrono::steady_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    CLog::Log(LOGDEBUG, "CAddonDatabase::GetAddons took {} ms", duration.count());
+
     return true;
   }
   catch (...)

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -235,7 +235,7 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAdd
     AddonCheckType addonCheckType) const
 {
   CSingleLock lock(m_critSection);
-  auto start = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   std::vector<std::shared_ptr<IAddon>> result;
   std::vector<std::shared_ptr<IAddon>> installed;
@@ -247,8 +247,11 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAdd
 
   addonRepos.BuildUpdateOrOutdatedList(installed, result, addonCheckType);
 
-  CLog::Log(LOGDEBUG, "CAddonMgr::GetAvailableUpdatesOrOutdatedAddons took %i ms",
-            XbmcThreads::SystemClockMillis() - start);
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  CLog::Log(LOGDEBUG, "CAddonMgr::GetAvailableUpdatesOrOutdatedAddons took {} ms",
+            duration.count());
+
   return result;
 }
 
@@ -256,7 +259,7 @@ bool CAddonMgr::GetAddonsWithAvailableUpdate(
     std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const
 {
   CSingleLock lock(m_critSection);
-  auto start = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   std::vector<std::shared_ptr<IAddon>> installed;
   CAddonRepos addonRepos(*this);
@@ -265,8 +268,9 @@ bool CAddonMgr::GetAddonsWithAvailableUpdate(
   GetAddonsForUpdate(installed);
   addonRepos.BuildAddonsWithUpdateList(installed, addonsWithUpdate);
 
-  CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__,
-            XbmcThreads::SystemClockMillis() - start);
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__, duration.count());
 
   return true;
 }
@@ -275,14 +279,15 @@ bool CAddonMgr::GetCompatibleVersions(
     const std::string& addonId, std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const
 {
   CSingleLock lock(m_critSection);
-  auto start = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   CAddonRepos addonRepos(*this);
   addonRepos.LoadAddonsFromDatabase(m_database, addonId);
   addonRepos.BuildCompatibleVersionsList(compatibleVersions);
 
-  CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__,
-            XbmcThreads::SystemClockMillis() - start);
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__, duration.count());
 
   return true;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2231,7 +2231,7 @@ bool CActiveAE::RunStages()
               CLog::Log(LOGWARNING,"ActiveAE::%s - viz ran out of free buffers", __FUNCTION__);
             AEDelayStatus status;
             m_stats.GetDelay(status);
-            int64_t now = XbmcThreads::SystemClockMillis();
+            int64_t now = std::chrono::steady_clock::now().time_since_epoch().count();
             int64_t timestamp = now + status.GetDelay() * 1000;
             busy |= m_vizBuffers->ResampleBuffers(timestamp);
             while(!m_vizBuffers->m_outputSamples.empty())

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -15,7 +15,6 @@
 #include "cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "threads/SingleLock.h"
-#include "threads/SystemClock.h"
 #include "utils/StringUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
@@ -83,7 +82,6 @@ CAESinkDirectSound::CAESinkDirectSound() :
   m_dwBufferLen   (0    ),
   m_BufferOffset  (0    ),
   m_CacheLen      (0    ),
-  m_LastCacheCheck(0    ),
   m_BufferTimeouts(0    ),
   m_running       (false),
   m_initialized   (false),
@@ -268,7 +266,6 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
 
   m_BufferOffset = 0;
   m_CacheLen = 0;
-  m_LastCacheCheck = XbmcThreads::SystemClockMillis();
   m_initialized = true;
   m_isDirtyDS = false;
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -64,7 +64,6 @@ private:
 
   unsigned int        m_BufferOffset;
   unsigned int        m_CacheLen;
-  unsigned int        m_LastCacheCheck;
   unsigned int        m_BufferTimeouts;
 
   bool                m_running;

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -55,7 +55,7 @@ CExternalPlayer::CExternalPlayer(IPlayerCallback& callback)
 {
   m_bAbortRequest = false;
   m_bIsPlaying = false;
-  m_playbackStartTime = 0;
+  m_playbackStartTime = {};
   m_speed = 1;
   m_time = 0;
 
@@ -87,7 +87,7 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
     m_file = file;
     m_bIsPlaying = true;
     m_time = 0;
-    m_playbackStartTime = XbmcThreads::SystemClockMillis();
+    m_playbackStartTime = std::chrono::steady_clock::now();
     m_launchFilename = file.GetDynPath();
     CLog::Log(LOGINFO, "%s: %s", __FUNCTION__, m_launchFilename.c_str());
     Create();
@@ -286,7 +286,7 @@ void CExternalPlayer::Process()
   LockSetForegroundWindow(LSFW_UNLOCK);
 #endif
 
-  m_playbackStartTime = XbmcThreads::SystemClockMillis();
+  m_playbackStartTime = std::chrono::steady_clock::now();
 
   /* Suspend AE temporarily so exclusive or hog-mode sinks */
   /* don't block external player's access to audio device  */
@@ -313,9 +313,10 @@ void CExternalPlayer::Process()
 #elif defined(TARGET_POSIX) && !defined(TARGET_DARWIN_EMBEDDED)
   ret = ExecuteAppLinux(strFArgs.c_str());
 #endif
-  int64_t elapsedMillis = XbmcThreads::SystemClockMillis() - m_playbackStartTime;
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - m_playbackStartTime);
 
-  if (ret && (m_islauncher || elapsedMillis < LAUNCHER_PROCESS_TIME))
+  if (ret && (m_islauncher || duration.count() < LAUNCHER_PROCESS_TIME))
   {
     if (m_hidexbmc)
     {
@@ -372,7 +373,7 @@ void CExternalPlayer::Process()
 
   CBookmark bookmark;
   bookmark.totalTimeInSeconds = 1;
-  bookmark.timeInSeconds = (elapsedMillis / 1000 >= m_playCountMinTime) ? 1 : 0;
+  bookmark.timeInSeconds = (duration.count() / 1000 >= m_playCountMinTime) ? 1 : 0;
   bookmark.player = m_name;
   m_callback.OnPlayerCloseFile(m_file, bookmark);
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -64,7 +64,7 @@ private:
 
   bool m_bAbortRequest;
   bool m_bIsPlaying;
-  int64_t m_playbackStartTime;
+  std::chrono::time_point<std::chrono::steady_clock> m_playbackStartTime;
   float m_speed;
   int m_time;
   std::string m_launchFilename;

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -8,8 +8,7 @@
 
 #include "GameLoop.h"
 
-#include "threads/SystemClock.h"
-
+#include <chrono>
 #include <cmath>
 
 using namespace KODI;
@@ -129,5 +128,7 @@ double CGameLoop::SleepTimeMs() const
 
 double CGameLoop::NowMs() const
 {
-  return static_cast<double>(XbmcThreads::SystemClockMillis());
+  return std::chrono::duration<double, std::milli>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
 }

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -8,7 +8,6 @@
 
 #include "DVDFileInfo.h"
 #include "ServiceBroker.h"
-#include "threads/SystemClock.h"
 #include "FileItem.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -92,7 +91,7 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
                                 int64_t pos)
 {
   const std::string redactPath = CURL::GetRedacted(fileItem.GetPath());
-  unsigned int nTime = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   CFileItem item(fileItem);
   item.SetMimeTypeForInternetFile();
@@ -297,8 +296,11 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
       file.Close();
   }
 
-  unsigned int nTotalTime = XbmcThreads::SystemClockMillis() - nTime;
-  CLog::Log(LOGDEBUG,"%s - measured %u ms to extract thumb from file <%s> in %d packets. ", __FUNCTION__, nTotalTime, redactPath.c_str(), packetsTried);
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  CLog::Log(LOGDEBUG, "{} - measured {} ms to extract thumb from file <{}> in {} packets. ",
+            __FUNCTION__, duration.count(), redactPath, packetsTried);
+
   return bOk;
 }
 

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -32,12 +32,16 @@ public:
     std::shared_ptr<CEvent> e_done(m_done);
 
     Create();
-    unsigned int start = XbmcThreads::SystemClockMillis();
+    auto start = std::chrono::steady_clock::now();
     if (!CGUIDialogBusy::WaitOnEvent(*e_done, displaytime, allowCancel))
     {
       m_runnable->Cancel();
-      unsigned int elapsed = XbmcThreads::SystemClockMillis() - start;
-      unsigned int remaining = (elapsed >= displaytime) ? 0 : displaytime - elapsed;
+
+      auto end = std::chrono::steady_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+      unsigned int remaining =
+          (duration.count() >= displaytime) ? 0 : displaytime - duration.count();
       CGUIDialogBusy::WaitOnEvent(*e_done, remaining, false);
       return false;
     }

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -11,7 +11,7 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIProgressControl.h"
 #include "threads/SingleLock.h"
-#include "threads/SystemClock.h"
+#include "utils/TimeUtils.h"
 
 #include <cmath>
 
@@ -74,7 +74,7 @@ bool CGUIDialogExtendedProgressBar::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_INIT:
     {
-      m_iLastSwitchTime = XbmcThreads::SystemClockMillis();
+      m_iLastSwitchTime = CTimeUtils::GetFrameTime();
       m_iCurrentItem = 0;
       CGUIDialog::OnMessage(message);
 

--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -147,7 +147,11 @@ void DllLibCurlGlobal::CheckIdle()
   VEC_CURLSESSIONS::iterator it = m_sessions.begin();
   while (it != m_sessions.end())
   {
-    if (!it->m_busy && (XbmcThreads::SystemClockMillis() - it->m_idletimestamp) > idletime)
+    auto now = std::chrono::steady_clock::now();
+    auto duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - it->m_idletimestamp);
+
+    if (!it->m_busy && duration.count() > idletime)
     {
       CLog::Log(LOGDEBUG, "%s - Closing session to %s://%s (easy=%p, multi=%p)", __FUNCTION__,
                 it->m_protocol.c_str(), it->m_hostname.c_str(), static_cast<void*>(it->m_easy),
@@ -255,7 +259,7 @@ void DllLibCurlGlobal::easy_release(CURL_HANDLE** easy_handle, CURLM** multi_han
       /* will reset verbose too so it won't print that it closed connections on cleanup*/
       easy_reset(easy);
       it.m_busy = false;
-      it.m_idletimestamp = XbmcThreads::SystemClockMillis();
+      it.m_idletimestamp = std::chrono::steady_clock::now();
       return;
     }
   }

--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -82,7 +82,8 @@ public:
   /* structure holding a session info */
   typedef struct SSession
   {
-    unsigned int m_idletimestamp; // timestamp of when this object when idle
+    std::chrono::time_point<std::chrono::steady_clock>
+        m_idletimestamp; // timestamp of when this object when idle
     std::string m_protocol;
     std::string m_hostname;
     bool m_busy;

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -234,7 +234,7 @@ std::string CMultiPathDirectory::ConstructMultiPath(const std::set<std::string> 
 void CMultiPathDirectory::MergeItems(CFileItemList &items)
 {
   CLog::Log(LOGDEBUG, "CMultiPathDirectory::MergeItems, items = %i", items.Size());
-  unsigned int time = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
   if (items.Size() == 0)
     return;
   // sort items by label
@@ -289,9 +289,11 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
     i++;
   }
 
-  CLog::Log(LOGDEBUG,
-            "CMultiPathDirectory::MergeItems, items = %i,  took %d ms",
-            items.Size(), XbmcThreads::SystemClockMillis() - time);
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  CLog::Log(LOGDEBUG, "CMultiPathDirectory::MergeItems, items = {},  took {} ms", items.Size(),
+            duration.count());
 }
 
 bool CMultiPathDirectory::SupportsWriteFileOperations(const std::string &strPath)

--- a/xbmc/filesystem/MusicSearchDirectory.cpp
+++ b/xbmc/filesystem/MusicSearchDirectory.cpp
@@ -12,7 +12,6 @@
 #include "URL.h"
 #include "guilib/LocalizeStrings.h"
 #include "music/MusicDatabase.h"
-#include "threads/SystemClock.h"
 #include "utils/log.h"
 
 using namespace XFILE;
@@ -32,13 +31,17 @@ bool CMusicSearchDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   // and retrieve the search details
   items.SetURL(url);
-  unsigned int time = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
   CMusicDatabase db;
   db.Open();
   db.Search(search, items);
   db.Close();
-  CLog::Log(LOGDEBUG, "%s (%s) took %u ms",
-            __FUNCTION__, url.GetRedacted().c_str(), XbmcThreads::SystemClockMillis() - time);
+
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  CLog::Log(LOGDEBUG, "{} ({}) took {} ms", __FUNCTION__, url.GetRedacted(), duration.count());
+
   items.SetLabel(g_localizeStrings.Get(137)); // Search
   return true;
 }

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -17,7 +17,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
-#include "threads/SystemClock.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -143,14 +142,18 @@ struct nfs_context *CNfsConnection::getContextFromMap(const std::string &exportn
   if (it != m_openContextMap.end())
   {
     //check if context has timed out already
-    uint64_t now = XbmcThreads::SystemClockMillis();
-    if((now - it->second.lastAccessedTime) < CONTEXT_TIMEOUT || forceCacheHit)
+    auto now = std::chrono::steady_clock::now();
+    auto duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - it->second.lastAccessedTime);
+    if (duration.count() < CONTEXT_TIMEOUT || forceCacheHit)
     {
       //its not timedout yet or caller wants the cached entry regardless of timeout
       //refresh access time of that
       //context and return it
       if (!forceCacheHit) // only log it if this isn't the resetkeepalive on each read ;)
-        CLog::Log(LOGDEBUG, "NFS: Refreshing context for %s, old: %" PRId64", new: %" PRId64, exportname.c_str(), it->second.lastAccessedTime, now);
+        CLog::Log(LOGDEBUG, "NFS: Refreshing context for {}, old: {}, new: {}", exportname,
+                  it->second.lastAccessedTime.time_since_epoch().count(),
+                  now.time_since_epoch().count());
       it->second.lastAccessedTime = now;
       pRet = it->second.pContext;
     }
@@ -189,7 +192,7 @@ int CNfsConnection::getContextForExport(const std::string &exportname)
       CSingleLock lock(openContextLock);
       setOptions(m_pNfsContext);
       tmp.pContext = m_pNfsContext;
-      tmp.lastAccessedTime = XbmcThreads::SystemClockMillis();
+      tmp.lastAccessedTime = std::chrono::steady_clock::now();
       m_openContextMap[exportname] = tmp; //add context to list of all contexts
       ret = CONTEXT_NEW;
     }
@@ -199,7 +202,7 @@ int CNfsConnection::getContextForExport(const std::string &exportname)
     ret = CONTEXT_CACHED;
     CLog::Log(LOGDEBUG,"NFS: Using cached context.");
   }
-  m_lastAccessedTime = XbmcThreads::SystemClockMillis(); //refresh last access time of m_pNfsContext
+  m_lastAccessedTime = std::chrono::steady_clock::now();
 
   return ret;
 }
@@ -273,9 +276,11 @@ bool CNfsConnection::Connect(const CURL& url, std::string &relativePath)
   resolveHost(url);
   bool ret = splitUrlIntoExportAndPath(url, exportPath, relativePath);
 
-  if( (ret && (exportPath != m_exportPath  ||
-       url.GetHostName() != m_hostName))    ||
-      (XbmcThreads::SystemClockMillis() - m_lastAccessedTime) > CONTEXT_TIMEOUT )
+  auto now = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastAccessedTime);
+
+  if ((ret && (exportPath != m_exportPath || url.GetHostName() != m_hostName)) ||
+      duration.count() > CONTEXT_TIMEOUT)
   {
     int contextRet = getContextForExport(url.GetHostName() + exportPath);
 
@@ -386,7 +391,7 @@ void CNfsConnection::resetKeepAlive(const std::string& _exportPath, struct nfsfh
   // its last access time too here
   if (m_pNfsContext == pContext)
   {
-    m_lastAccessedTime = XbmcThreads::SystemClockMillis();
+    m_lastAccessedTime = std::chrono::steady_clock::now();
   }
 
   //adds new keys - refreshs existing ones

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -14,6 +14,7 @@
 #include "URL.h"
 #include "threads/CriticalSection.h"
 
+#include <chrono>
 #include <list>
 #include <map>
 
@@ -37,7 +38,7 @@ public:
   struct contextTimeout
   {
     struct nfs_context *pContext;
-    uint64_t lastAccessedTime;
+    std::chrono::time_point<std::chrono::steady_clock> lastAccessedTime;
   };
 
   typedef std::map<std::string, struct contextTimeout> tOpenContextMap;
@@ -83,7 +84,8 @@ private:
   unsigned int m_IdleTimeout = 0;//timeout for idle connection close and dyunload
   tFileKeepAliveMap m_KeepAliveTimeouts;//mapping filehandles to its idle timeout
   tOpenContextMap m_openContextMap;//unique map for tracking all open contexts
-  uint64_t m_lastAccessedTime = 0;//last access time for m_pNfsContext
+  std::chrono::time_point<std::chrono::steady_clock>
+      m_lastAccessedTime; //last access time for m_pNfsContext
   std::list<std::string> m_exportList;//list of exported paths of current connected servers
   CCriticalSection keepAliveLock;
   CCriticalSection openContextLock;

--- a/xbmc/input/KeyboardStat.h
+++ b/xbmc/input/KeyboardStat.h
@@ -27,6 +27,7 @@
 #include "input/Key.h"
 #include "input/XBMC_keyboard.h"
 
+#include <chrono>
 #include <string>
 
 class CKeyboardStat
@@ -48,5 +49,5 @@ private:
   static bool LookupSymAndUnicodePeripherals(XBMC_keysym& keysym, uint8_t* key, char* unicode);
 
   XBMC_keysym m_lastKeysym;
-  unsigned int m_lastKeyTime;
+  std::chrono::time_point<std::chrono::steady_clock> m_lastKeyTime;
 };

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -90,8 +90,7 @@ CAxisDetector::CAxisDetector(CButtonMapping* buttonMapping,
     m_type(AXIS_TYPE::UNKNOWN),
     m_initialPositionKnown(false),
     m_initialPosition(0.0f),
-    m_initialPositionChanged(false),
-    m_activationTimeMs(0)
+    m_initialPositionChanged(false)
 {
 }
 
@@ -127,7 +126,7 @@ bool CAxisDetector::OnMotion(float position)
         m_activatedPrimitive =
             CDriverPrimitive(m_axisIndex, m_config.center,
                              CJoystickTranslator::PositionToSemiAxisDirection(position), 1);
-        m_activationTimeMs = SystemClockMillis();
+        m_activationTimeMs = std::chrono::steady_clock::now();
       }
     }
   }
@@ -144,7 +143,9 @@ void CAxisDetector::ProcessMotion()
     bool bIgnore = false;
     if (m_type == AXIS_TYPE::OFFSET)
     {
-      unsigned int elapsedMs = SystemClockMillis() - m_activationTimeMs;
+      unsigned int elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   std::chrono::steady_clock::now() - m_activationTimeMs)
+                                   .count();
       if (elapsedMs < TRIGGER_DELAY_MS)
         bIgnore = true;
     }

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -386,7 +386,7 @@ private:
   std::map<XBMCKey, CKeyDetector> m_keys;
   std::map<MOUSE::BUTTON_ID, CMouseButtonDetector> m_mouseButtons;
   std::unique_ptr<CPointerDetector> m_pointer;
-  unsigned int m_lastAction;
+  std::chrono::time_point<std::chrono::steady_clock> m_lastAction;
   uint64_t m_frameCount;
 };
 } // namespace JOYSTICK

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -15,6 +15,7 @@
 #include "input/mouse/MouseTypes.h"
 #include "input/mouse/interfaces/IMouseDriverHandler.h"
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <stdint.h>
@@ -215,7 +216,7 @@ private:
   bool m_initialPositionKnown; // set to true on first motion
   float m_initialPosition; // set to position of first motion
   bool m_initialPositionChanged; // set to true when position differs from the initial position
-  unsigned int
+  std::chrono::time_point<std::chrono::steady_clock>
       m_activationTimeMs; // only used to delay anomalous trigger mapping to detect full range
 };
 

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -14,7 +14,6 @@
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/interfaces/IButtonMap.h"
 #include "input/joysticks/interfaces/IInputHandler.h"
-#include "threads/SystemClock.h"
 #include "utils/log.h"
 
 #include <vector>
@@ -53,17 +52,17 @@ bool CJoystickFeature::AcceptsInput(bool bActivation)
 
 void CJoystickFeature::ResetMotion()
 {
-  m_motionStartTimeMs = 0;
+  m_motionStartTimeMs = {};
 }
 
 void CJoystickFeature::StartMotion()
 {
-  m_motionStartTimeMs = XbmcThreads::SystemClockMillis();
+  m_motionStartTimeMs = std::chrono::steady_clock::now();
 }
 
 bool CJoystickFeature::InMotion() const
 {
-  return m_motionStartTimeMs > 0;
+  return m_motionStartTimeMs.time_since_epoch().count() > 0;
 }
 
 unsigned int CJoystickFeature::MotionTimeMs() const
@@ -71,7 +70,10 @@ unsigned int CJoystickFeature::MotionTimeMs() const
   if (!InMotion())
     return 0;
 
-  return XbmcThreads::SystemClockMillis() - m_motionStartTimeMs;
+  auto now = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_motionStartTimeMs);
+
+  return duration.count();
 }
 
 // --- CScalarFeature ----------------------------------------------------------

--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -10,6 +10,7 @@
 
 #include "input/joysticks/JoystickTypes.h"
 
+#include <chrono>
 #include <memory>
 
 namespace KODI
@@ -105,7 +106,7 @@ protected:
   const bool m_bEnabled;
 
 private:
-  unsigned int m_motionStartTimeMs = 0;
+  std::chrono::time_point<std::chrono::steady_clock> m_motionStartTimeMs;
 };
 
 class CScalarFeature : public CJoystickFeature

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -44,7 +44,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SystemClock.h"
 #include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
@@ -97,7 +96,7 @@ void CMusicInfoScanner::Process()
       return;
     }
 
-    unsigned int tick = XbmcThreads::SystemClockMillis();
+    auto tick = std::chrono::steady_clock::now();
     m_musicDatabase.Open();
     m_bCanInterrupt = true;
 
@@ -192,9 +191,11 @@ void CMusicInfoScanner::Process()
 
       m_musicDatabase.EmptyCache();
 
-      tick = XbmcThreads::SystemClockMillis() - tick;
-      CLog::Log(LOGINFO, "My Music: Scanning for music info using worker thread, operation took %s",
-                StringUtils::SecondsToTimeString(tick / 1000).c_str());
+      auto elapsed =
+          std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - tick);
+      CLog::Log(LOGINFO,
+                "My Music: Scanning for music info using worker thread, operation took {}s",
+                elapsed.count());
     }
     if (m_scanType == 1) // load album info
     {

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -333,7 +333,7 @@ void CGUIWindowMusicBase::RefreshContent(const std::string& strContent)
 /// \brief Retrieve tag information for \e m_vecItems
 void CGUIWindowMusicBase::RetrieveMusicInfo()
 {
-  unsigned int startTick = XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   OnRetrieveMusicInfo(*m_vecItems);
 
@@ -369,8 +369,10 @@ void CGUIWindowMusicBase::RetrieveMusicInfo()
   }
   m_vecItems->Append(itemsForAdd);
 
-  CLog::Log(LOGDEBUG, "RetrieveMusicInfo() took %u msec",
-            XbmcThreads::SystemClockMillis() - startTick);
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  CLog::Log(LOGDEBUG, "RetrieveMusicInfo() took {} ms", duration.count());
 }
 
 /// \brief Add selected list/thumb control item to playlist and start playing
@@ -394,7 +396,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem, bool first)
 
   if (item->IsRAR() || item->IsZIP())
     return;
-  
+
   // Check for the partymode playlist item, do nothing when "PartyMode.xsp" not exist
   if (item->IsSmartPlayList())
   {
@@ -555,7 +557,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
   {
     const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-    // Check for the partymode playlist item. 
+    // Check for the partymode playlist item.
     // When "PartyMode.xsp" not exist, only context menu button is edit
     if (item->IsSmartPlayList() &&
         (item->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) &&
@@ -913,15 +915,16 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
   bool bShowProgress = !CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true);
   bool bProgressVisible = false;
 
-  unsigned int tick=XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   while (m_musicInfoLoader.IsLoading())
   {
     if (bShowProgress)
     { // Do we have to init a progress dialog?
-      unsigned int elapsed=XbmcThreads::SystemClockMillis()-tick;
+      auto end = std::chrono::steady_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-      if (!bProgressVisible && elapsed>1500 && m_dlgProgress)
+      if (!bProgressVisible && duration.count() > 1500 && m_dlgProgress)
       { // tag loading takes more then 1.5 secs, show a progress dialog
         CURL url(items.GetPath());
         m_dlgProgress->SetHeading(CVariant{189});
@@ -953,8 +956,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
   {
     // We want to expand disc images when browsing in file view but not on library, smartplaylist
     // or node menu music windows
-    if (!items.GetPath().empty() && 
-        !StringUtils::StartsWithNoCase(items.GetPath(), "musicdb://") &&
+    if (!items.GetPath().empty() && !StringUtils::StartsWithNoCase(items.GetPath(), "musicdb://") &&
         !StringUtils::StartsWithNoCase(items.GetPath(), "special://") &&
         !StringUtils::StartsWithNoCase(items.GetPath(), "library://"))
       CDirectory::FilterFileDirectories(items, ".iso", true);

--- a/xbmc/network/UdpClient.cpp
+++ b/xbmc/network/UdpClient.cpp
@@ -6,17 +6,17 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "threads/SystemClock.h"
 #include "UdpClient.h"
 #ifdef TARGET_POSIX
 #include <sys/ioctl.h>
 #endif
 #include "Network.h"
-#include "windowing/GraphicContext.h"
-#include "utils/log.h"
-#include "utils/TimeUtils.h"
-
 #include "threads/SingleLock.h"
+#include "utils/TimeUtils.h"
+#include "utils/log.h"
+#include "windowing/GraphicContext.h"
+
+#include <chrono>
 
 #include <arpa/inet.h>
 
@@ -177,8 +177,12 @@ void CUdpClient::Process()
 
         std::string message = messageBuffer;
 
-        CLog::Log(UDPCLIENT_DEBUG_LEVEL, "UDPCLIENT RX: %u\t\t<- '%s'",
-                  XbmcThreads::SystemClockMillis(), message.c_str() );
+        auto now = std::chrono::steady_clock::now();
+        auto timestamp =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+
+        CLog::Log(UDPCLIENT_DEBUG_LEVEL, "UDPCLIENT RX: {}\t\t<- '{}'", timestamp.count(),
+                  message.c_str());
 
         OnMessage(remoteAddress, message, reinterpret_cast<unsigned char*>(messageBuffer), messageLength);
       }
@@ -220,9 +224,14 @@ bool CUdpClient::DispatchNextCommand()
   if (command.binarySize > 0)
   {
     // only perform the following if logging level at debug
-    CLog::Log(UDPCLIENT_DEBUG_LEVEL, "UDPCLIENT TX: %u\t\t-> "
-                                     "<binary payload %u bytes>",
-              XbmcThreads::SystemClockMillis(), command.binarySize );
+
+    auto now = std::chrono::steady_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+
+    CLog::Log(UDPCLIENT_DEBUG_LEVEL,
+              "UDPCLIENT TX: {}\t\t-> "
+              "<binary payload {} bytes>",
+              timestamp.count(), command.binarySize);
 
     do
     {
@@ -235,8 +244,11 @@ bool CUdpClient::DispatchNextCommand()
   else
   {
     // only perform the following if logging level at debug
-    CLog::Log(UDPCLIENT_DEBUG_LEVEL, "UDPCLIENT TX: %u\t\t-> '%s'",
-              XbmcThreads::SystemClockMillis(), command.message.c_str() );
+    auto now = std::chrono::steady_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+
+    CLog::Log(UDPCLIENT_DEBUG_LEVEL, "UDPCLIENT TX: {}\t\t-> '{}'", timestamp.count(),
+              command.message.c_str());
 
     do
     {

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -679,7 +679,7 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
 
     if (!load) {
         // cache anything that takes more than a second to retrieve
-        unsigned int time = XbmcThreads::SystemClockMillis();
+        auto start = std::chrono::steady_clock::now();
 
         if (parent_id.StartsWith("virtualpath://upnproot")) {
             CFileItemPtr item;
@@ -709,9 +709,13 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
             DefaultSortItems(items);
         }
 
-        if (items.CacheToDiscAlways() || (items.CacheToDiscIfSlow() && (XbmcThreads::SystemClockMillis() - time) > 1000 )) {
-            NPT_AutoLock lock(m_CacheMutex);
-            items.Save();
+        auto end = std::chrono::steady_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+        if (items.CacheToDiscAlways() || (items.CacheToDiscIfSlow() && duration.count() > 1000))
+        {
+          NPT_AutoLock lock(m_CacheMutex);
+          items.Save();
         }
     }
 

--- a/xbmc/peripherals/EventScanner.h
+++ b/xbmc/peripherals/EventScanner.h
@@ -15,6 +15,7 @@
 #include "threads/Event.h"
 #include "threads/Thread.h"
 
+#include <chrono>
 #include <set>
 
 namespace PERIPHERALS
@@ -58,7 +59,7 @@ protected:
   void Process() override;
 
 private:
-  double GetScanIntervalMs() const;
+  std::chrono::milliseconds GetScanIntervalMs() const;
 
   // Construction parameters
   IEventScannerCallback& m_callback;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -41,6 +41,7 @@ public:
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 
+#include <chrono>
 #include <queue>
 #include <vector>
 
@@ -169,7 +170,7 @@ private:
   std::vector<CecButtonPress> m_buttonQueue;
   CecButtonPress m_currentButton;
   std::queue<CecVolumeChange> m_volumeChangeQueue;
-  unsigned int m_lastKeypress;
+  std::chrono::time_point<std::chrono::steady_clock> m_lastKeypress;
   CecVolumeChange m_lastChange;
   int m_iExitCode;
   bool m_bIsMuted;

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -31,7 +31,6 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SystemClock.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -199,15 +198,16 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
   bool bShowProgress = !CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true);
   bool bProgressVisible = false;
 
-  unsigned int tick=XbmcThreads::SystemClockMillis();
+  auto start = std::chrono::steady_clock::now();
 
   while (loader.IsLoading() && m_dlgProgress && !m_dlgProgress->IsCanceled())
   {
     if (bShowProgress)
     { // Do we have to init a progress dialog?
-      unsigned int elapsed=XbmcThreads::SystemClockMillis()-tick;
+      auto end = std::chrono::steady_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-      if (!bProgressVisible && elapsed>1500 && m_dlgProgress)
+      if (!bProgressVisible && duration.count() > 1500 && m_dlgProgress)
       { // tag loading takes more then 1.5 secs, show a progress dialog
         CURL url(items.GetPath());
 

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -143,7 +143,7 @@ void CLirc::ProcessCode(char *buf)
   if (repeat == 0)
   {
     CLog::Log(LOGDEBUG, "LIRC: - NEW %s %s %s %s (%s)", &scanCode[0], &repeatStr[0], &buttonName[0], &deviceName[0], buttonName);
-    m_firstClickTime = XbmcThreads::SystemClockMillis();
+    m_firstClickTime = std::chrono::steady_clock::now();
 
     XBMC_Event newEvent;
     newEvent.type = XBMC_BUTTON;
@@ -159,7 +159,11 @@ void CLirc::ProcessCode(char *buf)
     XBMC_Event newEvent;
     newEvent.type = XBMC_BUTTON;
     newEvent.keybutton.button = button;
-    newEvent.keybutton.holdtime = XbmcThreads::SystemClockMillis() - m_firstClickTime;
+
+    auto now = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_firstClickTime);
+
+    newEvent.keybutton.holdtime = duration.count();
     std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
     if (appPort)
       appPort->OnEvent(newEvent);

--- a/xbmc/platform/linux/input/LIRC.h
+++ b/xbmc/platform/linux/input/LIRC.h
@@ -12,6 +12,7 @@
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 
+#include <chrono>
 #include <string>
 
 class CLirc : CThread
@@ -27,7 +28,7 @@ protected:
   bool CheckDaemon();
 
   int m_fd = -1;
-  uint32_t m_firstClickTime = 0;
+  std::chrono::time_point<std::chrono::steady_clock> m_firstClickTime;
   CCriticalSection m_critSection;
   CIRTranslator m_irTranslator;
   int m_profileId;

--- a/xbmc/platform/win10/input/RemoteControlXbox.h
+++ b/xbmc/platform/win10/input/RemoteControlXbox.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 
 #include <winrt/Windows.Media.h>
@@ -28,7 +29,7 @@ private:
   int32_t TranslateMediaKey(winrt::Windows::Media::SystemMediaTransportControlsButton mk);
 
   bool m_bInitialized;
-  uint32_t m_firstClickTime;
+  std::chrono::time_point<std::chrono::steady_clock> m_firstClickTime;
   uint32_t m_repeatCount;
   winrt::event_token m_token;
   winrt::event_token m_mediatoken;

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1634,16 +1634,18 @@ namespace PVR
     /* start the channel scan */
     CLog::LogFC(LOGDEBUG, LOGPVR, "Starting to scan for channels on client {}",
                 scanClient->GetFriendlyName());
-    long perfCnt = XbmcThreads::SystemClockMillis();
+    auto start = std::chrono::steady_clock::now();
 
     /* do the scan */
     if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
       HELPERS::ShowOKDialogText(CVariant{257},    // "Error"
                                     CVariant{19193}); // "The channel scan can't be started. Check the log for more information about this message."
 
-    CLog::LogFC(LOGDEBUG, LOGPVR, "Channel scan finished after {}.{} seconds",
-                (XbmcThreads::SystemClockMillis() - perfCnt) / 1000,
-                (XbmcThreads::SystemClockMillis() - perfCnt) % 1000);
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    CLog::LogFC(LOGDEBUG, LOGPVR, "Channel scan finished after {} ms", duration.count());
+
     m_bChannelScanRunning = false;
     return true;
   }

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.h
@@ -10,6 +10,7 @@
 
 #include "threads/CriticalSection.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -65,7 +66,7 @@ namespace PVR
     std::string m_strNextRecordingTime;
     std::string m_strNextTimerInfo;
 
-    unsigned int m_iTimerInfoToggleStart;
+    std::chrono::time_point<std::chrono::steady_clock> m_iTimerInfoToggleStart;
     unsigned int m_iTimerInfoToggleCurrent;
 
     mutable CCriticalSection m_critSection;

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -18,7 +18,6 @@
 #include "Application.h"
 #include "filesystem/SpecialProtocol.h"
 #include "input/Key.h"
-#include "threads/SystemClock.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
@@ -1163,11 +1162,11 @@ void CTeletextDecoder::RenderPage()
         if (c == NULL)
           return;
 
-        memset(c, 0x00, sizeof(TextSubtitleCache_t));
+        c = {};
         m_RenderInfo.SubtitleCache[j] = c;
       }
       c->Valid = true;
-      c->Timestamp = XbmcThreads::SystemClockMillis()/1000;
+      c->Timestamp = std::chrono::steady_clock::now();
 
       if (m_txtCache->SubPageTable[m_txtCache->Page] != 0xFF)
       {
@@ -1207,10 +1206,12 @@ void CTeletextDecoder::RenderPage()
   {
     if (m_RenderInfo.DelayStarted)
     {
-      long now = XbmcThreads::SystemClockMillis()/1000;
+      auto now = std::chrono::steady_clock::now();
       for (TextSubtitleCache_t* const subtitleCache : m_RenderInfo.SubtitleCache)
       {
-        if (subtitleCache && subtitleCache->Valid && now - subtitleCache->Timestamp >= (long)m_RenderInfo.SubtitleDelay)
+        if (subtitleCache && subtitleCache->Valid &&
+            std::chrono::duration_cast<std::chrono::seconds>(now - subtitleCache->Timestamp)
+                    .count() >= m_RenderInfo.SubtitleDelay)
         {
           memcpy(m_RenderInfo.PageChar, subtitleCache->PageChar, 40 * 25);
           memcpy(m_RenderInfo.PageAtrb, subtitleCache->PageAtrb, 40 * 25 * sizeof(TextPageAttr_t));
@@ -1312,7 +1313,7 @@ void CTeletextDecoder::DoFlashing(int startrow)
   /* Flashing */
   TextPageAttr_t flashattr;
   char flashchar;
-  long flashphase = XbmcThreads::SystemClockMillis() % 1000;
+  long flashphase = std::chrono::steady_clock::now().time_since_epoch().count() % 1000;
 
   int srow = startrow;
   int erow = 24;

--- a/xbmc/video/TeletextDefines.h
+++ b/xbmc/video/TeletextDefines.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 
 #define FLOFSIZE 4
@@ -381,7 +382,7 @@ typedef struct
 typedef struct
 {
   bool Valid;
-  long Timestamp;
+  std::chrono::time_point<std::chrono::steady_clock> Timestamp;
   unsigned char  PageChar[TELETEXT_PAGE_SIZE];
   TextPageAttr_t PageAtrb[TELETEXT_PAGE_SIZE];
 } TextSubtitleCache_t;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3786,9 +3786,6 @@ void CVideoDatabase::GetDetailsFromDB(const dbiplus::sql_record* const record, i
   }
 }
 
-DWORD movieTime = 0;
-DWORD castTime = 0;
-
 CVideoInfoTag CVideoDatabase::GetDetailsByTypeAndId(VIDEODB_CONTENT_TYPE type, int id)
 {
   CVideoInfoTag details;
@@ -3969,7 +3966,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   if (record == NULL)
     return details;
 
-  DWORD time = XbmcThreads::SystemClockMillis();
   int idMovie = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_MIN, VIDEODB_ID_MAX, DbMovieOffsets, details);
@@ -4000,12 +3996,10 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
     details.SetYear(record->at(VIDEODB_DETAILS_MOVIE_PREMIERED).get_asInt());
   else
     details.SetPremieredFromDBDate(premieredString);
-  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
   if (getDetails)
   {
-      GetCast(details.m_iDbId, MediaTypeMovie, details.m_cast);
-      castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
+    GetCast(details.m_iDbId, MediaTypeMovie, details.m_cast);
 
     if (getDetails & VideoDbDetailsTag)
       GetTags(details.m_iDbId, MediaTypeMovie, details.m_tags);
@@ -4052,7 +4046,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
   if (record == NULL)
     return details;
 
-  DWORD time = XbmcThreads::SystemClockMillis();
   int idTvShow = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_TV_MIN, VIDEODB_ID_TV_MAX, DbTvShowOffsets, details, 1);
@@ -4075,14 +4068,11 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
   details.SetUniqueID(record->at(VIDEODB_DETAILS_TVSHOW_UNIQUEID_VALUE).get_asString(), record->at(VIDEODB_DETAILS_TVSHOW_UNIQUEID_TYPE).get_asString(), true);
   details.SetDuration(record->at(VIDEODB_DETAILS_TVSHOW_DURATION).get_asInt());
 
-  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
-
   if (getDetails)
   {
     if (getDetails & VideoDbDetailsCast)
     {
       GetCast(details.m_iDbId, "tvshow", details.m_cast);
-      castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     }
 
     if (getDetails & VideoDbDetailsTag)
@@ -4123,7 +4113,6 @@ CVideoInfoTag CVideoDatabase::GetBasicDetailsForEpisode(const dbiplus::sql_recor
   if (record == nullptr)
     return details;
 
-  unsigned int time = XbmcThreads::SystemClockMillis();
   int idEpisode = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_EPISODE_MIN, VIDEODB_ID_EPISODE_MAX, DbEpisodeOffsets, details);
@@ -4134,7 +4123,6 @@ CVideoInfoTag CVideoDatabase::GetBasicDetailsForEpisode(const dbiplus::sql_recor
   details.m_iIdSeason = record->at(VIDEODB_DETAILS_EPISODE_SEASON_ID).get_asInt();
   details.m_iUserRating = record->at(VIDEODB_DETAILS_EPISODE_USER_RATING).get_asInt();
 
-  movieTime += XbmcThreads::SystemClockMillis() - time;
   return details;
 }
 
@@ -4151,8 +4139,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
     return details;
 
   details = GetBasicDetailsForEpisode(record);
-
-  unsigned int time = XbmcThreads::SystemClockMillis();
 
   details.m_strPath = record->at(VIDEODB_DETAILS_EPISODE_PATH).get_asString();
   std::string strFileName = record->at(VIDEODB_DETAILS_EPISODE_FILE).get_asString();
@@ -4174,7 +4160,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
                     record->at(VIDEODB_DETAILS_EPISODE_VOTES).get_asInt(),
                     record->at(VIDEODB_DETAILS_EPISODE_RATING_TYPE).get_asString(), true);
   details.SetUniqueID(record->at(VIDEODB_DETAILS_EPISODE_UNIQUEID_VALUE).get_asString(), record->at(VIDEODB_DETAILS_EPISODE_UNIQUEID_TYPE).get_asString(), true);
-  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
   if (getDetails)
   {
@@ -4182,7 +4167,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
     {
       GetCast(details.m_iDbId, MediaTypeEpisode, details.m_cast);
       GetCast(details.m_iIdShow, MediaTypeTvShow, details.m_cast);
-      castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     }
 
     if (getDetails & VideoDbDetailsRating)
@@ -4215,7 +4199,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(const dbiplus::sql_record*
   if (record == nullptr)
     return details;
 
-  unsigned int time = XbmcThreads::SystemClockMillis();
   int idMVideo = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_MUSICVIDEO_MIN, VIDEODB_ID_MUSICVIDEO_MAX, DbMusicVideoOffsets, details);
@@ -4239,8 +4222,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(const dbiplus::sql_record*
   else
     details.SetPremieredFromDBDate(premieredString);
 
-  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
-
   if (getDetails)
   {
     if (getDetails & VideoDbDetailsTag)
@@ -4252,7 +4233,6 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(const dbiplus::sql_record*
     if (getDetails & VideoDbDetailsAll)
     {
       GetCast(details.m_iDbId, "musicvideo", details.m_cast);
-      castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     }
 
     details.m_parsedDetails = getDetails;
@@ -6603,7 +6583,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
 
     if (!strArtist.empty())
       items.SetProperty("customtitle",strArtist); // change displayed path from eg /23 to /Artist
-//    CLog::Log(LOGDEBUG, __FUNCTION__" Time: %d ms", XbmcThreads::SystemClockMillis() - time);
+
     return true;
   }
   catch (...)
@@ -7415,9 +7395,6 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
 {
   try
   {
-    movieTime = 0;
-    castTime = 0;
-
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS)
@@ -7532,8 +7509,6 @@ bool CVideoDatabase::GetTvShowsByWhere(const std::string& strBaseDir, const Filt
 {
   try
   {
-    movieTime = 0;
-
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS)
@@ -7660,9 +7635,6 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
 {
   try
   {
-    movieTime = 0;
-    castTime = 0;
-
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS)
@@ -8556,8 +8528,6 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
 {
   try
   {
-    movieTime = 0;
-    castTime = 0;
 
     if (nullptr == m_pDB)
       return false;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -36,7 +36,6 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "tags/VideoInfoTagLoaderFactory.h"
-#include "threads/SystemClock.h"
 #include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/RegExp.h"
@@ -98,7 +97,7 @@ namespace VIDEO
         return;
       }
 
-      unsigned int tick = XbmcThreads::SystemClockMillis();
+      auto start = std::chrono::steady_clock::now();
 
       m_database.Open();
 
@@ -156,9 +155,11 @@ namespace VIDEO
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().ResetLibraryBools();
       m_database.Close();
 
-      tick = XbmcThreads::SystemClockMillis() - tick;
-      CLog::Log(LOGINFO, "VideoInfoScanner: Finished scan. Scanning for video info took %s",
-                StringUtils::SecondsToTimeString(tick / 1000).c_str());
+      auto end = std::chrono::steady_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+      CLog::Log(LOGINFO, "VideoInfoScanner: Finished scan. Scanning for video info took {} ms",
+                duration.count());
     }
     catch (...)
     {

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -10,6 +10,8 @@
 
 #include "guilib/GUIWindow.h"
 
+#include <chrono>
+
 class CGUIDialog;
 
 class CGUIWindowFullScreen : public CGUIWindow
@@ -37,7 +39,7 @@ private:
   CGUIDialog *GetOSD();
 
   bool m_viewModeChanged;
-  unsigned int m_dwShowViewModeTimeout;
+  std::chrono::time_point<std::chrono::steady_clock> m_dwShowViewModeTimeout;
 
   bool m_bShowCurrentTime;
 };

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -12,6 +12,7 @@
 #include "threads/Timer.h"
 #include "windowing/WinSystem.h"
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -93,7 +94,7 @@ protected:
   SDL_Surface* m_SDLSurface;
   CWinEventsOSX *m_osx_events;
   bool                         m_obscured;
-  unsigned int                 m_obscured_timecheck;
+  std::chrono::time_point<std::chrono::steady_clock> m_obscured_timecheck;
 
   bool                         m_movedToOtherScreen;
   int                          m_lastDisplayNr;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -659,7 +659,7 @@ CWinSystemOSX::CWinSystemOSX()
   m_SDLSurface = NULL;
   m_osx_events = NULL;
   m_obscured   = false;
-  m_obscured_timecheck = XbmcThreads::SystemClockMillis() + 1000;
+  m_obscured_timecheck = std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
   m_lastDisplayNr = -1;
   m_movedToOtherScreen = false;
   m_refreshRate = 0.0;
@@ -1428,11 +1428,11 @@ bool CWinSystemOSX::FlushBuffer(void)
 bool CWinSystemOSX::IsObscured(void)
 {
   // check once a second if we are obscured.
-  unsigned int now_time = XbmcThreads::SystemClockMillis();
+  auto now_time = std::chrono::steady_clock::now();
   if (m_obscured_timecheck > now_time)
     return m_obscured;
   else
-    m_obscured_timecheck = now_time + 1000;
+    m_obscured_timecheck = now_time + std::chrono::milliseconds(1000);
 
   NSOpenGLContext* cur_context = [NSOpenGLContext currentContext];
   NSView* view = [cur_context view];

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -50,7 +50,6 @@
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "threads/IRunnable.h"
-#include "threads/SystemClock.h"
 #include "utils/FileUtils.h"
 #include "utils/LabelFormatter.h"
 #include "utils/log.h"
@@ -747,7 +746,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   }
   else
   {
-    unsigned int time = XbmcThreads::SystemClockMillis();
+    auto start = std::chrono::steady_clock::now();
 
     if (strDirectory.empty())
       SetupShares();
@@ -760,7 +759,10 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
     items.Assign(dirItems);
 
     // took over a second, and not normally cached, so cache it
-    if ((XbmcThreads::SystemClockMillis() - time) > 1000  && items.CacheToDiscIfSlow())
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    if (duration.count() > 1000 && items.CacheToDiscIfSlow())
       items.Save(GetID());
 
     // if these items should replace the current listing, then pop it off the top


### PR DESCRIPTION
This is part of the continued effort to convert to `std::chrono`. This helps specifically to remove the usage of `XbmcThreads::SystemClockMillis()`.

These changes are relatively simple so I've included them all in a single PR. More intricate changes I will make separate PR's for.

Many of these changes are just to log duration. Some do effect functionality.

I've built and run with these changes but testing was limited. Please test.

clang-format has some interesting changes. If they are absolutely abhorrent to anyone just say so and I can un-clang-format or try and fix it as best as possible.

I'll include all relevant parties as reviewers.