### PR TITLE
[PVR] EPG tag search against specific channel fails when 'Use backend channel numbers' is enabled

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -18,6 +18,8 @@
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgSearchFilter.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 
 #include <string>
@@ -60,6 +62,10 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
   std::vector< std::pair<std::string, int> > labels;
   labels.emplace_back(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET);
 
+  const bool useBackendChannelNumbers =
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS);
+
   std::shared_ptr<CPVRChannelGroup> group;
   if (iChannelGroup == EPG_SEARCH_UNSET)
     group = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_searchFilter->IsRadio());
@@ -79,10 +85,14 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
     if (groupMember->Channel())
     {
       labels.emplace_back(std::make_pair(groupMember->Channel()->ChannelName(), iIndex));
-      m_channelNumbersMap.insert(std::make_pair(iIndex, groupMember->ChannelNumber()));
+
+      CPVRChannelNumber channelNumber = (useBackendChannelNumbers)
+                                            ? groupMember->ClientChannelNumber()
+                                            : groupMember->ChannelNumber();
+      m_channelNumbersMap.insert(std::make_pair(iIndex, channelNumber));
 
       if (iSelectedChannel == EPG_SEARCH_UNSET &&
-          groupMember->ChannelNumber() == m_searchFilter->GetChannelNumber())
+          channelNumber == m_searchFilter->GetChannelNumber())
         iSelectedChannel = iIndex;
 
       ++iIndex;


### PR DESCRIPTION
## Description
It was reported to me by a user of my PVR addon that the PVR Search function was not working if a specific Channel was set for the search; their investigation further clarified that it would only happen if the PVR & Live TV "Use backend channel numbers" setting is enabled. This change aims to resolve that concern.

## Motivation and context
The PVR Search dialog (GUIDialogPVRGuideSearch) was not taking this setting into account when populating the values for the channel spin control, ultimately causing the incorrect channel number to be applied to the search filter.

## How has this been tested?
Tested on Windows 10 (Desktop) x64, current master branch as of 2021.05.04.  

Prior to the proposed change, I verified that the search operation(s) worked as expected when "Use backend channel numbers" was disabled and a specific channel was set as part of the search criteria.  I also verified that the same search operation would fail when "Use backend channel numbers" was enabled.

After the proposed change, I verified that the spin control was being loaded with the backend channel numbers when "Use backend channel numbers" was enabled; the search operation was successful; and that a subsequent invocation of Search... would properly select the prior channel number as the default "Channel".

## What is the effect on users?
My _expectation_ is that the only effect on users would be that if they have "Use backend channel numbers" enabled the Search function would now work against a specific channel.

## Screenshots (if appropriate):
Here are the search results for what the user was expecting ("Sliders") when executed against "All Channels".  Note that there are three results for channel "WJLADT3":
![allchannels](https://user-images.githubusercontent.com/706055/117094330-8a496280-ad31-11eb-8bfb-40f1465114ec.png)


Here is the search criteria selecting channel "WJLADT3" from the "All Channels" results:
![singlechannel](https://user-images.githubusercontent.com/706055/117094292-6a19a380-ad31-11eb-925f-b4eacddb0c42.png)

Prior to the proposed change, this would result in "No results found":
![noresults](https://user-images.githubusercontent.com/706055/117094399-b5cc4d00-ad31-11eb-8946-049b7c97abdc.png)

After the proposed change, the same operation would return the previously expected three results for channel "WJLADT3":
![afterchange](https://user-images.githubusercontent.com/706055/117094469-dc8a8380-ad31-11eb-9021-2d24e47a5aeb.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
