### PR TITLE
CTimer: use std::chrono

### DIFF
--- a/xbmc/threads/Timer.h
+++ b/xbmc/threads/Timer.h
@@ -11,6 +11,7 @@
 #include "Event.h"
 #include "Thread.h"
 
+#include <chrono>
 #include <functional>
 
 class ITimerCallback
@@ -43,8 +44,8 @@ protected:
 
 private:
   std::function<void()> m_callback;
-  uint32_t m_timeout;
+  std::chrono::milliseconds m_timeout;
   bool m_interval;
-  uint32_t m_endTime;
+  std::chrono::time_point<std::chrono::steady_clock> m_endTime;
   CEvent m_eventTimeout;
 };


### PR DESCRIPTION
This converts `CTimer` to use `std::chrono` directly. This simply changes the internals only. A further cleanup should be done to allow the public interfaces to use `std::chrono` also.

The changes are straight forward but `CTimer` is an important class and is worth having the changes in it's own PR instead of in #19608 