### PR TITLE
[tools/depends] bump flatbuffers to 1.12.0

### DIFF
--- a/tools/depends/native/flatbuffers/Makefile
+++ b/tools/depends/native/flatbuffers/Makefile
@@ -5,7 +5,7 @@ DEPS=../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=flatbuffers
-VERSION=1.11.0
+VERSION=1.12.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
Updating my local machine to macOS 11.3 plus Xcode 12.5 broke dependency build. Bumping flatbuffers to latest version solves that.

@kambala-decapitator  PR motivation is not "it breaks my local unsupported setup". PR motivation is: currently, we have two different versions of flatbuffers in the build system. We should fix that.

@fuzzard could you runtime-test?

```
[ 16%] Building CXX object CMakeFiles/flatc.dir/src/reflection.cpp.o
-- Looking for memset - found
-- Looking for memcpy
-- Looking for memcpy - found
-- Check size of unsigned char
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:23:
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/idl.h:25:
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1720:25: error: definition of implicit copy constructor for 'TableKeyComparator<reflection::Object>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    TableKeyComparator &operator=(const TableKeyComparator &);
                        ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1735:27: note: in implicit copy constructor for 'flatbuffers::FlatBufferBuilder::TableKeyComparator<reflection::Object>' first required here
    std::sort(v, v + len, TableKeyComparator<T>(buf_));
                          ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1749:12: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Object>' requested here
    return CreateVectorOfSortedTables(data(*v), v->size());
           ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:2730:26: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Object>' requested here
  auto objs__ = builder_.CreateVectorOfSortedTables(&object_offsets);
                         ^
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:23:
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/idl.h:25:
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1720:25: error: definition of implicit copy constructor for 'TableKeyComparator<reflection::Enum>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    TableKeyComparator &operator=(const TableKeyComparator &);
                        ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1735:27: note: in implicit copy constructor for 'flatbuffers::FlatBufferBuilder::TableKeyComparator<reflection::Enum>' first required here
    std::sort(v, v + len, TableKeyComparator<T>(buf_));
                          ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1749:12: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Enum>' requested here
    return CreateVectorOfSortedTables(data(*v), v->size());
           ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:2731:26: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Enum>' requested here
  auto enum__ = builder_.CreateVectorOfSortedTables(&enum_offsets);
                         ^
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:23:
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/idl.h:25:
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1720:25: error: definition of implicit copy constructor for 'TableKeyComparator<reflection::Service>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    TableKeyComparator &operator=(const TableKeyComparator &);
                        ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1735:27: note: in implicit copy constructor for 'flatbuffers::FlatBufferBuilder::TableKeyComparator<reflection::Service>' first required here
    std::sort(v, v + len, TableKeyComparator<T>(buf_));
                          ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1749:12: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Service>' requested here
    return CreateVectorOfSortedTables(data(*v), v->size());
           ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:2734:26: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Service>' requested here
  auto serv__ = builder_.CreateVectorOfSortedTables(&service_offsets);
                         ^
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:23:
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/idl.h:25:
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1720:25: error: definition of implicit copy constructor for 'TableKeyComparator<reflection::Field>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    TableKeyComparator &operator=(const TableKeyComparator &);
                        ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1735:27: note: in implicit copy constructor for 'flatbuffers::FlatBufferBuilder::TableKeyComparator<reflection::Field>' first required here
    std::sort(v, v + len, TableKeyComparator<T>(buf_));
                          ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1749:12: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Field>' requested here
    return CreateVectorOfSortedTables(data(*v), v->size());
           ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:2781:26: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::Field>' requested here
  auto flds__ = builder->CreateVectorOfSortedTables(&field_offsets);
                         ^
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:23:
In file included from /Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/idl.h:25:
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1720:25: error: definition of implicit copy constructor for 'TableKeyComparator<reflection::KeyValue>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    TableKeyComparator &operator=(const TableKeyComparator &);
                        ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1735:27: note: in implicit copy constructor for 'flatbuffers::FlatBufferBuilder::TableKeyComparator<reflection::KeyValue>' first required here
    std::sort(v, v + len, TableKeyComparator<T>(buf_));
                          ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/include/flatbuffers/flatbuffers.h:1749:12: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::KeyValue>' requested here
    return CreateVectorOfSortedTables(data(*v), v->size());
           ^
/Users/kai/src/github/ksooo/xbmc/tools/depends/native/flatbuffers/x86_64-osx-native/src/idl_parser.cpp:3050:21: note: in instantiation of function template specialization 'flatbuffers::FlatBufferBuilder::CreateVectorOfSortedTables<reflection::KeyValue>' requested here
    return builder->CreateVectorOfSortedTables(&attrs);
                    ^
5 errors generated.
make[5]: *** [CMakeFiles/flatc.dir/src/idl_parser.cpp.o] Error 1
```

