### PR TITLE
[Windows] Removes unnecessary ERROR log lines when is build NSIS installer

### DIFF
--- a/tools/buildsteps/windows/BuildSetup.bat
+++ b/tools/buildsteps/windows/BuildSetup.bat
@@ -214,39 +214,29 @@ set WORKSPACE=%base_dir%\kodi-build.%TARGET_PLATFORM%
   SET APP_PDBFILE=%APP_NAME%Setup-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.pdb
   ECHO Creating installer %APP_SETUPFILE%...
   IF EXIST %APP_SETUPFILE% del %APP_SETUPFILE% > NUL
+
+  rem determine if current system is 32 or 64 bits
+  IF %PROCESSOR_ARCHITECTURE% == AMD64 (
+    SET NSIS_REG_KEY=HKLM\Software\Wow6432Node\NSIS
+  ) ELSE (
+    SET NSIS_REG_KEY=HKLM\Software\NSIS
+  )
+
   rem get path to makensis.exe from registry, first try tab delim
-  FOR /F "tokens=2* delims=  " %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
+  FOR /F "tokens=2* delims=  " %%A IN ('REG QUERY "%NSIS_REG_KEY%" /ve') DO SET NSISExePath=%%B
 
   IF NOT EXIST "%NSISExePath%" (
     rem try with space delim instead of tab
-    FOR /F "tokens=2* delims= " %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
+    FOR /F "tokens=2* delims= " %%A IN ('REG QUERY "%NSIS_REG_KEY%" /ve') DO SET NSISExePath=%%B
   )
 
   IF NOT EXIST "%NSISExePath%" (
     rem fails on localized windows (Default) becomes (Par D�faut)
-    FOR /F "tokens=3* delims=  " %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
+    FOR /F "tokens=3* delims=  " %%A IN ('REG QUERY "%NSIS_REG_KEY%" /ve') DO SET NSISExePath=%%B
   )
 
   IF NOT EXIST "%NSISExePath%" (
-    FOR /F "tokens=3* delims= " %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
-  )
-
-  rem proper x64 registry checks
-  IF NOT EXIST "%NSISExePath%" (
-    ECHO using x64 registry entries
-    FOR /F "tokens=2* delims=  " %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
-  )
-  IF NOT EXIST "%NSISExePath%" (
-    rem try with space delim instead of tab
-    FOR /F "tokens=2* delims= " %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
-  )
-  IF NOT EXIST "%NSISExePath%" (
-    rem on win 7 x64, the previous fails
-    FOR /F "tokens=3* delims=  " %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
-  )
-  IF NOT EXIST "%NSISExePath%" (
-    rem try with space delim instead of tab
-    FOR /F "tokens=3* delims= " %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
+    FOR /F "tokens=3* delims= " %%A IN ('REG QUERY "%NSIS_REG_KEY%" /ve') DO SET NSISExePath=%%B
   )
 
   SET NSISExe=%NSISExePath%\makensis.exe


### PR DESCRIPTION
## Description
Removes unnecessary ERROR log lines when is build NSIS installer.


## Motivation and context
On every installer build is shown this four error lines:

18:20:49 ------------------------------------------------------------
18:20:49 Build Succeeded!
18:20:49 ------------------------------------------------------------
18:20:49 Generating installer includes...
18:20:49 ------------------------------------------------------------
18:20:49 Downloading from mirror http://mirrors.kodi.tv
18:20:49 Creating installer KodiSetup-20210421-28b291e2-PR19608-merge-x64.exe...
**18:20:49 ERROR: The system was unable to find the specified registry key or value.
18:20:49 ERROR: The system was unable to find the specified registry key or value.
18:20:49 ERROR: The system was unable to find the specified registry key or value.
18:20:49 ERROR: The system was unable to find the specified registry key or value.**
18:20:49 using x64 registry entries
18:20:49 ------------------------------------------------------------
18:22:15 Done!
18:22:15 Setup is located at f:\builds\workspace\WIN-64\tools\buildsteps\windows\KodiSetup-20210421-28b291e2-PR19608-merge-x64.exe
18:22:15 ------------------------------------------------------------

The error es because BuildSetup.bat not takes into account if current system is 32 or 64 bits and try for various registry keys to locate NSIS installer path:

`HKLM\Software\Wow6432Node\NSIS`

and 

`HKLM\Software\NSIS`

NSIS is a 32 bit software then on 64 bits systems correct registry key is "Wow6432Node"

The improvement consists on check environment variable `PROCESSOR_ARCHITECTURE` that has `AMD64` value on 64 bits systems and then use directly `HKLM\Software\Wow6432Node\NSIS` key and if not use `HKLM\Software\NSIS`


## How has this been tested?
Build installer on 64 bits system and check build setup log and correct installer generation.

## What is the effect on users?
Cleans message "ERROR: The system was unable to find the specified registry key or value." from build installer log

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
