### PR TITLE
fixed: Properly store stream details for ripped DVD/BR files (stored on disk)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3131,6 +3131,14 @@ void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &boo
 
   if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteDatabases())
   {
+    // Use parent folder for DVD/BD file structures
+    if (fileItem.IsOpticalMediaFile())
+    {
+      auto strFile = fileItem.GetLocalMetadataPath();
+      URIUtils::RemoveSlashAtEnd(strFile);
+      fileItem.SetPath(strFile);
+    }
+
     CSaveFileState::DoWork(fileItem, resumeBookmark, playCountUpdate);
   }
 }


### PR DESCRIPTION
Follow up for #19510 . When a DVD/BR is ripped, VideoPlayer will store details for the file playing, which is eg. video_ts.ifo . Obviously this is wrong (and will only work once). Instead we should use the folder name that contains the files.