### PR TITLE
[Maintenance] Update format strings

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -370,7 +370,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
               && (bypassSettings))
         {
           bPlaying = true;
-          std::string strExec = StringUtils::Format("RecursiveSlideShow(%s)", pItem->GetPath().c_str());
+          std::string strExec = StringUtils::Format("RecursiveSlideShow({})", pItem->GetPath().c_str());
           CBuiltins::Execute(strExec);
           return true;
         }
@@ -446,7 +446,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
       if (!pItem->m_bIsFolder && pItem->IsPicture())
       {
         bPlaying = true;
-        std::string strExec = StringUtils::Format("RecursiveSlideShow(%s)", strDrive.c_str());
+        std::string strExec = StringUtils::Format("RecursiveSlideShow({})", strDrive.c_str());
         CBuiltins::Execute(strExec);
         break;
       }

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -78,11 +78,11 @@ bool CContextMenuItem::operator==(const CContextMenuItem& other) const
 std::string CContextMenuItem::ToString() const
 {
   if (IsGroup())
-    return StringUtils::Format("CContextMenuItem[group, id=%s, parent=%s, addon=%s]",
-        m_groupId.c_str(), m_parent.c_str(), m_addonId.c_str());
+    return StringUtils::Format("CContextMenuItem[group, id={}, parent={}, addon={}]",
+                               m_groupId.c_str(), m_parent.c_str(), m_addonId.c_str());
   else
-    return StringUtils::Format("CContextMenuItem[item, parent=%s, library=%s, addon=%s]",
-        m_parent.c_str(), m_library.c_str(), m_addonId.c_str());
+    return StringUtils::Format("CContextMenuItem[item, parent={}, library={}, addon={}]",
+                               m_parent.c_str(), m_library.c_str(), m_addonId.c_str());
 }
 
 CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const std::string& parent,

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -191,7 +191,7 @@ void CCueDocument::GetSongs(VECSONGS &songs)
     aSong.SetAlbumArtist(StringUtils::Split(m_strArtist, advancedSettings->m_musicItemSeparator));
     aSong.strAlbum = m_strAlbum;
     aSong.genre = StringUtils::Split(m_strGenre, advancedSettings->m_musicItemSeparator);
-    aSong.strReleaseDate = StringUtils::Format("%04i", m_iYear);
+    aSong.strReleaseDate = StringUtils::Format("{:04}", m_iYear);
     aSong.iTrack = track.iTrackNumber;
     if (m_iDiscNumber > 0)
       aSong.iTrack |= (m_iDiscNumber << 16); // see CMusicInfoTag::GetDiscNumber()

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -86,13 +86,13 @@ bool CDatabaseManager::Update(CDatabase &db, const DatabaseSettings &settings)
 
   int version = db.GetSchemaVersion();
   std::string latestDb = dbSettings.name;
-  latestDb += StringUtils::Format("%d", version);
+  latestDb += StringUtils::Format("{}", version);
 
   while (version >= db.GetMinSchemaVersion())
   {
     std::string dbName = dbSettings.name;
     if (version)
-      dbName += StringUtils::Format("%d", version);
+      dbName += StringUtils::Format("{}", version);
 
     if (db.Connect(dbName, dbSettings, false))
     {

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -337,7 +337,7 @@ CFileItem::CFileItem(const CMediaSource& share)
     URIUtils::AddSlashAtEnd(m_strPath);
   std::string label = share.strName;
   if (!share.strStatus.empty())
-    label = StringUtils::Format("%s (%s)", share.strName.c_str(), share.strStatus.c_str());
+    label = StringUtils::Format("{} ({})", share.strName.c_str(), share.strStatus.c_str());
   SetLabel(label);
   m_iLockMode = share.m_iLockMode;
   m_strLockCode = share.m_strLockCode;
@@ -1822,7 +1822,7 @@ void CFileItem::SetFromSong(const CSong &song)
   if (song.idSong > 0)
   {
     std::string strExt = URIUtils::GetExtension(song.strFileName);
-    m_strPath = StringUtils::Format("musicdb://songs/%li%s", song.idSong, strExt.c_str());
+    m_strPath = StringUtils::Format("musicdb://songs/{}{}", song.idSong, strExt.c_str());
   }
   else if (!song.strFileName.empty())
     m_strPath = song.strFileName;
@@ -3080,7 +3080,7 @@ void CFileItemList::RemoveDiscCache(const std::string& cacheFile) const
 
 void CFileItemList::RemoveDiscCacheCRC(const std::string& crc) const
 {
-  std::string cachefile = StringUtils::Format("special://temp/archive_cache/%s.fi", crc);
+  std::string cachefile = StringUtils::Format("special://temp/archive_cache/{}.fi", crc);
   RemoveDiscCache(cachefile);
 }
 
@@ -3093,21 +3093,21 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
 
   std::string cacheFile;
   if (IsCDDA() || IsOnDVD())
-    return StringUtils::Format("special://temp/archive_cache/r-%08x.fi", crc);
+    return StringUtils::Format("special://temp/archive_cache/r-{:08x}.fi", crc);
 
   if (IsMusicDb())
-    return StringUtils::Format("special://temp/archive_cache/mdb-%08x.fi", crc);
+    return StringUtils::Format("special://temp/archive_cache/mdb-{:08x}.fi", crc);
 
   if (IsVideoDb())
-    return StringUtils::Format("special://temp/archive_cache/vdb-%08x.fi", crc);
+    return StringUtils::Format("special://temp/archive_cache/vdb-{:08x}.fi", crc);
 
   if (IsSmartPlayList())
-    return StringUtils::Format("special://temp/archive_cache/sp-%08x.fi", crc);
+    return StringUtils::Format("special://temp/archive_cache/sp-{:08x}.fi", crc);
 
   if (windowID)
-    return StringUtils::Format("special://temp/archive_cache/%i-%08x.fi", windowID, crc);
+    return StringUtils::Format("special://temp/archive_cache/{}-{:08x}.fi", windowID, crc);
 
-  return StringUtils::Format("special://temp/archive_cache/%08x.fi", crc);
+  return StringUtils::Format("special://temp/archive_cache/{:08x}.fi", crc);
 }
 
 bool CFileItemList::AlwaysCache() const
@@ -3558,7 +3558,7 @@ bool CFileItem::LoadMusicTag()
       std::string strText = g_localizeStrings.Get(554); // "Track"
       if (!strText.empty() && strText[strText.size() - 1] != ' ')
         strText += " ";
-      std::string strTrack = StringUtils::Format((strText + "%i").c_str(), iTrack);
+      std::string strTrack = StringUtils::Format((strText + "{}").c_str(), iTrack);
       GetMusicInfoTag()->SetTitle(strTrack);
       GetMusicInfoTag()->SetLoaded(true);
       return true;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10827,7 +10827,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
           return StringUtils::SizeToString(item->m_dwSize);
         break;
       case LISTITEM_PROGRAM_COUNT:
-        return StringUtils::Format("%i", item->m_iprogramCount);
+        return StringUtils::Format("{}", item->m_iprogramCount);
       case LISTITEM_ACTUAL_ICON:
         return item->GetArt("icon");
       case LISTITEM_ICON:

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -160,7 +160,7 @@ bool CGUIPassword::CheckStartUpLock()
         std::string strLabel1;
         strLabel1 = g_localizeStrings.Get(12343); // "retries left"
         int iLeft = g_passwordManager.iMasterLockRetriesLeft-i;
-        std::string strLabel = StringUtils::Format("%i %s", iLeft, strLabel1.c_str());
+        std::string strLabel = StringUtils::Format("{} {}", iLeft, strLabel1.c_str());
 
         // PopUp OK and Display: MasterLock mode has changed but no new Mastercode has been set!
         HELPERS::ShowOKDialogLines(CVariant{12360}, CVariant{12367}, CVariant{strLabel}, CVariant{""});
@@ -323,7 +323,7 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
     }
     std::string dlgLine1 = "";
     if (0 < g_passwordManager.iMasterLockRetriesLeft)
-      dlgLine1 = StringUtils::Format("%d %s", g_passwordManager.iMasterLockRetriesLeft,
+      dlgLine1 = StringUtils::Format("{} {}", g_passwordManager.iMasterLockRetriesLeft,
                                      g_localizeStrings.Get(12343).c_str()); // "retries left"
     // prompt user for master lock code
     HELPERS::ShowOKDialogLines(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -1040,7 +1040,8 @@ std::string CLangInfo::GetTemperatureAsString(const CTemperature& temperature) c
     return g_localizeStrings.Get(13205); // "Unknown"
 
   CTemperature::Unit temperatureUnit = GetTemperatureUnit();
-  return StringUtils::Format("%s%s", temperature.ToString(temperatureUnit).c_str(), GetTemperatureUnitString().c_str());
+  return StringUtils::Format("{}{}", temperature.ToString(temperatureUnit).c_str(),
+                             GetTemperatureUnitString().c_str());
 }
 
 // Returns the temperature unit string for the current language
@@ -1088,7 +1089,8 @@ std::string CLangInfo::GetSpeedAsString(const CSpeed& speed) const
   if (!speed.IsValid())
     return g_localizeStrings.Get(13205); // "Unknown"
 
-  return StringUtils::Format("%s%s", speed.ToString(GetSpeedUnit()).c_str(), GetSpeedUnitString().c_str());
+  return StringUtils::Format("{}{}", speed.ToString(GetSpeedUnit()).c_str(),
+                             GetSpeedUnitString().c_str());
 }
 
 // Returns the speed unit string for the current language

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -321,7 +321,7 @@ bool CPartyModeManager::AddRandomSongs()
     bool bMusicVideos = false;
     for (int i = m_iMatchingSongsPicked; i < m_iMatchingSongsPicked + iMissingSongs; i++)
     {
-      std::string song = StringUtils::Format("%i,", m_songIDCache[i].second);
+      std::string song = StringUtils::Format("{},", m_songIDCache[i].second);
       if (m_songIDCache[i].first == 1)
       {
         sqlWhereMusic += song;

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -519,7 +519,9 @@ void CPlayListPlayer::SetShuffle(int iPlaylist, bool bYesNo, bool bNotify /* = f
 
     if (bNotify)
     {
-      std::string shuffleStr = StringUtils::Format("%s: %s", g_localizeStrings.Get(191).c_str(), g_localizeStrings.Get(bYesNo ? 593 : 591).c_str()); // Shuffle: All/Off
+      std::string shuffleStr = StringUtils::Format(
+          "{}: {}", g_localizeStrings.Get(191).c_str(),
+          g_localizeStrings.Get(bYesNo ? 593 : 591).c_str()); // Shuffle: All/Off
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559),  shuffleStr);
     }
 

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -263,8 +263,8 @@ bool CTextureCache::ClearCachedTexture(int id, std::string &cachedURL)
 std::string CTextureCache::GetCacheFile(const std::string &url)
 {
   auto crc = Crc32::ComputeFromLowerCase(url);
-  std::string hex = StringUtils::Format("%08x", crc);
-  std::string hash = StringUtils::Format("%c/%s", hex[0], hex.c_str());
+  std::string hex = StringUtils::Format("{:08x}", crc);
+  std::string hash = StringUtils::Format("{}/{}", hex[0], hex.c_str());
   return hash;
 }
 

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -230,7 +230,7 @@ std::string CTextureCacheJob::GetImageHash(const std::string &url)
     if (!time)
       time = st.st_ctime;
     if (time || st.st_size)
-      return StringUtils::Format("d%" PRId64"s%" PRId64, time, st.st_size);
+      return StringUtils::Format("d{}s{}", time, st.st_size);
 
     // the image exists but we couldn't determine the mtime/ctime and/or size
     // so set an obviously bad hash

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -283,7 +283,7 @@ void CURL::Parse(const std::string& strURL1)
   {
     if (m_strHostName != "" && m_strFileName != "")
     {
-      m_strFileName = StringUtils::Format("%s/%s", m_strHostName.c_str(), m_strFileName.c_str());
+      m_strFileName = StringUtils::Format("{}/{}", m_strHostName.c_str(), m_strFileName.c_str());
       m_strHostName = "";
     }
     else
@@ -536,7 +536,7 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
     if ( HasPort() )
     {
       protectIPv6(strHostName);
-      strURL += strHostName + StringUtils::Format(":%i", m_iPort);
+      strURL += strHostName + StringUtils::Format(":{}", m_iPort);
     }
     else
       strURL += strHostName;
@@ -599,7 +599,7 @@ std::string CURL::GetWithoutFilename() const
     if (HasPort())
     {
       protectIPv6(hostname);
-      strURL += hostname + StringUtils::Format(":%i", m_iPort);
+      strURL += hostname + StringUtils::Format(":{}", m_iPort);
     }
     else
       strURL += hostname;
@@ -698,7 +698,7 @@ std::string CURL::Encode(const std::string& strURLData)
     if (StringUtils::isasciialphanum(kar) || kar == '-' || kar == '.' || kar == '_' || kar == '!' || kar == '(' || kar == ')')
       strResult.push_back(kar);
     else
-      strResult += StringUtils::Format("%%%2.2x", (unsigned int)((unsigned char)kar));
+      strResult += StringUtils::Format("%{:02x}", (unsigned int)((unsigned char)kar));
   }
 
   return strResult;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -550,7 +550,7 @@ void CUtil::GetFileAndProtocol(const std::string& strURL, std::string& strDir)
   if (URIUtils::IsDVD(strURL)) return ;
 
   CURL url(strURL);
-  strDir = StringUtils::Format("%s://%s", url.GetProtocol().c_str(), url.GetFileName().c_str());
+  strDir = StringUtils::Format("{}://{}", url.GetProtocol().c_str(), url.GetFileName().c_str());
 }
 
 int CUtil::GetDVDIfoTitle(const std::string& strFile)
@@ -1470,7 +1470,7 @@ bool CUtil::MakeShortenPath(std::string StrInput, std::string& StrOutput, size_t
     iStrInputSize = StrInput.size();
   }
   // replace any additional /../../ with just /../ if necessary
-  std::string replaceDots = StringUtils::Format("..%c..", cDelim);
+  std::string replaceDots = StringUtils::Format("..{}..", cDelim);
   while (StrInput.size() > (unsigned int)iTextMaxLength)
     if (!StringUtils::Replace(StrInput, replaceDots, ".."))
       break;
@@ -2059,7 +2059,8 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
         {
           for (const auto &lang : TagConv.m_Langclass)
           {
-            std::string strDest = StringUtils::Format("special://temp/subtitle.%s.%zu.smi", lang.Name.c_str(), i);
+            std::string strDest =
+                StringUtils::Format("special://temp/subtitle.{}.{}.smi", lang.Name.c_str(), i);
             if (CFile::Copy(vecSubtitles[i], strDest))
             {
               CLog::Log(LOGINFO, " cached subtitle %s->%s",

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -841,7 +841,7 @@ std::string CDateTime::GetAsDBDate() const
   KODI::TIME::SystemTime st;
   GetAsSystemTime(st);
 
-  return StringUtils::Format("%04i-%02i-%02i", st.year, st.month, st.day);
+  return StringUtils::Format("{:04}-{:02}-{:02}", st.year, st.month, st.day);
 }
 
 std::string CDateTime::GetAsDBTime() const
@@ -849,7 +849,7 @@ std::string CDateTime::GetAsDBTime() const
   KODI::TIME::SystemTime st;
   GetAsSystemTime(st);
 
-  return StringUtils::Format("%02i:%02i:%02i", st.hour, st.minute, st.second);
+  return StringUtils::Format("{:02}:{:02}:{:02}", st.hour, st.minute, st.second);
 }
 
 std::string CDateTime::GetAsDBDateTime() const
@@ -857,8 +857,8 @@ std::string CDateTime::GetAsDBDateTime() const
   KODI::TIME::SystemTime st;
   GetAsSystemTime(st);
 
-  return StringUtils::Format("%04i-%02i-%02i %02i:%02i:%02i", st.year, st.month, st.day, st.hour,
-                             st.minute, st.second);
+  return StringUtils::Format("{:04}-{:02}-{:02} {:02}:{:02}:{:02}", st.year, st.month, st.day,
+                             st.hour, st.minute, st.second);
 }
 
 std::string CDateTime::GetAsSaveString() const
@@ -866,7 +866,7 @@ std::string CDateTime::GetAsSaveString() const
   KODI::TIME::SystemTime st;
   GetAsSystemTime(st);
 
-  return StringUtils::Format("%04i%02i%02i_%02i%02i%02i", st.year, st.month, st.day, st.hour,
+  return StringUtils::Format("{:04}{:02}{:02}_{:02}{:02}{:02}", st.year, st.month, st.day, st.hour,
                              st.minute, st.second);
 }
 
@@ -1237,9 +1237,9 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
       // Format hour string with the length of the mask
       std::string str;
       if (partLength==1)
-        str = StringUtils::Format("%d", hour);
+        str = StringUtils::Format("{}", hour);
       else
-        str = StringUtils::Format("%02d", hour);
+        str = StringUtils::Format("{:02}", hour);
 
       strOut+=str;
     }
@@ -1264,9 +1264,9 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
       // Format minute string with the length of the mask
       std::string str;
       if (partLength==1)
-        str = StringUtils::Format("%d", dateTime.minute);
+        str = StringUtils::Format("{}", dateTime.minute);
       else
-        str = StringUtils::Format("%02d", dateTime.minute);
+        str = StringUtils::Format("{:02}", dateTime.minute);
 
       strOut+=str;
     }
@@ -1293,9 +1293,9 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
         // Format seconds string with the length of the mask
         std::string str;
         if (partLength==1)
-          str = StringUtils::Format("%d", dateTime.second);
+          str = StringUtils::Format("{}", dateTime.second);
         else
-          str = StringUtils::Format("%02d", dateTime.second);
+          str = StringUtils::Format("{:02}", dateTime.second);
 
         strOut+=str;
       }
@@ -1386,9 +1386,9 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       // Format string with the length of the mask
       std::string str;
       if (partLength==1) // single-digit number
-        str = StringUtils::Format("%d", dateTime.day);
+        str = StringUtils::Format("{}", dateTime.day);
       else if (partLength==2) // two-digit number
-        str = StringUtils::Format("%02d", dateTime.day);
+        str = StringUtils::Format("{:02}", dateTime.day);
       else // Day of week string
       {
         int wday = dateTime.dayOfWeek;
@@ -1418,9 +1418,9 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       // Format string with the length of the mask
       std::string str;
       if (partLength==1) // single-digit number
-        str = StringUtils::Format("%d", dateTime.month);
+        str = StringUtils::Format("{}", dateTime.month);
       else if (partLength==2) // two-digit number
-        str = StringUtils::Format("%02d", dateTime.month);
+        str = StringUtils::Format("{:02}", dateTime.month);
       else // Month string
       {
         int wmonth = dateTime.month;
@@ -1448,7 +1448,7 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       }
 
       // Format string with the length of the mask
-      std::string str = StringUtils::Format("%d", dateTime.year); // four-digit number
+      std::string str = StringUtils::Format("{}", dateTime.year); // four-digit number
       if (partLength <= 2)
         str.erase(0, 2); // two-digit number
 
@@ -1535,7 +1535,9 @@ std::string CDateTime::GetAsRFC1123DateTime() const
   if (month != time.GetMonth())
     CLog::Log(LOGWARNING, "Invalid month %d in %s", time.GetMonth(), time.GetAsDBDateTime().c_str());
 
-  return StringUtils::Format("%s, %02i %s %04i %02i:%02i:%02i GMT", DAY_NAMES[weekDay], time.GetDay(), MONTH_NAMES[month - 1], time.GetYear(), time.GetHour(), time.GetMinute(), time.GetSecond());
+  return StringUtils::Format("{}, {:02} {} {:04} {:02}:{:02}:{:02} GMT", DAY_NAMES[weekDay],
+                             time.GetDay(), MONTH_NAMES[month - 1], time.GetYear(), time.GetHour(),
+                             time.GetMinute(), time.GetSecond());
 }
 
 std::string CDateTime::GetAsW3CDate() const
@@ -1543,7 +1545,7 @@ std::string CDateTime::GetAsW3CDate() const
   KODI::TIME::SystemTime st;
   GetAsSystemTime(st);
 
-  return StringUtils::Format("%04i-%02i-%02i", st.year, st.month, st.day);
+  return StringUtils::Format("{:04}-{:02}-{:02}", st.year, st.month, st.day);
 }
 
 std::string CDateTime::GetAsW3CDateTime(bool asUtc /* = false */) const
@@ -1554,13 +1556,15 @@ std::string CDateTime::GetAsW3CDateTime(bool asUtc /* = false */) const
   KODI::TIME::SystemTime st;
   w3cDate.GetAsSystemTime(st);
 
-  std::string result = StringUtils::Format("%04i-%02i-%02iT%02i:%02i:%02i", st.year, st.month,
+  std::string result = StringUtils::Format("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}", st.year, st.month,
                                            st.day, st.hour, st.minute, st.second);
   if (asUtc)
     return result + "Z";
 
   CDateTimeSpan bias = GetTimezoneBias();
-  return result + StringUtils::Format("%c%02i:%02i", (bias.GetSecondsTotal() >= 0 ? '+' : '-'), abs(bias.GetHours()), abs(bias.GetMinutes())).c_str();
+  return result + StringUtils::Format("{}{:02}:{:02}", (bias.GetSecondsTotal() >= 0 ? '+' : '-'),
+                                      abs(bias.GetHours()), abs(bias.GetMinutes()))
+                      .c_str();
 }
 
 int CDateTime::MonthStringToMonthNum(const std::string& month)

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -37,13 +37,14 @@ namespace ADDON
 {
 
 CAddon::CAddon(const AddonInfoPtr& addonInfo, TYPE addonType)
-  : m_addonInfo(addonInfo)
-  , m_userSettingsPath()
-  , m_loadSettingsFailed(false)
-  , m_hasUserSettings(false)
-  , m_profilePath(StringUtils::Format("special://profile/addon_data/%s/", m_addonInfo->ID().c_str()))
-  , m_settings(nullptr)
-  , m_type(addonType == ADDON_UNKNOWN ? addonInfo->MainType() : addonType)
+  : m_addonInfo(addonInfo),
+    m_userSettingsPath(),
+    m_loadSettingsFailed(false),
+    m_hasUserSettings(false),
+    m_profilePath(
+        StringUtils::Format("special://profile/addon_data/{}/", m_addonInfo->ID().c_str())),
+    m_settings(nullptr),
+    m_type(addonType == ADDON_UNKNOWN ? addonInfo->MainType() : addonType)
 {
   m_userSettingsPath = URIUtils::AddFileToFolder(m_profilePath, "settings.xml");
 }

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -80,7 +80,8 @@ void CAddonStatusHandler::Process()
 {
   CSingleLock lock(m_critSection);
 
-  std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(m_addon->Type(), true).c_str(), m_addon->Name().c_str());
+  std::string heading = StringUtils::Format(
+      "{}: {}", CAddonInfo::TranslateType(m_addon->Type(), true).c_str(), m_addon->Name().c_str());
 
   /* Request to restart the AddOn and data structures need updated */
   if (m_status == ADDON_STATUS_NEED_RESTART)

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -156,7 +156,7 @@ namespace ADDON
   {
     std::string out;
     if (mEpoch)
-      out = StringUtils::Format("%i:", mEpoch);
+      out = StringUtils::Format("{}:", mEpoch);
     out += mUpstream;
     if (!mRevision.empty())
       out += "-" + mRevision;

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -614,7 +614,7 @@ CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem &item)
   std::string sArtist = item.GetProperty("album.artist").asString();
   std::string sAlbumName;
   if (!sArtist.empty())
-    sAlbumName = StringUtils::Format("%s - %s", sArtist.c_str(), sTitle.c_str());
+    sAlbumName = StringUtils::Format("{} - {}", sArtist.c_str(), sTitle.c_str());
   else
     sAlbumName = sTitle;
 
@@ -992,11 +992,11 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
 
         // reconstruct a title for the user
         if (!sCompareYear.empty())
-          title += StringUtils::Format(" (%s)", sCompareYear.c_str());
+          title += StringUtils::Format(" ({})", sCompareYear.c_str());
 
         std::string sLanguage;
         if (XMLUtils::GetString(pxeMovie, "language", sLanguage) && !sLanguage.empty())
-          title += StringUtils::Format(" (%s)", sLanguage.c_str());
+          title += StringUtils::Format(" ({})", sLanguage.c_str());
 
         // filter for dupes from naughty scrapers
         if (stsDupeCheck.insert(scurlMovie.GetFirstThumbUrl() + " " + title).second)
@@ -1083,13 +1083,13 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
         std::string sArtist;
         std::string sAlbumName;
         if (XMLUtils::GetString(pxeAlbum, "artist", sArtist) && !sArtist.empty())
-          sAlbumName = StringUtils::Format("%s - %s", sArtist.c_str(), sTitle.c_str());
+          sAlbumName = StringUtils::Format("{} - {}", sArtist.c_str(), sTitle.c_str());
         else
           sAlbumName = sTitle;
 
         std::string sYear;
         if (XMLUtils::GetString(pxeAlbum, "year", sYear) && !sYear.empty())
-          sAlbumName = StringUtils::Format("%s (%s)", sAlbumName.c_str(), sYear.c_str());
+          sAlbumName = StringUtils::Format("{} ({})", sAlbumName.c_str(), sYear.c_str());
 
         // if no URL is provided, use the URL we got back from CreateAlbumSearchUrl
         // (e.g., in case we only got one result back and were sent to the detail page)

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -147,7 +147,8 @@ bool CAddonDll::LoadDll()
     delete m_pDll;
     m_pDll = nullptr;
 
-    std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
+    std::string heading = StringUtils::Format(
+        "{}: {}", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
     HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{24070}, CVariant{24071});
 
     return false;
@@ -199,7 +200,8 @@ ADDON_STATUS CAddonDll::Create(KODI_HANDLE firstKodiInstance)
     CLog::Log(LOGERROR, "ADDON: Dll %s - Client returned bad status (%i) from Create and is not usable", Name().c_str(), status);
 
     // @todo currently a copy and paste from other function and becomes improved.
-    std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
+    std::string heading = StringUtils::Format(
+        "{}: {}", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
     HELPERS::ShowOKDialogLines(CVariant{ heading }, CVariant{ 24070 }, CVariant{ 24071 });
   }
 

--- a/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
@@ -25,7 +25,7 @@ IAddonInstanceHandler::IAddonInstanceHandler(ADDON_TYPE type,
 {
   // if no special instance ID is given generate one from class pointer (is
   // faster as unique id and also safe enough for them).
-  m_instanceId = !instanceID.empty() ? instanceID : StringUtils::Format("%p", static_cast<void*>(this));
+  m_instanceId = !instanceID.empty() ? instanceID : StringUtils::Format("{}", fmt::ptr(this));
   m_addonBase = CServiceBroker::GetBinaryAddonManager().GetAddonBase(addonInfo, this, m_addon);
 }
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -379,7 +379,7 @@ void CGUIDialogAddonInfo::OnSelectVersion()
       if (versions[i].second == LOCAL_CACHE)
       {
         CAddonInstaller::GetInstance().InstallFromZip(
-            StringUtils::Format("special://home/addons/packages/%s-%s.zip", processAddonId.c_str(),
+            StringUtils::Format("special://home/addons/packages/{}-{}.zip", processAddonId.c_str(),
                                 versions[i].first.asString().c_str()));
       }
       else

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -198,7 +198,7 @@ void CGUIDialogAddonSettings::SetupView()
   SetProperty("Addon.ID", m_addon->ID());
 
   // set heading
-  SetHeading(StringUtils::Format("$LOCALIZE[10004] - %s",
+  SetHeading(StringUtils::Format("$LOCALIZE[10004] - {}",
                                  m_addon->Name().c_str())); // "Settings - AddonName"
 
   // set control labels

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -415,7 +415,7 @@ bool Interface_Base::set_setting_int(void* kodiBase, const char* id, int value)
     return false;
   }
 
-  if (Interface_Base::UpdateSettingInActiveDialog(addon, id, StringUtils::Format("%d", value)))
+  if (Interface_Base::UpdateSettingInActiveDialog(addon, id, StringUtils::Format("{}", value)))
     return true;
 
   if (!addon->UpdateSettingInt(id, value))
@@ -440,7 +440,7 @@ bool Interface_Base::set_setting_float(void* kodiBase, const char* id, float val
     return false;
   }
 
-  if (Interface_Base::UpdateSettingInActiveDialog(addon, id, StringUtils::Format("%f", value)))
+  if (Interface_Base::UpdateSettingInActiveDialog(addon, id, StringUtils::Format("{:f}", value)))
     return true;
 
   if (!addon->UpdateSettingNumber(id, value))

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -418,7 +418,7 @@ char* Interface_Filesystem::get_cache_thumb_name(void* kodiBase, const char* fil
   }
 
   const auto crc = Crc32::ComputeFromLowerCase(filename);
-  const auto hex = StringUtils::Format("%08x.tbn", crc);
+  const auto hex = StringUtils::Format("{:08x}.tbn", crc);
   char* buffer = strdup(hex.c_str());
   return buffer;
 }

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -375,9 +375,8 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
     StringUtils::Replace(result, "xx", "%p");
   }
   else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
-    result = StringUtils::Format("%s/%s",
-                                  g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
-                                  g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
+    result = StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
+                                 g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
   else
   {
     CLog::Log(LOGERROR, "Interface_General::{} -  add-on '{}' requests invalid id '{}'",

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -552,7 +552,7 @@ public:
   /// ~~~~~~~~~~~~~{.cpp}
   /// #include <kodi/tools/StringUtils.h>
   ///
-  /// std::string str = kodi::tools::StringUtils::Format("Hello %s %i", "World", 2020);
+  /// std::string str = kodi::tools::StringUtils::Format("Hello {} {}", "World", 2020);
   /// ~~~~~~~~~~~~~
   ///
   inline static std::string Format(const char* fmt, ...)
@@ -2936,13 +2936,13 @@ public:
 
     std::string strHMS;
     if (format == TIME_FORMAT_SECS)
-      strHMS = StringUtils::Format("%i", seconds);
+      strHMS = StringUtils::Format("{}", seconds);
     else if (format == TIME_FORMAT_MINS)
-      strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(seconds) / 60.0f));
+      strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(seconds) / 60.0f));
     else if (format == TIME_FORMAT_HOURS)
-      strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(seconds) / 3600.0f));
+      strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(seconds) / 3600.0f));
     else if (format & TIME_FORMAT_M)
-      strHMS += StringUtils::Format("%i", seconds % 3600 / 60);
+      strHMS += StringUtils::Format("{}", seconds % 3600 / 60);
     else
     {
       int hh = seconds / 3600;
@@ -2953,13 +2953,13 @@ public:
       if (format == TIME_FORMAT_GUESS)
         format = (hh >= 1) ? TIME_FORMAT_HH_MM_SS : TIME_FORMAT_MM_SS;
       if (format & TIME_FORMAT_HH)
-        strHMS += StringUtils::Format("%2.2i", hh);
+        strHMS += StringUtils::Format("{:02}", hh);
       else if (format & TIME_FORMAT_H)
-        strHMS += StringUtils::Format("%i", hh);
+        strHMS += StringUtils::Format("{}", hh);
       if (format & TIME_FORMAT_MM)
-        strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", mm);
+        strHMS += StringUtils::Format(strHMS.empty() ? "{:02}" : ":{:02}", mm);
       if (format & TIME_FORMAT_SS)
-        strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", ss);
+        strHMS += StringUtils::Format(strHMS.empty() ? "{:02}" : ":{:02}", ss);
     }
 
     if (isNegative)

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -82,9 +82,8 @@ bool CCDDARipJob::DoWork()
   CGUIDialogProgressBarHandle* handle = pDlgProgress->GetHandle(g_localizeStrings.Get(605));
 
   int iTrack = atoi(m_input.substr(13, m_input.size() - 13 - 5).c_str());
-  std::string strLine0 = StringUtils::Format("%02i. %s - %s", iTrack,
-                                            m_tag.GetArtistString().c_str(),
-                                            m_tag.GetTitle().c_str());
+  std::string strLine0 = StringUtils::Format(
+      "{:02}. {} - {}", iTrack, m_tag.GetArtistString().c_str(), m_tag.GetTitle().c_str());
   handle->SetText(strLine0);
 
   // start ripping
@@ -193,7 +192,8 @@ CEncoder* CCDDARipJob::SetupEncoder(CFile& reader)
     return NULL;
 
   // we have to set the tags before we init the Encoder
-  const std::string strTrack = StringUtils::Format("%li", strtol(m_input.substr(13, m_input.size() - 13 - 5).c_str(), nullptr, 10));
+  const std::string strTrack = StringUtils::Format(
+      "{}", strtol(m_input.substr(13, m_input.size() - 13 - 5).c_str(), nullptr, 10));
 
   const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
 

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -220,7 +220,8 @@ std::string CCDDARipper::GetAlbumDirName(const MUSIC_INFO::CMusicInfoTag& infoTa
   {
     std::string strAlbum = infoTag.GetAlbum();
     if (strAlbum.empty())
-      strAlbum = StringUtils::Format("Unknown Album %s", CDateTime::GetCurrentDateTime().GetAsLocalizedDateTime().c_str());
+      strAlbum = StringUtils::Format(
+          "Unknown Album {}", CDateTime::GetCurrentDateTime().GetAsLocalizedDateTime().c_str());
     else
       StringUtils::Replace(strAlbum, '/', '_');
     StringUtils::Replace(strAlbumDir, "%B", strAlbum);
@@ -273,7 +274,7 @@ std::string CCDDARipper::GetTrackName(CFileItem *item)
   // grab the label to use it as our ripped filename
   std::string track = destItem.GetLabel();
   if (track.empty())
-    track = StringUtils::Format("%s%02i", "Track-", trackNumber);
+    track = StringUtils::Format("{}{:02}", "Track-", trackNumber);
 
   const std::string encoder = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
       CSettings::SETTING_AUDIOCDS_ENCODER);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
@@ -84,11 +84,9 @@ bool CActiveAEFilter::CreateFilterGraph()
   const AVFilter* srcFilter = avfilter_get_by_name("abuffer");
   const AVFilter* outFilter = avfilter_get_by_name("abuffersink");
 
-  std::string args = StringUtils::Format("time_base=1/%d:sample_rate=%d:sample_fmt=%s:channel_layout=0x%" PRIx64,
-                                         m_sampleRate,
-                                         m_sampleRate,
-                                         av_get_sample_fmt_name(m_sampleFormat),
-                                         m_channelLayout);
+  std::string args = StringUtils::Format(
+      "time_base=1/{}:sample_rate={}:sample_fmt={}:channel_layout={}", m_sampleRate, m_sampleRate,
+      av_get_sample_fmt_name(m_sampleFormat), m_channelLayout);
 
   int ret = avfilter_graph_create_filter(&m_pFilterCtxIn, srcFilter, "in", args.c_str(), NULL, m_pFilterGraph);
   if (ret < 0)
@@ -115,7 +113,7 @@ bool CActiveAEFilter::CreateAtempoFilter()
 
   atempo = avfilter_get_by_name("atempo");
   m_pFilterCtxAtempo = avfilter_graph_alloc_filter(m_pFilterGraph, atempo, "atempo");
-  std::string args =  StringUtils::Format("tempo=%f", m_tempo);
+  std::string args = StringUtils::Format("tempo={:f}", m_tempo);
   int ret = avfilter_init_str(m_pFilterCtxAtempo, args.c_str());
 
   if (ret < 0)

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -197,13 +197,14 @@ extern "C" void __stdcall update_emu_environ()
     if (!settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).empty() &&
         !settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD).empty())
     {
-      strProxy = StringUtils::Format("%s:%s@",
-                                     settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).c_str(),
-                                     settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD).c_str());
+      strProxy = StringUtils::Format(
+          "{}:{}@", settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).c_str(),
+          settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD).c_str());
     }
 
     strProxy += settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);
-    strProxy += StringUtils::Format(":%d", settings->GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT));
+    strProxy +=
+        StringUtils::Format(":{}", settings->GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT));
 
     CEnvironment::setenv( "HTTP_PROXY", "http://" + strProxy, true );
     CEnvironment::setenv( "HTTPS_PROXY", "http://" + strProxy, true );

--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -96,7 +96,7 @@ void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
   }
 
   std::string message = StringUtils::FormatV(format, va);
-  std::string prefix = StringUtils::Format("ffmpeg[%pX]: ", static_cast<const void*>(threadId));
+  std::string prefix = StringUtils::Format("ffmpeg[{}]: ", fmt::ptr(threadId));
   if (avc)
   {
     if (avc->item_name)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -99,7 +99,7 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
       if(pos == std::string::npos)
         continue;
 
-      line2 = StringUtils::Format("%d,%s,%s", m_order++, layer.get(), line.substr(pos+1).c_str());
+      line2 = StringUtils::Format("{},{},{}", m_order++, layer.get(), line.substr(pos + 1).c_str());
 
       m_libass->DecodeDemuxPkt(line2.c_str(), line2.length(), beg, end - beg);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -220,7 +220,7 @@ int CDVDOverlayCodecTX3G::Decode(DemuxPacket *pPacket)
 
     // invert the order from above so we bracket the text correctly.
     if (bgnColorIndex == charIndex && textColorRGBA != m_textColor)
-      strUTF8 += StringUtils::Format("[COLOR %8x]", textColorRGBA);
+      strUTF8 += StringUtils::Format("[COLOR {:8x}]", textColorRGBA);
     // we do not support underline
     //if (bgnStyles & UNDERLINE)
     //  strUTF8.append("[U]");

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1142,14 +1142,12 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const std::string& filters, bool scale)
   const AVFilter* srcFilter = avfilter_get_by_name("buffer");
   const AVFilter* outFilter = avfilter_get_by_name("buffersink"); // should be last filter in the graph for now
 
-  std::string args = StringUtils::Format("%d:%d:%d:%d:%d:%d:%d",
-                                        m_pCodecContext->width,
-                                        m_pCodecContext->height,
-                                        m_pCodecContext->pix_fmt,
-                                        m_pCodecContext->time_base.num ? m_pCodecContext->time_base.num : 1,
-                                        m_pCodecContext->time_base.num ? m_pCodecContext->time_base.den : 1,
-                                        m_pCodecContext->sample_aspect_ratio.num != 0 ? m_pCodecContext->sample_aspect_ratio.num : 1,
-                                        m_pCodecContext->sample_aspect_ratio.num != 0 ? m_pCodecContext->sample_aspect_ratio.den : 1);
+  std::string args = StringUtils::Format(
+      "{}:{}:{}:{}:{}:{}:{}", m_pCodecContext->width, m_pCodecContext->height,
+      m_pCodecContext->pix_fmt, m_pCodecContext->time_base.num ? m_pCodecContext->time_base.num : 1,
+      m_pCodecContext->time_base.num ? m_pCodecContext->time_base.den : 1,
+      m_pCodecContext->sample_aspect_ratio.num != 0 ? m_pCodecContext->sample_aspect_ratio.num : 1,
+      m_pCodecContext->sample_aspect_ratio.num != 0 ? m_pCodecContext->sample_aspect_ratio.den : 1);
 
   if ((result = avfilter_graph_create_filter(&m_pFilterIn, srcFilter, "src", args.c_str(), NULL, m_pFilterGraph)) < 0)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -2926,14 +2926,10 @@ bool CFFmpegPostproc::Init(EINTERLACEMETHOD method)
   const AVFilter* srcFilter = avfilter_get_by_name("buffer");
   const AVFilter* outFilter = avfilter_get_by_name("buffersink");
 
-  std::string args = StringUtils::Format("%d:%d:%d:%d:%d:%d:%d",
-                                        m_config.vidWidth,
-                                        m_config.vidHeight,
-                                        AV_PIX_FMT_NV12,
-                                        1,
-                                        1,
-                                        (m_config.aspect.num != 0) ? m_config.aspect.num : 1,
-                                        (m_config.aspect.num != 0) ? m_config.aspect.den : 1);
+  std::string args = StringUtils::Format("{}:{}:{}:{}:{}:{}:{}", m_config.vidWidth,
+                                         m_config.vidHeight, AV_PIX_FMT_NV12, 1, 1,
+                                         (m_config.aspect.num != 0) ? m_config.aspect.num : 1,
+                                         (m_config.aspect.num != 0) ? m_config.aspect.den : 1);
 
   if (avfilter_graph_create_filter(&m_pFilterIn, srcFilter, "src", args.c_str(), NULL, m_pFilterGraph) < 0)
   {

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -767,11 +767,11 @@ std::string CEdl::GetInfo() const
       }
     }
     if (cutCount > 0)
-      strInfo += StringUtils::Format("c%i", cutCount);
+      strInfo += StringUtils::Format("c{}", cutCount);
     if (muteCount > 0)
-      strInfo += StringUtils::Format("m%i", muteCount);
+      strInfo += StringUtils::Format("m{}", muteCount);
     if (commBreakCount > 0)
-      strInfo += StringUtils::Format("b%i", commBreakCount);
+      strInfo += StringUtils::Format("b{}", commBreakCount);
   }
   if (HasSceneMarker())
     strInfo += StringUtils::Format("s{0}", m_vecSceneMarkers.size());
@@ -901,7 +901,7 @@ bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker)
 std::string CEdl::MillisecondsToTimeString(const int iMilliseconds)
 {
   std::string strTimeString = StringUtils::SecondsToTimeString((long)(iMilliseconds / 1000), TIME_FORMAT_HH_MM_SS); // milliseconds to seconds
-  strTimeString += StringUtils::Format(".%03i", iMilliseconds % 1000);
+  strTimeString += StringUtils::Format(".{:03}", iMilliseconds % 1000);
   return strTimeString;
 }
 

--- a/xbmc/cores/VideoPlayer/PTSTracker.cpp
+++ b/xbmc/cores/VideoPlayer/PTSTracker.cpp
@@ -314,7 +314,7 @@ std::string CPtsTracker::GetPatternStr()
   std::string patternstr;
 
   for (unsigned int i = 0; i < m_pattern.size(); i++)
-    patternstr += StringUtils::Format("%.2f ", m_pattern[i]);
+    patternstr += StringUtils::Format("{:.2f} ", m_pattern[i]);
 
   StringUtils::Trim(patternstr);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -485,7 +485,7 @@ void CSelectionStreams::Update(const std::shared_ptr<CDVDInputStream>& input,
       s.width = info.width;
       s.height = info.height;
       s.codec = info.codecName;
-      s.name = StringUtils::Format("%s %i", g_localizeStrings.Get(38032).c_str(), i);
+      s.name = StringUtils::Format("{} {}", g_localizeStrings.Get(38032).c_str(), i);
       Update(s);
     }
   }
@@ -789,7 +789,7 @@ bool CVideoPlayer::OpenInputStream()
 
     // load any subtitles from file item
     std::string key("subtitle:1");
-    for (unsigned s = 1; m_item.HasProperty(key); key = StringUtils::Format("subtitle:%u", ++s))
+    for (unsigned s = 1; m_item.HasProperty(key); key = StringUtils::Format("subtitle:{}", ++s))
       filenames.push_back(m_item.GetProperty(key).asString());
 
     for (unsigned int i=0;i<filenames.size();i++)
@@ -3165,16 +3165,14 @@ void CVideoPlayer::GetGeneralInfo(std::string& strGeneralInfo)
     CSingleLock lock(m_StateSection);
     if (m_State.cache_bytes >= 0)
     {
-      strBuf += StringUtils::Format(" forward:%s %2.0f%%"
-                                    , StringUtils::SizeToString(m_State.cache_bytes).c_str()
-                                    , m_State.cache_level * 100);
+      strBuf += StringUtils::Format(" forward:{} {:2.0f}%",
+                                    StringUtils::SizeToString(m_State.cache_bytes).c_str(),
+                                    m_State.cache_level * 100);
       if (m_playSpeed == 0 || m_caching == CACHESTATE_FULL)
-        strBuf += StringUtils::Format(" %d msec", DVD_TIME_TO_MSEC(m_State.cache_delay));
+        strBuf += StringUtils::Format(" {} msec", DVD_TIME_TO_MSEC(m_State.cache_delay));
     }
 
-    strGeneralInfo = StringUtils::Format("Player: a/v:% 6.3f, %s"
-                                         , dDiff
-                                         , strBuf.c_str());
+    strGeneralInfo = StringUtils::Format("Player: a/v:{: 6.3f}, {}", dDiff, strBuf.c_str());
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -1048,7 +1048,9 @@ unsigned int CDVDRadioRDSData::DecodePTYN(uint8_t *msgElement)
 
   if (!m_RTPlus_GenrePresent)
   {
-    std::string progTypeName = StringUtils::Format("%s: %s", g_localizeStrings.Get(pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name).c_str(), m_PTYN);
+    std::string progTypeName = StringUtils::Format(
+        "{}: {}", g_localizeStrings.Get(pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name).c_str(),
+        m_PTYN);
     SetRadioStyle(progTypeName);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -735,12 +735,12 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
 
         double refreshrate, clockspeed;
         int missedvblanks;
-        info.vsync =
-            StringUtils::Format("VSyncOff: %.1f latency: %.3f  ", m_clockSync.m_syncOffset / 1000,
-                                DVD_TIME_TO_MSEC(m_displayLatency) / 1000.0f);
+        info.vsync = StringUtils::Format("VSyncOff: {:.1f} latency: {:.3f}  ",
+                                         m_clockSync.m_syncOffset / 1000,
+                                         DVD_TIME_TO_MSEC(m_displayLatency) / 1000.0f);
         if (m_dvdClock.GetClockInfo(missedvblanks, clockspeed, refreshrate))
         {
-          info.vsync += StringUtils::Format("VSync: refresh:%.3f missed:%i speed:%.3f%%",
+          info.vsync += StringUtils::Format("VSync: refresh:{:.3f} missed:{} speed:{:.3f}%",
                                             refreshrate, missedvblanks, clockspeed * 100);
         }
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -524,7 +524,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   InitSettings(dbSettings);
 
   std::string dbName = dbSettings.name;
-  dbName += StringUtils::Format("%d", GetSchemaVersion());
+  dbName += StringUtils::Format("{}", GetSchemaVersion());
   return Connect(dbName, dbSettings, false);
 }
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -445,7 +445,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       // password entry and re-entry succeeded, write out the lock data
       share->m_iHasLock = LOCK_STATE_LOCKED;
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockcode", strNewPassword);
-      strNewPassword = StringUtils::Format("%i", share->m_iLockMode);
+      strNewPassword = StringUtils::Format("{}", share->m_iLockMode);
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockmode", strNewPassword);
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
@@ -505,7 +505,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       std::string strNewPW;
       std::string strNewLockMode;
       if (CGUIDialogLockSettings::ShowAndGetLock(share->m_iLockMode,strNewPW))
-        strNewLockMode = StringUtils::Format("%i",share->m_iLockMode);
+        strNewLockMode = StringUtils::Format("{}", share->m_iLockMode);
       else
         return false;
       // password ReSet and re-entry succeeded, write out the lock data

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -234,7 +234,8 @@ int CGUIDialogGamepad::ShowAndVerifyPassword(std::string& strPassword, const std
   if (0 < iRetries)
   {
     // Show a string telling user they have iRetries retries left
-    strLine2 = StringUtils::Format("%s %i %s", g_localizeStrings.Get(12342).c_str(), iRetries, g_localizeStrings.Get(12343).c_str());
+    strLine2 = StringUtils::Format("{} {} {}", g_localizeStrings.Get(12342).c_str(), iRetries,
+                                   g_localizeStrings.Get(12343).c_str());
   }
 
   // make a copy of strPassword to prevent from overwriting it later

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -415,7 +415,8 @@ void CGUIDialogMediaFilter::InitializeSettings()
       }
     }
 
-    std::string settingId = StringUtils::Format("filter.%s.%d", filter.mediaType.c_str(), filter.field);
+    std::string settingId =
+        StringUtils::Format("filter.{}.{}", filter.mediaType.c_str(), filter.field);
     if (filter.controlType == "edit")
     {
       CVariant data;
@@ -788,7 +789,9 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
       else if (m_mediaType == "tvshows")
       {
         table = "tvshow_view";
-        year = StringUtils::Format("strftime(\"%%Y\", %s)", DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPartWhere).c_str());
+        year = StringUtils::Format(
+            "strftime(\"%%Y\", {})",
+            DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPartWhere).c_str());
       }
       else if (m_mediaType == "musicvideos")
       {
@@ -823,7 +826,8 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
 
     if (m_mediaType == "episodes")
     {
-      std::string field = StringUtils::Format("CAST(strftime(\"%%s\", c%02d) AS INTEGER)", VIDEODB_ID_EPISODE_AIRED);
+      std::string field = StringUtils::Format("CAST(strftime(\"%%s\", c{:02}) AS INTEGER)",
+                                              VIDEODB_ID_EPISODE_AIRED);
 
       GetMinMax("episode_view", field, min, max);
       interval = 60 * 60 * 24 * 7; // 1 week

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -205,7 +205,7 @@ std::string CGUIDialogMediaSource::GetUniqueMediaSourceName()
     }
     if (i < pShares->size())
       // found a match -  try next
-      strName = StringUtils::Format("%s (%i)", m_name.c_str(), j++);
+      strName = StringUtils::Format("{} ({})", m_name.c_str(), j++);
     else
       bConfirmed = true;
   }

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -316,21 +316,21 @@ void CGUIDialogNumeric::FrameMove()
     strLabel = m_number;
   else if (m_mode == INPUT_TIME)
   { // format up the time
-    strLabel = StringUtils::Format("%2d:%02d", m_datetime.hour, m_datetime.minute);
+    strLabel = StringUtils::Format("{:2}:{:02}", m_datetime.hour, m_datetime.minute);
     start = m_block * 3;
     end = m_block * 3 + 2;
   }
   else if (m_mode == INPUT_TIME_SECONDS)
   { // format up the time
-    strLabel =
-        StringUtils::Format("%2d:%02d:%02d", m_datetime.hour, m_datetime.minute, m_datetime.second);
+    strLabel = StringUtils::Format("{:2}:{:02}:{:02}", m_datetime.hour, m_datetime.minute,
+                                   m_datetime.second);
     start = m_block * 3;
     end = m_block * 3 + 2;
   }
   else if (m_mode == INPUT_DATE)
   { // format up the date
     strLabel =
-        StringUtils::Format("%2d/%2d/%4d", m_datetime.day, m_datetime.month, m_datetime.year);
+        StringUtils::Format("{:2}/{:2}/{:4}", m_datetime.day, m_datetime.month, m_datetime.year);
     start = m_block * 3;
     end = m_block * 3 + 2;
     if (m_block == 2)
@@ -338,7 +338,7 @@ void CGUIDialogNumeric::FrameMove()
   }
   else if (m_mode == INPUT_IP_ADDRESS)
   { // format up the date
-    strLabel = StringUtils::Format("%3d.%3d.%3d.%3d", m_ip[0], m_ip[1], m_ip[2], m_ip[3]);
+    strLabel = StringUtils::Format("{:3}.{:3}.{:3}.{:3}", m_ip[0], m_ip[1], m_ip[2], m_ip[3]);
     start = m_block * 4;
     end = m_block * 4 + 3;
   }
@@ -457,14 +457,15 @@ std::string CGUIDialogNumeric::GetOutputString() const
   switch (m_mode)
   {
   case INPUT_DATE:
-    return StringUtils::Format("%02i/%02i/%04i", m_datetime.day, m_datetime.month, m_datetime.year);
+    return StringUtils::Format("{:02}/{:02}/{:04}", m_datetime.day, m_datetime.month,
+                               m_datetime.year);
   case INPUT_TIME:
-    return StringUtils::Format("%i:%02i", m_datetime.hour, m_datetime.minute);
+    return StringUtils::Format("{}:{:02}", m_datetime.hour, m_datetime.minute);
   case INPUT_TIME_SECONDS:
-    return StringUtils::Format("%i:%02i:%02i", m_datetime.hour, m_datetime.minute,
+    return StringUtils::Format("{}:{:02}:{:02}", m_datetime.hour, m_datetime.minute,
                                m_datetime.second);
   case INPUT_IP_ADDRESS:
-    return StringUtils::Format("%d.%d.%d.%d", m_ip[0], m_ip[1], m_ip[2], m_ip[3]);
+    return StringUtils::Format("{}.{}.{}.{}", m_ip[0], m_ip[1], m_ip[2], m_ip[3]);
   case INPUT_NUMBER:
   case INPUT_PASSWORD:
     return m_number;
@@ -604,7 +605,9 @@ int CGUIDialogNumeric::ShowAndVerifyPassword(std::string& strPassword, const std
   if (iRetries > 0)
   {
     // Show a string telling user they have iRetries retries left
-    strTempHeading = StringUtils::Format("%s. %s %i %s", strHeading.c_str(), g_localizeStrings.Get(12342).c_str(), iRetries, g_localizeStrings.Get(12343).c_str());
+    strTempHeading = StringUtils::Format("{}. {} {} {}", strHeading.c_str(),
+                                         g_localizeStrings.Get(12342).c_str(), iRetries,
+                                         g_localizeStrings.Get(12343).c_str());
   }
 
   // make a copy of strPassword to prevent from overwriting it later

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -354,8 +354,9 @@ void CGUIDialogSelect::OnInitWindow()
   }
   m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILED_LIST : CONTROL_SIMPLE_LIST);
 
-  SET_CONTROL_LABEL(CONTROL_NUMBER_OF_ITEMS, StringUtils::Format("%i %s",
-      m_vecList->Size(), g_localizeStrings.Get(127).c_str()));
+  SET_CONTROL_LABEL(
+      CONTROL_NUMBER_OF_ITEMS,
+      StringUtils::Format("{} {}", m_vecList->Size(), g_localizeStrings.Get(127).c_str()));
 
   if (m_multiSelection)
     EnableButton(true, 186);

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -175,7 +175,7 @@ bool CFavouritesService::IsFavourited(const CFileItem& item, int contextWindow) 
 
 std::string CFavouritesService::GetExecutePath(const CFileItem &item, int contextWindow) const
 {
-  return GetExecutePath(item, StringUtils::Format("%i", contextWindow));
+  return GetExecutePath(item, StringUtils::Format("{}", contextWindow));
 }
 
 std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std::string &contextWindow) const
@@ -190,31 +190,38 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
                                 !(item.IsSmartPlayList() || item.IsPlayList())))
   {
     if (!contextWindow.empty())
-      execute = StringUtils::Format("ActivateWindow(%s,%s,return)", contextWindow.c_str(), StringUtils::Paramify(item.GetPath()).c_str());
+      execute = StringUtils::Format("ActivateWindow({},{},return)", contextWindow.c_str(),
+                                    StringUtils::Paramify(item.GetPath()).c_str());
   }
   //! @todo STRING_CLEANUP
   else if (item.IsScript() && item.GetPath().size() > 9) // script://<foo>
-    execute = StringUtils::Format("RunScript(%s)", StringUtils::Paramify(item.GetPath().substr(9)).c_str());
+    execute = StringUtils::Format("RunScript({})",
+                                  StringUtils::Paramify(item.GetPath().substr(9)).c_str());
   else if (item.IsAddonsPath() && item.GetPath().size() > 9) // addons://<foo>
   {
     CURL url(item.GetPath());
     if (url.GetHostName() == "install")
       execute = "installfromzip";
     else
-      execute = StringUtils::Format("RunAddon(%s)", url.GetFileName().c_str());
+      execute = StringUtils::Format("RunAddon({})", url.GetFileName().c_str());
   }
   else if (item.IsAndroidApp() && item.GetPath().size() > 26) // androidapp://sources/apps/<foo>
-    execute = StringUtils::Format("StartAndroidActivity(%s)", StringUtils::Paramify(item.GetPath().substr(26)).c_str());
+    execute = StringUtils::Format("StartAndroidActivity({})",
+                                  StringUtils::Paramify(item.GetPath().substr(26)).c_str());
   else  // assume a media file
   {
     if (item.IsVideoDb() && item.HasVideoInfoTag())
-      execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
+      execute = StringUtils::Format(
+          "PlayMedia({})",
+          StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
     else if (item.IsMusicDb() && item.HasMusicInfoTag())
-      execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()).c_str());
+      execute = StringUtils::Format(
+          "PlayMedia({})", StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()).c_str());
     else if (item.IsPicture())
-      execute = StringUtils::Format("ShowPicture(%s)", StringUtils::Paramify(item.GetPath()).c_str());
+      execute =
+          StringUtils::Format("ShowPicture({})", StringUtils::Paramify(item.GetPath()).c_str());
     else
-      execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetPath()).c_str());
+      execute = StringUtils::Format("PlayMedia({})", StringUtils::Paramify(item.GetPath()).c_str());
   }
   return execute;
 }

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -873,7 +873,8 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
 
   std::string strLabel(addon->Name());
   if (CURL(path).GetHostName() == "search")
-    strLabel = StringUtils::Format("%s - %s", CAddonInfo::TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
+    strLabel = StringUtils::Format(
+        "{} - {}", CAddonInfo::TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
   item->SetLabel(strLabel);
   item->SetArt(addon->Art());
   item->SetArt("thumb", addon->Icon());
@@ -944,7 +945,7 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
       if (plugin && plugin->ProvidesSeveral())
       {
         CURL url(path);
-        std::string opt = StringUtils::Format("?content_type=%s", content.c_str());
+        std::string opt = StringUtils::Format("?content_type={}", content.c_str());
         url.SetOptions(opt);
         path = url.Get();
       }

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -115,7 +115,7 @@ CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const st
   std::string chap;
   CFileItemPtr item(new CFileItem("", false));
   CURL path(m_url);
-  buf = StringUtils::Format("BDMV/PLAYLIST/%05d.mpls", title->playlist);
+  buf = StringUtils::Format("BDMV/PLAYLIST/{:05}.mpls", title->playlist);
   path.SetFileName(buf);
   item->SetPath(path.Get());
   int duration = (int)(title->duration / 90000);

--- a/xbmc/filesystem/CDDADirectory.cpp
+++ b/xbmc/filesystem/CDDADirectory.cpp
@@ -54,11 +54,11 @@ bool CCDDADirectory::GetDirectory(const CURL& url, CFileItemList &items)
       continue;
 
     // Format standard cdda item label
-    std::string strLabel = StringUtils::Format("Track %2.2i", i);
+    std::string strLabel = StringUtils::Format("Track {:02}", i);
 
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->m_bIsFolder = false;
-    std::string path = StringUtils::Format("cdda://local/%2.2i.cdda", i);
+    std::string path = StringUtils::Format("cdda://local/{:02}.cdda", i);
     pItem->SetPath(path);
 
     struct __stat64 s64;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -615,8 +615,7 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
   {
     g_curlInterface.easy_setopt(h, CURLOPT_PROXYTYPE, proxyType2CUrlProxyType[m_proxytype]);
 
-    const std::string hostport = m_proxyhost +
-      StringUtils::Format(":%d", m_proxyport);
+    const std::string hostport = m_proxyhost + StringUtils::Format(":{}", m_proxyport);
     g_curlInterface.easy_setopt(h, CURLOPT_PROXY, hostport.c_str());
 
     std::string userpass;
@@ -1879,7 +1878,7 @@ void CCurlFile::SetRequestHeader(const std::string& header, const std::string& v
 
 void CCurlFile::SetRequestHeader(const std::string& header, long value)
 {
-  m_requestheaders[header] = StringUtils::Format("%ld", value);
+  m_requestheaders[header] = StringUtils::Format("{}", value);
 }
 
 std::string CCurlFile::GetURL(void)

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -159,7 +159,7 @@ void CMusicDatabaseDirectory::ClearDirectoryCache(const std::string& strDirector
 
   uint32_t crc = Crc32::ComputeFromLowerCase(path);
 
-  std::string strFileName = StringUtils::Format("special://temp/archive_cache/%08x.fi", crc);
+  std::string strFileName = StringUtils::Format("special://temp/archive_cache/{:08x}.fi", crc);
   CFile::Delete(strFileName);
 }
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -55,7 +55,7 @@ bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items) const
   for (int i=0; i<(int)albums.size(); ++i)
   {
     CAlbum& album=albums[i];
-    std::string strDir = StringUtils::Format("%s%ld/", BuildPath().c_str(), album.idAlbum);
+    std::string strDir = StringUtils::Format("{}{}/", BuildPath().c_str(), album.idAlbum);
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -55,7 +55,7 @@ bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items) const
   for (int i=0; i<(int)albums.size(); ++i)
   {
     CAlbum& album=albums[i];
-    std::string strDir = StringUtils::Format("%s%ld/", BuildPath().c_str(), album.idAlbum);
+    std::string strDir = StringUtils::Format("{}{}/", BuildPath().c_str(), album.idAlbum);
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -52,7 +52,7 @@ bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items) const
   for (int i=0; i<(int)albums.size(); ++i)
   {
     CAlbum& album=albums[i];
-    std::string strDir = StringUtils::Format("%s%ld/", BuildPath().c_str(), album.idAlbum);
+    std::string strDir = StringUtils::Format("{}{}/", BuildPath().c_str(), album.idAlbum);
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -76,7 +76,7 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
       continue;
 
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(OverviewChildren[i].label)));
-    std::string strDir = StringUtils::Format("%s/", OverviewChildren[i].id.c_str());
+    std::string strDir = StringUtils::Format("{}/", OverviewChildren[i].id.c_str());
     pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -47,7 +47,7 @@ bool CDirectoryNodeTop100::GetContent(CFileItemList& items) const
   for (const Node& node : Top100Children)
   {
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
-    std::string strDir = StringUtils::Format("%s/", node.id.c_str());
+    std::string strDir = StringUtils::Format("{}/", node.id.c_str());
     pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     items.Add(pItem);

--- a/xbmc/filesystem/MusicFileDirectory.cpp
+++ b/xbmc/filesystem/MusicFileDirectory.cpp
@@ -35,9 +35,11 @@ bool CMusicFileDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   for (int i=0; i<iStreams; ++i)
   {
-    std::string strLabel = StringUtils::Format("%s - %s %2.2i", strFileName.c_str(), g_localizeStrings.Get(554).c_str(), i+1);
+    std::string strLabel = StringUtils::Format("{} - {} {:02}", strFileName.c_str(),
+                                               g_localizeStrings.Get(554).c_str(), i + 1);
     CFileItemPtr pItem(new CFileItem(strLabel));
-    strLabel = StringUtils::Format("%s%s-%i.%s", strPath.c_str(), strFileName.c_str(), i+1, m_strExt.c_str());
+    strLabel = StringUtils::Format("{}{}-{}.{}", strPath.c_str(), strFileName.c_str(), i + 1,
+                                   m_strExt.c_str());
     pItem->SetPath(strLabel);
 
     /*

--- a/xbmc/filesystem/PipesManager.cpp
+++ b/xbmc/filesystem/PipesManager.cpp
@@ -265,7 +265,7 @@ PipesManager &PipesManager::GetInstance()
 std::string   PipesManager::GetUniquePipeName()
 {
   CSingleLock lock(m_lock);
-  return StringUtils::Format("pipe://%d/", m_nGenIdHelper++);
+  return StringUtils::Format("pipe://{}/", m_nGenIdHelper++);
 }
 
 XFILE::Pipe *PipesManager::CreatePipe(const std::string &name, int nMaxPipeSize)

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -119,7 +119,7 @@ void CVideoDatabaseDirectory::ClearDirectoryCache(const std::string& strDirector
 
   uint32_t crc = Crc32::ComputeFromLowerCase(path);
 
-  std::string strFileName = StringUtils::Format("special://temp/archive_cache/%08x.fi", crc);
+  std::string strFileName = StringUtils::Format("special://temp/archive_cache/{:08x}.fi", crc);
   CFile::Delete(strFileName);
 }
 
@@ -166,7 +166,7 @@ bool CVideoDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
   // get year
   if (params.GetYear() != -1)
   {
-    std::string strTemp = StringUtils::Format("%li",params.GetYear());
+    std::string strTemp = StringUtils::Format("{}", params.GetYear());
     if (!strLabel.empty())
       strLabel += " / ";
     strLabel += strTemp;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -67,7 +67,7 @@ bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
     }
 
     CVideoDbUrl itemUrl = videoUrl;
-    std::string strDir = StringUtils::Format("%s/", MovieChildren[i].id.c_str());
+    std::string strDir = StringUtils::Format("{}/", MovieChildren[i].id.c_str());
     itemUrl.AppendPath(strDir);
 
     CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), true));

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -60,7 +60,7 @@ bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
 
     CVideoDbUrl itemUrl = videoUrl;
-    std::string strDir = StringUtils::Format("%s/", node.id.c_str());
+    std::string strDir = StringUtils::Format("{}/", node.id.c_str());
     itemUrl.AppendPath(strDir);
     pItem->SetPath(itemUrl.ToString());
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -61,7 +61,7 @@ bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
 
     CVideoDbUrl itemUrl = videoUrl;
-    std::string strDir = StringUtils::Format("%s/", node.id.c_str());
+    std::string strDir = StringUtils::Format("{}/", node.id.c_str());
     itemUrl.AppendPath(strDir);
     pItem->SetPath(itemUrl.ToString());
 

--- a/xbmc/filesystem/test/TestFileFactory.cpp
+++ b/xbmc/filesystem/test/TestFileFactory.cpp
@@ -74,12 +74,12 @@ TEST_F(TestFileFactory, Read)
     std::cout << "File contents:" << std::endl;
     while ((size = file.Read(buf, sizeof(buf))) > 0)
     {
-      str = StringUtils::Format("  %08llX", count);
+      str = StringUtils::Format("  {:08X}", count);
       std::cout << str << "  ";
       count += size;
       for (i = 0; i < size; i++)
       {
-        str = StringUtils::Format("%02X ", buf[i]);
+        str = StringUtils::Format("{:02X} ", buf[i]);
         std::cout << str;
       }
       while (i++ < static_cast<ssize_t> (sizeof(buf)))
@@ -135,12 +135,12 @@ TEST_F(TestFileFactory, Write)
     std::cout << "File contents:\n";
     while ((size = file.Read(buf, sizeof(buf))) > 0)
     {
-      str = StringUtils::Format("  %08llX", count);
+      str = StringUtils::Format("  {:08X}", count);
       std::cout << str << "  ";
       count += size;
       for (i = 0; i < size; i++)
       {
-        str = StringUtils::Format("%02X ", buf[i]);
+        str = StringUtils::Format("{:02X} ", buf[i]);
         std::cout << str;
       }
       while (i++ < sizeof(buf))

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -72,7 +72,7 @@ protected:
     std::uniform_int_distribution<uint16_t> dist(49152, 65535);
     m_webServerPort = dist(mt);
 
-    m_baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":%u", m_webServerPort);
+    m_baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", m_webServerPort);
   }
 
   ~TestHTTPDirectory() override = default;

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -169,12 +169,12 @@ TEST_F(TestZipFile, CorruptedFile)
   std::cout << "File contents:" << std::endl;
   while ((size = file->Read(buf, sizeof(buf))) > 0)
   {
-    str = StringUtils::Format("  %08llX", count);
+    str = StringUtils::Format("  {:08X}", count);
     std::cout << str << "  ";
     count += size;
     for (i = 0; i < size; i++)
     {
-      str = StringUtils::Format("%02X ", buf[i]);
+      str = StringUtils::Format("{:02X} ", buf[i]);
       std::cout << str;
     }
     while (i++ < static_cast<ssize_t> (sizeof(buf)))

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -69,7 +69,7 @@ void CGUIAction::SetNavigation(int id)
   if (id == 0)
     return;
 
-  std::string strId = StringUtils::Format("%i", id);
+  std::string strId = StringUtils::Format("{}", id);
   for (auto &i : m_actions)
   {
     if (StringUtils::IsInteger(i.action) && i.condition.empty())

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -845,7 +845,7 @@ std::string CGUIBaseContainer::GetDescription() const
   {
     CGUIListItemPtr pItem = m_items[item];
     if (pItem->m_bIsFolder)
-      strLabel = StringUtils::Format("[%s]", pItem->GetLabel().c_str());
+      strLabel = StringUtils::Format("[{}]", pItem->GetLabel().c_str());
     else
       strLabel = pItem->GetLabel();
   }
@@ -1334,20 +1334,20 @@ std::string CGUIBaseContainer::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_NUM_PAGES:
-    label = StringUtils::Format("%u", (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage);
+    label = StringUtils::Format("{}", (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage);
     break;
   case CONTAINER_CURRENT_PAGE:
-    label = StringUtils::Format("%u", GetCurrentPage());
+    label = StringUtils::Format("{}", GetCurrentPage());
     break;
   case CONTAINER_POSITION:
-    label = StringUtils::Format("%i", GetCursor());
+    label = StringUtils::Format("{}", GetCursor());
     break;
   case CONTAINER_CURRENT_ITEM:
     {
       if (m_items.size() && m_items[0]->IsFileItem() && (std::static_pointer_cast<CFileItem>(m_items[0]))->IsParentFolder())
-        label = StringUtils::Format("%i", GetSelectedItem());
+        label = StringUtils::Format("{}", GetSelectedItem());
       else
-        label = StringUtils::Format("%i", GetSelectedItem() + 1);
+        label = StringUtils::Format("{}", GetSelectedItem() + 1);
     }
     break;
   case CONTAINER_NUM_ALL_ITEMS:
@@ -1355,9 +1355,9 @@ std::string CGUIBaseContainer::GetLabel(int info) const
     {
       unsigned int numItems = GetNumItems();
       if (info == CONTAINER_NUM_ITEMS && numItems && m_items[0]->IsFileItem() && (std::static_pointer_cast<CFileItem>(m_items[0]))->IsParentFolder())
-        label = StringUtils::Format("%u", numItems-1);
+        label = StringUtils::Format("{}", numItems - 1);
       else
-        label = StringUtils::Format("%u", numItems);
+        label = StringUtils::Format("{}", numItems);
     }
     break;
   case CONTAINER_NUM_NONFOLDER_ITEMS:
@@ -1368,7 +1368,7 @@ std::string CGUIBaseContainer::GetLabel(int info) const
         if (!item->m_bIsFolder)
           numItems++;
       }
-      label = StringUtils::Format("%u", numItems);
+      label = StringUtils::Format("{}", numItems);
     }
     break;
   default:

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -594,7 +594,7 @@ void CGUIControlFactory::GetInfoLabels(const TiXmlNode *pControlNode, const std:
   int labelNumber = 0;
   if (XMLUtils::GetInt(pControlNode, "number", labelNumber))
   {
-    std::string label = StringUtils::Format("%i", labelNumber);
+    std::string label = StringUtils::Format("{}", labelNumber);
     infoLabels.emplace_back(label);
     return; // done
   }
@@ -617,7 +617,7 @@ void CGUIControlFactory::GetInfoLabels(const TiXmlNode *pControlNode, const std:
     {
       if (infoNode->FirstChild())
       {
-        std::string info = StringUtils::Format("$INFO[%s]", infoNode->FirstChild()->Value());
+        std::string info = StringUtils::Format("$INFO[{}]", infoNode->FirstChild()->Value());
         infoLabels.emplace_back(info, fallback, parentID);
       }
       infoNode = infoNode->NextSibling("info");

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -445,11 +445,11 @@ std::string CGUIControlGroupList::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_CURRENT_ITEM:
-    return StringUtils::Format("%i", GetSelectedItem());
+    return StringUtils::Format("{}", GetSelectedItem());
   case CONTAINER_NUM_ITEMS:
-    return StringUtils::Format("%i", GetNumItems());
+    return StringUtils::Format("{}", GetNumItems());
   case CONTAINER_POSITION:
-    return StringUtils::Format("%i", m_focusedPosition);
+    return StringUtils::Format("{}", m_focusedPosition);
   default:
     break;
   }

--- a/xbmc/guilib/GUIControlProfiler.cpp
+++ b/xbmc/guilib/GUIControlProfiler.cpp
@@ -145,14 +145,14 @@ void CGUIControlProfilerItem::SaveToXML(TiXmlElement *parent)
     xmlControl->SetAttribute("type", lpszType);
   if (m_controlID != 0)
   {
-    std::string str = StringUtils::Format("%u", m_controlID);
+    std::string str = StringUtils::Format("{}", m_controlID);
     xmlControl->SetAttribute("id", str.c_str());
   }
 
   float pct = (float)GetTotalTime() / (float)m_pProfiler->GetTotalTime();
   if (pct > 0.01f)
   {
-    std::string str = StringUtils::Format("%.0f", pct * 100.0f);
+    std::string str = StringUtils::Format("{:.0f}", pct * 100.0f);
     xmlControl->SetAttribute("percent", str.c_str());
   }
 
@@ -172,13 +172,13 @@ void CGUIControlProfilerItem::SaveToXML(TiXmlElement *parent)
     std::string val;
     TiXmlElement *elem = new TiXmlElement("rendertime");
     xmlControl->LinkEndChild(elem);
-    val = StringUtils::Format("%u", rend);
+    val = StringUtils::Format("{}", rend);
     TiXmlText *text = new TiXmlText(val.c_str());
     elem->LinkEndChild(text);
 
     elem = new TiXmlElement("visibletime");
     xmlControl->LinkEndChild(elem);
-    val = StringUtils::Format("%u", vis);
+    val = StringUtils::Format("{}", vis);
     text = new TiXmlText(val.c_str());
     elem->LinkEndChild(text);
   }
@@ -324,7 +324,7 @@ bool CGUIControlProfiler::SaveResults(void)
   doc.InsertEndChild(decl);
 
   TiXmlElement *root = new TiXmlElement("guicontrolprofiler");
-  std::string str = StringUtils::Format("%d", m_iFrameCount);
+  std::string str = StringUtils::Format("{}", m_iFrameCount);
   root->SetAttribute("framecount", str.c_str());
   root->SetAttribute("timeunit", "ms");
   doc.LinkEndChild(root);

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -132,7 +132,8 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName, const std::str
   }
 
   // check if we already have this font file loaded (font object could differ only by color or style)
-  std::string TTFfontName = StringUtils::Format("%s_%f_%f%s", strFilename.c_str(), newSize, aspect, border ? "_border" : "");
+  std::string TTFfontName = StringUtils::Format("{}_{:f}_{:f}{}", strFilename.c_str(), newSize,
+                                                aspect, border ? "_border" : "");
 
   CGUIFontTTF* pFontFile = GetFontFile(TTFfontName);
   if (!pFontFile)
@@ -225,7 +226,8 @@ void GUIFontManager::ReloadTTFFonts(void)
 
     RescaleFontSizeAndAspect(&newSize, &aspect, fontInfo.sourceRes, fontInfo.preserveAspect);
 
-    std::string TTFfontName = StringUtils::Format("%s_%f_%f%s", strFilename.c_str(), newSize, aspect, fontInfo.border ? "_border" : "");
+    std::string TTFfontName = StringUtils::Format("{}_{:f}_{:f}{}", strFilename.c_str(), newSize,
+                                                  aspect, fontInfo.border ? "_border" : "");
     CGUIFontTTF* pFontFile = GetFontFile(TTFfontName);
     if (!pFontFile)
     {

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -207,10 +207,12 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(std::string& strPassword, const s
   if (1 > iRetries && strHeading.size())
     strHeadingTemp = strHeading;
   else
-    strHeadingTemp = StringUtils::Format("%s - %i %s",
-                                         g_localizeStrings.Get(12326).c_str(),
-                                         CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES) - iRetries,
-                                         g_localizeStrings.Get(12343).c_str());
+    strHeadingTemp =
+        StringUtils::Format("{} - {} {}", g_localizeStrings.Get(12326).c_str(),
+                            CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                CSettings::SETTING_MASTERLOCK_MAXRETRIES) -
+                                iRetries,
+                            g_localizeStrings.Get(12343).c_str());
 
   std::string strUserInput;
   //! @todo GUI Setting to enable disable this feature y/n?

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -275,7 +275,7 @@ CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, fl
 {
   m_layouts.emplace_back();
   m_layouts.back().CreateListControlLayouts(width, textureHeight + spaceBetweenItems, false, labelInfo, labelInfo2, textureButton, textureButtonFocus, textureHeight, itemWidth, itemHeight, "", "");
-  std::string condition = StringUtils::Format("control.hasfocus(%i)", controlID);
+  std::string condition = StringUtils::Format("control.hasfocus({})", controlID);
   std::string condition2 = "!" + condition;
   m_focusedLayouts.emplace_back();
   m_focusedLayouts.back().CreateListControlLayouts(width, textureHeight + spaceBetweenItems, true, labelInfo, labelInfo2, textureButton, textureButtonFocus, textureHeight, itemWidth, itemHeight, condition2, condition);

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -521,9 +521,9 @@ std::string CGUIPanelContainer::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_ROW:
-    return StringUtils::Format("%i", row);
+    return StringUtils::Format("{}", row);
   case CONTAINER_COLUMN:
-    return StringUtils::Format("%i", col);
+    return StringUtils::Format("{}", col);
   default:
     return CGUIBaseContainer::GetLabel(info);
   }

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -372,7 +372,7 @@ EVENT_RESULT GUIScrollBarControl::OnMouseEvent(const CPoint &point, const CMouse
 
 std::string GUIScrollBarControl::GetDescription() const
 {
-  return StringUtils::Format("%i/%i", m_offset, m_numItems);
+  return StringUtils::Format("{}/{}", m_offset, m_numItems);
 }
 
 bool GUIScrollBarControl::UpdateColors()

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -717,23 +717,24 @@ std::string CGUISliderControl::GetDescription() const
   if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
   {
     if (m_rangeSelection)
-      description = StringUtils::Format("[%2.2f, %2.2f]", m_floatValues[0], m_floatValues[1]);
+      description = StringUtils::Format("[{:2.2f}, {:2.2f}]", m_floatValues[0], m_floatValues[1]);
     else
-      description = StringUtils::Format("%2.2f", m_floatValues[0]);
+      description = StringUtils::Format("{:2.2f}", m_floatValues[0]);
   }
   else if (m_iType == SLIDER_CONTROL_TYPE_INT)
   {
     if (m_rangeSelection)
-      description = StringUtils::Format("[%i, %i]", m_intValues[0], m_intValues[1]);
+      description = StringUtils::Format("[{}, {}]", m_intValues[0], m_intValues[1]);
     else
-      description = StringUtils::Format("%i", m_intValues[0]);
+      description = StringUtils::Format("{}", m_intValues[0]);
   }
   else
   {
     if (m_rangeSelection)
-      description = StringUtils::Format("[%i%%, %i%%]", MathUtils::round_int(m_percentValues[0]), MathUtils::round_int(m_percentValues[1]));
+      description = StringUtils::Format("[{}%, {}%]", MathUtils::round_int(m_percentValues[0]),
+                                        MathUtils::round_int(m_percentValues[1]));
     else
-      description = StringUtils::Format("%i%%", MathUtils::round_int(m_percentValues[0]));
+      description = StringUtils::Format("{}%", MathUtils::round_int(m_percentValues[0]));
   }
   return description;
 }

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -422,11 +422,11 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
   {
     if (m_bShowRange)
     {
-      text = StringUtils::Format("%i/%i", m_iValue, m_iEnd);
+      text = StringUtils::Format("{}/{}", m_iValue, m_iEnd);
     }
     else
     {
-      text = StringUtils::Format("%i", m_iValue);
+      text = StringUtils::Format("{}", m_iValue);
     }
   }
   else if (m_iType == SPIN_CONTROL_TYPE_PAGE)
@@ -436,17 +436,17 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
     int currentPage = m_currentItem / m_itemsPerPage + 1;
     if (m_currentItem >= m_numItems - m_itemsPerPage)
       currentPage = numPages;
-    text = StringUtils::Format("%i/%i", currentPage, numPages);
+    text = StringUtils::Format("{}/{}", currentPage, numPages);
   }
   else if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
   {
     if (m_bShowRange)
     {
-      text = StringUtils::Format("%02.2f/%02.2f", m_fValue, m_fEnd);
+      text = StringUtils::Format("{:02.2f}/{:02.2f}", m_fValue, m_fEnd);
     }
     else
     {
-      text = StringUtils::Format("%02.2f", m_fValue);
+      text = StringUtils::Format("{:02.2f}", m_fValue);
     }
   }
   else
@@ -455,15 +455,16 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
     {
       if (m_bShowRange)
       {
-        text = StringUtils::Format("(%i/%i) %s", m_iValue + 1, (int)m_vecLabels.size(), m_vecLabels[m_iValue].c_str() );
+        text = StringUtils::Format("({}/{}) {}", m_iValue + 1, (int)m_vecLabels.size(),
+                                   m_vecLabels[m_iValue].c_str());
       }
       else
       {
-        text = StringUtils::Format("%s", m_vecLabels[m_iValue].c_str() );
+        text = StringUtils::Format("{}", m_vecLabels[m_iValue].c_str());
       }
     }
-    else text = StringUtils::Format("?%i?", m_iValue);
-
+    else
+      text = StringUtils::Format("?{}?", m_iValue);
   }
 
   changed |= m_label.SetText(text);
@@ -1030,7 +1031,7 @@ EVENT_RESULT CGUISpinControl::OnMouseEvent(const CPoint &point, const CMouseEven
 
 std::string CGUISpinControl::GetDescription() const
 {
-  return StringUtils::Format("%i/%i", 1 + GetValue(), GetMaximum());
+  return StringUtils::Format("{}/{}", 1 + GetValue(), GetMaximum());
 }
 
 bool CGUISpinControl::IsFocusedOnUp() const

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -111,7 +111,8 @@ const std::string CGUISpinControlEx::GetCurrentLabel() const
 
 std::string CGUISpinControlEx::GetDescription() const
 {
-  return StringUtils::Format("%s (%s)", m_buttonControl.GetDescription().c_str(), GetLabel().c_str());
+  return StringUtils::Format("{} ({})", m_buttonControl.GetDescription().c_str(),
+                             GetLabel().c_str());
 }
 
 void CGUISpinControlEx::SetItemInvalid(bool invalid)

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -410,10 +410,10 @@ std::string CGUITextBox::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_NUM_PAGES:
-    label = StringUtils::Format("%u", GetNumPages());
+    label = StringUtils::Format("{}", GetNumPages());
     break;
   case CONTAINER_CURRENT_PAGE:
-    label = StringUtils::Format("%u", GetCurrentPage());
+    label = StringUtils::Format("{}", GetCurrentPage());
     break;
   default:
     break;

--- a/xbmc/guilib/Shader.cpp
+++ b/xbmc/guilib/Shader.cpp
@@ -121,7 +121,7 @@ std::string CShader::GetSourceWithLineNumbers() const
   auto lines = StringUtils::Split(m_source, "\n");
   for (auto& line : lines)
   {
-    line.insert(0, StringUtils::Format("%3d: ", i));
+    line.insert(0, StringUtils::Format("{:3}: ", i));
     i++;
   }
 

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -105,7 +105,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
           }
           else if (info.m_info == CONTAINER_VIEWCOUNT)
           {
-            value = StringUtils::Format("%i", window->GetViewCount());
+            value = StringUtils::Format("{}", window->GetViewCount());
             return true;
           }
         }
@@ -223,7 +223,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
         }
         else if (info.m_info == CONTAINER_TOTALWATCHED || info.m_info == CONTAINER_TOTALUNWATCHED)
         {
-          value = StringUtils::Format("%i", count);
+          value = StringUtils::Format("{}", count);
           return true;
         }
       }
@@ -316,7 +316,9 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
       value = g_localizeStrings.Get(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
       return true;
     case SYSTEM_STARTUP_WINDOW:
-      value = StringUtils::Format("%i", CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_LOOKANDFEEL_STARTUPWINDOW));
+      value =
+          StringUtils::Format("{}", CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                        CSettings::SETTING_LOOKANDFEEL_STARTUPWINDOW));
       return true;
     case SYSTEM_CURRENT_CONTROL:
     case SYSTEM_CURRENT_CONTROL_ID:
@@ -328,7 +330,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
         if (control)
         {
           if (info.m_info == SYSTEM_CURRENT_CONTROL_ID)
-            value = StringUtils::Format("%i", control->GetID());
+            value = StringUtils::Format("{}", control->GetID());
           else if (info.m_info == SYSTEM_CURRENT_CONTROL)
             value = control->GetDescription();
           return true;
@@ -340,7 +342,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     {
       CGUIDialogProgress *bar = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
       if (bar && bar->IsDialogRunning())
-        value = StringUtils::Format("%i", bar->GetPercentage());
+        value = StringUtils::Format("{}", bar->GetPercentage());
       return true;
     }
 

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -43,13 +43,13 @@ std::string GetPlaylistLabel(int item, int playlistid /* = PLAYLIST_NONE */)
   {
     case PLAYLIST_LENGTH:
     {
-      return StringUtils::Format("%i", player.GetPlaylist(iPlaylist).size());
+      return StringUtils::Format("{}", player.GetPlaylist(iPlaylist).size());
     }
     case PLAYLIST_POSITION:
     {
       int currentSong = player.GetCurrentSong();
       if (currentSong > -1)
-        return StringUtils::Format("%i", currentSong + 1);
+        return StringUtils::Format("{}", currentSong + 1);
       break;
     }
     case PLAYLIST_RANDOM:

--- a/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
@@ -66,7 +66,7 @@ bool CGamesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     case RETROPLAYER_VIDEO_ROTATION:
     {
       const unsigned int rotationDegCCW = CMediaSettings::GetInstance().GetCurrentGameSettings().RotationDegCCW();
-      value = StringUtils::Format("%u", rotationDegCCW);
+      value = StringUtils::Format("{}", rotationDegCCW);
       return true;
     }
     default:

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -106,7 +106,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_PLAYCOUNT:
         if (tag->GetPlayCount() > 0)
         {
-          value = StringUtils::Format("%i", tag->GetPlayCount());
+          value = StringUtils::Format("{}", tag->GetPlayCount());
           return true;
         }
         break;
@@ -125,7 +125,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_TRACKNUMBER:
         if (tag->Loaded() && tag->GetTrackNumber() > 0)
         {
-          value = StringUtils::Format("%02i", tag->GetTrackNumber());
+          value = StringUtils::Format("{:02}", tag->GetTrackNumber());
           return true;
         }
         break;
@@ -133,13 +133,13 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_DISC_NUMBER:
         if (tag->GetDiscNumber() > 0)
         {
-          value = StringUtils::Format("%i", tag->GetDiscNumber());
+          value = StringUtils::Format("{}", tag->GetDiscNumber());
           return true;
         }
         break;
       case MUSICPLAYER_TOTALDISCS:
       case LISTITEM_TOTALDISCS:
-        value = StringUtils::Format("%i", tag->GetTotalDiscs());
+        value = StringUtils::Format("{}", tag->GetTotalDiscs());
         return true;
       case MUSICPLAYER_DISC_TITLE:
       case LISTITEM_DISC_TITLE:
@@ -216,7 +216,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_USER_RATING:
         if (tag->GetUserrating() > 0)
         {
-          value = StringUtils::Format("%i", tag->GetUserrating());
+          value = StringUtils::Format("{}", tag->GetUserrating());
           return true;
         }
         break;
@@ -237,7 +237,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int dbId = tag->GetDatabaseId();
         if (dbId > -1)
         {
-          value = StringUtils::Format("%i", dbId);
+          value = StringUtils::Format("{}", dbId);
           return true;
         }
         break;
@@ -264,7 +264,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_BPM:
         if (tag->GetBPM() > 0)
         {
-          value = StringUtils::Format("%i", tag->GetBPM());
+          value = StringUtils::Format("{}", tag->GetBPM());
           return true;
         }
         break;
@@ -317,7 +317,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int BitRate = tag->GetBitRate();
         if (BitRate > 0)
         {
-          value = StringUtils::Format("%i", BitRate);
+          value = StringUtils::Format("{}", BitRate);
           return true;
         }
         break;
@@ -327,7 +327,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int sampleRate = tag->GetSampleRate();
         if (sampleRate > 0)
         {
-          value = StringUtils::Format("%.5g", static_cast<double>(sampleRate) / 1000.0);
+          value = StringUtils::Format("{:.5}", static_cast<double>(sampleRate) / 1000.0);
           return true;
         }
         break;
@@ -337,7 +337,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int channels = tag->GetNoOfChannels();
         if (channels > 0)
         {
-          value = StringUtils::Format("%i", channels);
+          value = StringUtils::Format("{}", channels);
           return true;
         }
         break;
@@ -434,7 +434,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBitrate = m_audioInfo.bitrate;
       if (iBitrate > 0)
       {
-        value = StringUtils::Format("%li", std::lrint(static_cast<double>(iBitrate) / 1000.0));
+        value = StringUtils::Format("{}", std::lrint(static_cast<double>(iBitrate) / 1000.0));
         return true;
       }
       break;
@@ -444,7 +444,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iChannels = m_audioInfo.channels;
       if (iChannels > 0)
       {
-        value = StringUtils::Format("%i", iChannels);
+        value = StringUtils::Format("{}", iChannels);
         return true;
       }
       break;
@@ -454,7 +454,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBPS = m_audioInfo.bitspersample;
       if (iBPS > 0)
       {
-        value = StringUtils::Format("%i", iBPS);
+        value = StringUtils::Format("{}", iBPS);
         return true;
       }
       break;
@@ -464,13 +464,13 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iSamplerate = m_audioInfo.samplerate;
       if (iSamplerate > 0)
       {
-        value = StringUtils::Format("%.5g", static_cast<double>(iSamplerate) / 1000.0);
+        value = StringUtils::Format("{:.5}", static_cast<double>(iSamplerate) / 1000.0);
         return true;
       }
       break;
     }
     case MUSICPLAYER_CODEC:
-      value = StringUtils::Format("%s", m_audioInfo.codecName.c_str());
+      value = StringUtils::Format("{}", m_audioInfo.codecName.c_str());
       return true;
   }
 
@@ -511,7 +511,7 @@ bool CMusicGUIInfo::GetPartyModeLabel(std::string& value, const CGUIInfo &info) 
 
   if (iSongs >= 0)
   {
-    value = StringUtils::Format("%i", iSongs);
+    value = StringUtils::Format("{}", iSongs);
     return true;
   }
 
@@ -553,7 +553,7 @@ bool CMusicGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo &info) co
   }
   if (info.m_info == MUSICPLAYER_PLAYLISTPOS)
   {
-    value = StringUtils::Format("%i", index + 1);
+    value = StringUtils::Format("{}", index + 1);
     return true;
   }
   else if (info.m_info == MUSICPLAYER_COVER)

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -180,7 +180,7 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
         CGUIWindowSlideShow *slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
         if (slideshow && slideshow->NumSlides())
         {
-          value = StringUtils::Format("%d/%d", slideshow->CurrentSlide(), slideshow->NumSlides());
+          value = StringUtils::Format("{}/{}", slideshow->CurrentSlide(), slideshow->NumSlides());
           return true;
         }
         break;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -189,19 +189,22 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       value = std::to_string(std::lrintf(g_application.GetCachePercentage()));
       return true;
     case PLAYER_VOLUME:
-      value = StringUtils::Format("%2.1f dB", CAEUtil::PercentToGain(g_application.GetVolumeRatio()));
+      value =
+          StringUtils::Format("{:2.1f} dB", CAEUtil::PercentToGain(g_application.GetVolumeRatio()));
       return true;
     case PLAYER_SUBTITLE_DELAY:
-      value = StringUtils::Format("%2.3f s", g_application.GetAppPlayer().GetVideoSettings().m_SubtitleDelay);
+      value = StringUtils::Format("{:2.3f} s",
+                                  g_application.GetAppPlayer().GetVideoSettings().m_SubtitleDelay);
       return true;
     case PLAYER_AUDIO_DELAY:
-      value = StringUtils::Format("%2.3f s", g_application.GetAppPlayer().GetVideoSettings().m_AudioDelay);
+      value = StringUtils::Format("{:2.3f} s",
+                                  g_application.GetAppPlayer().GetVideoSettings().m_AudioDelay);
       return true;
     case PLAYER_CHAPTER:
-      value = StringUtils::Format("%02d", g_application.GetAppPlayer().GetChapter());
+      value = StringUtils::Format("{:02}", g_application.GetAppPlayer().GetChapter());
       return true;
     case PLAYER_CHAPTERCOUNT:
-      value = StringUtils::Format("%02d", g_application.GetAppPlayer().GetChapterCount());
+      value = StringUtils::Format("{:02}", g_application.GetAppPlayer().GetChapterCount());
       return true;
     case PLAYER_CHAPTERNAME:
       g_application.GetAppPlayer().GetChapterName(value);
@@ -222,7 +225,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       float speed = g_application.GetAppPlayer().GetPlaySpeed();
       if (speed == 1.0)
         speed = g_application.GetAppPlayer().GetPlayTempo();
-      value = StringUtils::Format("%.2f", speed);
+      value = StringUtils::Format("{:.2f}", speed);
       return true;
     }
     case PLAYER_TIME:
@@ -256,7 +259,9 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     {
       float speed = g_application.GetAppPlayer().GetPlaySpeed();
       if (speed != 1.0)
-        value = StringUtils::Format("%s (%ix)", GetCurrentPlayTime(static_cast<TIME_FORMAT>(info.GetData1())).c_str(), static_cast<int>(speed));
+        value = StringUtils::Format(
+            "{} ({}x)", GetCurrentPlayTime(static_cast<TIME_FORMAT>(info.GetData1())).c_str(),
+            static_cast<int>(speed));
       else
         value = GetCurrentPlayTime(TIME_FORMAT_GUESS);
       return true;
@@ -282,7 +287,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       int iLevel = g_application.GetAppPlayer().GetCacheLevel();
       if (iLevel >= 0)
       {
-        value = StringUtils::Format("%i", iLevel);
+        value = StringUtils::Format("{}", iLevel);
         return true;
       }
       break;
@@ -315,10 +320,10 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       value = CServiceBroker::GetDataCacheCore().GetVideoPixelFormat();
       return true;
     case PLAYER_PROCESS_VIDEOFPS:
-      value = StringUtils::Format("%.3f", CServiceBroker::GetDataCacheCore().GetVideoFps());
+      value = StringUtils::Format("{:.3f}", CServiceBroker::GetDataCacheCore().GetVideoFps());
       return true;
     case PLAYER_PROCESS_VIDEODAR:
-      value = StringUtils::Format("%.2f", CServiceBroker::GetDataCacheCore().GetVideoDAR());
+      value = StringUtils::Format("{:.2f}", CServiceBroker::GetDataCacheCore().GetVideoDAR());
       return true;
     case PLAYER_PROCESS_VIDEOWIDTH:
       value = StringUtils::FormatNumber(CServiceBroker::GetDataCacheCore().GetVideoWidth());
@@ -626,7 +631,7 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
 
     // create csv string from ranges
     for (const auto& range : ranges)
-      values += StringUtils::Format("%.5f,%.5f,", range.first, range.second);
+      values += StringUtils::Format("{:.5f},{:.5f},", range.first, range.second);
 
     if (!values.empty())
       values.pop_back(); // remove trailing comma

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -68,12 +68,12 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
     case SYSTEM_GPU_TEMPERATURE:
       return m_gpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_gpuTemp) : g_localizeStrings.Get(10005);
     case SYSTEM_FAN_SPEED:
-      text = StringUtils::Format("%i%%", m_fanSpeed * 2);
+      text = StringUtils::Format("{}%", m_fanSpeed * 2);
       break;
     case SYSTEM_CPU_USAGE:
       if (CServiceBroker::GetCPUInfo()->SupportsCPUUsage())
 #if defined(TARGET_DARWIN) || defined(TARGET_WINDOWS)
-        text = StringUtils::Format("%d%%", CServiceBroker::GetCPUInfo()->GetUsedPercentage());
+        text = StringUtils::Format("{}%", CServiceBroker::GetCPUInfo()->GetUsedPercentage());
 #else
         text = CServiceBroker::GetCPUInfo()->GetCoresUsageString();
 #endif
@@ -182,10 +182,11 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     {
       RESOLUTION_INFO& resInfo = CDisplaySettings::GetInstance().GetCurrentResolutionInfo();
       if (CServiceBroker::GetWinSystem()->IsFullScreen())
-        value = StringUtils::Format("%ix%i@%.2fHz - %s", resInfo.iScreenWidth, resInfo.iScreenHeight, resInfo.fRefreshRate,
-                                    g_localizeStrings.Get(244).c_str());
+        value =
+            StringUtils::Format("{}x{}@{:.2f}Hz - {}", resInfo.iScreenWidth, resInfo.iScreenHeight,
+                                resInfo.fRefreshRate, g_localizeStrings.Get(244).c_str());
       else
-        value = StringUtils::Format("%ix%i - %s", resInfo.iScreenWidth, resInfo.iScreenHeight,
+        value = StringUtils::Format("{}x{} - {}", resInfo.iScreenWidth, resInfo.iScreenHeight,
                                     g_localizeStrings.Get(242).c_str());
       return true;
     }
@@ -216,28 +217,31 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       int iMemPercentUsed = 100 - iMemPercentFree;
 
       if (info.m_info == SYSTEM_FREE_MEMORY)
-        value = StringUtils::Format("%uMB", static_cast<unsigned int>(stat.availPhys / MB));
+        value = StringUtils::Format("{}MB", static_cast<unsigned int>(stat.availPhys / MB));
       else if (info.m_info == SYSTEM_FREE_MEMORY_PERCENT)
-        value = StringUtils::Format("%i%%", iMemPercentFree);
+        value = StringUtils::Format("{}%", iMemPercentFree);
       else if (info.m_info == SYSTEM_USED_MEMORY)
-        value = StringUtils::Format("%uMB", static_cast<unsigned int>((stat.totalPhys - stat.availPhys) / MB));
+        value = StringUtils::Format(
+            "{}MB", static_cast<unsigned int>((stat.totalPhys - stat.availPhys) / MB));
       else if (info.m_info == SYSTEM_USED_MEMORY_PERCENT)
-        value = StringUtils::Format("%i%%", iMemPercentUsed);
+        value = StringUtils::Format("{}%", iMemPercentUsed);
       else if (info.m_info == SYSTEM_TOTAL_MEMORY)
-        value = StringUtils::Format("%uMB", static_cast<unsigned int>(stat.totalPhys / MB));
+        value = StringUtils::Format("{}MB", static_cast<unsigned int>(stat.totalPhys / MB));
       return true;
     }
     case SYSTEM_SCREEN_MODE:
       value = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo().strMode;
       return true;
     case SYSTEM_SCREEN_WIDTH:
-      value = StringUtils::Format("%i", CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo().iScreenWidth);
+      value = StringUtils::Format(
+          "{}", CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo().iScreenWidth);
       return true;
     case SYSTEM_SCREEN_HEIGHT:
-      value = StringUtils::Format("%i", CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo().iScreenHeight);
+      value = StringUtils::Format(
+          "{}", CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo().iScreenHeight);
       return true;
     case SYSTEM_FPS:
-      value = StringUtils::Format("%02.2f", m_fps);
+      value = StringUtils::Format("{:02.2f}", m_fps);
       return true;
 #ifdef HAS_DVD_DRIVE
     case SYSTEM_DVD_LABEL:
@@ -288,13 +292,13 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case SYSTEM_STEREOSCOPIC_MODE:
     {
       int iStereoMode = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE);
-      value = StringUtils::Format("%i", iStereoMode);
+      value = StringUtils::Format("{}", iStereoMode);
       return true;
     }
     case SYSTEM_GET_CORE_USAGE:
-      value = StringUtils::Format("%4.2f", CServiceBroker::GetCPUInfo()
-                                               ->GetCoreInfo(std::atoi(info.GetData3().c_str()))
-                                               .m_usagePercent);
+      value = StringUtils::Format("{:4.2f}", CServiceBroker::GetCPUInfo()
+                                                 ->GetCoreInfo(std::atoi(info.GetData3().c_str()))
+                                                 .m_usagePercent);
       return true;
     case SYSTEM_RENDER_VENDOR:
       value = CServiceBroker::GetRenderSystem()->GetRenderVendor();

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -140,7 +140,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_DBID:
         if (tag->m_iDbId > -1)
         {
-          value = StringUtils::Format("%i", tag->m_iDbId);
+          value = StringUtils::Format("{}", tag->m_iDbId);
           return true;
         }
         break;
@@ -148,7 +148,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_TVSHOWDBID:
         if (tag->m_iIdShow > -1)
         {
-          value = StringUtils::Format("%i", tag->m_iIdShow);
+          value = StringUtils::Format("{}", tag->m_iIdShow);
           return true;
         }
         break;
@@ -190,7 +190,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_USER_RATING:
         if (tag->m_iUserRating > 0)
         {
-          value = StringUtils::Format("%i", tag->m_iUserRating);
+          value = StringUtils::Format("{}", tag->m_iUserRating);
           return true;
         }
         break;
@@ -202,7 +202,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_YEAR:
         if (tag->HasYear())
         {
-          value = StringUtils::Format("%i", tag->GetYear());
+          value = StringUtils::Format("{}", tag->GetYear());
           return true;
         }
         break;
@@ -244,7 +244,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
 
         if (iEpisode >= 0)
         {
-          value = StringUtils::Format("%d", iEpisode);
+          value = StringUtils::Format("{}", iEpisode);
           return true;
         }
         break;
@@ -253,7 +253,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_SEASON:
         if (tag->m_iSeason >= 0)
         {
-          value = StringUtils::Format("%d", tag->m_iSeason);
+          value = StringUtils::Format("{}", tag->m_iSeason);
           return true;
         }
         break;
@@ -277,7 +277,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_TOP250:
         if (tag->m_iTop250 > 0)
         {
-          value = StringUtils::Format("%i", tag->m_iTop250);
+          value = StringUtils::Format("{}", tag->m_iTop250);
           return true;
         }
         break;
@@ -320,7 +320,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_PLAYCOUNT:
         if (tag->GetPlayCount() > 0)
         {
-          value = StringUtils::Format("%i", tag->GetPlayCount());
+          value = StringUtils::Format("{}", tag->GetPlayCount());
           return true;
         }
         break;
@@ -341,7 +341,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_TRACKNUMBER:
         if (tag->m_iTrack > -1 )
         {
-          value = StringUtils::Format("%i", tag->m_iTrack);
+          value = StringUtils::Format("{}", tag->m_iTrack);
           return true;
         }
         break;
@@ -378,7 +378,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_SETID:
         if (tag->m_set.id > 0)
         {
-          value = StringUtils::Format("%d", tag->m_set.id);
+          value = StringUtils::Format("{}", tag->m_set.id);
           return true;
         }
         break;
@@ -407,12 +407,12 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_APPEARANCES:
         if (tag->m_relevance > -1)
         {
-          value = StringUtils::Format("%i", tag->m_relevance);
+          value = StringUtils::Format("{}", tag->m_relevance);
           return true;
         }
         break;
       case LISTITEM_PERCENT_PLAYED:
-        value = StringUtils::Format("%d", GetPercentPlayed(tag));
+        value = StringUtils::Format("{}", GetPercentPlayed(tag));
         return true;
       case LISTITEM_VIDEO_CODEC:
         value = tag->m_streamDetails.GetVideoCodec();
@@ -431,7 +431,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int iChannels = tag->m_streamDetails.GetAudioChannels();
         if (iChannels > 0)
         {
-          value = StringUtils::Format("%i", iChannels);
+          value = StringUtils::Format("{}", iChannels);
           return true;
         }
         break;
@@ -558,7 +558,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iChannels = m_audioInfo.channels;
       if (iChannels > 0)
       {
-        value = StringUtils::Format("%i", iChannels);
+        value = StringUtils::Format("{}", iChannels);
         return true;
       }
       break;
@@ -568,7 +568,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBitrate = m_audioInfo.bitrate;
       if (iBitrate > 0)
       {
-        value = StringUtils::Format("%li", std::lrint(static_cast<double>(iBitrate) / 1000.0));
+        value = StringUtils::Format("{}", std::lrint(static_cast<double>(iBitrate) / 1000.0));
         return true;
       }
       break;
@@ -578,7 +578,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBitrate = m_videoInfo.bitrate;
       if (iBitrate > 0)
       {
-        value = StringUtils::Format("%li", std::lrint(static_cast<double>(iBitrate) / 1000.0));
+        value = StringUtils::Format("{}", std::lrint(static_cast<double>(iBitrate) / 1000.0));
         return true;
       }
       break;
@@ -621,7 +621,7 @@ bool CVideoGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo& info) co
   }
   if (info.m_info == VIDEOPLAYER_PLAYLISTPOS)
   {
-    value = StringUtils::Format("%i", index + 1);
+    value = StringUtils::Format("{}", index + 1);
     return true;
   }
   else if (info.m_info == VIDEOPLAYER_COVER)

--- a/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
@@ -41,9 +41,9 @@ bool CWeatherGUIInfo::GetLabel(std::string& value, const CFileItem *item, int co
       value = CServiceBroker::GetWeatherManager().GetInfo(WEATHER_IMAGE_CURRENT_ICON);
       return true;
     case WEATHER_TEMPERATURE:
-      value = StringUtils::Format("%s%s",
-                                  CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_CURRENT_TEMP).c_str(),
-                                  g_langInfo.GetTemperatureUnitString().c_str());
+      value = StringUtils::Format(
+          "{}{}", CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_CURRENT_TEMP).c_str(),
+          g_langInfo.GetTemperatureUnitString().c_str());
       return true;
     case WEATHER_LOCATION:
       value = CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_LOCATION);

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -123,7 +123,7 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
 
 std::string CKeyboardLayout::GetIdentifier() const
 {
-  return StringUtils::Format("%s %s", m_language.c_str(), m_layout.c_str());
+  return StringUtils::Format("{} {}", m_language.c_str(), m_layout.c_str());
 }
 
 std::string CKeyboardLayout::GetName() const

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -239,16 +239,16 @@ std::string CKeyboardStat::GetKeyName(int KeyID)
   if (VKeyFound)
     keyname.append(keytable.keyname);
   else
-    keyname += StringUtils::Format("%i", keyid);
+    keyname += StringUtils::Format("{}", keyid);
 
   // in case this might be an universalremote keyid
   // we also print the possible corresponding obc code
   // so users can easily find it in their universalremote
   // map xml
   if (VKeyFound || keyid > 255)
-    keyname += StringUtils::Format(" (0x%02x)", KeyID);
+    keyname += StringUtils::Format(" ({:#02x})", KeyID);
   else // obc keys are 255 -rawid
-    keyname += StringUtils::Format(" (0x%02x, obc%i)", KeyID, 255 - KeyID);
+    keyname += StringUtils::Format(" ({:#02x}, obc{})", KeyID, 255 - KeyID);
 
   return keyname;
 }

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -139,19 +139,24 @@ static int RunAddon(const std::vector<std::string>& params)
 
       std::string cmd;
       if (plugin->Provides(CPluginSource::VIDEO))
-        cmd = StringUtils::Format("ActivateWindow(Videos,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Videos,plugin://{}{},return)", addonid.c_str(),
+                                  urlParameters.c_str());
       else if (plugin->Provides(CPluginSource::AUDIO))
-        cmd = StringUtils::Format("ActivateWindow(Music,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Music,plugin://{}{},return)", addonid.c_str(),
+                                  urlParameters.c_str());
       else if (plugin->Provides(CPluginSource::EXECUTABLE))
-        cmd = StringUtils::Format("ActivateWindow(Programs,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Programs,plugin://{}{},return)", addonid.c_str(),
+                                  urlParameters.c_str());
       else if (plugin->Provides(CPluginSource::IMAGE))
-        cmd = StringUtils::Format("ActivateWindow(Pictures,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Pictures,plugin://{}{},return)", addonid.c_str(),
+                                  urlParameters.c_str());
       else if (plugin->Provides(CPluginSource::GAME))
-        cmd = StringUtils::Format("ActivateWindow(Games,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Games,plugin://{}{},return)", addonid.c_str(),
+                                  urlParameters.c_str());
       else
         // Pass the script name (addonid) and all the parameters
         // (params[1] ... params[x]) separated by a comma to RunPlugin
-        cmd = StringUtils::Format("RunPlugin(%s)", StringUtils::Join(params, ",").c_str());
+        cmd = StringUtils::Format("RunPlugin({})", StringUtils::Join(params, ",").c_str());
       CBuiltins::GetInstance().Execute(cmd);
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT,
@@ -165,7 +170,8 @@ static int RunAddon(const std::vector<std::string>& params)
     {
       // Pass the script name (addonid) and all the parameters
       // (params[1] ... params[x]) separated by a comma to RunScript
-      CBuiltins::GetInstance().Execute(StringUtils::Format("RunScript(%s)", StringUtils::Join(params, ",").c_str()));
+      CBuiltins::GetInstance().Execute(
+          StringUtils::Format("RunScript({})", StringUtils::Join(params, ",").c_str()));
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_GAMEDLL,
                                                     OnlyEnabled::YES))

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -207,9 +207,9 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITrans
 
   std::string cmd;
   if (params.empty())
-    cmd = StringUtils::Format("RunAddon(%s)", id.c_str());
+    cmd = StringUtils::Format("RunAddon({})", id.c_str());
   else
-    cmd = StringUtils::Format("RunAddon(%s, %s)", id.c_str(), argv.c_str());
+    cmd = StringUtils::Format("RunAddon({}, {})", id.c_str(), argv.c_str());
 
   if (params["wait"].asBoolean())
     CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -327,7 +327,7 @@ JSONRPC_STATUS CAudioLibrary::GetAlbumDetails(const std::string &method, ITransp
   if (!musicdatabase.GetAlbum(albumID, album, false))
     return InvalidParams;
 
-  std::string path = StringUtils::Format("musicdb://albums/%li/", albumID);
+  std::string path = StringUtils::Format("musicdb://albums/{}/", albumID);
 
   CFileItemPtr albumItem;
   FillAlbumItem(album, path, albumItem);
@@ -519,7 +519,8 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyAddedAlbums(const std::string &method, 
   CFileItemList items;
   for (unsigned int index = 0; index < albums.size(); index++)
   {
-    std::string path = StringUtils::Format("musicdb://recentlyaddedalbums/%li/", albums[index].idAlbum);
+    std::string path =
+        StringUtils::Format("musicdb://recentlyaddedalbums/{}/", albums[index].idAlbum);
 
     CFileItemPtr item;
     FillAlbumItem(albums[index], path, item);
@@ -569,7 +570,8 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyPlayedAlbums(const std::string &method,
   CFileItemList items;
   for (unsigned int index = 0; index < albums.size(); index++)
   {
-    std::string path = StringUtils::Format("musicdb://recentlyplayedalbums/%li/", albums[index].idAlbum);
+    std::string path =
+        StringUtils::Format("musicdb://recentlyplayedalbums/{}/", albums[index].idAlbum);
 
     CFileItemPtr item;
     FillAlbumItem(albums[index], path, item);
@@ -1026,7 +1028,9 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
 JSONRPC_STATUS CAudioLibrary::Scan(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
   std::string directory = parameterObject["directory"].asString();
-  std::string cmd = StringUtils::Format("updatelibrary(music, %s, %s)", StringUtils::Paramify(directory).c_str(), parameterObject["showdialogs"].asBoolean() ? "true" : "false");
+  std::string cmd =
+      StringUtils::Format("updatelibrary(music, {}, {})", StringUtils::Paramify(directory).c_str(),
+                          parameterObject["showdialogs"].asBoolean() ? "true" : "false");
 
   CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
@@ -1036,7 +1040,9 @@ JSONRPC_STATUS CAudioLibrary::Export(const std::string &method, ITransportLayer 
 {
   std::string cmd;
   if (parameterObject["options"].isMember("path"))
-    cmd = StringUtils::Format("exportlibrary2(music, singlefile, %s, albums, albumartists)", StringUtils::Paramify(parameterObject["options"]["path"].asString()).c_str());
+    cmd = StringUtils::Format(
+        "exportlibrary2(music, singlefile, {}, albums, albumartists)",
+        StringUtils::Paramify(parameterObject["options"]["path"].asString()).c_str());
   else
   {
     cmd = "exportlibrary2(music, library, dummy, albums, albumartists";
@@ -1052,7 +1058,8 @@ JSONRPC_STATUS CAudioLibrary::Export(const std::string &method, ITransportLayer 
 
 JSONRPC_STATUS CAudioLibrary::Clean(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  std::string cmd = StringUtils::Format("cleanlibrary(music, %s)", parameterObject["showdialogs"].asBoolean() ? "true" : "false");
+  std::string cmd = StringUtils::Format(
+      "cleanlibrary(music, {})", parameterObject["showdialogs"].asBoolean() ? "true" : "false");
   CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
 }

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -649,7 +649,7 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
   // Let's check the type of the provided parameter
   if (!IsType(value, type))
   {
-    errorMessage = StringUtils::Format("Invalid type %s received", ValueTypeToString(value.type()));
+    errorMessage = StringUtils::Format("Invalid type {} received", ValueTypeToString(value.type()));
     errorData["message"] = errorMessage.c_str();
     return InvalidParams;
   }
@@ -694,7 +694,8 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
       if (status != OK)
       {
         CLog::Log(LOGDEBUG, "JSONRPC: Value does not match extended type %s of type %s", extends.at(extendsIndex)->ID.c_str(), name.c_str());
-        errorMessage = StringUtils::Format("value does not match extended type %s", extends.at(extendsIndex)->ID.c_str());
+        errorMessage = StringUtils::Format("value does not match extended type {}",
+                                           extends.at(extendsIndex)->ID.c_str());
         errorData["message"] = errorMessage.c_str();
         return status;
       }
@@ -712,11 +713,14 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
     {
       CLog::Log(LOGDEBUG, "JSONRPC: Number of array elements does not match minItems and/or maxItems in type %s", name.c_str());
       if (minItems > 0 && maxItems > 0)
-        errorMessage = StringUtils::Format("Between %d and %d array items expected but %d received", minItems, maxItems, value.size());
+        errorMessage = StringUtils::Format("Between {} and {} array items expected but {} received",
+                                           minItems, maxItems, value.size());
       else if (minItems > 0)
-        errorMessage = StringUtils::Format("At least %d array items expected but only %d received", minItems, value.size());
+        errorMessage = StringUtils::Format("At least {} array items expected but only {} received",
+                                           minItems, value.size());
       else
-        errorMessage = StringUtils::Format("Only %d array items expected but %d received", maxItems, value.size());
+        errorMessage = StringUtils::Format("Only {} array items expected but {} received", maxItems,
+                                           value.size());
       errorData["message"] = errorMessage.c_str();
       return InvalidParams;
     }
@@ -736,7 +740,8 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
         if (status != OK)
         {
           CLog::Log(LOGDEBUG, "JSONRPC: Array element at index %u does not match in type %s", arrayIndex, name.c_str());
-          errorMessage = StringUtils::Format("array element at index %u does not match", arrayIndex);
+          errorMessage =
+              StringUtils::Format("array element at index {} does not match", arrayIndex);
           errorData["message"] = errorMessage.c_str();
           return status;
         }
@@ -796,7 +801,9 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
           if (!ok)
           {
             CLog::Log(LOGDEBUG, "JSONRPC: Array contains non-conforming additional items in type %s", name.c_str());
-            errorMessage = StringUtils::Format("Array element at index %u does not match the \"additionalItems\" schema", arrayIndex);
+            errorMessage = StringUtils::Format(
+                "Array element at index {} does not match the \"additionalItems\" schema",
+                arrayIndex);
             errorData["message"] = errorMessage.c_str();
             return InvalidParams;
           }
@@ -815,7 +822,9 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
           if (outputValue[checkingIndex] == outputValue[checkedIndex])
           {
             CLog::Log(LOGDEBUG, "JSONRPC: Not unique array element at index %u and %u in type %s", checkingIndex, checkedIndex, name.c_str());
-            errorMessage = StringUtils::Format("Array element at index %u is not unique (same as array element at index %u)", checkingIndex, checkedIndex);
+            errorMessage = StringUtils::Format(
+                "Array element at index {} is not unique (same as array element at index {})",
+                checkingIndex, checkedIndex);
             errorData["message"] = errorMessage.c_str();
             return InvalidParams;
           }
@@ -940,11 +949,15 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
     {
       CLog::Log(LOGDEBUG, "JSONRPC: Value does not lay between minimum and maximum in type %s", name.c_str());
       if (value.isDouble())
-        errorMessage = StringUtils::Format("Value between %f (%s) and %f (%s) expected but %f received",
-          minimum, exclusiveMinimum ? "exclusive" : "inclusive", maximum, exclusiveMaximum ? "exclusive" : "inclusive", numberValue);
+        errorMessage =
+            StringUtils::Format("Value between {:f} ({}) and {:f} ({}) expected but {:f} received",
+                                minimum, exclusiveMinimum ? "exclusive" : "inclusive", maximum,
+                                exclusiveMaximum ? "exclusive" : "inclusive", numberValue);
       else
-        errorMessage = StringUtils::Format("Value between %d (%s) and %d (%s) expected but %d received",
-          (int)minimum, exclusiveMinimum ? "exclusive" : "inclusive", (int)maximum, exclusiveMaximum ? "exclusive" : "inclusive", (int)numberValue);
+        errorMessage = StringUtils::Format(
+            "Value between {} ({}) and {} ({}) expected but {} received", (int)minimum,
+            exclusiveMinimum ? "exclusive" : "inclusive", (int)maximum,
+            exclusiveMaximum ? "exclusive" : "inclusive", (int)numberValue);
       errorData["message"] = errorMessage.c_str();
       return InvalidParams;
     }
@@ -952,7 +965,8 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
     if ((HasType(type, IntegerValue) && divisibleBy > 0 && ((int)numberValue % divisibleBy) != 0))
     {
       CLog::Log(LOGDEBUG, "JSONRPC: Value does not meet divisibleBy requirements in type %s", name.c_str());
-      errorMessage = StringUtils::Format("Value should be divisible by %d but %d received", divisibleBy, (int)numberValue);
+      errorMessage = StringUtils::Format("Value should be divisible by {} but {} received",
+                                         divisibleBy, (int)numberValue);
       errorData["message"] = errorMessage.c_str();
       return InvalidParams;
     }
@@ -965,7 +979,8 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
     if (size < minLength)
     {
       CLog::Log(LOGDEBUG, "JSONRPC: Value does not meet minLength requirements in type %s", name.c_str());
-      errorMessage = StringUtils::Format("Value should have a minimum length of %d but has a length of %d", minLength, size);
+      errorMessage = StringUtils::Format(
+          "Value should have a minimum length of {} but has a length of {}", minLength, size);
       errorData["message"] = errorMessage.c_str();
       return InvalidParams;
     }
@@ -973,7 +988,8 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
     if (maxLength >= 0 && size > maxLength)
     {
       CLog::Log(LOGDEBUG, "JSONRPC: Value does not meet maxLength requirements in type %s", name.c_str());
-      errorMessage = StringUtils::Format("Value should have a maximum length of %d but has a length of %d", maxLength, size);
+      errorMessage = StringUtils::Format(
+          "Value should have a maximum length of {} but has a length of {}", maxLength, size);
       errorData["message"] = errorMessage.c_str();
       return InvalidParams;
     }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -202,7 +202,7 @@ JSONRPC_STATUS CVideoLibrary::GetSeasons(const std::string &method, ITransportLa
 
   int tvshowID = (int)parameterObject["tvshowid"].asInteger();
 
-  std::string strPath = StringUtils::Format("videodb://tvshows/titles/%i/", tvshowID);
+  std::string strPath = StringUtils::Format("videodb://tvshows/titles/{}/", tvshowID);
   CFileItemList items;
   if (!videodatabase.GetSeasonsNav(strPath, items, -1, -1, -1, -1, tvshowID, false))
     return InternalError;
@@ -243,7 +243,7 @@ JSONRPC_STATUS CVideoLibrary::GetEpisodes(const std::string &method, ITransportL
   int tvshowID = (int)parameterObject["tvshowid"].asInteger();
   int season   = (int)parameterObject["season"].asInteger();
 
-  std::string strPath = StringUtils::Format("videodb://tvshows/titles/%i/%i/", tvshowID, season);
+  std::string strPath = StringUtils::Format("videodb://tvshows/titles/{}/{}/", tvshowID, season);
 
   CVideoDbUrl videoUrl;
   if (!videoUrl.FromString(strPath))
@@ -304,7 +304,8 @@ JSONRPC_STATUS CVideoLibrary::GetEpisodeDetails(const std::string &method, ITran
   if (tvshowid <= 0)
     tvshowid = videodatabase.GetTvShowForEpisode(id);
 
-  std::string basePath = StringUtils::Format("videodb://tvshows/titles/%i/%i/%i", tvshowid, infos.m_iSeason, id);
+  std::string basePath =
+      StringUtils::Format("videodb://tvshows/titles/{}/{}/{}", tvshowid, infos.m_iSeason, id);
   pItem->SetPath(basePath);
 
   HandleFileItem("episodeid", true, "episodedetails", pItem, parameterObject, parameterObject["properties"], result, false);
@@ -952,7 +953,9 @@ JSONRPC_STATUS CVideoLibrary::RemoveMusicVideo(const std::string &method, ITrans
 JSONRPC_STATUS CVideoLibrary::Scan(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
   std::string directory = parameterObject["directory"].asString();
-  std::string cmd = StringUtils::Format("updatelibrary(video, %s, %s)", StringUtils::Paramify(directory).c_str(), parameterObject["showdialogs"].asBoolean() ? "true" : "false");
+  std::string cmd =
+      StringUtils::Format("updatelibrary(video, {}, {})", StringUtils::Paramify(directory).c_str(),
+                          parameterObject["showdialogs"].asBoolean() ? "true" : "false");
 
   CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
@@ -962,7 +965,9 @@ JSONRPC_STATUS CVideoLibrary::Export(const std::string &method, ITransportLayer 
 {
   std::string cmd;
   if (parameterObject["options"].isMember("path"))
-    cmd = StringUtils::Format("exportlibrary2(video, singlefile, %s)", StringUtils::Paramify(parameterObject["options"]["path"].asString()).c_str());
+    cmd = StringUtils::Format(
+        "exportlibrary2(video, singlefile, {})",
+        StringUtils::Paramify(parameterObject["options"]["path"].asString()).c_str());
   else
   {
     cmd = "exportlibrary2(video, separate, dummy";

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -150,7 +150,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dcguard(languageHook);
       ADDON::AddonPtr addon(pAddon);
-      if (UpdateSettingInActiveDialog(id, StringUtils::Format("%d", value)))
+      if (UpdateSettingInActiveDialog(id, StringUtils::Format("{}", value)))
         return true;
 
       if (!addon->UpdateSettingInt(id, value))
@@ -165,7 +165,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dcguard(languageHook);
       ADDON::AddonPtr addon(pAddon);
-      if (UpdateSettingInActiveDialog(id, StringUtils::Format("%f", value)))
+      if (UpdateSettingInActiveDialog(id, StringUtils::Format("{:f}", value)))
         return true;
 
       if (!addon->UpdateSettingNumber(id, value))

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -300,7 +300,8 @@ namespace XBMCAddon
             timedate.year = atoi(sDefault.substr(sDefault.size() - 4).c_str());
           }
           if (CGUIDialogNumeric::ShowAndGetDate(timedate, heading))
-            value = StringUtils::Format("%2d/%2d/%4d", timedate.day, timedate.month, timedate.year);
+            value =
+                StringUtils::Format("{:2}/{:2}/{:4}", timedate.day, timedate.month, timedate.year);
           else
             return emptyString;
         }
@@ -313,7 +314,7 @@ namespace XBMCAddon
             timedate.minute = atoi(sDefault.substr(3, 2).c_str());
           }
           if (CGUIDialogNumeric::ShowAndGetTime(timedate, heading))
-            value = StringUtils::Format("%2d:%02d", timedate.hour, timedate.minute);
+            value = StringUtils::Format("{:2}:{:02}", timedate.hour, timedate.minute);
           else
             return emptyString;
         }
@@ -393,8 +394,8 @@ namespace XBMCAddon
               timedate.year = atoi(sDefault.substr(sDefault.size() - 4).c_str());
             }
             if (CGUIDialogNumeric::ShowAndGetDate(timedate, heading))
-              value =
-                  StringUtils::Format("%2d/%2d/%4d", timedate.day, timedate.month, timedate.year);
+              value = StringUtils::Format("{:2}/{:2}/{:4}", timedate.day, timedate.month,
+                                          timedate.year);
             else
               value = emptyString;
           }
@@ -408,7 +409,7 @@ namespace XBMCAddon
               timedate.minute = atoi(sDefault.substr(3, 2).c_str());
             }
             if (CGUIDialogNumeric::ShowAndGetTime(timedate, heading))
-              value = StringUtils::Format("%2d:%02d", timedate.hour, timedate.minute);
+              value = StringUtils::Format("{:2}:{:02}", timedate.hour, timedate.minute);
             else
               value = emptyString;
           }

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -91,7 +91,7 @@ namespace XBMCAddon
 
     String InfoTagVideo::getVotes()
     {
-      return StringUtils::Format("%i", infoTag->GetRating().votes);
+      return StringUtils::Format("{}", infoTag->GetRating().votes);
     }
 
     String InfoTagVideo::getCast()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -258,12 +258,12 @@ namespace XBMCAddon
       if (lowerKey == "startoffset")
       { // special case for start offset - don't actually store in a property,
         // we store it in item.m_lStartOffset instead
-        value = StringUtils::Format("%f", CUtil::ConvertMilliSecsToSecs(item->m_lStartOffset));
+        value = StringUtils::Format("{:f}", CUtil::ConvertMilliSecsToSecs(item->m_lStartOffset));
       }
       else if (lowerKey == "totaltime")
-        value = StringUtils::Format("%f", GetVideoInfoTag()->GetResumePoint().totalTimeInSeconds);
+        value = StringUtils::Format("{:f}", GetVideoInfoTag()->GetResumePoint().totalTimeInSeconds);
       else if (lowerKey == "resumetime")
-        value = StringUtils::Format("%f", GetVideoInfoTag()->GetResumePoint().timeInSeconds);
+        value = StringUtils::Format("{:f}", GetVideoInfoTag()->GetResumePoint().timeInSeconds);
       else if (lowerKey == "fanart_image")
         value = item->GetArt("fanart");
       else
@@ -813,8 +813,8 @@ namespace XBMCAddon
           throw ListItemException("Must pass in a list of tuples of pairs of strings. One entry in the list only has %d elements.",tuple.GetNumValuesSet());
 
         XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-        item->SetProperty(StringUtils::Format("contextmenulabel(%zu)", i), tuple.first());
-        item->SetProperty(StringUtils::Format("contextmenuaction(%zu)", i), tuple.second());
+        item->SetProperty(StringUtils::Format("contextmenulabel({})", i), tuple.first());
+        item->SetProperty(StringUtils::Format("contextmenuaction({})", i), tuple.second());
       }
     }
 
@@ -824,7 +824,7 @@ namespace XBMCAddon
       unsigned int i = 1;
       for (const auto& it: paths)
       {
-        String property = StringUtils::Format("subtitle:%u", i++);
+        String property = StringUtils::Format("subtitle:{}", i++);
         item->SetProperty(property, it);
       }
     }

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -374,7 +374,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       auto crc = Crc32::ComputeFromLowerCase(path);
-      return StringUtils::Format("%08x.tbn", crc);
+      return StringUtils::Format("{:08x}.tbn", crc);
     }
 
     Tuple<String,String> getCleanMovieTitle(const String& path, bool usefoldername)
@@ -435,7 +435,7 @@ namespace XBMCAddon
         }
         else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
           result =
-              StringUtils::Format("%s/%s", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
+              StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
                                   g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
 
         return result;

--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -228,10 +228,10 @@ namespace PythonBindings
 
     if (!exceptionType.empty())
     {
-      msg += StringUtils::Format("Error Type: %s\n", exceptionType.c_str());
+      msg += StringUtils::Format("Error Type: {}\n", exceptionType.c_str());
 
       if (!exceptionValue.empty())
-        msg += StringUtils::Format("Error Contents: %s\n", exceptionValue.c_str());
+        msg += StringUtils::Format("Error Contents: {}\n", exceptionValue.c_str());
 
       if (!exceptionTraceback.empty())
         msg += exceptionTraceback;

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -513,7 +513,7 @@ bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
     int year;
     XMLUtils::GetInt(album, "year", year);
     if (year > 0)
-      strReleaseDate = StringUtils::Format("%04i", year);
+      strReleaseDate = StringUtils::Format("{:04}", year);
   }
   XMLUtils::GetString(album, "originalreleasedate", strOrigReleaseDate);
   

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -891,7 +891,7 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
           std::string currentTitle = GetSingleValue(strSQL);
           if (currentTitle.empty())
           {
-            currentTitle = StringUtils::Format("%s %i", g_localizeStrings.Get(427), discValue);
+            currentTitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), discValue);
             strSQL =
                 PrepareSQL("UPDATE song SET strDiscSubtitle = '%s' WHERE song.idAlbum = %i AND "
                            "song.iTrack >> 16 = %i",
@@ -1063,7 +1063,7 @@ int CMusicDatabase::AddSong(const int idSong,
       if (isBoxset && strDiscSubtitle.empty())
       {
         int discno = iTrack >> 16;
-        strDiscSubtitle = StringUtils::Format("%s %i", g_localizeStrings.Get(427), discno);
+        strDiscSubtitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), discno);
       }
 
       // Validate ISO8601 dates and ensure none missing
@@ -3058,7 +3058,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
     std::string strFileName = record->at(song_strFileName).get_asString();
     std::string strExt = URIUtils::GetExtension(strFileName);
     std::string path =
-        StringUtils::Format("%i%s", record->at(song_idSong).get_asInt(), strExt.c_str());
+        StringUtils::Format("{}{}", record->at(song_idSong).get_asInt(), strExt.c_str());
     itemUrl.AppendPath(path);
     item->SetPath(itemUrl.ToString());
     item->SetDynPath(strRealPath);
@@ -3366,13 +3366,13 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& art
     const std::string& artistLabel(g_localizeStrings.Get(557)); // Artist
     while (!m_pDS->eof())
     {
-      std::string path = StringUtils::Format("musicdb://artists/%i/", m_pDS->fv(0).get_asInt());
+      std::string path = StringUtils::Format("musicdb://artists/{}/", m_pDS->fv(0).get_asInt());
       CFileItemPtr pItem(new CFileItem(path, true));
       std::string label =
-          StringUtils::Format("[%s] %s", artistLabel.c_str(), m_pDS->fv(1).get_asString().c_str());
+          StringUtils::Format("[{}] {}", artistLabel.c_str(), m_pDS->fv(1).get_asString().c_str());
       pItem->SetLabel(label);
       // sort label is stored in the title tag
-      label = StringUtils::Format("A %s", m_pDS->fv(1).get_asString().c_str());
+      label = StringUtils::Format("A {}", m_pDS->fv(1).get_asString().c_str());
       pItem->GetMusicInfoTag()->SetTitle(label);
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv(0).get_asInt(), MediaTypeArtist);
       artists.Add(pItem);
@@ -4052,13 +4052,13 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList& albu
     while (!m_pDS->eof())
     {
       CAlbum album = GetAlbumFromDataset(m_pDS.get());
-      std::string path = StringUtils::Format("musicdb://albums/%ld/", album.idAlbum);
+      std::string path = StringUtils::Format("musicdb://albums/{}/", album.idAlbum);
       CFileItemPtr pItem(new CFileItem(path, album));
       std::string label =
-          StringUtils::Format("[%s] %s", albumLabel.c_str(), album.strAlbum.c_str());
+          StringUtils::Format("[{}] {}", albumLabel.c_str(), album.strAlbum.c_str());
       pItem->SetLabel(label);
       // sort label is stored in the title tag
-      label = StringUtils::Format("B %s", album.strAlbum.c_str());
+      label = StringUtils::Format("B {}", album.strAlbum.c_str());
       pItem->GetMusicInfoTag()->SetTitle(label);
       albums.Add(pItem);
       m_pDS->next();
@@ -4626,7 +4626,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery /*=false*/)
   //  Delete old info if any
   if (bRequery)
   {
-    std::string strFile = StringUtils::Format("%x.cddb", pCdInfo->GetCddbDiscId());
+    std::string strFile = StringUtils::Format("{:x}.cddb", pCdInfo->GetCddbDiscId());
     CFile::Delete(URIUtils::AddFileToFolder(m_profileManager.GetCDDBFolder(), strFile));
   }
 
@@ -4706,7 +4706,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery /*=false*/)
         pCdInfo->SetNoCDDBInfo();
         // ..no, an error occurred, display it to the user
         std::string strErrorText =
-            StringUtils::Format("[%d] %s", cddb.getLastError(), cddb.getLastErrorText());
+            StringUtils::Format("[{}] {}", cddb.getLastError(), cddb.getLastErrorText());
         HELPERS::ShowOKDialogLines(CVariant{255}, CVariant{257}, CVariant{std::move(strErrorText)},
                                    CVariant{0});
       }
@@ -4786,7 +4786,7 @@ void CMusicDatabase::DeleteCDDBInfo()
     {
       if (i.second == strSelectedAlbum)
       {
-        std::string strFile = StringUtils::Format("%x.cddb", (unsigned int)i.first);
+        std::string strFile = StringUtils::Format("{:x}.cddb", (unsigned int)i.first);
         CFile::Delete(URIUtils::AddFileToFolder(m_profileManager.GetCDDBFolder(), strFile));
         break;
       }
@@ -4916,7 +4916,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv("genre.idGenre").get_asInt(), "genre");
 
       CMusicDbUrl itemUrl = musicUrl;
-      std::string strDir = StringUtils::Format("%i/", m_pDS->fv("genre.idGenre").get_asInt());
+      std::string strDir = StringUtils::Format("{}/", m_pDS->fv("genre.idGenre").get_asInt());
       itemUrl.AppendPath(strDir);
       pItem->SetPath(itemUrl.ToString());
 
@@ -5034,7 +5034,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv("source.idSource").get_asInt(), "source");
 
       CMusicDbUrl itemUrl = musicUrl;
-      std::string strDir = StringUtils::Format("%i/", m_pDS->fv("source.idSource").get_asInt());
+      std::string strDir = StringUtils::Format("{}/", m_pDS->fv("source.idSource").get_asInt());
       itemUrl.AppendPath(strDir);
       itemUrl.AddOption("sourceid", m_pDS->fv("source.idSource").get_asInt());
       pItem->SetPath(itemUrl.ToString());
@@ -5116,7 +5116,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
         pItem->GetMusicInfoTag()->SetDatabaseId(-1, "year");
 
       CMusicDbUrl itemUrl = musicUrl;
-      std::string strDir = StringUtils::Format("%i/", m_pDS->fv(0).get_asInt());
+      std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       itemUrl.AppendPath(strDir);
       if (useOriginalYears)
         itemUrl.AddOption("useoriginalyear", true);
@@ -5183,7 +5183,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
       pItem->GetMusicInfoTag()->SetTitle(labelValue);
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv("role.idRole").get_asInt(), "role");
       CMusicDbUrl itemUrl = musicUrl;
-      std::string strDir = StringUtils::Format("%i/", m_pDS->fv("role.idRole").get_asInt());
+      std::string strDir = StringUtils::Format("{}/", m_pDS->fv("role.idRole").get_asInt());
       itemUrl.AppendPath(strDir);
       itemUrl.AddOption("roleid", m_pDS->fv("role.idRole").get_asInt());
       pItem->SetPath(itemUrl.ToString());
@@ -5286,7 +5286,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
       CFileItemPtr pItem(new CFileItem(labelValue));
 
       CMusicDbUrl itemUrl = musicUrl;
-      std::string strDir = StringUtils::Format("%s/", labelValue.c_str());
+      std::string strDir = StringUtils::Format("{}/", labelValue.c_str());
       itemUrl.AppendPath(strDir);
       pItem->SetPath(itemUrl.ToString());
 
@@ -5518,7 +5518,7 @@ bool CMusicDatabase::GetArtistsByWhere(
         CFileItemPtr pItem(new CFileItem(artist));
 
         CMusicDbUrl itemUrl = musicUrl;
-        std::string path = StringUtils::Format("%ld/", artist.idArtist);
+        std::string path = StringUtils::Format("{}/", artist.idArtist);
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
@@ -5750,7 +5750,7 @@ bool CMusicDatabase::GetAlbumsByWhere(
       try
       {
         CMusicDbUrl itemUrl = musicUrl;
-        std::string path = StringUtils::Format("%i/", record->at(album_idAlbum).get_asInt());
+        std::string path = StringUtils::Format("{}/", record->at(album_idAlbum).get_asInt());
         itemUrl.AppendPath(path);
 
         CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), GetAlbumFromDataset(record)));
@@ -5942,7 +5942,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
         std::string strDiscSubtitle = record->at(1).get_asString();
         if (strDiscSubtitle.empty())
           // Make (fake) disc title from disc number
-          strDiscSubtitle = StringUtils::Format("%s %i", g_localizeStrings.Get(427), discnum);
+          strDiscSubtitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), discnum);
         else if (oldDiscTitle == strDiscSubtitle)
         { // When real disc titles are provided (as they ALWAYS are for boxed sets)
           // group discs together by title not number.
@@ -5953,7 +5953,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
           oldDiscTitle = strDiscSubtitle;
 
         CMusicDbUrl itemUrl = musicUrl;
-        std::string path = StringUtils::Format("%i/", discnum);
+        std::string path = StringUtils::Format("{}/", discnum);
         itemUrl.AppendPath(path);
 
         // When disc titles are provided group discs together by title not number.
@@ -10722,10 +10722,10 @@ bool CMusicDatabase::SearchAlbumsByArtistName(const std::string& strArtist, CFil
     while (!m_pDS->eof())
     {
       CAlbum album = GetAlbumFromDataset(m_pDS.get());
-      std::string path = StringUtils::Format("musicdb://albums/%ld/", album.idAlbum);
+      std::string path = StringUtils::Format("musicdb://albums/{}/", album.idAlbum);
       CFileItemPtr pItem(new CFileItem(path, album));
       std::string label =
-          StringUtils::Format("%s (%i)", album.strAlbum, pItem->GetMusicInfoTag()->GetYear());
+          StringUtils::Format("{} ({})", album.strAlbum, pItem->GetMusicInfoTag()->GetYear());
       pItem->SetLabel(label);
       items.Add(pItem);
       m_pDS->next();
@@ -10983,7 +10983,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
         pItem->GetMusicInfoTag()->SetTitle(strGenre);
         pItem->GetMusicInfoTag()->SetGenre(strGenre);
         pItem->GetMusicInfoTag()->SetDatabaseId(idGenre, "genre");
-        pItem->SetPath(StringUtils::Format("musicdb://genres/%i/", idGenre));
+        pItem->SetPath(StringUtils::Format("musicdb://genres/{}/", idGenre));
         pItem->m_bIsFolder = true;
         items.Add(pItem);
       }
@@ -11026,7 +11026,7 @@ std::string CMusicDatabase::GetAlbumDiscTitle(int idAlbum, int idDisc)
     disctitle = GetSingleValue("song", "strDiscSubtitle",
                                PrepareSQL("idAlbum = %i AND iTrack >> 16 = %i", idAlbum, idDisc));
     if (disctitle.empty())
-      disctitle = StringUtils::Format("%s %i", g_localizeStrings.Get(427), idDisc); // "Disc 1" etc.
+      disctitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), idDisc); // "Disc 1" etc.
     if (albumtitle.empty())
       albumtitle = disctitle;
     else
@@ -11706,7 +11706,7 @@ std::string CMusicDatabase::GetItemById(const std::string& itemType, int id)
   else if (StringUtils::EqualsNoCase(itemType, "sources"))
     return GetSourceById(id);
   else if (StringUtils::EqualsNoCase(itemType, "years"))
-    return StringUtils::Format("%d", id);
+    return StringUtils::Format("{}", id);
   else if (StringUtils::EqualsNoCase(itemType, "artists"))
     return GetArtistById(id);
   else if (StringUtils::EqualsNoCase(itemType, "albums"))

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -205,7 +205,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
             for (auto& artitem : artistart)
             {
               if (iOrder > 0)
-                artitem.prefix = StringUtils::Format("artist%i", iOrder);
+                artitem.prefix = StringUtils::Format("artist{}", iOrder);
               else
                 artitem.prefix = "artist";
             }
@@ -235,7 +235,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
               for (auto& artitem : artistart)
               {
                 if (iOrder > 0)
-                  artitem.prefix = StringUtils::Format("albumartist%i", iOrder);
+                  artitem.prefix = StringUtils::Format("albumartist{}", iOrder);
                 else
                   artitem.prefix = "albumartist";
               }

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -321,7 +321,7 @@ namespace MUSIC_UTILS
       dialog->SetHeading(CVariant{ 38023 });
       dialog->Add(g_localizeStrings.Get(38022));
       for (int i = 1; i <= 10; i++)
-        dialog->Add(StringUtils::Format("%s: %i", g_localizeStrings.Get(563).c_str(), i));
+        dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563).c_str(), i));
       dialog->SetSelected(iSelected);
       dialog->Open();
 

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -770,7 +770,7 @@ void CGUIDialogMusicInfo::OnGetArt()
   for (unsigned int i = 0; i < remotethumbs.size(); ++i)
   {
     std::string strItemPath;
-    strItemPath = StringUtils::Format("thumb://Remote%i", i);
+    strItemPath = StringUtils::Format("thumb://Remote{}", i);
     CFileItemPtr item(new CFileItem(strItemPath, false));
     item->SetArt("thumb", remotethumbs[i]);
     item->SetArt("icon", "DefaultPicture.png");
@@ -934,14 +934,14 @@ void CGUIDialogMusicInfo::OnSetUserrating() const
 
 void CGUIDialogMusicInfo::ShowForAlbum(int idAlbum)
 {
-  std::string path = StringUtils::Format("musicdb://albums/%li", idAlbum);
+  std::string path = StringUtils::Format("musicdb://albums/{}", idAlbum);
   CFileItem item(path, true); // An album, but IsAlbum() not set as didn't use SetAlbum()
   ShowFor(&item);
 }
 
 void CGUIDialogMusicInfo::ShowForArtist(int idArtist)
 {
-  std::string path = StringUtils::Format("musicdb://artists/%li", idArtist);
+  std::string path = StringUtils::Format("musicdb://artists/{}", idArtist);
   CFileItem item(path, true);
   ShowFor(&item);
 }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1586,7 +1586,8 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
           if (pDialog)
           {
             // set the label to [relevance]  album - artist
-            std::string strTemp = StringUtils::Format("[%0.2f]  %s", relevance, info.GetTitle2().c_str());
+            std::string strTemp =
+                StringUtils::Format("[{:0.2f}]  {}", relevance, info.GetTitle2().c_str());
             CFileItemPtr item(new CFileItem("", false));
             item->SetLabel(strTemp);
 
@@ -1847,7 +1848,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
             {
               std::string genres = StringUtils::Join(scraper.GetArtist(i).GetArtist().genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
               if (!genres.empty())
-                strTemp = StringUtils::Format("[%s] %s", genres.c_str(), strTemp.c_str());
+                strTemp = StringUtils::Format("[{}] {}", genres.c_str(), strTemp.c_str());
             }
             item.SetLabel(strTemp);
             item.m_idepth = i; // use this to hold the index of the album in the scraper
@@ -2072,7 +2073,7 @@ bool CMusicInfoScanner::AddAlbumArtwork(CAlbum& album)
         // Handle thumbs separately. Get thumb for path from textures db cached during scan
         // (could be embedded or local file from multiple confgurable file names)
         CFileItem item(pathpair.first.c_str(), true);
-        std::string strArtType = StringUtils::Format("%s%i", "thumb", discnum);
+        std::string strArtType = StringUtils::Format("{}{}", "thumb", discnum);
         strArt = loader.GetCachedImage(item, "thumb");
         if (strArt.empty())
           strArt = CScraperUrl::GetThumbUrl(album.thumbURL.GetFirstUrlByType(strArtType));
@@ -2231,7 +2232,7 @@ bool CMusicInfoScanner::AddLocalArtwork(std::map<std::string, std::string>& art,
       }
       else if (discnum > 0)
         // Append disc number when candidate art type (and file) not have it
-        strCandidate += StringUtils::Format("%i", discnum);
+        strCandidate += StringUtils::Format("{}", discnum);
 
       if (art.find(strCandidate) == art.end())
         art.insert(std::make_pair(strCandidate, artFile->GetPath()));

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -433,11 +433,11 @@ void CMusicInfoTag::SetYear(int year)
   // Parse integer year value into YYYY ISO8601 format (partial) date string
   // Add century for to 2 digit numbers, 41 -> 1941, 40 -> 2040
   if (year > 99)
-    SetReleaseDate(StringUtils::Format("%04i", year));
+    SetReleaseDate(StringUtils::Format("{:04}", year));
   else if (year > 40)
-    SetReleaseDate(StringUtils::Format("%04i", 19 + year));
+    SetReleaseDate(StringUtils::Format("{:04}", 19 + year));
   else  if (year > 0)
-    SetReleaseDate(StringUtils::Format("%04i", 20 + year));
+    SetReleaseDate(StringUtils::Format("{:04}", 20 + year));
   else
     m_strReleaseDate.clear();
 }
@@ -495,9 +495,8 @@ void CMusicInfoTag::AddReleaseDate(const std::string& strDateYear, bool isMonth 
     std::string strYYYY = GetReleaseYear();
     if (strYYYY.empty())
       strYYYY = "0000"; // Fake year when TYER not read yet
-    m_strReleaseDate =
-      StringUtils::Format("%s-%s-%s", strYYYY, StringUtils::Left(strDateYear, 2),
-        StringUtils::Right(strDateYear, 2));
+    m_strReleaseDate = StringUtils::Format("{}-{}-{}", strYYYY, StringUtils::Left(strDateYear, 2),
+                                           StringUtils::Right(strDateYear, 2));
   }
   // Given YYYY only (from YEAR tag) and already have YYYY-MM or YYYY-MM-DD (from DATE tag)
   else if (strDateYear.size() == 4 && (m_strReleaseDate.size() > 4))
@@ -1269,7 +1268,7 @@ const std::string CMusicInfoTag::GetContributorsText() const
   std::string strLabel;
   for (const auto& credit : m_musicRoles)
   {
-    strLabel += StringUtils::Format("%s\n", credit.GetArtist().c_str());
+    strLabel += StringUtils::Format("{}\n", credit.GetArtist().c_str());
   }
   return StringUtils::TrimRight(strLabel, "\n");
 }
@@ -1280,7 +1279,7 @@ const std::string CMusicInfoTag::GetContributorsAndRolesText() const
   for (const auto& credit : m_musicRoles)
   {
     strLabel +=
-        StringUtils::Format("%s - %s\n", credit.GetRoleDesc().c_str(), credit.GetArtist().c_str());
+        StringUtils::Format("{} - {}\n", credit.GetRoleDesc().c_str(), credit.GetArtist().c_str());
   }
   return StringUtils::TrimRight(strLabel, "\n");
 }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -321,9 +321,9 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
       // Change information provider, selected artist or album
       if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20195}, CVariant{38073}))
       {
-        std::string itempath = StringUtils::Format("musicdb://albums/%li/", id);
+        std::string itempath = StringUtils::Format("musicdb://albums/{}/", id);
         if (content == CONTENT_ARTISTS)
-          itempath = StringUtils::Format("musicdb://artists/%li/", id);
+          itempath = StringUtils::Format("musicdb://artists/{}/", id);
         OnItemInfoAll(itempath, true);
       }
     }
@@ -480,7 +480,7 @@ void CGUIWindowMusicNav::UpdateButtons()
       StringUtils::StartsWith(m_vecItems->Get(m_vecItems->Size()-1)->GetPath(), "/-1/"))
       iItems--;
   }
-  std::string items = StringUtils::Format("%i %s", iItems, g_localizeStrings.Get(127).c_str());
+  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127).c_str());
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   // set the filter label
@@ -693,7 +693,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         int idArtist = m_musicdatabase.GetArtistByName(item->GetLabel());
         if (idArtist == -1)
           return false;
-        std::string path = StringUtils::Format("musicdb://artists/%ld/", idArtist);
+        std::string path = StringUtils::Format("musicdb://artists/{}/", idArtist);
         CArtist artist;
         m_musicdatabase.GetArtist(idArtist, artist, false);
         *item = CFileItem(artist);
@@ -710,7 +710,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         int idAlbum = m_musicdatabase.GetAlbumByName(item->GetLabel());
         if (idAlbum == -1)
           return false;
-        std::string path = StringUtils::Format("musicdb://albums/%ld/", idAlbum);
+        std::string path = StringUtils::Format("musicdb://albums/{}/", idAlbum);
         CAlbum album;
         m_musicdatabase.GetAlbum(idAlbum, album, false);
         *item = CFileItem(path,album);
@@ -754,8 +754,9 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       std::string strPath;
       CVideoDatabase database;
       database.Open();
-      strPath = StringUtils::Format("videodb://musicvideos/artists/%i/",
-        database.GetMatchingMusicVideo(item->GetMusicInfoTag()->GetArtistString()));
+      strPath = StringUtils::Format(
+          "videodb://musicvideos/artists/{}/",
+          database.GetMatchingMusicVideo(item->GetMusicInfoTag()->GetArtistString()));
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VIDEO_NAV,strPath);
       return true;
     }

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -410,7 +410,8 @@ void CGUIWindowMusicPlayList::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_BTNREPEAT, g_localizeStrings.Get(iRepeat));
 
   // Update object count label
-  std::string items = StringUtils::Format("%i %s", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127).c_str());
+  std::string items = StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
+                                          g_localizeStrings.Get(127).c_str());
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   MarkPlaying();
@@ -473,7 +474,7 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
       // No music info and it's not CDDA so we'll just show the filename
       std::string str;
       str = CUtil::GetTitleFromPath(pItem->GetPath());
-      str = StringUtils::Format("%2.2i. %s ", pItem->m_iprogramCount, str.c_str());
+      str = StringUtils::Format("{:02}. {} ", pItem->m_iprogramCount, str.c_str());
       pItem->SetLabel(str);
     }
   }

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -219,7 +219,8 @@ void CGUIWindowMusicPlaylistEditor::UpdateButtons()
   CGUIWindowMusicBase::UpdateButtons();
 
   // Update object count label
-  std::string items = StringUtils::Format("%i %s", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127).c_str()); // " 14 Objects"
+  std::string items = StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
+                                          g_localizeStrings.Get(127).c_str()); // " 14 Objects"
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 }
 
@@ -297,7 +298,8 @@ void CGUIWindowMusicPlaylistEditor::UpdatePlaylist()
   OnMessage(msg);
 
   // indicate how many songs we have
-  std::string items = StringUtils::Format("%i %s", m_playlist->Size(), g_localizeStrings.Get(134).c_str()); // "123 Songs"
+  std::string items = StringUtils::Format("{} {}", m_playlist->Size(),
+                                          g_localizeStrings.Get(134).c_str()); // "123 Songs"
   SET_CONTROL_LABEL(CONTROL_LABEL_PLAYLIST, items);
 
   m_playlistThumbLoader.Load(*m_playlist);

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -533,13 +533,14 @@ void CAirPlayServer::CTCPClient::PushBuffer(CAirPlayServer *host, const char *bu
     const time_t ltime = time(NULL);
     char *date = asctime(gmtime(&ltime)); //Fri, 17 Dec 2010 11:18:01 GMT;
     date[strlen(date) - 1] = '\0'; // remove \n
-    response = StringUtils::Format("HTTP/1.1 %d %s\nDate: %s\r\n", status, statusMsg.c_str(), date);
+    response = StringUtils::Format("HTTP/1.1 {} {}\nDate: {}\r\n", status, statusMsg.c_str(), date);
     if (!responseHeader.empty())
     {
       response += responseHeader;
     }
 
-    response = StringUtils::Format("%sContent-Length: %ld\r\n\r\n", response.c_str(), responseBody.size());
+    response =
+        StringUtils::Format("{}Content-Length: {}\r\n\r\n", response.c_str(), responseBody.size());
 
     if (!responseBody.empty())
     {
@@ -601,8 +602,10 @@ void CAirPlayServer::CTCPClient::ComposeReverseEvent( std::string& reverseHeader
         break;
     }
     reverseHeader = "Content-Type: text/x-apple-plist+xml\r\n";
-    reverseHeader = StringUtils::Format("%sContent-Length: %ld\r\n",reverseHeader.c_str(), reverseBody.size());
-    reverseHeader = StringUtils::Format("%sx-apple-session-id: %s\r\n",reverseHeader.c_str(), m_sessionId.c_str());
+    reverseHeader =
+        StringUtils::Format("{}Content-Length: {}\r\n", reverseHeader.c_str(), reverseBody.size());
+    reverseHeader = StringUtils::Format("{}x-apple-session-id: {}\r\n", reverseHeader.c_str(),
+                                        m_sessionId.c_str());
     m_lastEvent = state;
   }
 }
@@ -610,7 +613,7 @@ void CAirPlayServer::CTCPClient::ComposeReverseEvent( std::string& reverseHeader
 void CAirPlayServer::CTCPClient::ComposeAuthRequestAnswer(std::string& responseHeader, std::string& responseBody)
 {
   int16_t random=rand();
-  std::string randomStr = StringUtils::Format("%i", random);
+  std::string randomStr = StringUtils::Format("{}", random);
   m_authNonce=CDigest::Calculate(CDigest::Type::MD5, randomStr);
   responseHeader = StringUtils::Format(AUTH_REQUIRED, m_authNonce.c_str());
   responseBody.clear();
@@ -986,7 +989,9 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
       if (g_application.GetAppPlayer().GetTotalTime())
       {
         float position = ((float) g_application.GetAppPlayer().GetTime()) / 1000;
-        responseBody = StringUtils::Format("duration: %.6f\r\nposition: %.6f\r\n", (float)g_application.GetAppPlayer().GetTotalTime() / 1000, position);
+        responseBody = StringUtils::Format(
+            "duration: {:.6f}\r\nposition: {:.6f}\r\n",
+            (float)g_application.GetAppPlayer().GetTotalTime() / 1000, position);
       }
       else
       {

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -594,9 +594,8 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
   if (ServerInstance->Initialize(pw))
   {
     success = true;
-    std::string appName = StringUtils::Format("%s@%s",
-                                             m_macAddress.c_str(),
-                                             CSysInfo::GetDeviceName().c_str());
+    std::string appName =
+        StringUtils::Format("{}@{}", m_macAddress.c_str(), CSysInfo::GetDeviceName().c_str());
 
     std::vector<std::pair<std::string, std::string> > txt;
     txt.emplace_back("txtvers", "1");

--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -35,7 +35,8 @@ bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAdd
 
   if (address != INADDR_NONE)
   {
-    strIpAddress = StringUtils::Format("%lu.%lu.%lu.%lu", (address & 0xFF), (address & 0xFF00) >> 8, (address & 0xFF0000) >> 16, (address & 0xFF000000) >> 24 );
+    strIpAddress = StringUtils::Format("{}.{}.{}.{}", (address & 0xFF), (address & 0xFF00) >> 8,
+                                       (address & 0xFF0000) >> 16, (address & 0xFF000000) >> 24);
     return true;
   }
 
@@ -91,8 +92,7 @@ bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAdd
   struct hostent *host = gethostbyname(strHostName.c_str());
   if (host && host->h_addr_list[0])
   {
-    strIpAddress = StringUtils::Format("%d.%d.%d.%d",
-                                       (unsigned char)host->h_addr_list[0][0],
+    strIpAddress = StringUtils::Format("{}.{}.{}.{}", (unsigned char)host->h_addr_list[0][0],
                                        (unsigned char)host->h_addr_list[0][1],
                                        (unsigned char)host->h_addr_list[0][2],
                                        (unsigned char)host->h_addr_list[0][3]);

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -255,7 +255,7 @@ void CGUIDialogNetworkSetup::OnProtocolChange()
       return;
     m_protocol = msg.GetParam1();
     // set defaults for the port
-    m_port = StringUtils::Format("%i", m_protocols[m_protocol].defaultPort);
+    m_port = StringUtils::Format("{}", m_protocols[m_protocol].defaultPort);
 
     UpdateButtons();
   }
@@ -413,7 +413,7 @@ bool CGUIDialogNetworkSetup::SetPath(const std::string &path)
   else
     m_username = url.GetUserName();
   m_password = url.GetPassWord();
-  m_port = StringUtils::Format("%i", url.GetPort());
+  m_port = StringUtils::Format("{}", url.GetPort());
   m_server = url.GetHostName();
   m_path = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(m_path);

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -414,7 +414,7 @@ std::vector<SOCKET> CreateTCPServerSocket(const int port, const bool bindLocal, 
   std::vector<SOCKET> sockets;
   struct addrinfo* results = nullptr;
 
-  std::string sPort = StringUtils::Format("%d", port);
+  std::string sPort = StringUtils::Format("{}", port);
   struct addrinfo hints = { 0 };
   hints.ai_family = PF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -955,7 +955,7 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo)
   {
   case 200: //Found exact match
     strtok(const_cast<char *>(recv_buffer.c_str()), " ");
-    read_buffer = StringUtils::Format("cddb read %s %08x", strtok(NULL, " "), discid);
+    read_buffer = StringUtils::Format("cddb read {} {:08x}", strtok(NULL, " "), discid);
     break;
 
   case 210: //Found exact matches, list follows (until terminating marker)
@@ -1062,7 +1062,7 @@ bool Xcddb::isCDCached( CCdInfo* pInfo )
 std::string Xcddb::GetCacheFile(uint32_t disc_id) const
 {
   std::string strFileName;
-  strFileName = StringUtils::Format("%x.cddb", disc_id);
+  strFileName = StringUtils::Format("{:x}.cddb", disc_id);
   return URIUtils::AddFileToFolder(cCacheDir, strFileName);
 }
 

--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
@@ -375,7 +375,7 @@ std::map<std::string, std::string> CHTTPPythonWsgiInvoker::createCgiEnvironment(
   environment.insert(std::make_pair("SERVER_NAME", httpRequest->hostname));
 
   // SERVER_PORT
-  environment.insert(std::make_pair("SERVER_PORT", StringUtils::Format("%hu", httpRequest->port)));
+  environment.insert(std::make_pair("SERVER_PORT", StringUtils::Format("{}", httpRequest->port)));
 
   // SERVER_PROTOCOL
   environment.insert(std::make_pair("SERVER_PROTOCOL", httpRequest->version));

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -57,7 +57,7 @@ protected:
       port = dist(mt);
     }
     webserverPort = port;
-    baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":%u", webserverPort);
+    baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", webserverPort);
   }
   ~TestWebServer() override = default;
 
@@ -174,7 +174,7 @@ protected:
     const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
     // check the protocol line for the expected HTTP status
-    std::string httpStatusString = StringUtils::Format(" %d ", httpStatus);
+    std::string httpStatusString = StringUtils::Format(" {} ", httpStatus);
     std::string protocolLine = httpHeader.GetProtoLine();
     ASSERT_TRUE(protocolLine.find(httpStatusString) != std::string::npos);
 
@@ -205,7 +205,7 @@ protected:
     const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
     // check the protocol line for the expected HTTP status
-    std::string httpStatusString = StringUtils::Format(" %d ", MHD_HTTP_PARTIAL_CONTENT);
+    std::string httpStatusString = StringUtils::Format(" {} ", MHD_HTTP_PARTIAL_CONTENT);
     std::string protocolLine = httpHeader.GetProtoLine();
     ASSERT_TRUE(protocolLine.find(httpStatusString) != std::string::npos);
 
@@ -250,7 +250,9 @@ protected:
       EXPECT_STREQ(expectedContent.c_str(), result.c_str());
 
       // and Content-Length
-      EXPECT_STREQ(StringUtils::Format("%u", static_cast<unsigned int>(expectedContent.size())).c_str(), httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
+      EXPECT_STREQ(
+          StringUtils::Format("{}", static_cast<unsigned int>(expectedContent.size())).c_str(),
+          httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
 
       return;
     }
@@ -336,7 +338,7 @@ protected:
 
   std::string GenerateRangeHeaderValue(unsigned int start, unsigned int end)
   {
-    return StringUtils::Format("bytes=%u-%u", start, end);
+    return StringUtils::Format("bytes={}-{}", start, end);
   }
 
   CWebServer webserver;
@@ -782,7 +784,8 @@ TEST_F(TestWebServer, CanGetRangedFileRange_Last)
 {
   const std::string rangedFileContent = TEST_FILES_DATA_RANGES;
   std::vector<std::string> rangedContent = StringUtils::Split(TEST_FILES_DATA_RANGES, ";");
-  const std::string range = StringUtils::Format("bytes=-%u", static_cast<unsigned int>(rangedContent.back().size()));
+  const std::string range =
+      StringUtils::Format("bytes=-{}", static_cast<unsigned int>(rangedContent.back().size()));
 
   CHttpRanges ranges;
   ASSERT_TRUE(ranges.Parse(range, rangedFileContent.size()));
@@ -799,8 +802,11 @@ TEST_F(TestWebServer, CanGetRangedFileRangeFirstSecond)
 {
   const std::string rangedFileContent = TEST_FILES_DATA_RANGES;
   std::vector<std::string> rangedContent = StringUtils::Split(TEST_FILES_DATA_RANGES, ";");
-  const std::string range = StringUtils::Format("bytes=0-%u,%u-%u", static_cast<unsigned int>(rangedContent.front().size() - 1),
-    static_cast<unsigned int>(rangedContent.front().size() + 1), static_cast<unsigned int>(rangedContent.front().size() + 1) + static_cast<unsigned int>(rangedContent.at(1).size() - 1));
+  const std::string range = StringUtils::Format(
+      "bytes=0-{},{}-{}", static_cast<unsigned int>(rangedContent.front().size() - 1),
+      static_cast<unsigned int>(rangedContent.front().size() + 1),
+      static_cast<unsigned int>(rangedContent.front().size() + 1) +
+          static_cast<unsigned int>(rangedContent.at(1).size() - 1));
 
   CHttpRanges ranges;
   ASSERT_TRUE(ranges.Parse(range, rangedFileContent.size()));
@@ -817,9 +823,12 @@ TEST_F(TestWebServer, CanGetRangedFileRangeFirstSecondLast)
 {
   const std::string rangedFileContent = TEST_FILES_DATA_RANGES;
   std::vector<std::string> rangedContent = StringUtils::Split(TEST_FILES_DATA_RANGES, ";");
-  const std::string range = StringUtils::Format("bytes=0-%u,%u-%u,-%u", static_cast<unsigned int>(rangedContent.front().size() - 1),
-    static_cast<unsigned int>(rangedContent.front().size() + 1), static_cast<unsigned int>(rangedContent.front().size() + 1) + static_cast<unsigned int>(rangedContent.at(1).size() - 1),
-    static_cast<unsigned int>(rangedContent.back().size()));
+  const std::string range = StringUtils::Format(
+      "bytes=0-{},{}-{},-{}", static_cast<unsigned int>(rangedContent.front().size() - 1),
+      static_cast<unsigned int>(rangedContent.front().size() + 1),
+      static_cast<unsigned int>(rangedContent.front().size() + 1) +
+          static_cast<unsigned int>(rangedContent.at(1).size() - 1),
+      static_cast<unsigned int>(rangedContent.back().size()));
 
   CHttpRanges ranges;
   ASSERT_TRUE(ranges.Parse(range, rangedFileContent.size()));

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1153,7 +1153,7 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
     {
       if(info.Match(PLT_ProtocolInfo("*", "*", type, "*")))
       {
-        std::string prop = StringUtils::Format("subtitle:%d", ++subs);
+        std::string prop = StringUtils::Format("subtitle:{}", ++subs);
         item.SetProperty(prop, (const char*)res.m_Uri);
         break;
       }

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -288,10 +288,10 @@ void CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
 
     std::string buffer;
 
-    buffer = StringUtils::Format("%" PRId64, data["volume"].asInteger());
+    buffer = StringUtils::Format("{}", data["volume"].asInteger());
     rct->SetStateVariable("Volume", buffer.c_str());
 
-    buffer = StringUtils::Format("%" PRId64, 256 * (data["volume"].asInteger() * 60 - 60) / 100);
+    buffer = StringUtils::Format("{}", 256 * (data["volume"].asInteger() * 60 - 60) / 100);
     rct->SetStateVariable("VolumeDb", buffer.c_str());
 
     rct->SetStateVariable("Mute", data["muted"].asBoolean() ? "1" : "0");
@@ -350,9 +350,9 @@ CUPnPRenderer::UpdateState()
         if (slideshow)
         {
           std::string index;
-          index = StringUtils::Format("%d", slideshow->NumSlides());
+          index = StringUtils::Format("{}", slideshow->NumSlides());
           avt->SetStateVariable("NumberOfTracks", index.c_str());
-          index = StringUtils::Format("%d", slideshow->CurrentSlide());
+          index = StringUtils::Format("{}", slideshow->CurrentSlide());
           avt->SetStateVariable("CurrentTrack", index.c_str());
 
         }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -181,8 +181,9 @@ CUPnPServer::PropagateUpdates()
     // only broadcast ids with modified bit set
     for (itr = m_UpdateIDs.begin(); itr != m_UpdateIDs.end(); ++itr) {
         if (itr->second.first) {
-            buffer.append(StringUtils::Format("%s,%ld,", itr->first.c_str(), itr->second.second).c_str());
-            itr->second.first = false;
+          buffer.append(
+              StringUtils::Format("{},{},", itr->first.c_str(), itr->second.second).c_str());
+          itr->second.first = false;
         }
     }
 
@@ -474,8 +475,9 @@ void CUPnPServer::Announce(AnnouncementFlag flag,
                 if (!db.Open()) return;
                 int show_id = db.GetTvShowForEpisode(item_id);
                 int season_id = db.GetSeasonForEpisode(item_id);
-                UpdateContainer(StringUtils::Format("videodb://tvshows/titles/%d/", show_id));
-                UpdateContainer(StringUtils::Format("videodb://tvshows/titles/%d/%d/?tvshowid=%d", show_id, season_id, show_id));
+                UpdateContainer(StringUtils::Format("videodb://tvshows/titles/{}/", show_id));
+                UpdateContainer(StringUtils::Format("videodb://tvshows/titles/{}/{}/?tvshowid={}",
+                                                    show_id, season_id, show_id));
                 UpdateContainer("videodb://recentlyaddedepisodes/");
             }
             else if(item_type == MediaTypeTvShow) {
@@ -498,9 +500,9 @@ void CUPnPServer::Announce(AnnouncementFlag flag,
             CAlbum album;
             if (!db.Open()) return;
             if (db.GetAlbumFromSong(item_id, album)) {
-                UpdateContainer(StringUtils::Format("musicdb://albums/%ld", album.idAlbum));
-                UpdateContainer("musicdb://songs/");
-                UpdateContainer("musicdb://recentlyaddedalbums/");
+              UpdateContainer(StringUtils::Format("musicdb://albums/{}", album.idAlbum));
+              UpdateContainer("musicdb://songs/");
+              UpdateContainer("musicdb://recentlyaddedalbums/");
             }
         }
     }
@@ -924,23 +926,23 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
 
         if (genre.GetLength() > 0) {
             // all tracks by genre filtered by artist and/or album
-            std::string strPath = StringUtils::Format("musicdb://genres/%i/%i/%i/",
-                                          database.GetGenreByName((const char*)genre),
-                                          database.GetArtistByName((const char*)artist), // will return -1 if no artist
-                                          database.GetAlbumByName((const char*)album));  // will return -1 if no album
+            std::string strPath = StringUtils::Format(
+                "musicdb://genres/{}/{}/{}/", database.GetGenreByName((const char*)genre),
+                database.GetArtistByName((const char*)artist), // will return -1 if no artist
+                database.GetAlbumByName((const char*)album)); // will return -1 if no album
 
             return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
         } else if (artist.GetLength() > 0) {
             // all tracks by artist name filtered by album if passed
-            std::string strPath = StringUtils::Format("musicdb://artists/%i/%i/",
-                                          database.GetArtistByName((const char*)artist),
-                                          database.GetAlbumByName((const char*)album)); // will return -1 if no album
+            std::string strPath = StringUtils::Format(
+                "musicdb://artists/{}/{}/", database.GetArtistByName((const char*)artist),
+                database.GetAlbumByName((const char*)album)); // will return -1 if no album
 
             return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
         } else if (album.GetLength() > 0) {
             // all tracks by album name
-            std::string strPath = StringUtils::Format("musicdb://albums/%i/",
-                                                     database.GetAlbumByName((const char*)album));
+            std::string strPath = StringUtils::Format("musicdb://albums/{}/",
+                                                      database.GetAlbumByName((const char*)album));
 
             return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
         }
@@ -962,14 +964,16 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
         database.Open();
 
         if (genre.GetLength() > 0) {
-            std::string strPath = StringUtils::Format("musicdb://genres/%i/%i/",
-                                                     database.GetGenreByName((const char*)genre),
-                                                     database.GetArtistByName((const char*)artist)); // no artist should return -1
-            return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
+          std::string strPath = StringUtils::Format(
+              "musicdb://genres/{}/{}/", database.GetGenreByName((const char*)genre),
+              database.GetArtistByName((const char*)artist)); // no artist should return -1
+          return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index,
+                                        requested_count, sort_criteria, context);
         } else if (artist.GetLength() > 0) {
-            std::string strPath = StringUtils::Format("musicdb://artists/%i/",
-                                                     database.GetArtistByName((const char*)artist));
-            return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
+          std::string strPath = StringUtils::Format("musicdb://artists/{}/",
+                                                    database.GetArtistByName((const char*)artist));
+          return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index,
+                                        requested_count, sort_criteria, context);
         }
 
         // all albums
@@ -980,7 +984,8 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
         if (genre.GetLength() > 0) {
             CMusicDatabase database;
             database.Open();
-            std::string strPath = StringUtils::Format("musicdb://genres/%i/", database.GetGenreByName((const char*)genre));
+            std::string strPath = StringUtils::Format("musicdb://genres/{}/",
+                                                      database.GetGenreByName((const char*)genre));
             return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
         }
         return OnBrowseDirectChildren(action, "musicdb://artists/", filter, starting_index, requested_count, sort_criteria, context);

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -311,7 +311,7 @@ public:
     if (iVal > 65536)
       iVal = 65536;
 
-    strHexString = StringUtils::Format("%04X", iVal);
+    strHexString = StringUtils::Format("{:04X}", iVal);
   };
 };
 

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -382,7 +382,7 @@ bool CPeripheralAddon::PerformDeviceScan(PeripheralScanResults& results)
       }
 
       result.m_strDeviceName = peripheral.Name();
-      result.m_strLocation = StringUtils::Format("%s/%d", ID().c_str(), peripheral.Index());
+      result.m_strLocation = StringUtils::Format("{}/{}", ID().c_str(), peripheral.Index());
       result.m_iVendorId = peripheral.VendorID();
       result.m_iProductId = peripheral.ProductID();
       result.m_mappedType = PERIPHERAL_JOYSTICK;

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -311,9 +311,9 @@ void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& ite
       strVersion = g_localizeStrings.Get(13205);
 
     std::string strDetails =
-        StringUtils::Format("%s %s", g_localizeStrings.Get(24051).c_str(), strVersion.c_str());
+        StringUtils::Format("{} {}", g_localizeStrings.Get(24051).c_str(), strVersion.c_str());
     if (peripheral->GetBusType() == PERIPHERAL_BUS_CEC && !peripheral->GetSettingBool("enabled"))
-      strDetails = StringUtils::Format("%s: %s", g_localizeStrings.Get(126).c_str(),
+      strDetails = StringUtils::Format("{}: {}", g_localizeStrings.Get(126).c_str(),
                                        g_localizeStrings.Get(13106).c_str());
 
     peripheralFile->SetProperty("version", strVersion);

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
@@ -79,5 +79,5 @@ void CPeripheralBusApplication::GetDirectory(const std::string& strPath, CFileIt
 
 std::string CPeripheralBusApplication::MakeLocation(unsigned int controllerIndex) const
 {
-  return StringUtils::Format("%u", controllerIndex);
+  return StringUtils::Format("{}", controllerIndex);
 }

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -60,7 +60,7 @@ CPeripheral::CPeripheral(CPeripherals& manager,
   if (scanResult.m_iSequence > 0)
   {
     m_strFileLocation =
-        StringUtils::Format("peripherals://%s/%s_%d.dev",
+        StringUtils::Format("peripherals://{}/{}_{}.dev",
                             PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
                             scanResult.m_strLocation.c_str(), scanResult.m_iSequence);
   }
@@ -148,7 +148,7 @@ bool CPeripheral::Initialise(void)
   if (m_iVendorId == 0x0000 && m_iProductId == 0x0000)
   {
     m_strSettingsFile =
-        StringUtils::Format("special://profile/peripheral_data/%s_%s.xml",
+        StringUtils::Format("special://profile/peripheral_data/{}_{}.xml",
                             PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
                             CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT).c_str());
   }
@@ -156,13 +156,13 @@ bool CPeripheral::Initialise(void)
   {
     // Backwards compatibility - old settings files didn't include the device name
     m_strSettingsFile =
-        StringUtils::Format("special://profile/peripheral_data/%s_%s_%s.xml",
+        StringUtils::Format("special://profile/peripheral_data/{}_{}_{}.xml",
                             PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
                             m_strVendorId.c_str(), m_strProductId.c_str());
 
     if (!XFILE::CFile::Exists(m_strSettingsFile))
       m_strSettingsFile =
-          StringUtils::Format("special://profile/peripheral_data/%s_%s_%s_%s.xml",
+          StringUtils::Format("special://profile/peripheral_data/{}_{}_{}_{}.xml",
                               PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
                               m_strVendorId.c_str(), m_strProductId.c_str(),
                               CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT).c_str());
@@ -499,7 +499,7 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
         std::shared_ptr<CSettingInt> intSetting =
             std::static_pointer_cast<CSettingInt>(itr.second.m_setting);
         if (intSetting)
-          strValue = StringUtils::Format("%d", intSetting->GetValue());
+          strValue = StringUtils::Format("{}", intSetting->GetValue());
       }
       break;
       case SettingType::Number:
@@ -507,7 +507,7 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
         std::shared_ptr<CSettingNumber> floatSetting =
             std::static_pointer_cast<CSettingNumber>(itr.second.m_setting);
         if (floatSetting)
-          strValue = StringUtils::Format("%.2f", floatSetting->GetValue());
+          strValue = StringUtils::Format("{:.2f}", floatSetting->GetValue());
       }
       break;
       case SettingType::Boolean:
@@ -515,7 +515,7 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
         std::shared_ptr<CSettingBool> boolSetting =
             std::static_pointer_cast<CSettingBool>(itr.second.m_setting);
         if (boolSetting)
-          strValue = StringUtils::Format("%d", boolSetting->GetValue() ? 1 : 0);
+          strValue = StringUtils::Format("{}", boolSetting->GetValue() ? 1 : 0);
       }
       break;
       default:

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -278,7 +278,7 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
 void CPeripheralCecAdapter::SetVersionInfo(const libcec_configuration& configuration)
 {
   m_strVersionInfo =
-      StringUtils::Format("libCEC %s - firmware v%d",
+      StringUtils::Format("libCEC {} - firmware v{}",
                           m_cecAdapter->VersionToString(configuration.serverVersion).c_str(),
                           configuration.iFirmwareVersion);
 
@@ -286,7 +286,7 @@ void CPeripheralCecAdapter::SetVersionInfo(const libcec_configuration& configura
   if (configuration.iFirmwareBuildDate != CEC_FW_BUILD_UNKNOWN)
   {
     CDateTime dt((time_t)configuration.iFirmwareBuildDate);
-    m_strVersionInfo += StringUtils::Format(" (%s)", dt.GetAsDBDate().c_str());
+    m_strVersionInfo += StringUtils::Format(" ({})", dt.GetAsDBDate().c_str());
   }
 }
 
@@ -761,7 +761,7 @@ void CPeripheralCecAdapter::CecAlert(void* cbParam,
   {
     std::string strLog(g_localizeStrings.Get(iAlertString));
     if (data.paramType == CEC_PARAMETER_TYPE_STRING && data.paramData)
-      strLog += StringUtils::Format(" - %s", (const char*)data.paramData);
+      strLog += StringUtils::Format(" - {}", (const char*)data.paramData);
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000),
                                           strLog);
   }
@@ -1298,7 +1298,7 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
                            m_configuration.iHDMIPort > CEC_MAX_HDMI_PORTNUMBER))
   {
     m_configuration.iPhysicalAddress = config.iPhysicalAddress;
-    strPhysicalAddress = StringUtils::Format("%x", config.iPhysicalAddress);
+    strPhysicalAddress = StringUtils::Format("{:x}", config.iPhysicalAddress);
   }
   bChanged |= SetSetting("physical_address", strPhysicalAddress);
 
@@ -1479,7 +1479,7 @@ bool CPeripheralCecAdapter::WriteLogicalAddresses(const cec_logical_addresses& a
     std::string strPowerOffDevices;
     for (unsigned int iPtr = CECDEVICE_TV; iPtr <= CECDEVICE_BROADCAST; iPtr++)
       if (addresses[iPtr])
-        strPowerOffDevices += StringUtils::Format(" %X", iPtr);
+        strPowerOffDevices += StringUtils::Format(" {:X}", iPtr);
     StringUtils::Trim(strPowerOffDevices);
     bChanged = SetSetting(strAdvancedSettingName, strPowerOffDevices);
   }
@@ -1588,7 +1588,7 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
     CLog::Log(LOGDEBUG,
               "%s - CEC capable amplifier found (%s). volume will be controlled on the amp",
               __FUNCTION__, ampName.c_str());
-    strAmpName += StringUtils::Format("%s", ampName.c_str());
+    strAmpName += StringUtils::Format("{}", ampName.c_str());
 
     // set amp present
     m_adapter->SetAudioSystemConnected(true);
@@ -1629,11 +1629,11 @@ bool CPeripheralCecAdapterUpdateThread::SetInitialConfiguration(void)
   std::string strNotification;
   std::string tvName(m_adapter->m_cecAdapter->GetDeviceOSDName(CECDEVICE_TV));
   strNotification =
-      StringUtils::Format("%s: %s", g_localizeStrings.Get(36016).c_str(), tvName.c_str());
+      StringUtils::Format("{}: {}", g_localizeStrings.Get(36016).c_str(), tvName.c_str());
 
   std::string strAmpName = UpdateAudioSystemStatus();
   if (!strAmpName.empty())
-    strNotification += StringUtils::Format("- %s", strAmpName.c_str());
+    strNotification += StringUtils::Format("- {}", strAmpName.c_str());
 
   m_adapter->m_bIsReady = true;
 

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -45,7 +45,7 @@ bool CPeripheralHID::InitialiseFeature(const PeripheralFeature feature)
 
     if (m_strKeymap.empty())
     {
-      m_strKeymap = StringUtils::Format("v%sp%s", VendorIdAsString(), ProductIdAsString());
+      m_strKeymap = StringUtils::Format("v{}p{}", VendorIdAsString(), ProductIdAsString());
       SetSetting("keymap", m_strKeymap);
     }
 

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -378,7 +378,7 @@ const std::string CPictureInfoTag::GetInfo(int info) const
   switch (info)
   {
   case SLIDESHOW_RESOLUTION:
-    value = StringUtils::Format("%d x %d", m_exifInfo.Width, m_exifInfo.Height);
+    value = StringUtils::Format("{} x {}", m_exifInfo.Width, m_exifInfo.Height);
     break;
   case SLIDESHOW_COLOUR:
     value = m_exifInfo.IsColor ? "Colour" : "Black and White";
@@ -444,7 +444,7 @@ const std::string CPictureInfoTag::GetInfo(int info) const
 //    value = m_exifInfo.Software;
   case SLIDESHOW_EXIF_APERTURE:
     if (m_exifInfo.ApertureFNumber)
-      value = StringUtils::Format("%3.1f", m_exifInfo.ApertureFNumber);
+      value = StringUtils::Format("{:3.1f}", m_exifInfo.ApertureFNumber);
     break;
   case SLIDESHOW_EXIF_ORIENTATION:
     switch (m_exifInfo.Orientation)
@@ -462,16 +462,16 @@ const std::string CPictureInfoTag::GetInfo(int info) const
   case SLIDESHOW_EXIF_FOCAL_LENGTH:
     if (m_exifInfo.FocalLength)
     {
-      value = StringUtils::Format("%4.2fmm", m_exifInfo.FocalLength);
+      value = StringUtils::Format("{:4.2f}mm", m_exifInfo.FocalLength);
       if (m_exifInfo.FocalLength35mmEquiv != 0)
-        value += StringUtils::Format("  (35mm Equivalent = %umm)", m_exifInfo.FocalLength35mmEquiv);
+        value += StringUtils::Format("  (35mm Equivalent = {}mm)", m_exifInfo.FocalLength35mmEquiv);
     }
     break;
   case SLIDESHOW_EXIF_FOCUS_DIST:
     if (m_exifInfo.Distance < 0)
       value = "Infinite";
     else if (m_exifInfo.Distance > 0)
-      value = StringUtils::Format("%4.2fm", m_exifInfo.Distance);
+      value = StringUtils::Format("{:4.2f}m", m_exifInfo.Distance);
     break;
   case SLIDESHOW_EXIF_EXPOSURE:
     switch (m_exifInfo.ExposureProgram)
@@ -490,16 +490,16 @@ const std::string CPictureInfoTag::GetInfo(int info) const
     if (m_exifInfo.ExposureTime)
     {
       if (m_exifInfo.ExposureTime < 0.010f)
-        value = StringUtils::Format("%6.4fs", m_exifInfo.ExposureTime);
+        value = StringUtils::Format("{:6.4f}s", m_exifInfo.ExposureTime);
       else
-        value = StringUtils::Format("%5.3fs", m_exifInfo.ExposureTime);
+        value = StringUtils::Format("{:5.3f}s", m_exifInfo.ExposureTime);
       if (m_exifInfo.ExposureTime <= 0.5)
-        value += StringUtils::Format(" (1/%d)", (int)(0.5 + 1/m_exifInfo.ExposureTime));
+        value += StringUtils::Format(" (1/{})", (int)(0.5 + 1 / m_exifInfo.ExposureTime));
     }
     break;
   case SLIDESHOW_EXIF_EXPOSURE_BIAS:
     if (m_exifInfo.ExposureBias != 0)
-      value = StringUtils::Format("%4.2f EV", m_exifInfo.ExposureBias);
+      value = StringUtils::Format("{:4.2f} EV", m_exifInfo.ExposureBias);
     break;
   case SLIDESHOW_EXIF_EXPOSURE_MODE:
     switch (m_exifInfo.ExposureMode)
@@ -566,15 +566,15 @@ const std::string CPictureInfoTag::GetInfo(int info) const
     break;
   case SLIDESHOW_EXIF_ISO_EQUIV:
     if (m_exifInfo.ISOequivalent)
-      value = StringUtils::Format("%2d", m_exifInfo.ISOequivalent);
+      value = StringUtils::Format("{:2}", m_exifInfo.ISOequivalent);
     break;
   case SLIDESHOW_EXIF_DIGITAL_ZOOM:
     if (m_exifInfo.DigitalZoomRatio)
-      value = StringUtils::Format("%1.3fx", m_exifInfo.DigitalZoomRatio);
+      value = StringUtils::Format("{:1.3f}x", m_exifInfo.DigitalZoomRatio);
     break;
   case SLIDESHOW_EXIF_CCD_WIDTH:
     if (m_exifInfo.CCDWidth)
-      value = StringUtils::Format("%4.2fmm", m_exifInfo.CCDWidth);
+      value = StringUtils::Format("{:4.2f}mm", m_exifInfo.CCDWidth);
     break;
   case SLIDESHOW_EXIF_GPS_LATITUDE:
     value = m_exifInfo.GpsLat;

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
@@ -45,7 +45,7 @@ bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         continue;
       CFileItemPtr pItem(new CFileItem(i.packageName));
       pItem->m_bIsFolder = false;
-      std::string path = StringUtils::Format("androidapp://%s/%s/%s", url.GetHostName().c_str(),
+      std::string path = StringUtils::Format("androidapp://{}/{}/{}", url.GetHostName().c_str(),
                                              dirname.c_str(), i.packageName.c_str());
       pItem->SetPath(path);
       pItem->SetLabel(i.packageLabel);

--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -78,13 +78,10 @@ std::string CNetworkInterfaceAndroid::GetMacAddress() const
   }
   if (interfaceMacAddrRaw.size() >= 6)
   {
-    return (StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X",
-                                      (uint8_t)interfaceMacAddrRaw[0],
-                                      (uint8_t)interfaceMacAddrRaw[1],
-                                      (uint8_t)interfaceMacAddrRaw[2],
-                                      (uint8_t)interfaceMacAddrRaw[3],
-                                      (uint8_t)interfaceMacAddrRaw[4],
-                                      (uint8_t)interfaceMacAddrRaw[5]));
+    return (StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+                                (uint8_t)interfaceMacAddrRaw[0], (uint8_t)interfaceMacAddrRaw[1],
+                                (uint8_t)interfaceMacAddrRaw[2], (uint8_t)interfaceMacAddrRaw[3],
+                                (uint8_t)interfaceMacAddrRaw[4], (uint8_t)interfaceMacAddrRaw[5]));
   }
   return "";
 }
@@ -135,9 +132,10 @@ bool CNetworkInterfaceAndroid::GetHostMacAddress(unsigned long host_ip, std::str
     return false;
 
   struct sockaddr* res = &areq.arp_ha;
-  mac = StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X",
-    (uint8_t) res->sa_data[0], (uint8_t) res->sa_data[1], (uint8_t) res->sa_data[2],
-    (uint8_t) res->sa_data[3], (uint8_t) res->sa_data[4], (uint8_t) res->sa_data[5]);
+  mac = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", (uint8_t)res->sa_data[0],
+                            (uint8_t)res->sa_data[1], (uint8_t)res->sa_data[2],
+                            (uint8_t)res->sa_data[3], (uint8_t)res->sa_data[4],
+                            (uint8_t)res->sa_data[5]);
 
   for (int i=0; i<6; ++i)
     if (res->sa_data[i])
@@ -186,7 +184,8 @@ std::string CNetworkInterfaceAndroid::GetCurrentNetmask() const
 
   int prefix = la.getPrefixLength();
   unsigned long mask = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF;
-  return StringUtils::Format("%lu.%lu.%lu.%lu", mask >> 24, (mask >> 16) & 0xFF, (mask >> 8) & 0xFF, mask & 0xFF);
+  return StringUtils::Format("{}.{}.{}.{}", mask >> 24, (mask >> 16) & 0xFF, (mask >> 8) & 0xFF,
+                             mask & 0xFF);
 }
 
 std::string CNetworkInterfaceAndroid::GetCurrentDefaultGateway() const
@@ -200,7 +199,7 @@ std::string CNetworkInterfaceAndroid::GetCurrentDefaultGateway() const
 
     CJNIInetAddress ia = ri.getGateway();
     std::vector<char> adr = ia.getAddress();
-    return StringUtils::Format("%u.%u.%u.%u", adr[0], adr[1], adr[2], adr[3]);
+    return StringUtils::Format("{}.{}.{}.{}", adr[0], adr[1], adr[2], adr[3]);
   }
   return "";
 }

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -27,7 +27,7 @@ static std::string PrintAxisIds(const std::vector<int>& axisIds)
     return "";
 
   if (axisIds.size() == 1)
-    return StringUtils::Format("%d", axisIds.front());
+    return StringUtils::Format("{}", axisIds.front());
 
   std::string strAxisIds;
   for (const auto& axisId : axisIds)
@@ -37,7 +37,7 @@ static std::string PrintAxisIds(const std::vector<int>& axisIds)
     else
       strAxisIds += " | ";
 
-    strAxisIds += StringUtils::Format("%d", axisId);
+    strAxisIds += StringUtils::Format("{}", axisId);
   }
   strAxisIds += "]";
 

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -326,7 +326,7 @@ PeripheralScanResults CPeripheralBusAndroid::GetInputDevices()
 
 std::string CPeripheralBusAndroid::GetDeviceLocation(int deviceId)
 {
-  return StringUtils::Format("%s%d", DeviceLocationPrefix.c_str(), deviceId);
+  return StringUtils::Format("{}{}", DeviceLocationPrefix.c_str(), deviceId);
 }
 
 bool CPeripheralBusAndroid::GetDeviceId(const std::string& deviceLocation, int& deviceId)

--- a/xbmc/platform/darwin/ios-common/peripherals/PeripheralBusDarwinEmbeddedManager.mm
+++ b/xbmc/platform/darwin/ios-common/peripherals/PeripheralBusDarwinEmbeddedManager.mm
@@ -165,7 +165,7 @@
 
 - (std::string)GetDeviceLocation:(int)deviceId
 {
-  return StringUtils::Format("%s%d", parentClass->getDeviceLocationPrefix().c_str(), deviceId);
+  return StringUtils::Format("{}{}", parentClass->getDeviceLocationPrefix().c_str(), deviceId);
 }
 
 #pragma mark - Logging Utils

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
@@ -90,8 +90,8 @@ bool CNetworkInterfaceOsx::GetHostMacAddress(unsigned long host_ip, std::string&
 
           u_char* cp = (u_char*)LLADDR(sdl);
 
-          mac = StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X", cp[0], cp[1], cp[2], cp[3],
-                                    cp[4], cp[5]);
+          mac = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", cp[0], cp[1],
+                                    cp[2], cp[3], cp[4], cp[5]);
           ret = true;
           break;
         }

--- a/xbmc/platform/darwin/osx/peripherals/PeripheralBusUSB.cpp
+++ b/xbmc/platform/darwin/osx/peripherals/PeripheralBusUSB.cpp
@@ -237,9 +237,10 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
           }
         }
         if (!ttlDeviceFilePath.empty())
-          privateDataRef->result.m_strLocation = StringUtils::Format("%s", ttlDeviceFilePath.c_str());
+          privateDataRef->result.m_strLocation =
+              StringUtils::Format("{}", ttlDeviceFilePath.c_str());
         else
-          privateDataRef->result.m_strLocation = StringUtils::Format("%d", locationId);
+          privateDataRef->result.m_strLocation = StringUtils::Format("{}", locationId);
 
         if (bDeviceClass == kUSBCompositeClass)
           privateDataRef->result.m_type = refCon->GetType(bInterfaceClass);

--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
@@ -173,13 +173,15 @@ void CTVOSTopShelf::SetTopShelfItems(CFileItemList& items, TVOSTopShelfItemsCate
         videoDb.Open();
         fillSharedDicts(
             items, @"tvshows", @(g_localizeStrings.Get(20387).c_str()),
-            [&videoDb](const CFileItemPtr& videoItem) {
+            [&videoDb](const CFileItemPtr& videoItem)
+            {
               int season = videoItem->GetVideoInfoTag()->m_iIdSeason;
               return season > 0 ? videoDb.GetArtForItem(season, MediaTypeSeason, "poster")
                                 : std::string{};
             },
-            [](const CFileItemPtr& videoItem) {
-              return StringUtils::Format("%s s%02de%02d",
+            [](const CFileItemPtr& videoItem)
+            {
+              return StringUtils::Format("{} s{:02}e{:02}",
                                          videoItem->GetVideoInfoTag()->m_strShowTitle.c_str(),
                                          videoItem->GetVideoInfoTag()->m_iSeason,
                                          videoItem->GetVideoInfoTag()->m_iEpisode);
@@ -213,7 +215,7 @@ void CTVOSTopShelf::RunTopShelf()
 
   // its a bit ugly, but only way to get resume window to show
   std::string cmd =
-      StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(url.c_str()).c_str());
+      StringUtils::Format("PlayMedia({})", StringUtils::Paramify(url.c_str()).c_str());
   KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1,
                                                                 nullptr, cmd);
 }

--- a/xbmc/platform/freebsd/network/NetworkFreebsd.cpp
+++ b/xbmc/platform/freebsd/network/NetworkFreebsd.cpp
@@ -122,8 +122,8 @@ bool CNetworkInterfaceFreebsd::GetHostMacAddress(unsigned long host_ip, std::str
 
           u_char* cp = (u_char*)LLADDR(sdl);
 
-          mac = StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X", cp[0], cp[1], cp[2], cp[3],
-                                    cp[4], cp[5]);
+          mac = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", cp[0], cp[1],
+                                    cp[2], cp[3], cp[4], cp[5]);
           ret = true;
           break;
         }

--- a/xbmc/platform/linux/network/NetworkLinux.cpp
+++ b/xbmc/platform/linux/network/NetworkLinux.cpp
@@ -104,7 +104,7 @@ bool CNetworkInterfaceLinux::GetHostMacAddress(unsigned long host_ip, std::strin
   }
 
   struct sockaddr* res = &areq.arp_ha;
-  mac = StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X", (uint8_t)res->sa_data[0],
+  mac = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", (uint8_t)res->sa_data[0],
                             (uint8_t)res->sa_data[1], (uint8_t)res->sa_data[2],
                             (uint8_t)res->sa_data[3], (uint8_t)res->sa_data[4],
                             (uint8_t)res->sa_data[5]);

--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUSB.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUSB.cpp
@@ -42,9 +42,9 @@ bool CPeripheralBusUSB::PerformDeviceScan(PeripheralScanResults &results)
                                  GetType(dev->config[0].interface[0].altsetting[0].bInterfaceClass) :
                                  GetType(dev->descriptor.bDeviceClass);
 #ifdef TARGET_FREEBSD
-      result.m_strLocation = StringUtils::Format("%s", dev->filename);
+      result.m_strLocation = StringUtils::Format("{}", dev->filename);
 #else
-      result.m_strLocation = StringUtils::Format("/bus%s/dev%s", bus->dirname, dev->filename);
+      result.m_strLocation = StringUtils::Format("/bus{}/dev{}", bus->dirname, dev->filename);
 #endif
       result.m_iSequence   = GetNumberOfPeripheralsWithId(result.m_iVendorId, result.m_iProductId);
       if (!results.ContainsResult(result))

--- a/xbmc/platform/linux/storage/UDisks2Provider.cpp
+++ b/xbmc/platform/linux/storage/UDisks2Provider.cpp
@@ -48,8 +48,8 @@ bool CUDisks2Provider::Drive::IsOptical()
 
 std::string CUDisks2Provider::Drive::toString()
 {
-  return StringUtils::Format("Drive %s: IsRemovable %s IsOptical %s",
-                             m_object, BOOL2SZ(m_isRemovable), BOOL2SZ(IsOptical()));
+  return StringUtils::Format("Drive {}: IsRemovable {} IsOptical {}", m_object,
+                             BOOL2SZ(m_isRemovable), BOOL2SZ(IsOptical()));
 }
 
 CUDisks2Provider::Block::Block(const char *object) : m_object(object)
@@ -63,9 +63,9 @@ bool CUDisks2Provider::Block::IsReady()
 
 std::string CUDisks2Provider::Block::toString()
 {
-  return StringUtils::Format("Block device %s: Device %s Label %s IsSystem: %s Drive %s",
-                             m_object, m_device, m_label.empty() ? "none" : m_label,
-                             BOOL2SZ(m_isSystem), m_driveobject.empty() ? "none" : m_driveobject);
+  return StringUtils::Format("Block device {}: Device {} Label {} IsSystem: {} Drive {}", m_object,
+                             m_device, m_label.empty() ? "none" : m_label, BOOL2SZ(m_isSystem),
+                             m_driveobject.empty() ? "none" : m_driveobject);
 }
 
 CUDisks2Provider::Filesystem::Filesystem(const char *object) : m_object(object)
@@ -74,8 +74,8 @@ CUDisks2Provider::Filesystem::Filesystem(const char *object) : m_object(object)
 
 std::string CUDisks2Provider::Filesystem::toString()
 {
-  return StringUtils::Format("Filesystem %s: IsMounted %s MountPoint %s",
-                             m_object, BOOL2SZ(m_isMounted), m_mountPoint.empty() ? "none" : m_mountPoint);
+  return StringUtils::Format("Filesystem {}: IsMounted {} MountPoint {}", m_object,
+                             BOOL2SZ(m_isMounted), m_mountPoint.empty() ? "none" : m_mountPoint);
 }
 
 bool CUDisks2Provider::Filesystem::IsReady()
@@ -135,7 +135,7 @@ std::string CUDisks2Provider::Filesystem::GetDisplayName()
   if (m_block->m_label.empty())
   {
     std::string strSize = StringUtils::SizeToString(m_block->m_size);
-    return StringUtils::Format("%s %s", strSize, g_localizeStrings.Get(155));
+    return StringUtils::Format("{} {}", strSize, g_localizeStrings.Get(155));
   }
   else
     return m_block->m_label;

--- a/xbmc/platform/linux/storage/UDisksProvider.cpp
+++ b/xbmc/platform/linux/storage/UDisksProvider.cpp
@@ -130,7 +130,8 @@ CMediaSource CUDiskDevice::ToMediaShare()
   if (m_Label.empty())
   {
     std::string strSize = StringUtils::SizeToString(m_PartitionSize);
-    source.strName = StringUtils::Format("%s %s", strSize.c_str(), g_localizeStrings.Get(155).c_str());
+    source.strName =
+        StringUtils::Format("{} {}", strSize.c_str(), g_localizeStrings.Get(155).c_str());
   }
   else
     source.strName = m_Label;
@@ -154,12 +155,12 @@ bool CUDiskDevice::IsApproved()
 
 std::string CUDiskDevice::toString()
 {
-  return StringUtils::Format("DeviceUDI %s: IsFileSystem %s HasFileSystem %s "
-      "IsSystemInternal %s IsMounted %s IsRemovable %s IsPartition %s "
-      "IsOptical %s",
-      m_DeviceKitUDI.c_str(), BOOL2SZ(m_isFileSystem), m_FileSystem.c_str(),
-      BOOL2SZ(m_isSystemInternal), BOOL2SZ(m_isMounted),
-      BOOL2SZ(m_isRemovable), BOOL2SZ(m_isPartition), BOOL2SZ(m_isOptical));
+  return StringUtils::Format("DeviceUDI {}: IsFileSystem {} HasFileSystem {} "
+                             "IsSystemInternal %s IsMounted %s IsRemovable %s IsPartition %s "
+                             "IsOptical %s",
+                             m_DeviceKitUDI.c_str(), BOOL2SZ(m_isFileSystem), m_FileSystem.c_str(),
+                             BOOL2SZ(m_isSystemInternal), BOOL2SZ(m_isMounted),
+                             BOOL2SZ(m_isRemovable), BOOL2SZ(m_isPartition), BOOL2SZ(m_isOptical));
 }
 
 CUDisksProvider::CUDisksProvider()

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -255,7 +255,7 @@ std::string CSMB::URLEncode(const CURL &url)
 
   if (url.HasPort())
   {
-    flat += StringUtils::Format(":%i", url.GetPort());
+    flat += StringUtils::Format(":{}", url.GetPort());
   }
 
   /* okey sadly since a slash is an invalid name we have to tokenize */

--- a/xbmc/platform/posix/network/NetworkPosix.cpp
+++ b/xbmc/platform/posix/network/NetworkPosix.cpp
@@ -23,7 +23,7 @@ CNetworkInterfacePosix::CNetworkInterfacePosix(CNetworkPosix* network,
                                                std::string interfaceName,
                                                char interfaceMacAddrRaw[6])
   : m_interfaceName(std::move(interfaceName)),
-    m_interfaceMacAdr(StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X",
+    m_interfaceMacAdr(StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
                                           (uint8_t)interfaceMacAddrRaw[0],
                                           (uint8_t)interfaceMacAddrRaw[1],
                                           (uint8_t)interfaceMacAddrRaw[2],

--- a/xbmc/platform/win10/network/NetworkWin10.cpp
+++ b/xbmc/platform/win10/network/NetworkWin10.cpp
@@ -78,7 +78,8 @@ std::string CNetworkInterfaceWin10::GetMacAddress() const
 {
   std::string result;
   unsigned char* mAddr = m_adapterAddr->PhysicalAddress;
-  result = StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X", mAddr[0], mAddr[1], mAddr[2], mAddr[3], mAddr[4], mAddr[5]);
+  result = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", mAddr[0], mAddr[1],
+                               mAddr[2], mAddr[3], mAddr[4], mAddr[5]);
   return result;
 }
 

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -151,7 +151,7 @@ std::vector<std::string> CStorageProvider::GetDiskUsage()
 
   auto localfolder = ApplicationData::Current().LocalFolder().Path();
   GetDiskFreeSpaceExW(localfolder.c_str(), nullptr, &ULTotal, &ULTotalFree);
-  strRet = StringUtils::Format("%s: %d MB %s", g_localizeStrings.Get(21440),
+  strRet = StringUtils::Format("{}: {} MB {}", g_localizeStrings.Get(21440),
                                (ULTotalFree.QuadPart / (1024 * 1024)),
                                g_localizeStrings.Get(160).c_str());
   result.push_back(strRet);
@@ -173,7 +173,9 @@ std::vector<std::string> CStorageProvider::GetDiskUsage()
     if (DRIVE_FIXED == GetDriveTypeA(strDrive.c_str())
       && GetDiskFreeSpaceExA((strDrive.c_str()), nullptr, &ULTotal, &ULTotalFree))
     {
-      strRet = StringUtils::Format("%s %d MB %s", strDrive.c_str(), int(ULTotalFree.QuadPart / (1024 * 1024)), g_localizeStrings.Get(160).c_str());
+      strRet = StringUtils::Format("{} {} MB {}", strDrive.c_str(),
+                                   int(ULTotalFree.QuadPart / (1024 * 1024)),
+                                   g_localizeStrings.Get(160).c_str());
       result.push_back(strRet);
     }
   }
@@ -242,17 +244,20 @@ void CStorageProvider::GetDrivesByType(VECSOURCES & localDrives, Drive_Types eDr
       switch (uDriveType)
       {
       case DRIVE_CDROM:
-        share.strName = StringUtils::Format("%s (%s)", share.strPath.c_str(), g_localizeStrings.Get(218).c_str());
+        share.strName = StringUtils::Format("{} ({})", share.strPath.c_str(),
+                                            g_localizeStrings.Get(218).c_str());
         break;
       case DRIVE_REMOVABLE:
         if (share.strName.empty())
-          share.strName = StringUtils::Format("%s (%s)", g_localizeStrings.Get(437).c_str(), share.strPath.c_str());
+          share.strName = StringUtils::Format("{} ({})", g_localizeStrings.Get(437).c_str(),
+                                              share.strPath.c_str());
         break;
       default:
         if (share.strName.empty())
           share.strName = share.strPath;
         else
-          share.strName = StringUtils::Format("%s (%s)", share.strPath.c_str(), share.strName.c_str());
+          share.strName =
+              StringUtils::Format("{} ({})", share.strPath.c_str(), share.strName.c_str());
         break;
       }
     }

--- a/xbmc/platform/win32/CPUInfoWin32.cpp
+++ b/xbmc/platform/win32/CPUInfoWin32.cpp
@@ -116,7 +116,7 @@ CCPUInfoWin32::CCPUInfoWin32()
     {
       if (i < m_coreCounters.size() &&
           PdhAddEnglishCounterW(
-              m_cpuQueryLoad, StringUtils::Format(L"\\Processor(%d)\\%% Idle Time", int(i)).c_str(),
+              m_cpuQueryLoad, StringUtils::Format(L"\\Processor({})\\% Idle Time", int(i)).c_str(),
               0, &m_coreCounters[i]) != ERROR_SUCCESS)
         m_coreCounters[i] = nullptr;
     }

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -285,16 +285,16 @@ std::string CWIN32Util::GetResInfoString()
 #ifdef TARGET_WINDOWS_STORE
   auto displayInfo = DisplayInformation::GetForCurrentView();
 
-  return StringUtils::Format("Desktop Resolution: %dx%d"
-    , displayInfo.ScreenWidthInRawPixels()
-    , displayInfo.ScreenHeightInRawPixels()
-  );
+  return StringUtils::Format("Desktop Resolution: {}x{}", displayInfo.ScreenWidthInRawPixels(),
+                             displayInfo.ScreenHeightInRawPixels());
 #else
   DEVMODE devmode;
   ZeroMemory(&devmode, sizeof(devmode));
   devmode.dmSize = sizeof(devmode);
   EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devmode);
-  return StringUtils::Format("Desktop Resolution: %dx%d %dBit at %dHz",devmode.dmPelsWidth,devmode.dmPelsHeight,devmode.dmBitsPerPel,devmode.dmDisplayFrequency);
+  return StringUtils::Format("Desktop Resolution: {}x{} {}Bit at {}Hz", devmode.dmPelsWidth,
+                             devmode.dmPelsHeight, devmode.dmBitsPerPel,
+                             devmode.dmDisplayFrequency);
 #endif
 }
 
@@ -531,10 +531,10 @@ HRESULT CWIN32Util::ToggleTray(const char cDriveLetter)
     cDL = dvdDevice[0];
   }
 
-  auto strVolFormat = ToW(StringUtils::Format("\\\\.\\%c:", cDL));
+  auto strVolFormat = ToW(StringUtils::Format("\\\\.\\{}:", cDL));
   HANDLE hDrive= CreateFile( strVolFormat.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
                              NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-  auto strRootFormat = ToW(StringUtils::Format("%c:\\", cDL));
+  auto strRootFormat = ToW(StringUtils::Format("{}:\\", cDL));
   if( ( hDrive != INVALID_HANDLE_VALUE || GetLastError() == NO_ERROR) &&
     ( GetDriveType( strRootFormat.c_str() ) == DRIVE_CDROM ) )
   {
@@ -547,7 +547,7 @@ HRESULT CWIN32Util::ToggleTray(const char cDriveLetter)
   if(dwReq == IOCTL_STORAGE_EJECT_MEDIA && bRet == 1)
   {
     CMediaSource share;
-    share.strPath = StringUtils::Format("%c:", cDL);
+    share.strPath = StringUtils::Format("{}:", cDL);
     share.strName = share.strPath;
     CServiceBroker::GetMediaManager().RemoveAutoSource(share);
   }
@@ -567,7 +567,7 @@ HRESULT CWIN32Util::EjectTray(const char cDriveLetter)
     cDL = dvdDevice[0];
   }
 
-  std::string strVolFormat = StringUtils::Format("\\\\.\\%c:", cDL);
+  std::string strVolFormat = StringUtils::Format("\\\\.\\{}:", cDL);
 
   if(GetDriveStatus(strVolFormat, true) != 1)
     return ToggleTray(cDL);
@@ -586,7 +586,7 @@ HRESULT CWIN32Util::CloseTray(const char cDriveLetter)
     cDL = dvdDevice[0];
   }
 
-  std::string strVolFormat = StringUtils::Format( "\\\\.\\%c:", cDL);
+  std::string strVolFormat = StringUtils::Format("\\\\.\\{}:", cDL);
 
   if(GetDriveStatus(strVolFormat, true) == 1)
     return ToggleTray(cDL);
@@ -1189,7 +1189,7 @@ bool CWIN32Util::IsUsbDevice(const std::wstring &strWdrive)
   }
   return false;
 #else
-  std::wstring strWDevicePath = StringUtils::Format(L"\\\\.\\%s",strWdrive.substr(0, 2).c_str());
+  std::wstring strWDevicePath = StringUtils::Format(L"\\\\.\\{}", strWdrive.substr(0, 2).c_str());
 
   HANDLE deviceHandle = CreateFileW(
     strWDevicePath.c_str(),
@@ -1237,9 +1237,9 @@ std::string CWIN32Util::WUSysMsg(DWORD dwError)
 
   if ( 0 != ::FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwError,
                              SS_DEFLANGID, szBuf, 511, NULL) )
-    return StringUtils::Format("%s (0x%X)", szBuf, dwError);
+    return StringUtils::Format("{} (0x{:X})", szBuf, dwError);
   else
-    return StringUtils::Format("Unknown error (0x%X)", dwError);
+    return StringUtils::Format("Unknown error (0x{:X})", dwError);
 }
 
 bool CWIN32Util::SetThreadLocalLocale(bool enable /* = true */)

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -48,7 +48,8 @@ std::string CNetworkInterfaceWin32::GetMacAddress() const
 {
   std::string result;
   const unsigned char* mAddr = m_adapter.PhysicalAddress;
-  result = StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X", mAddr[0], mAddr[1], mAddr[2], mAddr[3], mAddr[4], mAddr[5]);
+  result = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", mAddr[0], mAddr[1],
+                               mAddr[2], mAddr[3], mAddr[4], mAddr[5]);
   return result;
 }
 
@@ -67,7 +68,7 @@ std::string CNetworkInterfaceWin32::GetCurrentNetmask(void) const
   if (m_adapter.FirstUnicastAddress->Address.lpSockaddr->sa_family == AF_INET)
     return CNetworkBase::GetMaskByPrefixLength(m_adapter.FirstUnicastAddress->OnLinkPrefixLength);
 
-  return StringUtils::Format("%u", m_adapter.FirstUnicastAddress->OnLinkPrefixLength);
+  return StringUtils::Format("{}", m_adapter.FirstUnicastAddress->OnLinkPrefixLength);
 }
 
 std::string CNetworkInterfaceWin32::GetCurrentDefaultGateway(void) const
@@ -263,9 +264,10 @@ bool CNetworkInterfaceWin32::GetHostMacAddress(const struct sockaddr& host, std:
   {
     if (neighborIp.PhysicalAddressLength == 6)
     {
-      mac = StringUtils::Format("%02X:%02X:%02X:%02X:%02X:%02X",
-        neighborIp.PhysicalAddress[0], neighborIp.PhysicalAddress[1], neighborIp.PhysicalAddress[2],
-        neighborIp.PhysicalAddress[3], neighborIp.PhysicalAddress[4], neighborIp.PhysicalAddress[5]);
+      mac = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+                                neighborIp.PhysicalAddress[0], neighborIp.PhysicalAddress[1],
+                                neighborIp.PhysicalAddress[2], neighborIp.PhysicalAddress[3],
+                                neighborIp.PhysicalAddress[4], neighborIp.PhysicalAddress[5]);
       return true;
     }
     else

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -92,7 +92,7 @@ bool CWin32StorageProvider::Eject(const std::string& mountpath)
   if( !mountpath[0] )
     return false;
 
-  auto strVolFormat = ToW(StringUtils::Format("\\\\.\\%c:", mountpath[0]));
+  auto strVolFormat = ToW(StringUtils::Format("\\\\.\\{}:", mountpath[0]));
 
   long DiskNumber = -1;
 
@@ -156,7 +156,9 @@ std::vector<std::string > CWin32StorageProvider::GetDiskUsage()
       if( DRIVE_FIXED == GetDriveType( strDrive.c_str()  ) &&
         GetDiskFreeSpaceEx( ( strDrive.c_str() ), nullptr, &ULTotal, &ULTotalFree ) )
       {
-        strRet = KODI::PLATFORM::WINDOWS::FromW(StringUtils::Format(L"%s %d MB %s",strDrive.c_str(), int(ULTotalFree.QuadPart/(1024*1024)), KODI::PLATFORM::WINDOWS::ToW(g_localizeStrings.Get(160).c_str())));
+        strRet = KODI::PLATFORM::WINDOWS::FromW(StringUtils::Format(
+            L"{} {} MB {}", strDrive.c_str(), int(ULTotalFree.QuadPart / (1024 * 1024)),
+            KODI::PLATFORM::WINDOWS::ToW(g_localizeStrings.Get(160).c_str())));
         result.push_back(strRet);
       }
       iPos += (wcslen( pcBuffer.get() + iPos) + 1 );
@@ -240,17 +242,20 @@ void CWin32StorageProvider::GetDrivesByType(VECSOURCES &localDrives, Drive_Types
           switch(uDriveType)
           {
           case DRIVE_CDROM:
-            share.strName = StringUtils::Format( "%s (%s)", share.strPath.c_str(), g_localizeStrings.Get(218).c_str());
+            share.strName = StringUtils::Format("{} ({})", share.strPath.c_str(),
+                                                g_localizeStrings.Get(218).c_str());
             break;
           case DRIVE_REMOVABLE:
             if(share.strName.empty())
-              share.strName = StringUtils::Format( "%s (%s)", g_localizeStrings.Get(437).c_str(), share.strPath.c_str());
+              share.strName = StringUtils::Format("{} ({})", g_localizeStrings.Get(437).c_str(),
+                                                  share.strPath.c_str());
             break;
           default:
             if(share.strName.empty())
               share.strName = share.strPath;
             else
-              share.strName = StringUtils::Format( "%s (%s)", share.strPath.c_str(), share.strName.c_str());
+              share.strName =
+                  StringUtils::Format("{} ({})", share.strPath.c_str(), share.strName.c_str());
             break;
           }
         }

--- a/xbmc/playlists/PlayListB4S.cpp
+++ b/xbmc/playlists/PlayListB4S.cpp
@@ -112,15 +112,18 @@ void CPlayListB4S::Save(const std::string& strFileName) const
     return ;
   }
   std::string write;
-  write += StringUtils::Format("<?xml version=%c1.0%c encoding='UTF-8' standalone=%cyes%c?>\n", 34, 34, 34, 34);
+  write += StringUtils::Format("<?xml version={}1.0{} encoding='UTF-8' standalone={}yes{}?>\n", 34,
+                               34, 34, 34);
   write += StringUtils::Format("<WinampXML>\n");
   write += StringUtils::Format("  <playlist num_entries=\"{0}\" label=\"{1}\">\n", m_vecItems.size(),m_strPlayListName.c_str());
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     const CFileItemPtr item = m_vecItems[i];
-    write += StringUtils::Format("    <entry Playstring=%cfile:%s%c>\n", 34, item->GetPath().c_str(), 34 );
-    write += StringUtils::Format("      <Name>%s</Name>\n", item->GetLabel().c_str());
-    write += StringUtils::Format("      <Length>%u</Length>\n", item->GetMusicInfoTag()->GetDuration());
+    write += StringUtils::Format("    <entry Playstring={}file:{}{}>\n", 34,
+                                 item->GetPath().c_str(), 34);
+    write += StringUtils::Format("      <Name>{}</Name>\n", item->GetLabel().c_str());
+    write +=
+        StringUtils::Format("      <Length>{}</Length>\n", item->GetMusicInfoTag()->GetDuration());
   }
   write += StringUtils::Format("  </playlist>\n");
   write += StringUtils::Format("</WinampXML>\n");

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -217,7 +217,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     CLog::Log(LOGERROR, "Could not save M3U playlist: [%s]", strPlaylist.c_str());
     return;
   }
-  std::string strLine = StringUtils::Format("%s\n",StartMarker);
+  std::string strLine = StringUtils::Format("{}\n", StartMarker);
   if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
     return; // error
 
@@ -226,17 +226,20 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     CFileItemPtr item = m_vecItems[i];
     std::string strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
-    strLine = StringUtils::Format( "%s:%i,%s\n", InfoMarker, item->GetMusicInfoTag()->GetDuration() / 1000, strDescription.c_str() );
+    strLine =
+        StringUtils::Format("{}:{},{}\n", InfoMarker, item->GetMusicInfoTag()->GetDuration() / 1000,
+                            strDescription.c_str());
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
     if (item->m_lStartOffset != 0 || item->m_lEndOffset != 0)
     {
-      strLine = StringUtils::Format("%s:%" PRIi64 ",%" PRIi64 "\n", OffsetMarker, item->m_lStartOffset, item->m_lEndOffset);
+      strLine =
+          StringUtils::Format("{}:{},{}\n", OffsetMarker, item->m_lStartOffset, item->m_lEndOffset);
       file.Write(strLine.c_str(),strLine.size());
     }
     std::string strFileName = ResolveURL(item);
     g_charsetConverter.utf8ToStringCharset(strFileName);
-    strLine = StringUtils::Format("%s\n",strFileName.c_str());
+    strLine = StringUtils::Format("{}\n", strFileName.c_str());
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
   }

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -207,10 +207,10 @@ void CPlayListPLS::Save(const std::string& strFileName) const
     return;
   }
   std::string write;
-  write += StringUtils::Format("%s\n", START_PLAYLIST_MARKER);
+  write += StringUtils::Format("{}\n", START_PLAYLIST_MARKER);
   std::string strPlayListName=m_strPlayListName;
   g_charsetConverter.utf8ToStringCharset(strPlayListName);
-  write += StringUtils::Format("PlaylistName=%s\n", strPlayListName.c_str() );
+  write += StringUtils::Format("PlaylistName={}\n", strPlayListName.c_str());
 
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
@@ -219,9 +219,10 @@ void CPlayListPLS::Save(const std::string& strFileName) const
     g_charsetConverter.utf8ToStringCharset(strFileName);
     std::string strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
-    write += StringUtils::Format("File%i=%s\n", i + 1, strFileName.c_str() );
-    write += StringUtils::Format("Title%i=%s\n", i + 1, strDescription.c_str() );
-    write += StringUtils::Format("Length%i=%u\n", i + 1, item->GetMusicInfoTag()->GetDuration() / 1000 );
+    write += StringUtils::Format("File{}={}\n", i + 1, strFileName.c_str());
+    write += StringUtils::Format("Title{}={}\n", i + 1, strDescription.c_str());
+    write +=
+        StringUtils::Format("Length{}={}\n", i + 1, item->GetMusicInfoTag()->GetDuration() / 1000);
   }
 
   write += StringUtils::Format("NumberOfEntries={0}\n", m_vecItems.size());

--- a/xbmc/playlists/PlayListWPL.cpp
+++ b/xbmc/playlists/PlayListWPL.cpp
@@ -105,19 +105,22 @@ void CPlayListWPL::Save(const std::string& strFileName) const
     return ;
   }
   std::string write;
-  write += StringUtils::Format("<?wpl version=%c1.0%c>\n", 34, 34);
+  write += StringUtils::Format("<?wpl version={}1.0{}>\n", 34, 34);
   write += StringUtils::Format("<smil>\n");
   write += StringUtils::Format("    <head>\n");
-  write += StringUtils::Format("        <meta name=%cGenerator%c content=%cMicrosoft Windows Media Player -- 10.0.0.3646%c/>\n", 34, 34, 34, 34);
+  write += StringUtils::Format("        <meta name={}Generator{} content={}Microsoft Windows Media "
+                               "Player -- 10.0.0.3646{}/>\n",
+                               34, 34, 34, 34);
   write += StringUtils::Format("        <author/>\n");
-  write += StringUtils::Format("        <title>%s</title>\n", m_strPlayListName.c_str());
+  write += StringUtils::Format("        <title>{}</title>\n", m_strPlayListName.c_str());
   write += StringUtils::Format("    </head>\n");
   write += StringUtils::Format("    <body>\n");
   write += StringUtils::Format("        <seq>\n");
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     CFileItemPtr item = m_vecItems[i];
-    write += StringUtils::Format("            <media src=%c%s%c/>", 34, item->GetPath().c_str(), 34);
+    write +=
+        StringUtils::Format("            <media src={}{}{}/>", 34, item->GetPath().c_str(), 34);
   }
   write += StringUtils::Format("        </seq>\n");
   write += StringUtils::Format("    </body>\n");

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -170,20 +170,23 @@ void CPlayListXML::Save(const std::string& strFileName) const
   {
     CFileItemPtr item = m_vecItems[i];
     write += StringUtils::Format("  <stream>\n" );
-    write += StringUtils::Format("    <url>%s</url>", item->GetPath().c_str() );
-    write += StringUtils::Format("    <name>%s</name>", item->GetLabel().c_str() );
+    write += StringUtils::Format("    <url>{}</url>", item->GetPath().c_str());
+    write += StringUtils::Format("    <name>{}</name>", item->GetLabel().c_str());
 
     if ( !item->GetProperty("language").empty() )
-      write += StringUtils::Format("    <lang>%s</lang>", item->GetProperty("language").c_str() );
+      write += StringUtils::Format("    <lang>{}</lang>", item->GetProperty("language").c_str());
 
     if ( !item->GetProperty("category").empty() )
-      write += StringUtils::Format("    <category>%s</category>", item->GetProperty("category").c_str() );
+      write +=
+          StringUtils::Format("    <category>{}</category>", item->GetProperty("category").c_str());
 
     if ( !item->GetProperty("remotechannel").empty() )
-      write += StringUtils::Format("    <channel>%s</channel>", item->GetProperty("remotechannel").c_str() );
+      write += StringUtils::Format("    <channel>{}</channel>",
+                                   item->GetProperty("remotechannel").c_str());
 
     if (item->m_iHasLock > LOCK_STATE_NO_LOCK)
-      write += StringUtils::Format("    <lockpassword>%s<lockpassword>", item->m_strLockCode.c_str() );
+      write +=
+          StringUtils::Format("    <lockpassword>{}<lockpassword>", item->m_strLockCode.c_str());
 
     write += StringUtils::Format("  </stream>\n\n" );
   }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -730,7 +730,8 @@ bool CSmartPlaylistRule::CanGroupMix(Field group)
 
 std::string CSmartPlaylistRule::GetLocalizedRule() const
 {
-  return StringUtils::Format("%s %s %s", GetLocalizedField(m_field).c_str(), GetLocalizedOperator(m_operator).c_str(), GetParameter().c_str());
+  return StringUtils::Format("{} {} {}", GetLocalizedField(m_field).c_str(),
+                             GetLocalizedOperator(m_operator).c_str(), GetParameter().c_str());
 }
 
 std::string CSmartPlaylistRule::GetVideoResolutionQuery(const std::string &parameter) const
@@ -752,16 +753,16 @@ std::string CSmartPlaylistRule::GetVideoResolutionQuery(const std::string &param
   switch (m_operator)
   {
     case OPERATOR_EQUALS:
-      retVal += StringUtils::Format(">= %i AND iVideoWidth <= %i", min, max);
+      retVal += StringUtils::Format(">= {} AND iVideoWidth <= {}", min, max);
       break;
     case OPERATOR_DOES_NOT_EQUAL:
-      retVal += StringUtils::Format("< %i OR iVideoWidth > %i", min, max);
+      retVal += StringUtils::Format("< {} OR iVideoWidth > {}", min, max);
       break;
     case OPERATOR_LESS_THAN:
-      retVal += StringUtils::Format("< %i", min);
+      retVal += StringUtils::Format("< {}", min);
       break;
     case OPERATOR_GREATER_THAN:
-      retVal += StringUtils::Format("> %i", max);
+      retVal += StringUtils::Format("> {}", max);
       break;
     default:
       break;
@@ -824,7 +825,7 @@ std::string CSmartPlaylistRule::FormatParameter(const std::string &operatorStrin
   // special-casing
   if (m_field == FieldTime || m_field == FieldAlbumDuration)
   { // translate time to seconds
-    std::string seconds = StringUtils::Format("%li", StringUtils::TimeStringToSeconds(param));
+    std::string seconds = StringUtils::Format("{}", StringUtils::TimeStringToSeconds(param));
     return db.PrepareSQL(operatorString.c_str(), seconds.c_str());
   }
   return CDatabaseQueryRule::FormatParameter(operatorString, param, db, strType);
@@ -833,10 +834,12 @@ std::string CSmartPlaylistRule::FormatParameter(const std::string &operatorStrin
 std::string CSmartPlaylistRule::FormatLinkQuery(const char *field, const char *table, const MediaType& mediaType, const std::string& mediaField, const std::string& parameter)
 {
   // NOTE: no need for a PrepareSQL here, as the parameter has already been formatted
-  return StringUtils::Format(" EXISTS (SELECT 1 FROM %s_link"
-                             "         JOIN %s ON %s.%s_id=%s_link.%s_id"
-                             "         WHERE %s_link.media_id=%s AND %s.name %s AND %s_link.media_type = '%s')",
-                             field, table, table, table, field, table, field, mediaField.c_str(), table, parameter.c_str(), field, mediaType.c_str());
+  return StringUtils::Format(
+      " EXISTS (SELECT 1 FROM {}_link"
+      "         JOIN %s ON %s.%s_id=%s_link.%s_id"
+      "         WHERE %s_link.media_id=%s AND %s.name %s AND %s_link.media_type = '%s')",
+      field, table, table, table, field, table, field, mediaField.c_str(), table, parameter.c_str(),
+      field, mediaType.c_str());
 }
 
 std::string CSmartPlaylistRule::FormatYearQuery(const std::string& field,
@@ -1111,7 +1114,7 @@ std::string CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, c
           if (playlist.GetType() == strType)
           {
             if ((*it)->m_operator == CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL)
-              currentRule = StringUtils::Format("NOT (%s)", playlistQuery.c_str());
+              currentRule = StringUtils::Format("NOT ({})", playlistQuery.c_str());
             else
               currentRule = playlistQuery;
           }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -522,7 +522,8 @@ void CProfileManager::CreateProfileFolders()
   CDirectory::Create(GetBookmarksThumbFolder());
   CDirectory::Create(GetSavestatesFolder());
   for (size_t hex = 0; hex < 16; hex++)
-    CDirectory::Create(URIUtils::AddFileToFolder(GetThumbnailsFolder(), StringUtils::Format("%lx", hex)));
+    CDirectory::Create(
+        URIUtils::AddFileToFolder(GetThumbnailsFolder(), StringUtils::Format("{:x}", hex)));
 
   CDirectory::Create("special://profile/addon_data");
   CDirectory::Create("special://profile/keymaps");

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -497,7 +497,8 @@ bool CPVRDatabase::DeleteChannelsFromGroup(const CPVRChannelGroup& group, const 
     std::string strChannelsToDelete;
 
     for (unsigned int iChannelPtr = 0; iChannelPtr + iDeletedChannels < channelsToDelete.size() && iChannelPtr < 50; iChannelPtr++)
-      strChannelsToDelete += StringUtils::Format(", %d", channelsToDelete.at(iDeletedChannels + iChannelPtr));
+      strChannelsToDelete +=
+          StringUtils::Format(", {}", channelsToDelete.at(iDeletedChannels + iChannelPtr));
 
     if (!strChannelsToDelete.empty())
     {

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -577,7 +577,8 @@ bool CPVRManager::SetWakeupCommand()
     {
       nextEvent.GetAsTime(iWakeupTime);
 
-      std::string strExecCommand = StringUtils::Format("%s %ld", strWakeupCommand.c_str(), iWakeupTime);
+      std::string strExecCommand =
+          StringUtils::Format("{} {}", strWakeupCommand.c_str(), iWakeupTime);
 
       const int iReturn = system(strExecCommand.c_str());
       if (iReturn != 0)

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -441,7 +441,7 @@ bool CPVRClient::GetAddonProperties()
     return false;
 
   /* display name = backend name:connection string */
-  strFriendlyName = StringUtils::Format("%s:%s", strBackendName, strConnectionString);
+  strFriendlyName = StringUtils::Format("{}:{}", strBackendName, strConnectionString);
 
   /* backend version number */
   retVal = DoAddonCall(
@@ -2085,7 +2085,7 @@ void CPVRClientCapabilities::InitRecordingsLifetimeValues()
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("%d", iValue);
+        strDescr = StringUtils::Format("{}", iValue);
       }
       m_recordingsLifetimeValues.emplace_back(strDescr, iValue);
     }

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -67,7 +67,8 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId)
     m_iClientEncryptionSystem(channel.iEncryptionSystem)
 {
   if (m_strChannelName.empty())
-    m_strChannelName = StringUtils::Format("%s %d", g_localizeStrings.Get(19029).c_str(), m_iUniqueId);
+    m_strChannelName =
+        StringUtils::Format("{} {}", g_localizeStrings.Get(19029).c_str(), m_iUniqueId);
 
   UpdateEncryptionName();
 }
@@ -322,7 +323,7 @@ bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIco
   CSingleLock lock(m_critSection);
   if (m_strIconPath != strIconPath)
   {
-    m_strIconPath = StringUtils::Format("%s", strIconPath.c_str());
+    m_strIconPath = StringUtils::Format("{}", strIconPath.c_str());
 
     m_bChanged = true;
     m_bIsUserSetIcon = bIsUserSetIcon && !m_strIconPath.empty();
@@ -511,7 +512,7 @@ std::string CPVRChannel::GetEncryptionName(int iCaid)
     strName = "Verimatrix";
 
   if (iCaid >= 0)
-    strName += StringUtils::Format(" (%04X)", iCaid);
+    strName += StringUtils::Format(" ({:04X})", iCaid);
 
   return strName;
 }
@@ -637,7 +638,7 @@ bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
   {
     bool bCleanEPG = !m_strEPGScraper.empty() || strScraper.empty();
 
-    m_strEPGScraper = StringUtils::Format("%s", strScraper.c_str());
+    m_strEPGScraper = StringUtils::Format("{}", strScraper.c_str());
     m_bChanged = true;
 
     /* clear the previous EPG entries if needed */

--- a/xbmc/pvr/channels/PVRChannelNumber.cpp
+++ b/xbmc/pvr/channels/PVRChannelNumber.cpp
@@ -30,7 +30,7 @@ std::string CPVRChannelNumber::SortableChannelNumber() const
 std::string CPVRChannelNumber::ToString(char separator) const
 {
   if (m_iSubChannelNumber == 0)
-    return StringUtils::Format("%u", m_iChannelNumber);
+    return StringUtils::Format("{}", m_iChannelNumber);
   else
-    return StringUtils::Format("%u%c%u", m_iChannelNumber, separator, m_iSubChannelNumber);
+    return StringUtils::Format("{}{}{}", m_iChannelNumber, separator, m_iSubChannelNumber);
 }

--- a/xbmc/pvr/channels/PVRChannelsPath.cpp
+++ b/xbmc/pvr/channels/PVRChannelsPath.cpp
@@ -118,7 +118,8 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio, bool bHidden, const std::string&
     m_kind = Kind::GROUP;
 
   m_group = bHidden ? ".hidden" : strGroupName;
-  m_path = StringUtils::Format("pvr://channels/%s/%s", bRadio ? "radio" : "tv", CURL::Encode(m_group).c_str());
+  m_path = StringUtils::Format("pvr://channels/{}/{}", bRadio ? "radio" : "tv",
+                               CURL::Encode(m_group).c_str());
 
   if (!m_group.empty())
     m_path.append("/");
@@ -133,7 +134,8 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio, const std::string& strGroupName)
     m_kind = Kind::GROUP;
 
   m_group = strGroupName;
-  m_path = StringUtils::Format("pvr://channels/%s/%s", bRadio ? "radio" : "tv", CURL::Encode(m_group).c_str());
+  m_path = StringUtils::Format("pvr://channels/{}/{}", bRadio ? "radio" : "tv",
+                               CURL::Encode(m_group).c_str());
 
   if (!m_group.empty())
     m_path.append("/");
@@ -148,8 +150,8 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio, const std::string& strGroupName,
     m_group = strGroupName;
     m_clientID = strClientID;
     m_iChannelUID = iChannelUID;
-    m_path = StringUtils::Format("pvr://channels/%s/%s/%s_%d.pvr",
-                                 bRadio ? "radio" : "tv", CURL::Encode(m_group).c_str(), m_clientID.c_str(), m_iChannelUID);
+    m_path = StringUtils::Format("pvr://channels/{}/{}/{}_{}.pvr", bRadio ? "radio" : "tv",
+                                 CURL::Encode(m_group).c_str(), m_clientID.c_str(), m_iChannelUID);
   }
 }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -131,9 +131,9 @@ bool CGUIDialogPVRChannelManager::OnActionMove(const CAction& action)
           unsigned int iNewSelect = bMoveUp ? m_iSelected - 1 : m_iSelected + 1;
           if (m_channelItems->Get(iNewSelect)->GetProperty("Number").asString() != "-")
           {
-            strNumber = StringUtils::Format("%i", m_iSelected+1);
+            strNumber = StringUtils::Format("{}", m_iSelected + 1);
             m_channelItems->Get(iNewSelect)->SetProperty("Number", strNumber);
-            strNumber = StringUtils::Format("%i", iNewSelect+1);
+            strNumber = StringUtils::Format("{}", iNewSelect + 1);
             m_channelItems->Get(m_iSelected)->SetProperty("Number", strNumber);
           }
           m_channelItems->Swap(iNewSelect, m_iSelected);
@@ -732,7 +732,7 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty("EPGSource", 0);
     channelFile->SetProperty("ParentalLocked", channel->IsLocked());
     channelFile->SetProperty("Number",
-                             StringUtils::Format("%i", member->ChannelNumber().GetChannelNumber()));
+                             StringUtils::Format("{}", member->ChannelNumber().GetChannelNumber()));
 
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*channelFile);
     if (client)
@@ -869,7 +869,7 @@ void CGUIDialogPVRChannelManager::Renumber()
     pItem = m_channelItems->Get(iChannelPtr);
     if (pItem->GetProperty("ActiveChannel").asBoolean())
     {
-      strNumber = StringUtils::Format("%i", ++iNextChannelNumber);
+      strNumber = StringUtils::Format("{}", ++iNextChannelNumber);
       pItem->SetProperty("Number", strNumber);
     }
     else

--- a/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
@@ -72,7 +72,8 @@ void CGUIDialogPVRClientPriorities::InitializeSettings()
   CServiceBroker::GetPVRManager().Clients()->GetCreatedClients(m_clients);
   for (const auto& client : m_clients)
   {
-    setting = AddEdit(group, StringUtils::Format("%i", client.second->GetID()), 13205 /* Unknown */, SettingLevel::Basic, client.second->GetPriority());
+    setting = AddEdit(group, StringUtils::Format("{}", client.second->GetID()), 13205 /* Unknown */,
+                      SettingLevel::Basic, client.second->GetPriority());
   }
 }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -463,22 +463,23 @@ void CGUIDialogPVRGroupManager::Update()
 
     if (m_selectedGroup->IsInternalGroup())
     {
-      std::string strNewLabel = StringUtils::Format("%s %s",
-                                        g_localizeStrings.Get(19022).c_str(),
-                                        m_bIsRadio ? g_localizeStrings.Get(19024).c_str() : g_localizeStrings.Get(19023).c_str());
+      std::string strNewLabel = StringUtils::Format(
+          "{} {}", g_localizeStrings.Get(19022).c_str(),
+          m_bIsRadio ? g_localizeStrings.Get(19024).c_str() : g_localizeStrings.Get(19023).c_str());
       SET_CONTROL_LABEL(CONTROL_UNGROUPED_LABEL, strNewLabel);
 
-      strNewLabel = StringUtils::Format("%s %s",
-                                        g_localizeStrings.Get(19218).c_str(),
-                                        m_bIsRadio ? g_localizeStrings.Get(19024).c_str() : g_localizeStrings.Get(19023).c_str());
+      strNewLabel = StringUtils::Format("{} {}", g_localizeStrings.Get(19218).c_str(),
+                                        m_bIsRadio ? g_localizeStrings.Get(19024).c_str()
+                                                   : g_localizeStrings.Get(19023).c_str());
       SET_CONTROL_LABEL(CONTROL_IN_GROUP_LABEL, strNewLabel);
     }
     else
     {
-      std::string strNewLabel = StringUtils::Format("%s", g_localizeStrings.Get(19219).c_str());
+      std::string strNewLabel = StringUtils::Format("{}", g_localizeStrings.Get(19219).c_str());
       SET_CONTROL_LABEL(CONTROL_UNGROUPED_LABEL, strNewLabel);
 
-      strNewLabel = StringUtils::Format("%s %s", g_localizeStrings.Get(19220).c_str(), m_selectedGroup->GroupName().c_str());
+      strNewLabel = StringUtils::Format("{} {}", g_localizeStrings.Get(19220).c_str(),
+                                        m_selectedGroup->GroupName().c_str());
       SET_CONTROL_LABEL(CONTROL_IN_GROUP_LABEL, strNewLabel);
     }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -215,7 +215,9 @@ void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& sett
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(17999).c_str(), current) /* %i days */, current));
+      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(17999).c_str(),
+                                                               current) /* {} days */,
+                                           current));
     }
   }
   else

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -831,7 +831,7 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   {
     const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
     const std::string channelDescription =
-        StringUtils::Format("%s %s", groupMember->ChannelNumber().FormattedChannelNumber().c_str(),
+        StringUtils::Format("{} {}", groupMember->ChannelNumber().FormattedChannelNumber().c_str(),
                             channel->ChannelName().c_str());
     m_channelEntries.insert({index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});
     ++index;
@@ -1025,7 +1025,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format("%d", current), current));
+      list.insert(it, IntegerSettingOption(StringUtils::Format("{}", current), current));
     }
   }
   else
@@ -1061,7 +1061,9 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(17999).c_str(), current) /* %i days */, current));
+      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(17999).c_str(),
+                                                               current) /* {} days */,
+                                           current));
     }
   }
   else
@@ -1097,7 +1099,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format("%d", current), current));
+      list.insert(it, IntegerSettingOption(StringUtils::Format("{}", current), current));
     }
   }
   else
@@ -1162,7 +1164,9 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
     if (bInsertValue)
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(14044).c_str(), current) /* %i min */, current));
+      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(14044).c_str(),
+                                                               current) /* {} min */,
+                                           current));
     }
   }
   else

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -343,7 +343,7 @@ const std::string CPVREpgInfoTag::GetCastLabel() const
   // Note: see CVideoInfoTag::GetCast for reference implementation.
   std::string strLabel;
   for (const auto& castEntry : m_cast)
-    strLabel += StringUtils::Format("%s\n", castEntry.c_str());
+    strLabel += StringUtils::Format("{}\n", castEntry.c_str());
 
   return StringUtils::TrimRight(strLabel, "\n");
 }
@@ -573,7 +573,8 @@ std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
 
 void CPVREpgInfoTag::UpdatePath()
 {
-  m_strFileNameAndPath = StringUtils::Format("pvr://guide/%04i/%s.epg", EpgID(), m_startTime.GetAsDBDateTime().c_str());
+  m_strFileNameAndPath = StringUtils::Format("pvr://guide/{:04}/{}.epg", EpgID(),
+                                             m_startTime.GetAsDBDateTime().c_str());
 }
 
 int CPVREpgInfoTag::EpgID() const

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -79,7 +79,7 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   if (bAnyClientSupportingEPG)
   {
     item.reset(
-        new CFileItem(StringUtils::Format("pvr://guide/%s/", bRadio ? "radio" : "tv"), true));
+        new CFileItem(StringUtils::Format("pvr://guide/{}/", bRadio ? "radio" : "tv"), true));
     item->SetLabel(g_localizeStrings.Get(19069)); // Guide
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_GUIDE
                                                                                : WINDOW_TV_GUIDE));
@@ -122,7 +122,7 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   if (bAnyClientSupportingEPG)
   {
     item.reset(
-        new CFileItem(StringUtils::Format("pvr://search/%s/", bRadio ? "radio" : "tv"), true));
+        new CFileItem(StringUtils::Format("pvr://search/{}/", bRadio ? "radio" : "tv"), true));
     item->SetLabel(g_localizeStrings.Get(137)); // Search
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_SEARCH
                                                                                : WINDOW_TV_SEARCH));
@@ -326,9 +326,9 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     {
       item->IncrementProperty("watchedepisodes", 1);
     }
-    item->SetLabel2(StringUtils::Format("%s / %s",
-        item->GetProperty("watchedepisodes").asString().c_str(),
-        item->GetProperty("totalepisodes").asString().c_str()));
+    item->SetLabel2(StringUtils::Format("{} / {}",
+                                        item->GetProperty("watchedepisodes").asString().c_str(),
+                                        item->GetProperty("totalepisodes").asString().c_str()));
 
     item->IncrementProperty("sizeinbytes", recording->GetSizeInBytes());
   }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1412,21 +1412,23 @@ std::string CGUIEPGGridContainer::GetLabel(int info) const
   {
   case CONTAINER_NUM_PAGES:
     if (m_channelsPerPage > 0)
-      label = StringUtils::Format("%u", (m_gridModel->ChannelItemsSize() + m_channelsPerPage - 1) / m_channelsPerPage);
+      label = StringUtils::Format("{}", (m_gridModel->ChannelItemsSize() + m_channelsPerPage - 1) /
+                                            m_channelsPerPage);
     else
-      label = StringUtils::Format("%u", 0);
+      label = StringUtils::Format("{}", 0);
     break;
   case CONTAINER_CURRENT_PAGE:
     if (m_channelsPerPage > 0)
-      label = StringUtils::Format("%u", 1 + (m_channelCursor + m_channelOffset) / m_channelsPerPage);
+      label =
+          StringUtils::Format("{}", 1 + (m_channelCursor + m_channelOffset) / m_channelsPerPage);
     else
-      label = StringUtils::Format("%u", 1);
+      label = StringUtils::Format("{}", 1);
     break;
   case CONTAINER_POSITION:
-    label = StringUtils::Format("%i", 1 + m_channelCursor + m_channelOffset);
+    label = StringUtils::Format("{}", 1 + m_channelCursor + m_channelOffset);
     break;
   case CONTAINER_NUM_ITEMS:
-    label = StringUtils::Format("%u", m_gridModel->ChannelItemsSize());
+    label = StringUtils::Format("{}", m_gridModel->ChannelItemsSize());
     break;
   default:
       break;

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -74,7 +74,7 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
       // reset icon before searching for a new one
       channel->SetIconPath("");
 
-      const std::string strChannelUid = StringUtils::Format("%08d", channel->UniqueID());
+      const std::string strChannelUid = StringUtils::Format("{:08}", channel->UniqueID());
       std::string strLegalClientChannelName =
           CUtil::MakeLegalFileName(channel->ClientChannelName());
       StringUtils::ToLower(strLegalClientChannelName);

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -456,7 +456,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         }
         else if (recording->HasYear())
         {
-          strValue = StringUtils::Format("%i", recording->GetYear());
+          strValue = StringUtils::Format("{}", recording->GetYear());
           return true;
         }
         return false;
@@ -590,7 +590,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_YEAR:
         if (epgTag->Year() > 0)
         {
-          strValue = StringUtils::Format("%i", epgTag->Year());
+          strValue = StringUtils::Format("{}", epgTag->Year());
           return true;
         }
         return false;
@@ -598,7 +598,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_SEASON:
         if (epgTag->SeriesNumber() >= 0)
         {
-          strValue = StringUtils::Format("%i", epgTag->SeriesNumber());
+          strValue = StringUtils::Format("{}", epgTag->SeriesNumber());
           return true;
         }
         return false;
@@ -606,7 +606,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_EPISODE:
         if (epgTag->EpisodeNumber() >= 0)
         {
-          strValue = StringUtils::Format("%i", epgTag->EpisodeNumber());
+          strValue = StringUtils::Format("{}", epgTag->EpisodeNumber());
           return true;
         }
         return false;
@@ -638,7 +638,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_PARENTAL_RATING:
         if (epgTag->ParentalRating() > 0)
         {
-          strValue = StringUtils::Format("%i", epgTag->ParentalRating());
+          strValue = StringUtils::Format("{}", epgTag->ParentalRating());
           return true;
         }
         return false;
@@ -651,7 +651,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         }
         else if (epgTag->Year() > 0)
         {
-          strValue = StringUtils::Format("%i", epgTag->Year());
+          strValue = StringUtils::Format("{}", epgTag->Year());
           return true;
         }
         return false;
@@ -958,7 +958,7 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item, const CGUIInfo& info, 
       case RDS_ALBUM_TRACKNUMBER:
         if (tag->GetAlbumTrackNumber() > 0)
         {
-          strValue = StringUtils::Format("%i", tag->GetAlbumTrackNumber());
+          strValue = StringUtils::Format("{}", tag->GetAlbumTrackNumber());
           return true;
         }
         break;
@@ -978,43 +978,43 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item, const CGUIInfo& info, 
         strValue = tag->GetInfoStock();
         return true;
       case RDS_INFO_STOCK_SIZE:
-        strValue = StringUtils::Format("%i", static_cast<int>(tag->GetInfoStock().size()));
+        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoStock().size()));
         return true;
       case RDS_INFO_SPORT:
         strValue = tag->GetInfoSport();
         return true;
       case RDS_INFO_SPORT_SIZE:
-        strValue = StringUtils::Format("%i", static_cast<int>(tag->GetInfoSport().size()));
+        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoSport().size()));
         return true;
       case RDS_INFO_LOTTERY:
         strValue = tag->GetInfoLottery();
         return true;
       case RDS_INFO_LOTTERY_SIZE:
-        strValue = StringUtils::Format("%i", static_cast<int>(tag->GetInfoLottery().size()));
+        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoLottery().size()));
         return true;
       case RDS_INFO_WEATHER:
         strValue = tag->GetInfoWeather();
         return true;
       case RDS_INFO_WEATHER_SIZE:
-        strValue = StringUtils::Format("%i", static_cast<int>(tag->GetInfoWeather().size()));
+        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoWeather().size()));
         return true;
       case RDS_INFO_HOROSCOPE:
         strValue = tag->GetInfoHoroscope();
         return true;
       case RDS_INFO_HOROSCOPE_SIZE:
-        strValue = StringUtils::Format("%i", static_cast<int>(tag->GetInfoHoroscope().size()));
+        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoHoroscope().size()));
         return true;
       case RDS_INFO_CINEMA:
         strValue = tag->GetInfoCinema();
         return true;
       case RDS_INFO_CINEMA_SIZE:
-        strValue = StringUtils::Format("%i", static_cast<int>(tag->GetInfoCinema().size()));
+        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoCinema().size()));
         return true;
       case RDS_INFO_OTHER:
         strValue = tag->GetInfoOther();
         return true;
       case RDS_INFO_OTHER_SIZE:
-        strValue = StringUtils::Format("%i", static_cast<int>(tag->GetInfoOther().size()));
+        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoOther().size()));
         return true;
       case RDS_PROG_HOST:
         strValue = tag->GetProgHost();
@@ -1590,22 +1590,22 @@ void CPVRGUIInfo::CharInfoTotalDiskSpace(std::string& strValue) const
 
 void CPVRGUIInfo::CharInfoSignal(std::string& strValue) const
 {
-  strValue = StringUtils::Format("%d %%", m_qualityInfo.iSignal / 655);
+  strValue = StringUtils::Format("{} %", m_qualityInfo.iSignal / 655);
 }
 
 void CPVRGUIInfo::CharInfoSNR(std::string& strValue) const
 {
-  strValue = StringUtils::Format("%d %%", m_qualityInfo.iSNR / 655);
+  strValue = StringUtils::Format("{} %", m_qualityInfo.iSNR / 655);
 }
 
 void CPVRGUIInfo::CharInfoBER(std::string& strValue) const
 {
-  strValue = StringUtils::Format("%08lX", m_qualityInfo.iBER);
+  strValue = StringUtils::Format("{:08X}", m_qualityInfo.iBER);
 }
 
 void CPVRGUIInfo::CharInfoUNC(std::string& strValue) const
 {
-  strValue = StringUtils::Format("%08lX", m_qualityInfo.iUNC);
+  strValue = StringUtils::Format("{:08X}", m_qualityInfo.iUNC);
 }
 
 void CPVRGUIInfo::CharInfoFrontendName(std::string& strValue) const
@@ -1775,16 +1775,16 @@ void CPVRGUIInfo::UpdateBackendCache()
     m_strBackendHost = backend.host;
 
     if (backend.numChannels >= 0)
-      m_strBackendChannels = StringUtils::Format("%i", backend.numChannels);
+      m_strBackendChannels = StringUtils::Format("{}", backend.numChannels);
 
     if (backend.numTimers >= 0)
-      m_strBackendTimers = StringUtils::Format("%i", backend.numTimers);
+      m_strBackendTimers = StringUtils::Format("{}", backend.numTimers);
 
     if (backend.numRecordings >= 0)
-      m_strBackendRecordings = StringUtils::Format("%i", backend.numRecordings);
+      m_strBackendRecordings = StringUtils::Format("{}", backend.numRecordings);
 
     if (backend.numDeletedRecordings >= 0)
-      m_strBackendDeletedRecordings = StringUtils::Format("%i", backend.numDeletedRecordings);
+      m_strBackendDeletedRecordings = StringUtils::Format("{}", backend.numDeletedRecordings);
 
     m_iBackendDiskTotal = backend.diskTotal;
     m_iBackendDiskUsed = backend.diskUsed;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -96,10 +96,11 @@ void CPVRGUITimerInfo::UpdateTimersToggle()
     if (m_iTimerInfoToggleCurrent < activeTags.size())
     {
       const std::shared_ptr<CPVRTimerInfoTag> tag = activeTags.at(m_iTimerInfoToggleCurrent);
-      strActiveTimerTitle = StringUtils::Format("%s", tag->Title().c_str());
-      strActiveTimerChannelName = StringUtils::Format("%s", tag->ChannelName().c_str());
-      strActiveTimerChannelIcon = StringUtils::Format("%s", tag->ChannelIcon().c_str());
-      strActiveTimerTime = StringUtils::Format("%s", tag->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
+      strActiveTimerTitle = StringUtils::Format("{}", tag->Title().c_str());
+      strActiveTimerChannelName = StringUtils::Format("{}", tag->ChannelName().c_str());
+      strActiveTimerChannelIcon = StringUtils::Format("{}", tag->ChannelIcon().c_str());
+      strActiveTimerTime = StringUtils::Format(
+          "{}", tag->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
     }
   }
 
@@ -136,13 +137,14 @@ void CPVRGUITimerInfo::UpdateNextTimer()
   const std::shared_ptr<CPVRTimerInfoTag> timer = GetNextActiveTimer();
   if (timer)
   {
-    strNextRecordingTitle = StringUtils::Format("%s", timer->Title().c_str());
-    strNextRecordingChannelName = StringUtils::Format("%s", timer->ChannelName().c_str());
-    strNextRecordingChannelIcon = StringUtils::Format("%s", timer->ChannelIcon().c_str());
-    strNextRecordingTime = StringUtils::Format("%s", timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
+    strNextRecordingTitle = StringUtils::Format("{}", timer->Title().c_str());
+    strNextRecordingChannelName = StringUtils::Format("{}", timer->ChannelName().c_str());
+    strNextRecordingChannelIcon = StringUtils::Format("{}", timer->ChannelIcon().c_str());
+    strNextRecordingTime = StringUtils::Format(
+        "{}", timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
 
     strNextTimerInfo =
-        StringUtils::Format("%s %s %s %s", g_localizeStrings.Get(19106).c_str(),
+        StringUtils::Format("{} {} {} {}", g_localizeStrings.Get(19106).c_str(),
                             timer->StartAsLocalTime().GetAsLocalizedDate(true).c_str(),
                             g_localizeStrings.Get(19107).c_str(),
                             timer->StartAsLocalTime().GetAsLocalizedTime("", false).c_str());

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -438,7 +438,7 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
   }
 
   //Old Method of identifying TV show title and subtitle using m_strDirectory and strPlotOutline (deprecated)
-  std::string strShow = StringUtils::Format("%s - ", g_localizeStrings.Get(20364).c_str());
+  std::string strShow = StringUtils::Format("{} - ", g_localizeStrings.Get(20364).c_str());
   if (StringUtils::StartsWithNoCase(m_strPlotOutline, strShow))
   {
     CLog::Log(LOGWARNING, "PVR addon provides episode name in strPlotOutline which is deprecated");

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -66,11 +66,12 @@ CPVRRecordingsPath::CPVRRecordingsPath(const std::string& strPath)
 }
 
 CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio)
-: m_bValid(true),
-  m_bRoot(true),
-  m_bActive(!bDeleted),
-  m_bRadio(bRadio),
-  m_path(StringUtils::Format("pvr://recordings/%s/%s/", bRadio ? "radio" : "tv", bDeleted ? "deleted" : "active"))
+  : m_bValid(true),
+    m_bRoot(true),
+    m_bActive(!bDeleted),
+    m_bRadio(bRadio),
+    m_path(StringUtils::Format(
+        "pvr://recordings/{}/{}/", bRadio ? "radio" : "tv", bDeleted ? "deleted" : "active"))
 {
 }
 
@@ -86,38 +87,41 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio,
 {
   std::string strDirectoryN(TrimSlashes(strDirectory));
   if (!strDirectoryN.empty())
-    strDirectoryN = StringUtils::Format("%s/", strDirectoryN.c_str());
+    strDirectoryN = StringUtils::Format("{}/", strDirectoryN.c_str());
 
   std::string strTitleN(strTitle);
   strTitleN = CURL::Encode(strTitleN);
 
   std::string strSeasonEpisodeN;
   if ((iSeason > -1 && iEpisode > -1 && (iSeason > 0 || iEpisode > 0)))
-    strSeasonEpisodeN = StringUtils::Format("s%02de%02d", iSeason, iEpisode);
+    strSeasonEpisodeN = StringUtils::Format("s{:02}e{:02}", iSeason, iEpisode);
   if (!strSeasonEpisodeN.empty())
-    strSeasonEpisodeN = StringUtils::Format(" %s", strSeasonEpisodeN.c_str());
+    strSeasonEpisodeN = StringUtils::Format(" {}", strSeasonEpisodeN.c_str());
 
-  std::string strYearN(iYear > 0 ? StringUtils::Format(" (%i)", iYear) : "");
+  std::string strYearN(iYear > 0 ? StringUtils::Format(" ({})", iYear) : "");
 
   std::string strSubtitleN;
   if (!strSubtitle.empty())
   {
-    strSubtitleN = StringUtils::Format(" %s", strSubtitle.c_str());
+    strSubtitleN = StringUtils::Format(" {}", strSubtitle.c_str());
     strSubtitleN = CURL::Encode(strSubtitleN);
   }
 
   std::string strChannelNameN;
   if (!strChannelName.empty())
   {
-    strChannelNameN = StringUtils::Format(" (%s)", strChannelName.c_str());
+    strChannelNameN = StringUtils::Format(" ({})", strChannelName.c_str());
     strChannelNameN = CURL::Encode(strChannelNameN);
   }
 
-  m_directoryPath = StringUtils::Format("%s%s%s%s%s",
-                                        strDirectoryN.c_str(), strTitleN.c_str(), strSeasonEpisodeN.c_str(),
-                                        strYearN.c_str(), strSubtitleN.c_str());
-  m_params = StringUtils::Format(", TV%s, %s, %s.pvr", strChannelNameN.c_str(), recordingTime.GetAsSaveString().c_str(), strId.c_str());
-  m_path = StringUtils::Format("pvr://recordings/%s/%s/%s%s", bRadio ? "radio" : "tv", bDeleted ? "deleted" : "active", m_directoryPath.c_str(), m_params.c_str());
+  m_directoryPath =
+      StringUtils::Format("{}{}{}{}{}", strDirectoryN.c_str(), strTitleN.c_str(),
+                          strSeasonEpisodeN.c_str(), strYearN.c_str(), strSubtitleN.c_str());
+  m_params = StringUtils::Format(", TV{}, {}, {}.pvr", strChannelNameN.c_str(),
+                                 recordingTime.GetAsSaveString().c_str(), strId.c_str());
+  m_path = StringUtils::Format("pvr://recordings/{}/{}/{}{}", bRadio ? "radio" : "tv",
+                               bDeleted ? "deleted" : "active", m_directoryPath.c_str(),
+                               m_params.c_str());
 }
 
 std::string CPVRRecordingsPath::GetUnescapedDirectoryPath() const

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -161,7 +161,8 @@ void CPVRSettings::MarginTimeFiller(const SettingConstPtr& /*setting*/,
 
   for (int iValue : marginTimeValues)
   {
-    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044).c_str(), iValue) /* %i min */, iValue);
+    list.emplace_back(
+        StringUtils::Format(g_localizeStrings.Get(14044).c_str(), iValue) /* {} min */, iValue);
   }
 }
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -78,33 +78,41 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   UpdateSummary();
 }
 
-CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER& timer, const std::shared_ptr<CPVRChannel>& channel, unsigned int iClientId) :
-  m_strTitle(timer.strTitle),
-  m_strEpgSearchString(timer.strEpgSearchString),
-  m_bFullTextEpgSearch(timer.bFullTextEpgSearch),
-  m_strDirectory(timer.strDirectory),
-  m_state(timer.state),
-  m_iClientId(iClientId),
-  m_iClientIndex(timer.iClientIndex),
-  m_iParentClientIndex(timer.iParentClientIndex),
-  m_iClientChannelUid(channel ? channel->UniqueID() : (timer.iClientChannelUid > 0) ? timer.iClientChannelUid : PVR_CHANNEL_INVALID_UID),
-  m_bStartAnyTime(timer.bStartAnyTime),
-  m_bEndAnyTime(timer.bEndAnyTime),
-  m_iPriority(timer.iPriority),
-  m_iLifetime(timer.iLifetime),
-  m_iMaxRecordings(timer.iMaxRecordings),
-  m_iWeekdays(timer.iWeekdays),
-  m_iPreventDupEpisodes(timer.iPreventDuplicateEpisodes),
-  m_iRecordingGroup(timer.iRecordingGroup),
-  m_strFileNameAndPath(StringUtils::Format("pvr://client%i/timers/%i", m_iClientId, m_iClientIndex)),
-  m_bIsRadio(channel && channel->IsRadio()),
-  m_iMarginStart(timer.iMarginStart),
-  m_iMarginEnd(timer.iMarginEnd),
-  m_iEpgUid(timer.iEpgUid),
-  m_strSeriesLink(timer.strSeriesLink),
-  m_StartTime(timer.startTime + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection),
-  m_StopTime(timer.endTime + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection),
-  m_channel(channel)
+CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER& timer,
+                                   const std::shared_ptr<CPVRChannel>& channel,
+                                   unsigned int iClientId)
+  : m_strTitle(timer.strTitle),
+    m_strEpgSearchString(timer.strEpgSearchString),
+    m_bFullTextEpgSearch(timer.bFullTextEpgSearch),
+    m_strDirectory(timer.strDirectory),
+    m_state(timer.state),
+    m_iClientId(iClientId),
+    m_iClientIndex(timer.iClientIndex),
+    m_iParentClientIndex(timer.iParentClientIndex),
+    m_iClientChannelUid(channel                         ? channel->UniqueID()
+                        : (timer.iClientChannelUid > 0) ? timer.iClientChannelUid
+                                                        : PVR_CHANNEL_INVALID_UID),
+    m_bStartAnyTime(timer.bStartAnyTime),
+    m_bEndAnyTime(timer.bEndAnyTime),
+    m_iPriority(timer.iPriority),
+    m_iLifetime(timer.iLifetime),
+    m_iMaxRecordings(timer.iMaxRecordings),
+    m_iWeekdays(timer.iWeekdays),
+    m_iPreventDupEpisodes(timer.iPreventDuplicateEpisodes),
+    m_iRecordingGroup(timer.iRecordingGroup),
+    m_strFileNameAndPath(
+        StringUtils::Format("pvr://client{}/timers/{}", m_iClientId, m_iClientIndex)),
+    m_bIsRadio(channel && channel->IsRadio()),
+    m_iMarginStart(timer.iMarginStart),
+    m_iMarginEnd(timer.iMarginEnd),
+    m_iEpgUid(timer.iEpgUid),
+    m_strSeriesLink(timer.strSeriesLink),
+    m_StartTime(
+        timer.startTime +
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection),
+    m_StopTime(timer.endTime +
+               CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection),
+    m_channel(channel)
 {
   if (timer.firstDay)
     m_FirstDay = CDateTime(timer.firstDay + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection);
@@ -322,36 +330,38 @@ void CPVRTimerInfoTag::UpdateSummary()
 
   if (m_bEndAnyTime)
   {
-    m_strSummary = StringUtils::Format("%s %s %s",
-        m_iWeekdays != PVR_WEEKDAY_NONE ?
-          GetWeekdaysString().c_str() : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
+    m_strSummary = StringUtils::Format(
+        "{} {} {}",
+        m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString().c_str()
+                                        : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
         g_localizeStrings.Get(19107).c_str(), // "at"
-        m_bStartAnyTime ?
-          g_localizeStrings.Get(19161).c_str() /* "any time" */ : StartAsLocalTime().GetAsLocalizedTime("", false).c_str());
+        m_bStartAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
+                        : StartAsLocalTime().GetAsLocalizedTime("", false).c_str());
   }
   else if ((m_iWeekdays != PVR_WEEKDAY_NONE) || (startDate == endDate))
   {
-    m_strSummary = StringUtils::Format("%s %s %s %s %s",
-        m_iWeekdays != PVR_WEEKDAY_NONE ?
-          GetWeekdaysString().c_str() : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
+    m_strSummary = StringUtils::Format(
+        "{} {} {} {} {}",
+        m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString().c_str()
+                                        : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
         g_localizeStrings.Get(19159).c_str(), // "from"
-        m_bStartAnyTime ?
-          g_localizeStrings.Get(19161).c_str() /* "any time" */ : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
+        m_bStartAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
+                        : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
         g_localizeStrings.Get(19160).c_str(), // "to"
-        m_bEndAnyTime ?
-          g_localizeStrings.Get(19161).c_str() /* "any time" */ : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
+        m_bEndAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
+                      : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
   }
   else
   {
-    m_strSummary = StringUtils::Format("%s %s %s %s %s %s",
-        startDate.c_str(),
+    m_strSummary = StringUtils::Format(
+        "{} {} {} {} {} {}", startDate.c_str(),
         g_localizeStrings.Get(19159).c_str(), // "from"
-        m_bStartAnyTime ?
-          g_localizeStrings.Get(19161).c_str() /* "any time" */ : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
+        m_bStartAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
+                        : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
         g_localizeStrings.Get(19160).c_str(), // "to"
         endDate.c_str(),
-        m_bEndAnyTime ?
-          g_localizeStrings.Get(19161).c_str() /* "any time" */ : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
+        m_bEndAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
+                      : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
   }
 }
 
@@ -681,7 +691,7 @@ std::string CPVRTimerInfoTag::ChannelName() const
   if (channeltag)
     strReturn = channeltag->ChannelName();
   else if (m_timerType && m_timerType->IsEpgBasedTimerRule())
-    strReturn = StringUtils::Format("(%s)", g_localizeStrings.Get(809).c_str()); // "Any channel"
+    strReturn = StringUtils::Format("({})", g_localizeStrings.Get(809).c_str()); // "Any channel"
 
   return strReturn;
 }
@@ -1181,7 +1191,8 @@ std::string CPVRTimerInfoTag::GetNotificationText() const
   }
 
   if (stringID != 0)
-    return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(stringID).c_str(), m_strTitle.c_str());
+    return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID).c_str(),
+                               m_strTitle.c_str());
 
   return {};
 }
@@ -1205,7 +1216,8 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
       stringID = 19228; // Timer deleted
   }
 
-  return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(stringID).c_str(), m_strTitle.c_str());
+  return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID).c_str(),
+                             m_strTitle.c_str());
 }
 
 void CPVRTimerInfoTag::SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag)

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -257,7 +257,7 @@ void CPVRTimerType::InitPriorityValues(const PVR_TIMER_TYPE& type)
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("%d", type.priorities[i].iValue);
+        strDescr = StringUtils::Format("{}", type.priorities[i].iValue);
       }
       m_priorityValues.emplace_back(strDescr, type.priorities[i].iValue);
     }
@@ -268,7 +268,7 @@ void CPVRTimerType::InitPriorityValues(const PVR_TIMER_TYPE& type)
   {
     // No values given by addon, but priority supported. Use default values 1..100
     for (int i = 1; i < 101; ++i)
-      m_priorityValues.emplace_back(StringUtils::Format("%d", i), i);
+      m_priorityValues.emplace_back(StringUtils::Format("{}", i), i);
 
     m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
   }
@@ -296,7 +296,7 @@ void CPVRTimerType::InitLifetimeValues(const PVR_TIMER_TYPE& type)
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("%d", iValue);
+        strDescr = StringUtils::Format("{}", iValue);
       }
       m_lifetimeValues.emplace_back(strDescr, iValue);
     }
@@ -308,7 +308,8 @@ void CPVRTimerType::InitLifetimeValues(const PVR_TIMER_TYPE& type)
     // No values given by addon, but lifetime supported. Use default values 1..365
     for (int i = 1; i < 366; ++i)
     {
-      m_lifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999).c_str(), i), i); // "%s days"
+      m_lifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999).c_str(), i),
+                                    i); // "{} days"
     }
     m_iLifetimeDefault = DEFAULT_RECORDING_LIFETIME;
   }
@@ -335,7 +336,7 @@ void CPVRTimerType::InitMaxRecordingsValues(const PVR_TIMER_TYPE& type)
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("%d", type.maxRecordings[i].iValue);
+        strDescr = StringUtils::Format("{}", type.maxRecordings[i].iValue);
       }
       m_maxRecordingsValues.emplace_back(strDescr, type.maxRecordings[i].iValue);
     }
@@ -360,7 +361,7 @@ void CPVRTimerType::InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& typ
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("%d", type.preventDuplicateEpisodes[i].iValue);
+        strDescr = StringUtils::Format("{}", type.preventDuplicateEpisodes[i].iValue);
       }
       m_preventDupEpisodesValues.emplace_back(strDescr, type.preventDuplicateEpisodes[i].iValue);
     }
@@ -397,7 +398,7 @@ void CPVRTimerType::InitRecordingGroupValues(const PVR_TIMER_TYPE& type)
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("%s %d",
+        strDescr = StringUtils::Format("{} {}",
                                        g_localizeStrings.Get(811).c_str(), // Recording group
                                        type.recordingGroup[i].iValue);
       }

--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -34,11 +34,8 @@ CPVRTimersPath::CPVRTimersPath(const std::string& strPath, int iClientId, int iP
   if (Init(strPath))
   {
     // set/replace client and parent id.
-    m_path = StringUtils::Format("pvr://timers/%s/%s/%d/%d",
-                                 m_bRadio      ? "radio" : "tv",
-                                 m_bTimerRules ? "rules" : "timers",
-                                 iClientId,
-                                 iParentId);
+    m_path = StringUtils::Format("pvr://timers/{}/{}/{}/{}", m_bRadio ? "radio" : "tv",
+                                 m_bTimerRules ? "rules" : "timers", iClientId, iParentId);
     m_iClientId = iClientId;
     m_iParentId = iParentId;
     m_bRoot = false;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -291,18 +291,20 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
   {
     epg->ForceUpdate();
 
-    const std::string strMessage = StringUtils::Format("%s: '%s'",
-                                                       g_localizeStrings.Get(19253).c_str(), // "Guide update scheduled for channel"
-                                                       channel->ChannelName().c_str());
+    const std::string strMessage = StringUtils::Format(
+        "{}: '{}'",
+        g_localizeStrings.Get(19253).c_str(), // "Guide update scheduled for channel"
+        channel->ChannelName().c_str());
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
                                           g_localizeStrings.Get(19166), // "PVR information"
                                           strMessage);
   }
   else
   {
-    const std::string strMessage = StringUtils::Format("%s: '%s'",
-                                                       g_localizeStrings.Get(19254).c_str(), // "Guide update failed for channel"
-                                                       channel->ChannelName().c_str());
+    const std::string strMessage = StringUtils::Format(
+        "{}: '{}'",
+        g_localizeStrings.Get(19254).c_str(), // "Guide update failed for channel"
+        channel->ChannelName().c_str());
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
                                           g_localizeStrings.Get(19166), // "PVR information"
                                           strMessage);

--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -83,7 +83,7 @@ namespace DX
     WCHAR buff[2048];
     DXGetErrorDescriptionW(hr, buff, 2048);
 
-    return FromW(StringUtils::Format(L"%X - %s (%s)", hr, DXGetErrorStringW(hr), buff));
+    return FromW(StringUtils::Format(L"{:X} - {} ({})", hr, DXGetErrorStringW(hr), buff));
   }
 
   inline std::string GetFeatureLevelDescription(D3D_FEATURE_LEVEL featureLevel)

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -92,7 +92,7 @@ bool CRenderSystemDX::InitRenderSystem()
   uint32_t version = 0;
   for (uint32_t decimal = m_deviceResources->GetDeviceFeatureLevel() >> 8, round = 0; decimal > 0; decimal >>= 4, ++round)
     version += (decimal % 16) * std::pow(10, round);
-  m_RenderVersion = StringUtils::Format("%.1f", static_cast<float>(version) / 10.0f);
+  m_RenderVersion = StringUtils::Format("{:.1f}", static_cast<float>(version) / 10.0f);
 
   return true;
 }

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -684,9 +684,9 @@ std::string CDisplaySettings::GetStringFromResolution(RESOLUTION resolution, flo
     // also handle RES_DESKTOP resolutions with non-default refresh rates
     if (resolution != RES_DESKTOP || (refreshrate > 0.0f && refreshrate != info.fRefreshRate))
     {
-      return StringUtils::Format("%05i%05i%09.5f%s",
-                                 info.iScreenWidth, info.iScreenHeight,
-                                 refreshrate > 0.0f ? refreshrate : info.fRefreshRate, ModeFlagsToString(info.dwFlags, true).c_str());
+      return StringUtils::Format("{:05}{:05}{:09.5f}{}", info.iScreenWidth, info.iScreenHeight,
+                                 refreshrate > 0.0f ? refreshrate : info.fRefreshRate,
+                                 ModeFlagsToString(info.dwFlags, true).c_str());
     }
   }
 
@@ -723,9 +723,10 @@ void CDisplaySettings::SettingOptionsModesFiller(const std::shared_ptr<const CSe
     {
       auto setting = GetStringFromResolution((RESOLUTION)index, mode.fRefreshRate);
 
-      list.emplace_back(StringUtils::Format("%dx%d%s %0.2fHz", mode.iScreenWidth, mode.iScreenHeight,
-                                            ModeFlagsToString(mode.dwFlags, false).c_str(), mode.fRefreshRate),
-                        setting);
+      list.emplace_back(
+          StringUtils::Format("{}x{}{} {:0.2f}Hz", mode.iScreenWidth, mode.iScreenHeight,
+                              ModeFlagsToString(mode.dwFlags, false).c_str(), mode.fRefreshRate),
+          setting);
     }
   }
 
@@ -772,7 +773,7 @@ void CDisplaySettings::SettingOptionsRefreshRatesFiller(const SettingConstPtr& s
     std::string screenmode = GetStringFromResolution((RESOLUTION)refreshrate->ResInfo_Index, refreshrate->RefreshRate);
     if (!match && StringUtils::EqualsNoCase(std::static_pointer_cast<const CSettingString>(setting)->GetValue(), screenmode))
       match = true;
-    list.emplace_back(StringUtils::Format("%.2f", refreshrate->RefreshRate), screenmode);
+    list.emplace_back(StringUtils::Format("{:.2f}", refreshrate->RefreshRate), screenmode);
   }
 
   if (!match)
@@ -797,7 +798,7 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const SettingConstPtr& se
     std::vector<RESOLUTION_WHR> resolutions = CServiceBroker::GetWinSystem()->ScreenResolutions(info.fRefreshRate);
     for (std::vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); ++resolution)
     {
-      list.emplace_back(StringUtils::Format("%dx%d%s", resolution->width, resolution->height,
+      list.emplace_back(StringUtils::Format("{}x{}{}", resolution->width, resolution->height,
                                             ModeFlagsToString(resolution->flags, false).c_str()),
                         resolution->ResInfo_Index);
 

--- a/xbmc/settings/SettingUtils.cpp
+++ b/xbmc/settings/SettingUtils.cpp
@@ -77,7 +77,8 @@ bool CSettingUtils::ValuesToList(const std::shared_ptr<const CSettingList>& sett
   bool ret = true;
   for (const auto& value : values)
   {
-    SettingPtr settingValue = setting->GetDefinition()->Clone(StringUtils::Format("%s.%d", setting->GetId().c_str(), index++));
+    SettingPtr settingValue = setting->GetDefinition()->Clone(
+        StringUtils::Format("{}.{}", setting->GetId().c_str(), index++));
     if (settingValue == NULL)
       return false;
 

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -318,7 +318,8 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
       // recenter our control...
       pControl->SetPosition((info.iWidth - pControl->GetWidth()) / 2,
                             (info.iHeight - pControl->GetHeight()) / 2);
-      strStatus = StringUtils::Format("%s (%5.3f)", g_localizeStrings.Get(275).c_str(), info.fPixelRatio);
+      strStatus =
+          StringUtils::Format("{} ({:5.3f})", g_localizeStrings.Get(275).c_str(), info.fPixelRatio);
       SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 278);
     }
   }
@@ -333,7 +334,8 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
         {
           info.Overscan.left = pControl->GetXLocation();
           info.Overscan.top = pControl->GetYLocation();
-          strStatus = StringUtils::Format("%s (%i,%i)", g_localizeStrings.Get(272).c_str(), pControl->GetXLocation(), pControl->GetYLocation());
+          strStatus = StringUtils::Format("{} ({},{})", g_localizeStrings.Get(272).c_str(),
+                                          pControl->GetXLocation(), pControl->GetYLocation());
           SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 276);
         }
         break;
@@ -344,7 +346,8 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
           info.Overscan.bottom = pControl->GetYLocation();
           int iXOff1 = info.iWidth - pControl->GetXLocation();
           int iYOff1 = info.iHeight - pControl->GetYLocation();
-          strStatus = StringUtils::Format("%s (%i,%i)", g_localizeStrings.Get(273).c_str(), iXOff1, iYOff1);
+          strStatus =
+              StringUtils::Format("{} ({},{})", g_localizeStrings.Get(273).c_str(), iXOff1, iYOff1);
           SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 276);
         }
         break;
@@ -352,7 +355,8 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
       case CONTROL_SUBTITLES:
         {
           info.iSubtitles = pControl->GetYLocation();
-          strStatus = StringUtils::Format("%s (%i)", g_localizeStrings.Get(274).c_str(), pControl->GetYLocation());
+          strStatus = StringUtils::Format("{} ({})", g_localizeStrings.Get(274).c_str(),
+                                          pControl->GetYLocation());
           SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 277);
         }
         break;
@@ -365,18 +369,12 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
   // set the label control correctly
   std::string strText;
   if (CServiceBroker::GetWinSystem()->IsFullScreen())
-    strText = StringUtils::Format("%ix%i@%.2f - %s | %s",
-                                  info.iScreenWidth,
-                                  info.iScreenHeight,
-                                  info.fRefreshRate,
-                                  g_localizeStrings.Get(244).c_str(),
+    strText = StringUtils::Format("{}x{}@{:.2f} - {} | {}", info.iScreenWidth, info.iScreenHeight,
+                                  info.fRefreshRate, g_localizeStrings.Get(244).c_str(),
                                   strStatus.c_str());
   else
-    strText = StringUtils::Format("%ix%i - %s | %s",
-                                  info.iScreenWidth,
-                                  info.iScreenHeight,
-                                  g_localizeStrings.Get(242).c_str(),
-                                  strStatus.c_str());
+    strText = StringUtils::Format("{}x{} - {} | {}", info.iScreenWidth, info.iScreenHeight,
+                                  g_localizeStrings.Get(242).c_str(), strStatus.c_str());
 
   SET_CONTROL_LABEL(CONTROL_LABEL_ROW1, strText);
 }

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -46,7 +46,8 @@ bool CAutorunMediaJob::DoWork()
   int selection = pDialog->GetSelectedItem();
   if (selection >= 0)
   {
-    std::string strAction = StringUtils::Format("ActivateWindow(%s, %s)", GetWindowString(selection), m_path.c_str());
+    std::string strAction =
+        StringUtils::Format("ActivateWindow({}, {})", GetWindowString(selection), m_path.c_str());
     CBuiltins::GetInstance().Execute(strAction);
   }
 

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -331,7 +331,7 @@ std::string CMediaManager::TranslateDevicePath(const std::string& devicePath, bo
   if(bReturnAsDevice == false)
     StringUtils::Replace(strDevice, "\\\\.\\","");
   else if(!strDevice.empty() && strDevice[1]==':')
-    strDevice = StringUtils::Format("\\\\.\\%c:", strDevice[0]);
+    strDevice = StringUtils::Format("\\\\.\\{}:", strDevice[0]);
 
   URIUtils::RemoveSlashAtEnd(strDevice);
 #endif
@@ -559,7 +559,8 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
     return "";
   }
 
-  std::string strID = StringUtils::Format("removable://%s_%s", info.name.c_str(), info.serial.c_str());
+  std::string strID =
+      StringUtils::Format("removable://{}_{}", info.name.c_str(), info.serial.c_str());
   CLog::Log(LOGDEBUG, "GetDiskUniqueId: Got ID %s for %s with path %s", strID.c_str(), info.type.c_str(), CURL::GetRedacted(mediaPath).c_str());
 
   return strID;

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -221,7 +221,8 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
   Module.SizeOfStruct = sizeof(Module);
   int seq=0;
 
-  strOutput = StringUtils::Format("Thread %d (process %d)\r\n", GetCurrentThreadId(), GetCurrentProcessId());
+  strOutput = StringUtils::Format("Thread {} (process {})\r\n", GetCurrentThreadId(),
+                                  GetCurrentProcessId());
   WriteFile(hDumpFile, strOutput.c_str(), strOutput.size(), &dwBytes, NULL);
 
   while(pSW(IMAGE_FILE_MACHINE_I386, hCurProc, GetCurrentThread(), &frame, pEp->ContextRecord, NULL, pSFTA, pSGMB, NULL))
@@ -230,15 +231,15 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
     {
       DWORD64 symoffset=0;
       DWORD   lineoffset=0;
-      strOutput = StringUtils::Format("#%2d", seq++);
+      strOutput = StringUtils::Format("#{:2}", seq++);
 
       if(pSGSFA(hCurProc, frame.AddrPC.Offset, &symoffset, pSym))
       {
         if(pUDSN(pSym->Name, cTemp, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE)>0)
-          strOutput.append(StringUtils::Format(" %s", cTemp));
+          strOutput.append(StringUtils::Format(" {}", cTemp));
       }
       if(pSGLFA(hCurProc, frame.AddrPC.Offset, &lineoffset, &Line))
-        strOutput.append(StringUtils::Format(" at %s:%d", Line.FileName, Line.LineNumber));
+        strOutput.append(StringUtils::Format(" at {}:{}", Line.FileName, Line.LineNumber));
 
       strOutput.append("\r\n");
       WriteFile(hDumpFile, strOutput.c_str(), strOutput.size(), &dwBytes, NULL);

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -49,14 +49,14 @@ std::string CCPUInfo::GetCoresUsageString()
         if (!strCores.empty())
           strCores += ' ';
         if (core.m_usagePercent < 10.0)
-          strCores += StringUtils::Format("#%d: %1.1f%%", core.m_id, core.m_usagePercent);
+          strCores += StringUtils::Format("#{}: {:1.1f}%", core.m_id, core.m_usagePercent);
         else
-          strCores += StringUtils::Format("#%d: %3.0f%%", core.m_id, core.m_usagePercent);
+          strCores += StringUtils::Format("#{}: {:3.0f}%", core.m_id, core.m_usagePercent);
       }
     }
     else
     {
-      strCores += StringUtils::Format("%3.0f%%", static_cast<double>(m_lastUsedPercentage));
+      strCores += StringUtils::Format("{:3.0f}%", static_cast<double>(m_lastUsedPercentage));
     }
   }
 

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -147,16 +147,25 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
   {
     std::string result;
     if (field == FieldId) return "musicvideo_view.idMVideo";
-    else if (field == FieldTitle) result = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_TITLE);
-    else if (field == FieldTime) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_RUNTIME);
-    else if (field == FieldDirector) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_DIRECTOR);
-    else if (field == FieldStudio) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_STUDIOS);
+    else if (field == FieldTitle)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_TITLE);
+    else if (field == FieldTime)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_RUNTIME);
+    else if (field == FieldDirector)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_DIRECTOR);
+    else if (field == FieldStudio)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_STUDIOS);
     else if (field == FieldYear) return "musicvideo_view.premiered";
-    else if (field == FieldPlot) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_PLOT);
-    else if (field == FieldAlbum) result = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_ALBUM);
-    else if (field == FieldArtist) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_ARTIST);
-    else if (field == FieldGenre) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_GENRE);
-    else if (field == FieldTrackNumber) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_TRACK);
+    else if (field == FieldPlot)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_PLOT);
+    else if (field == FieldAlbum)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_ALBUM);
+    else if (field == FieldArtist)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_ARTIST);
+    else if (field == FieldGenre)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_GENRE);
+    else if (field == FieldTrackNumber)
+      result = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_TRACK);
     else if (field == FieldFilename) return "musicvideo_view.strFilename";
     else if (field == FieldPath) return "musicvideo_view.strPath";
     else if (field == FieldPlaycount) return "musicvideo_view.playCount";
@@ -175,28 +184,44 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
     {
       // We need some extra logic to get the title value if sorttitle isn't set
       if (queryPart == DatabaseQueryPartOrderBy)
-        result = StringUtils::Format("CASE WHEN length(movie_view.c%02d) > 0 THEN movie_view.c%02d ELSE movie_view.c%02d END", VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
+        result = StringUtils::Format("CASE WHEN length(movie_view.c{:02}) > 0 THEN "
+                                     "movie_view.c{:02} ELSE movie_view.c{:02} END",
+                                     VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
       else
-        result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TITLE);
+        result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TITLE);
     }
-    else if (field == FieldPlot) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_PLOT);
-    else if (field == FieldPlotOutline) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_PLOTOUTLINE);
-    else if (field == FieldTagline) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TAGLINE);
+    else if (field == FieldPlot)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_PLOT);
+    else if (field == FieldPlotOutline)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_PLOTOUTLINE);
+    else if (field == FieldTagline)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TAGLINE);
     else if (field == FieldVotes) return "movie_view.votes";
     else if (field == FieldRating) return "movie_view.rating";
-    else if (field == FieldWriter) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_CREDITS);
+    else if (field == FieldWriter)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_CREDITS);
     else if (field == FieldYear) return "movie_view.premiered";
-    else if (field == FieldSortTitle) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_SORTTITLE);
-    else if (field == FieldOriginalTitle) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_ORIGINALTITLE);
-    else if (field == FieldTime) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_RUNTIME);
-    else if (field == FieldMPAA) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_MPAA);
-    else if (field == FieldTop250) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TOP250);
+    else if (field == FieldSortTitle)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_SORTTITLE);
+    else if (field == FieldOriginalTitle)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_ORIGINALTITLE);
+    else if (field == FieldTime)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_RUNTIME);
+    else if (field == FieldMPAA)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_MPAA);
+    else if (field == FieldTop250)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TOP250);
     else if (field == FieldSet) return "movie_view.strSet";
-    else if (field == FieldGenre) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_GENRE);
-    else if (field == FieldDirector) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_DIRECTOR);
-    else if (field == FieldStudio) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_STUDIOS);
-    else if (field == FieldTrailer) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TRAILER);
-    else if (field == FieldCountry) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_COUNTRY);
+    else if (field == FieldGenre)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_GENRE);
+    else if (field == FieldDirector)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_DIRECTOR);
+    else if (field == FieldStudio)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_STUDIOS);
+    else if (field == FieldTrailer)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TRAILER);
+    else if (field == FieldCountry)
+      result = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_COUNTRY);
     else if (field == FieldFilename) return "movie_view.strFilename";
     else if (field == FieldPath) return "movie_view.strPath";
     else if (field == FieldPlaycount) return "movie_view.playCount";
@@ -215,20 +240,31 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
     {
       // We need some extra logic to get the title value if sorttitle isn't set
       if (queryPart == DatabaseQueryPartOrderBy)
-        result = StringUtils::Format("CASE WHEN length(tvshow_view.c%02d) > 0 THEN tvshow_view.c%02d ELSE tvshow_view.c%02d END", VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_TITLE);
+        result = StringUtils::Format("CASE WHEN length(tvshow_view.c{:02}) > 0 THEN "
+                                     "tvshow_view.c{:02} ELSE tvshow_view.c{:02} END",
+                                     VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_SORTTITLE,
+                                     VIDEODB_ID_TV_TITLE);
       else
-        result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_TITLE);
+        result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_TITLE);
     }
-    else if (field == FieldPlot) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_PLOT);
-    else if (field == FieldTvShowStatus) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_STATUS);
+    else if (field == FieldPlot)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_PLOT);
+    else if (field == FieldTvShowStatus)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_STATUS);
     else if (field == FieldVotes) return "tvshow_view.votes";
     else if (field == FieldRating) return "tvshow_view.rating";
-    else if (field == FieldYear) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_PREMIERED);
-    else if (field == FieldGenre) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_GENRE);
-    else if (field == FieldMPAA) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_MPAA);
-    else if (field == FieldStudio) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_STUDIOS);
-    else if (field == FieldSortTitle) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_SORTTITLE);
-    else if (field == FieldOriginalTitle) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_ORIGINALTITLE);
+    else if (field == FieldYear)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_PREMIERED);
+    else if (field == FieldGenre)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_GENRE);
+    else if (field == FieldMPAA)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_MPAA);
+    else if (field == FieldStudio)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_STUDIOS);
+    else if (field == FieldSortTitle)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_SORTTITLE);
+    else if (field == FieldOriginalTitle)
+      result = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_ORIGINALTITLE);
     else if (field == FieldPath) return "tvshow_view.strPath";
     else if (field == FieldDateAdded) return "tvshow_view.dateAdded";
     else if (field == FieldLastPlayed) return "tvshow_view.lastPlayed";
@@ -244,19 +280,30 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
   {
     std::string result;
     if (field == FieldId) return "episode_view.idEpisode";
-    else if (field == FieldTitle) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_TITLE);
-    else if (field == FieldPlot) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_PLOT);
+    else if (field == FieldTitle)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_TITLE);
+    else if (field == FieldPlot)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_PLOT);
     else if (field == FieldVotes) return "episode_view.votes";
     else if (field == FieldRating) return "episode_view.rating";
-    else if (field == FieldWriter) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_CREDITS);
-    else if (field == FieldAirDate) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_AIRED);
-    else if (field == FieldTime) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_RUNTIME);
-    else if (field == FieldDirector) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_DIRECTOR);
-    else if (field == FieldSeason) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_SEASON);
-    else if (field == FieldEpisodeNumber) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_EPISODE);
-    else if (field == FieldUniqueId) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_IDENT_ID);
-    else if (field == FieldEpisodeNumberSpecialSort) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_SORTEPISODE);
-    else if (field == FieldSeasonSpecialSort) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_SORTSEASON);
+    else if (field == FieldWriter)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_CREDITS);
+    else if (field == FieldAirDate)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_AIRED);
+    else if (field == FieldTime)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_RUNTIME);
+    else if (field == FieldDirector)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_DIRECTOR);
+    else if (field == FieldSeason)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_SEASON);
+    else if (field == FieldEpisodeNumber)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_EPISODE);
+    else if (field == FieldUniqueId)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_IDENT_ID);
+    else if (field == FieldEpisodeNumberSpecialSort)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_SORTEPISODE);
+    else if (field == FieldSeasonSpecialSort)
+      result = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_SORTSEASON);
     else if (field == FieldFilename) return "episode_view.strFilename";
     else if (field == FieldPath) return "episode_view.strPath";
     else if (field == FieldPlaycount) return "episode_view.playCount";

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -189,7 +189,7 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
           valueStr = std::to_string(attrs[i + 1]);
       }
 
-      eglString.append(StringUtils::Format("%s: %s\n", keyStr, valueStr));
+      eglString.append(StringUtils::Format("{}: {}\n", keyStr, valueStr));
     }
 
     CLog::Log(LOGDEBUG, "CEGLImage::{} - attributes:\n{}", __FUNCTION__, eglString);

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -157,7 +157,7 @@ bool CEGLUtils::HasClientExtension(const std::string& name)
 void CEGLUtils::Log(int logLevel, const std::string& what)
 {
   EGLenum error = eglGetError();
-  std::string errorStr = StringUtils::Format("0x%04X", error);
+  std::string errorStr = StringUtils::Format("{:#04X}", error);
 
   auto eglError = eglErrors.find(error);
   if (eglError != eglErrors.end())
@@ -365,10 +365,13 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool
   {
     EGLint value{0};
     if (eglGetConfigAttrib(m_eglDisplay, *currentConfig, eglAttribute.first, &value) != EGL_TRUE)
-      CEGLUtils::Log(LOGERROR, StringUtils::Format("failed to query EGL attribute %s", eglAttribute.second));
+      CEGLUtils::Log(LOGERROR,
+                     StringUtils::Format("failed to query EGL attribute {}", eglAttribute.second));
 
     // we only need to print the hex value if it's an actual EGL define
-    CLog::Log(LOGDEBUG, "  %s: %s", eglAttribute.second, (value >= 0x3000 && value <= 0x3200) ? StringUtils::Format("0x%04x", value) : StringUtils::Format("%d", value));
+    CLog::Log(LOGDEBUG, "  {}: {}", eglAttribute.second,
+              (value >= 0x3000 && value <= 0x3200) ? StringUtils::Format("{:#04x}", value)
+                                                   : StringUtils::Format("{}", value));
   }
 
   return true;

--- a/xbmc/utils/Fanart.cpp
+++ b/xbmc/utils/Fanart.cpp
@@ -163,7 +163,9 @@ bool CFanart::ParseColors(const std::string &colorsIn, std::string &colorsOut)
       { // convert
         if (colorsOut.size())
           colorsOut += ",";
-        colorsOut += StringUtils::Format("FF%2lx%2lx%2lx", atol(strTriplets[0].c_str()), atol(strTriplets[1].c_str()), atol(strTriplets[2].c_str()));
+        colorsOut +=
+            StringUtils::Format("FF{:2x}{:2x}{:2x}", atol(strTriplets[0].c_str()),
+                                atol(strTriplets[1].c_str()), atol(strTriplets[2].c_str()));
       }
     }
   }

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -316,14 +316,13 @@ bool CFileOperationJob::CFileOperation::OnFileCallback(void* pContext, int iperc
   double current = data->current + ((double)ipercent * data->opWeight * (double)m_time)/ 100.0;
 
   if (avgSpeed > 1000000.0f)
-    data->base->m_avgSpeed = StringUtils::Format("%.1f MB/s", avgSpeed / 1000000.0f);
+    data->base->m_avgSpeed = StringUtils::Format("{:.1f} MB/s", avgSpeed / 1000000.0f);
   else
-    data->base->m_avgSpeed = StringUtils::Format("%.1f KB/s", avgSpeed / 1000.0f);
+    data->base->m_avgSpeed = StringUtils::Format("{:.1f} KB/s", avgSpeed / 1000.0f);
 
   std::string line;
-  line = StringUtils::Format("%s (%s)",
-                              data->base->GetCurrentFile().c_str(),
-                              data->base->GetAverageSpeed().c_str());
+  line = StringUtils::Format("{} ({})", data->base->GetCurrentFile().c_str(),
+                             data->base->GetAverageSpeed().c_str());
   data->base->SetText(line);
   return !data->base->ShouldCancel((unsigned)current, 100);
 }

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -72,7 +72,7 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
       pItem->GetVideoInfoTag()->m_iDbId = set->first;
       pItem->GetVideoInfoTag()->m_type = MediaTypeVideoCollection;
 
-      std::string basePath = StringUtils::Format("videodb://movies/sets/%i/", set->first);
+      std::string basePath = StringUtils::Format("videodb://movies/sets/{}/", set->first);
       CVideoDbUrl videoUrl;
       if (!videoUrl.FromString(basePath))
         pItem->SetPath(basePath);

--- a/xbmc/utils/HTMLUtil.cpp
+++ b/xbmc/utils/HTMLUtil.cpp
@@ -218,9 +218,9 @@ void CHTMLUtil::ConvertHTMLToW(const std::wstring& strHTML, std::wstring& strStr
     num = strStripped.substr(i, iPos-i);
     wchar_t val = (wchar_t)wcstol(num.c_str(),NULL,base);
     if (base == 10)
-      num = StringUtils::Format(L"&#%ls;", num.c_str());
+      num = StringUtils::Format(L"&#{};", num.c_str());
     else
-      num = StringUtils::Format(L"&#x%ls;", num.c_str());
+      num = StringUtils::Format(L"&#x{};", num.c_str());
 
     StringUtils::Replace(strStripped, num,std::wstring(1,val));
     iPos = strStripped.find(L"&#", iStart);

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -160,13 +160,13 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   {
   case 'N':
     if (music && music->GetTrackNumber() > 0)
-      value = StringUtils::Format("%2.2i", music->GetTrackNumber());
+      value = StringUtils::Format("{:02}", music->GetTrackNumber());
     if (movie&& movie->m_iTrack > 0)
-      value = StringUtils::Format("%2.2i", movie->m_iTrack);
+      value = StringUtils::Format("{:02}", movie->m_iTrack);
     break;
   case 'S':
     if (music && music->GetDiscNumber() > 0)
-      value = StringUtils::Format("%2.2i", music->GetDiscNumber());
+      value = StringUtils::Format("{:02}", music->GetDiscNumber());
     break;
   case 'A':
     if (music && music->GetArtistString().size())
@@ -204,7 +204,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       if (movie->m_firstAired.IsValid())
         value = movie->m_firstAired.GetAsLocalizedDate();
       else if (movie->HasYear())
-        value = StringUtils::Format("%i", movie->GetYear());
+        value = StringUtils::Format("{}", movie->GetYear());
     }
     break;
   case 'F': // filename
@@ -245,32 +245,32 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'R': // rating
     if (music && music->GetRating() != 0.f)
-      value = StringUtils::Format("%.1f", music->GetRating());
+      value = StringUtils::Format("{:.1f}", music->GetRating());
     else if (movie && movie->GetRating().rating != 0.f)
-      value = StringUtils::Format("%.1f", movie->GetRating().rating);
+      value = StringUtils::Format("{:.1f}", movie->GetRating().rating);
     break;
   case 'C': // programs count
-    value = StringUtils::Format("%i", item->m_iprogramCount);
+    value = StringUtils::Format("{}", item->m_iprogramCount);
     break;
   case 'c': // relevance
-    value = StringUtils::Format("%i", movie->m_relevance);
+    value = StringUtils::Format("{}", movie->m_relevance);
     break;
   case 'K':
     value = item->m_strTitle;
     break;
   case 'M':
     if (movie && movie->m_iEpisode > 0)
-      value = StringUtils::Format("%i %s",
-                                  movie->m_iEpisode,
-                                  g_localizeStrings.Get(movie->m_iEpisode == 1 ? 20452 : 20453).c_str());
+      value = StringUtils::Format(
+          "{} {}", movie->m_iEpisode,
+          g_localizeStrings.Get(movie->m_iEpisode == 1 ? 20452 : 20453).c_str());
     break;
   case 'E':
     if (movie && movie->m_iEpisode > 0)
     { // episode number
       if (movie->m_iSeason == 0)
-        value = StringUtils::Format("S%2.2i", movie->m_iEpisode);
+        value = StringUtils::Format("S{:02}", movie->m_iEpisode);
       else
-        value = StringUtils::Format("%2.2i", movie->m_iEpisode);
+        value = StringUtils::Format("{:02}", movie->m_iEpisode);
     }
     break;
   case 'P':
@@ -281,9 +281,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     if (movie && movie->m_iEpisode > 0)
     { // season*100+episode number
       if (movie->m_iSeason == 0)
-        value = StringUtils::Format("S%2.2i", movie->m_iEpisode);
+        value = StringUtils::Format("S{:02}", movie->m_iEpisode);
       else
-        value = StringUtils::Format("%ix%2.2i", movie->m_iSeason,movie->m_iEpisode);
+        value = StringUtils::Format("{}x{:02}", movie->m_iSeason, movie->m_iEpisode);
     }
     break;
   case 'O':
@@ -300,19 +300,19 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'V': // Playcount
     if (music)
-      value = StringUtils::Format("%i", music->GetPlayCount());
+      value = StringUtils::Format("{}", music->GetPlayCount());
     if (movie)
-      value = StringUtils::Format("%i", movie->GetPlayCount());
+      value = StringUtils::Format("{}", movie->GetPlayCount());
     break;
   case 'X': // Bitrate
     if( !item->m_bIsFolder && item->m_dwSize != 0 )
-      value = StringUtils::Format("%" PRId64" kbps", item->m_dwSize);
+      value = StringUtils::Format("{} kbps", item->m_dwSize);
     break;
    case 'W': // Listeners
     if( !item->m_bIsFolder && music && music->GetListeners() != 0 )
-     value = StringUtils::Format("%i %s",
-                                 music->GetListeners(),
-                                 g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455).c_str());
+      value = StringUtils::Format(
+          "{} {}", music->GetListeners(),
+          g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455).c_str());
     break;
   case 'a': // Date Added
     if (movie && movie->m_dateAdded.IsValid())
@@ -322,7 +322,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'b': // Total number of discs
     if (music)
-      value = StringUtils::Format("%i", music->GetTotalDiscs());
+      value = StringUtils::Format("{}", music->GetTotalDiscs());
     break;
   case 'e': // Original release date
     if (music)
@@ -344,9 +344,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'r': // userrating
     if (movie && movie->m_iUserRating != 0)
-      value = StringUtils::Format("%i", movie->m_iUserRating);
+      value = StringUtils::Format("{}", movie->m_iUserRating);
     if (music && music->GetUserrating() != 0)
-      value = StringUtils::Format("%i", music->GetUserrating());
+      value = StringUtils::Format("{}", music->GetUserrating());
     break;
   case 't': // Date Taken
     if (pic && pic->GetDateTimeTaken().IsValid())
@@ -370,7 +370,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'f': // BPM
     if (music)
-      value = StringUtils::Format("%i", music->GetBPM());
+      value = StringUtils::Format("{}", music->GetBPM());
     break;
   }
   if (!value.empty())

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -59,8 +59,9 @@ bool CRecentlyAddedJob::UpdateVideo()
     for (; i < items.Size(); ++i)
     {
       auto item = items.Get(i);
-      std::string   value = StringUtils::Format("%i", i + 1);
-      std::string   strRating = StringUtils::Format("%.1f", item->GetVideoInfoTag()->GetRating().rating);
+      std::string value = StringUtils::Format("{}", i + 1);
+      std::string strRating =
+          StringUtils::Format("{:.1f}", item->GetVideoInfoTag()->GetRating().rating);
 
       home->SetProperty("LatestMovie." + value + ".Title"       , item->GetLabel());
       home->SetProperty("LatestMovie." + value + ".Rating"      , strRating);
@@ -80,7 +81,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("%i", i + 1);
+    std::string value = StringUtils::Format("{}", i + 1);
     home->SetProperty("LatestMovie." + value + ".Title"       , "");
     home->SetProperty("LatestMovie." + value + ".Thumb"       , "");
     home->SetProperty("LatestMovie." + value + ".Rating"      , "");
@@ -103,9 +104,10 @@ bool CRecentlyAddedJob::UpdateVideo()
       auto item          = TVShowItems.Get(i);
       int          EpisodeSeason = item->GetVideoInfoTag()->m_iSeason;
       int          EpisodeNumber = item->GetVideoInfoTag()->m_iEpisode;
-      std::string   EpisodeNo = StringUtils::Format("s%02de%02d", EpisodeSeason, EpisodeNumber);
-      std::string   value = StringUtils::Format("%i", i + 1);
-      std::string   strRating = StringUtils::Format("%.1f", item->GetVideoInfoTag()->GetRating().rating);
+      std::string EpisodeNo = StringUtils::Format("s{:02}e{:02}", EpisodeSeason, EpisodeNumber);
+      std::string value = StringUtils::Format("{}", i + 1);
+      std::string strRating =
+          StringUtils::Format("{:.1f}", item->GetVideoInfoTag()->GetRating().rating);
 
       home->SetProperty("LatestEpisode." + value + ".ShowTitle"     , item->GetVideoInfoTag()->m_strShowTitle);
       home->SetProperty("LatestEpisode." + value + ".EpisodeTitle"  , item->GetVideoInfoTag()->m_strTitle);
@@ -131,7 +133,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("%i", i + 1);
+    std::string value = StringUtils::Format("{}", i + 1);
     home->SetProperty("LatestEpisode." + value + ".ShowTitle"     , "");
     home->SetProperty("LatestEpisode." + value + ".EpisodeTitle"  , "");
     home->SetProperty("LatestEpisode." + value + ".Rating"        , "");
@@ -160,7 +162,7 @@ bool CRecentlyAddedJob::UpdateVideo()
     for (; i < MusicVideoItems.Size(); ++i)
     {
       auto item = MusicVideoItems.Get(i);
-      std::string   value = StringUtils::Format("%i", i + 1);
+      std::string value = StringUtils::Format("{}", i + 1);
 
       home->SetProperty("LatestMusicVideo." + value + ".Title"       , item->GetLabel());
       home->SetProperty("LatestMusicVideo." + value + ".Year"        , item->GetVideoInfoTag()->GetYear());
@@ -178,7 +180,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("%i", i + 1);
+    std::string value = StringUtils::Format("{}", i + 1);
     home->SetProperty("LatestMusicVideo." + value + ".Title"       , "");
     home->SetProperty("LatestMusicVideo." + value + ".Thumb"       , "");
     home->SetProperty("LatestMusicVideo." + value + ".Year"        , "");
@@ -218,7 +220,7 @@ bool CRecentlyAddedJob::UpdateMusic()
     for (; i < musicItems.Size(); ++i)
     {
       auto item = musicItems.Get(i);
-      std::string   value = StringUtils::Format("%d", i + 1);
+      std::string value = StringUtils::Format("{}", i + 1);
 
       std::string   strRating;
       std::string   strAlbum  = item->GetMusicInfoTag()->GetAlbum();
@@ -237,7 +239,7 @@ bool CRecentlyAddedJob::UpdateMusic()
         }
       }
 
-      strRating = StringUtils::Format("%c", item->GetMusicInfoTag()->GetUserrating());
+      strRating = StringUtils::Format("{}", item->GetMusicInfoTag()->GetUserrating());
 
       home->SetProperty("LatestSong." + value + ".Title"   , item->GetMusicInfoTag()->GetTitle());
       home->SetProperty("LatestSong." + value + ".Year"    , item->GetMusicInfoTag()->GetYear());
@@ -251,7 +253,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("%i", i + 1);
+    std::string value = StringUtils::Format("{}", i + 1);
     home->SetProperty("LatestSong." + value + ".Title"   , "");
     home->SetProperty("LatestSong." + value + ".Year"    , "");
     home->SetProperty("LatestSong." + value + ".Artist"  , "");
@@ -271,7 +273,7 @@ bool CRecentlyAddedJob::UpdateMusic()
     for (; j < albums.size(); ++j)
     {
       auto& album=albums[j];
-      std::string value = StringUtils::Format("%lu", j + 1);
+      std::string value = StringUtils::Format("{}", j + 1);
       std::string strThumb;
       std::string strFanart;
       bool artfound = false;
@@ -289,7 +291,7 @@ bool CRecentlyAddedJob::UpdateMusic()
         }
       }
 
-      std::string strDBpath = StringUtils::Format("musicdb://albums/%li/", album.idAlbum);
+      std::string strDBpath = StringUtils::Format("musicdb://albums/{}/", album.idAlbum);
 
       home->SetProperty("LatestAlbum." + value + ".Title"   , album.strAlbum);
       home->SetProperty("LatestAlbum." + value + ".Year"    , album.strReleaseDate);
@@ -303,7 +305,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("%i", i + 1);
+    std::string value = StringUtils::Format("{}", i + 1);
     home->SetProperty("LatestAlbum." + value + ".Title"   , "");
     home->SetProperty("LatestAlbum." + value + ".Year"    , "");
     home->SetProperty("LatestAlbum." + value + ".Artist"  , "");

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -536,7 +536,7 @@ void CRegExp::DumpOvector(int iLog /* = LOGDEBUG */)
   int size = GetSubCount(); // past the subpatterns is junk
   for (int i = 0; i <= size; i++)
   {
-    std::string t = StringUtils::Format("[%i,%i]", m_iOvector[(i*2)], m_iOvector[(i*2)+1]);
+    std::string t = StringUtils::Format("[{},{}]", m_iOvector[(i * 2)], m_iOvector[(i * 2) + 1]);
     if (i != size)
       t += ",";
     str += t;

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -144,7 +144,7 @@ void CScraperParser::ReplaceBuffers(std::string& strDest)
   for (int i=MAX_SCRAPER_BUFFERS-1; i>=0; i--)
   {
     iIndex = 0;
-    std::string temp = StringUtils::Format("$$%i",i+1);
+    std::string temp = StringUtils::Format("$${}", i + 1);
     while ((iIndex = strDest.find(temp,iIndex)) != std::string::npos)
     {
       strDest.replace(strDest.begin()+iIndex,strDest.begin()+iIndex+temp.size(),m_param[i]);
@@ -548,7 +548,7 @@ void CScraperParser::ConvertJSON(std::string &string)
     int pos = reg.GetSubStart(1);
     std::string szReplace(reg.GetMatch(1));
 
-    std::string replace = StringUtils::Format("&#x%s;", szReplace.c_str());
+    std::string replace = StringUtils::Format("&#x{};", szReplace.c_str());
     string.replace(string.begin()+pos-2, string.begin()+pos+4, replace);
   }
 
@@ -560,7 +560,7 @@ void CScraperParser::ConvertJSON(std::string &string)
     int pos2 = reg2.GetSubStart(2);
     std::string szHexValue(reg2.GetMatch(1));
 
-    std::string replace = StringUtils::Format("%li", strtol(szHexValue.c_str(), NULL, 16));
+    std::string replace = StringUtils::Format("{}", strtol(szHexValue.c_str(), NULL, 16));
     string.replace(string.begin()+pos1-2, string.begin()+pos2+reg2.GetSubLength(2), replace);
   }
 

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -260,7 +260,7 @@ void CScraperUrl::AddParsedUrl(const std::string& url,
     thumb.SetAttribute("gzip", "yes");
   if (season >= 0)
   {
-    thumb.SetAttribute("season", StringUtils::Format("%i", season));
+    thumb.SetAttribute("season", StringUtils::Format("{}", season));
     thumb.SetAttribute("type", "season");
   }
   thumb.SetAttribute("aspect", aspect);

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -56,12 +56,14 @@ std::string ByFile(SortAttribute attributes, const SortItem &values)
 {
   CURL url(values.at(FieldPath).asString());
 
-  return StringUtils::Format("%s %" PRId64, url.GetFileNameWithoutPath().c_str(), values.at(FieldStartOffset).asInteger());
+  return StringUtils::Format("{} {}", url.GetFileNameWithoutPath().c_str(),
+                             values.at(FieldStartOffset).asInteger());
 }
 
 std::string ByPath(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%s %" PRId64, values.at(FieldPath).asString().c_str(), values.at(FieldStartOffset).asInteger());
+  return StringUtils::Format("{} {}", values.at(FieldPath).asString().c_str(),
+                             values.at(FieldStartOffset).asInteger());
 }
 
 std::string ByLastPlayed(SortAttribute attributes, const SortItem &values)
@@ -69,12 +71,14 @@ std::string ByLastPlayed(SortAttribute attributes, const SortItem &values)
   if (attributes & SortAttributeIgnoreLabel)
     return values.at(FieldLastPlayed).asString();
 
-  return StringUtils::Format("%s %s", values.at(FieldLastPlayed).asString().c_str(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldLastPlayed).asString().c_str(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByPlaycount(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i %s", (int)values.at(FieldPlaycount).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldPlaycount).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByDate(SortAttribute attributes, const SortItem &values)
@@ -84,17 +88,19 @@ std::string ByDate(SortAttribute attributes, const SortItem &values)
 
 std::string ByDateAdded(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%s %d", values.at(FieldDateAdded).asString().c_str(), (int)values.at(FieldId).asInteger());
+  return StringUtils::Format("{} {}", values.at(FieldDateAdded).asString().c_str(),
+                             (int)values.at(FieldId).asInteger());
 }
 
 std::string BySize(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%" PRId64, values.at(FieldSize).asInteger());
+  return StringUtils::Format("{}", values.at(FieldSize).asInteger());
 }
 
 std::string ByDriveType(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%d %s", (int)values.at(FieldDriveType).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldDriveType).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByTitle(SortAttribute attributes, const SortItem &values)
@@ -111,11 +117,12 @@ std::string ByAlbum(SortAttribute attributes, const SortItem &values)
   if (attributes & SortAttributeIgnoreArticle)
     album = SortUtils::RemoveArticles(album);
 
-  std::string label = StringUtils::Format("%s %s", album.c_str(), ArrayToString(attributes, values.at(FieldArtist)).c_str());
+  std::string label = StringUtils::Format(
+      "{} {}", album.c_str(), ArrayToString(attributes, values.at(FieldArtist)).c_str());
 
   const CVariant &track = values.at(FieldTrackNumber);
   if (!track.isNull())
-    label += StringUtils::Format(" %i", (int)track.asInteger());
+    label += StringUtils::Format(" {}", (int)track.asInteger());
 
   return label;
 }
@@ -143,7 +150,7 @@ std::string ByArtist(SortAttribute attributes, const SortItem &values)
 
   const CVariant &track = values.at(FieldTrackNumber);
   if (!track.isNull())
-    label += StringUtils::Format(" %i", (int)track.asInteger());
+    label += StringUtils::Format(" {}", (int)track.asInteger());
 
   return label;
 }
@@ -162,7 +169,7 @@ std::string ByArtistThenYear(SortAttribute attributes, const SortItem &values)
 
   const CVariant &year = values.at(FieldYear);
   if (!year.isNull())
-    label += StringUtils::Format(" %i", static_cast<int>(year.asInteger()));
+    label += StringUtils::Format(" {}", static_cast<int>(year.asInteger()));
 
   const CVariant &album = values.at(FieldAlbum);
   if (!album.isNull())
@@ -170,19 +177,19 @@ std::string ByArtistThenYear(SortAttribute attributes, const SortItem &values)
 
   const CVariant &track = values.at(FieldTrackNumber);
   if (!track.isNull())
-    label += StringUtils::Format(" %i", (int)track.asInteger());
+    label += StringUtils::Format(" {}", (int)track.asInteger());
 
   return label;
 }
 
 std::string ByTrackNumber(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i", (int)values.at(FieldTrackNumber).asInteger());
+  return StringUtils::Format("{}", (int)values.at(FieldTrackNumber).asInteger());
 }
 
 std::string ByTotalDiscs(SortAttribute attributes, const SortItem& values)
 {
-  return StringUtils::Format("%d %s", static_cast<int>(values.at(FieldTotalDiscs).asInteger()),
+  return StringUtils::Format("{} {}", static_cast<int>(values.at(FieldTotalDiscs).asInteger()),
                              ByLabel(attributes, values));
 }
 std::string ByTime(SortAttribute attributes, const SortItem &values)
@@ -190,15 +197,15 @@ std::string ByTime(SortAttribute attributes, const SortItem &values)
   std::string label;
   const CVariant &time = values.at(FieldTime);
   if (time.isInteger())
-    label = StringUtils::Format("%i", (int)time.asInteger());
+    label = StringUtils::Format("{}", (int)time.asInteger());
   else
-    label = StringUtils::Format("%s", time.asString().c_str());
+    label = StringUtils::Format("{}", time.asString().c_str());
   return label;
 }
 
 std::string ByProgramCount(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i", (int)values.at(FieldProgramCount).asInteger());
+  return StringUtils::Format("{}", (int)values.at(FieldProgramCount).asInteger());
 }
 
 std::string ByPlaylistOrder(SortAttribute attributes, const SortItem &values)
@@ -224,7 +231,7 @@ std::string ByYear(SortAttribute attributes, const SortItem &values)
   if (!airDate.isNull() && !airDate.asString().empty())
     label = airDate.asString() + " ";
 
-  label += StringUtils::Format("%i", (int)values.at(FieldYear).asInteger());
+  label += StringUtils::Format("{}", (int)values.at(FieldYear).asInteger());
 
   const CVariant &album = values.at(FieldAlbum);
   if (!album.isNull())
@@ -232,7 +239,7 @@ std::string ByYear(SortAttribute attributes, const SortItem &values)
 
   const CVariant &track = values.at(FieldTrackNumber);
   if (!track.isNull())
-    label += StringUtils::Format(" %i", (int)track.asInteger());
+    label += StringUtils::Format(" {}", (int)track.asInteger());
 
   label += " " + ByLabel(attributes, values);
 
@@ -250,7 +257,7 @@ std::string ByOrigDate(SortAttribute attributes, const SortItem& values)
 
   const CVariant &track = values.at(FieldTrackNumber);
   if (!track.isNull())
-    label += StringUtils::Format(" %i", static_cast<int>(track.asInteger()));
+    label += StringUtils::Format(" {}", static_cast<int>(track.asInteger()));
 
   label += " " + ByLabel(attributes, values);
 
@@ -271,22 +278,26 @@ std::string BySortTitle(SortAttribute attributes, const SortItem &values)
 
 std::string ByRating(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%f %s", values.at(FieldRating).asFloat(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{:f} {}", values.at(FieldRating).asFloat(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByUserRating(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%d %s", static_cast<int>(values.at(FieldUserRating).asInteger()), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", static_cast<int>(values.at(FieldUserRating).asInteger()),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByVotes(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%d %s", (int)values.at(FieldVotes).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldVotes).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByTop250(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%d %s", (int)values.at(FieldTop250).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldTop250).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByMPAA(SortAttribute attributes, const SortItem &values)
@@ -324,7 +335,7 @@ std::string ByEpisodeNumber(SortAttribute attributes, const SortItem &values)
   if (title.empty())
     title = ByLabel(attributes, values);
 
-  return StringUtils::Format("%" PRIu64" %s", num, title.c_str());
+  return StringUtils::Format("{} {}", num, title.c_str());
 }
 
 std::string BySeason(SortAttribute attributes, const SortItem &values)
@@ -334,17 +345,19 @@ std::string BySeason(SortAttribute attributes, const SortItem &values)
   if (!specialSeason.isNull())
     season = (int)specialSeason.asInteger();
 
-  return StringUtils::Format("%i %s", season, ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", season, ByLabel(attributes, values).c_str());
 }
 
 std::string ByNumberOfEpisodes(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i %s", (int)values.at(FieldNumberOfEpisodes).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldNumberOfEpisodes).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByNumberOfWatchedEpisodes(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i %s", (int)values.at(FieldNumberOfWatchedEpisodes).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldNumberOfWatchedEpisodes).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByTvShowStatus(SortAttribute attributes, const SortItem &values)
@@ -364,52 +377,59 @@ std::string ByProductionCode(SortAttribute attributes, const SortItem &values)
 
 std::string ByVideoResolution(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i %s", (int)values.at(FieldVideoResolution).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldVideoResolution).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByVideoCodec(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%s %s", values.at(FieldVideoCodec).asString().c_str(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldVideoCodec).asString().c_str(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByVideoAspectRatio(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%.3f %s", values.at(FieldVideoAspectRatio).asFloat(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{:.3f} {}", values.at(FieldVideoAspectRatio).asFloat(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByAudioChannels(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i %s", (int)values.at(FieldAudioChannels).asInteger(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", (int)values.at(FieldAudioChannels).asInteger(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByAudioCodec(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%s %s", values.at(FieldAudioCodec).asString().c_str(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldAudioCodec).asString().c_str(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByAudioLanguage(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%s %s", values.at(FieldAudioLanguage).asString().c_str(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldAudioLanguage).asString().c_str(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string BySubtitleLanguage(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%s %s", values.at(FieldSubtitleLanguage).asString().c_str(), ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldSubtitleLanguage).asString().c_str(),
+                             ByLabel(attributes, values).c_str());
 }
 
 std::string ByBitrate(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%" PRId64, values.at(FieldBitrate).asInteger());
+  return StringUtils::Format("{}", values.at(FieldBitrate).asInteger());
 }
 
 std::string ByListeners(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%" PRId64, values.at(FieldListeners).asInteger());
+  return StringUtils::Format("{}", values.at(FieldListeners).asInteger());
 }
 
 std::string ByRandom(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i", CUtil::GetRandomNumber());
+  return StringUtils::Format("{}", CUtil::GetRandomNumber());
 }
 
 std::string ByChannel(SortAttribute attributes, const SortItem &values)
@@ -434,7 +454,7 @@ std::string ByDateTaken(SortAttribute attributes, const SortItem &values)
 
 std::string ByRelevance(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%i", (int)values.at(FieldRelevance).asInteger());
+  return StringUtils::Format("{}", (int)values.at(FieldRelevance).asInteger());
 }
 
 std::string ByInstallDate(SortAttribute attributes, const SortItem &values)
@@ -454,7 +474,7 @@ std::string ByLastUsed(SortAttribute attributes, const SortItem &values)
 
 std::string ByBPM(SortAttribute attributes, const SortItem& values)
 {
-  return StringUtils::Format("%d %s", static_cast<int>(values.at(FieldBPM).asInteger()),
+  return StringUtils::Format("{} {}", static_cast<int>(values.at(FieldBPM).asInteger()),
                              ByLabel(attributes, values));
 }
 

--- a/xbmc/utils/Speed.cpp
+++ b/xbmc/utils/Speed.cpp
@@ -578,5 +578,5 @@ std::string CSpeed::ToString(Unit speedUnit) const
   if (!IsValid())
     return "";
 
-  return StringUtils::Format("%2.0f", To(speedUnit));
+  return StringUtils::Format("{:2.0f}", To(speedUnit));
 }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1393,13 +1393,13 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
 
   std::string strHMS;
   if (format == TIME_FORMAT_SECS)
-    strHMS = StringUtils::Format("%i", lSeconds);
+    strHMS = StringUtils::Format("{}", lSeconds);
   else if (format == TIME_FORMAT_MINS)
-    strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(lSeconds) / 60.0f));
+    strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(lSeconds) / 60.0f));
   else if (format == TIME_FORMAT_HOURS)
-    strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(lSeconds) / 3600.0f));
+    strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(lSeconds) / 3600.0f));
   else if (format & TIME_FORMAT_M)
-    strHMS += StringUtils::Format("%i", lSeconds % 3600 / 60);
+    strHMS += StringUtils::Format("{}", lSeconds % 3600 / 60);
   else
   {
     int hh = lSeconds / 3600;
@@ -1410,13 +1410,13 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
     if (format == TIME_FORMAT_GUESS)
       format = (hh >= 1) ? TIME_FORMAT_HH_MM_SS : TIME_FORMAT_MM_SS;
     if (format & TIME_FORMAT_HH)
-      strHMS += StringUtils::Format("%2.2i", hh);
+      strHMS += StringUtils::Format("{:02}", hh);
     else if (format & TIME_FORMAT_H)
-      strHMS += StringUtils::Format("%i", hh);
+      strHMS += StringUtils::Format("{}", hh);
     if (format & TIME_FORMAT_MM)
-      strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", mm);
+      strHMS += StringUtils::Format(strHMS.empty() ? "{:02}" : ":{:02}", mm);
     if (format & TIME_FORMAT_SS)
-      strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", ss);
+      strHMS += StringUtils::Format(strHMS.empty() ? "{:02}" : ":{:02}", ss);
   }
 
   if (isNegative)
@@ -1501,14 +1501,14 @@ std::string StringUtils::SizeToString(int64_t size)
   else if (i == ARRAY_SIZE(prefixes))
   {
     if (s >= 1000.0)
-      strLabel = StringUtils::Format(">999.99 %cB", prefixes[i - 1]);
+      strLabel = StringUtils::Format(">999.99 {}B", prefixes[i - 1]);
     else
-      strLabel = StringUtils::Format("%.2lf %cB", s, prefixes[i - 1]);
+      strLabel = StringUtils::Format("{:.2f} {}B", s, prefixes[i - 1]);
   }
   else if (s >= 100.0)
-    strLabel = StringUtils::Format("%.1lf %cB", s, prefixes[i]);
+    strLabel = StringUtils::Format("{:.1f} {}B", s, prefixes[i]);
   else
-    strLabel = StringUtils::Format("%.2lf %cB", s, prefixes[i]);
+    strLabel = StringUtils::Format("{:.2f} {}B", s, prefixes[i]);
 
   return strLabel;
 }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -278,7 +278,7 @@ bool CSysInfoJob::DoWork()
   m_info.internetState     = GetInternetState();
   m_info.videoEncoder      = GetVideoEncoder();
   m_info.cpuFrequency =
-      StringUtils::Format("%4.0f MHz", CServiceBroker::GetCPUInfo()->GetCPUFrequency());
+      StringUtils::Format("{:4.0f} MHz", CServiceBroker::GetCPUInfo()->GetCPUFrequency());
   m_info.osVersionInfo     = CSysInfo::GetOsPrettyNameWithVersion() + " (kernel: " + CSysInfo::GetKernelName() + " " + CSysInfo::GetKernelVersionFull() + ")";
   m_info.macAddress        = GetMACAddress();
   m_info.batteryLevel      = GetBatteryLevel();
@@ -315,7 +315,7 @@ std::string CSysInfoJob::GetVideoEncoder()
 
 std::string CSysInfoJob::GetBatteryLevel()
 {
-  return StringUtils::Format("%d%%", CServiceBroker::GetPowerManager().BatteryLevel());
+  return StringUtils::Format("{}%", CServiceBroker::GetPowerManager().BatteryLevel());
 }
 
 bool CSysInfoJob::SystemUpTime(int iInputMinutes, int &iMinutes, int &iHours, int &iDays)
@@ -357,21 +357,19 @@ std::string CSysInfoJob::GetSystemUpTime(bool bTotalUptime)
   SystemUpTime(iInputMinutes,iMinutes, iHours, iDays);
   if (iDays > 0)
   {
-    strSystemUptime = StringUtils::Format("%i %s, %i %s, %i %s",
-                                          iDays, g_localizeStrings.Get(12393).c_str(),
-                                          iHours, g_localizeStrings.Get(12392).c_str(),
-                                          iMinutes, g_localizeStrings.Get(12391).c_str());
+    strSystemUptime = StringUtils::Format(
+        "{} {}, {} {}, {} {}", iDays, g_localizeStrings.Get(12393).c_str(), iHours,
+        g_localizeStrings.Get(12392).c_str(), iMinutes, g_localizeStrings.Get(12391).c_str());
   }
   else if (iDays == 0 && iHours >= 1 )
   {
-    strSystemUptime = StringUtils::Format("%i %s, %i %s",
-                                          iHours, g_localizeStrings.Get(12392).c_str(),
-                                          iMinutes, g_localizeStrings.Get(12391).c_str());
+    strSystemUptime =
+        StringUtils::Format("{} {}, {} {}", iHours, g_localizeStrings.Get(12392).c_str(), iMinutes,
+                            g_localizeStrings.Get(12391).c_str());
   }
   else if (iDays == 0 && iHours == 0 &&  iMinutes >= 0)
   {
-    strSystemUptime = StringUtils::Format("%i %s",
-                                          iMinutes, g_localizeStrings.Get(12391).c_str());
+    strSystemUptime = StringUtils::Format("{} {}", iMinutes, g_localizeStrings.Get(12391).c_str());
   }
   return strSystemUptime;
 }
@@ -541,13 +539,13 @@ std::string CSysInfo::GetKernelVersionFull(void)
   DWORD len = sizeof(DWORD);
 
   if (sysGetVersionExWByRef(osvi))
-    kernelVersionFull = StringUtils::Format("%d.%d.%d", osvi.dwMajorVersion, osvi.dwMinorVersion,
+    kernelVersionFull = StringUtils::Format("{}.{}.{}", osvi.dwMajorVersion, osvi.dwMinorVersion,
                                             osvi.dwBuildNumber);
   // get UBR (updates build revision)
   if (ERROR_SUCCESS == RegGetValueW(HKEY_LOCAL_MACHINE, REG_CURRENT_VERSION, L"UBR",
                                     RRF_RT_REG_DWORD, nullptr, &dwBuildRevision, &len))
   {
-    kernelVersionFull += StringUtils::Format(".%d", dwBuildRevision);
+    kernelVersionFull += StringUtils::Format(".{}", dwBuildRevision);
   }
 
 #elif  defined(TARGET_WINDOWS_STORE)
@@ -559,9 +557,9 @@ std::string CSysInfo::GetKernelVersionFull(void)
   unsigned long long v2 = (v & 0x0000FFFF00000000L) >> 32;
   unsigned long long v3 = (v & 0x00000000FFFF0000L) >> 16;
   unsigned long long v4 = (v & 0x000000000000FFFFL);
-  kernelVersionFull = StringUtils::Format("%lld.%lld.%lld", v1, v2, v3);
+  kernelVersionFull = StringUtils::Format("{}.{}.{}", v1, v2, v3);
   if (v4)
-    kernelVersionFull += StringUtils::Format(".%lld", v4);
+    kernelVersionFull += StringUtils::Format(".{}", v4);
 
 #elif defined(TARGET_POSIX)
   struct utsname un;
@@ -715,10 +713,10 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
     // Append Service Pack version if any
     if (osvi.wServicePackMajor > 0 || osvi.wServicePackMinor > 0)
     {
-      osNameVer.append(StringUtils::Format(" SP%d", osvi.wServicePackMajor));
+      osNameVer.append(StringUtils::Format(" SP{}", osvi.wServicePackMajor));
       if (osvi.wServicePackMinor > 0)
       {
-        osNameVer.append(StringUtils::Format(".%d", osvi.wServicePackMinor));
+        osNameVer.append(StringUtils::Format(".{}", osvi.wServicePackMinor));
       }
     }
   }
@@ -729,7 +727,8 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
 #elif defined(TARGET_FREEBSD) || defined(TARGET_DARWIN)
   osNameVer = GetOsName() + " " + GetOsVersion();
 #elif defined(TARGET_ANDROID)
-  osNameVer = GetOsName() + " " + GetOsVersion() + " API level " +   StringUtils::Format("%d", CJNIBuild::SDK_INT);
+  osNameVer = GetOsName() + " " + GetOsVersion() + " API level " +
+              StringUtils::Format("{}", CJNIBuild::SDK_INT);
 #elif defined(TARGET_LINUX)
   osNameVer = getValueFromOs_release("PRETTY_NAME");
   if (osNameVer.empty())
@@ -1042,19 +1041,19 @@ std::string CSysInfo::GetHddSpaceInfo(int& percent, int drive, bool shortText)
       switch(drive)
       {
       case SYSTEM_FREE_SPACE:
-        strRet = StringUtils::Format("%i MB %s", totalFree, g_localizeStrings.Get(160).c_str());
+        strRet = StringUtils::Format("{} MB {}", totalFree, g_localizeStrings.Get(160).c_str());
         break;
       case SYSTEM_USED_SPACE:
-        strRet = StringUtils::Format("%i MB %s", totalUsed, g_localizeStrings.Get(20162).c_str());
+        strRet = StringUtils::Format("{} MB {}", totalUsed, g_localizeStrings.Get(20162).c_str());
         break;
       case SYSTEM_TOTAL_SPACE:
-        strRet = StringUtils::Format("%i MB %s", total, g_localizeStrings.Get(20161).c_str());
+        strRet = StringUtils::Format("{} MB {}", total, g_localizeStrings.Get(20161).c_str());
         break;
       case SYSTEM_FREE_SPACE_PERCENT:
-        strRet = StringUtils::Format("%i %% %s", percentFree, g_localizeStrings.Get(160).c_str());
+        strRet = StringUtils::Format("{} % {}", percentFree, g_localizeStrings.Get(160).c_str());
         break;
       case SYSTEM_USED_SPACE_PERCENT:
-        strRet = StringUtils::Format("%i %% %s", percentused, g_localizeStrings.Get(20162).c_str());
+        strRet = StringUtils::Format("{} % {}", percentused, g_localizeStrings.Get(20162).c_str());
         break;
       }
     }
@@ -1207,7 +1206,7 @@ std::string CSysInfo::GetUserAgent()
   }
 #endif
 
-  result += " App_Bitness/" + StringUtils::Format("%d", GetXbmcBitness());
+  result += " App_Bitness/" + StringUtils::Format("{}", GetXbmcBitness());
 
   std::string fullVer(CSysInfo::GetVersion());
   StringUtils::Replace(fullVer, ' ', '-');
@@ -1223,7 +1222,7 @@ std::string CSysInfo::GetDeviceName()
   {
     std::string hostname("[unknown]");
     CServiceBroker::GetNetwork().GetHostName(hostname);
-    return StringUtils::Format("%s (%s)", friendlyName.c_str(), hostname.c_str());
+    return StringUtils::Format("{} ({})", friendlyName.c_str(), hostname.c_str());
   }
 
   return friendlyName;
@@ -1234,9 +1233,10 @@ std::string CSysInfo::GetDeviceName()
 std::string CSysInfo::GetVersionShort()
 {
   if (strlen(CCompileInfo::GetSuffix()) == 0)
-    return StringUtils::Format("%d.%d", CCompileInfo::GetMajor(), CCompileInfo::GetMinor());
+    return StringUtils::Format("{}.{}", CCompileInfo::GetMajor(), CCompileInfo::GetMinor());
   else
-    return StringUtils::Format("%d.%d-%s", CCompileInfo::GetMajor(), CCompileInfo::GetMinor(), CCompileInfo::GetSuffix());
+    return StringUtils::Format("{}.{}-{}", CCompileInfo::GetMajor(), CCompileInfo::GetMinor(),
+                               CCompileInfo::GetSuffix());
 }
 
 std::string CSysInfo::GetVersion()
@@ -1314,38 +1314,40 @@ std::string CSysInfo::GetBuildTargetPlatformVersionDecoded(void)
 {
 #if defined(TARGET_DARWIN_OSX)
   if (__MAC_OS_X_VERSION_MIN_REQUIRED % 100)
-    return StringUtils::Format("version %d.%d.%d", __MAC_OS_X_VERSION_MIN_REQUIRED / 10000,
+    return StringUtils::Format("version {}.{}.{}", __MAC_OS_X_VERSION_MIN_REQUIRED / 10000,
                                (__MAC_OS_X_VERSION_MIN_REQUIRED / 100) % 100,
                                __MAC_OS_X_VERSION_MIN_REQUIRED % 100);
   else
-    return StringUtils::Format("version %d.%d", __MAC_OS_X_VERSION_MIN_REQUIRED / 10000,
+    return StringUtils::Format("version {}.{}", __MAC_OS_X_VERSION_MIN_REQUIRED / 10000,
                                (__MAC_OS_X_VERSION_MIN_REQUIRED / 100) % 100);
 #elif defined(TARGET_DARWIN_EMBEDDED)
   std::string versionStr = GetBuildTargetPlatformVersion();
   static const int major = (std::stoi(versionStr) / 10000) % 100;
   static const int minor = (std::stoi(versionStr) / 100) % 100;
   static const int rev = std::stoi(versionStr) % 100;
-  return StringUtils::Format("version %d.%d.%d", major, minor, rev);
+  return StringUtils::Format("version {}.{}.{}", major, minor, rev);
 #elif defined(TARGET_FREEBSD)
   // FIXME: should works well starting from FreeBSD 8.1
   static const int major = (__FreeBSD_version / 100000) % 100;
   static const int minor = (__FreeBSD_version / 1000) % 100;
   static const int Rxx = __FreeBSD_version % 1000;
   if ((major < 9 && Rxx == 0))
-    return StringUtils::Format("version %d.%d-RELEASE", major, minor);
+    return StringUtils::Format("version {}.{}-RELEASE", major, minor);
   if (Rxx >= 500)
-    return StringUtils::Format("version %d.%d-STABLE", major, minor);
+    return StringUtils::Format("version {}.{}-STABLE", major, minor);
 
-  return StringUtils::Format("version %d.%d-CURRENT", major, minor);
+  return StringUtils::Format("version {}.{}-CURRENT", major, minor);
 #elif defined(TARGET_ANDROID)
   return "API level " XSTR_MACRO(__ANDROID_API__);
 #elif defined(TARGET_LINUX)
-  return StringUtils::Format("version %d.%d.%d", (LINUX_VERSION_CODE >> 16) & 0xFF , (LINUX_VERSION_CODE >> 8) & 0xFF, LINUX_VERSION_CODE & 0xFF);
+  return StringUtils::Format("version {}.{}.{}", (LINUX_VERSION_CODE >> 16) & 0xFF,
+                             (LINUX_VERSION_CODE >> 8) & 0xFF, LINUX_VERSION_CODE & 0xFF);
 #elif defined(TARGET_WINDOWS)
 #ifdef NTDDI_VERSION
-  std::string version(StringUtils::Format("version %d.%d", int(NTDDI_VERSION >> 24) & 0xFF, int(NTDDI_VERSION >> 16) & 0xFF));
+  std::string version(StringUtils::Format("version {}.{}", int(NTDDI_VERSION >> 24) & 0xFF,
+                                          int(NTDDI_VERSION >> 16) & 0xFF));
   if (SPVER(NTDDI_VERSION))
-    version += StringUtils::Format(" SP%d", int(SPVER(NTDDI_VERSION)));
+    version += StringUtils::Format(" SP{}", int(SPVER(NTDDI_VERSION)));
   return version;
 #else // !NTDDI_VERSION
   return "(unknown Win32 platform)";

--- a/xbmc/utils/Temperature.cpp
+++ b/xbmc/utils/Temperature.cpp
@@ -477,5 +477,5 @@ std::string CTemperature::ToString(Unit temperatureUnit) const
   if (!IsValid())
     return "";
 
-  return StringUtils::Format("%2.0f", To(temperatureUnit));
+  return StringUtils::Format("{:2.0f}", To(temperatureUnit));
 }

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -287,25 +287,25 @@ TiXmlNode* XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const s
 
 TiXmlNode* XMLUtils::SetInt(TiXmlNode* pRootNode, const char *strTag, int value)
 {
-  std::string strValue = StringUtils::Format("%i", value);
+  std::string strValue = StringUtils::Format("{}", value);
   return SetString(pRootNode, strTag, strValue);
 }
 
 void XMLUtils::SetLong(TiXmlNode* pRootNode, const char *strTag, long value)
 {
-  std::string strValue = StringUtils::Format("%ld", value);
+  std::string strValue = StringUtils::Format("{}", value);
   SetString(pRootNode, strTag, strValue);
 }
 
 TiXmlNode* XMLUtils::SetFloat(TiXmlNode* pRootNode, const char *strTag, float value)
 {
-  std::string strValue = StringUtils::Format("%f", value);
+  std::string strValue = StringUtils::Format("{:f}", value);
   return SetString(pRootNode, strTag, strValue);
 }
 
 TiXmlNode* XMLUtils::SetDouble(TiXmlNode* pRootNode, const char* strTag, double value)
 {
-  std::string strValue = StringUtils::Format("%lf", value);
+  std::string strValue = StringUtils::Format("{:f}", value);
   return SetString(pRootNode, strTag, strValue);
 }
 
@@ -316,7 +316,7 @@ void XMLUtils::SetBoolean(TiXmlNode* pRootNode, const char *strTag, bool value)
 
 void XMLUtils::SetHex(TiXmlNode* pRootNode, const char *strTag, uint32_t value)
 {
-  std::string strValue = StringUtils::Format("%x", value);
+  std::string strValue = StringUtils::Format("{:x}", value);
   SetString(pRootNode, strTag, strValue);
 }
 

--- a/xbmc/utils/test/TestDatabaseUtils.cpp
+++ b/xbmc/utils/test/TestDatabaseUtils.cpp
@@ -342,47 +342,47 @@ TEST(TestDatabaseUtils, GetField_MediaTypeMusicVideo)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_TITLE);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_TITLE);
   varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_RUNTIME);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_RUNTIME);
   varstr = DatabaseUtils::GetField(FieldTime, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_DIRECTOR);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_DIRECTOR);
   varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_STUDIOS);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_STUDIOS);
   varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_PLOT);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_PLOT);
   varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_ALBUM);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_ALBUM);
   varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_ARTIST);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_ARTIST);
   varstr = DatabaseUtils::GetField(FieldArtist, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_GENRE);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_GENRE);
   varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_TRACK);
+  refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_TRACK);
   varstr = DatabaseUtils::GetField(FieldTrackNumber, MediaTypeMusicVideo,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
@@ -442,29 +442,29 @@ TEST(TestDatabaseUtils, GetField_MediaTypeMovie)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TITLE);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TITLE);
   varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("CASE WHEN length(movie_view.c%02d) > 0 THEN movie_view.c%02d "
-                "ELSE movie_view.c%02d END", VIDEODB_ID_SORTTITLE,
-                VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
+  refstr = StringUtils::Format("CASE WHEN length(movie_view.c{:02}) > 0 THEN movie_view.c{:02} "
+                               "ELSE movie_view.c{:02} END",
+                               VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
   varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMovie,
                                    DatabaseQueryPartOrderBy);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_PLOT);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_PLOT);
   varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_PLOTOUTLINE);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_PLOTOUTLINE);
   varstr = DatabaseUtils::GetField(FieldPlotOutline, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TAGLINE);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TAGLINE);
   varstr = DatabaseUtils::GetField(FieldTagline, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
@@ -479,52 +479,52 @@ TEST(TestDatabaseUtils, GetField_MediaTypeMovie)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_CREDITS);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_CREDITS);
   varstr = DatabaseUtils::GetField(FieldWriter, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_SORTTITLE);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_SORTTITLE);
   varstr = DatabaseUtils::GetField(FieldSortTitle, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_RUNTIME);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_RUNTIME);
   varstr = DatabaseUtils::GetField(FieldTime, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_MPAA);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_MPAA);
   varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TOP250);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TOP250);
   varstr = DatabaseUtils::GetField(FieldTop250, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_GENRE);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_GENRE);
   varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_DIRECTOR);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_DIRECTOR);
   varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_STUDIOS);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_STUDIOS);
   varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TRAILER);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TRAILER);
   varstr = DatabaseUtils::GetField(FieldTrailer, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_COUNTRY);
+  refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_COUNTRY);
   varstr = DatabaseUtils::GetField(FieldCountry, MediaTypeMovie,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
@@ -574,24 +574,25 @@ TEST(TestDatabaseUtils, GetField_MediaTypeTvShow)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("CASE WHEN length(tvshow_view.c%02d) > 0 THEN tvshow_view.c%02d "
-                "ELSE tvshow_view.c%02d END", VIDEODB_ID_TV_SORTTITLE,
-                VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_TITLE);
+  refstr =
+      StringUtils::Format("CASE WHEN length(tvshow_view.c{:02}) > 0 THEN tvshow_view.c{:02} "
+                          "ELSE tvshow_view.c{:02} END",
+                          VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_TITLE);
   varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeTvShow,
                                    DatabaseQueryPartOrderBy);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_TITLE);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_TITLE);
   varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_PLOT);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_PLOT);
   varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_STATUS);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_STATUS);
   varstr = DatabaseUtils::GetField(FieldTvShowStatus, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
@@ -606,27 +607,27 @@ TEST(TestDatabaseUtils, GetField_MediaTypeTvShow)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_PREMIERED);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_PREMIERED);
   varstr = DatabaseUtils::GetField(FieldYear, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_GENRE);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_GENRE);
   varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_MPAA);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_MPAA);
   varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_STUDIOS);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_STUDIOS);
   varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_SORTTITLE);
+  refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_SORTTITLE);
   varstr = DatabaseUtils::GetField(FieldSortTitle, MediaTypeTvShow,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
@@ -676,12 +677,12 @@ TEST(TestDatabaseUtils, GetField_MediaTypeEpisode)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_TITLE);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_TITLE);
   varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_PLOT);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_PLOT);
   varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
@@ -696,32 +697,32 @@ TEST(TestDatabaseUtils, GetField_MediaTypeEpisode)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_CREDITS);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_CREDITS);
   varstr = DatabaseUtils::GetField(FieldWriter, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_AIRED);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_AIRED);
   varstr = DatabaseUtils::GetField(FieldAirDate, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_RUNTIME);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_RUNTIME);
   varstr = DatabaseUtils::GetField(FieldTime, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_DIRECTOR);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_DIRECTOR);
   varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_SEASON);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_SEASON);
   varstr = DatabaseUtils::GetField(FieldSeason, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_EPISODE);
+  refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_EPISODE);
   varstr = DatabaseUtils::GetField(FieldEpisodeNumber, MediaTypeEpisode,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -41,7 +41,7 @@ TEST(TestStringUtils, Format)
   std::string refstr = "test 25 2.7 ff FF";
 
   std::string varstr =
-      StringUtils::Format("%s %d %.1f %x %02X", "test", 25, 2.743f, 0x00ff, 0x00ff);
+      StringUtils::Format("{} {} {:.1f} {:x} {:02X}", "test", 25, 2.743f, 0x00ff, 0x00ff);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   varstr = StringUtils::Format("", "test", 25, 2.743f, 0x00ff, 0x00ff);
@@ -73,7 +73,7 @@ TEST(TestStringUtils, FormatEnumWidth)
   std::string varstr = StringUtils::Format("{:02d}", ECG::B);
   EXPECT_STREQ(one, varstr.c_str());
 
-  varstr = StringUtils::Format("%02d", EG::D);
+  varstr = StringUtils::Format("{:02}", EG::D);
   EXPECT_STREQ(one, varstr.c_str());
 }
 

--- a/xbmc/utils/test/TestXMLUtils.cpp
+++ b/xbmc/utils/test/TestXMLUtils.cpp
@@ -71,7 +71,7 @@ TEST(TestXMLUtils, GetDouble)
   EXPECT_TRUE(XMLUtils::GetDouble(a.RootElement(), "node", val));
 
   refstr = "1000.100000";
-  valstr = StringUtils::Format("%f", val);
+  valstr = StringUtils::Format("{:f}", val);
   EXPECT_STREQ(refstr.c_str(), valstr.c_str());
 }
 

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -71,7 +71,7 @@ bool CPlayerController::OnAction(const CAction &action)
           if (info.name.length() == 0)
             sub = lang;
           else
-            sub = StringUtils::Format("%s - %s", lang.c_str(), info.name.c_str());
+            sub = StringUtils::Format("{} - {}", lang.c_str(), info.name.c_str());
         }
         else
           sub = g_localizeStrings.Get(1223);
@@ -118,7 +118,7 @@ bool CPlayerController::OnAction(const CAction &action)
           if (info.name.length() == 0)
             sub = lang;
           else
-            sub = StringUtils::Format("%s - %s", lang.c_str(), info.name.c_str());
+            sub = StringUtils::Format("{} - {}", lang.c_str(), info.name.c_str());
         }
         else
           sub = g_localizeStrings.Get(1223);
@@ -218,9 +218,9 @@ bool CPlayerController::OnAction(const CAction &action)
         if (info.name.empty())
           aud = lan;
         else
-          aud = StringUtils::Format("%s - %s", lan.c_str(), info.name.c_str());
+          aud = StringUtils::Format("{} - {}", lan.c_str(), info.name.c_str());
         std::string caption = g_localizeStrings.Get(460);
-        caption += StringUtils::Format(" (%i/%i)", currentAudio + 1, audioStreamCount);
+        caption += StringUtils::Format(" ({}/{})", currentAudio + 1, audioStreamCount);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, aud, DisplTime, false, MsgTime);
         return true;
       }
@@ -239,7 +239,7 @@ bool CPlayerController::OnAction(const CAction &action)
         VideoStreamInfo info;
         g_application.GetAppPlayer().GetVideoStreamInfo(currentVideo, info);
         std::string caption = g_localizeStrings.Get(38031);
-        caption += StringUtils::Format(" (%i/%i)", currentVideo + 1, videoStreamCount);
+        caption += StringUtils::Format(" ({}/{})", currentVideo + 1, videoStreamCount);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, info.name, DisplTime, false, MsgTime);
         return true;
       }
@@ -527,7 +527,7 @@ void CPlayerController::OnSliderChange(void *data, CGUISliderControl *slider)
       m_sliderAction == ACTION_VSHIFT_UP || m_sliderAction == ACTION_VSHIFT_DOWN ||
       m_sliderAction == ACTION_SUBTITLE_VSHIFT_UP || m_sliderAction == ACTION_SUBTITLE_VSHIFT_DOWN)
   {
-    std::string strValue = StringUtils::Format("%1.2f",slider->GetFloatValue());
+    std::string strValue = StringUtils::Format("{:1.2f}", slider->GetFloatValue());
     slider->SetTextValue(strValue);
   }
   else if (m_sliderAction == ACTION_VOLAMP_UP ||

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1315,7 +1315,9 @@ namespace VIDEO
 
     if (showInfo && content == CONTENT_TVSHOWS)
     {
-      strTitle = StringUtils::Format("%s - %ix%i - %s", showInfo->m_strTitle.c_str(), movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle.c_str());
+      strTitle =
+          StringUtils::Format("{} - {}x{} - {}", showInfo->m_strTitle.c_str(),
+                              movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle.c_str());
     }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", TranslateContent(content), CURL::GetRedacted(pItem->GetPath()));
@@ -1920,7 +1922,9 @@ namespace VIDEO
         if (pItem->m_dwSize)
           digest.Update(std::to_string(pItem->m_dwSize));
         if (pItem->m_dateTime.IsValid())
-          digest.Update(StringUtils::Format("%02i.%02i.%04i", pItem->m_dateTime.GetDay(), pItem->m_dateTime.GetMonth(), pItem->m_dateTime.GetYear()));
+          digest.Update(StringUtils::Format("{:02}.{:02}.{:04}", pItem->m_dateTime.GetDay(),
+                                            pItem->m_dateTime.GetMonth(),
+                                            pItem->m_dateTime.GetYear()));
       }
       else
       {
@@ -2052,7 +2056,7 @@ namespace VIDEO
         else if (season == 0)
           basePath = "season-specials";
         else
-          basePath = StringUtils::Format("season%02i", season);
+          basePath = StringUtils::Format("season{:02}", season);
 
         AddLocalItemArtwork(art, artTypes,
           URIUtils::AddFileToFolder(show.m_strPath, basePath),

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -707,7 +707,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["plotoutline"] = m_strPlotOutline;
   value["plot"] = m_strPlot;
   value["title"] = m_strTitle;
-  value["votes"] = StringUtils::Format("%i", GetRating().votes);
+  value["votes"] = StringUtils::Format("{}", GetRating().votes);
   value["studio"] = m_studio;
   value["trailer"] = m_strTrailer;
   value["cast"] = CVariant(CVariant::VariantTypeArray);
@@ -946,9 +946,10 @@ const std::string CVideoInfoTag::GetCast(bool bIncludeRole /*= false*/) const
   {
     std::string character;
     if (it->strRole.empty() || !bIncludeRole)
-      character = StringUtils::Format("%s\n", it->strName.c_str());
+      character = StringUtils::Format("{}\n", it->strName.c_str());
     else
-      character = StringUtils::Format("%s %s %s\n", it->strName.c_str(), g_localizeStrings.Get(20347).c_str(), it->strRole.c_str());
+      character = StringUtils::Format("{} {} {}\n", it->strName.c_str(),
+                                      g_localizeStrings.Get(20347).c_str(), it->strRole.c_str());
     strLabel += character;
   }
   return StringUtils::TrimRight(strLabel, "\n");
@@ -1628,7 +1629,8 @@ void CVideoInfoTag::SetEpisodeGuide(std::string episodeGuide)
   if (StringUtils::StartsWith(episodeGuide, "<episodeguide"))
     m_strEpisodeGuide = Trim(std::move(episodeGuide));
   else
-    m_strEpisodeGuide = StringUtils::Format("<episodeguide>%s</episodeguide>", Trim(std::move(episodeGuide)).c_str());
+    m_strEpisodeGuide = StringUtils::Format("<episodeguide>{}</episodeguide>",
+                                            Trim(std::move(episodeGuide)).c_str());
 }
 
 void CVideoInfoTag::SetStatus(std::string status)

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -758,7 +758,7 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     // add audio language properties
     for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
-      std::string index = StringUtils::Format("%i", i);
+      std::string index = StringUtils::Format("{}", i);
       item.SetProperty("AudioChannels." + index, details.GetAudioChannels(i));
       item.SetProperty("AudioCodec."    + index, details.GetAudioCodec(i).c_str());
       item.SetProperty("AudioLanguage." + index, details.GetAudioLanguage(i).c_str());
@@ -767,7 +767,7 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     // add subtitle language properties
     for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
-      std::string index = StringUtils::Format("%i", i);
+      std::string index = StringUtils::Format("{}", i);
       item.SetProperty("SubtitleLanguage." + index, details.GetSubtitleLanguage(i).c_str());
     }
   }

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -336,7 +336,7 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(const SettingConstPtr& se
     strItem = StringUtils::Format(strFormat, strLanguage.c_str(), info.name.c_str(), info.channels);
 
     strItem += FormatFlags(info.flags);
-    strItem += StringUtils::Format(" (%i/%i)", i + 1, audioStreamCount);
+    strItem += StringUtils::Format(" ({}/{})", i + 1, audioStreamCount);
     list.emplace_back(strItem, i);
   }
 
@@ -402,7 +402,7 @@ std::string CGUIDialogAudioSettings::FormatFlags(StreamFlags flags)
   std::string formated = StringUtils::Join(localizedFlags, ", ");
 
   if (!formated.empty())
-    formated = StringUtils::Format(" [%s]", formated);
+    formated = StringUtils::Format(" [{}]", formated);
 
   return formated;
 }

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -341,10 +341,10 @@ void CGUIDialogSubtitleSettings::SubtitleStreamsOptionFiller(
     if (info.name.length() == 0)
       strItem = strLanguage;
     else
-      strItem = StringUtils::Format("%s - %s", strLanguage.c_str(), info.name.c_str());
+      strItem = StringUtils::Format("{} - {}", strLanguage.c_str(), info.name.c_str());
 
     strItem += FormatFlags(info.flags);
-    strItem += StringUtils::Format(" (%i/%i)", i + 1, subtitleStreamCount);
+    strItem += StringUtils::Format(" ({}/{})", i + 1, subtitleStreamCount);
 
     list.emplace_back(strItem, i);
   }
@@ -393,7 +393,7 @@ std::string CGUIDialogSubtitleSettings::FormatFlags(StreamFlags flags)
   std::string formated = StringUtils::Join(localizedFlags, ", ");
 
   if (!formated.empty())
-    formated = StringUtils::Format(" [%s]", formated);
+    formated = StringUtils::Format(" [{}]", formated);
 
   return formated;
 }

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -504,7 +504,8 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
 
     // construct subtitle path
     std::string strSubExt = URIUtils::GetExtension(strUrl);
-    std::string strSubName = StringUtils::Format("%s.%s%s", strFileName.c_str(), strSubLang.c_str(), strSubExt.c_str());
+    std::string strSubName =
+        StringUtils::Format("{}.{}{}", strFileName.c_str(), strSubLang.c_str(), strSubExt.c_str());
 
     // Handle URL encoding:
     std::string strDownloadFile = URIUtils::ChangeBasePath(strCurrentFilePath, strSubName, strDownloadPath);
@@ -551,7 +552,8 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
         strUrl = URIUtils::ReplaceExtension(strUrl, ".idx");
         if(CFile::Exists(strUrl))
         {
-          std::string strSubNameIdx = StringUtils::Format("%s.%s.idx", strFileName.c_str(), strSubLang.c_str());
+          std::string strSubNameIdx =
+              StringUtils::Format("{}.{}.idx", strFileName.c_str(), strSubLang.c_str());
           // Handle URL encoding:
           strDestFile = URIUtils::ChangeBasePath(strCurrentFilePath, strSubNameIdx, strDestPath);
           CFile::Copy(strUrl, strDestFile);

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -213,7 +213,7 @@ void CGUIDialogVideoBookmarks::UpdateItem(unsigned int chapterIdx)
 
   if (itemPos < m_vecItems->Size())
   {
-    std::string time = StringUtils::Format("chapter://%s/%i", m_filePath.c_str(), chapterIdx);
+    std::string time = StringUtils::Format("chapter://{}/{}", m_filePath.c_str(), chapterIdx);
     std::string cachefile = CTextureCache::GetInstance().GetCachedPath(CTextureCache::GetInstance().GetCacheFile(time) + ".jpg");
     if (XFILE::CFile::Exists(cachefile))
     {
@@ -247,7 +247,9 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   {
     std::string bookmarkTime;
     if (m_bookmarks[i].type == CBookmark::EPISODE)
-      bookmarkTime = StringUtils::Format("%s %li %s %li", g_localizeStrings.Get(20373).c_str(), m_bookmarks[i].seasonNumber, g_localizeStrings.Get(20359).c_str(), m_bookmarks[i].episodeNumber);
+      bookmarkTime = StringUtils::Format(
+          "{} {} {} {}", g_localizeStrings.Get(20373).c_str(), m_bookmarks[i].seasonNumber,
+          g_localizeStrings.Get(20359).c_str(), m_bookmarks[i].episodeNumber);
     else
       bookmarkTime = StringUtils::SecondsToTimeString((long)m_bookmarks[i].timeInSeconds, TIME_FORMAT_HH_MM_SS);
 
@@ -277,7 +279,7 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
     CFileItemPtr item(new CFileItem(chapterName));
     item->SetLabel2(time);
 
-    std::string chapterPath = StringUtils::Format("chapter://%s/%i", m_filePath.c_str(), i);
+    std::string chapterPath = StringUtils::Format("chapter://{}/{}", m_filePath.c_str(), i);
     std::string cachefile = CTextureCache::GetInstance().GetCachedPath(CTextureCache::GetInstance().GetCacheFile(chapterPath)+".jpg");
     if (XFILE::CFile::Exists(cachefile))
       item->SetArt("thumb", cachefile);
@@ -424,7 +426,8 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
     const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     auto crc = Crc32::ComputeFromLowerCase(g_application.CurrentFile());
-    bookmark.thumbNailImage = StringUtils::Format("%08x_%i.jpg", crc, (int)bookmark.timeInSeconds);
+    bookmark.thumbNailImage =
+        StringUtils::Format("{:08x}_{}.jpg", crc, (int)bookmark.timeInSeconds);
     bookmark.thumbNailImage = URIUtils::AddFileToFolder(profileManager->GetBookmarksThumbFolder(), bookmark.thumbNailImage);
 
     if (!CPicture::CreateThumbnailFromSurface(pixels, width, height, width * 4,
@@ -497,9 +500,9 @@ bool CGUIDialogVideoBookmarks::AddEpisodeBookmark()
     CContextButtons choices;
     for (unsigned int i=0; i < episodes.size(); ++i)
     {
-      std::string strButton = StringUtils::Format("%s %i, %s %i",
-                                                 g_localizeStrings.Get(20373).c_str(), episodes[i].m_iSeason,
-                                                 g_localizeStrings.Get(20359).c_str(), episodes[i].m_iEpisode);
+      std::string strButton = StringUtils::Format(
+          "{} {}, {} {}", g_localizeStrings.Get(20373).c_str(), episodes[i].m_iSeason,
+          g_localizeStrings.Get(20359).c_str(), episodes[i].m_iEpisode);
       choices.Add(i, strButton);
     }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -596,7 +596,7 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
   {
     std::string label = movies[i]->GetVideoInfoTag()->m_strTitle;
     if (movies[i]->GetVideoInfoTag()->HasYear())
-      label += StringUtils::Format(" (%i)", movies[i]->GetVideoInfoTag()->GetYear());
+      label += StringUtils::Format(" ({})", movies[i]->GetVideoInfoTag()->GetYear());
     movies[i]->SetLabel(label);
   }
   CGUIWindowVideoBase::AppendAndClearSearchItems(movies, "[" + g_localizeStrings.Get(20338) + "] ", items);
@@ -606,7 +606,7 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
   {
     std::string label = movies[i]->GetVideoInfoTag()->m_strShowTitle;
     if (movies[i]->GetVideoInfoTag()->HasYear())
-      label += StringUtils::Format(" (%i)", movies[i]->GetVideoInfoTag()->GetYear());
+      label += StringUtils::Format(" ({})", movies[i]->GetVideoInfoTag()->GetYear());
     movies[i]->SetLabel(label);
   }
   CGUIWindowVideoBase::AppendAndClearSearchItems(movies, "[" + g_localizeStrings.Get(20364) + "] ", items);
@@ -624,7 +624,7 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
   {
     std::string label = StringUtils::Join(movies[i]->GetVideoInfoTag()->m_artist, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator) + " - " + movies[i]->GetVideoInfoTag()->m_strTitle;
     if (movies[i]->GetVideoInfoTag()->HasYear())
-      label += StringUtils::Format(" (%i)", movies[i]->GetVideoInfoTag()->GetYear());
+      label += StringUtils::Format(" ({})", movies[i]->GetVideoInfoTag()->GetYear());
     movies[i]->SetLabel(label);
   }
   CGUIWindowVideoBase::AppendAndClearSearchItems(movies, "[" + g_localizeStrings.Get(20391) + "] ", items);
@@ -709,7 +709,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
     }
     else
     {
-      strPath = StringUtils::Format("videodb://tvshows/titles/%i/",
+      strPath = StringUtils::Format("videodb://tvshows/titles/{}/",
                                     m_movieItem->GetVideoInfoTag()->m_iDbId);
       Close();
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VIDEO_NAV,strPath);
@@ -719,7 +719,9 @@ void CGUIDialogVideoInfo::Play(bool resume)
 
   if (m_movieItem->GetVideoInfoTag()->m_type == MediaTypeVideoCollection)
   {
-    std::string strPath = StringUtils::Format("videodb://movies/sets/%i/?setid=%i",m_movieItem->GetVideoInfoTag()->m_iDbId,m_movieItem->GetVideoInfoTag()->m_iDbId);
+    std::string strPath = StringUtils::Format("videodb://movies/sets/{}/?setid={}",
+                                              m_movieItem->GetVideoInfoTag()->m_iDbId,
+                                              m_movieItem->GetVideoInfoTag()->m_iDbId);
     Close();
     CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VIDEO_NAV, strPath);
     return;
@@ -923,7 +925,7 @@ void CGUIDialogVideoInfo::OnGetArt()
 
     for (unsigned int i = 0; i < thumbs.size(); ++i)
     {
-      std::string strItemPath = StringUtils::Format("thumb://Remote%i", i);
+      std::string strItemPath = StringUtils::Format("thumb://Remote{}", i);
       CFileItemPtr item(new CFileItem(strItemPath, false));
       item->SetArt("thumb", thumbs[i]);
       item->SetArt("icon", "DefaultPicture.png");
@@ -1044,7 +1046,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
   {
     if (URIUtils::IsProtocol(m_movieItem->GetVideoInfoTag()->m_fanart.GetPreviewURL(i), "image"))
       continue;
-    std::string strItemPath = StringUtils::Format("fanart://Remote%i",i);
+    std::string strItemPath = StringUtils::Format("fanart://Remote{}", i);
     CFileItemPtr item(new CFileItem(strItemPath, false));
     std::string thumb = m_movieItem->GetVideoInfoTag()->m_fanart.GetPreviewURL(i);
     item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(thumb));
@@ -1155,7 +1157,7 @@ void CGUIDialogVideoInfo::OnSetUserrating() const
     dialog->SetHeading(CVariant{ 38023 });
     dialog->Add(g_localizeStrings.Get(38022));
     for (int i = 1; i <= 10; i++)
-      dialog->Add(StringUtils::Format("%s: %i", g_localizeStrings.Get(563).c_str(), i));
+      dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563).c_str(), i));
 
     dialog->SetSelected(m_movieItem->GetVideoInfoTag()->m_iUserRating);
 
@@ -1175,9 +1177,9 @@ void CGUIDialogVideoInfo::PlayTrailer()
   item.SetPath(m_movieItem->GetVideoInfoTag()->m_strTrailer);
   *item.GetVideoInfoTag() = *m_movieItem->GetVideoInfoTag();
   item.GetVideoInfoTag()->m_streamDetails.Reset();
-  item.GetVideoInfoTag()->m_strTitle = StringUtils::Format("%s (%s)",
-                                                           m_movieItem->GetVideoInfoTag()->m_strTitle.c_str(),
-                                                           g_localizeStrings.Get(20410).c_str());
+  item.GetVideoInfoTag()->m_strTitle =
+      StringUtils::Format("{} ({})", m_movieItem->GetVideoInfoTag()->m_strTitle.c_str(),
+                          g_localizeStrings.Get(20410).c_str());
   item.SetArt(m_movieItem->GetArt());
   item.GetVideoInfoTag()->m_iDbId = -1;
   item.GetVideoInfoTag()->m_iFileId = -1;
@@ -1691,7 +1693,8 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
   if (!videodb.Open())
     return false;
 
-  std::string baseDir = StringUtils::Format("videodb://movies/sets/%d", setItem->GetVideoInfoTag()->m_iDbId);
+  std::string baseDir =
+      StringUtils::Format("videodb://movies/sets/{}", setItem->GetVideoInfoTag()->m_iDbId);
 
   if (!CDirectory::GetDirectory(baseDir, originalMovies, "", DIR_FLAG_DEFAULTS) ||
       originalMovies.Size() <= 0) // keep a copy of the original members of the set
@@ -2082,7 +2085,8 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
     else if (type == MediaTypeVideoCollection)
     {
       CFileItemList items;
-      std::string baseDir = StringUtils::Format("videodb://movies/sets/%d", item->GetVideoInfoTag()->m_iDbId);
+      std::string baseDir =
+          StringUtils::Format("videodb://movies/sets/{}", item->GetVideoInfoTag()->m_iDbId);
       if (videodb.GetMoviesNav(baseDir, items))
       {
         for (int i=0; i < items.Size(); i++)

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -489,7 +489,7 @@ void CGUIDialogVideoSettings::VideoStreamsOptionFiller(
     if (!info.name.empty())
     {
       if (!strLanguage.empty())
-        strItem = StringUtils::Format("%s - %s", strLanguage.c_str(), info.name.c_str());
+        strItem = StringUtils::Format("{} - {}", strLanguage.c_str(), info.name.c_str());
       else
         strItem = info.name;
     }
@@ -499,17 +499,18 @@ void CGUIDialogVideoSettings::VideoStreamsOptionFiller(
     }
 
     if (info.codecName.empty())
-      strItem += StringUtils::Format(" (%ix%i", info.width, info.height);
+      strItem += StringUtils::Format(" ({}x{}", info.width, info.height);
     else
-      strItem += StringUtils::Format(" (%s, %ix%i", info.codecName.c_str(), info.width, info.height);
+      strItem +=
+          StringUtils::Format(" ({}, {}x{}", info.codecName.c_str(), info.width, info.height);
 
     if (info.bitrate)
-      strItem += StringUtils::Format(", %i bps)", info.bitrate);
+      strItem += StringUtils::Format(", {} bps)", info.bitrate);
     else
       strItem += ")";
 
     strItem += FormatFlags(info.flags);
-    strItem += StringUtils::Format(" (%i/%i)", i + 1, videoStreamCount);
+    strItem += StringUtils::Format(" ({}/{})", i + 1, videoStreamCount);
     list.emplace_back(strItem, i);
   }
 
@@ -546,7 +547,7 @@ std::string CGUIDialogVideoSettings::FormatFlags(StreamFlags flags)
   std::string formated = StringUtils::Join(localizedFlags, ", ");
 
   if (!formated.empty())
-    formated = StringUtils::Format(" [%s]", formated);
+    formated = StringUtils::Format(" [{}]", formated);
 
   return formated;
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -321,7 +321,7 @@ void CGUIWindowFullScreen::FrameMove()
       const auto& vs = g_application.GetAppPlayer().GetVideoSettings();
       int sId = CViewModeSettings::GetViewModeStringIndex(vs.m_ViewMode);
       const std::string& strMode = g_localizeStrings.Get(sId);
-      std::string strInfo = StringUtils::Format("%s : %s", strTitle.c_str(), strMode.c_str());
+      std::string strInfo = StringUtils::Format("{} : {}", strTitle.c_str(), strMode.c_str());
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW1);
       msg.SetLabel(strInfo);
       OnMessage(msg);
@@ -351,17 +351,12 @@ void CGUIWindowFullScreen::FrameMove()
     {
       std::string strStatus;
       if (CServiceBroker::GetWinSystem()->IsFullScreen())
-        strStatus = StringUtils::Format("%s %ix%i@%.2fHz - %s",
-                                        g_localizeStrings.Get(13287).c_str(),
-                                        res.iScreenWidth,
-                                        res.iScreenHeight,
-                                        res.fRefreshRate,
-                                        g_localizeStrings.Get(244).c_str());
+        strStatus = StringUtils::Format(
+            "{} {}x{}@{:.2f}Hz - {}", g_localizeStrings.Get(13287).c_str(), res.iScreenWidth,
+            res.iScreenHeight, res.fRefreshRate, g_localizeStrings.Get(244).c_str());
       else
-        strStatus = StringUtils::Format("%s %ix%i - %s",
-                                        g_localizeStrings.Get(13287).c_str(),
-                                        res.iScreenWidth,
-                                        res.iScreenHeight,
+        strStatus = StringUtils::Format("{} {}x{} - {}", g_localizeStrings.Get(13287).c_str(),
+                                        res.iScreenWidth, res.iScreenHeight,
                                         g_localizeStrings.Get(242).c_str());
 
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW3);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -664,7 +664,7 @@ void CGUIWindowVideoNav::UpdateButtons()
       StringUtils::StartsWith(m_vecItems->Get(m_vecItems->Size()-1)->GetPath(), "/-1/"))
       iItems--;
   }
-  std::string items = StringUtils::Format("%i %s", iItems, g_localizeStrings.Get(127).c_str());
+  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127).c_str());
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   // set the filter label
@@ -1047,7 +1047,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_GO_TO_ARTIST:
     {
       std::string strPath;
-      strPath = StringUtils::Format("musicdb://artists/%i/",
+      strPath = StringUtils::Format("musicdb://artists/{}/",
                                     item->GetProperty("artist_musicid").asInteger());
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_MUSIC_NAV, strPath);
       return true;
@@ -1055,7 +1055,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_GO_TO_ALBUM:
     {
       std::string strPath;
-      strPath = StringUtils::Format("musicdb://albums/%i/",
+      strPath = StringUtils::Format("musicdb://albums/{}/",
                                     item->GetProperty("album_musicid").asInteger());
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_MUSIC_NAV, strPath);
       return true;

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -316,7 +316,8 @@ void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
   {
     IGUIContainer *view = static_cast<IGUIContainer*>(m_visibleViews[i]);
-    std::string label = StringUtils::Format(g_localizeStrings.Get(534).c_str(), view->GetLabel().c_str()); // View: %s
+    std::string label = StringUtils::Format(g_localizeStrings.Get(534).c_str(),
+                                            view->GetLabel().c_str()); // View: {}
     labels.emplace_back(std::move(label), i);
   }
   CGUIMessage msg(GUI_MSG_SET_LABELS, m_parentWindow, m_viewAsControl, m_currentView);
@@ -324,7 +325,8 @@ void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg, m_parentWindow);
 
   // otherwise it's just a normal button
-  std::string label = StringUtils::Format(g_localizeStrings.Get(534).c_str(), viewLabel.c_str()); // View: %s
+  std::string label =
+      StringUtils::Format(g_localizeStrings.Get(534).c_str(), viewLabel.c_str()); // View: {}
   CGUIMessage msgSet(GUI_MSG_LABEL_SET, m_parentWindow, m_viewAsControl);
   msgSet.SetLabel(label);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msgSet, m_parentWindow);

--- a/xbmc/weather/GUIWindowWeather.cpp
+++ b/xbmc/weather/GUIWindowWeather.cpp
@@ -155,7 +155,7 @@ void CGUIWindowWeather::UpdateLocations()
     }
     else
     {
-      strLabel = StringUtils::Format("AreaCode %i", i);
+      strLabel = StringUtils::Format("AreaCode {}", i);
       labels.emplace_back(strLabel, i);
     }
     // in case it's a button, set the label
@@ -256,7 +256,7 @@ void CGUIWindowWeather::SetProperties()
   std::string day;
   for (int i = 0; i < NUM_DAYS; i++)
   {
-    day = StringUtils::Format("Day%i.", i);
+    day = StringUtils::Format("Day{}.", i);
     SetProperty(day + "Title", CServiceBroker::GetWeatherManager().GetForecast(i).m_day);
     SetProperty(day + "HighTemp", CServiceBroker::GetWeatherManager().GetForecast(i).m_high);
     SetProperty(day + "LowTemp", CServiceBroker::GetWeatherManager().GetForecast(i).m_low);
@@ -288,7 +288,7 @@ void CGUIWindowWeather::ClearProperties()
   std::string day;
   for (int i = 0; i < NUM_DAYS; i++)
   {
-    day = StringUtils::Format("Day%i.", i);
+    day = StringUtils::Format("Day{}.", i);
     SetProperty(day + "Title", "");
     SetProperty(day + "HighTemp", "");
     SetProperty(day + "LowTemp", "");

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -60,7 +60,7 @@ bool CWeatherJob::DoWork()
   std::vector<std::string> argv;
   argv.push_back(addon->LibPath());
 
-  std::string strSetting = StringUtils::Format("%i", m_location);
+  std::string strSetting = StringUtils::Format("{}", m_location);
   argv.push_back(strSetting);
 
   // Download our weather
@@ -122,7 +122,7 @@ void CWeatherJob::LocalizeOverview(std::string &str)
 void CWeatherJob::FormatTemperature(std::string &text, double temp)
 {
   CTemperature temperature = CTemperature::CreateFromCelsius(temp);
-  text = StringUtils::Format("%.0f", temperature.To(g_langInfo.GetTemperatureUnit()));
+  text = StringUtils::Format("{:.0f}", temperature.To(g_langInfo.GetTemperatureUnit()));
 }
 
 void CWeatherJob::LoadLocalizedToken()
@@ -206,29 +206,31 @@ void CWeatherJob::SetFromProperties()
       m_info.currentWind = StringUtils::Format(g_localizeStrings.Get(434).c_str(),
                                                direction.c_str(), (int)speed.To(g_langInfo.GetSpeedUnit()), g_langInfo.GetSpeedUnitString().c_str());
     }
-    std::string windspeed = StringUtils::Format("%i %s", (int)speed.To(g_langInfo.GetSpeedUnit()), g_langInfo.GetSpeedUnitString().c_str());
+    std::string windspeed = StringUtils::Format("{} {}", (int)speed.To(g_langInfo.GetSpeedUnit()),
+                                                g_langInfo.GetSpeedUnitString().c_str());
     window->SetProperty("Current.WindSpeed",windspeed);
     FormatTemperature(m_info.currentDewPoint,
                       strtod(window->GetProperty("Current.DewPoint").asString().c_str(), nullptr));
     if (window->GetProperty("Current.Humidity").asString().empty())
       m_info.currentHumidity.clear();
     else
-      m_info.currentHumidity = StringUtils::Format("%s%%", window->GetProperty("Current.Humidity").asString().c_str());
+      m_info.currentHumidity =
+          StringUtils::Format("{}%", window->GetProperty("Current.Humidity").asString().c_str());
     m_info.location = window->GetProperty("Current.Location").asString();
     for (int i=0;i<NUM_DAYS;++i)
     {
-      std::string strDay = StringUtils::Format("Day%i.Title",i);
+      std::string strDay = StringUtils::Format("Day{}.Title", i);
       m_info.forecast[i].m_day = window->GetProperty(strDay).asString();
       LocalizeOverviewToken(m_info.forecast[i].m_day);
-      strDay = StringUtils::Format("Day%i.HighTemp",i);
+      strDay = StringUtils::Format("Day{}.HighTemp", i);
       FormatTemperature(m_info.forecast[i].m_high,
                         strtod(window->GetProperty(strDay).asString().c_str(), nullptr));
-      strDay = StringUtils::Format("Day%i.LowTemp",i);
+      strDay = StringUtils::Format("Day{}.LowTemp", i);
       FormatTemperature(m_info.forecast[i].m_low,
                         strtod(window->GetProperty(strDay).asString().c_str(), nullptr));
-      strDay = StringUtils::Format("Day%i.OutlookIcon",i);
+      strDay = StringUtils::Format("Day{}.OutlookIcon", i);
       m_info.forecast[i].m_icon = ConstructPath(window->GetProperty(strDay).asString());
-      strDay = StringUtils::Format("Day%i.Outlook",i);
+      strDay = StringUtils::Format("Day{}.Outlook", i);
       m_info.forecast[i].m_overview = window->GetProperty(strDay).asString();
       LocalizeOverview(m_info.forecast[i].m_overview);
     }

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -94,7 +94,7 @@ std::string CWeatherManager::GetLocation(int iLocation)
   CGUIWindow* window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_WEATHER);
   if (window)
   {
-    std::string setting = StringUtils::Format("Location%i", iLocation);
+    std::string setting = StringUtils::Format("Location{}", iLocation);
     return window->GetProperty(setting).asString();
   }
   return "";

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -60,9 +60,9 @@ void CWinSystemBase::UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std:
   newRes.iHeight = height;
   newRes.iScreenWidth = width;
   newRes.iScreenHeight = height;
-  newRes.strMode = StringUtils::Format("%s: %dx%d", output.c_str(), width, height);
+  newRes.strMode = StringUtils::Format("{}: {}x{}", output.c_str(), width, height);
   if (refreshRate > 1)
-    newRes.strMode += StringUtils::Format(" @ %.2fHz", refreshRate);
+    newRes.strMode += StringUtils::Format(" @ {:.2f}Hz", refreshRate);
   if (dwFlags & D3DPRESENTFLAG_INTERLACED)
     newRes.strMode += "i";
   if (dwFlags & D3DPRESENTFLAG_MODE3DTB)

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -409,7 +409,8 @@ void CWinSystemX11::UpdateResolutions()
 
       CLog::Log(LOGINFO, "Pixel Ratio: %f", res.fPixelRatio);
 
-      res.strMode      = StringUtils::Format("%s: %s @ %.2fHz", out->name.c_str(), mode.name.c_str(), mode.hz);
+      res.strMode =
+          StringUtils::Format("{}: {} @ {:.2f}Hz", out->name.c_str(), mode.name.c_str(), mode.hz);
       res.strOutput    = out->name;
       res.strId        = mode.id;
       res.iSubtitles   = (int)(0.965*mode.h);

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -66,7 +66,7 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
   {
     cmd  = getenv("KODI_BIN_HOME");
     cmd += "/" + appname + "-xrandr";
-    cmd = StringUtils::Format("%s -q --screen %d", cmd.c_str(), screennum);
+    cmd = StringUtils::Format("{} -q --screen {}", cmd.c_str(), screennum);
   }
 
   FILE* file = popen(cmd.c_str(),"r");
@@ -156,7 +156,8 @@ bool CXRandR::TurnOffOutput(const std::string& name)
   {
     cmd  = getenv("KODI_BIN_HOME");
     cmd += "/" + appname + "-xrandr";
-    cmd = StringUtils::Format("%s --screen %d --output %s --off", cmd.c_str(), output->screen, name.c_str());
+    cmd = StringUtils::Format("{} --screen {} --output {} --off", cmd.c_str(), output->screen,
+                              name.c_str());
   }
 
   int status = system(cmd.c_str());

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -83,7 +83,7 @@ static void fetchDisplayModes()
         s_hasModeApi = true;
 
         CLog::Log(LOGDEBUG, "CAndroidUtils: current mode: %d: %dx%d@%f", m.getModeId(), m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
-        s_res_cur_displayMode.strId = StringUtils::Format("%d", m.getModeId());
+        s_res_cur_displayMode.strId = StringUtils::Format("{}", m.getModeId());
         s_res_cur_displayMode.iWidth = s_res_cur_displayMode.iScreenWidth = m.getPhysicalWidth();
         s_res_cur_displayMode.iHeight = s_res_cur_displayMode.iScreenHeight = m.getPhysicalHeight();
         s_res_cur_displayMode.fRefreshRate = m.getRefreshRate();
@@ -91,8 +91,10 @@ static void fetchDisplayModes()
         s_res_cur_displayMode.bFullScreen   = true;
         s_res_cur_displayMode.iSubtitles    = (int)(0.965 * s_res_cur_displayMode.iHeight);
         s_res_cur_displayMode.fPixelRatio   = 1.0f;
-        s_res_cur_displayMode.strMode       = StringUtils::Format("%dx%d @ %.6f%s - Full Screen", s_res_cur_displayMode.iScreenWidth, s_res_cur_displayMode.iScreenHeight, s_res_cur_displayMode.fRefreshRate,
-                                                                  s_res_cur_displayMode.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+        s_res_cur_displayMode.strMode = StringUtils::Format(
+            "{}x{} @ {:.6f}{} - Full Screen", s_res_cur_displayMode.iScreenWidth,
+            s_res_cur_displayMode.iScreenHeight, s_res_cur_displayMode.fRefreshRate,
+            s_res_cur_displayMode.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
 
         std::vector<CJNIDisplayMode> modes = display.getSupportedModes();
         for (auto m : modes)
@@ -100,7 +102,7 @@ static void fetchDisplayModes()
           CLog::Log(LOGDEBUG, "CAndroidUtils: available mode: %d: %dx%d@%f", m.getModeId(), m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
 
           RESOLUTION_INFO res;
-          res.strId = StringUtils::Format("%d", m.getModeId());
+          res.strId = StringUtils::Format("{}", m.getModeId());
           res.iWidth = res.iScreenWidth = m.getPhysicalWidth();
           res.iHeight = res.iScreenHeight = m.getPhysicalHeight();
           res.fRefreshRate = m.getRefreshRate();
@@ -108,8 +110,9 @@ static void fetchDisplayModes()
           res.bFullScreen   = true;
           res.iSubtitles    = (int)(0.965 * res.iHeight);
           res.fPixelRatio   = 1.0f;
-          res.strMode       = StringUtils::Format("%dx%d @ %.6f%s - Full Screen", res.iScreenWidth, res.iScreenHeight, res.fRefreshRate,
-                                                  res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+          res.strMode = StringUtils::Format("{}x{} @ {:.6f}{} - Full Screen", res.iScreenWidth,
+                                            res.iScreenHeight, res.fRefreshRate,
+                                            res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
 
           s_res_displayModes.push_back(res);
         }
@@ -223,8 +226,9 @@ bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO* res) const
     res->iScreenHeight = res->iHeight;
   }
   res->iSubtitles    = (int)(0.965 * res->iHeight);
-  res->strMode       = StringUtils::Format("%dx%d @ %.6f%s - Full Screen", res->iScreenWidth, res->iScreenHeight, res->fRefreshRate,
-                                           res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+  res->strMode =
+      StringUtils::Format("{}x{} @ {:.6f}{} - Full Screen", res->iScreenWidth, res->iScreenHeight,
+                          res->fRefreshRate, res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
   CLog::Log(LOGINFO, "CAndroidUtils: Current resolution: %dx%d %s", res->iWidth, res->iHeight,
             res->strMode.c_str());
   return true;
@@ -292,8 +296,9 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
           if (refreshRates[i] < 20.0 || refreshRates[i] > 70.0)
             continue;
           cur_res.fRefreshRate = refreshRates[i];
-          cur_res.strMode      = StringUtils::Format("%dx%d @ %.6f%s - Full Screen", cur_res.iScreenWidth, cur_res.iScreenHeight, cur_res.fRefreshRate,
-                                                 cur_res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+          cur_res.strMode = StringUtils::Format(
+              "{}x{} @ {:.6f}{} - Full Screen", cur_res.iScreenWidth, cur_res.iScreenHeight,
+              cur_res.fRefreshRate, cur_res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
           resolutions.push_back(cur_res);
         }
       }

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -645,8 +645,9 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
   else
     res.dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
 
-  res.strMode = StringUtils::Format("%dx%d%s @ %.6f Hz", res.iScreenWidth, res.iScreenHeight,
-                                    res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "", res.fRefreshRate);
+  res.strMode =
+      StringUtils::Format("{}x{}{} @ {:.6f} Hz", res.iScreenWidth, res.iScreenHeight,
+                          res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "", res.fRefreshRate);
   return res;
 }
 

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -405,8 +405,8 @@ void CWinSystemWin10::UpdateResolutions()
         res.iScreenWidth = res.iWidth;
         res.iScreenHeight = res.iHeight;
         res.iSubtitles = (int)(0.965 * res.iHeight);
-        res.strMode = StringUtils::Format("Default: %dx%d @ %.2fHz",
-                                          res.iWidth, res.iHeight, res.fRefreshRate);
+        res.strMode = StringUtils::Format("Default: {}x{} @ {:.2f}Hz", res.iWidth, res.iHeight,
+                                          res.fRefreshRate);
         GetGfxContext().ResetOverscan(res);
 
         if (AddResolution(res))

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -761,7 +761,8 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
               // optical medium
               if (lpdbv -> dbcv_flags & DBTF_MEDIA)
               {
-                std::string strdrive = StringUtils::Format("%c:", CWIN32Util::FirstDriveFromMask(lpdbv ->dbcv_unitmask));
+                std::string strdrive = StringUtils::Format(
+                    "{}:", CWIN32Util::FirstDriveFromMask(lpdbv->dbcv_unitmask));
                 if(wParam == DBT_DEVICEARRIVAL)
                 {
                   CLog::LogF(LOGDEBUG, "Drive %s Media has arrived.", strdrive.c_str());

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -968,7 +968,7 @@ void CWinSystemWin32::UpdateResolutions()
     res.iScreenWidth = res.iWidth;
     res.iScreenHeight = res.iHeight;
     res.iSubtitles = (int)(0.965 * res.iHeight);
-    res.strMode = StringUtils::Format("%s: %dx%d @ %.2fHz", monitorName.c_str(), res.iWidth,
+    res.strMode = StringUtils::Format("{}: {}x{} @ {:.2f}Hz", monitorName.c_str(), res.iWidth,
                                       res.iHeight, res.fRefreshRate);
     GetGfxContext().ResetOverscan(res);
     res.strOutput = strOutput;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -215,7 +215,7 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
 
   if (action.GetID() >= ACTION_FILTER_SMS2 && action.GetID() <= ACTION_FILTER_SMS9)
   {
-    std::string filter = StringUtils::Format("%i", action.GetID() - ACTION_FILTER_SMS2 + 2);
+    std::string filter = StringUtils::Format("{}", action.GetID() - ACTION_FILTER_SMS2 + 2);
     CGUIMessage message(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_FILTER_ITEMS, 1); // 1 for append
     message.SetStringParam(filter);
     OnMessage(message);
@@ -621,7 +621,8 @@ void CGUIMediaWindow::UpdateButtons()
     SET_CONTROL_LABEL(CONTROL_BTNSORTBY, sortLabel);
   }
 
-  std::string items = StringUtils::Format("%i %s", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127).c_str());
+  std::string items = StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
+                                          g_localizeStrings.Get(127).c_str());
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   SET_CONTROL_LABEL2(CONTROL_BTN_FILTER, GetProperty("filter").asString());
@@ -1386,9 +1387,7 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, std::str
   {
     // Could be a cue item, all items of a cue share the same filename
     // so add the offsets to build the history string
-    strHistoryString = StringUtils::Format("%" PRIi64 "%" PRIi64,
-                                           pItem->m_lStartOffset,
-                                           pItem->m_lEndOffset);
+    strHistoryString = StringUtils::Format("{}{}", pItem->m_lStartOffset, pItem->m_lEndOffset);
     strHistoryString += pItem->GetPath();
   }
   else
@@ -1754,9 +1753,11 @@ bool CGUIMediaWindow::OnPopupMenu(int itemIdx)
   //Add items from plugin
   {
     int i = 0;
-    while (item->HasProperty(StringUtils::Format("contextmenulabel(%i)", i)))
+    while (item->HasProperty(StringUtils::Format("contextmenulabel({})", i)))
     {
-      buttons.emplace_back(~buttons.size(), item->GetProperty(StringUtils::Format("contextmenulabel(%i)", i)).asString());
+      buttons.emplace_back(
+          ~buttons.size(),
+          item->GetProperty(StringUtils::Format("contextmenulabel({})", i)).asString());
       ++i;
     }
   }
@@ -1790,8 +1791,10 @@ bool CGUIMediaWindow::OnPopupMenu(int itemIdx)
   {
     bool saveVal = m_backgroundLoad;
     m_backgroundLoad = false;
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
-        item->GetProperty(StringUtils::Format("contextmenuaction(%i)", idx - pluginMenuRange.first)).asString());
+    CApplicationMessenger::GetInstance().SendMsg(
+        TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+        item->GetProperty(StringUtils::Format("contextmenuaction({})", idx - pluginMenuRange.first))
+            .asString());
     m_backgroundLoad = saveVal;
     return true;
   }

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -104,20 +104,30 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     std::string lcAppName = CCompileInfo::GetAppName();
     StringUtils::ToLower(lcAppName);
 #if !defined(TARGET_POSIX)
-    info = StringUtils::Format("LOG: %s%s.log\nMEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\nCPU: %s%s",
-                               CSpecialProtocol::TranslatePath("special://logpath").c_str(), lcAppName.c_str(),
-                               stat.availPhys / 1024, stat.totalPhys / 1024, CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetSystemInfoProvider().GetFPS(),
+    info = StringUtils::Format("LOG: {}{}.log\nMEM: {}/{} KB - FPS: {:2.1f} fps\nCPU: {}{}",
+                               CSpecialProtocol::TranslatePath("special://logpath").c_str(),
+                               lcAppName.c_str(), stat.availPhys / 1024, stat.totalPhys / 1024,
+                               CServiceBroker::GetGUI()
+                                   ->GetInfoManager()
+                                   .GetInfoProviders()
+                                   .GetSystemInfoProvider()
+                                   .GetFPS(),
                                strCores.c_str(), profiling.c_str());
 #else
     double dCPU = m_resourceCounter.GetCPUUsage();
     std::string ucAppName = lcAppName;
     StringUtils::ToUpper(ucAppName);
-    info = StringUtils::Format("LOG: %s%s.log\n"
-                                "MEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\n"
-                                "CPU: %s (CPU-%s %4.2f%%%s)",
-                                CSpecialProtocol::TranslatePath("special://logpath").c_str(), lcAppName.c_str(),
-                                stat.availPhys / 1024, stat.totalPhys / 1024, CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetSystemInfoProvider().GetFPS(),
-                                strCores.c_str(), ucAppName.c_str(), dCPU, profiling.c_str());
+    info = StringUtils::Format("LOG: {}{}.log\n"
+                               "MEM: %" PRIu64 "/%" PRIu64 " KB - FPS: %2.1f fps\n"
+                               "CPU: %s (CPU-%s %4.2f%%%s)",
+                               CSpecialProtocol::TranslatePath("special://logpath").c_str(),
+                               lcAppName.c_str(), stat.availPhys / 1024, stat.totalPhys / 1024,
+                               CServiceBroker::GetGUI()
+                                   ->GetInfoManager()
+                                   .GetInfoProviders()
+                                   .GetSystemInfoProvider()
+                                   .GetFPS(),
+                               strCores.c_str(), ucAppName.c_str(), dCPU, profiling.c_str());
 #endif
   }
 
@@ -145,12 +155,15 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
       point.y *= CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleY();
       CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(), false);
     }
-    info += StringUtils::Format("Mouse: (%d,%d)  ", static_cast<int>(point.x), static_cast<int>(point.y));
+    info += StringUtils::Format("Mouse: ({},{})  ", static_cast<int>(point.x),
+                                static_cast<int>(point.y));
     if (window)
     {
       CGUIControl *control = window->GetFocusedControl();
       if (control)
-        info += StringUtils::Format("Focused: %i (%s)", control->GetID(), CGUIControlFactory::TranslateControlType(control->GetControlType()).c_str());
+        info += StringUtils::Format(
+            "Focused: {} ({})", control->GetID(),
+            CGUIControlFactory::TranslateControlType(control->GetControlType()).c_str());
     }
   }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -432,9 +432,11 @@ void CGUIWindowFileManager::UpdateItemCounts()
     }
     std::string items;
     if (selectedCount > 0)
-      items = StringUtils::Format("%i/%i %s (%s)", selectedCount, totalCount, g_localizeStrings.Get(127).c_str(), StringUtils::SizeToString(selectedSize).c_str());
+      items = StringUtils::Format("{}/{} {} ({})", selectedCount, totalCount,
+                                  g_localizeStrings.Get(127).c_str(),
+                                  StringUtils::SizeToString(selectedSize).c_str());
     else
-      items = StringUtils::Format("%i %s", totalCount, g_localizeStrings.Get(127).c_str());
+      items = StringUtils::Format("{} {}", totalCount, g_localizeStrings.Get(127).c_str());
     SET_CONTROL_LABEL(CONTROL_NUMFILES_LEFT + i, items);
   }
 }

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -138,7 +138,7 @@ void CGUIWindowSystemInfo::FrameMove()
     {
       static std::string vendor = renderingSystem->GetRenderVendor();
       if (!vendor.empty())
-        SET_CONTROL_LABEL(i++, StringUtils::Format("%s %s", g_localizeStrings.Get(22007), vendor));
+        SET_CONTROL_LABEL(i++, StringUtils::Format("{} {}", g_localizeStrings.Get(22007), vendor));
 
 #if defined(HAS_DX)
       int renderVersionLabel = 22024;
@@ -148,7 +148,7 @@ void CGUIWindowSystemInfo::FrameMove()
       static std::string version = renderingSystem->GetRenderVersionString();
       if (!version.empty())
         SET_CONTROL_LABEL(
-            i++, StringUtils::Format("%s %s", g_localizeStrings.Get(renderVersionLabel), version));
+            i++, StringUtils::Format("{} {}", g_localizeStrings.Get(renderVersionLabel), version));
     }
 
     auto windowSystem = CServiceBroker::GetWinSystem();
@@ -157,7 +157,7 @@ void CGUIWindowSystemInfo::FrameMove()
       static std::string platform = windowSystem->GetName();
       if (platform != "platform default")
         SET_CONTROL_LABEL(i++,
-                          StringUtils::Format("%s %s", g_localizeStrings.Get(39153), platform));
+                          StringUtils::Format("{} {}", g_localizeStrings.Get(39153), platform));
     }
 
     SetControlLabel(i++, "%s %s", 22010, SYSTEM_GPU_TEMPERATURE);


### PR DESCRIPTION
This is part of a bigger change to update all format strings (including logging) to the new format.

I believe it was decided a while ago to just update the strings as we go but there is so many that will never happen organically.

The reason for doing this is to eventually remove the legacy `fmt::printf` usage. The reason for that is so that we can use the specialisation formatters to help out with `std::chrono` and `std::date` (eventually)

This will also allow use to clean up some `StringUtils` methods and `CLog` methods in the future.

This PR is (mostly) scripted. I wrote the regex to find and replace all the `StringUtils::Format` lines, I will likely use a similar thing for the Logging eventually. That is also why there is 245 commits (for 245 changed files). I can squash this into one commit if desired.

I did the best with the mapping as it's not exactly 1:1. fmt will complain if you use something like `{:2.2}` for an int (as there is no precision there and it needs to be updated to `{:02}` AFAIK).

The mapping is as follows. Please have a look through the changes and if you see something wonky I can adjust the mapping. I have also left our dropping the `c_str()` conversions as that can be done in a later PR. The changes are trivial after updating the mapping.

I only had to manually adjust a couple small spots (`strftime`) and cases where multi line formatting occured.

each line matches at least 1 item.

```
sed -i "${FILE}" -E \
-e '/StringUtils::Format/s/%s/{}/g' `: # s (don't copy s)` \
-e '/StringUtils::Format/s/%ls/{}/g' `: # s (don't copy s)` \
\
-e '/StringUtils::Format/s/%c/{}/g' `: # c (don't copy c)` \
\
-e '/StringUtils::Format/s/0x%([0-9]+)x/{:#\1x}/g' `: # x (copy x/X)` \
-e '/StringUtils::Format/s/0x%([0-9]+)X/{:#\1X}/g' \
-e '/StringUtils::Format/s/%([0-9]+)llX/{:\1X}/g' \
-e '/StringUtils::Format/s/%([0-9]+)lx/{:\1x}/g' \
-e '/StringUtils::Format/s/%([0-9]+)lX/{:\1X}/g' \
-e '/StringUtils::Format/s/%([0-9]+.)([0-9]+)x/{:0\2x}/g' \
-e '/StringUtils::Format/s/%([0-9]+)x/{:\1x}/g' \
-e '/StringUtils::Format/s/%([0-9]+)X/{:\1X}/g' \
-e '/StringUtils::Format/s/%lx/{:x}/g' \
-e '/StringUtils::Format/s/%x/{:x}/g' \
-e '/StringUtils::Format/s/%X/{:X}/g' \
\
-e '/StringUtils::Format/s/%(.[0-9]+)g/{:\1}/g' `: # g (don't copy g)`\
\
-e '/StringUtils::Format/s/0x%" PRIx64,/{}",/g' `: # special int (remove)` \
-e '/StringUtils::Format/s/%([0-9]+)" PR[a-zA-Z]+[0-9]+ "/{:\1}/g' \
-e '/StringUtils::Format/s/%" PR[a-zA-Z]+[0-9]+ "/{}/g' \
-e '/StringUtils::Format/s/%" PR[a-zA-Z]+[0-9]+,/{}",/g' \
-e '/StringUtils::Format/s/%" PR[a-zA-Z]+[0-9]+"/{}/g' \
\
-e '/StringUtils::Format/s/%([ 0-9]+.[0-9]+f)/{:\1}/g' `: # float (copy f)` \
-e '/StringUtils::Format/s/%(.[0-9]+f)/{:\1}/g' \
-e '/StringUtils::Format/s/%f/{:f}/g' \
-e '/StringUtils::Format/s/%(.[0-9]+)lf/{:\1f}/g' \
-e '/StringUtils::Format/s/%lf/{:f}/g' \
\
-e '/StringUtils::Format/s/%(.[0-9]+)ll/{:\1}/g' `: # long (remove l)` \
-e '/StringUtils::Format/s/%ll/{}/g' \
-e '/StringUtils::Format/s/%li/{}/g' \
-e '/StringUtils::Format/s/%ld/{}/g' \
-e '/StringUtils::Format/s/%lu/{}/g' \
\
-e '/StringUtils::Format/s/%([0-9]+.)([0-9]+)i/{:0\2}/g' `: # int (remove i)` \
-e '/StringUtils::Format/s/%(.[0-9]+)i/{:\1}/g' \
-e '/StringUtils::Format/s/%([0-9]+)i/{:\1}/g' \
-e '/StringUtils::Format/s/%i/{}/g' \
\
-e '/StringUtils::Format/s/%(.[0-9]+)d/{:\1}/g' `: # int (remove d)` \
-e '/StringUtils::Format/s/%([0-9]+)d/{:\1}/g' \
-e '/StringUtils::Format/s/%d/{}/g' \
\
-e '/StringUtils::Format/s/%(.[0-9]+)u/{:\1}/g' `: # int (remove u)` \
-e '/StringUtils::Format/s/%([0-9]+)u/{:\1}/g' \
-e '/StringUtils::Format/s/%u/{}/g' \
\
-e '/StringUtils::Format/s/%zu/{}/g' `: # int (remove z)` \
\
-e '/StringUtils::Format/s/%hu/{}/g' `: # int (remove h)` \
\
-e '/StringUtils::Format/s/%pX(.*)static_cast<const void\*>/{}\1fmt::ptr/g' `: # p (don't copy p and use fmt:ptr)` \
-e '/StringUtils::Format/s/%p(.*)static_cast<void\*>/{}\1fmt::ptr/g' \
\
-e '/StringUtils::Format/s/%%/%/g' `: # escaped percent`
```