### PR TITLE
[PVR] Remove "group member attributes cached at channel instances" hack

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -35,6 +35,7 @@
 #include "playlists/PlayListFactory.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecording.h"
@@ -198,6 +199,12 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannel>& channel)
 
   FillMusicInfoTag(channel, epgNow);
   FillInMimeType(false);
+}
+
+CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroupMember)
+  : CFileItem(channelGroupMember->Channel())
+{
+  m_pvrChannelGroupMemberInfoTag = channelGroupMember;
 }
 
 CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
@@ -443,6 +450,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
 
   m_epgInfoTag = item.m_epgInfoTag;
   m_pvrChannelInfoTag = item.m_pvrChannelInfoTag;
+  m_pvrChannelGroupMemberInfoTag = item.m_pvrChannelGroupMemberInfoTag;
   m_pvrRecordingInfoTag = item.m_pvrRecordingInfoTag;
   m_pvrTimerInfoTag = item.m_pvrTimerInfoTag;
   m_addonInfo = item.m_addonInfo;
@@ -516,6 +524,7 @@ void CFileItem::Reset()
   m_videoInfoTag=NULL;
   m_epgInfoTag.reset();
   m_pvrChannelInfoTag.reset();
+  m_pvrChannelGroupMemberInfoTag.reset();
   m_pvrRecordingInfoTag.reset();
   m_pvrTimerInfoTag.reset();
   delete m_pictureInfoTag;
@@ -720,6 +729,9 @@ void CFileItem::ToSortable(SortItem &sortable, Field field) const
 
   if (HasPVRChannelInfoTag())
     GetPVRChannelInfoTag()->ToSortable(sortable, field);
+
+  if (HasPVRChannelGroupMemberInfoTag())
+    GetPVRChannelGroupMemberInfoTag()->ToSortable(sortable, field);
 
   if (HasAddonInfo())
   {

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -47,6 +47,7 @@ namespace GAME
 namespace PVR
 {
 class CPVRChannel;
+class CPVRChannelGroupMember;
 class CPVREpgInfoTag;
 class CPVRRecording;
 class CPVRTimerInfoTag;
@@ -112,6 +113,7 @@ public:
   explicit CFileItem(const CVideoInfoTag& movie);
   explicit CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRChannel>& channel);
+  explicit CFileItem(const std::shared_ptr<PVR::CPVRChannelGroupMember>& channelGroupMember);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRRecording>& record);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRTimerInfoTag>& timer);
   explicit CFileItem(const CMediaSource& share);
@@ -298,6 +300,16 @@ public:
   inline const std::shared_ptr<PVR::CPVRChannel> GetPVRChannelInfoTag() const
   {
     return m_pvrChannelInfoTag;
+  }
+
+  inline bool HasPVRChannelGroupMemberInfoTag() const
+  {
+    return m_pvrChannelGroupMemberInfoTag.get() != nullptr;
+  }
+
+  inline const std::shared_ptr<PVR::CPVRChannelGroupMember> GetPVRChannelGroupMemberInfoTag() const
+  {
+    return m_pvrChannelGroupMemberInfoTag;
   }
 
   inline bool HasPVRRecordingInfoTag() const
@@ -596,6 +608,7 @@ private:
   std::shared_ptr<PVR::CPVRChannel> m_pvrChannelInfoTag;
   std::shared_ptr<PVR::CPVRRecording> m_pvrRecordingInfoTag;
   std::shared_ptr<PVR::CPVRTimerInfoTag> m_pvrTimerInfoTag;
+  std::shared_ptr<PVR::CPVRChannelGroupMember> m_pvrChannelGroupMemberInfoTag;
   CPictureInfoTag* m_pictureInfoTag;
   std::shared_ptr<const ADDON::IAddon> m_addonInfo;
   KODI::GAME::CGameInfoTag* m_gameInfoTag;

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -22,6 +22,7 @@
 #include "pictures/PictureInfoTag.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/recordings/PVRRecordings.h"
@@ -453,6 +454,8 @@ void CFileItemHandler::HandleFileItem(const char* ID,
 
     if (item->HasPVRChannelInfoTag())
       FillDetails(item->GetPVRChannelInfoTag().get(), item, fields, object, thumbLoader);
+    if (item->HasPVRChannelGroupMemberInfoTag())
+      FillDetails(item->GetPVRChannelGroupMemberInfoTag().get(), item, fields, object, thumbLoader);
     if (item->HasEPGInfoTag())
       FillDetails(item->GetEPGInfoTag().get(), item, fields, object, thumbLoader);
     if (item->HasPVRRecordingInfoTag())

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -29,6 +29,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/guilib/PVRGUIActions.h"
@@ -740,7 +741,13 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     if (!channel)
       return InvalidParams;
 
-    if (!CServiceBroker::GetPVRManager().GUIActions()->PlayMedia(std::make_shared<CFileItem>(channel)))
+    const std::shared_ptr<CPVRChannelGroupMember> groupMember =
+        CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(CFileItem(channel));
+    if (!groupMember || !groupMember->Channel())
+      return InvalidParams;
+
+    if (!CServiceBroker::GetPVRManager().GUIActions()->PlayMedia(
+            std::make_shared<CFileItem>(groupMember)))
       return FailedToExecute;
 
     return ACK;

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -84,6 +84,10 @@ namespace PVR
     {
       return m_item->GetPVRTimerInfoTag()->Channel();
     }
+    else if (m_item->IsPVRRecording())
+    {
+      return m_item->GetPVRRecordingInfoTag()->Channel();
+    }
     else
     {
       CLog::LogF(LOGERROR, "Unsupported item type!");

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -88,8 +88,6 @@ void CPVRChannel::Serialize(CVariant& value) const
   value["uniqueid"]  = m_iUniqueId;
   CDateTime lastPlayed(m_iLastWatched);
   value["lastplayed"] = lastPlayed.IsValid() ? lastPlayed.GetAsDBDate() : "";
-  value["channelnumber"] = m_channelNumber.GetChannelNumber();
-  value["subchannelnumber"] = m_channelNumber.GetSubChannelNumber();
 
   std::shared_ptr<CPVREpgInfoTag> epg = GetEPGNow();
   if (epg)
@@ -243,12 +241,6 @@ bool CPVRChannel::SetChannelID(int iChannelId)
   }
 
   return false;
-}
-
-const CPVRChannelNumber& CPVRChannel::ChannelNumber() const
-{
-  CSingleLock lock(m_critSection);
-  return m_channelNumber;
 }
 
 bool CPVRChannel::SetHidden(bool bIsHidden)
@@ -658,32 +650,11 @@ bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
   return false;
 }
 
-void CPVRChannel::SetChannelNumber(const CPVRChannelNumber& channelNumber)
-{
-  CSingleLock lock(m_critSection);
-  m_channelNumber = channelNumber;
-}
-
-void CPVRChannel::SetClientChannelNumber(const CPVRChannelNumber& clientChannelNumber)
-{
-  CSingleLock lock(m_critSection);
-  m_clientChannelNumber = clientChannelNumber;
-}
-
 void CPVRChannel::ToSortable(SortItem& sortable, Field field) const
 {
   CSingleLock lock(m_critSection);
   if (field == FieldChannelName)
     sortable[FieldChannelName] = m_strChannelName;
-  else if (field == FieldChannelNumber)
-    sortable[FieldChannelNumber] = m_channelNumber.SortableChannelNumber();
-  else if (field == FieldClientChannelOrder)
-  {
-    if (m_iOrder)
-      sortable[FieldClientChannelOrder] = m_iOrder;
-    else
-      sortable[FieldClientChannelOrder] = m_clientChannelNumber.SortableChannelNumber();
-  }
   else if (field == FieldLastPlayed)
   {
     const CDateTime lastWatched(m_iLastWatched);
@@ -832,10 +803,4 @@ bool CPVRChannel::CanRecord() const
 {
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   return client && client->GetClientCapabilities().SupportsRecordings();
-}
-
-void CPVRChannel::SetClientOrder(int iOrder)
-{
-  CSingleLock lock(m_critSection);
-  m_iOrder = iOrder;
 }

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -85,24 +85,6 @@ namespace PVR
     bool SetChannelID(int iDatabaseId);
 
     /*!
-     * @brief Set the channel number for this channel.
-     * @param channelNumber The new channel number
-     */
-    void SetChannelNumber(const CPVRChannelNumber& channelNumber);
-
-    /*!
-     * @brief Set the client channel number for this channel.
-     * @param clientChannelNumber The new client channel number
-     */
-    void SetClientChannelNumber(const CPVRChannelNumber& clientChannelNumber);
-
-    /*!
-     * @brief Get the channel number for this channel.
-     * @return The channel number.
-     */
-    const CPVRChannelNumber& ChannelNumber() const;
-
-    /*!
      * @return True if this channel is a radio channel, false if not.
      */
     bool IsRadio() const { return m_bIsRadio; }
@@ -449,13 +431,7 @@ namespace PVR
      * @brief Get the client order for this channel
      * @return iOrder The order for this channel
      */
-    int ClientOrder() const { return m_iOrder; }
-
-    /*!
-     * @brief Change the client order for this channel
-     * @param iOrder The new order for this channel
-     */
-    void SetClientOrder(int iOrder);
+    int ClientOrder() const { return m_iClientOrder; }
 
     /*!
      * @brief CEventStream callback for PVR events.
@@ -502,7 +478,6 @@ namespace PVR
     std::string m_strChannelName; /*!< the name for this channel used by XBMC */
     time_t m_iLastWatched = 0; /*!< last time channel has been watched */
     bool m_bChanged = false; /*!< true if anything in this entry was changed that needs to be persisted */
-    CPVRChannelNumber m_channelNumber; /*!< the active channel number this channel has in the currently selected channel group */
     std::shared_ptr<CPVRRadioRDSInfoTag> m_rdsTag; /*! < the radio rds data, if available for the channel. */
     bool m_bHasArchive = false; /*!< true if this channel supports archive */
     //@}
@@ -521,14 +496,14 @@ namespace PVR
     //@{
     int m_iUniqueId = -1; /*!< the unique identifier for this channel */
     int m_iClientId = -1; /*!< the identifier of the client that serves this channel */
-    CPVRChannelNumber m_clientChannelNumber; /*!< the channel number on the client for the currently selected channel group */
+    CPVRChannelNumber m_clientChannelNumber; /*!< the channel number on the client */
     std::string m_strClientChannelName; /*!< the name of this channel on the client */
     std::string
         m_strMimeType; /*!< the stream input type based mime type, see @ref https://www.iana.org/assignments/media-types/media-types.xhtml#video */
     std::string m_strFileNameAndPath; /*!< the filename to be used by PVRManager to open and read the stream */
     int m_iClientEncryptionSystem = -1; /*!< the encryption system used by this channel. 0 for FreeToAir, -1 for unknown */
     std::string m_strClientEncryptionName; /*!< the name of the encryption system used by this channel */
-    int m_iOrder = 0; /*!< the order from this channels currently selected group memeber */
+    int m_iClientOrder = 0; /*!< the order from this channels group member */
     //@}
 
     mutable CCriticalSection m_critSection;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -290,6 +290,14 @@ namespace PVR
     std::shared_ptr<CPVRChannel> GetLastPlayedChannel(int iCurrentChannel = -1) const;
 
     /*!
+     * @brief Get the channel group member that was played last.
+     * @param iCurrentChannel The channelid of the current channel that is playing, or -1 if none
+     * @return The requested channel group member or nullptr.
+     */
+    std::shared_ptr<CPVRChannelGroupMember> GetLastPlayedChannelGroupMember(
+        int iCurrentChannel) const;
+
+    /*!
      * @brief Get a channel given it's active channel number
      * @param channelNumber The channel number.
      * @return The channel or nullptr if it wasn't found.
@@ -453,22 +461,6 @@ namespace PVR
     bool HasValidDataFromClient(int iClientId) const;
 
     /*!
-     * @brief For each channel and its corresponding epg channel data update the order from the group members
-     */
-    void UpdateClientOrder();
-
-    /*!
-     * @brief For each channel and its corresponding epg channel data update the channel number from the group members
-     */
-    void UpdateChannelNumbers();
-
-    /*!
-     * @brief Update whether or not this group is currently selected
-     * @param isSelectedGroup whether or not this group is the currently selected group.
-     */
-    void SetSelectedGroup(bool isSelectedGroup) { m_bIsSelectedGroup = isSelectedGroup; }
-
-    /*!
      * @brief Update the channel numbers according to the all channels group and publish event.
      * @return True, if a channel number was changed, false otherwise.
      */
@@ -557,7 +549,6 @@ namespace PVR
     mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClients;
     CEventSource<PVREvent> m_events;
-    bool m_bIsSelectedGroup = false; /*!< Whether or not this group is currently selected */
     bool m_bStartGroupChannelNumbersFromOne = false; /*!< true if we start group channel numbers from one when not using backend channel numbers, false otherwise */
     bool m_bSyncChannelGroups = false; /*!< true if channel groups should be synced with the backend, false otherwise */
 

--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -8,7 +8,32 @@
 
 #include "PVRChannelGroupMember.h"
 
+#include "utils/DatabaseUtils.h"
+#include "utils/SortUtils.h"
+#include "utils/Variant.h"
+
 using namespace PVR;
+
+void CPVRChannelGroupMember::Serialize(CVariant& value) const
+{
+  value["channelnumber"] = m_channelNumber.GetChannelNumber();
+  value["subchannelnumber"] = m_channelNumber.GetSubChannelNumber();
+}
+
+void CPVRChannelGroupMember::ToSortable(SortItem& sortable, Field field) const
+{
+  if (field == FieldChannelNumber)
+  {
+    sortable[FieldChannelNumber] = m_channelNumber.SortableChannelNumber();
+  }
+  else if (field == FieldClientChannelOrder)
+  {
+    if (m_iOrder)
+      sortable[FieldClientChannelOrder] = m_iOrder;
+    else
+      sortable[FieldClientChannelOrder] = m_clientChannelNumber.SortableChannelNumber();
+  }
+}
 
 void CPVRChannelGroupMember::SetChannelNumber(const CPVRChannelNumber& channelNumber)
 {

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "pvr/channels/PVRChannelNumber.h"
+#include "utils/ISerializable.h"
+#include "utils/ISortable.h"
 
 #include <memory>
 
@@ -17,7 +19,7 @@ namespace PVR
 
 class CPVRChannel;
 
-class CPVRChannelGroupMember
+class CPVRChannelGroupMember : public ISerializable, public ISortable
 {
   friend class CPVRDatabase;
 
@@ -38,6 +40,12 @@ public:
   }
 
   virtual ~CPVRChannelGroupMember() = default;
+
+  // ISerializable implementation
+  void Serialize(CVariant& value) const override;
+
+  // ISortable implementation
+  void ToSortable(SortItem& sortable, Field field) const override;
 
   std::shared_ptr<CPVRChannel> Channel() const { return m_channel; }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -247,9 +247,6 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
     if (bSyncWithBackends && !group->IsInternalGroup() && group->Size() == 0)
       emptyGroups.emplace_back(group);
 
-    if (bReturn && group == m_selectedGroup)
-      UpdateSelectedGroup();
-
     if (bReturn &&
         group->IsInternalGroup() &&
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRChannelIconsAutoScan)
@@ -277,8 +274,6 @@ bool CPVRChannelGroups::PropagateChannelNumbersAndPersist()
   bool bChanged = false;
   for (auto& group : m_groups)
     bChanged = group->UpdateChannelNumbersFromAllChannelsGroup();
-
-  m_selectedGroup->UpdateChannelNumbers();
 
   return bChanged;
 }
@@ -525,22 +520,10 @@ void CPVRChannelGroups::SetSelectedGroup(const std::shared_ptr<CPVRChannelGroup>
 {
   CSingleLock lock(m_critSection);
   m_selectedGroup = selectedGroup;
-  m_selectedGroup->UpdateClientOrder();
-  m_selectedGroup->UpdateChannelNumbers();
-
-  for (auto& group : m_groups)
-    group->SetSelectedGroup(group == m_selectedGroup);
 
   auto duration = std::chrono::system_clock::now().time_since_epoch();
   uint64_t tsMillis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
   m_selectedGroup->SetLastOpened(tsMillis);
-}
-
-void CPVRChannelGroups::UpdateSelectedGroup()
-{
-  CSingleLock lock(m_critSection);
-  m_selectedGroup->UpdateClientOrder();
-  m_selectedGroup->UpdateChannelNumbers();
 }
 
 bool CPVRChannelGroups::AddGroup(const std::string& strName)

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -162,11 +162,6 @@ namespace PVR
     void SetSelectedGroup(const std::shared_ptr<CPVRChannelGroup>& selectedGroup);
 
     /*!
-     * @brief Update the selected groups channel numbers and client order.
-     */
-    void UpdateSelectedGroup();
-
-    /*!
      * @brief Add a group to this container.
      * @param strName The name of the group.
      * @return True if the group was added, false otherwise.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -716,7 +716,7 @@ void CGUIDialogPVRChannelManager::Update()
   std::shared_ptr<CFileItem> channelFile;
   for (const auto& member : groupMembers)
   {
-    channelFile = std::make_shared<CFileItem>(member->Channel());
+    channelFile = std::make_shared<CFileItem>(member);
     if (!channelFile || !channelFile->HasPVRChannelInfoTag())
       continue;
     const std::shared_ptr<CPVRChannel> channel(channelFile->GetPVRChannelInfoTag());
@@ -727,7 +727,8 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty("Icon", channel->IconPath());
     channelFile->SetProperty("EPGSource", 0);
     channelFile->SetProperty("ParentalLocked", channel->IsLocked());
-    channelFile->SetProperty("Number", StringUtils::Format("%i", channel->ChannelNumber().GetChannelNumber()));
+    channelFile->SetProperty("Number",
+                             StringUtils::Format("%i", member->ChannelNumber().GetChannelNumber()));
 
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*channelFile);
     if (client)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -178,7 +178,7 @@ void CGUIDialogPVRChannelsOSD::Update()
           group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : groupMembers)
       {
-        m_vecItems->Add(std::make_shared<CFileItem>(groupMember->Channel()));
+        m_vecItems->Add(std::make_shared<CFileItem>(groupMember));
       }
 
       m_viewControl.SetItems(*m_vecItems);
@@ -274,7 +274,7 @@ void CGUIDialogPVRChannelsOSD::OnInputDone()
     int itemIndex = 0;
     for (const CFileItemPtr& channel : *m_vecItems)
     {
-      if (channel->GetPVRChannelInfoTag()->ChannelNumber() == channelNumber)
+      if (channel->GetPVRChannelGroupMemberInfoTag()->ChannelNumber() == channelNumber)
       {
         m_viewControl.SetSelectedItem(itemIndex);
         return;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -490,9 +490,9 @@ void CGUIDialogPVRGroupManager::Update()
       for (const auto& groupMember : groupMembers)
       {
         if (groupMember->Channel()->IsHidden())
-          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->Channel()));
+          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember));
         else
-          m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->Channel()));
+          m_groupMembers->Add(std::make_shared<CFileItem>(groupMember));
       }
     }
     else
@@ -501,7 +501,7 @@ void CGUIDialogPVRGroupManager::Update()
           m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : groupMembers)
       {
-        m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->Channel()));
+        m_groupMembers->Add(std::make_shared<CFileItem>(groupMember));
       }
 
       /* for the center part, get all channels of the "all" channels group that are not in this group */
@@ -511,7 +511,7 @@ void CGUIDialogPVRGroupManager::Update()
       for (const auto& groupMember : allGroupMembers)
       {
         if (!m_selectedGroup->IsGroupMember(groupMember->Channel()))
-          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->Channel()));
+          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember));
       }
     }
     m_viewGroupMembers.SetItems(*m_groupMembers);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -830,8 +830,9 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   for (const auto& groupMember : groupMembers)
   {
     const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
-    const std::string channelDescription
-      = StringUtils::Format("%s %s", channel->ChannelNumber().FormattedChannelNumber().c_str(), channel->ChannelName().c_str());
+    const std::string channelDescription =
+        StringUtils::Format("%s %s", groupMember->ChannelNumber().FormattedChannelNumber().c_str(),
+                            channel->ChannelName().c_str());
     m_channelEntries.insert({index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});
     ++index;
   }

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -12,6 +12,8 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
+#include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
@@ -168,8 +170,17 @@ bool CPVREpgSearchFilter::MatchChannelNumber(const std::shared_ptr<CPVREpgInfoTa
 
   if (m_channelNumber.IsValid())
   {
-    const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
-    bReturn = channel && (m_channelNumber ==  channel->ChannelNumber());
+    const std::shared_ptr<CPVRChannelGroupsContainer> groups =
+        CServiceBroker::GetPVRManager().ChannelGroups();
+    const std::shared_ptr<CPVRChannelGroup> group =
+        (m_iChannelGroup == EPG_SEARCH_UNSET) ? groups->GetGroupAll(m_bIsRadio)
+                                              : groups->Get(m_bIsRadio)->GetById(m_iChannelGroup);
+    if (group)
+    {
+      const std::shared_ptr<CPVRChannelGroupMember>& groupMember =
+          group->GetByUniqueID({tag->UniqueChannelID(), tag->ClientID()});
+      bReturn = m_channelNumber == groupMember->ChannelNumber();
+    }
   }
 
   return bReturn;

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -502,7 +502,7 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
           if (bShowHiddenChannels != groupMember->Channel()->IsHidden())
             continue;
 
-          results.Add(std::make_shared<CFileItem>(groupMember->Channel()));
+          results.Add(std::make_shared<CFileItem>(groupMember));
         }
       }
       else

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -19,6 +19,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/guilib/GUIEPGGridContainerModel.h"
 #include "utils/MathUtils.h"
@@ -1124,7 +1125,7 @@ bool CGUIEPGGridContainer::SetChannel(const CPVRChannelNumber& channelNumber)
   for (int iIndex = 0; iIndex < m_gridModel->ChannelItemsSize(); iIndex++)
   {
     const CPVRChannelNumber& number =
-        m_gridModel->GetChannelItem(iIndex)->GetPVRChannelInfoTag()->ChannelNumber();
+        m_gridModel->GetChannelItem(iIndex)->GetPVRChannelGroupMemberInfoTag()->ChannelNumber();
     if (number == channelNumber)
     {
       GoToChannel(iIndex);

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -37,6 +37,7 @@ namespace PVR
     SUCCESS
   };
 
+  class CPVRChannelGroupMember;
   class CPVRRecording;
   class CPVRStreamProperties;
   class CPVRTimerInfoTag;
@@ -397,6 +398,14 @@ namespace PVR
      * @param iThreshold the value in seconds to trigger seek to start of current event instead of start of previous event.
      */
     void SeekBackward(unsigned int iThreshold);
+
+    /*!
+     * @brief Get a channel group member for the given item, either from the currently active group
+     * or if not found there, from the 'all channels' group.
+     * @param item the item containing a channel, channel group, recording, timer or epg tag.
+     * @return the group member or nullptr if not found.
+     */
+    std::shared_ptr<CPVRChannelGroupMember> GetChannelGroupMember(const CFileItem& item) const;
 
     /*!
      * @brief Get the currently active channel number input handler.

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -23,6 +23,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
 #include "pvr/epg/EpgInfoTag.h"
@@ -431,10 +432,11 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case VIDEOPLAYER_CHANNEL_NUMBER:
       case LISTITEM_CHANNEL_NUMBER:
       {
-        const std::shared_ptr<CPVRChannel> channel = recording->Channel();
-        if (channel)
+        const std::shared_ptr<CPVRChannelGroupMember> groupMember =
+            CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(*item);
+        if (groupMember)
         {
-          strValue = channel->ChannelNumber().FormattedChannelNumber();
+          strValue = groupMember->ChannelNumber().FormattedChannelNumber();
           return true;
         }
         break;
@@ -689,8 +691,16 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case MUSICPLAYER_CHANNEL_NUMBER:
       case VIDEOPLAYER_CHANNEL_NUMBER:
       case LISTITEM_CHANNEL_NUMBER:
-        strValue = channel->ChannelNumber().FormattedChannelNumber();
-        return true;
+      {
+        const std::shared_ptr<CPVRChannelGroupMember> groupMember =
+            CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(*item);
+        if (groupMember)
+        {
+          strValue = groupMember->ChannelNumber().FormattedChannelNumber();
+          return true;
+        }
+        break;
+      }
       case MUSICPLAYER_CHANNEL_GROUP:
       case VIDEOPLAYER_CHANNEL_GROUP:
       {

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -25,6 +25,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRChannelsPath.h"
 #include "pvr/dialogs/GUIDialogPVRChannelManager.h"
@@ -337,7 +338,7 @@ void CGUIWindowPVRChannelsBase::OnInputDone()
     int itemIndex = 0;
     for (const CFileItemPtr& channel : *m_vecItems)
     {
-      if (channel->GetPVRChannelInfoTag()->ChannelNumber() == channelNumber)
+      if (channel->GetPVRChannelGroupMemberInfoTag()->ChannelNumber() == channelNumber)
       {
         m_viewControl.SetSelectedItem(itemIndex);
         return;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -26,7 +26,6 @@
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
-#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRChannelsPath.h"
 #include "pvr/epg/EpgChannelData.h"
@@ -708,7 +707,7 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
 
       for (const auto& groupMember : groupMembers)
       {
-        channels->Add(std::make_shared<CFileItem>(groupMember->Channel()));
+        channels->Add(std::make_shared<CFileItem>(groupMember));
       }
 
       if (m_guiState)


### PR DESCRIPTION
Kodi PVR knows channels, channel group members and channel groups.

A channel represents a TV or radio channel, providing the respective basic attributes, like channel name, channel logo etc.
As every channel can be part of different channel groups, it must not contain attributes which can be different per channel group. Those attributes should be only provided by channel group members. Most prominent example for such a group specific channel attribute is the channel number.
 
![IMG_5692](https://user-images.githubusercontent.com/3226626/117315329-e4f4d280-ae87-11eb-950c-92adcf4317d3.JPG)

Currently, PVR core uses a strange and hard to understand/maintain construct to provide channel numbers for channels. Instead of providing those via a method CPVRChannelGroupMember::ChannelName(), it has the "concept" (well, bad hack imo) to know a "selected channel group" (assuming there can be only one active group in the GUI at a time) and to copy the channel number and other group specific attributes from the respective group member instances to the corresponding CPVRChannel instances whenever the "selected group" changes. This has been the cause for many hard to track down bugs in the past and there are still some left I know. ;-)

This PR completely removes that silly "caching" logics and strictly uses channel numbers provided by CPVRChannelGroupMember instances. It removes the group specific members and access methods from CPVRChannel. As a side effect it fixes some of the long standing bugs caused by the hack now removed.

BTW: One of my next PRs will remove the concept of "selected channel group", but let's do one step after the other.

I runtime-tested the changes for some weeks now and could not find any regression.

@phunkyfish when you find some time for a review...  
