### PR TITLE
[PVR][GUI] Channel manager does not rename backend channel (if supported)

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -664,6 +664,8 @@ PVR_ERROR CPVRClient::RenameChannel(const std::shared_ptr<CPVRChannel>& channel)
       [channel](const AddonInstance* addon) {
         PVR_CHANNEL addonChannel;
         WriteClientChannelInfo(channel, addonChannel);
+        strncpy(addonChannel.strChannelName, channel->ChannelName().c_str(),
+                sizeof(addonChannel.strChannelName) - 1);
         return addon->toAddon->RenameChannel(addon, &addonChannel);
       },
       m_clientCapabilities.SupportsChannelSettings());


### PR DESCRIPTION
## Description
When a PVR addon supports the Channel Settings capability flag and a channel is renamed via the Kodi Channel Manager dialog, the PVR addon will be asked to persist the channel name it already has rather than the new name.  When the channel(s) are refreshed from the addon, the original name will end up coming back as it was never persisted.

## Motivation and context
This solves a problem with the PVR Channel Manager dialog that prevents the information provided by the user to rename a channel to be persisted by a backend that supports Channel Settings.

I realize that the proposed solution will incur a second call to strncpy() for a field that was already populated but did not feel that it would be worth changing WriteClientChannelInfo() to specify a name parameter.  Am happy to rework with a new WriteClientChannelInfo() overload that accepts a name, a new **const char***  parameter on the existing WriteClientChannelInfo() function (would default to nullptr) or any other preferred approach.

## How has this been tested?
Tested on Windows 10 (Desktop), x64, against the current master branch as of 2021.04.30.  The addon this was tested with stores its channel information in a local SQLite database; prior to the change the Channel Name would never be updated and would ultimately revert itself in Kodi.  After the change the addon was given the new name to persist and the end user experience was consistent.

## What is the effect on users?
The effect on users should be that a channel renamed via the Channel Settings dialog against a backend that supports it would properly persist and make permanent the name that was specified.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
