### PR TITLE
[PVR][Estuary] PVR channel manger dialog GUI adjustments

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelManager.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelManager.xml
@@ -5,12 +5,12 @@
 	<controls>
 		<control type="group">
 			<centertop>50%</centertop>
-			<height>830</height>
+			<height>895</height>
 			<centerleft>50%</centerleft>
 			<width>1820</width>
 			<include content="DialogBackgroundCommons">
 				<param name="width" value="1820" />
-				<param name="height" value="830" />
+				<param name="height" value="895" />
 				<param name="header_label" value="$VAR[PVRChannelMgrHeader]$INFO[Container(20).NumItems, (,)]" />
 				<param name="header_id" value="2" />
 			</include>
@@ -21,7 +21,7 @@
 					<left>660</left>
 					<top>30</top>
 					<width>12</width>
-					<height>710</height>
+					<height>770</height>
 					<onleft>20</onleft>
 					<onright>9002</onright>
 					<orientation>vertical</orientation>
@@ -30,14 +30,14 @@
 					<left>0</left>
 					<top>10</top>
 					<width>672</width>
-					<height>750</height>
+					<height>810</height>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
 				<control type="list" id="20">
 					<left>20</left>
 					<top>30</top>
 					<width>630</width>
-					<height>710</height>
+					<height>770</height>
 					<onup>20</onup>
 					<ondown>20</ondown>
 					<onleft>9000</onleft>
@@ -143,7 +143,7 @@
 					<onright>9000</onright>
 					<onup>34</onup>
 					<ondown>30</ondown>
-					<itemgap>-25</itemgap>
+					<itemgap>-22</itemgap>
 					<control type="label" id="9001">
 						<description>channel options Header</description>
 						<width>700</width>
@@ -201,17 +201,16 @@
 					<texture background="true">$INFO[Container(20).ListItem.Property(icon)]</texture>
 				</control>
 				<control type="grouplist">
-					<top>565</top>
-					<itemgap>-15</itemgap>
+					<top>590</top>
+					<itemgap>-18</itemgap>
 					<onleft>60</onleft>
 					<onright>9000</onright>
 					<onup>14</onup>
 					<ondown>7</ondown>
-					<animation effect="slide" start="0,0" end="0,45" time="0" condition="!Control.IsVisible(31)">Conditional</animation>
 					<control type="label" id="9003">
-						<description>channel options Header</description>
+						<description>misc options Header</description>
 						<width>700</width>
-						<height>50</height>
+						<height>52</height>
 						<textoffsetx>30</textoffsetx>
 						<font>font12</font>
 						<label>$LOCALIZE[31021]</label>

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -751,9 +751,9 @@ void CGUIDialogPVRChannelManager::Update()
     m_bAllowNewChannel = true;
 
   if (m_bAllowNewChannel)
-    SET_CONTROL_VISIBLE(BUTTON_NEW_CHANNEL);
+    CONTROL_ENABLE(BUTTON_NEW_CHANNEL);
   else
-    SET_CONTROL_HIDDEN(BUTTON_NEW_CHANNEL);
+    CONTROL_DISABLE(BUTTON_NEW_CHANNEL);
 
   Renumber();
   m_viewControl.SetItems(*m_channelItems);


### PR DESCRIPTION
## Description
This is a minor/cosmetic-only PR that primarily impacts the Estuary skin, but does have a very small code change included to support it.  The basic gist is that I found the PVR Channel Manager dialog box to have a few layout/visual concerns that I felt would be annoying from an end user's perspective:

- The dialog was not tall enough to accommodate all three of the possible "Misc options" buttons without some clipping.
- The channel list control was not aligned to the height of the list entries, which could cause a partial list item to be displayed.
- The "slide" animation used when the "New channel" button wouldn't be available was kind of weird looking/awkward to me; I felt this would look better as a disabled button that is always present in the dialog rather than hiding it from the user and causing animation weirdness if they toggle between Radio/TV addons that don't all support the same feature set.

I am happy to remove/add anything deemed necessary here or is deemed a "personal preference" that most users will not get any benefit from.

## Motivation and context
Please see above; this PR is a few GUI suggestions that would not impact functionality if it's either approved or discarded.

NOTE: I have a number of proposed changes to this dialog that I'm working on as time allows'; this PR is very "low-hanging fruit" to try and baseline the cosmetic aspect of the work.

## How has this been tested?
Tested on Windows 10 x64 Desktop (20H2), with a display set to 120 DPI.  A Windows system with a 4K display is available if necessary to verify the proposed changes., but Kodi scales controls/dialogs very well and do not anticipate any visual difference.

## What is the effect on users?
The intended effect for end users is that dialog controls will be better aligned and the seemingly strange animation effect used to add the "New channel" button will be replaced with a static (yet disabled) control.

## Screenshots (if appropriate):

BEFORE CHANGE:

This view illustrates the primary problem the PR intends to address, note that when all three buttons are present the bottom button is clipped and the group itself gets a little bunched up.  In the as-is the NEW CHANNEL button is hidden by default and when the user switches to either Radio or TV and that button would be visible, the animation is a bit weird looking.  Also (very minor thing) highlights that the channel list view is a tad too big.  Since the PR makes the dialog/list view bigger it was more pronounced, which is why it was mentioned (see image below):

![before](https://user-images.githubusercontent.com/706055/117558467-b6275980-b04b-11eb-9495-7796bd92cab2.png)

AFTER CHANGE:

This is a view of the proposed layout that illustrates the disabled NEW CHANNEL button as opposed to it not being present as well as the alignment of the list view and the lower button.  **NOTE:** there is an unrelated state issue with the dialog box that causes stale information to show as "Channel options", this has nothing to do with the skin and is intended to be addressed separately:

![after-tv](https://user-images.githubusercontent.com/706055/117558414-2b465f00-b04b-11eb-95d5-0d788efaa18b.png)

This is a view of the proposed layout with a fully populated list view and with the NEW CHANNEL button enabled. It also illustrates that the list view is sized such that no partial entry will be present:

![after-radio](https://user-images.githubusercontent.com/706055/117558420-4ca74b00-b04b-11eb-9497-0e9cec43405c.png)




## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
