### PR TITLE
[UWP] [Xbox] Fix 4K HEVC crash due out of memory

### DIFF
--- a/project/Win32BuildSetup/AppxManifest.xml.in
+++ b/project/Win32BuildSetup/AppxManifest.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<Package IgnorableNamespaces="uap" xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+<Package IgnorableNamespaces="uap rescap" xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
   <Identity Name="@PACKAGE_IDENTITY@" ProcessorArchitecture="@TARGET_ARCHITECTURE@" Publisher="CN=@PACKAGE_PUBLISHER@" Version="@VERSION_CODE@.0" />
   <Properties>
     <DisplayName>@APP_NAME@</DisplayName>
@@ -169,5 +169,6 @@
     <uap:Capability Name="videosLibrary" />
     <uap:Capability Name="removableStorage" />
     <uap:Capability Name="picturesLibrary" />
+    <rescap:Capability Name="expandedResources" />
   </Capabilities>
 </Package>

--- a/tools/windows/packaging/uwp/package.appxmanifest.in
+++ b/tools/windows/packaging/uwp/package.appxmanifest.in
@@ -4,7 +4,8 @@
 	xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
 	xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
 	xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
-	IgnorableNamespaces="mp uap uap3">
+	xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+	IgnorableNamespaces="mp uap uap3 rescap">
 
   <Identity Name="@APP_PACKAGE_IDENTITY@" ProcessorArchitecture="@SDK_TARGET_ARCH@" Publisher="CN=@APP_PACKAGE_PUBLISHER@" Version="@APP_VERSION_CODE@.0" />
   <mp:PhoneIdentity PhoneProductId="0175E9D8-B885-4F34-BE46-F3BA2C70C00C" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
@@ -236,5 +237,6 @@
     <uap:Capability Name="userAccountInformation" />
     <uap:Capability Name="videosLibrary" />
     <uap3:Capability Name="backgroundMediaPlayback" />
+    <rescap:Capability Name="expandedResources" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/19221

## Motivation and context
It's to make it easier to get Matrix test builds with this patch. 

It doesn't necessarily have to go in v19.1


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
