### PR TITLE
[PVR] Optimize persisting channel groups

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -13,6 +13,7 @@
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
@@ -117,10 +118,10 @@ JSONRPC_STATUS CPVROperations::GetChannels(const std::string &method, ITransport
     return InvalidParams;
 
   CFileItemList channels;
-  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+  const auto groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   for (const auto& groupMember : groupMembers)
   {
-    channels.Add(std::make_shared<CFileItem>(groupMember->channel));
+    channels.Add(std::make_shared<CFileItem>(groupMember->Channel()));
   }
 
   HandleFileItemList("channelid", false, "channels", channels, parameterObject, result, true);
@@ -338,10 +339,10 @@ void CPVROperations::FillChannelGroupDetails(const std::shared_ptr<CPVRChannelGr
   else
   {
     CFileItemList channels;
-    const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+    const auto groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
     for (const auto& groupMember : groupMembers)
     {
-      channels.Add(std::make_shared<CFileItem>(groupMember->channel));
+      channels.Add(std::make_shared<CFileItem>(groupMember->Channel()));
     }
 
     object["channels"] = CVariant(CVariant::VariantTypeArray);

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -358,7 +358,7 @@ void CPVRDatabase::InsertChannelIntoGroup(const std::shared_ptr<CPVRChannel>& ch
   group.m_members.insert(std::make_pair(channel->StorageId(), newMember));
 }
 
-int CPVRDatabase::Get(CPVRChannelGroup& results, bool bCompressDB)
+int CPVRDatabase::Get(CPVRChannelGroup& results)
 {
   int iReturn = 0;
   std::string strQuery = PrepareSQL("SELECT channels.idChannel, channels.iUniqueId, channels.bIsRadio, channels.bIsHidden, channels.bIsUserSetIcon, channels.bIsUserSetName, "
@@ -413,10 +413,6 @@ int CPVRDatabase::Get(CPVRChannelGroup& results, bool bCompressDB)
   }
 
   m_pDS->close();
-
-  if (iReturn > 0 && bCompressDB)
-    Compress(true);
-
   return iReturn;
 }
 

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -264,6 +264,8 @@ namespace PVR
     bool PersistChannels(CPVRChannelGroup& group);
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup& group);
+    void InsertChannelIntoGroup(const std::shared_ptr<CPVRChannel>& channel,
+                                CPVRChannelGroup& group);
 
     int GetClientIdByChannelId(int iChannelId);
 

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -126,10 +126,9 @@ namespace PVR
     /*!
      * @brief Get the list of channels from the database
      * @param results The channel group to store the results in.
-     * @param bCompressDB Compress the DB after getting the list
      * @return The amount of channels that were added.
      */
-    int Get(CPVRChannelGroup& results, bool bCompressDB);
+    int Get(CPVRChannelGroup& results);
 
     //@}
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1767,8 +1767,8 @@ void CPVRClient::cb_transfer_channel_entry(void* kodiInstance,
         std::make_shared<CPVRChannel>(*channel, client->GetID());
     CPVRChannelGroupInternal* channels =
         static_cast<CPVRChannelGroupInternal*>(handle->dataAddress);
-    channels->UpdateFromClient(transferChannel, CPVRChannelNumber(), channel->iOrder,
-                               transferChannel->ClientChannelNumber());
+    channels->UpdateFromClient(transferChannel, transferChannel->ClientChannelNumber(),
+                               channel->iOrder);
   });
 }
 

--- a/xbmc/pvr/channels/CMakeLists.txt
+++ b/xbmc/pvr/channels/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES PVRChannel.cpp
             PVRChannelGroup.cpp
             PVRChannelGroupInternal.cpp
+            PVRChannelGroupMember.cpp
             PVRChannelGroups.cpp
             PVRChannelGroupsContainer.cpp
             PVRChannelNumber.cpp
@@ -10,6 +11,7 @@ set(SOURCES PVRChannel.cpp
 set(HEADERS PVRChannel.h
             PVRChannelGroup.h
             PVRChannelGroupInternal.h
+            PVRChannelGroupMember.h
             PVRChannelGroups.h
             PVRChannelGroupsContainer.h
             PVRChannelNumber.h

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -184,26 +184,17 @@ void CPVRChannel::ResetEPG()
 
 bool CPVRChannel::UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel)
 {
-  SetClientID(channel->ClientID());
-
   CSingleLock lock(m_critSection);
 
-  if (m_clientChannelNumber != channel->m_clientChannelNumber ||
-      m_strMimeType != channel->MimeType() ||
-      m_iClientEncryptionSystem != channel->EncryptionSystem() ||
-      m_strClientChannelName != channel->ClientChannelName() ||
-      m_bHasArchive != channel->HasArchive())
-  {
-    m_clientChannelNumber = channel->m_clientChannelNumber;
-    m_strMimeType = channel->MimeType();
-    m_iClientEncryptionSystem = channel->EncryptionSystem();
-    m_strClientChannelName = channel->ClientChannelName();
-    m_bHasArchive = channel->HasArchive();
+  SetClientID(channel->ClientID());
+  SetArchive(channel->HasArchive());
 
-    UpdateEncryptionName();
+  m_clientChannelNumber = channel->m_clientChannelNumber;
+  m_strMimeType = channel->MimeType();
+  m_iClientEncryptionSystem = channel->EncryptionSystem();
+  m_strClientChannelName = channel->ClientChannelName();
 
-    m_bChanged = true;
-  }
+  UpdateEncryptionName();
 
   // only update the channel name and icon if the user hasn't changed them manually
   if (m_strChannelName.empty() || !IsUserSetName())
@@ -318,6 +309,20 @@ bool CPVRChannel::HasArchive() const
 {
   CSingleLock lock(m_critSection);
   return m_bHasArchive;
+}
+
+bool CPVRChannel::SetArchive(bool bHasArchive)
+{
+  CSingleLock lock(m_critSection);
+
+  if (m_bHasArchive != bHasArchive)
+  {
+    m_bHasArchive = bHasArchive;
+    m_bChanged = true;
+    return true;
+  }
+
+  return false;
 }
 
 bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIcon /* = false */)

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -155,6 +155,13 @@ namespace PVR
     bool HasArchive() const;
 
     /*!
+     * @brief Set the archive support flag for this channel.
+     * @param bHasArchive True to set the flag, false to reset.
+     * @return True if the flag was changed, false otherwise.
+     */
+    bool SetArchive(bool bHasArchive);
+
+    /*!
      * @return The path to the icon for this channel.
      */
     std::string IconPath() const;
@@ -208,6 +215,10 @@ namespace PVR
      */
     bool IsEmpty() const;
 
+    /*!
+     * @brief Check whether this channel has unpersisted data changes.
+     * @return True if this channel has changes to persist, false otherwise
+     */
     bool IsChanged() const;
 
     /*!

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -482,7 +482,7 @@ void CPVRChannelGroup::GetChannelNumbers(std::vector<std::string>& channelNumber
   }
 }
 
-int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)
+int CPVRChannelGroup::LoadFromDb()
 {
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
   if (!database)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -484,10 +484,9 @@ namespace PVR
 
     /*!
      * @brief Load the channels stored in the database.
-     * @param bCompress If true, compress the database after storing the channels.
      * @return The amount of channels that were added.
      */
-    virtual int LoadFromDb(bool bCompress = false);
+    virtual int LoadFromDb();
 
     /*!
      * @brief Update the current channel list with the given list.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -31,31 +31,8 @@ namespace PVR
   enum class PVREvent;
 
   class CPVRChannel;
+  class CPVRChannelGroupMember;
   class CPVREpgInfoTag;
-
-  struct PVRChannelGroupMember
-  {
-    PVRChannelGroupMember() = default;
-
-    PVRChannelGroupMember(const std::shared_ptr<CPVRChannel>& _channel,
-                          const CPVRChannelNumber& _channelNumber,
-                          int _iClientPriority,
-                          int _iOrder,
-                          const CPVRChannelNumber& _clientChannelNumber)
-      : channel(_channel),
-        channelNumber(_channelNumber),
-        clientChannelNumber(_clientChannelNumber),
-        iClientPriority(_iClientPriority),
-        iOrder(_iOrder)
-    {
-    }
-
-    std::shared_ptr<CPVRChannel> channel;
-    CPVRChannelNumber channelNumber; // the channel number this channel has in the group
-    CPVRChannelNumber clientChannelNumber; // the client channel number this channel has in the group
-    int iClientPriority = 0;
-    int iOrder = 0; // The value denoting the order of this member in the group
-  };
 
   enum EpgDateType
   {
@@ -102,7 +79,7 @@ namespace PVR
     /**
      * Empty group member
      */
-    static std::shared_ptr<PVRChannelGroupMember> EmptyMember;
+    static std::shared_ptr<CPVRChannelGroupMember> EmptyMember;
 
     /*!
      * @brief Query the events available for CEventStream
@@ -368,7 +345,8 @@ namespace PVR
      * @param eFilter A filter to apply.
      * @return The group members
      */
-    std::vector<std::shared_ptr<PVRChannelGroupMember>> GetMembers(Include eFilter = Include::ALL) const;
+    std::vector<std::shared_ptr<CPVRChannelGroupMember>> GetMembers(
+        Include eFilter = Include::ALL) const;
 
     /*!
      * @brief Get the list of active channel numbers in a group.
@@ -458,8 +436,9 @@ namespace PVR
      * @param id The storage id (a pair of client id and unique channel id).
      * @return A reference to the group member or an empty group member if it wasn't found.
      */
-    std::shared_ptr<PVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id);
-    const std::shared_ptr<PVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id) const;
+    std::shared_ptr<CPVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id);
+    const std::shared_ptr<CPVRChannelGroupMember>& GetByUniqueID(
+        const std::pair<int, int>& id) const;
 
     bool SetHidden(bool bHidden);
     bool IsHidden() const;
@@ -574,8 +553,10 @@ namespace PVR
     uint64_t m_iLastOpened = 0; /*!< time in milliseconds from epoch this group was last opened */
     bool m_bHidden = false; /*!< true if this group is hidden, false otherwise */
     int m_iPosition = 0; /*!< the position of this group within the group list */
-    std::vector<std::shared_ptr<PVRChannelGroupMember>> m_sortedMembers; /*!< members sorted by channel number */
-    std::map<std::pair<int, int>, std::shared_ptr<PVRChannelGroupMember>> m_members; /*!< members with key clientid+uniqueid */
+    std::vector<std::shared_ptr<CPVRChannelGroupMember>>
+        m_sortedMembers; /*!< members sorted by channel number */
+    std::map<std::pair<int, int>, std::shared_ptr<CPVRChannelGroupMember>>
+        m_members; /*!< members with key clientid+uniqueid */
     mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClients;
     CEventSource<PVREvent> m_events;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -223,9 +223,8 @@ namespace PVR
     /*!
      * @brief Last time group has been watched
      * @param iLastWatched The new value.
-     * @return True if something changed, false otherwise.
      */
-    bool SetLastWatched(time_t iLastWatched);
+    void SetLastWatched(time_t iLastWatched);
 
     /*!
      * @return Time in milliseconds from epoch this group was last opened.
@@ -235,9 +234,8 @@ namespace PVR
     /*!
      * @brief Set the time in milliseconds from epoch this group was last opened.
      * @param iLastOpened The new value.
-     * @return True if something changed, false otherwise.
      */
-    bool SetLastOpened(uint64_t iLastOpened);
+    void SetLastOpened(uint64_t iLastOpened);
 
     /*!
      * @brief Set if sorting and renumbering should happen after adding/updating channels to group.
@@ -367,11 +365,6 @@ namespace PVR
     bool HasChannels() const;
 
     /*!
-     * @return True if there is at least one channel in this group with changes that haven't been persisted, false otherwise.
-     */
-    bool HasChangedChannels() const;
-
-    /*!
      * @return True if there is at least one new channel in this group that hasn't been persisted, false otherwise.
      */
     bool HasNewChannels() const;
@@ -380,6 +373,11 @@ namespace PVR
      * @return True if anything changed in this group that hasn't been persisted, false otherwise.
      */
     bool HasChanges() const;
+
+    /*!
+     * @return True if the group was never persisted, false otherwise.
+     */
+    bool IsNew() const;
 
     /*!
      * @brief Create an EPG table for each channel.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -204,7 +204,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const std::shared_ptr<CPVRChannel
       Persist();
 }
 
-int CPVRChannelGroupInternal::LoadFromDb(bool bCompress /* = false */)
+int CPVRChannelGroupInternal::LoadFromDb()
 {
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
   if (!database)
@@ -212,7 +212,7 @@ int CPVRChannelGroupInternal::LoadFromDb(bool bCompress /* = false */)
 
   int iChannelCount = Size();
 
-  if (database->Get(*this, bCompress) == 0)
+  if (database->Get(*this) == 0)
     CLog::LogFC(LOGDEBUG, LOGPVR, "No channels in the database");
 
   SortByChannelNumber();

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -40,12 +40,13 @@ namespace PVR
     /*!
      * @brief Callback for add-ons to update a channel.
      * @param channel The updated channel.
-     * @param channelNumber A new channel number for the channel.
-     * @param iOrder The value denoting the order of this member in the group, 0 if unknown and needs to be generated
      * @param clientChannelNumber The client channel number of the channel to add. (optional)
+     * @param iOrder The value denoting the order of this member in the group, 0 if unknown and needs to be generated
      * @return The new/updated channel.
      */
-    std::shared_ptr<CPVRChannel> UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel, const CPVRChannelNumber& channelNumber, int iOrder, const CPVRChannelNumber& clientChannelNumber = {});
+    std::shared_ptr<CPVRChannel> UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel,
+                                                  const CPVRChannelNumber& clientChannelNumber,
+                                                  int iOrder);
 
     /*!
      * @see CPVRChannelGroup::IsGroupMember

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -82,10 +82,9 @@ namespace PVR
   protected:
     /*!
      * @brief Load all channels from the database.
-     * @param bCompress Compress the database after changing anything.
      * @return The amount of channels that were loaded.
      */
-    int LoadFromDb(bool bCompress = false) override;
+    int LoadFromDb() override;
 
     /*!
      * @brief Load all channels from the clients.

--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -12,20 +12,36 @@ using namespace PVR;
 
 void CPVRChannelGroupMember::SetChannelNumber(const CPVRChannelNumber& channelNumber)
 {
-  m_channelNumber = channelNumber;
+  if (m_channelNumber != channelNumber)
+  {
+    m_channelNumber = channelNumber;
+    m_bChanged = true;
+  }
 }
 
 void CPVRChannelGroupMember::SetClientChannelNumber(const CPVRChannelNumber& clientChannelNumber)
 {
-  m_clientChannelNumber = clientChannelNumber;
+  if (m_clientChannelNumber != clientChannelNumber)
+  {
+    m_clientChannelNumber = clientChannelNumber;
+    m_bChanged = true;
+  }
 }
 
 void CPVRChannelGroupMember::SetClientPriority(int iClientPriority)
 {
-  m_iClientPriority = iClientPriority;
+  if (m_iClientPriority != iClientPriority)
+  {
+    m_iClientPriority = iClientPriority;
+    m_bChanged = true;
+  }
 }
 
 void CPVRChannelGroupMember::SetOrder(int iOrder)
 {
-  m_iOrder = iOrder;
+  if (m_iOrder != iOrder)
+  {
+    m_iOrder = iOrder;
+    m_bChanged = true;
+  }
 }

--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2012-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRChannelGroupMember.h"
+
+using namespace PVR;
+
+void CPVRChannelGroupMember::SetChannelNumber(const CPVRChannelNumber& channelNumber)
+{
+  m_channelNumber = channelNumber;
+}
+
+void CPVRChannelGroupMember::SetClientChannelNumber(const CPVRChannelNumber& clientChannelNumber)
+{
+  m_clientChannelNumber = clientChannelNumber;
+}
+
+void CPVRChannelGroupMember::SetClientPriority(int iClientPriority)
+{
+  m_iClientPriority = iClientPriority;
+}
+
+void CPVRChannelGroupMember::SetOrder(int iOrder)
+{
+  m_iOrder = iOrder;
+}

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -22,7 +22,7 @@ class CPVRChannelGroupMember
   friend class CPVRDatabase;
 
 public:
-  CPVRChannelGroupMember() = default;
+  CPVRChannelGroupMember() : m_bChanged(false) {}
 
   CPVRChannelGroupMember(const std::shared_ptr<CPVRChannel>& channel,
                          const CPVRChannelNumber& channelNumber,
@@ -53,6 +53,9 @@ public:
   int Order() const { return m_iOrder; }
   void SetOrder(int iOrder);
 
+  bool NeedsSave() const { return m_bChanged; }
+  void SetSaved() { m_bChanged = false; }
+
 private:
   std::shared_ptr<CPVRChannel> m_channel;
   CPVRChannelNumber m_channelNumber; // the channel number this channel has in the group
@@ -60,6 +63,8 @@ private:
       m_clientChannelNumber; // the client channel number this channel has in the group
   int m_iClientPriority = 0;
   int m_iOrder = 0; // The value denoting the order of this member in the group
+
+  bool m_bChanged = true;
 };
 
 } // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2012-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/channels/PVRChannelNumber.h"
+
+#include <memory>
+
+namespace PVR
+{
+
+class CPVRChannel;
+
+class CPVRChannelGroupMember
+{
+  friend class CPVRDatabase;
+
+public:
+  CPVRChannelGroupMember() = default;
+
+  CPVRChannelGroupMember(const std::shared_ptr<CPVRChannel>& channel,
+                         const CPVRChannelNumber& channelNumber,
+                         int iClientPriority,
+                         int iOrder,
+                         const CPVRChannelNumber& clientChannelNumber)
+    : m_channel(channel),
+      m_channelNumber(channelNumber),
+      m_clientChannelNumber(clientChannelNumber),
+      m_iClientPriority(iClientPriority),
+      m_iOrder(iOrder)
+  {
+  }
+
+  virtual ~CPVRChannelGroupMember() = default;
+
+  std::shared_ptr<CPVRChannel> Channel() const { return m_channel; }
+
+  const CPVRChannelNumber& ChannelNumber() const { return m_channelNumber; }
+  void SetChannelNumber(const CPVRChannelNumber& channelNumber);
+
+  const CPVRChannelNumber& ClientChannelNumber() const { return m_clientChannelNumber; }
+  void SetClientChannelNumber(const CPVRChannelNumber& clientChannelNumber);
+
+  int ClientPriority() const { return m_iClientPriority; }
+  void SetClientPriority(int iClientPriority);
+
+  int Order() const { return m_iOrder; }
+  void SetOrder(int iOrder);
+
+private:
+  std::shared_ptr<CPVRChannel> m_channel;
+  CPVRChannelNumber m_channelNumber; // the channel number this channel has in the group
+  CPVRChannelNumber
+      m_clientChannelNumber; // the client channel number this channel has in the group
+  int m_iClientPriority = 0;
+  int m_iOrder = 0; // The value denoting the order of this member in the group
+};
+
+} // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -28,7 +28,7 @@
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRGroupManager.h"
@@ -705,11 +705,11 @@ void CGUIDialogPVRChannelManager::Update()
   if(!channels)
     return;
 
-  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channels->GetMembers();
+  const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers = channels->GetMembers();
   std::shared_ptr<CFileItem> channelFile;
   for (const auto& member : groupMembers)
   {
-    channelFile = std::make_shared<CFileItem>(member->channel);
+    channelFile = std::make_shared<CFileItem>(member->Channel());
     if (!channelFile || !channelFile->HasPVRChannelInfoTag())
       continue;
     const std::shared_ptr<CPVRChannel> channel(channelFile->GetPVRChannelInfoTag());

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -19,7 +19,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
@@ -174,10 +174,11 @@ void CGUIDialogPVRChannelsOSD::Update()
     const std::shared_ptr<CPVRChannelGroup> group = pvrMgr.PlaybackState()->GetPlayingGroup(channel->IsRadio());
     if (group)
     {
-      const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
+          group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : groupMembers)
       {
-        m_vecItems->Add(std::make_shared<CFileItem>(groupMember->channel));
+        m_vecItems->Add(std::make_shared<CFileItem>(groupMember->Channel()));
       }
 
       m_viewControl.SetItems(*m_vecItems);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -23,6 +23,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/filesystem/PVRGUIDirectory.h"
@@ -484,30 +485,33 @@ void CGUIDialogPVRGroupManager::Update()
     // Slightly different handling for "all" group...
     if (m_selectedGroup->IsInternalGroup())
     {
-      const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ALL);
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
+          m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ALL);
       for (const auto& groupMember : groupMembers)
       {
-        if (groupMember->channel->IsHidden())
-          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->channel));
+        if (groupMember->Channel()->IsHidden())
+          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->Channel()));
         else
-          m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->channel));
+          m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->Channel()));
       }
     }
     else
     {
-      const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
+          m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : groupMembers)
       {
-        m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->channel));
+        m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->Channel()));
       }
 
       /* for the center part, get all channels of the "all" channels group that are not in this group */
       const std::shared_ptr<CPVRChannelGroup> allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
-      const std::vector<std::shared_ptr<PVRChannelGroupMember>> allGroupMembers = allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>> allGroupMembers =
+          allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : allGroupMembers)
       {
-        if (!m_selectedGroup->IsGroupMember(groupMember->channel))
-          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->channel));
+        if (!m_selectedGroup->IsGroupMember(groupMember->Channel()))
+          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->Channel()));
       }
     }
     m_viewGroupMembers.SetItems(*m_groupMembers);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -14,7 +14,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgSearchFilter.h"
@@ -70,17 +70,19 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
     group = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_searchFilter->IsRadio());
 
   m_channelNumbersMap.clear();
-  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+  const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
+      group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   int iIndex = 0;
   int iSelectedChannel = EPG_SEARCH_UNSET;
   for (const auto& groupMember : groupMembers)
   {
-    if (groupMember->channel)
+    if (groupMember->Channel())
     {
-      labels.emplace_back(std::make_pair(groupMember->channel->ChannelName(), iIndex));
-      m_channelNumbersMap.insert(std::make_pair(iIndex, groupMember->channelNumber));
+      labels.emplace_back(std::make_pair(groupMember->Channel()->ChannelName(), iIndex));
+      m_channelNumbersMap.insert(std::make_pair(iIndex, groupMember->ChannelNumber()));
 
-      if (iSelectedChannel == EPG_SEARCH_UNSET && groupMember->channelNumber == m_searchFilter->GetChannelNumber())
+      if (iSelectedChannel == EPG_SEARCH_UNSET &&
+          groupMember->ChannelNumber() == m_searchFilter->GetChannelNumber())
         iSelectedChannel = iIndex;
 
       ++iIndex;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -18,6 +18,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
@@ -824,10 +825,11 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
 
   // Add regular channels
   const std::shared_ptr<CPVRChannelGroup> allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
-  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+  const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
+      allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   for (const auto& groupMember : groupMembers)
   {
-    const std::shared_ptr<CPVRChannel> channel = groupMember->channel;
+    const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
     const std::string channelDescription
       = StringUtils::Format("%s %s", channel->ChannelNumber().FormattedChannelNumber().c_str(), channel->ChannelName().c_str());
     m_channelEntries.insert({index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -16,7 +16,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRChannelsPath.h"
@@ -495,13 +495,14 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
 
       if (group)
       {
-        const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers();
+        const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
+            group->GetMembers();
         for (const auto& groupMember : groupMembers)
         {
-          if (bShowHiddenChannels != groupMember->channel->IsHidden())
+          if (bShowHiddenChannels != groupMember->Channel()->IsHidden())
             continue;
 
-          results.Add(std::make_shared<CFileItem>(groupMember->channel));
+          results.Add(std::make_shared<CFileItem>(groupMember->Channel()));
         }
       }
       else

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -39,7 +39,7 @@
 #include "pvr/addons/PVRClientMenuHooks.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRChannelGuide.h"
@@ -1458,10 +1458,12 @@ namespace PVR
       if (channelGroup)
       {
         // try to start playback of first channel in this group
-        const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channelGroup->GetMembers();
+        const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
+            channelGroup->GetMembers();
         if (!groupMembers.empty())
         {
-          return SwitchToChannel(std::make_shared<CFileItem>((*groupMembers.begin())->channel), true);
+          return SwitchToChannel(std::make_shared<CFileItem>((*groupMembers.begin())->Channel()),
+                                 true);
         }
       }
     }
@@ -1502,7 +1504,7 @@ namespace PVR
       if (channels.empty())
         return false;
 
-      channel = channels.front()->channel;
+      channel = channels.front()->Channel();
     }
 
     CLog::Log(LOGINFO, "PVR is starting playback of channel '{}'", channel->ChannelName());

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -16,6 +16,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/guilib/PVRGUIProgressHandler.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -58,23 +59,26 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
 
   for (const auto& group : m_groups)
   {
-    const std::vector<std::shared_ptr<PVRChannelGroupMember>> members = group->GetMembers();
+    const std::vector<std::shared_ptr<CPVRChannelGroupMember>> members = group->GetMembers();
     int channelIndex = 0;
     for (const auto& member : members)
     {
-      progressHandler->UpdateProgress(member->channel->ChannelName(), channelIndex++, members.size());
+      const std::shared_ptr<CPVRChannel> channel = member->Channel();
+
+      progressHandler->UpdateProgress(channel->ChannelName(), channelIndex++, members.size());
 
       // skip if an icon is already set and exists
-      if (XFILE::CFile::Exists(member->channel->IconPath()))
+      if (XFILE::CFile::Exists(channel->IconPath()))
         continue;
 
       // reset icon before searching for a new one
-      member->channel->SetIconPath("");
+      channel->SetIconPath("");
 
-      const std::string strChannelUid = StringUtils::Format("%08d", member->channel->UniqueID());
-      std::string strLegalClientChannelName = CUtil::MakeLegalFileName(member->channel->ClientChannelName());
+      const std::string strChannelUid = StringUtils::Format("%08d", channel->UniqueID());
+      std::string strLegalClientChannelName =
+          CUtil::MakeLegalFileName(channel->ClientChannelName());
       StringUtils::ToLower(strLegalClientChannelName);
-      std::string strLegalChannelName = CUtil::MakeLegalFileName(member->channel->ChannelName());
+      std::string strLegalChannelName = CUtil::MakeLegalFileName(channel->ChannelName());
       StringUtils::ToLower(strLegalChannelName);
 
       std::map<std::string, std::string>::iterator itItem;
@@ -82,11 +86,13 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
           (itItem = fileItemMap.find(strLegalChannelName)) != fileItemMap.end() ||
           (itItem = fileItemMap.find(strChannelUid)) != fileItemMap.end())
       {
-        member->channel->SetIconPath(itItem->second, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRAutoScanIconsUserSet);
+        channel->SetIconPath(itItem->second, CServiceBroker::GetSettingsComponent()
+                                                 ->GetAdvancedSettings()
+                                                 ->m_bPVRAutoScanIconsUserSet);
       }
 
       if (m_bUpdateDb)
-        member->channel->Persist();
+        channel->Persist();
     }
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -26,6 +26,7 @@
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRChannelsPath.h"
 #include "pvr/epg/EpgChannelData.h"
@@ -702,12 +703,12 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
         endDate = maxFutureDate;
 
       std::unique_ptr<CFileItemList> channels(new CFileItemList);
-      const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers =
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
           group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
 
       for (const auto& groupMember : groupMembers)
       {
-        channels->Add(std::make_shared<CFileItem>(groupMember->channel));
+        channels->Add(std::make_shared<CFileItem>(groupMember->Channel()));
       }
 
       if (m_guiState)


### PR DESCRIPTION
I noticed that on Kodi startup we're writing up to ten times (or even more often - did not count exactly) into the PVR database, even though since last Kodi run nothing has changed in the backend with respect to channels and channel groups (which channels, which groups, their names and channel numbers etc. ....).

This PR fixes this down to the absolutely necessary writes on startup which are two write operations - one for last opened radio channel group, one for the last opened tv channel group.

Approach taken is to know more fine-grained (actually including some fixes for the existing logic) when a channel, channel group, channel group member actually has changed and only then to write data to database.

Runtime-tested several weeks on my "local unsupported mac development setup" (this one is for @kambala-decapitator ;-) and in my living room on Android.

@phunkyfish when you find some time for the review...