### PR TITLE
[Subtitles][ASS] Libass improvements

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -26,6 +26,8 @@ CDVDOverlayCodecSSA::CDVDOverlayCodecSSA()
   m_pOverlay = NULL;
   m_order    = 0;
   m_output   = false;
+
+  m_libass->Configure();
 }
 
 CDVDOverlayCodecSSA::~CDVDOverlayCodecSSA()

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -17,6 +17,7 @@ CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream>
   : CDVDSubtitleParserText(std::move(pStream), strFile),
     m_libass(std::make_shared<CDVDSubtitlesLibass>())
 {
+  m_libass->Configure();
 }
 
 CDVDSubtitleParserSSA::~CDVDSubtitleParserSSA()

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -192,7 +192,7 @@ ASS_Event* CDVDSubtitlesLibass::GetEvents()
   return m_track->events;
 }
 
-int CDVDSubtitlesLibass::GetNrOfEvents()
+int CDVDSubtitlesLibass::GetNrOfEvents() const
 {
   CSingleLock lock(m_section);
   if(!m_track)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -20,6 +20,12 @@ public:
   CDVDSubtitlesLibass();
   ~CDVDSubtitlesLibass();
 
+  /*!
+  * \brief Configure libass. This method groups any configurations
+  * that might change throughout the lifecycle of libass (e.g. fonts)
+  */
+  void Configure();
+
   ASS_Image* RenderImage(int frameWidth, int frameHeight, int videoWidth, int videoHeight, int sourceWidth, int sourceHeight,
                          double pts, int useMargin = 0, double position = 0.0, int* changes = NULL);
   ASS_Event* GetEvents();

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -30,7 +30,11 @@ public:
                          double pts, int useMargin = 0, double position = 0.0, int* changes = NULL);
   ASS_Event* GetEvents();
 
-  int GetNrOfEvents();
+  /*!
+  * \brief Get the number of events (subtitle entries) in the ASS track
+  * \return The number of events in the ASS track
+  */
+  int GetNrOfEvents() const;
 
   bool DecodeHeader(char* data, int size);
   bool DecodeDemuxPkt(const char* data, int size, double start, double duration);
@@ -40,6 +44,6 @@ private:
   ASS_Library* m_library = nullptr;
   ASS_Track* m_track = nullptr;
   ASS_Renderer* m_renderer = nullptr;
-  CCriticalSection m_section;
+  mutable CCriticalSection m_section;
 };
 


### PR DESCRIPTION
## Description
This PR provides two different improvements to our libass usage implementation:

- https://github.com/xbmc/xbmc/commit/6114b122524b95d8a3c8f11fec4b28cd2e40a2d9 - Moves all font related settings/configurations to a different method. Right now they are only used in the libass constructor. Means that in the future, if we want to actively react to settings change we have to be able to call/re-init the font settings

- https://github.com/xbmc/xbmc/commit/498334d5baa77a46c2347ad399e2498c45b7cea0 - Makes one of the getters const correct and adds the respective documentation

## Motivation and context
Better subtitle support, one step at a time

## How has this been tested?
Against all my ASS samples

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
