### PR TITLE
[Windows] Updates VC runtime to be compatible with both VS2019 and VS2017

### DIFF
--- a/project/Win32BuildSetup/genNsisInstaller.nsi
+++ b/project/Win32BuildSetup/genNsisInstaller.nsi
@@ -328,14 +328,14 @@ SectionEnd
 ;vs redist installer Section
 SectionGroup "Microsoft Visual C++ packages" SEC_VCREDIST
 
-Section "VS2017 C++ re-distributable Package (${TARGET_ARCHITECTURE})" SEC_VCREDIST1
-DetailPrint "Running VS2017 re-distributable setup..."
+Section "VS2017-2019 C++ re-distributable Package (${TARGET_ARCHITECTURE})" SEC_VCREDIST1
+DetailPrint "Running VS2017-2019 re-distributable setup..."
   SectionIn 1 2 #section is in install type Full
-  SetOutPath "$TEMP\vc2017"
-  File "${app_root}\..\..\BuildDependencies\downloads\vcredist\2017\vcredist_${TARGET_ARCHITECTURE}.exe"
-  ExecWait '"$TEMP\vc2017\vcredist_${TARGET_ARCHITECTURE}.exe" /install /quiet /norestart' $VSRedistSetupError
-  RMDir /r "$TEMP\vc2017"
-  DetailPrint "Finished VS2017 re-distributable setup"
+  SetOutPath "$TEMP\vc2019"
+  File "${app_root}\..\..\BuildDependencies\downloads\vcredist\2017-2019\vcredist_${TARGET_ARCHITECTURE}.exe"
+  ExecWait '"$TEMP\vc2019\vcredist_${TARGET_ARCHITECTURE}.exe" /install /quiet /norestart' $VSRedistSetupError
+  RMDir /r "$TEMP\vc2019"
+  DetailPrint "Finished VS2017-2019 re-distributable setup"
   SetOutPath "$INSTDIR"
 SectionEnd
 

--- a/project/Win32BuildSetup/getdeploydependencies.bat
+++ b/project/Win32BuildSetup/getdeploydependencies.bat
@@ -1,18 +1,17 @@
 @echo off
 
-REM If KODI_MIRROR is not set externally to this script, set it to the default mirror URL
-IF "%KODI_MIRROR%" == "" SET KODI_MIRROR=http://mirrors.kodi.tv
-echo Downloading from mirror %KODI_MIRROR%
-
+set DOWNLOAD_URL=https://aka.ms/vs/16/release/vc_redist.%TARGET_ARCHITECTURE%.exe
+set DOWNLOAD_FOLDER=..\BuildDependencies\downloads\vcredist\2017-2019
+set DOWNLOAD_FILE=vcredist_%TARGET_ARCHITECTURE%.exe
 
 :: Following commands expect this script's parent directory to be the current directory, so make sure that's so
 PUSHD %~dp0
 
-if not exist ..\BuildDependencies\downloads\vcredist\2017 mkdir ..\BuildDependencies\downloads\vcredist\2017
+if not exist %DOWNLOAD_FOLDER% mkdir %DOWNLOAD_FOLDER%
 
-if not exist ..\BuildDependencies\downloads\vcredist\2017\vcredist_%TARGET_ARCHITECTURE%.exe (
-  echo Downloading vc141 redist...
-  ..\BuildDependencies\bin\wget --tries=5 --retry-connrefused --waitretry=2 -nv -O ..\BuildDependencies\downloads\vcredist\2017\vcredist_%TARGET_ARCHITECTURE%.exe %KODI_MIRROR%/build-deps/win32/vcredist/2017/vcredist_%TARGET_ARCHITECTURE%.exe
+if not exist %DOWNLOAD_FOLDER%\%DOWNLOAD_FILE% (
+  echo Downloading vc142 redist...
+  ..\BuildDependencies\bin\wget --tries=5 --retry-connrefused --waitretry=2 -nv -O %DOWNLOAD_FOLDER%\%DOWNLOAD_FILE% %DOWNLOAD_URL%
 )
 :: Restore the previous current directory
 POPD


### PR DESCRIPTION
## Description
Updates VC runtime to be compatible with both VS2019 and VS2017.

## Motivation and context
Since https://github.com/xbmc/xbmc/pull/18222 was merged it is assumed that there is full compatibility with Visual Studio 2019, however the VC runtimes are not updated. Someone who compiles Kodi with VS2019 and installs it on a clean machine is not going to work because the installer only includes VS2017 runtimes. 

This PR fixes this. Also maintains backward compatibility with VS2017 because newer VC runtimes are common for VC 2015, 2017 and 2019 (https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0).

The VC runtimes is "one time" download so I think can be download directly from source and is not needed store in Kodi mirrors although this can be changed of course.


## How has this been tested?
Build and test x86 and x64

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
