### PR TITLE
EndTime: fix infinite value and some other changes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -125,8 +125,7 @@ void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(
 {
   CSingleLock lock(m_instance->m_cs);
 
-  list.emplace_back(g_localizeStrings.Get(20422),
-                    static_cast<int>(XbmcThreads::EndTime::InfiniteValue.count()));
+  list.emplace_back(g_localizeStrings.Get(20422), std::numeric_limits<int>::max());
   list.emplace_back(g_localizeStrings.Get(13551), 0);
 
   if (m_instance->m_audioEngine.SupportsSilenceTimeout())

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1140,7 +1140,7 @@ void CActiveAESink::GenerateNoise()
 void CActiveAESink::SetSilenceTimer()
 {
   if (m_extStreaming)
-    m_extSilenceTimeout = static_cast<unsigned int>(XbmcThreads::EndTime::InfiniteValue.count());
+    m_extSilenceTimeout = std::numeric_limits<unsigned int>::max();
   else if (m_extAppFocused)
     m_extSilenceTimeout = m_silenceTimeOut;
   else

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -36,8 +36,11 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       int timeoutMS = ceil(timeout * 1000);
-      XbmcThreads::EndTime endTime(timeoutMS > 0 ? timeoutMS
-                                                 : XbmcThreads::EndTime::InfiniteValue.count());
+      XbmcThreads::EndTime endTime(timeoutMS);
+
+      if (timeoutMS <= 0)
+        endTime.SetInfinite();
+
       while (!endTime.IsTimePast())
       {
         {

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -436,7 +436,7 @@ void CPVREpgContainer::Process()
 
   // store data on exit
   CLog::Log(LOGINFO, "EPG Container: Persisting unsaved events...");
-  PersistAll(static_cast<unsigned int>(XbmcThreads::EndTime::InfiniteValue.count()));
+  PersistAll(std::numeric_limits<unsigned int>::max());
   CLog::Log(LOGINFO, "EPG Container: Persisting events done");
 }
 
@@ -523,7 +523,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgContainer::GetTags(
     const PVREpgSearchData& searchData) const
 {
   // make sure we have up-to-date data in the database.
-  PersistAll(static_cast<unsigned int>(XbmcThreads::EndTime::InfiniteValue.count()));
+  PersistAll(std::numeric_limits<unsigned int>::max());
 
   const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
   std::vector<std::shared_ptr<CPVREpgInfoTag>> results = database->GetEpgTags(searchData);

--- a/xbmc/threads/SystemClock.cpp
+++ b/xbmc/threads/SystemClock.cpp
@@ -46,7 +46,10 @@ bool EndTime::IsTimePast() const
 unsigned int EndTime::MillisLeft() const
 {
   if (m_totalWaitTime == InfiniteValue)
-    return static_cast<unsigned int>(InfiniteValue.count());
+  {
+    //! @todo: this is a hack for now
+    return std::numeric_limits<unsigned int>::max();
+  }
 
   if (m_totalWaitTime == std::chrono::milliseconds(0))
     return 0;
@@ -81,7 +84,4 @@ unsigned int SystemClockMillis()
                                        std::chrono::system_clock::now().time_since_epoch())
                                        .count());
 }
-
-const std::chrono::milliseconds EndTime::InfiniteValue =
-    std::numeric_limits<std::chrono::milliseconds>::max();
 }

--- a/xbmc/threads/SystemClock.cpp
+++ b/xbmc/threads/SystemClock.cpp
@@ -16,19 +16,19 @@ namespace XbmcThreads
 {
 
 EndTime::EndTime()
-  : m_startTime(std::chrono::system_clock::now()), m_totalWaitTime(std::chrono::milliseconds(0))
+  : m_startTime(std::chrono::steady_clock::now()), m_totalWaitTime(std::chrono::milliseconds(0))
 {
 }
 
 EndTime::EndTime(unsigned int millisecondsIntoTheFuture)
-  : m_startTime(std::chrono::system_clock::now()),
+  : m_startTime(std::chrono::steady_clock::now()),
     m_totalWaitTime(static_cast<std::chrono::milliseconds>(millisecondsIntoTheFuture))
 {
 }
 
 void EndTime::Set(unsigned int millisecondsIntoTheFuture)
 {
-  m_startTime = std::chrono::system_clock::now();
+  m_startTime = std::chrono::steady_clock::now();
   m_totalWaitTime = static_cast<std::chrono::milliseconds>(millisecondsIntoTheFuture);
 }
 
@@ -40,7 +40,7 @@ bool EndTime::IsTimePast() const
   if (m_totalWaitTime == std::chrono::milliseconds(0))
     return true;
 
-  return ((std::chrono::system_clock::now() - m_startTime) >= m_totalWaitTime);
+  return ((std::chrono::steady_clock::now() - m_startTime) >= m_totalWaitTime);
 }
 
 unsigned int EndTime::MillisLeft() const
@@ -55,7 +55,7 @@ unsigned int EndTime::MillisLeft() const
     return 0;
 
   std::chrono::milliseconds timeWaitedAlready =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() -
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
                                                             m_startTime);
 
   if (timeWaitedAlready >= m_totalWaitTime)
@@ -81,7 +81,7 @@ unsigned int EndTime::GetStartTime() const
 unsigned int SystemClockMillis()
 {
   return static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                       std::chrono::system_clock::now().time_since_epoch())
+                                       std::chrono::steady_clock::now().time_since_epoch())
                                        .count());
 }
 }

--- a/xbmc/threads/SystemClock.cpp
+++ b/xbmc/threads/SystemClock.cpp
@@ -15,7 +15,8 @@
 namespace XbmcThreads
 {
 
-EndTime::EndTime() : m_startTime(std::chrono::system_clock::now())
+EndTime::EndTime()
+  : m_startTime(std::chrono::system_clock::now()), m_totalWaitTime(std::chrono::milliseconds(0))
 {
 }
 

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -52,10 +52,11 @@ namespace XbmcThreads
     unsigned int GetInitialTimeoutValue() const;
     unsigned int GetStartTime() const;
 
-    static const std::chrono::milliseconds InfiniteValue;
-
   private:
     std::chrono::system_clock::time_point m_startTime;
     std::chrono::milliseconds m_totalWaitTime;
+
+    const std::chrono::milliseconds InfiniteValue =
+        std::chrono::milliseconds(std::numeric_limits<std::chrono::milliseconds::rep>::max());
   };
 }

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -53,7 +53,7 @@ namespace XbmcThreads
     unsigned int GetStartTime() const;
 
   private:
-    std::chrono::system_clock::time_point m_startTime;
+    std::chrono::steady_clock::time_point m_startTime;
     std::chrono::milliseconds m_totalWaitTime;
 
     const std::chrono::milliseconds InfiniteValue =

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -27,9 +27,7 @@ void CommonTests(XbmcThreads::EndTime& endTime)
   EXPECT_EQ(static_cast<unsigned int>(0), endTime.MillisLeft());
 
   endTime.SetInfinite();
-  EXPECT_EQ(
-      static_cast<unsigned int>(std::numeric_limits<std::chrono::milliseconds>::max().count()),
-      endTime.GetInitialTimeoutValue());
+  EXPECT_EQ(std::numeric_limits<unsigned int>::max(), endTime.GetInitialTimeoutValue());
   endTime.SetExpired();
   EXPECT_EQ(static_cast<unsigned int>(0), endTime.GetInitialTimeoutValue());
 }


### PR DESCRIPTION
I made this PR because I noticed the cpu usage wasn't updating. Upon inspection I found that `std::numeric_limits<std::chrono::milliseconds>::max()` doesn't actually do what I want (it just reports `0`). This caused problems if the wait time of the EndTime was also `0`.

I've made the `InfiniteValue` member private and replaced it's usage in various areas with std::numeric_limits<T>::max().

I've also fixed an issue where `m_totalWaitTime` isn't initialized in the constructor.

I've also changed `system_clock` to `steady_clock`. The reason for this is here -> https://stackoverflow.com/questions/31552193/difference-between-steady-clock-vs-system-clock/31553641#31553641

@phunkyfish I notice you use `system_clock` in the add-on representation of `EndTime` You may want to update that like I've done here (for the meantime as I think we will just get rid of `EndTime` eventually).

This PR should fix all the outstanding issues and will make removing `EndTime` easier all together.