### PR TITLE
CPlayerCoreFactory: update to use lists of unique_ptr's

### DIFF
--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -43,9 +43,6 @@ CPlayerCoreFactory::CPlayerCoreFactory(const CProfileManager &profileManager) :
 CPlayerCoreFactory::~CPlayerCoreFactory()
 {
   m_settings->GetSettingsManager()->UnregisterSettingsHandler(this);
-
-  for(std::vector<CPlayerSelectionRule *>::iterator it = m_vecCoreSelectionRules.begin(); it != m_vecCoreSelectionRules.end(); ++it)
-    delete *it;
 }
 
 void CPlayerCoreFactory::OnSettingsLoaded()
@@ -104,7 +101,7 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
   GetPlayers(validPlayers);
 
   // Process rules
-  for (auto rule: m_vecCoreSelectionRules)
+  for (auto& rule : m_vecCoreSelectionRules)
     rule->GetPlayers(item, validPlayers, players);
 
   CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: matched {0} rules with players", players.size());
@@ -308,9 +305,6 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
   if (clear)
   {
     m_vecPlayerConfigs.clear();
-
-    for (auto rule: m_vecCoreSelectionRules)
-      delete rule;
     m_vecCoreSelectionRules.clear();
 
     // Builtin players
@@ -380,21 +374,21 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
     {
       if (StringUtils::CompareNoCase(szAction, "append") == 0)
       {
-        m_vecCoreSelectionRules.push_back(new CPlayerSelectionRule(pRule));
+        m_vecCoreSelectionRules.emplace_back(std::make_unique<CPlayerSelectionRule>(pRule));
       }
       else if (StringUtils::CompareNoCase(szAction, "prepend") == 0)
       {
-        m_vecCoreSelectionRules.insert(m_vecCoreSelectionRules.begin(), 1, new CPlayerSelectionRule(pRule));
+        m_vecCoreSelectionRules.emplace_front(std::make_unique<CPlayerSelectionRule>(pRule));
       }
       else
       {
         m_vecCoreSelectionRules.clear();
-        m_vecCoreSelectionRules.push_back(new CPlayerSelectionRule(pRule));
+        m_vecCoreSelectionRules.emplace_back(std::make_unique<CPlayerSelectionRule>(pRule));
       }
     }
     else
     {
-      m_vecCoreSelectionRules.push_back(new CPlayerSelectionRule(pRule));
+      m_vecCoreSelectionRules.emplace_back(std::make_unique<CPlayerSelectionRule>(pRule));
     }
 
     pRule = pRule->NextSiblingElement("rules");

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -11,6 +11,7 @@
 #include "settings/lib/ISettingsHandler.h"
 #include "threads/CriticalSection.h"
 
+#include <list>
 #include <memory>
 #include <string>
 #include <vector>
@@ -63,6 +64,6 @@ private:
   bool LoadConfiguration(const std::string &file, bool clear);
 
   std::vector<std::unique_ptr<CPlayerCoreConfig>> m_vecPlayerConfigs;
-  std::vector<CPlayerSelectionRule *> m_vecCoreSelectionRules;
+  std::list<std::unique_ptr<CPlayerSelectionRule>> m_vecCoreSelectionRules;
   mutable CCriticalSection m_section;
 };

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -62,7 +62,7 @@ private:
 
   bool LoadConfiguration(const std::string &file, bool clear);
 
-  std::vector<CPlayerCoreConfig *> m_vecPlayerConfigs;
+  std::vector<std::unique_ptr<CPlayerCoreConfig>> m_vecPlayerConfigs;
   std::vector<CPlayerSelectionRule *> m_vecCoreSelectionRules;
   mutable CCriticalSection m_section;
 };

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -26,15 +26,6 @@ CPlayerSelectionRule::CPlayerSelectionRule(TiXmlElement* pRule)
   Initialize(pRule);
 }
 
-CPlayerSelectionRule::~CPlayerSelectionRule()
-{
-  for (unsigned int i = 0; i < vecSubRules.size(); i++)
-  {
-    delete vecSubRules[i];
-  }
-  vecSubRules.clear();
-}
-
 void CPlayerSelectionRule::Initialize(TiXmlElement* pRule)
 {
   m_name = XMLUtils::GetAttribute(pRule, "name");
@@ -84,7 +75,7 @@ void CPlayerSelectionRule::Initialize(TiXmlElement* pRule)
   TiXmlElement* pSubRule = pRule->FirstChildElement("rule");
   while (pSubRule)
   {
-    vecSubRules.push_back(new CPlayerSelectionRule(pSubRule));
+    vecSubRules.emplace_back(std::make_unique<CPlayerSelectionRule>(pSubRule));
     pSubRule = pSubRule->NextSiblingElement("rule");
   }
 }
@@ -187,8 +178,8 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, std::vector<std::st
 
   CLog::Log(LOGDEBUG, "CPlayerSelectionRule::GetPlayers: matches rule: %s", m_name.c_str());
 
-  for (unsigned int i = 0; i < vecSubRules.size(); i++)
-    vecSubRules[i]->GetPlayers(item, validPlayers, players);
+  for (const auto& rule : vecSubRules)
+    rule->GetPlayers(item, validPlayers, players);
 
   if (std::find(validPlayers.begin(), validPlayers.end(), m_playerName) != validPlayers.end())
   {

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -21,7 +21,7 @@ class CPlayerSelectionRule
 {
 public:
   explicit CPlayerSelectionRule(TiXmlElement* rule);
-  virtual ~CPlayerSelectionRule();
+  virtual ~CPlayerSelectionRule() = default;
 
   void GetPlayers(const CFileItem& item, std::vector<std::string>&validPlayers, std::vector<std::string>&players);
 
@@ -58,5 +58,5 @@ private:
 
   std::string m_playerName;
 
-  std::vector<CPlayerSelectionRule *> vecSubRules;
+  std::vector<std::unique_ptr<CPlayerSelectionRule>> vecSubRules;
 };


### PR DESCRIPTION
This PR updates some lists to use unique_ptr's instead of raw pointers.

The changes are pretty trivial.

I've changed `m_vecCoreSelectionRules` to be a `std::list` so we can use `push_front`/`emplace_front`

I've also included changes to `CPlayerSelectionRule` as they are similar changes.