### PR TITLE
[PVR] EPG Tags: Add flags for recordable and playable

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
@@ -559,6 +559,12 @@ extern "C"
 
     /// @brief __0001 0000__ : This EPG entry will be flagged as live.
     EPG_TAG_FLAG_IS_LIVE = (1 << 4),
+
+    /// @brief __0010 0000__ : This EPG entry will be flagged as recordable.
+    EPG_TAG_FLAG_IS_RECORDABLE = (1 << 5),
+
+    /// @brief __0100 0000__ : This EPG entry will be flagged as playable.
+    EPG_TAG_FLAG_IS_PLAYABLE = (1 << 6),
   } EPG_TAG_FLAG;
   ///@}
   //----------------------------------------------------------------------------

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -595,8 +595,9 @@ bool CPVREpgInfoTag::IsRecordable() const
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsRecordable(shared_from_this(), bIsRecordable) != PVR_ERROR_NO_ERROR))
   {
-    // event end time based fallback
-    bIsRecordable = EndAsLocalTime() > CDateTime::GetCurrentDateTime();
+    // flag and event end time based fallback
+    bIsRecordable = (m_iFlags & EPG_TAG_FLAG_IS_RECORDABLE) > 0 &&
+                    EndAsLocalTime() > CDateTime::GetCurrentDateTime();
   }
   return bIsRecordable;
 }
@@ -609,8 +610,8 @@ bool CPVREpgInfoTag::IsPlayable() const
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
   {
-    // fallback
-    bIsPlayable = false;
+    // flag based fallback
+    bIsPlayable = (m_iFlags & EPG_TAG_FLAG_IS_PLAYABLE) > 0;
   }
   return bIsPlayable;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This adds two flags for EPG tag recordable / playable state.

For pvr plugins that implement custom methods for isPlayable or isRecorable, only the fallback changes. For plugins that fetch the playable / recordable state together with EPG information, this allows to store this information within the EPG tag.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The existing PVR API queries the pvr plugins for the recordable/playable state of EPG tags multiple times and forces addons to maintain the tag state, even though this information is already available when fetching the EPG information. With this PR, addons can pass the playable/recordable state to Kodi, which uses it for the fallback.


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
