### PR TITLE
[PVR] Reserve epg tag flags for addons internal custom usage

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
@@ -559,6 +559,18 @@ extern "C"
 
     /// @brief __0001 0000__ : This EPG entry will be flagged as live.
     EPG_TAG_FLAG_IS_LIVE = (1 << 4),
+
+    /// @brief __0001 0000 0000 0000 0000 0000 0000 0000__ : This flag is reserved for PVR addons internal usage.
+    EPG_TAG_FLAG_ADDON_FLAG_1 = (1 << 28),
+
+    /// @brief __0010 0000 0000 0000 0000 0000 0000 0000__ : This flag is reserved for PVR addons internal usage.
+    EPG_TAG_FLAG_ADDON_FLAG_2 = (1 << 29),
+
+    /// @brief __0100 0000 0000 0000 0000 0000 0000 0000__ : This flag is reserved for PVR addons internal usage.
+    EPG_TAG_FLAG_ADDON_FLAG_3 = (1 << 30),
+
+    /// @brief __1000 0000 0000 0000 0000 0000 0000 0000__ : This flag is reserved for PVR addons internal usage.
+    EPG_TAG_FLAG_ADDON_FLAG_4 = (1 << 31),
   } EPG_TAG_FLAG;
   ///@}
   //----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
This PR extends the enum of epg tags for two reserved flags for pvr plugin custom usage.
<!--- Describe your change in detail here. -->

The usage/purpose depends on individual pvr addon needs. 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I am maintaining a pvr addon. When fetching the epg from a pvr plugin (in my case pvr.waipu), the information whether an epg tag is recordable or or playable can also be retrieved from API. Up to now, I fetch the recordable/playable information and maintain a data structure to store this information during addon lifetime.

However, if Kodi is closed, epg is still stored within the database and epg is not fetched again. For these tags, no playable / recordable state is available.

One solution is, to refetch the full epg again. This would cause massive stupid load at backend.

Another solution is to re-fetch the epg tag, when kodi queries the recordable / playable state. But this would cause a lot of delay and multiple single http requests.

A third solution would be to permanently store this information in the local file system, like this is implemented in pvr.zattoo with an epg cache db. However, this is IMO overkill and error prone.

My suggestion is to reserve two flags in epg tags for pvr addons, that they can use for their individual needs. In case of pvr.waipu, this implementation would simplify the logic: https://github.com/flubshi/pvr.waipu/pull/116/commits/72a4ef6ea2686763302ae76e8999a9f4825bd2d2


Another option would be to provide epg tag flags for recordable / playable state. However, for Kodi it would not be possible to determine if a tag is playable only at a certain time. In case of waipu, there is a replay feature that allows to restart the currently running tv show. This would not be possible to be implemented by a static "is_playable" state.

Or is there a better solution?

@ksooo 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
