### PR TITLE
[cleanup] fix a bunch of double-promotion warnings

### DIFF
--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -155,7 +155,7 @@ if(PLATFORM_DEFINES)
 endif()
 
 if(NOT MSVC)
-  add_options(ALL_LANGUAGES ALL_BUILDS "-Wall")
+  add_options(ALL_LANGUAGES ALL_BUILDS "-Wall" "-Wdouble-promotion")
   add_options(ALL_LANGUAGES DEBUG "-g" "-D_DEBUG")
 endif()
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2256,8 +2256,8 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     float frameTime = m_frameTime.GetElapsedSeconds();
     m_frameTime.StartZero();
     // never set a frametime less than 2 fps to avoid problems when debugging and on breaks
-    if( frameTime > 0.5 )
-      frameTime = 0.5;
+    if (frameTime > 0.5f)
+      frameTime = 0.5f;
 
     if (processGUI && m_renderGUI)
     {
@@ -2785,7 +2785,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       }
       else if (item.m_lStartOffset == STARTOFFSET_RESUME)
       {
-        options.starttime = 0.0f;
+        options.starttime = 0.0;
         if (item.IsResumePointSet())
         {
           options.starttime = item.GetCurrentResumeTime();
@@ -2807,7 +2807,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
           }
         }
 
-        if (options.starttime == 0.0f && item.HasVideoInfoTag())
+        if (options.starttime == 0.0 && item.HasVideoInfoTag())
         {
           // No resume point is set, but check if this item is part of a multi-episode file
           const CVideoInfoTag *tag = item.GetVideoInfoTag();
@@ -2839,7 +2839,8 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   }
 
   // a disc image might be Blu-Ray disc
-  if (!(options.startpercent > 0.0f || options.starttime > 0.0f) && (item.IsBDFile() || item.IsDiscImage()))
+  if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
+      (item.IsBDFile() || item.IsDiscImage()))
   {
     //check if we must show the simplified bd menu
     if (!CGUIDialogSimpleMenu::ShowPlaySelection(item))
@@ -3042,7 +3043,7 @@ void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &boo
   float percent = 0.0f;
 
   // Make sure we don't reset existing bookmark etc. on eg. player start failure
-  if (bookmark.timeInSeconds == 0.0f)
+  if (bookmark.timeInSeconds == 0.0)
     return;
 
   if (m_stackHelper.GetRegisteredStack(fileItem) != nullptr && m_stackHelper.GetRegisteredStackTotalTimeMs(fileItem) > 0)
@@ -3070,9 +3071,10 @@ void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &boo
 
   if (advancedSettings->m_videoIgnorePercentAtEnd > 0 &&
       bookmark.totalTimeInSeconds - bookmark.timeInSeconds <
-        0.01f * advancedSettings->m_videoIgnorePercentAtEnd * bookmark.totalTimeInSeconds)
+          0.01 * static_cast<double>(advancedSettings->m_videoIgnorePercentAtEnd) *
+              bookmark.totalTimeInSeconds)
   {
-    resumeBookmark.timeInSeconds = -1.0f;
+    resumeBookmark.timeInSeconds = -1.0;
   }
   else if (bookmark.timeInSeconds > advancedSettings->m_videoIgnoreSecondsAtStart)
   {
@@ -3085,7 +3087,7 @@ void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &boo
   }
   else
   {
-    resumeBookmark.timeInSeconds = 0.0f;
+    resumeBookmark.timeInSeconds = 0.0;
   }
 
   if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteDatabases())
@@ -4442,9 +4444,9 @@ double CApplication::GetTotalTime() const
   if (m_appPlayer.IsPlaying())
   {
     if (m_stackHelper.IsPlayingRegularStack())
-      rc = m_stackHelper.GetStackTotalTimeMs() * 0.001f;
+      rc = m_stackHelper.GetStackTotalTimeMs() * 0.001;
     else
-      rc = static_cast<double>(m_appPlayer.GetTotalTime() * 0.001f);
+      rc = m_appPlayer.GetTotalTime() * 0.001;
   }
 
   return rc;
@@ -4477,10 +4479,10 @@ double CApplication::GetTime() const
     if (m_stackHelper.IsPlayingRegularStack())
     {
       uint64_t startOfCurrentFile = m_stackHelper.GetCurrentStackPartStartTimeMs();
-      rc = (startOfCurrentFile + m_appPlayer.GetTime()) * 0.001f;
+      rc = (startOfCurrentFile + m_appPlayer.GetTime()) * 0.001;
     }
     else
-      rc = static_cast<double>(m_appPlayer.GetTime() * 0.001f);
+      rc = m_appPlayer.GetTime() * 0.001;
   }
 
   return rc;
@@ -4537,7 +4539,7 @@ float CApplication::GetPercentage() const
     if (m_stackHelper.IsPlayingRegularStack())
     {
       double totalTime = GetTotalTime();
-      if (totalTime > 0.0f)
+      if (totalTime > 0.0)
         return (float)(GetTime() / totalTime * 100);
     }
     else
@@ -4566,12 +4568,12 @@ float CApplication::GetCachePercentage() const
 
 void CApplication::SeekPercentage(float percent)
 {
-  if (m_appPlayer.IsPlaying() && (percent >= 0.0))
+  if (m_appPlayer.IsPlaying() && (percent >= 0.0f))
   {
     if (!m_appPlayer.CanSeek())
       return;
     if (m_stackHelper.IsPlayingRegularStack())
-      SeekTime(percent * 0.01 * GetTotalTime());
+      SeekTime(static_cast<double>(percent) * 0.01 * GetTotalTime());
     else
       m_appPlayer.SeekPercentage(percent);
   }

--- a/xbmc/AutoSwitch.cpp
+++ b/xbmc/AutoSwitch.cpp
@@ -53,7 +53,7 @@ int CAutoSwitch::GetView(const CFileItemList &vecItems)
 
   default:
     {
-      if(MetadataPercentage(vecItems) > 0.25)
+      if (MetadataPercentage(vecItems) > 0.25f)
         return DEFAULT_VIEW_INFO;
       else
         return DEFAULT_VIEW_LIST;
@@ -182,7 +182,7 @@ bool CAutoSwitch::ByFileCount(const CFileItemList& vecItems)
 {
   if (vecItems.Size() == 0) return false;
   float fPercent = (float)vecItems.GetFileCount() / vecItems.Size();
-  return (fPercent > 0.25);
+  return (fPercent > 0.25f);
 }
 
 // returns true if:

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -140,7 +140,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
     if (totalTime < 0)
       totalTime = 0;
 
-    double seekSize = (amount * amount * speed) * totalTime / 100;
+    double seekSize = static_cast<double>(amount * amount * speed) * totalTime / 100.0;
     if (forward)
       SetSeekSize(m_seekSize + seekSize);
     else

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1411,7 +1411,7 @@ double CUtil::AlbumRelevance(const std::string& strAlbumTemp1, const std::string
   std::string strAlbum = strAlbum1;
   StringUtils::ToLower(strAlbum);
   double fAlbumPercentage = fstrcmp(strAlbumTemp.c_str(), strAlbum.c_str());
-  double fArtistPercentage = 0.0f;
+  double fArtistPercentage = 0.0;
   if (!strArtist1.empty())
   {
     std::string strArtistTemp = strArtistTemp1;
@@ -1420,7 +1420,7 @@ double CUtil::AlbumRelevance(const std::string& strAlbumTemp1, const std::string
     StringUtils::ToLower(strArtist);
     fArtistPercentage = fstrcmp(strArtistTemp.c_str(), strArtist.c_str());
   }
-  double fRelevance = fAlbumPercentage * 0.5f + fArtistPercentage * 0.5f;
+  double fRelevance = fAlbumPercentage * 0.5 + fArtistPercentage * 0.5;
   return fRelevance;
 }
 

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -443,7 +443,7 @@ bool Interface_Base::set_setting_float(void* kodiBase, const char* id, float val
   if (Interface_Base::UpdateSettingInActiveDialog(addon, id, StringUtils::Format("{:f}", value)))
     return true;
 
-  if (!addon->UpdateSettingNumber(id, value))
+  if (!addon->UpdateSettingNumber(id, static_cast<double>(value)))
   {
     CLog::Log(LOGERROR, "Interface_Base::{} - invalid setting type", __func__);
     return false;

--- a/xbmc/addons/interfaces/AudioEngine.cpp
+++ b/xbmc/addons/interfaces/AudioEngine.cpp
@@ -731,11 +731,11 @@ double Interface_AudioEngine::aestream_get_resample_ratio(void* kodiBase,
     CLog::Log(LOGERROR,
               "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
               __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
-    return -1.0f;
+    return -1.0;
   }
 
   if (!CServiceBroker::GetActiveAE())
-    return -1.0f;
+    return -1.0;
 
   return static_cast<IAEStream*>(streamHandle)->GetResampleRatio();
 }

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -959,7 +959,7 @@ double Interface_Filesystem::get_file_download_speed(void* kodiBase, void* file)
   {
     CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
               __FUNCTION__, kodiBase, file);
-    return 0.0f;
+    return 0.0;
   }
 
   return static_cast<CFile*>(file)->GetDownloadSpeed();

--- a/xbmc/contrib/kissfft/_kiss_fft_guts.h
+++ b/xbmc/contrib/kissfft/_kiss_fft_guts.h
@@ -129,7 +129,7 @@ struct kiss_fft_state{
 #else
 #  define KISS_FFT_COS(phase) (kiss_fft_scalar) cos(phase)
 #  define KISS_FFT_SIN(phase) (kiss_fft_scalar) sin(phase)
-#  define HALF_OF(x) ((x)*.5)
+#  define HALF_OF(x) ((x)*.5f)
 #endif
 
 #define  kf_cexp(x,phase) \

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -674,9 +674,9 @@ float CActiveAEBufferPoolAtempo::GetDelay()
 
 void CActiveAEBufferPoolAtempo::SetTempo(float tempo)
 {
-  if (tempo > 2.0)
+  if (tempo > 2.0f)
     tempo = 2.0;
-  else if (tempo < 0.5)
+  else if (tempo < 0.5f)
     tempo = 0.5;
 
   if (tempo != m_tempo)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -103,7 +103,7 @@ protected:
   bool m_remap = false;
   CSampleBuffer *m_procSample = nullptr;
   IAEResample *m_resampler = nullptr;
-  double m_resampleRatio = 1.0f;
+  double m_resampleRatio = 1.0;
   double m_centerMixLevel = M_SQRT1_2;
   bool m_fillPackets = false;
   bool m_normalize = true;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
@@ -50,7 +50,7 @@ void CActiveAEFilter::Init(AVSampleFormat fmt, int sampleRate, uint64_t channelL
 bool CActiveAEFilter::SetTempo(float tempo)
 {
   m_tempo = tempo;
-  if (m_tempo == 1.0)
+  if (m_tempo == 1.0f)
   {
     CloseFilter();
     return true;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -302,11 +302,12 @@ unsigned int CActiveAEStream::AddData(const uint8_t* const *data, unsigned int o
         if (m_format.m_dataFormat != AE_FMT_RAW)
         {
           m_currentBuffer->pkt->nb_samples += minFrames;
-          m_bufferedTime += (double)minFrames / m_currentBuffer->pkt->config.sample_rate;
+          m_bufferedTime +=
+              static_cast<float>(minFrames) / m_currentBuffer->pkt->config.sample_rate;
         }
         else
         {
-          m_bufferedTime += m_format.m_streamInfo.GetDuration() / 1000;
+          m_bufferedTime += static_cast<float>(m_format.m_streamInfo.GetDuration()) / 1000;
           m_currentBuffer->pkt->nb_samples += minFrames;
           rawPktComplete = true;
         }
@@ -370,17 +371,17 @@ bool CActiveAEStream::IsBuffering()
 
 double CActiveAEStream::GetCacheTime()
 {
-  return m_activeAE->GetCacheTime(this);
+  return static_cast<double>(m_activeAE->GetCacheTime(this));
 }
 
 double CActiveAEStream::GetCacheTotal()
 {
-  return m_activeAE->GetCacheTotal();
+  return static_cast<double>(m_activeAE->GetCacheTotal());
 }
 
 double CActiveAEStream::GetMaxDelay()
 {
-  return m_activeAE->GetMaxDelay();
+  return static_cast<double>(m_activeAE->GetMaxDelay());
 }
 
 void CActiveAEStream::Pause()
@@ -740,7 +741,7 @@ void CActiveAEStreamBuffers::SetRR(double rr, double atempoThreshold)
 double CActiveAEStreamBuffers::GetRR()
 {
   double tempo = m_resampleBuffers->GetRR();
-  tempo /= m_atempoBuffers->GetTempo();
+  tempo /= static_cast<double>(m_atempoBuffers->GetTempo());
   return tempo;
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -37,7 +37,7 @@ public:
 
   void Flush(int interval = 100)
   {
-    m_buffer = 0.0f;
+    m_buffer = 0.0;
     m_lastError = 0.0;
     m_count  = 0;
     m_timer.Set(interval);
@@ -45,7 +45,7 @@ public:
 
   void SetErrorInterval(int interval = 100)
   {
-    m_buffer = 0.0f;
+    m_buffer = 0.0;
     m_count = 0;
     m_timer.Set(interval);
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
@@ -206,7 +206,7 @@ void CAAudioUnitSink::getDelay(AEDelayStatus& status)
   } while(lock.retry());
 
   status.delay /= m_sampleRate;
-  status.delay += m_bufferDuration + m_outputLatency;
+  status.delay += static_cast<double>(m_bufferDuration + m_outputLatency);
 }
 
 double CAAudioUnitSink::cacheSize()

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -335,7 +335,7 @@ void CAAudioUnitSink::updatedelay(AEDelayStatus& status)
   status.delay += static_cast<double>(size) / static_cast<double>(m_frameSize) /
                   static_cast<double>(m_sampleRate);
   // add in hw delay and total latency (in seconds)
-  status.delay += m_totalLatency;
+  status.delay += static_cast<double>(m_totalLatency);
 }
 
 double CAAudioUnitSink::buffertime()

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -54,7 +54,7 @@ void CCoreAudioDevice::Close()
     SetMixingSupport((m_MixerRestore ? true : false));
   m_MixerRestore = -1;
 
-  if (m_SampleRateRestore != 0.0f)
+  if (m_SampleRateRestore != 0.0)
     SetNominalSampleRate(m_SampleRateRestore);
 
   if (m_BufferSizeRestore && m_BufferSizeRestore != GetBufferSize())
@@ -702,28 +702,28 @@ bool CCoreAudioDevice::GetDataSources(CoreAudioDataSourceList* pList) const
 Float64 CCoreAudioDevice::GetNominalSampleRate()
 {
   if (!m_DeviceId)
-    return 0.0f;
+    return 0.0;
 
   AudioObjectPropertyAddress  propertyAddress;
   propertyAddress.mScope    = kAudioDevicePropertyScopeOutput;
   propertyAddress.mElement  = 0;
   propertyAddress.mSelector = kAudioDevicePropertyNominalSampleRate;
 
-  Float64 sampleRate = 0.0f;
+  Float64 sampleRate = 0.0;
   UInt32  propertySize = sizeof(Float64);
   OSStatus ret = AudioObjectGetPropertyData(m_DeviceId, &propertyAddress, 0, NULL, &propertySize, &sampleRate);
   if (ret != noErr)
   {
     CLog::Log(LOGERROR, "CCoreAudioDevice::GetNominalSampleRate: "
       "Unable to retrieve current device sample rate. Error = %s", GetError(ret).c_str());
-    return 0.0f;
+    return 0.0;
   }
   return sampleRate;
 }
 
 bool CCoreAudioDevice::SetNominalSampleRate(Float64 sampleRate)
 {
-  if (!m_DeviceId || sampleRate == 0.0f)
+  if (!m_DeviceId || sampleRate == 0.0)
     return false;
 
   Float64 currentRate = GetNominalSampleRate();
@@ -743,7 +743,7 @@ bool CCoreAudioDevice::SetNominalSampleRate(Float64 sampleRate)
       (float)sampleRate, GetError(ret).c_str());
     return false;
   }
-  if (m_SampleRateRestore == 0.0f)
+  if (m_SampleRateRestore == 0.0)
     m_SampleRateRestore = currentRate;
 
   return true;

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -76,7 +76,7 @@ protected:
   AudioDeviceIOProc m_IoProc = nullptr;
   AudioObjectPropertyListenerProc m_ObjectListenerProc = nullptr;
 
-  Float64 m_SampleRateRestore = 0.0f;
+  Float64 m_SampleRateRestore = 0.0;
   pid_t m_HogPid = -1;
   unsigned int m_frameSize = 0;
   unsigned int m_OutputBufferIndex = 0;

--- a/xbmc/cores/AudioEngine/Utils/AELimiter.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AELimiter.cpp
@@ -47,7 +47,9 @@ float CAELimiter::Run(float* frame[AE_CH_MAX], int channels, int offset /*= 0*/,
   if (sample * m_attenuation > 1.0f)
   {
     m_attenuation = 1.0f / sample;
-    m_holdcounter = MathUtils::round_int(m_samplerate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_limiterHold);
+    m_holdcounter = MathUtils::round_int(static_cast<double>(
+        m_samplerate *
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_limiterHold));
     m_increase = powf(std::min(sample, 10000.0f), 1.0f / (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_limiterRelease * m_samplerate));
   }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -367,7 +367,7 @@ uint64_t CRetroPlayer::GetTotalTime()
 
 void CRetroPlayer::SetSpeed(float speed)
 {
-  if (m_playback->GetSpeed() != speed)
+  if (m_playback->GetSpeed() != static_cast<double>(speed))
   {
     if (speed == 1.0f)
       m_callback.OnPlayBackResumed();

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
@@ -149,10 +149,10 @@ void CRenderUtils::CalcNormalRenderRect(const CRect& viewRect,
   float posY = (height - newHeight) / 2;
   float posX = (width - newWidth) / 2;
 
-  destRect.x1 = static_cast<float>(MathUtils::round_int(posX + offsetX));
-  destRect.x2 = destRect.x1 + MathUtils::round_int(newWidth);
-  destRect.y1 = static_cast<float>(MathUtils::round_int(posY + offsetY));
-  destRect.y2 = destRect.y1 + MathUtils::round_int(newHeight);
+  destRect.x1 = static_cast<float>(MathUtils::round_int(static_cast<double>(posX + offsetX)));
+  destRect.x2 = destRect.x1 + MathUtils::round_int(static_cast<double>(newWidth));
+  destRect.y1 = static_cast<float>(MathUtils::round_int(static_cast<double>(posY + offsetY)));
+  destRect.y2 = destRect.y1 + MathUtils::round_int(static_cast<double>(newHeight));
 }
 
 void CRenderUtils::ClipRect(const CRect& viewRect, CRect& sourceRect, CRect& destRect)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -164,7 +164,7 @@ void CRPRendererOpenGL::DrawBlackBars()
   glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
 
   // top quad
-  if (m_rotatedDestCoords[0].y > 0.0)
+  if (m_rotatedDestCoords[0].y > 0.0f)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;
@@ -206,7 +206,7 @@ void CRPRendererOpenGL::DrawBlackBars()
   }
 
   // left quad
-  if (m_rotatedDestCoords[0].x > 0.0)
+  if (m_rotatedDestCoords[0].x > 0.0f)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -132,7 +132,7 @@ void CRPRendererOpenGLES::DrawBlackBars()
   glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
 
   // top quad
-  if (m_rotatedDestCoords[0].y > 0.0)
+  if (m_rotatedDestCoords[0].y > 0.0f)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;
@@ -174,7 +174,7 @@ void CRPRendererOpenGLES::DrawBlackBars()
   }
 
   // left quad
-  if (m_rotatedDestCoords[0].x > 0.0)
+  if (m_rotatedDestCoords[0].x > 0.0f)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -97,8 +97,9 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   }
 
   float applyDrc = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioApplyDrc;
-  if (applyDrc >= 0.0)
-    av_opt_set_double(m_pCodecContext, "drc_scale", applyDrc, AV_OPT_SEARCH_CHILDREN);
+  if (applyDrc >= 0.0f)
+    av_opt_set_double(m_pCodecContext, "drc_scale", static_cast<double>(applyDrc),
+                      AV_OPT_SEARCH_CHILDREN);
 
   if (avcodec_open2(m_pCodecContext, pCodec, NULL) < 0)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -256,7 +256,7 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
 
     pVideoPicture->iDisplayWidth = pVideoPicture->iWidth;
     pVideoPicture->iDisplayHeight = pVideoPicture->iHeight;
-    if (m_displayAspect > 0.0)
+    if (m_displayAspect > 0.0f)
     {
       pVideoPicture->iDisplayWidth = ((int)lrint(pVideoPicture->iHeight * m_displayAspect)) & ~3;
       if (pVideoPicture->iDisplayWidth > pVideoPicture->iWidth)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -876,7 +876,7 @@ bool CDVDVideoCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
         m_hints.fpsscale = m_mpeg2_sequence->fps_scale;
         m_hints.width    = m_mpeg2_sequence->width;
         m_hints.height   = m_mpeg2_sequence->height;
-        m_hints.aspect   = m_mpeg2_sequence->ratio;
+        m_hints.aspect = static_cast<double>(m_mpeg2_sequence->ratio);
 
         m_processInfo.SetVideoDAR(m_hints.aspect);
         UpdateFpsDuration();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -952,7 +952,7 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
     aspect_ratio = av_q2d(pixel_aspect) * pVideoPicture->iWidth / pVideoPicture->iHeight;
 
   if (aspect_ratio <= 0.0)
-    aspect_ratio = (float)pVideoPicture->iWidth / (float)pVideoPicture->iHeight;
+    aspect_ratio = static_cast<double>(pVideoPicture->iWidth) / pVideoPicture->iHeight;
 
   if (m_DAR != aspect_ratio)
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -963,7 +963,7 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   // do calculations in floats as they can easily overflow otherwise
   // we don't care for having a completely exact timestamp anyway
   double timestamp = (double)pts * num / den;
-  double starttime = 0.0f;
+  double starttime = 0.0;
 
   std::shared_ptr<CDVDInputStream::IMenus> menu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
   if (!menu && m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
@@ -977,7 +977,7 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
     if (timestamp > starttime || m_checkTransportStream)
       timestamp -= starttime;
     // allow for largest possible difference in pts and dts for a single packet
-    else if (timestamp + 0.5f > starttime)
+    else if (timestamp + 0.5 > starttime)
       timestamp = 0;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -669,7 +669,7 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
 
 static uint8_t  clamp(double v)
 {
-  return (v) > 255.0 ? 255 : ((v) < 0.0 ? 0 : static_cast<uint32_t>((v+0.5f)));
+  return (v) > 255.0 ? 255 : ((v) < 0.0 ? 0 : static_cast<uint32_t>((v + 0.5)));
 }
 
 static uint32_t build_rgba(const BD_PG_PALETTE_ENTRY &e)
@@ -1185,7 +1185,7 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_REGION_CODE, static_cast<uint32_t>(region));
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_PARENTAL, 99);
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_3D_CAP, 0xffffffff);
-#if (BLURAY_VERSION >= BLURAY_VERSION_CODE(1, 0, 2))  
+#if (BLURAY_VERSION >= BLURAY_VERSION_CODE(1, 0, 2))
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_PLAYER_PROFILE, BLURAY_PLAYER_PROFILE_6_v3_1);
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_UHD_CAP, 0xffffffff);
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_UHD_DISPLAY_CAP, 0xffffffff);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -417,7 +417,7 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
     videoStream->iFpsRate = stream->m_FpsRate;
     videoStream->iWidth = stream->m_Width;
     videoStream->iHeight = stream->m_Height;
-    videoStream->fAspect = stream->m_Aspect;
+    videoStream->fAspect = static_cast<double>(stream->m_Aspect);
     videoStream->iBitRate = stream->m_BitRate;
     videoStream->profile = ConvertVideoCodecProfile(stream->m_codecProfile);
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -293,7 +293,7 @@ void CInputStreamPVRBase::UpdateStreamMap()
       streamVideo->iFpsRate = stream.iFPSRate;
       streamVideo->iHeight = stream.iHeight;
       streamVideo->iWidth = stream.iWidth;
-      streamVideo->fAspect = stream.fAspect;
+      streamVideo->fAspect = static_cast<double>(stream.fAspect);
 
       dStream = streamVideo;
     }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -326,8 +326,8 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
     if (sscanf(szBuffer, "%lf %lf", &dStartFrame, &dEndFrame) == 2)
     {
       Cut cut;
-      cut.start = (int64_t)(dStartFrame / fFrameRate * 1000);
-      cut.end = (int64_t)(dEndFrame / fFrameRate * 1000);
+      cut.start = static_cast<int64_t>(dStartFrame / static_cast<double>(fFrameRate) * 1000.0);
+      cut.end = static_cast<int64_t>(dEndFrame / static_cast<double>(fFrameRate) * 1000.0);
       cut.action = Action::COMM_BREAK;
       bValid = AddCut(cut);
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -563,8 +563,8 @@ int CSelectionStreams::CountTypeOfSource(StreamType type, StreamSource source) c
 
 int CSelectionStreams::CountType(StreamType type) const
 {
-  return std::count_if(m_Streams.begin(), m_Streams.end(), 
-    [&](const SelectionStream& stream) {return stream.type == type;});
+  return std::count_if(m_Streams.begin(), m_Streams.end(),
+                       [&](const SelectionStream& stream) { return stream.type == type; });
 }
 
 //------------------------------------------------------------------------------
@@ -1251,7 +1251,8 @@ void CVideoPlayer::Prepare()
   {
     if (m_playerOptions.startpercent > 0 && m_pDemuxer)
     {
-      int playerStartTime = (int)( ( (float) m_pDemuxer->GetStreamLength() ) * ( m_playerOptions.startpercent/(float)100 ) );
+      int playerStartTime = static_cast<int>((static_cast<double>(
+          m_pDemuxer->GetStreamLength() * (m_playerOptions.startpercent / 100.0))));
       starttime = m_Edl.RestoreCutTime(playerStartTime);
     }
     else
@@ -2105,14 +2106,14 @@ void CVideoPlayer::HandlePlaySpeed()
       }
     }
   }
-  
+
   // reset tempo
   if (!m_State.cantempo)
   {
     float currentTempo = m_processInfo->GetNewTempo();
-    if (currentTempo != 1.0)
+    if (currentTempo != 1.0f)
     {
-      SetTempo(1.0);
+      SetTempo(1.0f);
     }
   }
 }
@@ -2873,7 +2874,7 @@ void CVideoPlayer::HandleMessages()
       if (m_playSpeed == DVD_PLAYSPEED_PAUSE)
       {
         int frames = static_cast<CDVDMsgInt*>(pMsg)->m_value;
-        double time = DVD_TIME_BASE / m_processInfo->GetVideoFps() * frames;
+        double time = DVD_TIME_BASE / static_cast<double>(m_processInfo->GetVideoFps()) * frames;
         m_processInfo->SetFrameAdvance(true);
         m_clock.Advance(time);
       }
@@ -3216,7 +3217,7 @@ float CVideoPlayer::GetAVDelay()
 void CVideoPlayer::SetSubTitleDelay(float fValue)
 {
   m_processInfo->UpdateVideoSettings().SetSubtitleDelay(fValue);
-  m_VideoPlayerVideo->SetSubtitleDelay(-fValue * DVD_TIME_BASE);
+  m_VideoPlayerVideo->SetSubtitleDelay(static_cast<double>(-fValue) * DVD_TIME_BASE);
 }
 
 float CVideoPlayer::GetSubTitleDelay()
@@ -3347,7 +3348,7 @@ void CVideoPlayer::SetSpeed(float speed)
     if (iSpeed == DVD_PLAYSPEED_NORMAL)
     {
       float currentTempo = m_processInfo->GetNewTempo();
-      if (currentTempo != 1.0)
+      if (currentTempo != 1.0f)
       {
         SetTempo(currentTempo);
         return;
@@ -3359,7 +3360,7 @@ void CVideoPlayer::SetSpeed(float speed)
 
 void CVideoPlayer::SetTempo(float tempo)
 {
-  tempo = floor(tempo * 100 + 0.5) / 100;
+  tempo = floor(tempo * 100.0f + 0.5f) / 100.0f;
   if (m_processInfo->IsTempoAllowed(tempo))
   {
     int speed = tempo * DVD_PLAYSPEED_NORMAL;
@@ -3553,9 +3554,9 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   {
     /* set aspect ratio as requested by navigator for dvd's */
     float aspect = std::static_pointer_cast<CDVDInputStreamNavigator>(m_pInputStream)->GetVideoAspectRatio();
-    if (aspect != 0.0)
+    if (aspect != 0.0f)
     {
-      hint.aspect = aspect;
+      hint.aspect = static_cast<double>(aspect);
       hint.forced_aspect = true;
     }
     hint.dvd = true;
@@ -4033,7 +4034,7 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
         m_overlayContainer.Clear();
 
         //Force an aspect ratio that is set in the dvdheaders if available
-        m_CurrentVideo.hint.aspect = pStream->GetVideoAspectRatio();
+        m_CurrentVideo.hint.aspect = static_cast<double>(pStream->GetVideoAspectRatio());
         if( m_VideoPlayerVideo->IsInited() )
           m_VideoPlayerVideo->SendMessage(new CDVDMsgDouble(CDVDMsg::VIDEO_SET_ASPECT, m_CurrentVideo.hint.aspect));
 

--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
@@ -230,7 +230,7 @@ double CVideoReferenceClock::GetSpeed()
 void CVideoReferenceClock::UpdateRefreshrate()
 {
   CSingleLock SingleLock(m_CritSection);
-  m_RefreshRate = m_pVideoSync->GetFps();
+  m_RefreshRate = static_cast<double>(m_pVideoSync->GetFps());
   m_ClockSpeed = 1.0;
 
   CLog::Log(LOGDEBUG, "CVideoReferenceClock: Detected refreshrate: %.3f hertz", m_RefreshRate);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -190,10 +190,10 @@ void CBaseRenderer::CalcNormalRenderRect(float offsetX, float offsetY, float wid
   else if (verticalShift < -1.0f)
     posY += shiftRange * (verticalShift + 1.0f);
 
-  m_destRect.x1 = (float)MathUtils::round_int(posX + offsetX);
-  m_destRect.x2 = m_destRect.x1 + MathUtils::round_int(newWidth);
-  m_destRect.y1 = (float)MathUtils::round_int(posY + offsetY);
-  m_destRect.y2 = m_destRect.y1 + MathUtils::round_int(newHeight);
+  m_destRect.x1 = (float)MathUtils::round_int(static_cast<double>(posX + offsetX));
+  m_destRect.x2 = m_destRect.x1 + MathUtils::round_int(static_cast<double>(newWidth));
+  m_destRect.y1 = (float)MathUtils::round_int(static_cast<double>(posY + offsetY));
+  m_destRect.y2 = m_destRect.y1 + MathUtils::round_int(static_cast<double>(newHeight));
 
   // clip as needed
   if (!(CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo() || CServiceBroker::GetWinSystem()->GetGfxContext().IsCalibrating()))
@@ -410,7 +410,8 @@ void CBaseRenderer::SetViewMode(int viewMode)
   { // super zoom
     float stretchAmount = (screenWidth / screenHeight) * info.fPixelRatio / sourceFrameRatio;
     CDisplaySettings::GetInstance().SetPixelRatio(pow(stretchAmount, float(2.0/3.0)));
-    CDisplaySettings::GetInstance().SetZoomAmount(pow(stretchAmount, float((stretchAmount < 1.0) ? -1.0/3.0 : 1.0/3.0)));
+    CDisplaySettings::GetInstance().SetZoomAmount(
+        pow(stretchAmount, float((stretchAmount < 1.0f) ? -1.0 / 3.0 : 1.0 / 3.0)));
     CDisplaySettings::GetInstance().SetNonLinearStretched(true);
   }
   else if (m_videoSettings.m_ViewMode == ViewModeStretch16x9 ||

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -157,9 +157,9 @@ void CRendererMediaCodecSurface::RenderUpdate(int index, int index2, bool clear,
       break;
     case RENDER_STEREO_MODE_MONO:
       if (CONF_FLAGS_STEREO_MODE_MASK(m_iFlags) == CONF_FLAGS_STEREO_MODE_TAB)
-        m_surfDestRect.y2 = m_surfDestRect.y2 * 2.0;
+        m_surfDestRect.y2 = m_surfDestRect.y2 * 2.0f;
       else
-        m_surfDestRect.x2 = m_surfDestRect.x2 * 2.0;
+        m_surfDestRect.x2 = m_surfDestRect.x2 * 2.0f;
       break;
     default:
       break;
@@ -182,8 +182,10 @@ void CRendererMediaCodecSurface::ReorderDrawPoints()
     case 90:
     case 270:
     {
-      double scale = (double)m_surfDestRect.Height() / m_surfDestRect.Width();
-      int diff = (int) ((m_surfDestRect.Height()*scale - m_surfDestRect.Width()) / 2);
+      double scale = static_cast<double>(m_surfDestRect.Height() / m_surfDestRect.Width());
+      int diff = static_cast<int>(static_cast<double>(m_surfDestRect.Height()) * scale -
+                                  static_cast<double>(m_surfDestRect.Width())) /
+                 2;
       m_surfDestRect = CRect(m_surfDestRect.x1 - diff, m_surfDestRect.y1, m_surfDestRect.x2 + diff, m_surfDestRect.y2);
     }
     default:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -557,7 +557,7 @@ void CLinuxRendererGL::DrawBlackBars()
   int osWindowHeight = CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight();
 
   //top quad
-  if (m_destRect.y1 > 0.0)
+  if (m_destRect.y1 > 0.0f)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;
@@ -599,7 +599,7 @@ void CLinuxRendererGL::DrawBlackBars()
   }
 
   // left quad
-  if (m_destRect.x1 > 0.0)
+  if (m_destRect.x1 > 0.0f)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -223,7 +223,7 @@ void CLinuxRendererGLES::CalculateTextureSourceRects(int source, int num_planes)
         float offset_y = 0.5;
         if(plane != 0)
         {
-          offset_y += 0.5;
+          offset_y += 0.5f;
         }
 
         if(field == FIELD_BOT)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -500,10 +500,10 @@ void COverlayTextureGL::Render(SRenderState& state)
   DRAWRECT rd;
   if (m_pos == POSITION_RELATIVE)
   {
-    rd.top     = state.y - state.height * 0.5;
-    rd.bottom  = state.y + state.height * 0.5;
-    rd.left    = state.x - state.width  * 0.5;
-    rd.right   = state.x + state.width  * 0.5;
+    rd.top = state.y - state.height * 0.5f;
+    rd.bottom = state.y + state.height * 0.5f;
+    rd.left = state.x - state.width * 0.5f;
+    rd.right = state.x + state.width * 0.5f;
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
@@ -32,7 +32,7 @@ static uint32_t build_rgba(int a, int r, int g, int b, bool mergealpha)
          | b << PIXEL_BSHIFT;
 }
 
-#define clamp(x) (x) > 255.0 ? 255 : ((x) < 0.0 ? 0 : (int)(x+0.5f))
+#define clamp(x) (x) > 255.0 ? 255 : ((x) < 0.0 ? 0 : (int)(x + 0.5))
 static uint32_t build_rgba(int yuv[3], int alpha, bool mergealpha)
 {
   int    a = alpha + ( (alpha << 4) & 0xff );

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -866,7 +866,8 @@ void CRenderManager::UpdateLatencyTweak()
   float refresh = fps;
   if (CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution() == RES_WINDOW)
     refresh = 0; // No idea about refresh rate when windowed, just get the default latency
-  m_latencyTweak = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->GetLatencyTweak(refresh);
+  m_latencyTweak = static_cast<double>(
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->GetLatencyTweak(refresh));
 }
 
 void CRenderManager::UpdateResolution()
@@ -1099,9 +1100,15 @@ void CRenderManager::PrepareNextRender()
     return;
 
   double frameOnScreen = m_dvdClock.GetClock();
-  double frametime = 1.0 / CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS() * DVD_TIME_BASE;
+  double frametime = 1.0 /
+                     static_cast<double>(CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS()) *
+                     DVD_TIME_BASE;
 
-  m_displayLatency = DVD_MSEC_TO_TIME(m_latencyTweak + CServiceBroker::GetWinSystem()->GetGfxContext().GetDisplayLatency() - m_videoDelay - CServiceBroker::GetWinSystem()->GetFrameLatencyAdjustment());
+  m_displayLatency = DVD_MSEC_TO_TIME(
+      m_latencyTweak +
+      static_cast<double>(CServiceBroker::GetWinSystem()->GetGfxContext().GetDisplayLatency()) -
+      m_videoDelay -
+      static_cast<double>(CServiceBroker::GetWinSystem()->GetFrameLatencyAdjustment()));
 
   double renderPts = frameOnScreen + m_displayLatency;
 
@@ -1171,7 +1178,8 @@ void CRenderManager::PrepareNextRender()
       m_queued.pop_front();
     }
 
-    int lateframes = static_cast<int>((renderPts - m_Queue[idx].pts) * m_fps / DVD_TIME_BASE);
+    int lateframes = static_cast<int>((renderPts - m_Queue[idx].pts) *
+                                      static_cast<double>(m_fps / DVD_TIME_BASE));
     if (lateframes)
       m_lateframes += lateframes;
     else
@@ -1230,7 +1238,7 @@ void CRenderManager::CheckEnableClockSync()
 
   if (m_fps != 0)
   {
-    double fps = m_fps;
+    double fps = static_cast<double>(m_fps);
     double refreshrate, clockspeed;
     int missedvblanks;
     if (m_dvdClock.GetClockInfo(missedvblanks, clockspeed, refreshrate))
@@ -1238,7 +1246,7 @@ void CRenderManager::CheckEnableClockSync()
       fps *= clockspeed;
     }
 
-    diff = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS() / fps;
+    diff = static_cast<double>(CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS()) / fps;
     if (diff < 1.0)
       diff = 1.0 / diff;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
@@ -326,7 +326,7 @@ float PrimaryToXYZ::CalcGy(const float p[3][2], const float w[2], const float By
 
 float PrimaryToXYZ::CalcRy(const float By, const float Gy)
 {
-  return 1.0 - Gy - By;
+  return 1.0f - Gy - By;
 }
 
 PrimaryToRGB::PrimaryToRGB(float (&primaries)[3][2], float (&whitepoint)[2]) : PrimaryToXYZ(primaries, whitepoint)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConvolutionKernels.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConvolutionKernels.cpp
@@ -265,7 +265,7 @@ void CConvolutionKernel::ToIntFract()
 
   for (int i = 0; i < m_size * 4; i++)
   {
-    int value = MathUtils::round_int((m_floatpixels[i] + 1.0) / 2.0 * 65535.0);
+    int value = MathUtils::round_int((static_cast<double>(m_floatpixels[i]) + 1.0) / 2.0 * 65535.0);
     if (value < 0)
       value = 0;
     else if (value > 65535)
@@ -286,7 +286,7 @@ void CConvolutionKernel::ToUint8()
 
   for (int i = 0; i < m_size * 4; i++)
   {
-    int value = MathUtils::round_int((m_floatpixels[i] * 0.5 + 0.5) * 255.0);
+    int value = MathUtils::round_int((static_cast<double>(m_floatpixels[i]) * 0.5 + 0.5) * 255.0);
     if (value < 0)
       value = 0;
     else if (value > 255)

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -470,7 +470,7 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
   si->m_stream->SetVolume(si->m_volume);
   float peak = 1.0;
   float gain = si->m_decoder.GetReplayGain(peak);
-  if (peak * gain <= 1.0)
+  if (peak * gain <= 1.0f)
     // No clipping protection needed
     si->m_stream->SetReplayGain(gain);
   else if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING))
@@ -980,7 +980,7 @@ bool PAPlayer::SetTotalTimeInternal(int64_t time)
 
   m_currentStream->m_decoder.SetTotalTime(time);
   UpdateGUIData(m_currentStream);
-  
+
   return true;
 }
 
@@ -994,7 +994,7 @@ bool PAPlayer::SetTimeInternal(int64_t time)
 
   if (m_currentStream->m_stream)
     m_currentStream->m_framesSent += m_currentStream->m_stream->GetDelay() * m_currentStream->m_audioFormat.m_sampleRate;
-  
+
   return true;
 }
 

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -188,7 +188,7 @@ std::string field_value::get_asString() const {
     }
     case ft_Float: {
       char t[16];
-      sprintf(t,"%f",float_value);
+      sprintf(t, "%f", static_cast<double>(float_value));
       return tmp = t;
     }
     case ft_Double: {
@@ -288,7 +288,7 @@ char field_value::get_asChar() const {
     }
     case ft_Float: {
       char t[16];
-      sprintf(t,"%f",float_value);
+      sprintf(t, "%f", static_cast<double>(float_value));
       return t[0];
     }
     case ft_Double: {

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -307,8 +307,8 @@ void CGUIDialogMediaFilter::OnSettingChanged(const std::shared_ptr<const CSettin
       float valueLower = values.at(0).asFloat();
       float valueUpper = values.at(1).asFloat();
 
-      if (valueLower > definitionNumber->GetMinimum() ||
-          valueUpper < definitionNumber->GetMaximum())
+      if (static_cast<double>(valueLower) > definitionNumber->GetMinimum() ||
+          static_cast<double>(valueUpper) < definitionNumber->GetMaximum())
       {
         strValueLower = values.at(0).asString();
         strValueUpper = values.at(1).asString();

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -173,7 +173,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
       // calculate the current and average speeds
       float end = timer.GetElapsedSeconds();
 
-      if (pCallback && end - start > 0.5 && end)
+      if (pCallback && end - start > 0.5f && end)
       {
         start = end;
 
@@ -1081,7 +1081,7 @@ double CFile::GetDownloadSpeed()
 {
   if (m_pFile)
     return m_pFile->GetDownloadSpeed();
-  return 0.0f;
+  return 0.0;
 }
 
 //*********************************************************************************************

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -107,7 +107,7 @@ public:
    * It can also be used to indicate a file system is non buffered *
    * but accepts any read size, have it return the value 1         */
   virtual int  GetChunkSize() {return 0;}
-  virtual double GetDownloadSpeed(){ return 0.0f; };
+  virtual double GetDownloadSpeed() { return 0.0; };
 
   virtual bool Delete(const CURL& url) { return false; }
   virtual bool Rename(const CURL& url, const CURL& urlnew) { return false; }

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -76,7 +76,7 @@ static bool FindDeviceWait(CUPnP* upnp, const char* uuid, PLT_DeviceDataReferenc
     // (and wait for it to respond for 5 secs if we're just starting upnp client)
     NPT_TimeStamp watchdog;
     NPT_System::GetCurrentTimeStamp(watchdog);
-    watchdog += 5.f;
+    watchdog += 5.0;
 
     for (;;) {
         if (NPT_SUCCEEDED(upnp->m_MediaBrowser->FindServer(uuid, device)) && !device.IsNull())

--- a/xbmc/games/addons/streams/GameClientStreamVideo.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamVideo.cpp
@@ -98,7 +98,7 @@ RETRO::VideoStreamProperties* CGameClientStreamVideo::TranslateProperties(
 
   // Game API: If aspect_ratio is <= 0.0, an aspect ratio of
   // (nominal_width / nominal_height) is assumed
-  if (properties.aspect_ratio <= 0.0)
+  if (properties.aspect_ratio <= 0.0f)
     pixelAspectRatio = 1.0f;
   else
     pixelAspectRatio = properties.aspect_ratio * nominalHeight / nominalWidth;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -747,7 +747,7 @@ EVENT_RESULT CGUIBaseContainer::OnMouseEvent(const CPoint &point, const CMouseEv
   { // do the drag and validate our offset (corrects for end of scroll)
     m_scroller.SetValue(m_scroller.GetValue() - ((m_orientation == HORIZONTAL) ? event.m_offsetX : event.m_offsetY));
     float size = (m_layout) ? m_layout->Size(m_orientation) : 10.0f;
-    int offset = MathUtils::round_int(m_scroller.GetValue() / size);
+    int offset = MathUtils::round_int(static_cast<double>(m_scroller.GetValue() / size));
     m_lastScrollStartTimer.Stop();
     m_scrollTimer.Start();
     const int absCursor = CorrectOffset(GetOffset(), GetCursor());
@@ -778,7 +778,7 @@ EVENT_RESULT CGUIBaseContainer::OnMouseEvent(const CPoint &point, const CMouseEv
     // and compute the nearest offset from this and scroll there
     float size = (m_layout) ? m_layout->Size(m_orientation) : 10.0f;
     float offset = m_scroller.GetValue() / size;
-    int toOffset = MathUtils::round_int(offset);
+    int toOffset = MathUtils::round_int(static_cast<double>(offset));
     if (toOffset < offset)
       SetOffset(toOffset+1);
     else

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -170,9 +170,11 @@ void CGUIControl::DoRender()
 {
   if (IsVisible())
   {
-    bool hasStereo = m_stereo != 0.0
-                  && CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RENDER_STEREO_MODE_MONO
-                  && CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RENDER_STEREO_MODE_OFF;
+    bool hasStereo =
+        m_stereo != 0.0f &&
+        CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() !=
+            RENDER_STEREO_MODE_MONO &&
+        CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RENDER_STEREO_MODE_OFF;
 
     CServiceBroker::GetWinSystem()->GetGfxContext().SetTransform(m_cachedTransform);
     if (m_hasCamera)

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -44,7 +44,7 @@ bool CGUIFixedListContainer::OnAction(const CAction &action)
     {
       m_analogScrollCount += action.GetAmount() * action.GetAmount();
       bool handled = false;
-      while (m_analogScrollCount > 0.4)
+      while (m_analogScrollCount > 0.4f)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;
@@ -57,7 +57,7 @@ bool CGUIFixedListContainer::OnAction(const CAction &action)
     {
       m_analogScrollCount += action.GetAmount() * action.GetAmount();
       bool handled = false;
-      while (m_analogScrollCount > 0.4)
+      while (m_analogScrollCount > 0.4f)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -90,7 +90,8 @@ void CGUIFont::DrawText( float x, float y, const std::vector<UTILS::Color> &colo
   if (clip && ClippedRegionIsEmpty(x, y, maxPixelWidth, alignment))
     return;
 
-  maxPixelWidth = ROUND(maxPixelWidth / CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX());
+  maxPixelWidth = ROUND(static_cast<double>(
+      maxPixelWidth / CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX()));
   std::vector<UTILS::Color> renderColors;
   for (unsigned int i = 0; i < colors.size(); i++)
     renderColors.push_back(CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(colors[i] ? colors[i] : m_textColor));
@@ -174,8 +175,11 @@ void CGUIFont::DrawScrollingText(float x, float y, const std::vector<UTILS::Colo
 
   assert(scrollInfo.m_totalWidth != 0);
 
-  float textPixelWidth = ROUND(scrollInfo.m_textWidth / CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX());
-  float suffixPixelWidth = ROUND((scrollInfo.m_totalWidth - scrollInfo.m_textWidth) / CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX());
+  float textPixelWidth = ROUND(static_cast<double>(
+      scrollInfo.m_textWidth / CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX()));
+  float suffixPixelWidth =
+      ROUND(static_cast<double>((scrollInfo.m_totalWidth - scrollInfo.m_textWidth) /
+                                CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX()));
 
   float offset;
   if(scrollInfo.pixelSpeed >= 0)

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -103,7 +103,7 @@ public:
 #endif // ! TARGET_WINDOWS
 
     unsigned int ydpi = 72; // 72 points to the inch is the freetype default
-    unsigned int xdpi = (unsigned int)MathUtils::round_int(ydpi * aspect);
+    unsigned int xdpi = (unsigned int)MathUtils::round_int(static_cast<double>(ydpi * aspect));
 
     // we set our screen res currently to 96dpi in both directions (windows default)
     // we cache our characters (for rendering speed) so it's probably
@@ -292,8 +292,9 @@ bool CGUIFontTTF::Load(
 
   // scale to pixel sizing, rounding so that maximal extent is obtained
   float scaler  = height / m_face->units_per_EM;
-  cellDescender = MathUtils::round_int(cellDescender * scaler - 0.5f);   // round down
-  cellAscender  = MathUtils::round_int(cellAscender  * scaler + 0.5f);   // round up
+  cellDescender =
+      MathUtils::round_int(cellDescender * static_cast<double>(scaler) - 0.5); // round down
+  cellAscender = MathUtils::round_int(cellAscender * static_cast<double>(scaler) + 0.5); // round up
 
   m_cellBaseLine = cellAscender;
   m_cellHeight   = cellAscender - cellDescender;
@@ -791,7 +792,8 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch)
   ch->top = isEmptyGlyph ? 0 : ((float)m_posY + ch->offsetY);
   ch->right = ch->left + bitmap.width;
   ch->bottom = ch->top + bitmap.rows;
-  ch->advance = (float)MathUtils::round_int( (float)m_face->glyph->advance.x / 64 );
+  ch->advance =
+      static_cast<float>(MathUtils::round_int(static_cast<double>(m_face->glyph->advance.x) / 64));
 
   // we need only render if we actually have some pixels
   if (!isEmptyGlyph)
@@ -857,10 +859,10 @@ void CGUIFontTTF::RenderCharacter(float posX,
     // altering the width of thin characters substantially.  This only really works for positive
     // coordinates (due to the direction of truncation for negatives) but this is the only case that
     // really interests us anyway.
-    float rx0 = (float)MathUtils::round_int(x[0]);
-    float rx3 = (float)MathUtils::round_int(x[3]);
-    x[1] = (float)MathUtils::truncate_int(x[1]);
-    x[2] = (float)MathUtils::truncate_int(x[2]);
+    float rx0 = static_cast<float>(MathUtils::round_int(static_cast<double>(x[0])));
+    float rx3 = static_cast<float>(MathUtils::round_int(static_cast<double>(x[3])));
+    x[1] = static_cast<float>(MathUtils::truncate_int(static_cast<double>(x[1])));
+    x[2] = static_cast<float>(MathUtils::truncate_int(static_cast<double>(x[2])));
     if (x[0] > 0.0f && rx0 > x[0])
       x[1] += 1;
     else if (x[0] < 0.0f && rx0 < x[0])
@@ -873,15 +875,23 @@ void CGUIFontTTF::RenderCharacter(float posX,
     x[3] = rx3;
   }
 
-  y[0] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x1, vertex.y1));
-  y[1] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x2, vertex.y1));
-  y[2] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x2, vertex.y2));
-  y[3] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x1, vertex.y2));
+  y[0] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x1, vertex.y1))));
+  y[1] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x2, vertex.y1))));
+  y[2] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x2, vertex.y2))));
+  y[3] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x1, vertex.y2))));
 
-  z[0] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x1, vertex.y1));
-  z[1] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x2, vertex.y1));
-  z[2] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x2, vertex.y2));
-  z[3] = (float)MathUtils::round_int(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x1, vertex.y2));
+  z[0] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x1, vertex.y1))));
+  z[1] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x2, vertex.y1))));
+  z[2] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x2, vertex.y2))));
+  z[3] = static_cast<float>(MathUtils::round_int(static_cast<double>(
+      CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalZCoord(vertex.x1, vertex.y2))));
 
   // tex coords converted to 0..1 range
   float tl = texture.x1 * m_textureScaleX;

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -57,7 +57,7 @@ bool CGUIListContainer::OnAction(const CAction &action)
     {
       m_analogScrollCount += action.GetAmount() * action.GetAmount();
       bool handled = false;
-      while (m_analogScrollCount > 0.4)
+      while (m_analogScrollCount > 0.4f)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;
@@ -77,7 +77,7 @@ bool CGUIListContainer::OnAction(const CAction &action)
     {
       m_analogScrollCount += action.GetAmount() * action.GetAmount();
       bool handled = false;
-      while (m_analogScrollCount > 0.4)
+      while (m_analogScrollCount > 0.4f)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -348,7 +348,7 @@ void CGUISliderControl::Move(int iNumSteps)
 void CGUISliderControl::SendClick()
 {
   float percent = 100*GetProportion();
-  SEND_CLICK_MESSAGE(GetID(), GetParentID(), MathUtils::round_int(percent));
+  SEND_CLICK_MESSAGE(GetID(), GetParentID(), MathUtils::round_int(static_cast<double>(percent)));
   if (m_action && (!m_dragging || m_action->fireOnDrag))
   {
     std::string action = StringUtils::Format(m_action->formatString, percent);
@@ -456,7 +456,7 @@ int CGUISliderControl::GetIntValue(RangeSelector selector /* = RangeSelectorLowe
   else if (m_iType == SLIDER_CONTROL_TYPE_INT)
     return m_intValues[selector];
   else
-    return MathUtils::round_int(m_percentValues[selector]);
+    return MathUtils::round_int(static_cast<double>(m_percentValues[selector]));
 }
 
 void CGUISliderControl::SetFloatValue(float fValue, RangeSelector selector /* = RangeSelectorLower */, bool updateCurrent /* = false */)
@@ -731,10 +731,10 @@ std::string CGUISliderControl::GetDescription() const
   else
   {
     if (m_rangeSelection)
-      description = StringUtils::Format("[{}%, {}%]", MathUtils::round_int(m_percentValues[0]),
-                                        MathUtils::round_int(m_percentValues[1]));
+      description = StringUtils::Format("[{}%, {}%]", MathUtils::round_int(static_cast<double>(m_percentValues[0])),
+                                        MathUtils::round_int(static_cast<double>(m_percentValues[1])));
     else
-      description = StringUtils::Format("{}%", MathUtils::round_int(m_percentValues[0]));
+      description = StringUtils::Format("{}%", MathUtils::round_int(static_cast<double>(m_percentValues[0])));
   }
   return description;
 }

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -185,7 +185,8 @@ void CGUITextBox::Process(unsigned int currentTime, CDirtyRegionList &dirtyregio
 
   if (m_pageControl)
   {
-    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, MathUtils::round_int(m_scrollOffset / m_itemHeight));
+    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl,
+                    MathUtils::round_int(static_cast<double>(m_scrollOffset / m_itemHeight)));
     SendWindowMessage(msg);
   }
 

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -243,7 +243,7 @@ void CGUITexture::Render(float left,
 
   float x[4], y[4], z[4];
 
-#define ROUND_TO_PIXEL(x) (float)(MathUtils::round_int(x))
+#define ROUND_TO_PIXEL(x) static_cast<float>(MathUtils::round_int(static_cast<double>(x)))
 
   x[0] = ROUND_TO_PIXEL(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalXCoord(vertex.x1, vertex.y1));
   y[0] = ROUND_TO_PIXEL(CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(vertex.x1, vertex.y1));

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -48,7 +48,7 @@ bool CGUIWrappingListContainer::OnAction(const CAction &action)
     {
       m_analogScrollCount += action.GetAmount() * action.GetAmount();
       bool handled = false;
-      while (m_analogScrollCount > 0.4)
+      while (m_analogScrollCount > 0.4f)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;
@@ -61,7 +61,7 @@ bool CGUIWrappingListContainer::OnAction(const CAction &action)
     {
       m_analogScrollCount += action.GetAmount() * action.GetAmount();
       bool handled = false;
-      while (m_analogScrollCount > 0.4)
+      while (m_analogScrollCount > 0.4f)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;

--- a/xbmc/guilib/Tween.h
+++ b/xbmc/guilib/Tween.h
@@ -34,7 +34,7 @@
 #include <math.h>
 
 #ifndef M_PI
-#define M_PI 3.14159265358979323846f
+#define M_PI 3.14159265358979323846
 #endif
 
 enum TweenerType
@@ -212,18 +212,18 @@ public:
     switch (m_tweenerType)
       {
       case EASE_IN:
-        return change * (1 - cos(time * M_PI / 2.0f)) + start;
+        return change * (1 - cos(time * static_cast<float>(M_PI) / 2.0f)) + start;
         break;
 
       case EASE_OUT:
-        return change * sin(time * M_PI / 2.0f) + start;
+        return change * sin(time * static_cast<float>(M_PI) / 2.0f) + start;
         break;
 
       case EASE_INOUT:
-        return change/2 * (1 - cos(M_PI * time)) + start;
+        return change / 2 * (1 - cos(static_cast<float>(M_PI) * time)) + start;
         break;
       }
-    return (change/2) * (1 - cos(M_PI * time)) + start;
+      return (change / 2) * (1 - cos(static_cast<float>(M_PI) * time)) + start;
   }
 };
 
@@ -257,15 +257,22 @@ protected:
   static float easeOut(float time, float start, float change, float duration)
   {
     time /= duration;
-    if (time < (1/2.75)) {
+    if (time < (1 / 2.75f))
+    {
       return  change * (7.5625f * time * time) + start;
-    } else if (time < (2/2.75)) {
+    }
+    else if (time < (2 / 2.75f))
+    {
       time -= (1.5f/2.75f);
       return change * (7.5625f * time * time + .75f) + start;
-    } else if (time < (2.5/2.75)) {
+    }
+    else if (time < (2.5f / 2.75f))
+    {
       time -= (2.25f/2.75f);
       return change * (7.5625f * time * time + .9375f) + start;
-    } else {
+    }
+    else
+    {
       time -= (2.625f/2.75f);
       return change * (7.5625f * time * time + .984375f) + start;
     }
@@ -320,10 +327,12 @@ protected:
     }
     else
     {
-      s = p / (2 * M_PI) * asin (change / a);
+      s = p / (2 * static_cast<float>(M_PI)) * asin(change / a);
     }
     time--;
-    return -(a * pow(2.0f, 10*time) * sin((time * duration - s) * (2 * M_PI) / p )) + start;
+    return -(a * pow(2.0f, 10 * time) *
+             sin((time * duration - s) * (2 * static_cast<float>(M_PI)) / p)) +
+           start;
   }
 
   float easeOut(float time, float start, float change, float duration) const
@@ -346,9 +355,11 @@ protected:
     }
     else
     {
-      s = p / (2 * M_PI) * asin (change / a);
+      s = p / (2 * static_cast<float>(M_PI)) * asin(change / a);
     }
-    return (a * pow(2.0f, -10*time) * sin((time * duration - s) * (2 * M_PI) / p )) + change + start;
+    return (a * pow(2.0f, -10 * time) *
+            sin((time * duration - s) * (2 * static_cast<float>(M_PI)) / p)) +
+           change + start;
   }
 
   float easeInOut(float time, float start, float change, float duration) const
@@ -371,16 +382,20 @@ protected:
     }
     else
     {
-      s = p / (2 * M_PI) * asin (change / a);
+      s = p / (2 * static_cast<float>(M_PI)) * asin(change / a);
     }
 
     if (time < 1)
     {
       time--;
-      return -.5f * (a * pow(2.0f, 10 * (time)) * sin((time * duration - s) * (2 * M_PI) / p )) + start;
+      return -.5f * (a * pow(2.0f, 10 * (time)) *
+                     sin((time * duration - s) * (2 * static_cast<float>(M_PI)) / p)) +
+             start;
     }
     time--;
-    return a * pow(2.0f, -10 * (time)) * sin((time * duration-s) * (2 * M_PI) / p ) * .5f + change + start;
+    return a * pow(2.0f, -10 * (time)) *
+               sin((time * duration - s) * (2 * static_cast<float>(M_PI)) / p) * .5f +
+           change + start;
   }
 };
 

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -223,7 +223,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case PLAYER_PLAYSPEED:
     {
       float speed = g_application.GetAppPlayer().GetPlaySpeed();
-      if (speed == 1.0)
+      if (speed == 1.0f)
         speed = g_application.GetAppPlayer().GetPlayTempo();
       value = StringUtils::Format("{:.2f}", speed);
       return true;
@@ -249,7 +249,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       int playTimeRemaining = GetPlayTimeRemaining();
       float speed = g_application.GetAppPlayer().GetPlaySpeed();
       float tempo = g_application.GetAppPlayer().GetPlayTempo();
-      if (speed == 1.0)
+      if (speed == 1.0f)
         playTimeRemaining /= tempo;
       time += CDateTimeSpan(0, 0, 0, playTimeRemaining);
       value = time.GetAsLocalizedTime(static_cast<TIME_FORMAT>(info.GetData1()));
@@ -258,7 +258,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case PLAYER_TIME_SPEED:
     {
       float speed = g_application.GetAppPlayer().GetPlaySpeed();
-      if (speed != 1.0)
+      if (speed != 1.0f)
         value = StringUtils::Format(
             "{} ({}x)", GetCurrentPlayTime(static_cast<TIME_FORMAT>(info.GetData1())).c_str(),
             static_cast<int>(speed));
@@ -433,16 +433,16 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = g_application.GetAppPlayer().IsPlayingGame();
       return true;
     case PLAYER_PLAYING:
-      value = g_application.GetAppPlayer().GetPlaySpeed() == 1.0;
+      value = g_application.GetAppPlayer().GetPlaySpeed() == 1.0f;
       return true;
     case PLAYER_PAUSED:
       value = g_application.GetAppPlayer().IsPausedPlayback();
       return true;
     case PLAYER_REWINDING:
-      value = g_application.GetAppPlayer().GetPlaySpeed() < 0;
+      value = g_application.GetAppPlayer().GetPlaySpeed() < 0.0f;
       return true;
     case PLAYER_FORWARDING:
-      value = g_application.GetAppPlayer().GetPlaySpeed() > 1.5;
+      value = g_application.GetAppPlayer().GetPlaySpeed() > 1.5f;
       return true;
     case PLAYER_REWINDING_2x:
       value = g_application.GetAppPlayer().GetPlaySpeed() == -2;
@@ -485,8 +485,8 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       return true;
     case PLAYER_IS_TEMPO:
     {
-      value = (g_application.GetAppPlayer().GetPlayTempo() != 1.0 &&
-               g_application.GetAppPlayer().GetPlaySpeed() == 1.0);
+      value = (g_application.GetAppPlayer().GetPlayTempo() != 1.0f &&
+               g_application.GetAppPlayer().GetPlaySpeed() == 1.0f);
       return true;
     }
     case PLAYER_CACHING:

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -249,13 +249,14 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       return true;
 #endif
     case SYSTEM_ALARM_POS:
-      if (g_alarmClock.GetRemaining("shutdowntimer") == 0.f)
+      if (g_alarmClock.GetRemaining("shutdowntimer") == 0.0)
         value.clear();
       else
       {
         double fTime = g_alarmClock.GetRemaining("shutdowntimer");
-        if (fTime > 60.f)
-          value = StringUtils::Format(g_localizeStrings.Get(13213).c_str(), g_alarmClock.GetRemaining("shutdowntimer")/60.f);
+        if (fTime > 60.0)
+          value = StringUtils::Format(g_localizeStrings.Get(13213).c_str(),
+                                      g_alarmClock.GetRemaining("shutdowntimer") / 60.0);
         else
           value = StringUtils::Format(g_localizeStrings.Get(13214).c_str(), g_alarmClock.GetRemaining("shutdowntimer"));
       }

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -44,7 +44,8 @@ int CVideoGUIInfo::GetPercentPlayed(const CVideoInfoTag* tag) const
 {
   CBookmark bookmark = tag->GetResumePoint();
   if (bookmark.IsPartWay())
-    return std::lrintf(static_cast<float>(bookmark.timeInSeconds) / bookmark.totalTimeInSeconds * 100.0f);
+    return std::lrintf(static_cast<float>(bookmark.timeInSeconds) /
+                       static_cast<float>(bookmark.totalTimeInSeconds) * 100.0f);
   else
     return 0;
 }
@@ -347,8 +348,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         break;
       case LISTITEM_PLOT:
         {
-          std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>( 
-            CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
+          std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(
+              CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
+                  CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
           if (tag->m_type != MediaTypeTvShow && tag->m_type != MediaTypeVideoCollection &&
               tag->GetPlayCount() == 0 && setting &&
               ((tag->m_type == MediaTypeMovie &&

--- a/xbmc/interfaces/builtins/PVRBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PVRBuiltins.cpp
@@ -70,7 +70,9 @@ static int SeekPercentage(const std::vector<std::string>& params)
       int iTimeshiftBufferStart = 0;
       infoMgr.GetInt(iTimeshiftBufferStart, PVR_TIMESHIFT_PROGRESS_BUFFER_START);
 
-      float fPlayerPercentage = static_cast<float>(iTimeshiftProgressDuration) / g_application.GetTotalTime() * (fTimeshiftPercentage - iTimeshiftBufferStart);
+      float fPlayerPercentage = static_cast<float>(iTimeshiftProgressDuration) /
+                                static_cast<float>(g_application.GetTotalTime()) *
+                                (fTimeshiftPercentage - static_cast<float>(iTimeshiftBufferStart));
       fPlayerPercentage = std::max(0.0f, std::min(fPlayerPercentage, 100.0f));
 
       g_application.SeekPercentage(fPlayerPercentage);

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -136,7 +136,7 @@ namespace XBMCAddon
 
     double InfoTagVideo::getRating()
     {
-      return infoTag->GetRating().rating;
+      return static_cast<double>(infoTag->GetRating().rating);
     }
 
     int InfoTagVideo::getUserRating()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -221,13 +221,13 @@ namespace XBMCAddon
       else if (lowerKey == "totaltime")
       {
         CBookmark resumePoint(GetVideoInfoTag()->GetResumePoint());
-        resumePoint.totalTimeInSeconds = static_cast<float>(atof(value.c_str()));
+        resumePoint.totalTimeInSeconds = atof(value.c_str());
         GetVideoInfoTag()->SetResumePoint(resumePoint);
       }
       else if (lowerKey == "resumetime")
       {
         CBookmark resumePoint(GetVideoInfoTag()->GetResumePoint());
-        resumePoint.timeInSeconds = static_cast<float>(atof(value.c_str()));
+        resumePoint.timeInSeconds = atof(value.c_str());
         GetVideoInfoTag()->SetResumePoint(resumePoint);
       }
       else if (lowerKey == "specialsort")

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -516,7 +516,7 @@ bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
       strReleaseDate = StringUtils::Format("{:04}", year);
   }
   XMLUtils::GetString(album, "originalreleasedate", strOrigReleaseDate);
-  
+
   const TiXmlElement* rElement = album->FirstChildElement("rating");
   if (rElement)
   {
@@ -539,7 +539,7 @@ bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
       rating *= (10.f / max_rating); // Normalise the Rating to between 0 and 10
     if (rating > 10.f)
       rating = 10.f;
-    iUserrating = MathUtils::round_int(rating);
+    iUserrating = MathUtils::round_int(static_cast<double>(rating));
   }
   XMLUtils::GetInt(album, "votes", iVotes);
 
@@ -655,7 +655,7 @@ bool CAlbum::Save(TiXmlNode *node, const std::string &tag, const std::string& st
     userrating->ToElement()->SetAttribute("max", 10);
 
   XMLUtils::SetInt(album,           "votes", iVotes);
-  
+
   for (const auto& artistCredit : artistCredits)
   {
     // add an <albumArtistCredits> tag

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1110,12 +1110,12 @@ int CMusicDatabase::AddSong(const int idSong,
         strSQL += PrepareSQL(",%i,%i,%i,'%s', %.1f, %i, %i, '%s','%s', '%s')", //
                              iTimesPlayed, iStartOffset, iEndOffset,
                              dtLastPlayed.GetAsDBDateTime().c_str(), //
-                             rating, userrating, votes, //
+                             static_cast<double>(rating), userrating, votes, //
                              strComment.c_str(), strMood.c_str(), replayGain.Get().c_str());
       else
         strSQL += PrepareSQL(",%i,%i,%i,NULL, %.1f, %i, %i,'%s', '%s', '%s')", //
                              iTimesPlayed, iStartOffset, iEndOffset, //
-                             rating, userrating, votes, //
+                             static_cast<double>(rating), userrating, votes, //
                              strComment.c_str(), strMood.c_str(), replayGain.Get().c_str());
       m_pDS->exec(strSQL);
       if (idSong <= 0)
@@ -1340,8 +1340,8 @@ int CMusicDatabase::UpdateSong(int idSong,
 
   strSQL += PrepareSQL(", iStartOffset = %i, iEndOffset = %i, rating = %.1f, userrating = %i, "
                        "votes = %i, comment = '%s', mood = '%s', strReplayGain = '%s' ",
-                       iStartOffset, iEndOffset, rating, userrating, votes, strComment.c_str(),
-                       strMood.c_str(), replayGain.Get().c_str());
+                       iStartOffset, iEndOffset, static_cast<double>(rating), userrating, votes,
+                       strComment.c_str(), strMood.c_str(), replayGain.Get().c_str());
 
   if (dtLastPlayed.IsValid())
     strSQL += PrepareSQL(", iTimesPlayed = %i, lastplayed = '%s' ", iTimesPlayed,
@@ -1529,7 +1529,7 @@ int CMusicDatabase::UpdateAlbum(int idAlbum,
                       strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(), //
                       strMoods.c_str(), strStyles.c_str(), strThemes.c_str(), //
                       strReview.c_str(), strImageURLs.c_str(), strLabel.c_str(), //
-                      strType.c_str(), fRating, iUserrating, iVotes, //
+                      strType.c_str(), static_cast<double>(fRating), iUserrating, iVotes, //
                       strReleaseDate.c_str(), strOrigReleaseDate.c_str(), //
                       bBoxedSet, bCompilation, //
                       CAlbum::ReleaseTypeToString(releaseType).c_str(), strReleaseStatus.c_str(), //
@@ -12374,7 +12374,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
             rating *= (10.f / max_rating); // Normalise the value to between 0 and 10
           if (rating > 10.f)
             rating = 10.f;
-          iUserrating = MathUtils::round_int(rating);
+          iUserrating = MathUtils::round_int(static_cast<double>(rating));
         }
 
         strSQLSong = PrepareSQL("(%d, %d, ", current + 1, iTrack);
@@ -12394,7 +12394,8 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
           strSQLSong += PrepareSQL("NULL, ");
         else
           strSQLSong += PrepareSQL("'%s', ", lastplayed.c_str());
-        strSQLSong += PrepareSQL("%.1f, %d, %d, -1, -1)", fRating, iVotes, iUserrating);
+        strSQLSong +=
+            PrepareSQL("%.1f, %d, %d, -1, -1)", static_cast<double>(fRating), iVotes, iUserrating);
 
         if (current > 0)
           strSQLSong = ", " + strSQLSong;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1089,7 +1089,7 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const std::string &p
   if (albums.size() == 1)
   {
     CFileItem album(path, true);
-    /* 
+    /*
      If we are scanning a directory served over http(s) the root directory for an album will set
      IsInternetStream to true which prevents scanning it for art.  As we can't reach this point
      without having read some tags (and tags are not read from streams) we can safely check for
@@ -1335,7 +1335,7 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
     bool overridetags = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_OVERRIDETAGS);
     // Remove art accidentally set by the Python scraper, it only provides URLs of possible artwork
     // Art is selected later applying whitelist and other art preferences
-    albumInfo.GetAlbum().art.clear(); 
+    albumInfo.GetAlbum().art.clear();
     album.MergeScrapedAlbum(albumInfo.GetAlbum(), overridetags);
     m_musicDatabase.UpdateAlbum(album);
     albumInfo.SetLoaded(true);
@@ -1553,7 +1553,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
     if (scraper.Succeeded() && scraper.GetAlbumCount() >= 1)
     {
       double bestRelevance = 0;
-      double minRelevance = THRESHOLD;
+      double minRelevance = static_cast<double>(THRESHOLD);
       if (pDialog || scraper.GetAlbumCount() > 1) // score the matches
       {
         //show dialog with all albums found
@@ -1570,7 +1570,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
         for (int i = 0; i < scraper.GetAlbumCount(); ++i)
         {
           CMusicAlbumInfo& info = scraper.GetAlbum(i);
-          double relevance = info.GetRelevance();
+          double relevance = static_cast<double>(info.GetRelevance());
           if (relevance < 0)
             relevance = CUtil::AlbumRelevance(info.GetAlbum().strAlbum, album.strAlbum,
                         info.GetAlbum().GetAlbumArtistString(),
@@ -1606,7 +1606,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
 
             items.Add(item);
           }
-          if (!pDialog && relevance > .999f) // we're so close, no reason to search further
+          if (!pDialog && relevance > 0.999) // we're so close, no reason to search further
             break;
         }
 
@@ -1649,13 +1649,13 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
       else
       {
         CMusicAlbumInfo& info = scraper.GetAlbum(0);
-        double relevance = info.GetRelevance();
+        double relevance = static_cast<double>(info.GetRelevance());
         if (relevance < 0)
           relevance = CUtil::AlbumRelevance(info.GetAlbum().strAlbum,
                                             album.strAlbum,
                                             info.GetAlbum().GetAlbumArtistString(),
                                             album.GetAlbumArtistString());
-        if (relevance < THRESHOLD)
+        if (relevance < static_cast<double>(THRESHOLD))
           return INFO_NOT_FOUND;
 
         iSelectedAlbum = 0;

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -797,7 +797,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
   else if (uri == "/rate")
   {
       const char* found = strstr(queryString.c_str(), "value=");
-      int rate = found ? (int)(atof(found + strlen("value=")) + 0.5f) : 0;
+      int rate = found ? (int)(atof(found + strlen("value=")) + 0.5) : 0;
 
       CLog::Log(LOGDEBUG, "AIRPLAY: got request %s with rate %i", uri.c_str(), rate);
 

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -422,7 +422,7 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
         std::list<CEventButtonState>::iterator it2 = (++it).base();
 
         /* if last event had an amount, we must resend without amount */
-        if(it2->m_bUseAmount && it2->m_fAmount != 0.0)
+        if (it2->m_bUseAmount && it2->m_fAmount != 0.0f)
         {
           m_buttonQueue.push_back(state);
         }
@@ -445,7 +445,7 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
       else if(active && !it->m_bActive)
       {
         m_buttonQueue.push_back(state);
-        if(!state.m_bRepeat && state.m_bAxis && state.m_fAmount != 0.0)
+        if (!state.m_bRepeat && state.m_bAxis && state.m_fAmount != 0.0f)
         {
           state.m_bActive = false;
           state.m_bRepeat = false;
@@ -476,7 +476,7 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
     {
       /* when a button is released that had amount, make sure *
        * to resend the keypress with an amount of 0           */
-      if((flags & PTB_USE_AMOUNT) && m_currentButton.m_fAmount > 0.0)
+      if ((flags & PTB_USE_AMOUNT) && m_currentButton.m_fAmount > 0.0f)
       {
         CEventButtonState state( m_currentButton.m_iKeyCode,
                                  m_currentButton.m_mapName,

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -422,8 +422,8 @@ bool CPeripheral::SetSetting(const std::string& strKey, float fValue)
         std::static_pointer_cast<CSettingNumber>((*it).second.m_setting);
     if (floatSetting)
     {
-      bChanged = floatSetting->GetValue() != fValue;
-      floatSetting->SetValue(fValue);
+      bChanged = floatSetting->GetValue() != static_cast<double>(fValue);
+      floatSetting->SetValue(static_cast<double>(fValue));
       if (bChanged && m_bInitialised)
         m_changedSettings.insert(strKey);
     }

--- a/xbmc/pictures/ExifParse.cpp
+++ b/xbmc/pictures/ExifParse.cpp
@@ -815,9 +815,10 @@ bool CExifParse::Process (const unsigned char* const ExifSection, const unsigned
     {
       // Compute 35 mm equivalent focal length based on sensor geometry if we haven't
       // already got it explicitly from a tag.
-      if (m_ExifInfo->CCDWidth != 0.0)
+      if (m_ExifInfo->CCDWidth != 0.0f)
       {
-        m_ExifInfo->FocalLength35mmEquiv = (int)(m_ExifInfo->FocalLength/m_ExifInfo->CCDWidth*36 + 0.5);
+        m_ExifInfo->FocalLength35mmEquiv =
+            (int)(m_ExifInfo->FocalLength / m_ExifInfo->CCDWidth * 36 + 0.5f);
       }
     }
   }
@@ -936,7 +937,7 @@ void CExifParse::ProcessGpsInfo(
       case TAG_GPS_ALT:
         {
           char temp[18];
-          sprintf(temp, "%.2fm", static_cast<float>(ConvertAnyFormat(ValuePtr, Format)));
+          sprintf(temp, "%.2fm", static_cast<double>(ConvertAnyFormat(ValuePtr, Format)));
           strcat(m_ExifInfo->GpsAlt, temp);
         }
       break;

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -493,8 +493,8 @@ const std::string CPictureInfoTag::GetInfo(int info) const
         value = StringUtils::Format("{:6.4f}s", m_exifInfo.ExposureTime);
       else
         value = StringUtils::Format("{:5.3f}s", m_exifInfo.ExposureTime);
-      if (m_exifInfo.ExposureTime <= 0.5)
-        value += StringUtils::Format(" (1/{})", (int)(0.5 + 1 / m_exifInfo.ExposureTime));
+      if (m_exifInfo.ExposureTime <= 0.5f)
+        value += StringUtils::Format(" (1/{})", static_cast<int>(0.5f + 1 / m_exifInfo.ExposureTime));
     }
     break;
   case SLIDESHOW_EXIF_EXPOSURE_BIAS:

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -139,7 +139,7 @@ void CSlideShowPic::SetTexture_Internal(int iSlideNumber,
   // initialize our display effect
   if (dispEffect == EFFECT_RANDOM)
   {
-    if (((m_fWidth / m_fHeight) > 1.9) || ((m_fHeight / m_fWidth) > 1.9))
+    if (((m_fWidth / m_fHeight) > 1.9f) || ((m_fHeight / m_fWidth) > 1.9f))
       m_displayEffect = EFFECT_PANORAMA;
     else
       m_displayEffect = (DISPLAY_EFFECT)((rand() % (EFFECT_RANDOM - 1)) + 1);
@@ -329,7 +329,7 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
           int i;
           for (i = 0; i < 10; i++)
           {
-            if (fabs(m_fZoomAmount - zoomamount[i]) < 0.01*zoomamount[i])
+            if (fabs(m_fZoomAmount - zoomamount[i]) < 0.01f * zoomamount[i])
             {
               m_fZoomAmount = zoomamount[i];
               break;
@@ -448,8 +448,8 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
   // Rotate the image as needed
   float x[4];
   float y[4];
-  float si = (float)sin(m_fAngle / 180.0f * M_PI);
-  float co = (float)cos(m_fAngle / 180.0f * M_PI);
+  float si = sin(m_fAngle / 180.0f * static_cast<float>(M_PI));
+  float co = cos(m_fAngle / 180.0f * static_cast<float>(M_PI));
   x[0] = -m_fWidth * co + m_fHeight * si;
   y[0] = -m_fWidth * si - m_fHeight * co;
   x[1] = m_fWidth * co + m_fHeight * si;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -553,10 +553,10 @@ void CXBMCApp::SetRefreshRateCallback(CVariant* rateVariant)
   if (window)
   {
     CJNIWindowManagerLayoutParams params = window.getAttributes();
-    if (fabs(params.getpreferredRefreshRate() - rate) > 0.001)
+    if (fabs(params.getpreferredRefreshRate() - rate) > 0.001f)
     {
       params.setpreferredRefreshRate(rate);
-      if (params.getpreferredRefreshRate() > 0.0)
+      if (params.getpreferredRefreshRate() > 0.0f)
       {
         window.setAttributes(params);
         return;
@@ -589,14 +589,14 @@ void CXBMCApp::SetDisplayModeCallback(CVariant* variant)
 
 void CXBMCApp::SetRefreshRate(float rate)
 {
-  if (rate < 1.0)
+  if (rate < 1.0f)
     return;
 
   CJNIWindow window = getWindow();
   if (window)
   {
     CJNIWindowManagerLayoutParams params = window.getAttributes();
-    if (fabs(params.getpreferredRefreshRate() - rate) <= 0.001)
+    if (fabs(params.getpreferredRefreshRate() - rate) <= 0.001f)
       return;
   }
 

--- a/xbmc/platform/darwin/ios-common/peripherals/Input_Gamecontroller.mm
+++ b/xbmc/platform/darwin/ios-common/peripherals/Input_Gamecontroller.mm
@@ -679,7 +679,7 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_Y
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_Y)];
 
-        message = [message stringByAppendingFormat:@" Up %f", 0.0f];
+        message = [message stringByAppendingFormat:@" Up %f", 0.0];
         [cbmanager SetAxisEvent:newReleaseEvent];
       }
       else
@@ -699,7 +699,8 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_Y
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_Y)];
 
-        message = [message stringByAppendingFormat:@" Up %f", thumbstick.yAxis.value];
+        message = [message
+            stringByAppendingFormat:@" Up %f", static_cast<double>(thumbstick.yAxis.value)];
         [cbmanager SetAxisEvent:*event];
       }
     }
@@ -725,7 +726,7 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_Y
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_Y)];
 
-        message = [message stringByAppendingFormat:@" Down %f", 0.0f];
+        message = [message stringByAppendingFormat:@" Down %f", 0.0];
         [cbmanager SetAxisEvent:newReleaseEvent];
       }
       else
@@ -745,7 +746,8 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_Y
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_Y)];
 
-        message = [message stringByAppendingFormat:@" Down %f", thumbstick.yAxis.value];
+        message = [message
+            stringByAppendingFormat:@" Down %f", static_cast<double>(thumbstick.yAxis.value)];
         [cbmanager SetAxisEvent:*event];
       }
     }
@@ -771,7 +773,7 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_X
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_X)];
 
-        message = [message stringByAppendingFormat:@" Left %f", 0.0f];
+        message = [message stringByAppendingFormat:@" Left %f", 0.0];
         [cbmanager SetAxisEvent:newReleaseEvent];
       }
       else
@@ -791,7 +793,8 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_X
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_X)];
 
-        message = [message stringByAppendingFormat:@" Left %f", thumbstick.xAxis.value];
+        message = [message
+            stringByAppendingFormat:@" Left %f", static_cast<double>(thumbstick.xAxis.value)];
         [cbmanager SetAxisEvent:*event];
       }
     }
@@ -817,7 +820,7 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_X
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_X)];
 
-        message = [message stringByAppendingFormat:@" Right %f", 0.0f];
+        message = [message stringByAppendingFormat:@" Right %f", 0.0];
         [cbmanager SetAxisEvent:newReleaseEvent];
       }
       else
@@ -837,7 +840,8 @@ struct PlayerControllerState
                                 ? GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHTTHUMB_X
                                 : GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::LEFTTHUMB_X)];
 
-        message = [message stringByAppendingFormat:@" Right %f", thumbstick.xAxis.value];
+        message = [message
+            stringByAppendingFormat:@" Right %f", static_cast<double>(thumbstick.xAxis.value)];
         [cbmanager SetAxisEvent:*event];
       }
     }

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -867,7 +867,7 @@ public:
       break;
   }
   // reset the rotation of the view
-  view.layer.transform = CATransform3DMakeRotation(angle, 0, 0.0, 1.0);
+  view.layer.transform = CATransform3DMakeRotation(static_cast<double>(angle), 0, 0.0, 1.0);
   view.layer.bounds = view.bounds;
   m_window.screen = screen;
   [view setFrame:m_window.frame];

--- a/xbmc/platform/darwin/osx/OSXTextInputResponder.mm
+++ b/xbmc/platform/darwin/osx/OSXTextInputResponder.mm
@@ -148,7 +148,7 @@ void SendEditingText(const char *text, unsigned int location, unsigned int lengt
 
   NSWindow *window = [self window];
   NSRect contentRect = [window contentRectForFrameRect: [window frame]];
-  float windowHeight = contentRect.size.height;
+  double windowHeight = contentRect.size.height;
   NSRect rect = NSMakeRect(_inputRect.origin.x, windowHeight - _inputRect.origin.y - _inputRect.size.height,
                            _inputRect.size.width, _inputRect.size.height);
 

--- a/xbmc/platform/darwin/tvos/input/LibInputTouch.mm
+++ b/xbmc/platform/darwin/tvos/input/LibInputTouch.mm
@@ -409,8 +409,8 @@
     static UIPanGestureRecognizerDirection direction = UIPanGestureRecognizerDirectionUndefined;
     // speed       == how many clicks full swipe will give us(1000x1000px)
     // minVelocity == min velocity to trigger fast scroll, add this to settings?
-    float speed = 240.0f;
-    float minVelocity = 1300.0f;
+    double speed = 240.0;
+    double minVelocity = 1300.0;
     switch (sender.state)
     {
 

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -352,7 +352,7 @@ float CCPUInfoLinux::GetCPUFrequency()
     return 0;
 
   CSysfsPath path{m_freqPath};
-  return path.Get<float>() / 1000.0;
+  return path.Get<float>() / 1000.0f;
 }
 
 bool CCPUInfoLinux::GetTemperature(CTemperature& temperature)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -224,9 +224,11 @@ void CGUIEPGGridContainer::Process(unsigned int currentTime, CDirtyRegionList& d
 
   if (m_pageControl)
   {
-    int iItem = (m_orientation == VERTICAL)
-      ? MathUtils::round_int(m_channelScrollOffset / m_channelHeight)
-      : MathUtils::round_int(m_programmeScrollOffset / (m_gridHeight / m_blocksPerPage));
+    int iItem =
+        (m_orientation == VERTICAL)
+            ? MathUtils::round_int(static_cast<double>(m_channelScrollOffset / m_channelHeight))
+            : MathUtils::round_int(
+                  static_cast<double>(m_programmeScrollOffset / (m_gridHeight / m_blocksPerPage)));
 
     CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, iItem);
     SendWindowMessage(msg);
@@ -542,7 +544,7 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
 
-        while (m_analogScrollCount > 0.4)
+        while (m_analogScrollCount > 0.4f)
         {
           handled = true;
           m_analogScrollCount -= 0.4f;
@@ -561,7 +563,7 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
 
-        while (m_analogScrollCount > 0.4)
+        while (m_analogScrollCount > 0.4f)
         {
           handled = true;
           m_analogScrollCount -= 0.4f;
@@ -585,7 +587,7 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
 
-        while (m_analogScrollCount > 0.4)
+        while (m_analogScrollCount > 0.4f)
         {
           handled = true;
           m_analogScrollCount -= 0.4f;
@@ -606,7 +608,7 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
 
-        while (m_analogScrollCount > 0.4)
+        while (m_analogScrollCount > 0.4f)
         {
           handled = true;
           m_analogScrollCount -= 0.4f;
@@ -859,7 +861,8 @@ float CGUIEPGGridContainer::GetProgrammeScrollOffsetPos() const
 int CGUIEPGGridContainer::GetChannelScrollOffset(CGUIListItemLayout* layout) const
 {
   if (m_bEnableChannelScrolling)
-    return MathUtils::round_int(m_channelScrollOffset / layout->Size(m_orientation));
+    return MathUtils::round_int(
+        static_cast<double>(m_channelScrollOffset / layout->Size(m_orientation)));
   else
     return m_channelOffset;
 }
@@ -867,7 +870,7 @@ int CGUIEPGGridContainer::GetChannelScrollOffset(CGUIListItemLayout* layout) con
 int CGUIEPGGridContainer::GetProgrammeScrollOffset() const
 {
   if (m_bEnableProgrammeScrolling)
-    return MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
+    return MathUtils::round_int(static_cast<double>(m_programmeScrollOffset / m_blockSize));
   else
     return m_blockOffset;
 }
@@ -1269,9 +1272,11 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point, const CMous
       // we're done with exclusive access
       CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, 0, GetParentID());
       SendWindowMessage(msg);
-      ScrollToChannelOffset(MathUtils::round_int(m_channelScrollOffset / m_channelLayout->Size(m_orientation)));
+      ScrollToChannelOffset(MathUtils::round_int(
+          static_cast<double>(m_channelScrollOffset / m_channelLayout->Size(m_orientation))));
       SetChannel(m_channelCursor);
-      ScrollToBlockOffset(MathUtils::round_int(m_programmeScrollOffset / m_blockSize));
+      ScrollToBlockOffset(
+          MathUtils::round_int(static_cast<double>(m_programmeScrollOffset / m_blockSize)));
       SetBlock(m_blockCursor);
       return EVENT_RESULT_HANDLED;
     }
@@ -1283,8 +1288,10 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point, const CMous
       {
         CSingleLock lock(m_critSection);
 
-        m_channelOffset = MathUtils::round_int(m_channelScrollOffset / m_channelLayout->Size(m_orientation));
-        m_blockOffset = MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
+        m_channelOffset = MathUtils::round_int(
+            static_cast<double>(m_channelScrollOffset / m_channelLayout->Size(m_orientation)));
+        m_blockOffset =
+            MathUtils::round_int(static_cast<double>(m_programmeScrollOffset / m_blockSize));
         ValidateOffset();
       }
       return EVENT_RESULT_HANDLED;
@@ -2506,8 +2513,8 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
         // increment our X position
         posA2 += m_gridModel->GetGridItemWidth(
             channel, block); // assumes focused & unfocused layouts have equal length
-        block +=
-            MathUtils::round_int(m_gridModel->GetGridItemOriginWidth(channel, block) / m_blockSize);
+        block += MathUtils::round_int(
+            static_cast<double>(m_gridModel->GetGridItemOriginWidth(channel, block) / m_blockSize));
       }
     }
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
@@ -111,7 +111,7 @@ void CPVRGUITimesInfo::UpdateTimeshiftData()
   time_t iStartTime;
   int64_t iPlayTime, iMinTime, iMaxTime;
   CServiceBroker::GetDataCacheCore().GetPlayTimes(iStartTime, iPlayTime, iMinTime, iMaxTime);
-  bool bPlaying = CServiceBroker::GetDataCacheCore().GetSpeed() == 1.0;
+  bool bPlaying = CServiceBroker::GetDataCacheCore().GetSpeed() == 1.0f;
   const std::shared_ptr<CPVRChannel> playingChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
 
   CSingleLock lock(m_critSection);

--- a/xbmc/rendering/MatrixGL.cpp
+++ b/xbmc/rendering/MatrixGL.cpp
@@ -106,7 +106,7 @@ void CMatrixGL::Scalef(GLfloat x, GLfloat y, GLfloat z)
 void CMatrixGL::Rotatef(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
 {
   GLfloat modulus = std::sqrt((x*x)+(y*y)+(z*z));
-  if (modulus != 0.0)
+  if (modulus != 0.0f)
   {
     x /= modulus;
     y /= modulus;
@@ -176,7 +176,7 @@ void CMatrixGL::LookAt(GLfloat eyex, GLfloat eyey, GLfloat eyez, GLfloat centerx
   up[2] = upz;
 
   GLfloat tmp = std::sqrt(forward[0]*forward[0] + forward[1]*forward[1] + forward[2]*forward[2]);
-  if (tmp != 0.0)
+  if (tmp != 0.0f)
   {
     forward[0] /= tmp;
     forward[1] /= tmp;
@@ -188,7 +188,7 @@ void CMatrixGL::LookAt(GLfloat eyex, GLfloat eyey, GLfloat eyez, GLfloat centerx
   side[2] = forward[0]*up[1] - forward[1]*up[0];
 
   tmp = std::sqrt(side[0]*side[0] + side[1]*side[1] + side[2]*side[2]);
-  if (tmp != 0.0)
+  if (tmp != 0.0f)
   {
     side[0] /= tmp;
     side[1] /= tmp;
@@ -235,15 +235,15 @@ bool CMatrixGL::Project(GLfloat objx, GLfloat objy, GLfloat objz, const GLfloat 
   in[3]=1.0;
   __gluMultMatrixVecf(modelMatrix, in, out);
   __gluMultMatrixVecf(projMatrix, out, in);
-  if (in[3] == 0.0)
+  if (in[3] == 0.0f)
     return false;
   in[0] /= in[3];
   in[1] /= in[3];
   in[2] /= in[3];
   /* Map x, y and z to range 0-1 */
-  in[0] = in[0] * 0.5 + 0.5;
-  in[1] = in[1] * 0.5 + 0.5;
-  in[2] = in[2] * 0.5 + 0.5;
+  in[0] = in[0] * 0.5f + 0.5f;
+  in[1] = in[1] * 0.5f + 0.5f;
+  in[2] = in[2] * 0.5f + 0.5f;
 
   /* Map x,y to viewport */
   in[0] = in[0] * viewport[2] + viewport[0];

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -353,7 +353,7 @@ void CRenderSystemGL::SetCameraPosition(const CPoint &camera, int screenWidth, i
 
   glMatrixModview->LoadIdentity();
   glMatrixModview->Translatef(-(w + offset.x - stereoFactor), +(h + offset.y), 0);
-  glMatrixModview->LookAt(0.0, 0.0, -2.0*h, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0);
+  glMatrixModview->LookAt(0.0f, 0.0f, -2.0f * h, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f);
   glMatrixModview.Load();
 
   glMatrixProject->LoadIdentity();
@@ -454,10 +454,10 @@ void CRenderSystemGL::SetScissors(const CRect &rect)
 {
   if (!m_bRenderCreated)
     return;
-  GLint x1 = MathUtils::round_int(rect.x1);
-  GLint y1 = MathUtils::round_int(rect.y1);
-  GLint x2 = MathUtils::round_int(rect.x2);
-  GLint y2 = MathUtils::round_int(rect.y2);
+  GLint x1 = MathUtils::round_int(static_cast<double>(rect.x1));
+  GLint y1 = MathUtils::round_int(static_cast<double>(rect.y1));
+  GLint x2 = MathUtils::round_int(static_cast<double>(rect.x2));
+  GLint y2 = MathUtils::round_int(static_cast<double>(rect.y2));
   glScissor(x1, m_height - y2, x2-x1, y2-y1);
 }
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -288,7 +288,7 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
 
   glMatrixModview->LoadIdentity();
   glMatrixModview->Translatef(-(w + offset.x - stereoFactor), +(h + offset.y), 0);
-  glMatrixModview->LookAt(0.0, 0.0, -2.0*h, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0);
+  glMatrixModview->LookAt(0.0f, 0.0f, -2.0f * h, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f);
   glMatrixModview.Load();
 
   glMatrixProject->LoadIdentity();
@@ -363,10 +363,10 @@ void CRenderSystemGLES::SetScissors(const CRect &rect)
 {
   if (!m_bRenderCreated)
     return;
-  GLint x1 = MathUtils::round_int(rect.x1);
-  GLint y1 = MathUtils::round_int(rect.y1);
-  GLint x2 = MathUtils::round_int(rect.x2);
-  GLint y2 = MathUtils::round_int(rect.y2);
+  GLint x1 = MathUtils::round_int(static_cast<double>(rect.x1));
+  GLint y1 = MathUtils::round_int(static_cast<double>(rect.y1));
+  GLint x2 = MathUtils::round_int(static_cast<double>(rect.x2));
+  GLint y2 = MathUtils::round_int(static_cast<double>(rect.y2));
   glScissor(x1, m_height - y2, x2-x1, y2-y1);
 }
 

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -646,9 +646,9 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(
     return NULL;
 
   setting->SetControl(GetSpinnerControl("number", delayed, minimumLabel, formatLabel));
-  setting->SetMinimum(minimum);
-  setting->SetStep(step);
-  setting->SetMaximum(maximum);
+  setting->SetMinimum(static_cast<double>(minimum));
+  setting->SetStep(static_cast<double>(step));
+  setting->SetMaximum(static_cast<double>(maximum));
   setSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
@@ -679,9 +679,9 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(
     return NULL;
 
   setting->SetControl(GetSpinnerControl("number", delayed, minimumLabel, -1, formatString));
-  setting->SetMinimum(minimum);
-  setting->SetStep(step);
-  setting->SetMaximum(maximum);
+  setting->SetMinimum(static_cast<double>(minimum));
+  setting->SetStep(static_cast<double>(step));
+  setting->SetMaximum(static_cast<double>(maximum));
   setSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
@@ -1133,9 +1133,9 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(
     return NULL;
 
   setting->SetControl(GetSliderControl("number", delayed, heading, usePopup, formatLabel));
-  setting->SetMinimum(minimum);
-  setting->SetStep(step);
-  setting->SetMaximum(maximum);
+  setting->SetMinimum(static_cast<double>(minimum));
+  setting->SetStep(static_cast<double>(step));
+  setting->SetMaximum(static_cast<double>(maximum));
   setSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
@@ -1167,9 +1167,9 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(
     return NULL;
 
   setting->SetControl(GetSliderControl("number", delayed, heading, usePopup, -1, formatString));
-  setting->SetMinimum(minimum);
-  setting->SetStep(step);
-  setting->SetMaximum(maximum);
+  setting->SetMinimum(static_cast<double>(minimum));
+  setting->SetStep(static_cast<double>(step));
+  setting->SetMaximum(static_cast<double>(maximum));
   setSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
@@ -1439,9 +1439,9 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(
   if (settingDefinition == NULL)
     return NULL;
 
-  settingDefinition->SetMinimum(minimum);
-  settingDefinition->SetStep(step);
-  settingDefinition->SetMaximum(maximum);
+  settingDefinition->SetMinimum(static_cast<double>(minimum));
+  settingDefinition->SetStep(static_cast<double>(step));
+  settingDefinition->SetMaximum(static_cast<double>(maximum));
 
   std::shared_ptr<CSettingList> setting = std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
   if (setting == NULL)

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -1141,7 +1141,9 @@ CSettingNumber::CSettingNumber(const std::string& id,
                                int label,
                                float value,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingNumber"), m_value(value), m_default(value)
+  : CTraitedSetting(id, settingsManager, "CSettingNumber"),
+    m_value(static_cast<double>(value)),
+    m_default(static_cast<double>(value))
 {
   SetLabel(label);
 }
@@ -1154,11 +1156,11 @@ CSettingNumber::CSettingNumber(const std::string& id,
                                float maximum,
                                CSettingsManager* settingsManager /* = nullptr */)
   : CTraitedSetting(id, settingsManager, "CSettingNumber"),
-    m_value(value),
-    m_default(value),
-    m_min(minimum),
-    m_step(step),
-    m_max(maximum)
+    m_value(static_cast<double>(value)),
+    m_default(static_cast<double>(value)),
+    m_min(static_cast<double>(minimum)),
+    m_step(static_cast<double>(step)),
+    m_max(static_cast<double>(maximum))
 {
   SetLabel(label);
 }

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -438,7 +438,7 @@ bool CGUIControlSpinExSetting::OnClick()
       auto pSettingNumber = std::static_pointer_cast<CSettingNumber>(m_pSetting);
       const auto& controlFormat = m_pSetting->GetControl()->GetFormat();
       if (controlFormat == "number")
-        SetValid(pSettingNumber->SetValue(m_pSpin->GetFloatValue()));
+        SetValid(pSettingNumber->SetValue(static_cast<double>(m_pSpin->GetFloatValue())));
       else
         SetValid(pSettingNumber->SetValue(pSettingNumber->GetMinimum() +
                                           pSettingNumber->GetStep() * m_pSpin->GetValue()));
@@ -1362,7 +1362,7 @@ bool CGUIControlSliderSetting::OnClick()
 
     case SettingType::Number:
       SetValid(std::static_pointer_cast<CSettingNumber>(m_pSetting)
-                   ->SetValue(m_pSlider->GetFloatValue()));
+                   ->SetValue(static_cast<double>(m_pSlider->GetFloatValue())));
       break;
 
     default:
@@ -1407,7 +1407,7 @@ void CGUIControlSliderSetting::Update(bool fromControl, bool updateDisplayOnly)
           std::static_pointer_cast<CSettingNumber>(m_pSetting);
       double value;
       if (fromControl)
-        value = m_pSlider->GetFloatValue();
+        value = static_cast<double>(m_pSlider->GetFloatValue());
       else
       {
         value = std::static_pointer_cast<CSettingNumber>(m_pSetting)->GetValue();

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -35,7 +35,7 @@ void CAlarmClock::Start(const std::string& strName, float n_secs, const std::str
   StringUtils::ToLower(lowerName);
   Stop(lowerName);
   SAlarmClockEvent event;
-  event.m_fSecs = n_secs;
+  event.m_fSecs = static_cast<double>(n_secs);
   event.m_strCommand = strCommand;
   event.m_loop = bLoop;
   if (!m_bIsRunning)
@@ -94,15 +94,15 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
   if (iter->second.watch.IsRunning())
     elapsed = iter->second.watch.GetElapsedSeconds();
 
-  if (elapsed > iter->second.m_fSecs)
+  if (elapsed > static_cast<float>(iter->second.m_fSecs))
     strMessage = g_localizeStrings.Get(13211);
   else
   {
-    float remaining = static_cast<float>(iter->second.m_fSecs - elapsed);
+    float remaining = static_cast<float>(iter->second.m_fSecs) - elapsed;
     strMessage = StringUtils::Format(g_localizeStrings.Get(13212).c_str(), static_cast<int>(remaining) / 60, static_cast<int>(remaining) % 60);
   }
 
-  if (iter->second.m_strCommand.empty() || iter->second.m_fSecs > elapsed)
+  if (iter->second.m_strCommand.empty() || static_cast<float>(iter->second.m_fSecs) > elapsed)
   {
     EventPtr alarmClockActivity(new CNotificationEvent(labelAlarmClock, strMessage));
     if (bSilent)
@@ -132,8 +132,8 @@ void CAlarmClock::Process()
     {
       CSingleLock lock(m_events);
       for (std::map<std::string,SAlarmClockEvent>::iterator iter=m_event.begin();iter != m_event.end(); ++iter)
-        if ( iter->second.watch.IsRunning()
-          && iter->second.watch.GetElapsedSeconds() >= iter->second.m_fSecs)
+        if (iter->second.watch.IsRunning() &&
+            iter->second.watch.GetElapsedSeconds() >= static_cast<float>(iter->second.m_fSecs))
         {
           Stop(iter->first);
           if ((iter = m_event.find(strLast)) == m_event.end())

--- a/xbmc/utils/AlarmClock.h
+++ b/xbmc/utils/AlarmClock.h
@@ -48,10 +48,12 @@ public:
     std::map<std::string,SAlarmClockEvent>::iterator iter;
     if ((iter=m_event.find(strName)) != m_event.end())
     {
-      return iter->second.m_fSecs-(iter->second.watch.IsRunning() ? iter->second.watch.GetElapsedSeconds() : 0.f);
+      return iter->second.m_fSecs - static_cast<double>(iter->second.watch.IsRunning()
+                                                            ? iter->second.watch.GetElapsedSeconds()
+                                                            : 0.f);
     }
 
-    return 0.f;
+    return 0.0;
   }
 
   void Stop(const std::string& strName, bool bSilent = false);

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -118,7 +118,8 @@ namespace MathUtils
     int i;
 #if defined(HAVE_SSE2) && defined(__SSE2__)
     const float round_dn_to_nearest = 0.4999999f;
-    i = (x > 0) ? _mm_cvttsd_si32(_mm_set_sd(x + round_to_nearest)) : _mm_cvttsd_si32(_mm_set_sd(x - round_dn_to_nearest));
+    i = (x > 0) ? _mm_cvttsd_si32(_mm_set_sd(x + static_cast<double>(round_to_nearest)))
+                : _mm_cvttsd_si32(_mm_set_sd(x - static_cast<double>(round_dn_to_nearest)));
 
 #elif defined(TARGET_WINDOWS)
     __asm

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -117,7 +117,7 @@ void CSaveFileState::DoWork(CFileItem& item,
           if (!item.HasVideoInfoTag() ||
               item.GetVideoInfoTag()->GetResumePoint().timeInSeconds != bookmark.timeInSeconds)
           {
-            if (bookmark.timeInSeconds <= 0.0f)
+            if (bookmark.timeInSeconds <= 0.0)
               videodatabase.ClearBookMarksOfFile(progressTrackingFile, CBookmark::RESUME);
             else
               videodatabase.AddBookMarkToFile(progressTrackingFile, bookmark, CBookmark::RESUME);

--- a/xbmc/utils/Temperature.cpp
+++ b/xbmc/utils/Temperature.cpp
@@ -15,7 +15,7 @@
 
 CTemperature::CTemperature()
 {
-  m_value=0.0f;
+  m_value = 0.0;
   m_valid=false;
 }
 
@@ -338,33 +338,33 @@ CTemperature CTemperature::CreateFromFahrenheit(double value)
 
 CTemperature CTemperature::CreateFromReaumur(double value)
 {
-  return CTemperature(value*2.25f+32.0f);
+  return CTemperature(value * 2.25 + 32.0);
 }
 
 CTemperature CTemperature::CreateFromRankine(double value)
 {
-  return CTemperature(value-459.67f);
+  return CTemperature(value - 459.67);
 }
 
 CTemperature CTemperature::CreateFromRomer(double value)
 {
-  return CTemperature((value-7.5f)*24.0f/7.0f+32.0f);
+  return CTemperature((value - 7.5) * 24.0 / 7.0 + 32.0);
 }
 
 CTemperature CTemperature::CreateFromDelisle(double value)
 {
-  CTemperature temp(212.0f - value * 1.2f);
+  CTemperature temp(212.0 - value * 1.2);
   return temp;
 }
 
 CTemperature CTemperature::CreateFromNewton(double value)
 {
-  return CTemperature(value*60.0f/11.0f+32.0f);
+  return CTemperature(value * 60.0 / 11.0 + 32.0);
 }
 
 CTemperature CTemperature::CreateFromCelsius(double value)
 {
-  return CTemperature(value*1.8f+32.0f);
+  return CTemperature(value * 1.8 + 32.0);
 }
 
 CTemperature CTemperature::CreateFromKelvin(double value)
@@ -398,37 +398,37 @@ double CTemperature::ToFahrenheit() const
 
 double CTemperature::ToKelvin() const
 {
-  return (m_value+459.67F)/1.8f;
+  return (m_value + 459.67) / 1.8;
 }
 
 double CTemperature::ToCelsius() const
 {
-  return (m_value-32.0f)/1.8f;
+  return (m_value - 32.0) / 1.8;
 }
 
 double CTemperature::ToReaumur() const
 {
-  return (m_value-32.0f)/2.25f;
+  return (m_value - 32.0) / 2.25;
 }
 
 double CTemperature::ToRankine() const
 {
-  return m_value+459.67f;
+  return m_value + 459.67;
 }
 
 double CTemperature::ToRomer() const
 {
-  return (m_value-32.0f)*7.0f/24.0f+7.5f;
+  return (m_value - 32.0) * 7.0 / 24.0 + 7.5;
 }
 
 double CTemperature::ToDelisle() const
 {
-  return (212.f-m_value)*5.0f/6.0f;
+  return (212.0 - m_value) * 5.0 / 6.0;
 }
 
 double CTemperature::ToNewton() const
 {
-  return (m_value-32.0f)*11.0f/60.0f;
+  return (m_value - 32.0) * 11.0 / 60.0;
 }
 
 double CTemperature::To(Unit temperatureUnit) const

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -464,9 +464,9 @@ float CVariant::asFloat(float fallback) const
     case VariantTypeUnsignedInteger:
       return (float)m_data.unsignedinteger;
     case VariantTypeString:
-      return (float)str2double(*m_data.string, fallback);
+      return (float)str2double(*m_data.string, static_cast<double>(fallback));
     case VariantTypeWideString:
-      return (float)str2double(*m_data.wstring, fallback);
+      return (float)str2double(*m_data.wstring, static_cast<double>(fallback));
     default:
       return fallback;
   }

--- a/xbmc/utils/rfft.cpp
+++ b/xbmc/utils/rfft.cpp
@@ -52,7 +52,8 @@ void RFFT::calc(const float* input, float* output)
 
   auto&& filter = [&](kiss_fft_cpx& data)
   {
-    return sqrt(data.r*data.r+data.i*data.i) * 2.0/m_size * (m_windowed?sqrt(8.0/3.0):1.0);
+    return static_cast<double>(sqrt(data.r * data.r + data.i * data.i)) * 2.0 / m_size *
+           (m_windowed ? sqrt(8.0 / 3.0) : 1.0);
   };
 
   // interleave while taking magnitudes and normalizing
@@ -68,5 +69,5 @@ void RFFT::calc(const float* input, float* output)
 void RFFT::hann(std::vector<kiss_fft_scalar>& data)
 {
   for (size_t i=0;i<data.size();++i)
-    data[i] *= 0.5*(1.0-cos(2*M_PI*i/(data.size()-1)));
+    data[i] *= 0.5f * (1.0f - cos(2.0f * static_cast<float>(M_PI) * i / (data.size() - 1)));
 }

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -524,7 +524,7 @@ TEST(TestStringUtils, CompareFuzzy)
 {
   double ref, var;
 
-  ref = 6.25f;
+  ref = 6.25;
   var = StringUtils::CompareFuzzy("test string", "string test");
   EXPECT_EQ(ref, var);
 }
@@ -536,7 +536,7 @@ TEST(TestStringUtils, FindBestMatch)
   std::vector<std::string> strarray;
 
   refint = 3;
-  refdouble = 0.5625f;
+  refdouble = 0.5625;
   strarray.emplace_back("");
   strarray.emplace_back("a");
   strarray.emplace_back("e");

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -54,7 +54,7 @@ void CGUIDialogAudioSettings::FrameMove()
   // update the volume setting if necessary
   float newVolume = g_application.GetVolumeRatio();
   if (newVolume != m_volume)
-    GetSettingsManager()->SetNumber(SETTING_AUDIO_VOLUME, newVolume);
+    GetSettingsManager()->SetNumber(SETTING_AUDIO_VOLUME, static_cast<double>(newVolume));
 
   if (g_application.GetAppPlayer().HasPlayer())
   {
@@ -62,7 +62,8 @@ void CGUIDialogAudioSettings::FrameMove()
 
     // these settings can change on the fly
     //! @todo (needs special handling): m_settingsManager->SetInt(SETTING_AUDIO_STREAM, g_application.GetAppPlayer().GetAudioStream());
-    GetSettingsManager()->SetNumber(SETTING_AUDIO_DELAY, videoSettings.m_AudioDelay);
+    GetSettingsManager()->SetNumber(SETTING_AUDIO_DELAY,
+                                    static_cast<double>(videoSettings.m_AudioDelay));
     GetSettingsManager()->SetBool(SETTING_AUDIO_PASSTHROUGH, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH));
   }
 

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -158,7 +158,8 @@ void CGUIDialogCMSSettings::InitializeSettings()
   settingCmsGammaMode->SetDependencies(depsCmsIcc);
 
   float currentGamma = settings->GetInt(SETTING_VIDEO_CMSGAMMA)/100.0f;
-  if (currentGamma == 0.0) currentGamma = 2.20;
+  if (currentGamma == 0.0f)
+    currentGamma = 2.20f;
   std::shared_ptr<CSettingNumber> settingCmsGamma = AddSlider(groupColorManagement, SETTING_VIDEO_CMSGAMMA, 36574, SettingLevel::Basic, currentGamma, 36597, 1.6, 0.05, 2.8, 36574, usePopup);
   settingCmsGamma->SetDependencies(depsCmsGamma);
 

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -64,7 +64,8 @@ void CGUIDialogSubtitleSettings::FrameMove()
     // these settings can change on the fly
     //! @todo m_settingsManager->SetBool(SETTING_SUBTITLE_ENABLE, g_application.GetAppPlayer().GetSubtitleVisible());
     //   \-> Unless subtitle visibility can change on the fly, while Dialog is up, this code should be removed.
-    GetSettingsManager()->SetNumber(SETTING_SUBTITLE_DELAY, videoSettings.m_SubtitleDelay);
+    GetSettingsManager()->SetNumber(SETTING_SUBTITLE_DELAY,
+                                    static_cast<double>(videoSettings.m_SubtitleDelay));
     //! @todo (needs special handling): m_settingsManager->SetInt(SETTING_SUBTITLE_STREAM, g_application.GetAppPlayer().GetSubtitle());
   }
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -103,9 +103,11 @@ void CGUIDialogVideoSettings::OnSettingChanged(const std::shared_ptr<const CSett
                                                vs.m_CustomNonLinStretch);
 
     m_viewModeChanged = true;
-    GetSettingsManager()->SetNumber(SETTING_VIDEO_ZOOM, vs.m_CustomZoomAmount);
-    GetSettingsManager()->SetNumber(SETTING_VIDEO_PIXEL_RATIO, vs.m_CustomPixelRatio);
-    GetSettingsManager()->SetNumber(SETTING_VIDEO_VERTICAL_SHIFT, vs.m_CustomVerticalShift);
+    GetSettingsManager()->SetNumber(SETTING_VIDEO_ZOOM, static_cast<double>(vs.m_CustomZoomAmount));
+    GetSettingsManager()->SetNumber(SETTING_VIDEO_PIXEL_RATIO,
+                                    static_cast<double>(vs.m_CustomPixelRatio));
+    GetSettingsManager()->SetNumber(SETTING_VIDEO_VERTICAL_SHIFT,
+                                    static_cast<double>(vs.m_CustomVerticalShift));
     GetSettingsManager()->SetBool(SETTING_VIDEO_NONLIN_STRETCH, vs.m_CustomNonLinStretch);
     m_viewModeChanged = false;
   }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -290,7 +290,7 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
 void CGUIWindowFullScreen::FrameMove()
 {
   float playspeed = g_application.GetAppPlayer().GetPlaySpeed();
-  if (playspeed != 1.0 && !g_application.GetAppPlayer().HasGame() &&
+  if (playspeed != 1.0f && !g_application.GetAppPlayer().HasGame() &&
       !g_application.GetAppPlayer().IsPausedPlayback())
     CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
 

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -336,7 +336,7 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
           bTriggerUpdateRes = true;
       }
     }
-    
+
     bool allowResolutionChangeOnStop = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_ON_START;
     RESOLUTION targetResolutionOnStop = RES_DESKTOP;
     if (bTriggerUpdateRes)
@@ -345,7 +345,7 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
     {
       targetResolutionOnStop = CDisplaySettings::GetInstance().GetCurrentResolution();
     }
-    
+
     if (allowResolutionChangeOnStop && !bTriggerUpdateRes)
     {
       SetVideoResolution(targetResolutionOnStop, false);
@@ -650,7 +650,7 @@ void CGraphicContext::SetResInfo(RESOLUTION res, const RESOLUTION_INFO& info)
   {
     curr.Overscan.right  = info.Overscan.right  * 2 + info.iBlanking;
     if((curr.dwFlags & D3DPRESENTFLAG_MODE3DSBS) == 0)
-      curr.fPixelRatio  /= 2.0;
+      curr.fPixelRatio /= 2.0f;
   }
 
   if(info.dwFlags & D3DPRESENTFLAG_MODE3DTB)
@@ -658,7 +658,7 @@ void CGraphicContext::SetResInfo(RESOLUTION res, const RESOLUTION_INFO& info)
     curr.Overscan.bottom = info.Overscan.bottom * 2 + info.iBlanking;
     curr.iSubtitles      = info.iSubtitles      * 2 + info.iBlanking;
     if((curr.dwFlags & D3DPRESENTFLAG_MODE3DTB) == 0)
-      curr.fPixelRatio  *= 2.0;
+      curr.fPixelRatio *= 2.0f;
   }
 }
 

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -378,14 +378,14 @@ bool CResolutionUtils::FindResolutionFromOverride(float fps, int width, bool is3
 float CResolutionUtils::RefreshWeight(float refresh, float fps)
 {
   float div   = refresh / fps;
-  int   round = MathUtils::round_int(div);
+  int round = MathUtils::round_int(static_cast<double>(div));
 
   float weight = 0.0f;
 
   if (round < 1)
     weight = (fps - refresh) / fps;
   else
-    weight = (float)fabs(div / round - 1.0);
+    weight = fabs(div / round - 1.0f);
 
   // punish higher refreshrates and prefer better matching
   // e.g. 30 fps content at 60 hz is better than
@@ -394,7 +394,7 @@ float CResolutionUtils::RefreshWeight(float refresh, float fps)
   // punish when refreshrate > 60 hz to not have to switch
   // twice for 30i content
   if (refresh > 60 && round > 1)
-    weight += round / 10000.0;
+    weight += round / 10000.0f;
 
   return weight;
 }

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -117,7 +117,7 @@ static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int
       // check if the refresh rate of this resolution is better suited than
       // the refresh rate of the resolution with the same width/height/interlaced
       // property and if so replace it
-      if (bestRefreshrate > 0.0 && refreshrate == bestRefreshrate)
+      if (bestRefreshrate > 0.0f && refreshrate == bestRefreshrate)
         resolutions[idx].ResInfo_Index = addindex;
 
       // no need to add the resolution again

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -43,7 +43,7 @@ static float currentRefreshRate()
   if (window)
   {
     float preferredRate = window.getAttributes().getpreferredRefreshRate();
-    if (preferredRate > 20.0 && preferredRate < 70.0)
+    if (preferredRate > 20.0f && preferredRate < 70.0f)
     {
       CLog::Log(LOGINFO, "CAndroidUtils: Preferred refresh rate: %f", preferredRate);
       return preferredRate;
@@ -54,7 +54,7 @@ static float currentRefreshRate()
       if (display)
       {
         float reportedRate = display.getRefreshRate();
-        if (reportedRate > 20.0 && reportedRate < 70.0)
+        if (reportedRate > 20.0f && reportedRate < 70.0f)
         {
           CLog::Log(LOGINFO, "CAndroidUtils: Current display refresh rate: %f", reportedRate);
           return reportedRate;
@@ -293,7 +293,7 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
       {
         for (unsigned int i = 0; i < refreshRates.size(); i++)
         {
-          if (refreshRates[i] < 20.0 || refreshRates[i] > 70.0)
+          if (refreshRates[i] < 20.0f || refreshRates[i] > 70.0f)
             continue;
           cur_res.fRefreshRate = refreshRates[i];
           cur_res.strMode = StringUtils::Format(

--- a/xbmc/windowing/android/VideoSyncAndroid.cpp
+++ b/xbmc/windowing/android/VideoSyncAndroid.cpp
@@ -67,7 +67,7 @@ void CVideoSyncAndroid::FrameCallback(int64_t frameTimeNanos)
 
   //calculate how many vblanks happened
   VBlankTime = (double)(frameTimeNanos - m_LastVBlankTime) / (double)CurrentHostFrequency();
-  NrVBlanks = MathUtils::round_int(VBlankTime * m_fps);
+  NrVBlanks = MathUtils::round_int(VBlankTime * static_cast<double>(m_fps));
 
   //save the timestamp of this vblank so we can calculate how many happened next time
   m_LastVBlankTime = frameTimeNanos;

--- a/xbmc/windowing/ios/VideoSyncIos.cpp
+++ b/xbmc/windowing/ios/VideoSyncIos.cpp
@@ -67,7 +67,7 @@ void CVideoSyncIos::IosVblankHandler()
 
   //calculate how many vblanks happened
   VBlankTime = (double)(nowtime - m_LastVBlankTime) / (double)CurrentHostFrequency();
-  NrVBlanks = MathUtils::round_int(VBlankTime * m_fps);
+  NrVBlanks = MathUtils::round_int(VBlankTime * static_cast<double>(m_fps));
 
   //save the timestamp of this vblank so we can calculate how many happened next time
   m_LastVBlankTime = nowtime;

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -187,7 +187,7 @@ bool CWinSystemIOS::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   m_bFullScreen = fullScreen;
 
   CLog::Log(LOGDEBUG, "About to switch to %i x %i",m_nWidth, m_nHeight);
-  SwitchToVideoMode(res.iWidth, res.iHeight, res.fRefreshRate);
+  SwitchToVideoMode(res.iWidth, res.iHeight, static_cast<double>(res.fRefreshRate));
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
 
   return true;

--- a/xbmc/windowing/osx/VideoSyncOsx.mm
+++ b/xbmc/windowing/osx/VideoSyncOsx.mm
@@ -100,7 +100,7 @@ void CVideoSyncOsx::VblankHandler(int64_t nowtime, uint32_t timebase)
   if (m_LastVBlankTime != 0)
   {
     VBlankTime = (double)(nowtime - m_LastVBlankTime) / (double)timebase;
-    NrVBlanks = MathUtils::round_int(VBlankTime * m_fps);
+    NrVBlanks = MathUtils::round_int(VBlankTime * static_cast<double>(m_fps));
 
     //update the vblank timestamp, update the clock and send a signal that we got a vblank
     UpdateClock(NrVBlanks, Now, m_refClock);

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -954,7 +954,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   if (m_bFullScreen)
   {
     // switch videomode
-    SwitchToVideoMode(res.iWidth, res.iHeight, res.fRefreshRate);
+    SwitchToVideoMode(res.iWidth, res.iHeight, static_cast<double>(res.fRefreshRate));
   }
 
   //no context? done.

--- a/xbmc/windowing/tvos/VideoSyncTVos.cpp
+++ b/xbmc/windowing/tvos/VideoSyncTVos.cpp
@@ -66,7 +66,7 @@ void CVideoSyncTVos::TVosVblankHandler()
   //calculate how many vblanks happened
   double VBlankTime =
       static_cast<double>(nowtime - m_LastVBlankTime) / static_cast<double>(CurrentHostFrequency());
-  int NrVBlanks = MathUtils::round_int(VBlankTime * m_fps);
+  int NrVBlanks = MathUtils::round_int(VBlankTime * static_cast<double>(m_fps));
 
   //save the timestamp of this vblank so we can calculate how many happened next time
   m_LastVBlankTime = nowtime;

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -223,7 +223,7 @@ bool CWinSystemTVOS::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool b
   m_bFullScreen = fullScreen;
 
   CLog::Log(LOGDEBUG, "About to switch to {} x {} @ {}", m_nWidth, m_nHeight, res.fRefreshRate);
-  SwitchToVideoMode(res.iWidth, res.iHeight, res.fRefreshRate);
+  SwitchToVideoMode(res.iWidth, res.iHeight, static_cast<double>(res.fRefreshRate));
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
 
   return true;
@@ -243,7 +243,7 @@ bool CWinSystemTVOS::GetScreenResolution(int* w, int* h, double* fps, int screen
 {
   *w = [g_xbmcController.displayManager getScreenSize].width;
   *h = [g_xbmcController.displayManager getScreenSize].height;
-  *fps = [g_xbmcController.displayManager getDisplayRate];
+  *fps = static_cast<double>([g_xbmcController.displayManager getDisplayRate]);
 
   CLog::Log(LOGDEBUG, "Current resolution Screen: {} with {} x {} @ {}", screenIdx, *w, *h, *fps);
   return true;

--- a/xbmc/windowing/wayland/Output.cpp
+++ b/xbmc/windowing/wayland/Output.cpp
@@ -128,7 +128,10 @@ float COutput::GetDpiForMode(const Mode& mode) const
 
     float diagonalPixels = std::sqrt(mode.size.Width() * mode.size.Width() + mode.size.Height() * mode.size.Height());
     // physicalWidth/physicalHeight is in millimeters
-    float diagonalInches = std::sqrt(m_physicalSize.Width() * m_physicalSize.Width() + m_physicalSize.Height() * m_physicalSize.Height()) / INCH_MM_RATIO;
+    float diagonalInches =
+        std::sqrt(static_cast<float>(m_physicalSize.Width() * m_physicalSize.Width() +
+                                     m_physicalSize.Height() * m_physicalSize.Height())) /
+        INCH_MM_RATIO;
 
     return diagonalPixels / diagonalInches;
   }


### PR DESCRIPTION
This PR aims to fix a bunch of the double-promotion warnings that we have. This fixes all of the warnings for my current platform and build configuration (should be a large chunk of the generic ones).

Most changes are trivial by either adding or removing the float literal `f`.

Some changes are a little more involved as they require casting to double or to float. I've done basic testing but the database changes could use a second set of eyes.

Please comment if you see anything concerning or have any questions about choices that I made.