### PR TITLE
[Application] Reset current item on application cleanup.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2342,11 +2342,18 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 }
 
 
+void CApplication::ResetCurrentItem()
+{
+  m_itemCurrentFile->Reset();
+  if (m_pGUI)
+    m_pGUI->GetInfoManager().ResetCurrentItem();
+}
 
 bool CApplication::Cleanup()
 {
   try
   {
+    ResetCurrentItem();
     StopPlaying();
 
     if (m_ServiceManager)
@@ -3866,8 +3873,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 
   case GUI_MSG_PLAYBACK_STOPPED:
     m_playerEvent.Set();
-    m_itemCurrentFile->Reset();
-    CServiceBroker::GetGUI()->GetInfoManager().ResetCurrentItem();
+    ResetCurrentItem();
     PlaybackCleanup();
 #ifdef HAS_PYTHON
     CServiceBroker::GetXBPython().OnPlayBackStopped();
@@ -3881,8 +3887,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       PlayFile(m_stackHelper.SetNextStackPartCurrentFileItem(), "", true);
       return true;
     }
-    m_itemCurrentFile->Reset();
-    CServiceBroker::GetGUI()->GetInfoManager().ResetCurrentItem();
+    ResetCurrentItem();
     if (!CServiceBroker::GetPlaylistPlayer().PlayNext(1, true))
       m_appPlayer.ClosePlayer();
 
@@ -3894,8 +3899,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
     return true;
 
   case GUI_MSG_PLAYLISTPLAYER_STOPPED:
-    m_itemCurrentFile->Reset();
-    CServiceBroker::GetGUI()->GetInfoManager().ResetCurrentItem();
+    ResetCurrentItem();
     if (m_appPlayer.IsPlaying())
       StopPlaying();
     PlaybackCleanup();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -423,6 +423,7 @@ protected:
 
 private:
   void PrintStartupLog();
+  void ResetCurrentItem();
 
   mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
 


### PR DESCRIPTION
This fixes occasional crashes on Kodi shutdown I encountered on Android. Root cause is undefined order of global static instances.

If CApplication global is destructed  after CJobManager singeleton, and the current file item hold by g_application is a PVR channel item with an EPG attached, the EPG instance will be destructed after CJobManager has been destructed. The EPG instance is an event source, and in case the event source has pending events (EPG data updates for example), those pending events will be cancled, which requires the CJobManager singelton.

This PR does not fix the general problems arising from  undefined destruction sequence for global statics, but it definitely fixes the particular crash I encountered. Means, there might be other situations where destructing the jobmanager before the application might bite us into the ass.

Annotated stack trace:

```log
04-05 14:30:15.729 25002 25042 F libc    : FORTIFY: pthread_mutex_lock called on a destroyed mutex (0x262f07e1a0)
04-05 14:30:15.729 25002 25042 F libc    : Fatal signal 6 (SIGABRT), code -6 (SI_TKILL) in tid 25042 (Thread-2), pid 25002 (org.xbmc.kodi)
04-05 14:30:15.925 32538 32538 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
04-05 14:30:15.925 32538 32538 F DEBUG   : Build fingerprint: 'NVIDIA/mdarcy/mdarcy:9/PPR1.180610.011/4079208_2513.0256:user/release-keys'
04-05 14:30:15.925 32538 32538 F DEBUG   : Revision: '0'
04-05 14:30:15.925 32538 32538 F DEBUG   : ABI: 'arm64'
04-05 14:30:15.925 32538 32538 F DEBUG   : pid: 25002, tid: 25042, name: Thread-2  >>> org.xbmc.kodi <<<
04-05 14:30:15.925 32538 32538 F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
04-05 14:30:15.925 32538 32538 F DEBUG   : Abort message: 'FORTIFY: pthread_mutex_lock called on a destroyed mutex (0x262f07e1a0)'
04-05 14:30:15.925 32538 32538 F DEBUG   :     x0  0000000000000000  x1  00000000000061d2  x2  0000000000000006  x3  0000000000000008
04-05 14:30:15.925 32538 32538 F DEBUG   :     x4  0000000000008080  x5  0000000000008080  x6  0000000000008080  x7  0000000000000038
04-05 14:30:15.925 32538 32538 F DEBUG   :     x8  0000000000000083  x9  5b2389595d30b328  x10 0000000000000000  x11 fffffffc7ffffbdf
04-05 14:30:15.925 32538 32538 F DEBUG   :     x12 0000000000000001  x13 00000000606b02d7  x14 002b26f26ef52000  x15 000052aec9ea2333
04-05 14:30:15.925 32538 32538 F DEBUG   :     x16 000000258d6b12b8  x17 000000258d5ef110  x18 000000260fc91c40  x19 00000000000061aa
04-05 14:30:15.925 32538 32538 F DEBUG   :     x20 00000000000061d2  x21 0000000000000000  x22 000000263de1e400  x23 000000263de1e410
04-05 14:30:15.925 32538 32538 F DEBUG   :     x24 000000258d6ba000  x25 000000262b872f94  x26 000000258d6ba000  x27 0000000000000018
04-05 14:30:15.925 32538 32538 F DEBUG   :     x28 0000000000000003  x29 000000262a454e50
04-05 14:30:15.925 32538 32538 F DEBUG   :     sp  000000262a454e10  lr  000000258d5e3c3c  pc  000000258d5e3c64
04-05 14:30:16.022 32538 32538 F DEBUG   : 
04-05 14:30:16.022 32538 32538 F DEBUG   : backtrace:
04-05 14:30:16.022 32538 32538 F DEBUG   :     #00 pc 0000000000021c64  /system/lib64/libc.so (abort+116)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #01 pc 0000000000082f38  /system/lib64/libc.so (__fortify_fatal(char const*, ...)+120)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #02 pc 0000000000082634  /system/lib64/libc.so (HandleUsingDestroyedMutex(pthread_mutex_t*, char const*)+52)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #03 pc 00000000000824e8  /system/lib64/libc.so (pthread_mutex_lock+228)
==> CJobManager singleton (static instance) already destroyed !!!
04-05 14:30:16.022 32538 32538 F DEBUG   :     #04 pc 00000000010e3868  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (CJobManager::CancelJob(unsigned int)+36)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #05 pc 00000000010e3b84  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (CJobQueue::CancelJobs()+80)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #06 pc 00000000010e3ae0  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (CJobQueue::~CJobQueue()+32)
==> CEventSource<PVREvent> m_events dtor ->  CJobQueue m_queue dtor
04-05 14:30:16.022 32538 32538 F DEBUG   :     #07 pc 0000000001537f68  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (PVR::CPVREpg::~CPVREpg()+40)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #08 pc 000000000153809c  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (PVR::CPVREpg::~CPVREpg()+16)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #09 pc 000000000156c0c8  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (PVR::CPVRChannel::ResetEPG()+260)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #10 pc 000000000156bec4  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (PVR::CPVRChannel::~CPVRChannel()+44)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #11 pc 000000000156c140  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (PVR::CPVRChannel::~CPVRChannel()+16)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #12 pc 0000000000f790f4  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (std::__ndk1::shared_ptr<PVR::CPVRChannel>::~shared_ptr()+68)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #13 pc 00000000013e3220  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (CFileItem::~CFileItem()+204)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #14 pc 00000000013e32bc  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (CFileItem::~CFileItem()+16)
==>  CFileItemPtr m_itemCurrentFile dtor
04-05 14:30:16.022 32538 32538 F DEBUG   :     #15 pc 0000000000d821dc  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (std::__ndk1::shared_ptr<CFileItem>::~shared_ptr()+68)

04-05 14:30:16.022 32538 32538 F DEBUG   :     #16 pc 00000000013aab60  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (CApplication::~CApplication()+352)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #17 pc 00000000013aac90  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (CApplication::~CApplication()+16)
==> g_application singleton dtor
04-05 14:30:16.022 32538 32538 F DEBUG   :     #18 pc 0000000000d4ec20  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (std::__ndk1::shared_ptr<CApplication>::~shared_ptr()+68)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #19 pc 0000000000d4ffac  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (xbmcutil::GlobalsSingleton<CApplication>::Deleter<std::__ndk1::shared_ptr<CApplication>>::~Deleter()+24)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #20 pc 0000000000084650  /system/lib64/libc.so (__cxa_finalize+196)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #21 pc 000000000001c518  /system/lib64/libc.so (exit+24)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #22 pc 000000000186ed28  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so (android_main+216)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #23 pc 000000000187948c  /data/app/org.xbmc.kodi-FgWXqxU5EVTEiB22DeGwSg==/lib/arm64/libkodi.so
04-05 14:30:16.022 32538 32538 F DEBUG   :     #24 pc 000000000008196c  /system/lib64/libc.so (__pthread_start(void*)+36)
04-05 14:30:16.022 32538 32538 F DEBUG   :     #25 pc 00000000000234b8  /system/lib64/libc.so (__start_thread+68)
```

```c++
void CJobQueue::CJobPointer::CancelJob()
{
  CJobManager::GetInstance().CancelJob(m_id);
  m_id = 0;
}
```