### PR TITLE
[Estuary] PVR channels OSD dialog: Fix direct channel number input label z order

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">11</defaultcontrol>
 	<controls>
-		<include>PVRChannelNumberInput</include>
 		<control type="group">
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
 			<control type="group">
@@ -69,5 +68,6 @@
 				</control>
 			</control>
 		</control>
+		<include>PVRChannelNumberInput</include>
 	</controls>
 </window>


### PR DESCRIPTION
Fixes a small visual glitch in PVR channels OSD dialog.

Before ("11" painted behind the dialog):

![screenshot00002](https://user-images.githubusercontent.com/3226626/116937096-062ba800-ac69-11eb-89e4-6a9647f8bd1f.png)

After ("8" painted correctly):

![screenshot00004](https://user-images.githubusercontent.com/3226626/116937092-0461e480-ac69-11eb-848f-3803616523fd.png)

@ronie good to go in?


