### PR TITLE
[UWP] [Xbox] Fix HDR toggle logic and other fixes for UWP/Xbox

### DIFF
--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -70,7 +70,9 @@ public:
   static bool SetThreadLocalLocale(bool enable = true);
 
   // HDR display support
+#ifdef TARGET_WINDOWS_DESKTOP
   static HDR_STATUS ToggleWindowsHDR(DXGI_MODE_DESC& modeDesc);
+#endif // TARGET_WINDOWS_DESKTOP
   static HDR_STATUS GetWindowsHDRStatus();
 
   static void PlatformSyslog();

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -81,6 +81,9 @@ namespace DX
 
     // HDR display support
     HDR_STATUS ToggleHDR();
+#ifdef TARGET_WINDOWS_STORE
+    HDR_STATUS XboxSwitchHDMIMode(bool needPQ);
+#endif
     void SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const;
     void SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpace);
     bool IsHDROutput() const { return m_IsHDROutput; }


### PR DESCRIPTION
## Description
- Fix HDR toggle logic and other fixes for UWP/Xbox.
- ~This PR _should_ enable HDR passthrough on Xbox Series S / X.~
- ~If HDR is disabled on Xbox settings (or not supported by TV)~ allows advanced tone mapping methods (Hable / ACES Filmic).
- Provides alternative code to `DX::DeviceResources::GetDisplayMode` for UWP Xbox and UWP Windows 10 fallback.
- Maybe can fix some rare HDR toggling issues reported with AMD old drivers/HW (Windows 10 x64).


## Motivation and context
Once 4K HEVC playback is enabled on Xbox by https://github.com/xbmc/xbmc/pull/19221, only good things can happen...  

## How has this been tested?
**Tested on Windows 10 UWP**

**Part1:   Windows 10 HDR switch = ON (from display settings)**
Playback HDR10 video ---> **Passed** (10 bit output, HDR10 metadata passed out, BT2020 color sp, transfer PQ enabled)
Playback SDR video ----> **Passed** (10 bit output, BT2020 color sp, no metadata passed, transfer PQ disabled) [Windows tone maps SDR to pseudo 'HDR' with internal Windows 10 routines] picture is OK.

**Part2:   Windows 10 HDR switch = OFF (from display settings)**
Playback HDR10 video ---> **Passed** (8 bit output, tone mapping enabled with Hable / ACES) picture OK same as Windows x64 
Playback SDR video ----> **Passed** (8 bit output, normal SDR video parameters). 

Test build available here:
https://github.com/thexai/xbmc/releases/tag/19.1-Preview3

## What is the effect on users?
- Enables HDR passthrough on ~Xbox Series S / X~ Windows 10 UWP.
- Enables advanced tone mapping methods (Hable / ACES Filmic) on both Xbox and Windows 10 UWP

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
