### PR TITLE
[videoplayer] - Correctly save streamdetails for DVD/Bluray iso etc

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3173,7 +3173,14 @@ void CApplication::OnPlayBackStarted(const CFileItem &file)
   CLog::LogF(LOGDEBUG,"CApplication::OnPlayBackStarted");
 
   // check if VideoPlayer should set file item stream details from its current streams
-  if (file.GetProperty("get_stream_details_from_player").asBoolean())
+  if (file.GetProperty("get_stream_details_from_player").asBoolean()
+      || ((!file.HasVideoInfoTag() || !file.GetVideoInfoTag()->HasStreamDetails())
+      && (file.IsDiscImage()
+      || file.IsDVDFile()
+      || file.IsBDFile()
+      || file.IsBluray()
+      || file.IsDVD()
+      || file.IsOnDVD())))
     m_appPlayer.SetUpdateStreamDetails();
 
   if (m_stackHelper.IsPlayingISOStack() || m_stackHelper.IsPlayingRegularStack())

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1040,24 +1040,29 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
   {
   case DVD_AUDIO_FORMAT_AC3:
     info.name += " AC3";
+    info.codecName = "ac3";
     break;
   case DVD_AUDIO_FORMAT_UNKNOWN_1:
     info.name += " UNKNOWN #1";
     break;
   case DVD_AUDIO_FORMAT_MPEG:
     info.name += " MPEG AUDIO";
+    info.codecName = "mp1";
     break;
   case DVD_AUDIO_FORMAT_MPEG2_EXT:
     info.name += " MP2 Ext.";
+    info.codecName = "mp2";
     break;
   case DVD_AUDIO_FORMAT_LPCM:
     info.name += " LPCM";
+    info.codecName = "pcm";
     break;
   case DVD_AUDIO_FORMAT_UNKNOWN_5:
     info.name += " UNKNOWN #5";
     break;
   case DVD_AUDIO_FORMAT_DTS:
     info.name += " DTS";
+    info.codecName = "dts";
     break;
   case DVD_AUDIO_FORMAT_SDDS:
     info.name += " SDDS";
@@ -1602,7 +1607,7 @@ VideoStreamInfo CDVDInputStreamNavigator::GetVideoStreamInfo()
 
   // Until we add get_video_attr or get_video_codec we can't distinguish MPEG-1 (h261)
   // from MPEG-2 (h262). The latter is far more common, so use this.
-  info.codecName = "h262";
+  info.codecName = "mpeg2";
 
   return info;
 }


### PR DESCRIPTION

## Description
Backport of #19510 and fix  #19645 - Saves the stream details of the currently playing DVD/Blu-ray ISO to the database.  These details include video and audio codecs, aspect ratio, subtitles etc.

## Motivation and context
This functionality was present in Kodi Krypton but has been missing since.

## How has this been tested?
Tested locally with bluray and dvd iso's and video_ts/bdmv directory structures.  Also tested by several forum members.

## What is the effect on users?
Restores Kodi's ability to save the stream details from a DVD/Blu-ray ISO or video_ts/bdmv directory to the database when the ISO etc is played.  These details include video and audio codecs, aspect ratio, subtitles etc. The details will only be saved for items that don't already have details.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
