### PR TITLE
[utils] job manager/queue fixes

### DIFF
--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -211,7 +211,10 @@ unsigned int CJobManager::AddJob(CJob *job, IJobCallback *callback, CJob::PRIORI
   CSingleLock lock(m_section);
 
   if (!m_running)
+  {
+    delete job;
     return 0;
+  }
 
   // increment the job counter, ensuring 0 (invalid job) is never hit
   m_jobCounter++;

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -147,17 +147,27 @@ public:
   /*!
    \brief The callback used when a job completes.
 
-   OnJobComplete is called at the completion of the CJob::DoWork function, and is used
-   to return information to the caller on the result of the job.  On returning from this function
-   the CJobManager will destroy this job.
+   CJobQueue implementation will cleanup the internal processing queue and then queue the next
+   job at the job manager, if any.
 
-   Subclasses should override this function if they wish to transfer information from the job prior
-   to it's deletion.  They must then call this base class function, which will move on to the next
-   job.
-
-   \sa CJobManager, IJobCallback and  CJob
+   \param jobID the unique id of the job (as retrieved from CJobManager::AddJob)
+   \param success the result from the DoWork call
+   \param job the job that has been processed.
+   \sa CJobManager, IJobCallback and CJob
    */
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
+
+  /*!
+   \brief The callback used when a job will be aborted.
+
+   CJobQueue implementation will cleanup the internal processing queue and then queue the next
+   job at the job manager, if any.
+
+   \param jobID the unique id of the job (as retrieved from CJobManager::AddJob)
+   \param job the job that has been aborted.
+   \sa CJobManager, IJobCallback and CJob
+   */
+  void OnJobAbort(unsigned int jobID, CJob* job) override;
 
 protected:
   /*!
@@ -167,6 +177,7 @@ protected:
   bool QueueEmpty() const;
 
 private:
+  void OnJobNotify(CJob* job);
   void QueueNextJob();
 
   typedef std::deque<CJobPointer> Queue;

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -104,8 +104,10 @@ public:
 
   /*!
    \brief Add a job to the queue
-   On completion of the job (or destruction of the job queue) the CJob object will be destroyed.
+   On completion of the job, destruction of the job queue or in case the job could not be added successfully, the CJob object will be destroyed.
    \param job a pointer to the job to add. The job should be subclassed from CJob.
+   \return True if the job was added successfully, false otherwise.
+   In case of failure, the passed CJob object will be deleted before returning from this method.
    \sa CJob
    */
   bool AddJob(CJob *job);
@@ -233,10 +235,12 @@ public:
 
   /*!
    \brief Add a job to the threaded job manager.
+   On completion or abort of the job or in case the job could not be added successfully, the CJob object will be destroyed.
    \param job a pointer to the job to add. The job should be subclassed from CJob
    \param callback a pointer to an IJobCallback instance to receive job progress and completion notices.
    \param priority the priority that this job should run at.
-   \return a unique identifier for this job, to be used with other interaction
+   \return On success, a unique identifier for this job, to be used with other interaction, 0 otherwise.
+   In case of failure, the passed CJob object will be deleted before returning from this method.
    \sa CJob, IJobCallback, CancelJob()
    */
   unsigned int AddJob(CJob *job, IJobCallback *callback, CJob::PRIORITY priority = CJob::PRIORITY_LOW);


### PR DESCRIPTION
Two fixes here:

1) Memory leak. Jobs NOT successfully added to CJobManager, because the manager is not running, were never deleted. I checked every calling code and found, that no callee inspects the return value of AddJob and all jobs are actually leaked. The callee not deleting the job is fine as the contract is that the callee hands over ownership of the job it has created to CJobManager. Now, AddJob deletes the job passed to it in case it cannot be added. I updated the documentation accordingly. BTW, CJobQueue::AddJob did not have the memory leak, because it was already deleting the passed job in case of error. I updated CJobQueue's documentation to be clear on that behavior.

2) Fixed access to freed memory thus crash happened after CJobManager::CancelJobs was called (on Kodi exit). The two annotated screen shots try to explain what happened exactly:

<img width="1286" alt="Screenshot 2021-05-04 at 15 47 32" src="https://user-images.githubusercontent.com/3226626/117143044-adffbd80-adb0-11eb-9711-9c8adf28ccc8.png">
<img width="1522" alt="Screenshot 2021-05-04 at 15 48 46" src="https://user-images.githubusercontent.com/3226626/117143054-b0621780-adb0-11eb-8220-26b12b0a5aa1.png">

As I can easily reproduce both the crash and the memory leak, I did extensive runtime tests and know that the two commits of this PR do fix both abovementioned problems.

@phunkyfish @lrusak due to lack of a maintainer for the CJob* classes, could you please take a look?