### PR TITLE
[PVR] Fix CPVREpgSearchFilter::MatchChannelNumber regression.

### DIFF
--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -178,7 +178,7 @@ bool CPVREpgSearchFilter::MatchChannelNumber(const std::shared_ptr<CPVREpgInfoTa
     if (group)
     {
       const std::shared_ptr<CPVRChannelGroupMember>& groupMember =
-          group->GetByUniqueID({tag->UniqueChannelID(), tag->ClientID()});
+          group->GetByUniqueID({tag->ClientID(), tag->UniqueChannelID()});
       bReturn = m_channelNumber == groupMember->ChannelNumber();
     }
   }


### PR DESCRIPTION
Fixes a regression introduced by #19699 . 

Somehow I managed to mess up parameter order ;-)

@phunkyfish whenever you find some time for a review.