### PR TITLE
[PVR] Fix CPVREpgDatabase::QueueDeleteEpgTags to actually delete the tags from epgtags table.

### DIFF
--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -1099,7 +1099,7 @@ bool CPVREpgDatabase::QueueDeleteEpgTags(int iEpgId)
   filter.AppendWhere(PrepareSQL("idEpg = %u", iEpgId));
 
   std::string strQuery;
-  BuildSQL(PrepareSQL("DELETE FROM %s ", "epg"), filter, strQuery);
+  BuildSQL(PrepareSQL("DELETE FROM %s ", "epgtags"), filter, strQuery);
   return QueueDeleteQuery(strQuery);
 }
 


### PR DESCRIPTION
Fixes a regression introduced by #18700.

Runtime-tested on macOS, latest master.

@phunkyfish when you find some time.