### PR TITLE
[Windows] move WS-Discovery initialize to CPlatformWin32::InitStageThree

### DIFF
--- a/xbmc/platform/win32/PlatformWin32.cpp
+++ b/xbmc/platform/win32/PlatformWin32.cpp
@@ -12,11 +12,17 @@
 #include "win32util.h"
 #include "windowing/windows/WinSystemWin32DX.h"
 
+#include "platform/win32/network/WSDiscoveryWin32.h"
 #include "platform/win32/powermanagement/Win32PowerSyscall.h"
 
 CPlatform* CPlatform::CreateInstance()
 {
   return new CPlatformWin32();
+}
+
+CPlatformWin32::~CPlatformWin32()
+{
+  CWSDiscoverySupport::Get()->Terminate();
 }
 
 bool CPlatformWin32::InitStageOne()
@@ -32,6 +38,16 @@ bool CPlatformWin32::InitStageOne()
   CWinSystemWin32DX::Register();
 
   CWin32PowerSyscall::Register();
+
+  return true;
+}
+
+bool CPlatformWin32::InitStageThree()
+{
+  if (!CPlatform::InitStageThree())
+    return false;
+
+  CWSDiscoverySupport::Get()->Initialize();
 
   return true;
 }

--- a/xbmc/platform/win32/PlatformWin32.h
+++ b/xbmc/platform/win32/PlatformWin32.h
@@ -15,8 +15,9 @@ class CPlatformWin32 : public CPlatform
 public:
   CPlatformWin32() = default;
 
-  ~CPlatformWin32() override = default;
+  ~CPlatformWin32() override;
 
   bool InitStageOne() override;
+  bool InitStageThree() override;
   void PlatformSyslog() override;
 };

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -34,7 +34,6 @@
 
 #include "platform/win32/CharsetConverter.h"
 #include "platform/win32/input/IRServerSuite.h"
-#include "platform/win32/network/WSDiscoveryWin32.h"
 
 #include <algorithm>
 
@@ -81,14 +80,10 @@ CWinSystemWin32::CWinSystemWin32()
     m_irss->Initialize();
   }
   m_dpms = std::make_shared<CWin32DPMSSupport>();
-
-  CWSDiscoverySupport::Get()->Initialize();
 }
 
 CWinSystemWin32::~CWinSystemWin32()
 {
-  CWSDiscoverySupport::Get()->Terminate();
-
   if (m_hIcon)
   {
     DestroyIcon(m_hIcon);


### PR DESCRIPTION
## Description
Move WS-Discovery initialize to `CPlatformWin32::InitStageThree`

## Motivation and context
It is a more appropriate place. @lrusak, @fuzzard and @Paxxi they know the origin of this.

## How has this been tested?
Runtime tested

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
