### PR TITLE
CVideoPlayer: use std::chrono

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1446,12 +1446,15 @@ void CVideoPlayer::Process()
         // stills will be skipped
         if(m_dvd.state == DVDSTATE_STILL)
         {
-          if (m_dvd.iDVDStillTime > 0)
+          if (m_dvd.iDVDStillTime > 0ms)
           {
-            if ((XbmcThreads::SystemClockMillis() - m_dvd.iDVDStillStartTime) >= m_dvd.iDVDStillTime)
+            const auto now = std::chrono::steady_clock::now();
+            const auto duration = now - m_dvd.iDVDStillStartTime;
+
+            if (duration >= m_dvd.iDVDStillTime)
             {
-              m_dvd.iDVDStillTime = 0;
-              m_dvd.iDVDStillStartTime = 0;
+              m_dvd.iDVDStillTime = 0ms;
+              m_dvd.iDVDStillStartTime = {};
               m_dvd.state = DVDSTATE_NORMAL;
               pStream->SkipStill();
               continue;
@@ -2809,8 +2812,8 @@ void CVideoPlayer::HandleMessages()
         if(ptr->SetState(pMsgPlayerSetState->GetState()))
         {
           m_dvd.state = DVDSTATE_NORMAL;
-          m_dvd.iDVDStillStartTime = 0;
-          m_dvd.iDVDStillTime = 0;
+          m_dvd.iDVDStillStartTime = {};
+          m_dvd.iDVDStillTime = 0ms;
         }
       }
 
@@ -3896,23 +3899,24 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
       {
         // else notify the player we have received a still frame
 
-        m_dvd.iDVDStillTime = *static_cast<int*>(pData);
-        m_dvd.iDVDStillStartTime = XbmcThreads::SystemClockMillis();
+        m_dvd.iDVDStillTime = std::chrono::milliseconds(*static_cast<int*>(pData));
+        m_dvd.iDVDStillStartTime = std::chrono::steady_clock::now();
 
-        if (m_dvd.iDVDStillTime != 0)
+        if (m_dvd.iDVDStillTime > 0ms)
           m_dvd.iDVDStillTime *= 1000;
 
         /* adjust for the output delay in the video queue */
-        unsigned int time = 0;
-        if (m_CurrentVideo.stream && m_dvd.iDVDStillTime > 0)
+        std::chrono::milliseconds time = 0ms;
+        if (m_CurrentVideo.stream && m_dvd.iDVDStillTime > 0ms)
         {
-          time = (unsigned int)(m_VideoPlayerVideo->GetOutputDelay() / (DVD_TIME_BASE / 1000));
-          if (time < 10000 && time > 0)
+          time = std::chrono::milliseconds(
+              static_cast<int>(m_VideoPlayerVideo->GetOutputDelay() / (DVD_TIME_BASE / 1000)));
+          if (time < 10000ms && time > 0ms)
             m_dvd.iDVDStillTime += time;
         }
         m_dvd.state = DVDSTATE_STILL;
-        CLog::Log(LOGDEBUG, "BD_EVENT_STILL_TIME - waiting {} sec, with delay of {} sec",
-                  m_dvd.iDVDStillTime, time / 1000);
+        CLog::Log(LOGDEBUG, "BD_EVENT_STILL_TIME - waiting {} msec, with delay of {} msec",
+                  m_dvd.iDVDStillTime.count(), time.count());
       }
     }
     break;
@@ -3922,15 +3926,15 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
       if (on && m_dvd.state != DVDSTATE_STILL)
       {
         m_dvd.state = DVDSTATE_STILL;
-        m_dvd.iDVDStillStartTime = XbmcThreads::SystemClockMillis();
-        m_dvd.iDVDStillTime = 0;
+        m_dvd.iDVDStillStartTime = std::chrono::steady_clock::now();
+        m_dvd.iDVDStillTime = 0ms;
         CLog::Log(LOGDEBUG, "CDVDPlayer::OnDVDNavResult - libbluray DVDSTATE_STILL start");
       }
       else if (!on && m_dvd.state == DVDSTATE_STILL)
       {
         m_dvd.state = DVDSTATE_NORMAL;
-        m_dvd.iDVDStillStartTime = 0;
-        m_dvd.iDVDStillTime = 0;
+        m_dvd.iDVDStillStartTime = {};
+        m_dvd.iDVDStillTime = 0ms;
         CLog::Log(LOGDEBUG, "CDVDPlayer::OnDVDNavResult - libbluray DVDSTATE_STILL end");
       }
     }
@@ -3976,23 +3980,24 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
           // else notify the player we have received a still frame
 
           if(still_event->length < 0xff)
-            m_dvd.iDVDStillTime = still_event->length * 1000;
+            m_dvd.iDVDStillTime = std::chrono::seconds(still_event->length);
           else
-            m_dvd.iDVDStillTime = 0;
+            m_dvd.iDVDStillTime = 0ms;
 
-          m_dvd.iDVDStillStartTime = XbmcThreads::SystemClockMillis();
+          m_dvd.iDVDStillStartTime = std::chrono::steady_clock::now();
 
           /* adjust for the output delay in the video queue */
-          unsigned int time = 0;
-          if( m_CurrentVideo.stream && m_dvd.iDVDStillTime > 0 )
+          std::chrono::milliseconds time = 0ms;
+          if (m_CurrentVideo.stream && m_dvd.iDVDStillTime > 0ms)
           {
-            time = (unsigned int)(m_VideoPlayerVideo->GetOutputDelay() / ( DVD_TIME_BASE / 1000 ));
-            if( time < 10000 && time > 0 )
+            time = std::chrono::milliseconds(
+                static_cast<int>(m_VideoPlayerVideo->GetOutputDelay() / (DVD_TIME_BASE / 1000)));
+            if (time < 10000ms && time > 0ms)
               m_dvd.iDVDStillTime += time;
           }
           m_dvd.state = DVDSTATE_STILL;
-          CLog::Log(LOGDEBUG, "DVDNAV_STILL_FRAME - waiting {} sec, with delay of {} sec",
-                    still_event->length, time / 1000);
+          CLog::Log(LOGDEBUG, "DVDNAV_STILL_FRAME - waiting {} sec, with delay of {} msec",
+                    still_event->length, time.count());
         }
         return NAVRESULT_HOLD;
       }
@@ -4151,7 +4156,8 @@ bool CVideoPlayer::OnAction(const CAction &action)
   std::shared_ptr<CDVDInputStream::IMenus> pMenus = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream);
   if (pMenus)
   {
-    if (m_dvd.state == DVDSTATE_STILL && m_dvd.iDVDStillTime != 0 && pMenus->GetTotalButtons() == 0)
+    if (m_dvd.state == DVDSTATE_STILL && m_dvd.iDVDStillTime != 0ms &&
+        pMenus->GetTotalButtons() == 0)
     {
       switch(action.GetID())
       {
@@ -4163,8 +4169,8 @@ bool CVideoPlayer::OnAction(const CAction &action)
             THREAD_ACTION(action);
             /* this will force us out of the stillframe */
             CLog::Log(LOGDEBUG, "{} - User asked to exit stillframe", __FUNCTION__);
-            m_dvd.iDVDStillStartTime = 0;
-            m_dvd.iDVDStillTime = 1;
+            m_dvd.iDVDStillStartTime = {};
+            m_dvd.iDVDStillTime = 1ms;
           }
           return true;
       }
@@ -4707,8 +4713,11 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
       if (m_dvd.state == DVDSTATE_STILL)
       {
-        state.time = XbmcThreads::SystemClockMillis() - m_dvd.iDVDStillStartTime;
-        state.timeMax = m_dvd.iDVDStillTime;
+        const auto now = std::chrono::steady_clock::now();
+        const auto duration =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - m_dvd.iDVDStillStartTime);
+        state.time = duration.count();
+        state.timeMax = m_dvd.iDVDStillTime.count();
         state.isInMenu = true;
       }
       else if (IsInMenuInternal())

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -25,6 +25,7 @@
 #include "threads/Thread.h"
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -514,15 +515,17 @@ protected:
       iSelectedSPUStream   = -1;
       iSelectedAudioStream = -1;
       iSelectedVideoStream = -1;
-      iDVDStillTime        =  0;
-      iDVDStillStartTime   =  0;
+      iDVDStillTime = std::chrono::milliseconds::zero();
+      iDVDStillStartTime = {};
       syncClock = false;
     }
 
     int state;                // current dvdstate
     bool syncClock;
-    unsigned int iDVDStillTime;      // total time in ticks we should display the still before continuing
-    unsigned int iDVDStillStartTime; // time in ticks when we started the still
+    std::chrono::milliseconds
+        iDVDStillTime; // total time in ticks we should display the still before continuing
+    std::chrono::time_point<std::chrono::steady_clock>
+        iDVDStillStartTime; // time in ticks when we started the still
     int iSelectedSPUStream;   // mpeg stream id, or -1 if disabled
     int iSelectedAudioStream; // mpeg stream id, or -1 if disabled
     int iSelectedVideoStream; // mpeg stream id or angle, -1 if disabled


### PR DESCRIPTION
More cleanup to go with #19608 but the changes here are more significant and worth a separate PR.

Tested with a simple play test of a few files including a Bluray ISO.