### PR TITLE
[Windows] Fix: enables passwordless SMB authentication

### DIFF
--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -686,10 +686,20 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
   connInfo.dwType = RESOURCETYPE_ANY;
   connInfo.lpRemoteName = (LPWSTR)serverShareNameW.c_str();
   DWORD connRes;
+
   for (int i = 0; i < 3; i++) // make up to three attempts to connect
   {
+    // try with provided user/password or NULL user/password (NULL = current Windows user/password)
     connRes = WNetAddConnection2W(&connInfo, passwordW.empty() ? NULL : (LPWSTR)passwordW.c_str(),
                                   usernameW.empty() ? NULL : (LPWSTR)usernameW.c_str(), CONNECT_TEMPORARY);
+
+    // try with passwordless access (guest user and no password)
+    if (usernameW.empty() && passwordW.empty() &&
+        (connRes == ERROR_ACCESS_DENIED || connRes == ERROR_BAD_USERNAME ||
+         connRes == ERROR_INVALID_PASSWORD || connRes == ERROR_LOGON_FAILURE ||
+         connRes == ERROR_LOGON_TYPE_NOT_GRANTED || connRes == ERROR_LOGON_NOT_GRANTED))
+      connRes = WNetAddConnection2W(&connInfo, L"", L"guest", CONNECT_TEMPORARY);
+
     if (connRes == NO_ERROR)
     {
       CLog::LogF(LOGDEBUG, "Connected to \"%s\" %s", serverShareName.c_str(), loginDescr.c_str());


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/19599

Fixes https://github.com/xbmc/xbmc/issues/19600


## How has this been tested?
Runtime tested

Matrix Build is available here: 
https://github.com/thexai/xbmc/releases/tag/9.2.0

## What is the effect on users?
Avoids Kodi prompts for user/password if SMB resource has no password configured.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
