### PR TITLE
[Estuary] Fix OSD Button Visibility

### DIFF
--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -46,14 +46,14 @@
 						<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 					</include>
 					<onclick>PlayerControl(Previous)</onclick>
-					<visible>MusicPlayer.HasPrevious | Player.SeekEnabled</visible>
+					<visible>Player.ChapterCount | MusicPlayer.HasPrevious | [Player.SeekEnabled + MusicPlayer.Content(livetv)]</visible>
 				</control>
 				<control type="radiobutton" id="601">
 					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/rewind.png"/>
 					</include>
 					<onclick>PlayerControl(Rewind)</onclick>
-					<visible>Player.SeekEnabled</visible>
+					<visible>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</visible>
 				</control>
 				<control type="group" id="698">
 					<width>76</width>
@@ -94,14 +94,14 @@
 						<param name="texture" value="osd/fullscreen/buttons/forward.png"/>
 					</include>
 					<onclick>PlayerControl(Forward)</onclick>
-					<visible>Player.SeekEnabled</visible>
+					<visible>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</visible>
 				</control>
 				<control type="radiobutton" id="607">
 					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 					</include>
 					<onclick>PlayerControl(Next)</onclick>
-					<visible>MusicPlayer.HasNext | [MusicPlayer.Content(LiveTV) + Player.SeekEnabled]</visible>
+					<visible>Player.ChapterCount | MusicPlayer.HasNext | PVR.IsTimeShift</visible>
 				</control>
 				<control type="radiobutton" id="608">
 					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/record-white.png</textureradioonfocus>

--- a/addons/skin.estuary/xml/VideoOSD.xml
+++ b/addons/skin.estuary/xml/VideoOSD.xml
@@ -51,14 +51,14 @@
 							<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 						</include>
 						<onclick>PlayerControl(Previous)</onclick>
-						<visible>Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | [VideoPlayer.Content(LiveTV) + Player.SeekEnabled]</visible>
+						<visible>Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | [Player.SeekEnabled + VideoPlayer.Content(livetv)]</visible>
 					</control>
 					<control type="radiobutton" id="601">
 						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/rewind.png"/>
 						</include>
 						<onclick>PlayerControl(Rewind)</onclick>
-						<visible>Player.SeekEnabled + !VideoPlayer.Content(livetv)</visible>
+						<visible>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</visible>
 					</control>
 					<control type="group" id="698">
 						<width>76</width>
@@ -99,7 +99,7 @@
 							<param name="texture" value="osd/fullscreen/buttons/forward.png"/>
 						</include>
 						<onclick>PlayerControl(Forward)</onclick>
-						<visible>Player.SeekEnabled + !VideoPlayer.Content(livetv)</visible>
+						<visible>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</visible>
 					</control>
 					<control type="radiobutton" id="607">
 						<include content="OSDButton">


### PR DESCRIPTION
## Description
Fix - Inconsistant OSD button visibility between Live TV and Live Radio
Fix - Do not show non-functioning Rewind/Fast Forward buttons

## Motivation and context

### PVR OSD Buttons

@phunkyfish reported inconsistant button visility between Live TV and Live Radio. I wasn't able to exactly replicate what phunkyfish said he was seeing for Radio, however I've made sure that the visibility conditions for the buttons in MusicOSD.xml for Radio are now aligned as close as possible to the buttons in the correctly functioning VideoOSD.xml for Live TV.

**Live TV in timeshift**
**Previous** & **Next** buttons for navigating Timeshift buffer.
![image](https://user-images.githubusercontent.com/5781142/117537185-54d59b00-aff7-11eb-9651-6b65159ec307.png)

**Radio in timeshift before**
No **Previous** & **Next** buttons for navigating Timeshift buffer.
![image](https://user-images.githubusercontent.com/5781142/117537222-80f11c00-aff7-11eb-9971-bb8f6f157f73.png)

**Fixed - Radio in timeshift after**
**Next** button now visible. Using PVR.HTS with tvheadend backend I could never get **Previous** button displayed as **Player.SeekEnabled** for Radio appears to never be true (while it can be true for LiveTV) in my test setup.
![image](https://user-images.githubusercontent.com/5781142/117537233-8a7a8400-aff7-11eb-9b7f-6ab9238d3705.png)

### Rewind / Fast Forward Buttons

The player actions **PlayerControl(Rewind)** and **PlayerControl(Forward)** do not do anything when video is **Paused**. Reported on forum at https://forum.kodi.tv/showthread.php?tid=361875 and confirmed on my local setup.

**Before**
![image](https://user-images.githubusercontent.com/5781142/117537513-57d18b00-aff9-11eb-934a-343300bc0bfa.png)

**After**
Hide Rewind / Fast Forward when Paused
![image](https://user-images.githubusercontent.com/5781142/117537610-070e6200-affa-11eb-9c70-bf44f35714ff.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
