### PR TITLE
CThread: remove unused methods

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -15,7 +15,6 @@
 
 #include "commons/Exception.h"
 #include "threads/SingleLock.h"
-#include "threads/SystemClock.h"
 #include "utils/log.h"
 
 #include <atomic>
@@ -75,9 +74,7 @@ void CThread::Create(bool bAutoDelete)
       exit(1);
     }
   }
-  m_iLastTime = XbmcThreads::SystemClockMillis() * 10000ULL;
-  m_iLastUsage = 0;
-  m_fLastUsage = 0.0f;
+
   m_bAutoDelete = bAutoDelete;
   m_bStop = false;
   m_StopEvent.Reset();
@@ -295,24 +292,3 @@ void CThread::Action()
     e.LogThrowMessage("OnExit");
   }
 }
-
-float CThread::GetRelativeUsage()
-{
-  unsigned int iTime = XbmcThreads::SystemClockMillis();
-  iTime *= 10000; // convert into 100ns tics
-
-  // only update every 1 second
-  if (iTime < m_iLastTime + 1000 * 10000)
-    return m_fLastUsage;
-
-  int64_t iUsage = GetAbsoluteUsage();
-
-  if (m_iLastUsage > 0 && m_iLastTime > 0)
-    m_fLastUsage = static_cast<float>(iUsage - m_iLastUsage) / static_cast<float>(iTime - m_iLastTime);
-
-  m_iLastUsage = iUsage;
-  m_iLastTime = iTime;
-
-  return m_fLastUsage;
-}
-

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -62,7 +62,6 @@ public:
   int GetPriority(void);
   bool SetPriority(const int iPriority);
 
-  int64_t GetAbsoluteUsage();
   // -----------------------------------------------------------------------------------
 
   static CThread* GetCurrentThread();

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -62,7 +62,6 @@ public:
   int GetPriority(void);
   bool SetPriority(const int iPriority);
 
-  float GetRelativeUsage();  // returns the relative cpu usage of this thread since last call
   int64_t GetAbsoluteUsage();
   // -----------------------------------------------------------------------------------
 
@@ -108,10 +107,6 @@ private:
   CEvent m_StartEvent;
   CCriticalSection m_CriticalSection;
   IRunnable* m_pRunnable;
-
-  uint64_t m_iLastUsage = 0;
-  uint64_t m_iLastTime = 0;
-  float m_fLastUsage = 0.0f;
 
   std::string m_ThreadName;
   std::thread* m_thread = nullptr;

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -91,33 +91,6 @@ int CThread::GetPriority()
   return iReturn;
 }
 
-int64_t CThread::GetAbsoluteUsage()
-{
-#ifdef TARGET_WINDOWS_STORE
-  // GetThreadTimes is available since 10.0.15063 only
-  return 0;
-#else
-  CSingleLock lock(m_CriticalSection);
-
-  if (m_thread == nullptr)
-    return 0;
-
-  HANDLE tid = static_cast<HANDLE>(m_lwpId);
-
-  if (!tid)
-    return 0;
-
-  uint64_t time = 0;
-  FILETIME CreationTime, ExitTime, UserTime, KernelTime;
-  if( GetThreadTimes(tid, &CreationTime, &ExitTime, &KernelTime, &UserTime ) )
-  {
-    time = (((uint64_t)UserTime.dwHighDateTime) << 32) + ((uint64_t)UserTime.dwLowDateTime);
-    time += (((uint64_t)KernelTime.dwHighDateTime) << 32) + ((uint64_t)KernelTime.dwLowDateTime);
-  }
-  return time;
-#endif
-}
-
 void CThread::SetSignalHandlers()
 {
 }


### PR DESCRIPTION
This is part of the std::chrono cleanup however instead of converting the current methods I've just dropped them as they aren't used anywhere.