### PR TITLE
[Docs] Fix typos in build docs

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -211,7 +211,7 @@ make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build
 
 Build Kodi:
 ```
-cd $HOME/kodi/build
+cd $HOME/kodi-build
 make -j$(getconf _NPROCESSORS_ONLN)
 ```
 

--- a/docs/README.macOS.md
+++ b/docs/README.macOS.md
@@ -254,7 +254,7 @@ xcodebuild -target dmg
 ````
 **OR**
 ```
-cd $HOME/kodi-build/build
+cd $HOME/kodi-build
 /Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake --build . --target "dmg" --config "Debug"
 ```
 
@@ -262,11 +262,11 @@ Generated `dmg` file will be inside `$HOME/kodi-build/tools/darwin/packaging/osx
 
 Alternatively, if you built using make:
 ```
-cd $HOME/kodi/build
+cd $HOME/kodi-build
 make dmg
 ```
 
-Generated `dmg` file will be inside `$HOME/kodi/build/tools/darwin/packaging/osx/`.
+Generated `dmg` file will be inside `$HOME/kodi-build/tools/darwin/packaging/osx/`.
 
 **[back to top](#table-of-contents)**
 


### PR DESCRIPTION
## Description
This fixes simple typos (or misleading info) found on our build docs

## Motivation and context
Found while compiling kodi for android
