### PR TITLE
CDVDSubtitlesLibass: remove use of IDVDResourceCounted and use as a shared_ptr

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -41,13 +41,7 @@ bool CDVDOverlayCodecSSA::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 
   Dispose();
 
-  m_hints  = hints;
-  return InitLibass();
-}
-
-bool CDVDOverlayCodecSSA::InitLibass()
-{
-  return m_libass->DecodeHeader(static_cast<char*>(m_hints.extradata), m_hints.extrasize);
+  return m_libass->DecodeHeader(static_cast<char*>(hints.extradata), hints.extrasize);
 }
 
 void CDVDOverlayCodecSSA::Dispose()
@@ -152,7 +146,6 @@ void CDVDOverlayCodecSSA::Flush()
 {
   m_order = 0;
   m_output = false;
-  InitLibass();
 }
 
 CDVDOverlay* CDVDOverlayCodecSSA::GetOverlay()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -18,11 +18,12 @@
 
 #include <memory>
 
+#include "system.h"
 
-CDVDOverlayCodecSSA::CDVDOverlayCodecSSA() : CDVDOverlayCodec("SSA Subtitle Decoder")
+CDVDOverlayCodecSSA::CDVDOverlayCodecSSA()
+  : CDVDOverlayCodec("SSA Subtitle Decoder"), m_libass(std::make_shared<CDVDSubtitlesLibass>())
 {
   m_pOverlay = NULL;
-  m_libass   = NULL;
   m_order    = 0;
   m_output   = false;
 }
@@ -46,16 +47,11 @@ bool CDVDOverlayCodecSSA::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 
 bool CDVDOverlayCodecSSA::InitLibass()
 {
-  if (!m_libass)
-    m_libass = new CDVDSubtitlesLibass();
   return m_libass->DecodeHeader(static_cast<char*>(m_hints.extradata), m_hints.extrasize);
 }
 
 void CDVDOverlayCodecSSA::Dispose()
 {
-  if(m_libass)
-    SAFE_RELEASE(m_libass);
-
   if(m_pOverlay)
     SAFE_RELEASE(m_pOverlay);
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
@@ -27,13 +27,8 @@ public:
   CDVDOverlay* GetOverlay() override;
 
 private:
-  /*! \brief Initializes the libass handler
-   */
-  bool InitLibass();
-
   std::shared_ptr<CDVDSubtitlesLibass> m_libass;
   CDVDOverlaySSA*      m_pOverlay;
   bool                 m_output;
-  CDVDStreamInfo       m_hints;
   int                  m_order;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
@@ -31,7 +31,7 @@ private:
    */
   bool InitLibass();
 
-  CDVDSubtitlesLibass* m_libass;
+  std::shared_ptr<CDVDSubtitlesLibass> m_libass;
   CDVDOverlaySSA*      m_pOverlay;
   bool                 m_output;
   CDVDStreamInfo       m_hints;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
@@ -11,31 +11,23 @@
 #include "../../DVDSubtitles/DVDSubtitlesLibass.h"
 #include "DVDOverlay.h"
 
-#include "system.h" // for SAFE_RELEASE
-
 class CDVDOverlaySSA : public CDVDOverlay
 {
 public:
-
-  explicit CDVDOverlaySSA(CDVDSubtitlesLibass* libass) : CDVDOverlay(DVDOVERLAY_TYPE_SSA)
+  explicit CDVDOverlaySSA(std::shared_ptr<CDVDSubtitlesLibass> libass)
+    : CDVDOverlay(DVDOVERLAY_TYPE_SSA)
   {
     replace = true;
-    m_libass = libass;
-    libass->Acquire();
+    m_libass = std::move(libass);
   }
 
   CDVDOverlaySSA(CDVDOverlaySSA& src)
     : CDVDOverlay(src)
     , m_libass(src.m_libass)
   {
-    m_libass->Acquire();
   }
 
-  ~CDVDOverlaySSA() override
-  {
-    if(m_libass)
-      SAFE_RELEASE(m_libass);
-  }
+  ~CDVDOverlaySSA() override = default;
 
   CDVDOverlaySSA* Clone() override
   {
@@ -46,8 +38,8 @@ public:
    \brief Getter for the libass handler
    \return The libass handler.
    */
-  CDVDSubtitlesLibass* GetLibass() const { return m_libass; }
+  std::shared_ptr<CDVDSubtitlesLibass> GetLibass() const { return m_libass; }
 
 private:
-  CDVDSubtitlesLibass* m_libass;
+  std::shared_ptr<CDVDSubtitlesLibass> m_libass;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -12,10 +12,11 @@
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "utils/log.h"
 
-CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile)
-    : CDVDSubtitleParserText(std::move(pStream), strFile)
+CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream>&& pStream,
+                                             const std::string& strFile)
+  : CDVDSubtitleParserText(std::move(pStream), strFile),
+    m_libass(std::make_shared<CDVDSubtitlesLibass>())
 {
-  m_libass = new CDVDSubtitlesLibass();
 }
 
 CDVDSubtitleParserSSA::~CDVDSubtitleParserSSA()
@@ -57,10 +58,5 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo &hints)
 
 void CDVDSubtitleParserSSA::Dispose()
 {
-  if(m_libass)
-  {
-    SAFE_RELEASE(m_libass);
-    CLog::Log(LOGINFO, "SSA Parser: Releasing reference to ASS Library");
-  }
   CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.h
@@ -23,5 +23,5 @@ public:
   void Dispose() override;
 
 private:
-  CDVDSubtitlesLibass* m_libass;
+  std::shared_ptr<CDVDSubtitlesLibass> m_libass;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -8,18 +8,17 @@
 
 #pragma once
 
-#include "DVDResource.h"
 #include "threads/CriticalSection.h"
 
 #include <ass/ass.h>
 
 /** Wrapper for Libass **/
 
-class CDVDSubtitlesLibass : public IDVDResourceCounted<CDVDSubtitlesLibass>
+class CDVDSubtitlesLibass
 {
 public:
   CDVDSubtitlesLibass();
-  ~CDVDSubtitlesLibass() override;
+  ~CDVDSubtitlesLibass();
 
   ASS_Image* RenderImage(int frameWidth, int frameHeight, int videoWidth, int videoHeight, int sourceWidth, int sourceHeight,
                          double pts, int useMargin = 0, double position = 0.0, int* changes = NULL);


### PR DESCRIPTION
This removes the use of `IDVDResourceCounted` from `CDVDSubtitlesLibass` and instead allows it to be used as a `shared_ptr` instead.

I've briefly tested this with my (small) collection of libass subtitles.

This also changes the initialisation of `CDVDSubtitlesLibass` to be in the constructor of  `CDVDOverlayCodecSSA`.

There are other changes and cleanups that can be done here but I wanted to keep the changes minimal.