### PR TITLE
[PVR][GUI] Opening PVR channel manager within the 'Radio channels' context when explicitly accessed from the Radio channels view should default to 'Radio'

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -66,6 +66,7 @@ CGUIDialogPVRChannelManager::CGUIDialogPVRChannelManager() :
     CGUIDialog(WINDOW_DIALOG_PVR_CHANNEL_MANAGER, "DialogPVRChannelManager.xml"),
     m_channelItems(new CFileItemList)
 {
+  SetRadio(false);
 }
 
 CGUIDialogPVRChannelManager::~CGUIDialogPVRChannelManager()
@@ -159,7 +160,6 @@ void CGUIDialogPVRChannelManager::OnInitWindow()
   CGUIDialog::OnInitWindow();
 
   m_iSelected = 0;
-  m_bIsRadio = false;
   m_bMovingMode = false;
   m_bContainsChanges = false;
   m_bAllowNewChannel = false;
@@ -168,8 +168,6 @@ void CGUIDialogPVRChannelManager::OnInitWindow()
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   m_bAllowRenumber = !settings->GetBool(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER) &&
                      !settings->GetBool(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS);
-
-  SetProperty("IsRadio", "");
 
   Update();
 
@@ -196,6 +194,12 @@ void CGUIDialogPVRChannelManager::OnDeinitWindow(int nextWindowID)
   Clear();
 
   CGUIDialog::OnDeinitWindow(nextWindowID);
+}
+
+void CGUIDialogPVRChannelManager::SetRadio(bool bIsRadio)
+{
+  m_bIsRadio = bIsRadio;
+  SetProperty("IsRadio", m_bIsRadio ? "true" : "");
 }
 
 void CGUIDialogPVRChannelManager::Open(const std::shared_ptr<CFileItem>& initialSelection)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -37,6 +37,7 @@ namespace PVR
     CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
     void Open(const std::shared_ptr<CFileItem>& initialSelection);
+    void SetRadio(bool bIsRadio);
 
   protected:
     void OnInitWindow() override;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -314,6 +314,8 @@ void CGUIWindowPVRChannelsBase::ShowChannelManager()
   if (!dialog)
     return;
 
+  dialog->SetRadio(m_bRadio);
+
   const int iItem = m_viewControl.GetSelectedItem();
   dialog->Open(iItem >= 0 && iItem < m_vecItems->Size() ? m_vecItems->Get(iItem) : nullptr);
 }


### PR DESCRIPTION
## Description
When a user selects "Manage... / Channel manager" while browsing/viewing Radio channels, the Channel manager dialog will still default to a TV channel view rather than the expected Radio channel view.

## Motivation and context
I propose that if the user is browsing/viewing channels in the context of Radio that the Channel manager dialog should instead open in that (Radio) context.  While this PR attempts to do just that, I recognize that "TV" is significantly more prevalent than "Radio" in Kodi and tried to limit the scope appropriately.  This could theoretically be extended to apply to the generic PVR & Live TV / Settings "Channel manager" button/action in that Kodi could determine if there are no TV channels available but there are Radio channels available it would also default to Radio, but I didn't feel that was necessary after using the application with both PVR types available.

## How has this been tested?
Tested on Windows 10 (Desktop), x64, against master branch current as of 2021.05.08.  Prior to the change, if the user was in "Radio / Channels" and selected "Manage ... / Channel manager" the dialog would open in the context of "TV".  After the change the dialog would open in the context of "Radio".

## What is the effect on users?
The intended effect for users is limited to displaying a proper channel context when accessing "Manage ... / Channel manager".

## Screenshots (if appropriate):
N/A, can provide if required.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
