### PR TITLE
Subtitles: Make m_libass private exposed via a getter

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
@@ -17,8 +17,6 @@ class CDVDOverlaySSA : public CDVDOverlay
 {
 public:
 
-  CDVDSubtitlesLibass* m_libass;
-
   explicit CDVDOverlaySSA(CDVDSubtitlesLibass* libass) : CDVDOverlay(DVDOVERLAY_TYPE_SSA)
   {
     replace = true;
@@ -43,4 +41,13 @@ public:
   {
     return new CDVDOverlaySSA(*this);
   }
+
+  /*!
+   \brief Getter for the libass handler
+   \return The libass handler.
+   */
+  CDVDSubtitlesLibass* GetLibass() const { return m_libass; }
+
+private:
+  CDVDSubtitlesLibass* m_libass;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -386,8 +386,9 @@ COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
   else
     position = 0.0;
   int changes = 0;
-  ASS_Image* images = o->m_libass->RenderImage(targetWidth, targetHeight, videoWidth, videoHeight, sourceWidth, sourceHeight,
-                                               pts, useMargin, position, &changes);
+  ASS_Image* images =
+      o->GetLibass()->RenderImage(targetWidth, targetHeight, videoWidth, videoHeight, sourceWidth,
+                                  sourceHeight, pts, useMargin, position, &changes);
 
   if(o->m_textureid)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -341,6 +341,11 @@ void CRenderer::SetStereoMode(const std::string &stereomode)
 
 COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
 {
+  if (!o || !o->GetLibass())
+  {
+    return nullptr;
+  }
+
   // libass render in a target area which named as frame. the frame size may bigger than video size,
   // and including margins between video to frame edge. libass allow to render subtitles into the margins.
   // this has been used to show subtitles in the top or bottom "black bar" between video to frame border.


### PR DESCRIPTION
## Description
Code cosmetic change, makes the overlay libass member variable private and exposes a getter instead. Also adds documentation for the new method.

## Motivation and context
Best practice. Part of my work on subtitles, without any dependency on other functionality

## How has this been tested?
Against my ASS samples, no regressions

## What is the effect on users?
None
