### PR TITLE
[linux] allow logging to console

### DIFF
--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -25,6 +25,8 @@
 namespace
 {
 std::vector<std::string> availableWindowSystems = CCompileInfo::GetAvailableWindowSystems();
+std::array<std::string, 1> availableLogTargets = {"console"};
+
 } // namespace
 #endif
 
@@ -79,6 +81,12 @@ void CAppParamParser::DisplayHelp()
   for (const auto& windowSystem : availableWindowSystems)
     printf(" %s", windowSystem.c_str());
   printf("\n");
+  printf("  --logging=<target>\tSelect which log target to use (log file will always be used in "
+         "conjunction).\n");
+  printf("  \t\t\t\tAvailable log targets are:");
+  for (const auto& logTarget : availableLogTargets)
+    printf(" %s", logTarget.c_str());
+  printf("\n");
 #endif
   exit(0);
 }
@@ -113,6 +121,23 @@ void CAppParamParser::ParseArg(const std::string &arg)
       std::cout << "    Available window systems:";
       for (const auto& windowSystem : availableWindowSystems)
         std::cout << " " << windowSystem;
+      std::cout << std::endl;
+      exit(0);
+    }
+  }
+  else if (arg.substr(0, 10) == "--logging=")
+  {
+    if (std::find(availableLogTargets.begin(), availableLogTargets.end(), arg.substr(10)) !=
+        availableLogTargets.end())
+    {
+      m_logTarget = arg.substr(10);
+    }
+    else
+    {
+      std::cout << "Selected logging target not available: " << arg << std::endl;
+      std::cout << "    Available log targest:";
+      for (const auto& logTarget : availableLogTargets)
+        std::cout << " " << logTarget;
       std::cout << std::endl;
       exit(0);
     }

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -31,6 +31,7 @@ public:
   bool m_testmode = false;
   bool m_standAlone = false;
   std::string m_windowing;
+  std::string m_logTarget;
 
 private:
   void ParseArg(const std::string &arg);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -349,6 +349,7 @@ bool CApplication::Create(const CAppParamParser &params)
   m_bTestMode = params.m_testmode;
   m_bStandalone = params.m_standAlone;
   m_windowing = params.m_windowing;
+  m_logTarget = params.m_logTarget;
 
   CServiceBroker::CreateLogging();
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -316,6 +316,8 @@ public:
   bool IsStandAlone() { return m_bStandalone; }
   bool IsEnableTestMode() { return m_bTestMode; }
 
+  const std::string& GetLogTarget() const { return m_logTarget; }
+
   bool IsAppFocused() const { return m_AppFocused; }
 
   bool ToggleDPMS(bool manual);
@@ -446,6 +448,7 @@ protected:
   unsigned int m_lastRenderTime = 0;
   bool m_skipGuiRender = false;
 
+  std::string m_logTarget;
   bool m_bStandalone = false;
   bool m_bTestMode = false;
   bool m_bSystemScreenSaverEnable = false;

--- a/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
+++ b/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
@@ -8,9 +8,21 @@
 
 #include "PosixInterfaceForCLog.h"
 
+#include "Application.h"
+
+#include <spdlog/sinks/dist_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
 #if !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN)
 std::unique_ptr<IPlatformLog> IPlatformLog::CreatePlatformLog()
 {
   return std::make_unique<CPosixInterfaceForCLog>();
 }
 #endif
+
+void CPosixInterfaceForCLog::AddSinks(
+    std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const
+{
+  if (g_application.GetLogTarget() == "console")
+    distributionSink->add_sink(std::make_shared<spdlog::sinks::stdout_color_sink_st>());
+}

--- a/xbmc/platform/posix/utils/PosixInterfaceForCLog.h
+++ b/xbmc/platform/posix/utils/PosixInterfaceForCLog.h
@@ -18,7 +18,5 @@ public:
 
   spdlog_filename_t GetLogFilename(const std::string& filename) const override { return filename; }
   void AddSinks(
-      std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const override
-  {
-  }
+      std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const override;
 };


### PR DESCRIPTION
This PR adds the ability to output logging to the console (in addition to the log file).

I find this useful for a few reasons:
1) I don't have to constantly run `tail -f ~/.kodi/temp/kodi.log`
2) I can see all the early logging (that may be missed before initialising the file logging).
3) When running kodi as a service (say with systemd) I can log everything to the journal. I can then see the last invocation with `journalctl --user _SYSTEMD_INVOCATION_ID=$(systemctl --user show -p InvocationID --value kodi.service)` and use all the other great log utilities that journald provides.

A couple notes about this PR.
1) I locked this feature to linux because I don't know if it's actually useful for other platforms, if it is I can just remove the guards.
2) I don't like having to go through `CApplication` anytime a new app param is added. I'm not sure yet the best way to solve this.
3) I'm not sure if we should have platform param parser so we can remove the ifdefs in `CAppParamParser`, though I'm not aware of any other app params being added as of now.
4) I left the file logging in place because I didn't want to mess with the default behaviour of Kodi.
5) I use the available logging target nomenclature because I had the thought of adding other logging targets also (syslog, rotating log) but I'm unsure if I'll go down that road or not.

Usage:
```
$ ./kodi.bin --help
Usage: kodi [OPTION]... [FILE]...

Arguments:
  -fs			Runs Kodi in full screen
  --standalone		Kodi runs in a stand alone environment without a window 
			manager and supporting applications. For example, that
			enables network settings.
  -p or --portable	Kodi will look for configurations in install folder instead of ~/.kodi
  --debug		Enable debug logging
  --version		Print version information
  --test		Enable test mode. [FILE] required.
  --settings=<filename>		Loads specified file after advancedsettings.xml replacing any settings specified
  				specified file must exist in special://xbmc/system/
  --windowing=<system>	Select which windowing method to use.
  				Available window systems are: x11 wayland gbm
  --logging=<target>	Select which log target to use (log file will always be used in conjunction).
  				Available log targets are: console
```

Running:
```
$ ./kodi.bin --logging=console
2021-04-23 08:12:43.450 T:1723162    INFO <general>: Log level changed to "TRACE"
2021-04-23 08:12:43.455 T:1723162   DEBUG <general>: CSettings: loaded settings definition from special://xbmc/system/settings/settings.xml
2021-04-23 08:12:43.463 T:1723162   DEBUG <general>: CSettings: loaded settings definition from special://xbmc/system/settings/linux.xml
2021-04-23 08:12:43.465 T:1723163   DEBUG <general>: Thread Announce start, auto delete: false
2021-04-23 08:12:43.560 T:1723162    INFO <general>: PulseAudio: Server found running - will try to use Pulse
2021-04-23 08:12:43.561 T:1723162   DEBUG <general>: PulseAudio: Context authorizing
2021-04-23 08:12:43.561 T:1723162   DEBUG <general>: PulseAudio: Context setting name
2021-04-23 08:12:43.621 T:1723162   DEBUG <general>: PulseAudio: Context ready
2021-04-23 08:12:43.622 T:1723162    INFO <general>: -----------------------------------------------------------------------
2021-04-23 08:12:43.622 T:1723162    INFO <general>: Starting Kodi (20.0-ALPHA1 (19.90.101) Git:20210422-6950d3e7a7). Platform: Linux x86 64-bit
2021-04-23 08:12:43.622 T:1723162    INFO <general>: Using Debug Kodi x64
2021-04-23 08:12:43.622 T:1723162    INFO <general>: Kodi compiled 2021-04-23 by GCC 10.2.1 for Linux x86 64-bit version 5.11.11 (330507)
2021-04-23 08:12:43.622 T:1723162    INFO <general>: Running on Fedora 33 (Workstation Edition), kernel: Linux x86 64-bit version 5.11.12-200.fc33.x86_64
2021-04-23 08:12:43.622 T:1723162    INFO <general>: FFmpeg version/source: 4.3.2-Kodi
2021-04-23 08:12:43.622 T:1723162    INFO <general>: Host CPU: Intel(R) Core(TM) i7-8705G CPU @ 3.10GHz, 8 cores available
```

This PR also makes me think we should move some of the registration to `initStageTwo` when available as we miss some of the logging as you can see.