### PR TITLE
[fix] trim m_cpuModel on all platforms

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4760,7 +4760,6 @@ void CApplication::PrintStartupLog()
   std::string cpuModel(CServiceBroker::GetCPUInfo()->GetCPUModel());
   if (!cpuModel.empty())
   {
-    // cpuModel must use c_str(), otherwise some cpuid calls provide null bytes in the string
     CLog::Log(LOGINFO, "Host CPU: {}, {} core{} available", cpuModel,
               CServiceBroker::GetCPUInfo()->GetCPUCount(),
               (CServiceBroker::GetCPUInfo()->GetCPUCount() == 1) ? "" : "s");

--- a/xbmc/platform/darwin/ios-common/CPUInfoDarwinEmbed.cpp
+++ b/xbmc/platform/darwin/ios-common/CPUInfoDarwinEmbed.cpp
@@ -38,6 +38,8 @@ CCPUInfoDarwinEmbed::CCPUInfoDarwinEmbed() : m_resourceCounter(new CPosixResourc
   if (sysctlbyname("machdep.cpu.brand_string", buffer.data(), &length, nullptr, 0) == 0)
     m_cpuModel = buffer.data();
 
+  m_cpuModel.substr(0, m_cpuModel.find(char(0))); // remove extra null terminations
+
   buffer = {};
   if (sysctlbyname("machdep.cpu.vendor", buffer.data(), &length, nullptr, 0) == 0)
     m_cpuVendor = buffer.data();

--- a/xbmc/platform/darwin/osx/CPUInfoOsx.cpp
+++ b/xbmc/platform/darwin/osx/CPUInfoOsx.cpp
@@ -38,6 +38,8 @@ CCPUInfoOsx::CCPUInfoOsx() : m_resourceCounter(new CPosixResourceCounter())
   if (sysctlbyname("machdep.cpu.brand_string", buffer.data(), &bufferLength, nullptr, 0) == 0)
     m_cpuModel = buffer.data();
 
+  m_cpuModel = m_cpuModel.substr(0, m_cpuModel.find(char(0))); // remove extra null terminations
+
   buffer = {};
   if (sysctlbyname("machdep.cpu.vendor", buffer.data(), &bufferLength, nullptr, 0) == 0)
     m_cpuVendor = buffer.data();

--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -110,6 +110,8 @@ CCPUInfoFreebsd::CCPUInfoFreebsd()
     }
   }
 
+  m_cpuModel = m_cpuModel.substr(0, m_cpuModel.find(char(0))); // remove extra null terminations
+
   if (__get_cpuid(CPUID_INFOTYPE_STANDARD, &eax, &eax, &ecx, &edx))
   {
     if (edx & CPUID_00000001_EDX_MMX)

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -275,6 +275,8 @@ CCPUInfoLinux::CCPUInfoLinux()
   }
 #endif
 
+  m_cpuModel = m_cpuModel.substr(0, m_cpuModel.find(char(0))); // remove extra null terminations
+
 #if defined(HAS_NEON) && defined(__arm__)
   if (getauxval(AT_HWCAP) & HWCAP_NEON)
     m_cpuFeatures |= CPU_FEATURE_NEON;


### PR DESCRIPTION
## Description
removes trailing null characters + duplicated spaces and tabs and finally trims the `m_cpuModel` string for all platforms. so far this was only done for Win32. not sure if it is needed for Darwin or BSD, but it wouldn't hurt though. conversion to a `c_str()` is no longer needed for correct logging.

## Motivation and context
__get_cpuid calls on linux for the CpuModel string gets filled with null bytes with some procs.
see https://github.com/xbmc/xbmc/pull/19637

## How has this been tested?
debian buster. cpu model shows up correctly in kodi.log and gui.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
