### PR TITLE
DVDAudioCodecFFmpeg:Try to fallback to using hints for channel layout…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -78,6 +78,7 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_matrixEncoding = AV_MATRIX_ENCODING_NONE;
   m_channels = 0;
   m_pCodecContext->channels = hints.channels;
+  m_hint_layout = hints.channellayout;
   m_pCodecContext->sample_rate = hints.samplerate;
   m_pCodecContext->block_align = hints.blockalign;
   m_pCodecContext->bit_rate = hints.bitrate;
@@ -360,9 +361,15 @@ void CDVDAudioCodecFFmpeg::BuildChannelMap()
   {
     CLog::Log(LOGINFO,
               "CDVDAudioCodecFFmpeg::GetChannelMap - FFmpeg reported {} channels, but the layout "
-              "contains {} ignoring",
+              "contains {} - trying hints",
               m_pCodecContext->channels, bits);
-    layout = av_get_default_channel_layout(m_pCodecContext->channels);
+    if (static_cast<int>(count_bits(m_hint_layout)) == m_pCodecContext->channels)
+      layout = m_hint_layout;
+    else
+    {
+      layout = av_get_default_channel_layout(m_pCodecContext->channels);
+      CLog::Log(LOGINFO, "Using default layout...");
+    }
   }
 
   m_channelLayout.Reset();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -59,5 +59,6 @@ protected:
   int m_channels;
   uint64_t m_layout;
   std::string m_codecName;
+  uint64_t m_hint_layout;
 };
 


### PR DESCRIPTION
… before using default layout

## Description
Kodi should check to see if a channel layout was obtained in the streaminfo and use it if it contains the right number of channels, before falling back to using a default layout.  Thanks to @fritsch for his invaluable input.

## Motivation and context
The default layout is not always the correct layout.  F.e. there is a file linked in this thread https://forum.kodi.tv/showthread.php?tid=362238 which contains 3.0 audio (FR, FL, FC) but with the current code, Kodi will open the default layout, which for 3 channels is FR, FL, LFE.  This is incorrect.  The correct layout is present in `hints.channellayout` so we should check that first before falling back to any default layout.


## How has this been tested?
Runtime tested with the sample file in the linked thread.  Kodi correctly opens FR, FL, FC

## What is the effect on users?
Better handling of channel layouts in some circumstances where the default layout is not correct.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
