### PR TITLE
[cleanup] fix a bunch of missing-field-initializers warnings

### DIFF
--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -155,7 +155,7 @@ if(PLATFORM_DEFINES)
 endif()
 
 if(NOT MSVC)
-  add_options(ALL_LANGUAGES ALL_BUILDS "-Wall" "-Wdouble-promotion")
+  add_options(ALL_LANGUAGES ALL_BUILDS "-Wall" "-Wdouble-promotion" "-Wmissing-field-initializers")
   add_options(ALL_LANGUAGES DEBUG "-g" "-D_DEBUG")
 endif()
 

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -36,8 +36,6 @@ typedef struct
   char string[14];
   TextureField field;
   CDatabaseQueryRule::FIELD_TYPE type;
-  bool browseable;
-  int localizedString;
 } translateField;
 
 static const translateField fields[] = {

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -650,7 +650,7 @@ bool CDateTime::ToFileTime(const time_t& time, KODI::TIME::FileTime& fileTime) c
 
 bool CDateTime::ToFileTime(const tm& time, KODI::TIME::FileTime& fileTime) const
 {
-  KODI::TIME::SystemTime st = {0};
+  KODI::TIME::SystemTime st = {};
 
   st.year = time.tm_year + 1900;
   st.month = time.tm_mon + 1;
@@ -779,7 +779,7 @@ int CDateTime::GetMinuteOfDay() const
 
 bool CDateTime::SetDateTime(int year, int month, int day, int hour, int minute, int second)
 {
-  KODI::TIME::SystemTime st = {0};
+  KODI::TIME::SystemTime st = {};
 
   st.year = year;
   st.month = month;

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -163,7 +163,7 @@ private:
    * This structure is defined in:
    * /xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
    */
-  AddonGlobalInterface m_interface = {0};
+  AddonGlobalInterface m_interface = {};
 };
 
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -33,7 +33,7 @@ bool Interface_Base::InitInterface(CAddonDll* addon,
                                    AddonGlobalInterface& addonInterface,
                                    KODI_HANDLE firstKodiInstance)
 {
-  addonInterface = {0};
+  addonInterface = {};
 
   addonInterface.libBasePath =
       strdup(CSpecialProtocol::TranslatePath("special://xbmcbinaddons").c_str());
@@ -92,7 +92,7 @@ void Interface_Base::DeInitInterface(AddonGlobalInterface& addonInterface)
 
   delete addonInterface.toKodi;
   delete addonInterface.toAddon;
-  addonInterface = {0};
+  addonInterface = {};
 }
 
 void Interface_Base::RegisterInterface(ADDON_GET_INTERFACE_FN fn)

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -1019,7 +1019,7 @@ bool Interface_Filesystem::io_control_get_cache_status(void* kodiBase,
     return -1;
   }
 
-  SCacheStatus data = {0};
+  SCacheStatus data = {};
   int ret = static_cast<CFile*>(file)->IoControl(EIoControl::IOCTRL_CACHE_STATUS, &data);
   if (ret >= 0)
   {

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -1412,7 +1412,7 @@ int CGUIAddonWindow::GetCurrentContainerControlId()
 
 void CGUIAddonWindow::GetContextButtons(int itemNumber, CContextButtons& buttons)
 {
-  gui_context_menu_pair c_buttons[ADDON_MAX_CONTEXT_ENTRIES] = {{0}};
+  gui_context_menu_pair c_buttons[ADDON_MAX_CONTEXT_ENTRIES] = {};
   unsigned int size = ADDON_MAX_CONTEXT_ENTRIES;
   if (CBGetContextButtons)
   {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -224,7 +224,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   }
 
   AEDeviceEnumerationOSX devEnum(deviceID);
-  AudioStreamBasicDescription outputFormat = { 0 };
+  AudioStreamBasicDescription outputFormat = {};
   AudioStreamID outputStream = 0;
   UInt32 numOutputChannels = 0;
   m_planes = 1;
@@ -246,7 +246,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
     return false;
   }
 
-  AudioStreamBasicDescription outputFormatVirt = { 0 };
+  AudioStreamBasicDescription outputFormatVirt = {};
   AudioStreamID outputStreamVirt = 0;
   UInt32 numOutputChannelsVirt = 0;
   if (passthrough)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -300,7 +300,7 @@ bool CAAudioUnitSink::deactivate()
     AudioOutputUnitStop(m_audioUnit);
 
     // detach the render callback on the unit
-    AURenderCallbackStruct callbackStruct = {0};
+    AURenderCallbackStruct callbackStruct = {};
     AudioUnitSetProperty(m_audioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input,
                          0, &callbackStruct, sizeof(callbackStruct));
 
@@ -465,7 +465,7 @@ bool CAAudioUnitSink::setupAudio()
   }
 
   // Attach a render callback on the unit
-  AURenderCallbackStruct callbackStruct = {0};
+  AURenderCallbackStruct callbackStruct = {};
   callbackStruct.inputProc = renderCallback;
   callbackStruct.inputProcRefCon = this;
   status = AudioUnitSetProperty(m_audioUnit, kAudioUnitProperty_SetRenderCallback,
@@ -654,7 +654,7 @@ bool CAESinkDARWINTVOS::Initialize(AEAudioFormat& format, std::string& device)
   if (!found)
     return false;
 
-  AudioStreamBasicDescription audioFormat = {0};
+  AudioStreamBasicDescription audioFormat = {};
   audioFormat.mFormatID = kAudioFormatLinearPCM;
 
   // check if are we dealing with raw formats or pcm

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -338,12 +338,11 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - latency: {}/{} ({:.3f}s)", __FUNCTION__, frames,
             format.m_sampleRate, static_cast<double>(frames) / format.m_sampleRate);
 
-  spa_audio_info_raw info = {
-      .format = pwFormat,
-      .flags = SPA_AUDIO_FLAG_NONE,
-      .rate = format.m_sampleRate,
-      .channels = static_cast<uint32_t>(pwChannels.size()),
-  };
+  spa_audio_info_raw info{};
+  info.format = pwFormat;
+  info.flags = SPA_AUDIO_FLAG_NONE;
+  info.rate = format.m_sampleRate;
+  info.channels = static_cast<uint32_t>(pwChannels.size());
 
   for (size_t index = 0; index < pwChannels.size(); index++)
     info.position[index] = pwChannels[index];

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
@@ -35,10 +35,15 @@ public:
 private:
   static void OnCoreDone(void* userdata, uint32_t id, int seq);
 
-  const pw_core_events m_coreEvents = {
-      PW_VERSION_CORE_EVENTS,
-      .done = OnCoreDone,
-  };
+  const pw_core_events m_coreEvents = {.version = PW_VERSION_CORE_EVENTS,
+                                       .info = nullptr,
+                                       .done = OnCoreDone,
+                                       .ping = nullptr,
+                                       .error = nullptr,
+                                       .remove_id = nullptr,
+                                       .bound_id = nullptr,
+                                       .add_mem = nullptr,
+                                       .remove_mem = nullptr};
 
   spa_hook m_coreListener;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -55,7 +55,8 @@ private:
                     uint32_t next,
                     const struct spa_pod* param);
 
-  const pw_node_events m_nodeEvents = {PW_VERSION_NODE_EVENTS, .info = Info, .param = Param};
+  const pw_node_events m_nodeEvents = {
+      .version = PW_VERSION_NODE_EVENTS, .info = Info, .param = Param};
 
   spa_hook m_objectListener;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
@@ -41,11 +41,12 @@ private:
   static void Bound(void* userdata, uint32_t id);
   static void Removed(void* userdata);
 
-  const pw_proxy_events m_proxyEvents = {
-      PW_VERSION_PROXY_EVENTS,
-      .bound = Bound,
-      .removed = Removed,
-  };
+  const pw_proxy_events m_proxyEvents = {.version = PW_VERSION_PROXY_EVENTS,
+                                         .destroy = nullptr,
+                                         .bound = Bound,
+                                         .removed = Removed,
+                                         .done = nullptr,
+                                         .error = nullptr};
 
   spa_hook m_proxyListener;
 };

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -40,7 +40,7 @@ private:
   static void OnGlobalRemoved(void* userdata, uint32_t id);
 
   const pw_registry_events m_registryEvents = {
-      PW_VERSION_REGISTRY_EVENTS,
+      .version = PW_VERSION_REGISTRY_EVENTS,
       .global = OnGlobalAdded,
       .global_remove = OnGlobalRemoved,
   };

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -53,8 +53,16 @@ private:
   static void Process(void* userdata);
   static void Drained(void* userdata);
 
-  const pw_stream_events m_streamEvents = {PW_VERSION_STREAM_EVENTS, .state_changed = StateChanged,
-                                           .process = Process, .drained = Drained};
+  const pw_stream_events m_streamEvents = {.version = PW_VERSION_STREAM_EVENTS,
+                                           .destroy = nullptr,
+                                           .state_changed = StateChanged,
+                                           .control_info = nullptr,
+                                           .io_changed = nullptr,
+                                           .param_changed = nullptr,
+                                           .add_buffer = nullptr,
+                                           .remove_buffer = nullptr,
+                                           .process = Process,
+                                           .drained = Drained};
 
   spa_hook m_streamListener;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -2015,7 +2015,7 @@ void CMixer::PostProcOff()
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_NOISE_REDUCTION};
 
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2024,7 +2024,7 @@ void CMixer::PostProcOff()
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_SHARPNESS};
 
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2163,7 +2163,7 @@ void CMixer::SetNoiseReduction()
 
   if (!m_config.processInfo->GetVideoSettings().m_NoiseReduction)
   {
-    VdpBool enabled[]= {0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
     return;
@@ -2190,7 +2190,7 @@ void CMixer::SetSharpness()
 
   if (!m_config.processInfo->GetVideoSettings().m_Sharpness)
   {
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
     return;
@@ -2372,7 +2372,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L1))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L1 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2380,7 +2380,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L2))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L2 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2388,7 +2388,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L3))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L3 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2396,7 +2396,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L4))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L4 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2404,7 +2404,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L5))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L5 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2412,7 +2412,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L6))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L6 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2420,7 +2420,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L7))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L7 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2428,7 +2428,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L8))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L8 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }
@@ -2436,7 +2436,7 @@ void CMixer::DisableHQScaling()
   if(m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L9))
   {
     VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L9 };
-    VdpBool enabled[]={0};
+    VdpBool enabled[] = {};
     vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     CheckStatus(vdp_st, __LINE__);
   }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -58,8 +58,8 @@ CInputStreamAddon::CInputStreamAddon(const AddonInfoPtr& addonInfo,
     StringUtils::Trim(key);
     key = name + "." + key;
   }
-  m_struct = { 0 };
-  m_caps = { 0 };
+  m_struct = {};
+  m_caps = {};
 }
 
 CInputStreamAddon::~CInputStreamAddon()
@@ -140,7 +140,7 @@ bool CInputStreamAddon::Open()
   if (CreateInstance(&m_struct) != ADDON_STATUS_OK || !m_struct.toAddon->open)
     return false;
 
-  INPUTSTREAM_PROPERTY props = {0};
+  INPUTSTREAM_PROPERTY props = {};
   std::map<std::string, std::string> propsMap;
   for (auto &key : m_fileItemProps)
   {
@@ -185,7 +185,7 @@ bool CInputStreamAddon::Open()
   bool ret = m_struct.toAddon->open(&m_struct, &props);
   if (ret)
   {
-    m_caps = { 0 };
+    m_caps = {};
     m_struct.toAddon->get_capabilities(&m_struct, &m_caps);
 
     m_subAddonProvider = std::shared_ptr<CInputStreamProvider>(
@@ -204,7 +204,7 @@ void CInputStreamAddon::Close()
   delete m_struct.toAddon;
   delete m_struct.toKodi;
   delete m_struct.props;
-  m_struct = { 0 };
+  m_struct = {};
 }
 
 bool CInputStreamAddon::IsEOF()
@@ -352,7 +352,7 @@ std::vector<CDemuxStream*> CInputStreamAddon::GetStreams() const
 {
   std::vector<CDemuxStream*> streams;
 
-  INPUTSTREAM_IDS streamIDs = {0};
+  INPUTSTREAM_IDS streamIDs = {};
   bool ret = m_struct.toAddon->get_stream_ids(&m_struct, &streamIDs);
   if (!ret || streamIDs.m_streamCount > INPUTSTREAM_MAX_STREAM_COUNT)
     return streams;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -87,7 +87,7 @@ protected:
   CVaapiRenderPicture *m_vaapiPic = nullptr;
   struct GLSurface
   {
-    VAImage vaImage{VA_INVALID_ID};
+    VAImage vaImage;
     VABufferInfo vBufInfo;
     EGLImageKHR eglImage;
     EGLImageKHR eglImageY, eglImageVU;
@@ -114,7 +114,7 @@ private:
   struct MappedTexture
   {
     EGLImageKHR eglImage{EGL_NO_IMAGE_KHR};
-    GLuint glTexture{0};
+    GLuint glTexture{};
   };
 
   InteropInfo m_interop;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -83,8 +83,8 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
   }
 
   AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
-  uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0}, flags = 0;
-  uint64_t modifier[4] = {0};
+  uint32_t handles[4] = {}, pitches[4] = {}, offsets[4] = {}, flags = 0;
+  uint64_t modifier[4] = {};
   int ret;
 
   // convert Prime FD to GEM handle
@@ -147,7 +147,8 @@ void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
   {
     if (buffer->m_handles[i])
     {
-      struct drm_gem_close gem_close = {.handle = buffer->m_handles[i]};
+      struct drm_gem_close gem_close;
+      gem_close.handle = buffer->m_handles[i];
       drmIoctl(m_DRM->GetFileDescriptor(), DRM_IOCTL_GEM_CLOSE, &gem_close);
       buffer->m_handles[i] = 0;
     }
@@ -176,10 +177,8 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
   {
     m_hdr_metadata.metadata_type = HDMI_STATIC_METADATA_TYPE1;
-    m_hdr_metadata.hdmi_metadata_type1 = {
-        .eotf = GetEOTF(picture),
-        .metadata_type = HDMI_STATIC_METADATA_TYPE1,
-    };
+    m_hdr_metadata.hdmi_metadata_type1.eotf = GetEOTF(picture);
+    m_hdr_metadata.hdmi_metadata_type1.metadata_type = HDMI_STATIC_METADATA_TYPE1;
 
     if (m_hdr_blob_id)
       drmModeDestroyPropertyBlob(m_DRM->GetFileDescriptor(), m_hdr_blob_id);

--- a/xbmc/dialogs/GUIDialogMediaFilter.h
+++ b/xbmc/dialogs/GUIDialogMediaFilter.h
@@ -44,9 +44,9 @@ public:
     std::string controlType;
     std::string controlFormat;
     CDatabaseQueryRule::SEARCH_OPERATOR ruleOperator;
-    std::shared_ptr<CSetting> setting;
-    CSmartPlaylistRule *rule;
-    void *data;
+    std::shared_ptr<CSetting> setting = nullptr;
+    CSmartPlaylistRule* rule = nullptr;
+    void* data = nullptr;
   } Filter;
 
 protected:

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -36,13 +36,13 @@ using namespace KODI::MESSAGING;
 using KODI::UTILITY::CDigest;
 
 CGUIDialogNumeric::CGUIDialogNumeric(void)
-  : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml")
-  , m_bConfirmed{false}
-  , m_bCanceled{false}
-  , m_mode{INPUT_PASSWORD}
-  , m_block{0}
-  , m_lastblock{0}
-  , m_dirty{false}
+  : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml"),
+    m_bConfirmed{false},
+    m_bCanceled{false},
+    m_mode{INPUT_PASSWORD},
+    m_block{},
+    m_lastblock{},
+    m_dirty{false}
 {
   memset(&m_datetime, 0, sizeof(KODI::TIME::SystemTime));
   m_loadType = KEEP_IN_MEMORY;
@@ -480,7 +480,7 @@ bool CGUIDialogNumeric::ShowAndGetSeconds(std::string &timeString, const std::st
   CGUIDialogNumeric *pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogNumeric>(WINDOW_DIALOG_NUMERIC);
   if (!pDialog) return false;
   int seconds = StringUtils::TimeStringToSeconds(timeString);
-  KODI::TIME::SystemTime time = {0};
+  KODI::TIME::SystemTime time = {};
   time.hour = seconds / 3600;
   time.minute = (seconds - time.hour * 3600) / 60;
   time.second = seconds - time.hour * 3600 - time.minute * 60;

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -64,7 +64,7 @@ void CDAVDirectory::ParseResponse(const TiXmlElement *pElement, CFileItem &item)
               else
               if (CDAVCommon::ValueWithoutNamespace(pPropChild, "getlastmodified") && !pPropChild->NoChildren())
               {
-                struct tm timeDate = {0};
+                struct tm timeDate = {};
                 strptime(pPropChild->FirstChild()->Value(), "%a, %d %b %Y %T", &timeDate);
                 item.m_dateTime = mktime(&timeDate);
               }
@@ -76,7 +76,7 @@ void CDAVDirectory::ParseResponse(const TiXmlElement *pElement, CFileItem &item)
               else
               if (!item.m_dateTime.IsValid() && CDAVCommon::ValueWithoutNamespace(pPropChild, "creationdate") && !pPropChild->NoChildren())
               {
-                struct tm timeDate = {0};
+                struct tm timeDate = {};
                 strptime(pPropChild->FirstChild()->Value(), "%Y-%m-%dT%T", &timeDate);
                 item.m_dateTime = mktime(&timeDate);
               }

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -119,7 +119,7 @@ bool CNFSDirectory::ResolveSymlink( const std::string &dirName, struct nfsdirent
 
   if(ret == 0)
   {
-    NFSSTAT tmpBuffer = {0};
+    NFSSTAT tmpBuffer = {};
     fullpath = dirName;
     URIUtils::AddSlashAtEnd(fullpath);
     fullpath.append(resolvedLink);

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -598,7 +598,7 @@ int CNFSFile::Stat(const CURL& url, struct __stat64* buffer)
     return -1;
 
 
-  NFSSTAT tmpBuffer = {0};
+  NFSSTAT tmpBuffer = {};
 
   ret = nfs_stat(gNfsConnection.GetNfsContext(), filename.c_str(), &tmpBuffer);
 
@@ -850,7 +850,7 @@ bool CNFSFile::OpenForWrite(const CURL& url, bool bOverWrite)
   }
   m_url=url;
 
-  struct __stat64 tmpBuffer = {0};
+  struct __stat64 tmpBuffer = {};
 
   //only stat if file was not created
   if(!bOverWrite)

--- a/xbmc/filesystem/NptXbmcFile.cpp
+++ b/xbmc/filesystem/NptXbmcFile.cpp
@@ -492,33 +492,40 @@ NPT_File::GetWorkingDir(NPT_String& path)
 NPT_Result
 NPT_File::GetInfo(const char* path, NPT_FileInfo* info)
 {
-    struct __stat64 stat_buffer = {0};
-    int result;
+  struct __stat64 stat_buffer = {};
+  int result;
 
-    if (!info)
-      return NPT_FAILURE;
+  if (!info)
+    return NPT_FAILURE;
 
-    NPT_SetMemory(info, 0, sizeof(*info));
+  NPT_SetMemory(info, 0, sizeof(*info));
 
-    result = CFile::Stat(path, &stat_buffer);
-    if (result !=0) return MapErrno(errno);
-    if (info)
+  result = CFile::Stat(path, &stat_buffer);
+  if (result != 0)
+    return MapErrno(errno);
+  if (info)
+  {
+    info->m_Size = stat_buffer.st_size;
+    if (S_ISREG(stat_buffer.st_mode))
     {
-      info->m_Size = stat_buffer.st_size;
-      if (S_ISREG(stat_buffer.st_mode)) {
-          info->m_Type = NPT_FileInfo::FILE_TYPE_REGULAR;
-      } else if (S_ISDIR(stat_buffer.st_mode)) {
-          info->m_Type = NPT_FileInfo::FILE_TYPE_DIRECTORY;
-      } else {
-          info->m_Type = NPT_FileInfo::FILE_TYPE_OTHER;
-      }
-      info->m_AttributesMask &= NPT_FILE_ATTRIBUTE_READ_ONLY;
-      if ((stat_buffer.st_mode & S_IWUSR) == 0) {
-          info->m_Attributes &= NPT_FILE_ATTRIBUTE_READ_ONLY;
-      }
-      info->m_CreationTime.SetSeconds(0);
-      info->m_ModificationTime.SetSeconds(stat_buffer.st_mtime);
+      info->m_Type = NPT_FileInfo::FILE_TYPE_REGULAR;
     }
+    else if (S_ISDIR(stat_buffer.st_mode))
+    {
+      info->m_Type = NPT_FileInfo::FILE_TYPE_DIRECTORY;
+    }
+    else
+    {
+      info->m_Type = NPT_FileInfo::FILE_TYPE_OTHER;
+    }
+    info->m_AttributesMask &= NPT_FILE_ATTRIBUTE_READ_ONLY;
+    if ((stat_buffer.st_mode & S_IWUSR) == 0)
+    {
+      info->m_Attributes &= NPT_FILE_ATTRIBUTE_READ_ONLY;
+    }
+    info->m_CreationTime.SetSeconds(0);
+    info->m_ModificationTime.SetSeconds(stat_buffer.st_mtime);
+  }
 
     return NPT_SUCCESS;
 }

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -84,7 +84,7 @@ static bool IsPathToThumbnail(const std::string& strPath )
 
 static time_t ParseDate(const std::string & strDate)
 {
-  struct tm pubDate = {0};
+  struct tm pubDate = {};
   //! @todo Handle time zone
   strptime(strDate.c_str(), "%a, %d %b %Y %H:%M:%S", &pubDate);
   // Check the difference between the time of last check and time of the item

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -466,7 +466,7 @@ void CGUIFontTTF::DrawTextInternal(float x,
       Character* ch = GetCharacter(pos);
       if (!ch)
       {
-        Character null = { 0 };
+        Character null = {};
         characters.push(null);
         continue;
       }

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -298,7 +298,7 @@ void CGUIVisualisationControl::UpdateTrack()
   std::string albumArtist(tag->GetAlbumArtistString());
   std::string genre(StringUtils::Join(tag->GetGenre(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator));
 
-  VIS_TRACK track = {0};
+  VIS_TRACK track = {};
   track.title       = tag->GetTitle().c_str();
   track.artist      = artist.c_str();
   track.album       = tag->GetAlbum().c_str();

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -234,7 +234,7 @@ int CWindowTranslator::TranslateWindow(const std::string& window)
   }
 
   // Run through the window structure
-  auto it = WindowMappingByName.find(WindowMapItem{strWindow.c_str()});
+  auto it = WindowMappingByName.find({strWindow.c_str(), {}});
   if (it != WindowMappingByName.end())
     return it->windowId;
 

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -181,7 +181,8 @@ void CGenericTouchActionHandler::sendEvent(int actionId,
                                            float y3,
                                            int pointers /* = 1 */)
 {
-  XBMC_Event newEvent{XBMC_TOUCH};
+  XBMC_Event newEvent{};
+  newEvent.type = XBMC_TOUCH;
 
   newEvent.touch.action = actionId;
   newEvent.touch.x = x;
@@ -199,7 +200,8 @@ void CGenericTouchActionHandler::sendEvent(int actionId,
 
 void CGenericTouchActionHandler::focusControl(float x, float y)
 {
-  XBMC_Event newEvent{XBMC_SETFOCUS};
+  XBMC_Event newEvent{};
+  newEvent.type = XBMC_SETFOCUS;
 
   newEvent.focus.x = static_cast<int>(std::round(x));
   newEvent.focus.y = static_cast<int>(std::round(y));

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -885,7 +885,11 @@ namespace PythonBindings
       "${module.@name}",
       "",
       -1,
-      ${module.@name}_methods
+      ${module.@name}_methods,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
   };
 
   PyObject *PyInit_Module_${module.@name}()

--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -18,7 +18,62 @@ namespace PythonBindings
 {
   TypeInfo::TypeInfo(const std::type_info& ti) : swigType(NULL), parentType(NULL), typeIndex(ti)
   {
-    static PyTypeObject py_type_object_header = {PyVarObject_HEAD_INIT(NULL, 0)};
+    static PyTypeObject py_type_object_header =
+    { PyVarObject_HEAD_INIT(nullptr, 0) 0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+#if PY_VERSION_HEX > 0x03080000
+      0,
+      0,
+#endif
+#if PY_VERSION_HEX < 0x03090000
+      0,
+#endif
+    };
+
     static int size = (long*)&(py_type_object_header.tp_name) - (long*)&py_type_object_header;
     memcpy(&(this->pythonType), &py_type_object_header, size);
   }

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -436,7 +436,7 @@ void CGUIDialogNetworkSetup::UpdateAvailableProtocols()
   m_protocols.clear();
 #ifdef HAS_FILESYSTEM_SMB
   // most popular protocol at the first place
-  m_protocols.emplace_back(Protocol{ true, true, true, false, true, 0, "smb", 20171 });
+  m_protocols.emplace_back(Protocol{true, true, true, false, true, 0, "smb", 20171, ""});
 #endif
   // protocols from vfs addon next
   if (CServiceBroker::IsBinaryAddonCacheUp())
@@ -455,19 +455,18 @@ void CGUIDialogNetworkSetup::UpdateAvailableProtocols()
     }
   }
   // internals
-  const std::vector<Protocol> defaults =
-        {{ true,  true,  true,  true, false, 443, "https", 20301},
-         { true,  true,  true,  true, false,  80,  "http", 20300},
-         { true,  true,  true,  true, false, 443,  "davs", 20254},
-         { true,  true,  true,  true, false,  80,   "dav", 20253},
-         { true,  true,  true,  true, false,  21,   "ftp", 20173},
-         { true,  true,  true,  true, false, 990,  "ftps", 20174},
-         {false, false, false, false,  true,   0,  "upnp", 20175},
-         { true,  true,  true,  true, false,  80,   "rss", 20304},
-         { true,  true,  true,  true, false, 443,  "rsss", 20305}};
+  const std::vector<Protocol> defaults = {{true, true, true, true, false, 443, "https", 20301, ""},
+                                          {true, true, true, true, false, 80, "http", 20300, ""},
+                                          {true, true, true, true, false, 443, "davs", 20254, ""},
+                                          {true, true, true, true, false, 80, "dav", 20253, ""},
+                                          {true, true, true, true, false, 21, "ftp", 20173, ""},
+                                          {true, true, true, true, false, 990, "ftps", 20174, ""},
+                                          {false, false, false, false, true, 0, "upnp", 20175, ""},
+                                          {true, true, true, true, false, 80, "rss", 20304, ""},
+                                          {true, true, true, true, false, 443, "rsss", 20305, ""}};
 
   m_protocols.insert(m_protocols.end(), defaults.begin(), defaults.end());
 #ifdef HAS_FILESYSTEM_NFS
-  m_protocols.emplace_back(Protocol{true, false, false, false, true, 0, "nfs", 20259});
+  m_protocols.emplace_back(Protocol{true, false, false, false, true, 0, "nfs", 20259, ""});
 #endif
 }

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -415,7 +415,7 @@ std::vector<SOCKET> CreateTCPServerSocket(const int port, const bool bindLocal, 
   struct addrinfo* results = nullptr;
 
   std::string sPort = std::to_string(port);
-  struct addrinfo hints = { 0 };
+  struct addrinfo hints = {};
   hints.ai_family = PF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags = AI_PASSIVE;

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -171,8 +171,8 @@ MHD_RESULT CWebServer::AnswerToConnection(void* cls,
 
   ConnectionHandler* connectionHandler = reinterpret_cast<ConnectionHandler*>(*con_cls);
   HTTPMethod methodType = GetHTTPMethod(method);
-  HTTPRequest request = {webServer, connection, connectionHandler->fullUri,
-                         url,       methodType, version};
+  HTTPRequest request = {webServer, connection, connectionHandler->fullUri, url, methodType,
+                         version,   {}};
 
   if (connectionHandler->isNew)
     webServer->LogRequest(request);

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.h
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.h
@@ -68,12 +68,12 @@ namespace PERIPHERALS
     struct JoystickAxis
     {
       std::vector<int> ids;
-      float flat;
-      float fuzz;
-      float min;
-      float max;
-      float range;
-      float resolution;
+      float flat = 0.0f;
+      float fuzz = 0.0f;
+      float min = 0.0f;
+      float max = 0.0f;
+      float range = 0.0f;
+      float resolution = 0.0f;
     };
 
     using JoystickAxes = std::vector<JoystickAxis>;

--- a/xbmc/platform/linux/storage/UDevProvider.cpp
+++ b/xbmc/platform/linux/storage/UDevProvider.cpp
@@ -218,7 +218,7 @@ bool CUDevProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
   FD_SET(udev_monitor_get_fd(m_udevMon), &readfds);
 
   // non-blocking, check the file descriptor for received data
-  struct timeval tv = {0};
+  struct timeval tv = {};
   int count = select(udev_monitor_get_fd(m_udevMon) + 1, &readfds, nullptr, nullptr, &tv);
   if (count < 0)
     return false;

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -123,7 +123,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         // set this here to if the stat should fail
         bIsDir = (aDir.type == SMBC_DIR);
 
-        struct stat info = {0};
+        struct stat info = {};
         if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_sambastatfiles)
         {
           // make sure we use the authenticated path wich contains any default username

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -490,7 +490,7 @@ int CSMBFile::Stat(struct __stat64* buffer)
   if (m_fd == -1)
     return -1;
 
-  struct stat tmpBuffer = {0};
+  struct stat tmpBuffer = {};
 
   CSingleLock lock(smb);
   if (!smb.IsSmbValid())
@@ -508,7 +508,7 @@ int CSMBFile::Stat(const CURL& url, struct __stat64* buffer)
 
   if (!smb.IsSmbValid())
     return -1;
-  struct stat tmpBuffer = {0};
+  struct stat tmpBuffer = {};
   int iResult = smbc_stat(strFileName.c_str(), &tmpBuffer);
   CUtil::StatToStat64(buffer, &tmpBuffer);
   return iResult;

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -262,7 +262,7 @@ int CPVRClient::GetID() const
 void CPVRClient::WriteClientGroupInfo(const CPVRChannelGroup& xbmcGroup,
                                       PVR_CHANNEL_GROUP& addonGroup)
 {
-  addonGroup = {{0}};
+  addonGroup = {};
   addonGroup.bIsRadio = xbmcGroup.IsRadio();
   strncpy(addonGroup.strGroupName, xbmcGroup.GroupName().c_str(),
           sizeof(addonGroup.strGroupName) - 1);
@@ -279,7 +279,7 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording& xbmcRecording,
   time_t recTime;
   xbmcRecording.RecordingTimeAsUTC().GetAsTime(recTime);
 
-  addonRecording = {{0}};
+  addonRecording = {};
   strncpy(addonRecording.strRecordingId, xbmcRecording.m_strRecordingId.c_str(),
           sizeof(addonRecording.strRecordingId) - 1);
   strncpy(addonRecording.strTitle, xbmcRecording.m_strTitle.c_str(),
@@ -339,7 +339,7 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag& xbmcTimer, PVR_TIM
   int iPVRTimeCorrection =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection;
 
-  addonTimer = {0};
+  addonTimer = {};
   addonTimer.iClientIndex = xbmcTimer.m_iClientIndex;
   addonTimer.iParentClientIndex = xbmcTimer.m_iParentClientIndex;
   addonTimer.state = xbmcTimer.m_state;
@@ -381,7 +381,7 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag& xbmcTimer, PVR_TIM
 void CPVRClient::WriteClientChannelInfo(const std::shared_ptr<CPVRChannel>& xbmcChannel,
                                         PVR_CHANNEL& addonChannel)
 {
-  addonChannel = {0};
+  addonChannel = {};
   addonChannel.iUniqueId = xbmcChannel->UniqueID();
   addonChannel.iChannelNumber = xbmcChannel->ClientChannelNumber().GetChannelNumber();
   addonChannel.iSubChannelNumber = xbmcChannel->ClientChannelNumber().GetSubChannelNumber();
@@ -398,10 +398,10 @@ void CPVRClient::WriteClientChannelInfo(const std::shared_ptr<CPVRChannel>& xbmc
 
 bool CPVRClient::GetAddonProperties()
 {
-  char strBackendName[PVR_ADDON_NAME_STRING_LENGTH] = {0};
-  char strConnectionString[PVR_ADDON_NAME_STRING_LENGTH] = {0};
-  char strBackendVersion[PVR_ADDON_NAME_STRING_LENGTH] = {0};
-  char strBackendHostname[PVR_ADDON_NAME_STRING_LENGTH] = {0};
+  char strBackendName[PVR_ADDON_NAME_STRING_LENGTH] = {};
+  char strConnectionString[PVR_ADDON_NAME_STRING_LENGTH] = {};
+  char strBackendVersion[PVR_ADDON_NAME_STRING_LENGTH] = {};
+  char strBackendHostname[PVR_ADDON_NAME_STRING_LENGTH] = {};
   std::string strFriendlyName;
   PVR_ADDON_CAPABILITIES addonCapabilities = {};
   std::vector<std::shared_ptr<CPVRTimerType>> timerTypes;
@@ -675,8 +675,9 @@ PVR_ERROR CPVRClient::GetEPGForChannel(int iChannelUid, CPVREpg* epg, time_t sta
 {
   return DoAddonCall(
       __func__,
-      [this, iChannelUid, epg, start, end](const AddonInstance* addon) {
-        ADDON_HANDLE_STRUCT handle = {0};
+      [this, iChannelUid, epg, start, end](const AddonInstance* addon)
+      {
+        ADDON_HANDLE_STRUCT handle = {};
         handle.callerAddress = this;
         handle.dataAddress = epg;
 
@@ -879,8 +880,9 @@ PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups)
 {
   return DoAddonCall(
       __func__,
-      [this, groups](const AddonInstance* addon) {
-        ADDON_HANDLE_STRUCT handle = {0};
+      [this, groups](const AddonInstance* addon)
+      {
+        ADDON_HANDLE_STRUCT handle = {};
         handle.callerAddress = this;
         handle.dataAddress = groups;
         return addon->toAddon->GetChannelGroups(addon, &handle, groups->IsRadio());
@@ -892,8 +894,9 @@ PVR_ERROR CPVRClient::GetChannelGroupMembers(CPVRChannelGroup* group)
 {
   return DoAddonCall(
       __func__,
-      [this, group](const AddonInstance* addon) {
-        ADDON_HANDLE_STRUCT handle = {0};
+      [this, group](const AddonInstance* addon)
+      {
+        ADDON_HANDLE_STRUCT handle = {};
         handle.callerAddress = this;
         handle.dataAddress = group;
 
@@ -916,8 +919,9 @@ PVR_ERROR CPVRClient::GetChannels(CPVRChannelGroup& channels, bool radio)
 {
   return DoAddonCall(
       __func__,
-      [this, &channels, radio](const AddonInstance* addon) {
-        ADDON_HANDLE_STRUCT handle = {0};
+      [this, &channels, radio](const AddonInstance* addon)
+      {
+        ADDON_HANDLE_STRUCT handle = {};
         handle.callerAddress = this;
         handle.dataAddress = &channels;
         return addon->toAddon->GetChannels(addon, &handle, radio);
@@ -942,8 +946,9 @@ PVR_ERROR CPVRClient::GetRecordings(CPVRRecordings* results, bool deleted)
 {
   return DoAddonCall(
       __func__,
-      [this, results, deleted](const AddonInstance* addon) {
-        ADDON_HANDLE_STRUCT handle = {0};
+      [this, results, deleted](const AddonInstance* addon)
+      {
+        ADDON_HANDLE_STRUCT handle = {};
         handle.callerAddress = this;
         handle.dataAddress = results;
         return addon->toAddon->GetRecordings(addon, &handle, deleted);
@@ -1099,8 +1104,9 @@ PVR_ERROR CPVRClient::GetTimers(CPVRTimersContainer* results)
 {
   return DoAddonCall(
       __func__,
-      [this, results](const AddonInstance* addon) {
-        ADDON_HANDLE_STRUCT handle = {0};
+      [this, results](const AddonInstance* addon)
+      {
+        ADDON_HANDLE_STRUCT handle = {};
         handle.callerAddress = this;
         handle.dataAddress = results;
         return addon->toAddon->GetTimers(addon, &handle);
@@ -1249,7 +1255,7 @@ PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<CPVRChann
     if (!CanPlayChannel(channel))
       return PVR_ERROR_NO_ERROR; // no error, but no need to obtain the values from the addon
 
-    PVR_CHANNEL tag = {0};
+    PVR_CHANNEL tag = {};
     WriteClientChannelInfo(channel, tag);
 
     unsigned int iPropertyCount = STREAM_MAX_PROPERTY_COUNT;
@@ -1272,7 +1278,7 @@ PVR_ERROR CPVRClient::GetRecordingStreamProperties(const std::shared_ptr<CPVRRec
     if (!m_clientCapabilities.SupportsRecordings())
       return PVR_ERROR_NO_ERROR; // no error, but no need to obtain the values from the addon
 
-    PVR_RECORDING tag = {{0}};
+    PVR_RECORDING tag = {};
     WriteClientRecordingInfo(*recording, tag);
 
     unsigned int iPropertyCount = STREAM_MAX_PROPERTY_COUNT;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -100,7 +100,7 @@ void CPVRGUIInfo::ClearQualityInfo(PVR_SIGNAL_STATUS& qualityInfo)
 
 void CPVRGUIInfo::ClearDescrambleInfo(PVR_DESCRAMBLE_INFO& descrambleInfo)
 {
-  descrambleInfo = {0};
+  descrambleInfo = {};
 }
 
 void CPVRGUIInfo::Start()

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -635,7 +635,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       TiXmlElement* pRefreshOverride = pAdjustRefreshrate->FirstChildElement("override");
       while (pRefreshOverride)
       {
-        RefreshOverride override = {0};
+        RefreshOverride override = {};
 
         float fps;
         if (XMLUtils::GetFloat(pRefreshOverride, "fps", fps))
@@ -682,7 +682,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       TiXmlElement* pRefreshFallback = pAdjustRefreshrate->FirstChildElement("fallback");
       while (pRefreshFallback)
       {
-        RefreshOverride fallback = {0};
+        RefreshOverride fallback = {};
         fallback.fallback = true;
 
         float refresh;
@@ -726,7 +726,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
       while (pRefreshVideoLatency)
       {
-        RefreshVideoLatency videolatency = {0};
+        RefreshVideoLatency videolatency = {};
 
         if (XMLUtils::GetFloat(pRefreshVideoLatency, "rate", refresh))
         {

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -375,7 +375,7 @@ void CSettingsManager::RegisterCallback(ISettingCallback *callback, const std::s
       if (m_initialized)
         continue;
 
-      Setting tmpSetting = { nullptr };
+      Setting tmpSetting = {};
       std::pair<SettingMap::iterator, bool> tmpIt = InsertSetting(setting, tmpSetting);
       itSetting = tmpIt.first;
     }
@@ -1217,7 +1217,7 @@ void CSettingsManager::AddSetting(const std::shared_ptr<CSetting>& setting)
   auto addedSetting = FindSetting(setting->GetId());
   if (addedSetting == m_settings.end())
   {
-    Setting tmpSetting = { nullptr };
+    Setting tmpSetting = {};
     auto tmpIt = InsertSetting(setting->GetId(), tmpSetting);
     addedSetting = tmpIt.first;
   }

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -30,8 +30,7 @@ std::shared_ptr<CLibcdio> CLibcdio::m_pInstance;
 #define UDF_ANCHOR_SECTOR     256  /* buffer[5] */
 
 
-signature_t CCdIoSupport::sigs[] =
-  {
+signature_t CCdIoSupport::sigs[] = {
     /*buffer[x] off look for     description */
     {0, 1, "CD001\0", "ISO 9660\0"},
     {0, 1, "CD-I", "CD-I"},
@@ -47,8 +46,7 @@ signature_t CCdIoSupport::sigs[] =
     {4, 0, "VIDEO_CD", "VIDEO CD"},
     {4, 0, "SUPERVCD", "Chaoji VCD"},
     {0, 1, "BEA01", "UDF"},
-    { 0 }
-  };
+    {}};
 
 #undef DEBUG_CDIO
 

--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -110,8 +110,10 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint64_t size)
     }
   }
 
-  struct dma_heap_allocation_data allocData = {
-      .len = m_size, .fd_flags = (O_CLOEXEC | O_RDWR), .heap_flags = 0};
+  struct dma_heap_allocation_data allocData{};
+  allocData.len = m_size;
+  allocData.fd_flags = (O_CLOEXEC | O_RDWR);
+  allocData.heap_flags = 0;
 
   int ret = ioctl(m_dmaheapfd, DMA_HEAP_IOCTL_ALLOC, &allocData);
   if (ret < 0)

--- a/xbmc/utils/DumbBufferObject.cpp
+++ b/xbmc/utils/DumbBufferObject.cpp
@@ -62,7 +62,10 @@ bool CDumbBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
       throw std::runtime_error("CDumbBufferObject: pixel format not implemented");
   }
 
-  struct drm_mode_create_dumb create_dumb = {.height = height, .width = width, .bpp = bpp};
+  struct drm_mode_create_dumb create_dumb{};
+  create_dumb.height = height;
+  create_dumb.width = width;
+  create_dumb.bpp = bpp;
 
   int ret = drmIoctl(m_device, DRM_IOCTL_MODE_CREATE_DUMB, &create_dumb);
   if (ret < 0)
@@ -122,7 +125,8 @@ uint8_t* CDumbBufferObject::GetMemory()
     return nullptr;
   }
 
-  struct drm_mode_map_dumb map_dumb = {.handle = handle};
+  struct drm_mode_map_dumb map_dumb{};
+  map_dumb.handle = handle;
 
   ret = drmIoctl(m_device, DRM_IOCTL_MODE_MAP_DUMB, &map_dumb);
   if (ret < 0)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -456,7 +456,7 @@ bool CSysInfo::GetDiskSpace(std::string drive,int& iTotal, int& iTotalFree, int&
 {
   using namespace KODI::PLATFORM::FILESYSTEM;
 
-  space_info total = { 0 };
+  space_info total = {};
   std::error_code ec;
 
   // None of this makes sense but the idea of total space

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -125,11 +125,10 @@ bool CUDMABufferObject::CreateBufferObject(uint64_t size)
     }
   }
 
-  struct udmabuf_create_item create = {
-      .memfd = static_cast<uint32_t>(m_memfd),
-      .offset = 0,
-      .size = m_size,
-  };
+  struct udmabuf_create_item create{};
+  create.memfd = static_cast<uint32_t>(m_memfd);
+  create.offset = 0;
+  create.size = m_size;
 
   m_fd = ioctl(m_udmafd, UDMABUF_CREATE, &create);
   if (m_fd < 0)

--- a/xbmc/video/ViewModeSettings.cpp
+++ b/xbmc/video/ViewModeSettings.cpp
@@ -16,8 +16,8 @@ struct ViewModeProperties
 {
   int stringIndex;
   int viewMode;
-  bool hideFromQuickCycle;
-  bool hideFromList;
+  bool hideFromQuickCycle = false;
+  bool hideFromList = false;
 };
 
 #define HIDE_ITEM true

--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
@@ -71,15 +71,9 @@ bool CDRMLegacy::WaitingForFlip()
     0,
   };
 
-  drmEventContext drm_evctx =
-  {
-    DRM_EVENT_CONTEXT_VERSION,
-    nullptr,
-    PageFlipHandler,
-  #if DRM_EVENT_CONTEXT_VERSION > 2
-    nullptr,
-  #endif
-  };
+  drmEventContext drm_evctx{};
+  drm_evctx.version = DRM_EVENT_CONTEXT_VERSION;
+  drm_evctx.page_flip_handler = PageFlipHandler;
 
   while(flip_happening)
   {

--- a/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
@@ -139,7 +139,8 @@ XBMC_Event CInputProcessorKeyboard::SendKey(unsigned char scancode, XBMCKey key,
 {
   assert(m_keymap);
 
-  XBMC_Event event{static_cast<unsigned char> (pressed ? XBMC_KEYDOWN : XBMC_KEYUP)};
+  XBMC_Event event{};
+  event.type = pressed ? XBMC_KEYDOWN : XBMC_KEYUP;
   event.key.keysym =
   {
     .scancode = scancode,

--- a/xbmc/windowing/wayland/InputProcessorPointer.cpp
+++ b/xbmc/windowing/wayland/InputProcessorPointer.cpp
@@ -121,14 +121,16 @@ void CInputProcessorPointer::SetMousePosFromSurface(CPointGen<double> position)
 
 void CInputProcessorPointer::SendMouseMotion()
 {
-  XBMC_Event event{XBMC_MOUSEMOTION};
+  XBMC_Event event{};
+  event.type = XBMC_MOUSEMOTION;
   event.motion = {m_pointerPosition.x, m_pointerPosition.y};
   m_handler.OnPointerEvent(event);
 }
 
 void CInputProcessorPointer::SendMouseButton(unsigned char button, bool pressed)
 {
-  XBMC_Event event{static_cast<unsigned char> (pressed ? XBMC_MOUSEBUTTONDOWN : XBMC_MOUSEBUTTONUP)};
+  XBMC_Event event{};
+  event.type = pressed ? XBMC_MOUSEBUTTONDOWN : XBMC_MOUSEBUTTONUP;
   event.button = {button, m_pointerPosition.x, m_pointerPosition.y};
   m_handler.OnPointerEvent(event);
 }

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -841,7 +841,8 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
     {
       if (m_bFullScreen)
       {
-        XBMC_Event msg{XBMC_MODECHANGE};
+        XBMC_Event msg{};
+        msg.type = XBMC_MODECHANGE;
         msg.mode.res = RES_WINDOW;
         SetWindowResolution(sizes.bufferSize.Width(), sizes.bufferSize.Height());
         // FIXME
@@ -851,7 +852,8 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
       }
       else
       {
-        XBMC_Event msg{XBMC_VIDEORESIZE};
+        XBMC_Event msg{};
+        msg.type = XBMC_VIDEORESIZE;
         msg.resize = {sizes.bufferSize.Width(), sizes.bufferSize.Height()};
         // FIXME
         dynamic_cast<CWinEventsWayland&>(*m_winEvents).MessagePush(&msg);
@@ -874,7 +876,8 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
         res = static_cast<RESOLUTION> (CDisplaySettings::GetInstance().ResolutionInfoSize() - 1);
       }
 
-      XBMC_Event msg{XBMC_MODECHANGE};
+      XBMC_Event msg{};
+      msg.type = XBMC_MODECHANGE;
       msg.mode.res = res;
       // FIXME
       dynamic_cast<CWinEventsWayland&>(*m_winEvents).MessagePush(&msg);

--- a/xbmc/windowing/wayland/WindowDecorator.cpp
+++ b/xbmc/windowing/wayland/WindowDecorator.cpp
@@ -667,7 +667,11 @@ CWindowDecorator::BorderSurface CWindowDecorator::MakeBorderSurface()
   surface.wlSurface = m_compositor.create_surface();
   auto subsurface = m_subcompositor.get_subsurface(surface.wlSurface, m_mainSurface);
 
-  return {surface, subsurface};
+  CWindowDecorator::BorderSurface boarderSurface;
+  boarderSurface.surface = surface;
+  boarderSurface.subsurface = subsurface;
+
+  return boarderSurface;
 }
 
 bool CWindowDecorator::IsDecorationActive() const


### PR DESCRIPTION
This PR aims to fix a bunch of missing-field-initializers warnings. This fixes all the warnings for my current build and configuration (should be a good chunk of the generic ones).

Most fixes are done by allowing the type to be default initialised using `{}`. For some reason we seem to use `{0}` a lot and I'm not sure why. This doesn't work if there are non integer types in a struct.

Some other fixes are done by modifying the default values of the struct or removing unused members all together.

I don't think there is anything wrong with we currently do but this should make sure we default initialise all members of the struct.

 