### PR TITLE
[python] Add default button param to yesno/yesnocustom dialog

### DIFF
--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -73,7 +73,7 @@ void CGUIDialogYesNo::OnInitWindow()
   else
     SET_CONTROL_HIDDEN(CONTROL_CUSTOM_BUTTON);
   SET_CONTROL_HIDDEN(CONTROL_PROGRESS_BAR);
-  SET_CONTROL_FOCUS(CONTROL_NO_BUTTON, 0);
+  SET_CONTROL_FOCUS(m_defaultButtonId, 0);
 
   CGUIDialogBoxBase::OnInitWindow();
 }
@@ -121,6 +121,7 @@ bool CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
   dialog->SetChoice(1, !yesLabel.empty() ? yesLabel : 107);
   dialog->SetChoice(2, "");
   dialog->m_bCanceled = false;
+  dialog->m_defaultButtonId = CONTROL_NO_BUTTON;
   dialog->Open();
 
   bCanceled = dialog->m_bCanceled;
@@ -138,9 +139,11 @@ bool CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
                                       bool& bCanceled,
                                       const CVariant& noLabel /* = "" */,
                                       const CVariant& yesLabel /* = "" */,
-                                      unsigned int autoCloseTime)
+                                      unsigned int autoCloseTime,
+                                      int defaultButtonId /* = CONTROL_NO_BUTTON */)
 {
-  int result = ShowAndGetInput(heading, text, noLabel, yesLabel, "", autoCloseTime);
+  int result =
+      ShowAndGetInput(heading, text, noLabel, yesLabel, "", autoCloseTime, defaultButtonId);
 
   bCanceled = result == -1;
   return result == 1;
@@ -152,6 +155,7 @@ void CGUIDialogYesNo::Reset()
   m_bCanceled = false;
   m_bCustom = false;
   m_bAutoClosed = false;
+  m_defaultButtonId = CONTROL_NO_BUTTON;
 }
 
 int CGUIDialogYesNo::GetResult() const
@@ -171,7 +175,8 @@ int CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
                                      const CVariant& noLabel,
                                      const CVariant& yesLabel,
                                      const CVariant& customLabel,
-                                     unsigned int autoCloseTime)
+                                     unsigned int autoCloseTime,
+                                     int defaultButtonId /* = CONTROL_NO_BUTTON */)
 {
   CGUIDialogYesNo *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
   if (!dialog)
@@ -183,10 +188,10 @@ int CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
     dialog->SetAutoClose(autoCloseTime);
   dialog->m_bCanceled = false;
   dialog->m_bCustom = false;
+  dialog->m_defaultButtonId = defaultButtonId;
   dialog->SetChoice(0, !noLabel.empty() ? noLabel : 106);
   dialog->SetChoice(1, !yesLabel.empty() ? yesLabel : 107);
   dialog->SetChoice(2, customLabel);  // Button only visible when label is not empty
-
   dialog->Open();
 
   return dialog->GetResult();
@@ -213,6 +218,7 @@ int CGUIDialogYesNo::ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogYesNo
     SetAutoClose(options.autoclose);
   m_bCanceled = false;
   m_bCustom = false;
+  m_defaultButtonId = CONTROL_NO_BUTTON;
 
   for (size_t i = 0; i < 3; ++i)
   {

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -103,6 +103,7 @@ public:
    \param iNoLabel Localized label id or string for the no button
    \param iYesLabel Localized label id or string for the yes button
    \param autoCloseTime Time in ms before the dialog becomes automatically closed
+   \param defaultButtonId Specifies the default focused button
    \return true if user selects Yes, otherwise false if user selects No.
    */
   static bool ShowAndGetInput(const CVariant& heading,
@@ -110,7 +111,8 @@ public:
                               bool& bCanceled,
                               const CVariant& noLabel,
                               const CVariant& yesLabel,
-                              unsigned int autoCloseTime);
+                              unsigned int autoCloseTime,
+                              int defaultButtonId = CONTROL_NO_BUTTON);
 
   /*! \brief Show a yes-no dialog with 3rd custom button, then wait for user to dismiss it.
   \param heading Localized label id or string for the heading of the dialog
@@ -119,6 +121,7 @@ public:
   \param yesLabel Localized label id or string for the yes button
   \param customLabel Localized label id or string for the custom button
   \param autoCloseTime Time in ms before the dialog becomes automatically closed
+  \param defaultButtonId Specifies the default focused button
   \return -1 for cancelled, 0 for No, 1 for Yes and 2 for custom button
   */
   static int ShowAndGetInput(const CVariant& heading,
@@ -126,7 +129,8 @@ public:
                              const CVariant& noLabel,
                              const CVariant& yesLabel,
                              const CVariant& customLabel,
-                             unsigned int autoCloseTime);
+                             unsigned int autoCloseTime,
+                             int defaultButtonId = CONTROL_NO_BUTTON);
 
   /*!
     \brief Open a Yes/No dialog and wait for input
@@ -145,4 +149,5 @@ protected:
 
   bool m_bCanceled;
   bool m_bCustom;
+  int m_defaultButtonId;
 };

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -42,12 +42,15 @@ namespace XBMCAddon
   {
     Dialog::~Dialog() = default;
 
-    bool Dialog::yesno(const String& heading, const String& message,
+    bool Dialog::yesno(const String& heading,
+                       const String& message,
                        const String& nolabel,
                        const String& yeslabel,
-                       int autoclose)
+                       int autoclose,
+                       int defaultbutton)
     {
-      return yesNoCustomInternal(heading, message, nolabel, yeslabel, emptyString, autoclose) == 1;
+      return yesNoCustomInternal(heading, message, nolabel, yeslabel, emptyString, autoclose,
+                                 defaultbutton) == 1;
     }
 
     int Dialog::yesnocustom(const String& heading,
@@ -55,9 +58,11 @@ namespace XBMCAddon
                             const String& customlabel,
                             const String& nolabel,
                             const String& yeslabel,
-                            int autoclose)
+                            int autoclose,
+                            int defaultbutton)
     {
-      return yesNoCustomInternal(heading, message, nolabel, yeslabel, customlabel, autoclose);
+      return yesNoCustomInternal(heading, message, nolabel, yeslabel, customlabel, autoclose,
+                                 defaultbutton);
     }
 
     int Dialog::yesNoCustomInternal(const String& heading,
@@ -65,7 +70,8 @@ namespace XBMCAddon
                                     const String& nolabel,
                                     const String& yeslabel,
                                     const String& customlabel,
-                                    int autoclose)
+                                    int autoclose,
+                                    int defaultbutton)
     {
       DelayedCallGuard dcguard(languageHook);
       CGUIDialogYesNo* pDialog =
@@ -75,7 +81,8 @@ namespace XBMCAddon
         throw WindowException("Error: Window is null");
 
       return pDialog->ShowAndGetInput(CVariant{heading}, CVariant{message}, CVariant{nolabel},
-                                      CVariant{yeslabel}, CVariant{customlabel}, autoclose);
+                                      CVariant{yeslabel}, CVariant{customlabel}, autoclose,
+                                      defaultbutton);
     }
 
     bool Dialog::info(const ListItem* item)

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -12,8 +12,10 @@
 #include "AddonString.h"
 #include "Alternative.h"
 #include "ListItem.h"
+#include "dialogs/GUIDialogBoxBase.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogProgress.h"
+#include "swighelper.h"
 
 #include <string>
 #include <vector>
@@ -63,6 +65,13 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// @param nolabel        [opt] label to put on the no button.
       /// @param yeslabel       [opt] label to put on the yes button.
       /// @param autoclose      [opt] integer - milliseconds to autoclose dialog. (default=do not autoclose)
+      /// @param defaultbutton  [opt] integer - specifies the default focused button.
+      ///                       <em>(default=DLG_YESNO_NO_BTN)</em>
+      ///  |  Value:                       | Description:                                      |
+      ///  |------------------------------:|---------------------------------------------------|
+      ///  | xbmcgui.DLG_YESNO_NO_BTN     | Set the "No" button as default.
+      ///  | xbmcgui.DLG_YESNO_YES_BTN    | Set the "Yes" button as default.
+      ///  | xbmcgui.DLG_YESNO_CUSTOM_BTN | Set the "Custom" button as default.
       /// @return Returns True if 'Yes' was pressed, else False.
       ///
       ///
@@ -72,6 +81,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// @python_v19 Renamed option **line1** to **message**.
       /// @python_v19 Removed option **line2**.
       /// @python_v19 Removed option **line3**.
+      /// @python_v20 Added new option **defaultbutton**.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -83,10 +93,12 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       ///
       yesno(...);
 #else
-      bool yesno(const String& heading, const String& message,
+      bool yesno(const String& heading,
+                 const String& message,
                  const String& nolabel = emptyString,
                  const String& yeslabel = emptyString,
-                 int autoclose = 0);
+                 int autoclose = 0,
+                 int defaultbutton = CONTROL_NO_BUTTON);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -105,12 +117,20 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// @param nolabel        [opt] label to put on the no button.
       /// @param yeslabel       [opt] label to put on the yes button.
       /// @param autoclose      [opt] integer - milliseconds to autoclose dialog. (default=do not autoclose)
+      /// @param defaultbutton  [opt] integer - specifies the default focused button.
+      ///                       <em>(default=DLG_YESNO_NO_BTN)</em>
+      ///  |  Value:                       | Description:                                      |
+      ///  |------------------------------:|---------------------------------------------------|
+      ///  | xbmcgui.DLG_YESNO_NO_BTN     | Set the "No" button as default.
+      ///  | xbmcgui.DLG_YESNO_YES_BTN    | Set the "Yes" button as default.
+      ///  | xbmcgui.DLG_YESNO_CUSTOM_BTN | Set the "Custom" button as default.
       /// @return Returns the integer value for the selected button (-1:cancelled, 0:no, 1:yes, 2:custom)
       ///
       ///
       ///
       ///------------------------------------------------------------------------
       /// @python_v19 New function added.
+      /// @python_v20 Added new option **defaultbutton**.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -127,7 +147,8 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
                       const String& customlabel,
                       const String& nolabel = emptyString,
                       const String& yeslabel = emptyString,
-                      int autoclose = 0);
+                      int autoclose = 0,
+                      int defaultbutton = CONTROL_NO_BUTTON);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -629,7 +650,8 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
                               const String& nolabel,
                               const String& yeslabel,
                               const String& customlabel,
-                              int autoclose);
+                              int autoclose,
+                              int defaultbutton);
 #endif
     };
     //@}
@@ -880,6 +902,10 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
 #endif
     };
     //@}
-
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+    SWIG_CONSTANT2(int, DLG_YESNO_NO_BTN, CONTROL_NO_BUTTON);
+    SWIG_CONSTANT2(int, DLG_YESNO_YES_BTN, CONTROL_YES_BUTTON);
+    SWIG_CONSTANT2(int, DLG_YESNO_CUSTOM_BTN, CONTROL_CUSTOM_BUTTON);
+#endif
 } // namespace xbmcgui
 } // namespace XBMCAddon


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add the feature to set the default button as default action on the dialog box,
e.g. focus `Yes` button or the `Custom` button instead the `No` button

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is no options to set the default button when you open a dialog box,
until now the only way was to swap the button labels not really nice to look
and button switching is inconsistent with the default windows dialog

Note that the swap button can be done only with "yesnocustom" dialog not with "yesno" dialog
because the "yesno" python dialog has been implemented without the support of "cancel" result value
then e.g. if you press back on the remote it would be like pressing Yes...

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```python
xbmcgui.Dialog().yesno("title", "message", defaultbutton=xbmcgui.DLG_YESNO_YES_BTN)
xbmcgui.Dialog().yesnocustom("title", "message", customlabel="Sunny", defaultbutton=xbmcgui.DLG_YESNO_CUSTOM_BTN)
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed