### PR TITLE
CPlayListPlayer: use std::chrono

### DIFF
--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -12,6 +12,7 @@
 #include "guilib/IMsgTargetCallback.h"
 #include "messaging/IMessageTarget.h"
 
+#include <chrono>
 #include <memory>
 
 #define PLAYLIST_NONE    -1
@@ -194,7 +195,7 @@ protected:
   bool m_bPlayedFirstFile;
   bool m_bPlaybackStarted;
   int m_iFailedSongs;
-  unsigned int m_failedSongsStart;
+  std::chrono::time_point<std::chrono::steady_clock> m_failedSongsStart;
   int m_iCurrentSong;
   int m_iCurrentPlayList;
   CPlayList* m_PlaylistMusic;


### PR DESCRIPTION
I decided to PR this separate from the changes in #19608 as the behaviour is a little tricky. We move from `0` starting point to the current time. I don't think I've broken anything but it's probably worth a test.