### PR TITLE
AESinkAudioTrack: Restore Behaviour of Leia for Verification and use less buffer for HD PT formats

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -267,7 +267,7 @@ bool CAESinkAUDIOTRACK::VerifySinkConfiguration(int sampleRate,
 
   // make sure to have enough buffer as minimum might not be enough to open
   if (!isRaw)
-    minBufferSize *= 4;
+    minBufferSize *= 2;
 
   if (supported)
   {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -490,17 +490,31 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
     {
       m_format.m_frameSize = m_format.m_channelLayout.Count() * (CAEUtil::DataFormatToBits(m_format.m_dataFormat) / 8);
       m_sink_frameSize = m_format.m_frameSize;
-      // aim at 200 ms buffer and 50 ms periods
-      m_audiotrackbuffer_sec =
-          static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
-      while (m_audiotrackbuffer_sec < 0.15)
+      bool isHDiec = ((m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD) ||
+                      (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD_MA));
+      if (m_passthrough && isHDiec)
       {
-        m_min_buffer_size += min_buffer;
+        // Certain boxes have issues opening DTS-HD / TrueHD with this large amount of data
+        // adjust accordingly
+        m_min_buffer_size *= 2;
+        m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / 2;
         m_audiotrackbuffer_sec =
             static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
       }
-      // division by 4 -> 4 periods into one buffer
-      m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / 4;
+      else
+      {
+        // aim at 200 ms buffer and 50 ms periods
+        m_audiotrackbuffer_sec =
+            static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
+        while (m_audiotrackbuffer_sec < 0.15)
+        {
+          m_min_buffer_size += min_buffer;
+          m_audiotrackbuffer_sec =
+              static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
+        }
+        // division by 4 -> 4 periods into one buffer
+        m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / 4;
+      }
     }
 
     if (m_passthrough && !m_info.m_wantsIECPassthrough)


### PR DESCRIPTION
The good intention caused a regression on MI Box. MI Box is among the few boxes that implements 8 channel IEC and did not like to open this format with around 200 ms buffer, which was plain too large for this box.
