### PR TITLE
[maintenance] remove c_str usage from StringUtils::Format calls

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -608,9 +608,9 @@ bool CApplication::Initialize()
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   profileManager->GetEventLog().Add(EventPtr(new CNotificationEvent(
-    StringUtils::Format(g_localizeStrings.Get(177).c_str(), g_sysinfo.GetAppName().c_str()),
-    StringUtils::Format(g_localizeStrings.Get(178).c_str(), g_sysinfo.GetAppName().c_str()),
-    "special://xbmc/media/icon256x256.png", EventLevel::Basic)));
+      StringUtils::Format(g_localizeStrings.Get(177), g_sysinfo.GetAppName()),
+      StringUtils::Format(g_localizeStrings.Get(178), g_sysinfo.GetAppName()),
+      "special://xbmc/media/icon256x256.png", EventLevel::Basic)));
 
   m_ServiceManager->GetNetwork().WaitForNet();
 
@@ -3734,7 +3734,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 
           // migration (incompatible addons) dialog
           auto addonList = StringUtils::Join(disabledAddonNames, ", ");
-          auto msg = StringUtils::Format(g_localizeStrings.Get(24149).c_str(), addonList.c_str());
+          auto msg = StringUtils::Format(g_localizeStrings.Get(24149), addonList);
           HELPERS::ShowOKDialogText(CVariant{24148}, CVariant{std::move(msg)});
           m_incompatibleAddons.clear();
         }

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -370,7 +370,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
               && (bypassSettings))
         {
           bPlaying = true;
-          std::string strExec = StringUtils::Format("RecursiveSlideShow({})", pItem->GetPath().c_str());
+          std::string strExec = StringUtils::Format("RecursiveSlideShow({})", pItem->GetPath());
           CBuiltins::Execute(strExec);
           return true;
         }
@@ -446,7 +446,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
       if (!pItem->m_bIsFolder && pItem->IsPicture())
       {
         bPlaying = true;
-        std::string strExec = StringUtils::Format("RecursiveSlideShow({})", strDrive.c_str());
+        std::string strExec = StringUtils::Format("RecursiveSlideShow({})", strDrive);
         CBuiltins::Execute(strExec);
         break;
       }

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -78,11 +78,11 @@ bool CContextMenuItem::operator==(const CContextMenuItem& other) const
 std::string CContextMenuItem::ToString() const
 {
   if (IsGroup())
-    return StringUtils::Format("CContextMenuItem[group, id={}, parent={}, addon={}]",
-                               m_groupId.c_str(), m_parent.c_str(), m_addonId.c_str());
+    return StringUtils::Format("CContextMenuItem[group, id={}, parent={}, addon={}]", m_groupId,
+                               m_parent, m_addonId);
   else
-    return StringUtils::Format("CContextMenuItem[item, parent={}, library={}, addon={}]",
-                               m_parent.c_str(), m_library.c_str(), m_addonId.c_str());
+    return StringUtils::Format("CContextMenuItem[item, parent={}, library={}, addon={}]", m_parent,
+                               m_library, m_addonId);
 }
 
 CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const std::string& parent,

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -86,13 +86,13 @@ bool CDatabaseManager::Update(CDatabase &db, const DatabaseSettings &settings)
 
   int version = db.GetSchemaVersion();
   std::string latestDb = dbSettings.name;
-  latestDb += StringUtils::Format("{}", version);
+  latestDb += std::to_string(version);
 
   while (version >= db.GetMinSchemaVersion())
   {
     std::string dbName = dbSettings.name;
     if (version)
-      dbName += StringUtils::Format("{}", version);
+      dbName += std::to_string(version);
 
     if (db.Connect(dbName, dbSettings, false))
     {

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -345,7 +345,7 @@ CFileItem::CFileItem(const CMediaSource& share)
     URIUtils::AddSlashAtEnd(m_strPath);
   std::string label = share.strName;
   if (!share.strStatus.empty())
-    label = StringUtils::Format("{} ({})", share.strName.c_str(), share.strStatus.c_str());
+    label = StringUtils::Format("{} ({})", share.strName, share.strStatus);
   SetLabel(label);
   m_iLockMode = share.m_iLockMode;
   m_strLockCode = share.m_strLockCode;
@@ -1828,7 +1828,7 @@ void CFileItem::SetFromSong(const CSong &song)
   if (song.idSong > 0)
   {
     std::string strExt = URIUtils::GetExtension(song.strFileName);
-    m_strPath = StringUtils::Format("musicdb://songs/{}{}", song.idSong, strExt.c_str());
+    m_strPath = StringUtils::Format("musicdb://songs/{}{}", song.idSong, strExt);
   }
   else if (!song.strFileName.empty())
     m_strPath = song.strFileName;
@@ -3564,7 +3564,7 @@ bool CFileItem::LoadMusicTag()
       std::string strText = g_localizeStrings.Get(554); // "Track"
       if (!strText.empty() && strText[strText.size() - 1] != ' ')
         strText += " ";
-      std::string strTrack = StringUtils::Format((strText + "{}").c_str(), iTrack);
+      std::string strTrack = StringUtils::Format((strText + "{}"), iTrack);
       GetMusicInfoTag()->SetTitle(strTrack);
       GetMusicInfoTag()->SetLoaded(true);
       return true;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10827,7 +10827,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
           return StringUtils::SizeToString(item->m_dwSize);
         break;
       case LISTITEM_PROGRAM_COUNT:
-        return StringUtils::Format("{}", item->m_iprogramCount);
+        return std::to_string(item->m_iprogramCount);
       case LISTITEM_ACTUAL_ICON:
         return item->GetArt("icon");
       case LISTITEM_ICON:

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -160,7 +160,7 @@ bool CGUIPassword::CheckStartUpLock()
         std::string strLabel1;
         strLabel1 = g_localizeStrings.Get(12343); // "retries left"
         int iLeft = g_passwordManager.iMasterLockRetriesLeft-i;
-        std::string strLabel = StringUtils::Format("{} {}", iLeft, strLabel1.c_str());
+        std::string strLabel = StringUtils::Format("{} {}", iLeft, strLabel1);
 
         // PopUp OK and Display: MasterLock mode has changed but no new Mastercode has been set!
         HELPERS::ShowOKDialogLines(CVariant{12360}, CVariant{12367}, CVariant{strLabel}, CVariant{""});
@@ -324,7 +324,7 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
     std::string dlgLine1 = "";
     if (0 < g_passwordManager.iMasterLockRetriesLeft)
       dlgLine1 = StringUtils::Format("{} {}", g_passwordManager.iMasterLockRetriesLeft,
-                                     g_localizeStrings.Get(12343).c_str()); // "retries left"
+                                     g_localizeStrings.Get(12343)); // "retries left"
     // prompt user for master lock code
     HELPERS::ShowOKDialogLines(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});
   }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -133,12 +133,13 @@ static std::string ToTimeFormat(bool use24HourClock, bool singleHour, bool merid
   if (!meridiem)
     return singleHour ? TIME_FORMAT_SINGLE_12 : TIME_FORMAT_DOUBLE_12;
 
-  return StringUtils::Format(g_localizeStrings.Get(12382).c_str(), ToTimeFormat(false, singleHour, false).c_str());
+  return StringUtils::Format(g_localizeStrings.Get(12382), ToTimeFormat(false, singleHour, false));
 }
 
 static std::string ToSettingTimeFormat(const CDateTime& time, const std::string& timeFormat)
 {
-  return StringUtils::Format(g_localizeStrings.Get(20036).c_str(), time.GetAsLocalizedTime(timeFormat, true).c_str(), timeFormat.c_str());
+  return StringUtils::Format(g_localizeStrings.Get(20036),
+                             time.GetAsLocalizedTime(timeFormat, true), timeFormat);
 }
 
 static CTemperature::Unit StringToTemperatureUnit(const std::string& temperatureUnit)
@@ -1040,8 +1041,8 @@ std::string CLangInfo::GetTemperatureAsString(const CTemperature& temperature) c
     return g_localizeStrings.Get(13205); // "Unknown"
 
   CTemperature::Unit temperatureUnit = GetTemperatureUnit();
-  return StringUtils::Format("{}{}", temperature.ToString(temperatureUnit).c_str(),
-                             GetTemperatureUnitString().c_str());
+  return StringUtils::Format("{}{}", temperature.ToString(temperatureUnit),
+                             GetTemperatureUnitString());
 }
 
 // Returns the temperature unit string for the current language
@@ -1089,8 +1090,7 @@ std::string CLangInfo::GetSpeedAsString(const CSpeed& speed) const
   if (!speed.IsValid())
     return g_localizeStrings.Get(13205); // "Unknown"
 
-  return StringUtils::Format("{}{}", speed.ToString(GetSpeedUnit()).c_str(),
-                             GetSpeedUnitString().c_str());
+  return StringUtils::Format("{}{}", speed.ToString(GetSpeedUnit()), GetSpeedUnitString());
 }
 
 // Returns the speed unit string for the current language
@@ -1247,9 +1247,9 @@ void CLangInfo::SettingOptionsShortDateFormatsFiller(const SettingConstPtr& sett
   CDateTime now = CDateTime::GetCurrentDateTime();
 
   list.emplace_back(
-    StringUtils::Format(g_localizeStrings.Get(20035).c_str(),
-                        now.GetAsLocalizedDate(g_langInfo.m_currentRegion->m_strDateFormatShort).c_str()),
-    SETTING_REGIONAL_DEFAULT);
+      StringUtils::Format(g_localizeStrings.Get(20035),
+                          now.GetAsLocalizedDate(g_langInfo.m_currentRegion->m_strDateFormatShort)),
+      SETTING_REGIONAL_DEFAULT);
   if (shortDateFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;
@@ -1282,9 +1282,9 @@ void CLangInfo::SettingOptionsLongDateFormatsFiller(const SettingConstPtr& setti
   CDateTime now = CDateTime::GetCurrentDateTime();
 
   list.emplace_back(
-    StringUtils::Format(g_localizeStrings.Get(20035).c_str(),
-                        now.GetAsLocalizedDate(g_langInfo.m_currentRegion->m_strDateFormatLong).c_str()),
-    SETTING_REGIONAL_DEFAULT);
+      StringUtils::Format(g_localizeStrings.Get(20035),
+                          now.GetAsLocalizedDate(g_langInfo.m_currentRegion->m_strDateFormatLong)),
+      SETTING_REGIONAL_DEFAULT);
   if (longDateFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;
@@ -1318,9 +1318,9 @@ void CLangInfo::SettingOptionsTimeFormatsFiller(const SettingConstPtr& setting,
   bool use24hourFormat = g_langInfo.Use24HourClock();
 
   list.emplace_back(
-    StringUtils::Format(g_localizeStrings.Get(20035).c_str(),
-                        ToSettingTimeFormat(now, g_langInfo.m_currentRegion->m_strTimeFormat).c_str()),
-    SETTING_REGIONAL_DEFAULT);
+      StringUtils::Format(g_localizeStrings.Get(20035),
+                          ToSettingTimeFormat(now, g_langInfo.m_currentRegion->m_strTimeFormat)),
+      SETTING_REGIONAL_DEFAULT);
   if (timeFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;
@@ -1390,8 +1390,8 @@ void CLangInfo::SettingOptions24HourClockFormatsFiller(const SettingConstPtr& se
 
   // determine the 24-hour clock format of the regional setting
   int regionalClock24HourFormatLabel = DetermineUse24HourClockFromTimeFormat(g_langInfo.m_currentRegion->m_strTimeFormat) ? 12384 : 12383;
-  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035).c_str(),
-                                        g_localizeStrings.Get(regionalClock24HourFormatLabel).c_str()),
+  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035),
+                                        g_localizeStrings.Get(regionalClock24HourFormatLabel)),
                     SETTING_REGIONAL_DEFAULT);
   if (clock24HourFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
@@ -1425,9 +1425,10 @@ void CLangInfo::SettingOptionsTemperatureUnitsFiller(const SettingConstPtr& sett
   bool match = false;
   const std::string& temperatureUnitSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
-  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035).c_str(),
-                                        GetTemperatureUnitString(g_langInfo.m_currentRegion->m_tempUnit).c_str()),
-                    SETTING_REGIONAL_DEFAULT);
+  list.emplace_back(
+      StringUtils::Format(g_localizeStrings.Get(20035),
+                          GetTemperatureUnitString(g_langInfo.m_currentRegion->m_tempUnit)),
+      SETTING_REGIONAL_DEFAULT);
   if (temperatureUnitSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;
@@ -1457,9 +1458,10 @@ void CLangInfo::SettingOptionsSpeedUnitsFiller(const SettingConstPtr& setting,
   bool match = false;
   const std::string& speedUnitSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
-  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035).c_str(),
-                                        GetSpeedUnitString(g_langInfo.m_currentRegion->m_speedUnit).c_str()),
-                    SETTING_REGIONAL_DEFAULT);
+  list.emplace_back(
+      StringUtils::Format(g_localizeStrings.Get(20035),
+                          GetSpeedUnitString(g_langInfo.m_currentRegion->m_speedUnit)),
+      SETTING_REGIONAL_DEFAULT);
   if (speedUnitSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -519,9 +519,9 @@ void CPlayListPlayer::SetShuffle(int iPlaylist, bool bYesNo, bool bNotify /* = f
 
     if (bNotify)
     {
-      std::string shuffleStr = StringUtils::Format(
-          "{}: {}", g_localizeStrings.Get(191).c_str(),
-          g_localizeStrings.Get(bYesNo ? 593 : 591).c_str()); // Shuffle: All/Off
+      std::string shuffleStr =
+          StringUtils::Format("{}: {}", g_localizeStrings.Get(191),
+                              g_localizeStrings.Get(bYesNo ? 593 : 591)); // Shuffle: All/Off
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559),  shuffleStr);
     }
 

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -236,9 +236,9 @@ void CSeekHandler::SettingOptionsSeekStepsFiller(const SettingConstPtr& setting,
   for (int seconds : CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_seekSteps)
   {
     if (seconds > 60)
-      label = StringUtils::Format(g_localizeStrings.Get(14044).c_str(), seconds / 60);
+      label = StringUtils::Format(g_localizeStrings.Get(14044), seconds / 60);
     else
-      label = StringUtils::Format(g_localizeStrings.Get(14045).c_str(), seconds);
+      label = StringUtils::Format(g_localizeStrings.Get(14045), seconds);
 
     list.insert(list.begin(), IntegerSettingOption("-" + label, seconds * -1));
     list.emplace_back(label, seconds);

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -283,7 +283,7 @@ void CURL::Parse(const std::string& strURL1)
   {
     if (m_strHostName != "" && m_strFileName != "")
     {
-      m_strFileName = StringUtils::Format("{}/{}", m_strHostName.c_str(), m_strFileName.c_str());
+      m_strFileName = StringUtils::Format("{}/{}", m_strHostName, m_strFileName);
       m_strHostName = "";
     }
     else

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -550,7 +550,7 @@ void CUtil::GetFileAndProtocol(const std::string& strURL, std::string& strDir)
   if (URIUtils::IsDVD(strURL)) return ;
 
   CURL url(strURL);
-  strDir = StringUtils::Format("{}://{}", url.GetProtocol().c_str(), url.GetFileName().c_str());
+  strDir = StringUtils::Format("{}://{}", url.GetProtocol(), url.GetFileName());
 }
 
 int CUtil::GetDVDIfoTitle(const std::string& strFile)
@@ -716,7 +716,7 @@ std::string CUtil::GetNextFilename(const std::string &fn_template, int max)
 {
   std::string searchPath = URIUtils::GetDirectory(fn_template);
   std::string mask = URIUtils::GetExtension(fn_template);
-  std::string name = StringUtils::Format(fn_template.c_str(), 0);
+  std::string name = StringUtils::Format(fn_template, 0);
 
   CFileItemList items;
   if (!CDirectory::GetDirectory(searchPath, items, mask, DIR_FLAG_NO_FILE_DIRS))
@@ -725,7 +725,7 @@ std::string CUtil::GetNextFilename(const std::string &fn_template, int max)
   items.SetFastLookup(true);
   for (int i = 0; i <= max; i++)
   {
-    std::string name = StringUtils::Format(fn_template.c_str(), i);
+    std::string name = StringUtils::Format(fn_template, i);
     if (!items.Get(name))
       return name;
   }
@@ -739,7 +739,7 @@ std::string CUtil::GetNextPathname(const std::string &path_template, int max)
 
   for (int i = 0; i <= max; i++)
   {
-    std::string name = StringUtils::Format(path_template.c_str(), i);
+    std::string name = StringUtils::Format(path_template, i);
     if (!CFile::Exists(name) && !CDirectory::Exists(name))
       return name;
   }
@@ -2060,7 +2060,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
           for (const auto &lang : TagConv.m_Langclass)
           {
             std::string strDest =
-                StringUtils::Format("special://temp/subtitle.{}.{}.smi", lang.Name.c_str(), i);
+                StringUtils::Format("special://temp/subtitle.{}.{}.smi", lang.Name, i);
             if (CFile::Copy(vecSubtitles[i], strDest))
             {
               CLog::Log(LOGINFO, " cached subtitle %s->%s",

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1563,8 +1563,7 @@ std::string CDateTime::GetAsW3CDateTime(bool asUtc /* = false */) const
 
   CDateTimeSpan bias = GetTimezoneBias();
   return result + StringUtils::Format("{}{:02}:{:02}", (bias.GetSecondsTotal() >= 0 ? '+' : '-'),
-                                      abs(bias.GetHours()), abs(bias.GetMinutes()))
-                      .c_str();
+                                      abs(bias.GetHours()), abs(bias.GetMinutes()));
 }
 
 int CDateTime::MonthStringToMonthNum(const std::string& month)

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1237,7 +1237,7 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
       // Format hour string with the length of the mask
       std::string str;
       if (partLength==1)
-        str = StringUtils::Format("{}", hour);
+        str = std::to_string(hour);
       else
         str = StringUtils::Format("{:02}", hour);
 
@@ -1264,7 +1264,7 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
       // Format minute string with the length of the mask
       std::string str;
       if (partLength==1)
-        str = StringUtils::Format("{}", dateTime.minute);
+        str = std::to_string(dateTime.minute);
       else
         str = StringUtils::Format("{:02}", dateTime.minute);
 
@@ -1293,7 +1293,7 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
         // Format seconds string with the length of the mask
         std::string str;
         if (partLength==1)
-          str = StringUtils::Format("{}", dateTime.second);
+          str = std::to_string(dateTime.second);
         else
           str = StringUtils::Format("{:02}", dateTime.second);
 
@@ -1386,7 +1386,7 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       // Format string with the length of the mask
       std::string str;
       if (partLength==1) // single-digit number
-        str = StringUtils::Format("{}", dateTime.day);
+        str = std::to_string(dateTime.day);
       else if (partLength==2) // two-digit number
         str = StringUtils::Format("{:02}", dateTime.day);
       else // Day of week string
@@ -1418,7 +1418,7 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       // Format string with the length of the mask
       std::string str;
       if (partLength==1) // single-digit number
-        str = StringUtils::Format("{}", dateTime.month);
+        str = std::to_string(dateTime.month);
       else if (partLength==2) // two-digit number
         str = StringUtils::Format("{:02}", dateTime.month);
       else // Month string
@@ -1448,7 +1448,7 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       }
 
       // Format string with the length of the mask
-      std::string str = StringUtils::Format("{}", dateTime.year); // four-digit number
+      std::string str = std::to_string(dateTime.year); // four-digit number
       if (partLength <= 2)
         str.erase(0, 2); // two-digit number
 

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -41,8 +41,7 @@ CAddon::CAddon(const AddonInfoPtr& addonInfo, TYPE addonType)
     m_userSettingsPath(),
     m_loadSettingsFailed(false),
     m_hasUserSettings(false),
-    m_profilePath(
-        StringUtils::Format("special://profile/addon_data/{}/", m_addonInfo->ID().c_str())),
+    m_profilePath(StringUtils::Format("special://profile/addon_data/{}/", m_addonInfo->ID())),
     m_settings(nullptr),
     m_type(addonType == ADDON_UNKNOWN ? addonInfo->MainType() : addonType)
 {

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -291,9 +291,9 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   if (!CDirectory::GetDirectory(zipDir, items, "", DIR_FLAG_DEFAULTS) ||
       items.Size() != 1 || !items[0]->m_bIsFolder)
   {
-    CServiceBroker::GetEventLog().AddWithNotification(EventPtr(new CNotificationEvent(24045,
-        StringUtils::Format(g_localizeStrings.Get(24143).c_str(), path.c_str()),
-        "special://xbmc/media/icon256x256.png", EventLevel::Error)));
+    CServiceBroker::GetEventLog().AddWithNotification(EventPtr(
+        new CNotificationEvent(24045, StringUtils::Format(g_localizeStrings.Get(24143), path),
+                               "special://xbmc/media/icon256x256.png", EventLevel::Error)));
     return false;
   }
 
@@ -302,9 +302,9 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
     return DoInstall(addon, RepositoryPtr(), BackgroundJob::YES, ModalJob::NO, AutoUpdateJob::NO,
                      DependencyJob::NO, AllowCheckForUpdates::YES);
 
-  CServiceBroker::GetEventLog().AddWithNotification(EventPtr(new CNotificationEvent(24045,
-      StringUtils::Format(g_localizeStrings.Get(24143).c_str(), path.c_str()),
-      "special://xbmc/media/icon256x256.png", EventLevel::Error)));
+  CServiceBroker::GetEventLog().AddWithNotification(EventPtr(
+      new CNotificationEvent(24045, StringUtils::Format(g_localizeStrings.Get(24143), path),
+                             "special://xbmc/media/icon256x256.png", EventLevel::Error)));
   return false;
 }
 
@@ -519,7 +519,7 @@ bool CAddonInstallJob::DoWork()
 {
   m_currentType = CAddonInstallJob::TYPE_DOWNLOAD;
 
-  SetTitle(StringUtils::Format(g_localizeStrings.Get(24057).c_str(), m_addon->Name().c_str()));
+  SetTitle(StringUtils::Format(g_localizeStrings.Get(24057), m_addon->Name()));
   SetProgress(0);
 
   // check whether all the dependencies are available or not
@@ -527,7 +527,8 @@ bool CAddonInstallJob::DoWork()
   std::pair<std::string, std::string> failedDep;
   if (!CAddonInstaller::GetInstance().CheckDependencies(m_addon, failedDep))
   {
-    std::string details = StringUtils::Format(g_localizeStrings.Get(24142).c_str(), failedDep.first.c_str(), failedDep.second.c_str());
+    std::string details =
+        StringUtils::Format(g_localizeStrings.Get(24142), failedDep.first, failedDep.second);
     CLog::Log(LOGERROR, "CAddonInstallJob[%s]: %s", m_addon->ID().c_str(), details.c_str());
     ReportInstallError(m_addon->ID(), m_addon->ID(), details);
     return false;
@@ -1019,8 +1020,8 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
   }
   else
   {
-    activity = EventPtr(new CNotificationEvent(24045,
-        !msg.empty() ? msg : StringUtils::Format(g_localizeStrings.Get(24143).c_str(), fileName.c_str()),
+    activity = EventPtr(new CNotificationEvent(
+        24045, !msg.empty() ? msg : StringUtils::Format(g_localizeStrings.Get(24143), fileName),
         EventLevel::Error));
 
     if (IsModal())

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -81,7 +81,7 @@ void CAddonStatusHandler::Process()
   CSingleLock lock(m_critSection);
 
   std::string heading = StringUtils::Format(
-      "{}: {}", CAddonInfo::TranslateType(m_addon->Type(), true).c_str(), m_addon->Name().c_str());
+      "{}: {}", CAddonInfo::TranslateType(m_addon->Type(), true), m_addon->Name());
 
   /* Request to restart the AddOn and data structures need updated */
   if (m_status == ADDON_STATUS_NEED_RESTART)

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -614,7 +614,7 @@ CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem &item)
   std::string sArtist = item.GetProperty("album.artist").asString();
   std::string sAlbumName;
   if (!sArtist.empty())
-    sAlbumName = StringUtils::Format("{} - {}", sArtist.c_str(), sTitle.c_str());
+    sAlbumName = StringUtils::Format("{} - {}", sArtist, sTitle);
   else
     sAlbumName = sTitle;
 
@@ -992,11 +992,11 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
 
         // reconstruct a title for the user
         if (!sCompareYear.empty())
-          title += StringUtils::Format(" ({})", sCompareYear.c_str());
+          title += StringUtils::Format(" ({})", sCompareYear);
 
         std::string sLanguage;
         if (XMLUtils::GetString(pxeMovie, "language", sLanguage) && !sLanguage.empty())
-          title += StringUtils::Format(" ({})", sLanguage.c_str());
+          title += StringUtils::Format(" ({})", sLanguage);
 
         // filter for dupes from naughty scrapers
         if (stsDupeCheck.insert(scurlMovie.GetFirstThumbUrl() + " " + title).second)
@@ -1083,13 +1083,13 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
         std::string sArtist;
         std::string sAlbumName;
         if (XMLUtils::GetString(pxeAlbum, "artist", sArtist) && !sArtist.empty())
-          sAlbumName = StringUtils::Format("{} - {}", sArtist.c_str(), sTitle.c_str());
+          sAlbumName = StringUtils::Format("{} - {}", sArtist, sTitle);
         else
           sAlbumName = sTitle;
 
         std::string sYear;
         if (XMLUtils::GetString(pxeAlbum, "year", sYear) && !sYear.empty())
-          sAlbumName = StringUtils::Format("{} ({})", sAlbumName.c_str(), sYear.c_str());
+          sAlbumName = StringUtils::Format("{} ({})", sAlbumName, sYear);
 
         // if no URL is provided, use the URL we got back from CreateAlbumSearchUrl
         // (e.g., in case we only got one result back and were sent to the detail page)

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -147,8 +147,8 @@ bool CAddonDll::LoadDll()
     delete m_pDll;
     m_pDll = nullptr;
 
-    std::string heading = StringUtils::Format(
-        "{}: {}", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
+    std::string heading =
+        StringUtils::Format("{}: {}", CAddonInfo::TranslateType(Type(), true), Name());
     HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{24070}, CVariant{24071});
 
     return false;
@@ -200,8 +200,8 @@ ADDON_STATUS CAddonDll::Create(KODI_HANDLE firstKodiInstance)
     CLog::Log(LOGERROR, "ADDON: Dll %s - Client returned bad status (%i) from Create and is not usable", Name().c_str(), status);
 
     // @todo currently a copy and paste from other function and becomes improved.
-    std::string heading = StringUtils::Format(
-        "{}: {}", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
+    std::string heading =
+        StringUtils::Format("{}: {}", CAddonInfo::TranslateType(Type(), true), Name());
     HELPERS::ShowOKDialogLines(CVariant{ heading }, CVariant{ 24070 }, CVariant{ 24071 });
   }
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -278,8 +278,7 @@ int CGUIDialogAddonInfo::AskForVersion(std::vector<std::pair<AddonVersion, std::
 
   for (const auto& versionInfo : versions)
   {
-    CFileItem item(StringUtils::Format(g_localizeStrings.Get(21339).c_str(),
-                                       versionInfo.first.asString().c_str()));
+    CFileItem item(StringUtils::Format(g_localizeStrings.Get(21339), versionInfo.first.asString()));
     if (m_localAddon && m_localAddon->Version() == versionInfo.first &&
         m_item->GetAddonInfo()->Origin() == versionInfo.second)
       item.Select(true);
@@ -379,8 +378,8 @@ void CGUIDialogAddonInfo::OnSelectVersion()
       if (versions[i].second == LOCAL_CACHE)
       {
         CAddonInstaller::GetInstance().InstallFromZip(
-            StringUtils::Format("special://home/addons/packages/{}-{}.zip", processAddonId.c_str(),
-                                versions[i].first.asString().c_str()));
+            StringUtils::Format("special://home/addons/packages/{}-{}.zip", processAddonId,
+                                versions[i].first.asString()));
       }
       else
       {
@@ -527,8 +526,7 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
 
   if (!deps.empty())
   {
-    std::string line0 =
-        StringUtils::Format(g_localizeStrings.Get(24046).c_str(), m_localAddon->Name().c_str());
+    std::string line0 = StringUtils::Format(g_localizeStrings.Get(24046), m_localAddon->Name());
     std::string line1 = StringUtils::Join(deps, ", ");
     HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{std::move(line0)},
                                CVariant{std::move(line1)}, CVariant{line2});
@@ -647,10 +645,10 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
           }
 
           item->SetLabel2(StringUtils::Format(
-              g_localizeStrings.Get(messageId).c_str(), it.m_depInfo.versionMin.asString().c_str(),
-              it.m_installed ? it.m_installed->Version().asString().c_str() : "",
-              it.m_available ? it.m_available->Version().asString().c_str() : "",
-              it.m_depInfo.optional ? g_localizeStrings.Get(24184).c_str() : ""));
+              g_localizeStrings.Get(messageId), it.m_depInfo.versionMin.asString(),
+              it.m_installed ? it.m_installed->Version().asString() : "",
+              it.m_available ? it.m_available->Version().asString() : "",
+              it.m_depInfo.optional ? g_localizeStrings.Get(24184) : ""));
 
           item->SetArt("icon", infoAddon->Icon());
           item->SetProperty("addon_id", it.m_depInfo.id);

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -199,7 +199,7 @@ void CGUIDialogAddonSettings::SetupView()
 
   // set heading
   SetHeading(StringUtils::Format("$LOCALIZE[10004] - {}",
-                                 m_addon->Name().c_str())); // "Settings - AddonName"
+                                 m_addon->Name())); // "Settings - AddonName"
 
   // set control labels
   SET_CONTROL_LABEL(CONTROL_SETTINGS_OKAY_BUTTON, 186);

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -415,7 +415,7 @@ bool Interface_Base::set_setting_int(void* kodiBase, const char* id, int value)
     return false;
   }
 
-  if (Interface_Base::UpdateSettingInActiveDialog(addon, id, StringUtils::Format("{}", value)))
+  if (Interface_Base::UpdateSettingInActiveDialog(addon, id, std::to_string(value)))
     return true;
 
   if (!addon->UpdateSettingInt(id, value))

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -375,8 +375,8 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
     StringUtils::Replace(result, "xx", "%p");
   }
   else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
-    result = StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
-                                 g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
+    result = StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM),
+                                 g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM));
   else
   {
     CLog::Log(LOGERROR, "Interface_General::{} -  add-on '{}' requests invalid id '{}'",

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -2936,13 +2936,13 @@ public:
 
     std::string strHMS;
     if (format == TIME_FORMAT_SECS)
-      strHMS = StringUtils::Format("{}", seconds);
+      strHMS = std::to_string(seconds);
     else if (format == TIME_FORMAT_MINS)
-      strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(seconds) / 60.0f));
+      strHMS = std::to_string(lrintf(static_cast<float>(seconds) / 60.0f));
     else if (format == TIME_FORMAT_HOURS)
-      strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(seconds) / 3600.0f));
+      strHMS = std::to_string(lrintf(static_cast<float>(seconds) / 3600.0f));
     else if (format & TIME_FORMAT_M)
-      strHMS += StringUtils::Format("{}", seconds % 3600 / 60);
+      strHMS += std::to_string(seconds % 3600 / 60);
     else
     {
       int hh = seconds / 3600;
@@ -2955,7 +2955,7 @@ public:
       if (format & TIME_FORMAT_HH)
         strHMS += StringUtils::Format("{:02}", hh);
       else if (format & TIME_FORMAT_H)
-        strHMS += StringUtils::Format("{}", hh);
+        strHMS += std::to_string(hh);
       if (format & TIME_FORMAT_MM)
         strHMS += StringUtils::Format(strHMS.empty() ? "{:02}" : ":{:02}", mm);
       if (format & TIME_FORMAT_SS)

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -492,7 +492,7 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(
           category->AddGroup(group);
 
           // and create a new one
-          group.reset(new CSettingGroup(StringUtils::Format("{}", groupId), GetSettingsManager()));
+          group.reset(new CSettingGroup(std::to_string(groupId), GetSettingsManager()));
           groupId += 1;
         }
 

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -82,8 +82,8 @@ bool CCDDARipJob::DoWork()
   CGUIDialogProgressBarHandle* handle = pDlgProgress->GetHandle(g_localizeStrings.Get(605));
 
   int iTrack = atoi(m_input.substr(13, m_input.size() - 13 - 5).c_str());
-  std::string strLine0 = StringUtils::Format(
-      "{:02}. {} - {}", iTrack, m_tag.GetArtistString().c_str(), m_tag.GetTitle().c_str());
+  std::string strLine0 =
+      StringUtils::Format("{:02}. {} - {}", iTrack, m_tag.GetArtistString(), m_tag.GetTitle());
   handle->SetText(strLine0);
 
   // start ripping
@@ -193,7 +193,7 @@ CEncoder* CCDDARipJob::SetupEncoder(CFile& reader)
 
   // we have to set the tags before we init the Encoder
   const std::string strTrack = StringUtils::Format(
-      "{}", strtol(m_input.substr(13, m_input.size() - 13 - 5).c_str(), nullptr, 10));
+      "{}", std::stol(m_input.substr(13, m_input.size() - 13 - 5), nullptr, 10));
 
   const std::string itemSeparator = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
 

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -220,8 +220,8 @@ std::string CCDDARipper::GetAlbumDirName(const MUSIC_INFO::CMusicInfoTag& infoTa
   {
     std::string strAlbum = infoTag.GetAlbum();
     if (strAlbum.empty())
-      strAlbum = StringUtils::Format(
-          "Unknown Album {}", CDateTime::GetCurrentDateTime().GetAsLocalizedDateTime().c_str());
+      strAlbum = StringUtils::Format("Unknown Album {}",
+                                     CDateTime::GetCurrentDateTime().GetAsLocalizedDateTime());
     else
       StringUtils::Replace(strAlbum, '/', '_');
     StringUtils::Replace(strAlbumDir, "%B", strAlbum);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -130,10 +130,10 @@ void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(
 
   if (m_instance->m_audioEngine.SupportsSilenceTimeout())
   {
-    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13554).c_str(), 1), 1);
+    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13554), 1), 1);
     for (int i = 2; i <= 10; i++)
     {
-      list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13555).c_str(), i), i);
+      list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13555), i), i);
     }
   }
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -310,7 +310,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   m_latency = 20; // ms
   uint32_t frames = std::nearbyint((m_latency * format.m_sampleRate) / 1000.0);
-  std::string fraction = StringUtils::Format("%u/%u", frames, format.m_sampleRate);
+  std::string fraction = StringUtils::Format("{}/{}", frames, format.m_sampleRate);
 
   std::array<spa_dict_item, 5> items = {
       SPA_DICT_ITEM_INIT(PW_KEY_MEDIA_TYPE, "Audio"),

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -198,8 +198,8 @@ extern "C" void __stdcall update_emu_environ()
         !settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD).empty())
     {
       strProxy = StringUtils::Format(
-          "{}:{}@", settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).c_str(),
-          settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD).c_str());
+          "{}:{}@", settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME),
+          settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD));
     }
 
     strProxy += settings->GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -99,7 +99,7 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
       if(pos == std::string::npos)
         continue;
 
-      line2 = StringUtils::Format("{},{},{}", m_order++, layer.get(), line.substr(pos + 1).c_str());
+      line2 = StringUtils::Format("{},{},{}", m_order++, layer.get(), line.substr(pos + 1));
 
       m_libass->DecodeDemuxPkt(line2.c_str(), line2.length(), beg, end - beg);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -210,9 +210,9 @@ static DWORD VP3DeviceID [] = {
 static std::string GUIDToString(const GUID& guid)
 {
   std::string buffer = StringUtils::Format(
-      "%08X-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x", guid.Data1, guid.Data2, guid.Data3,
-      guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3], guid.Data4[4], guid.Data4[5],
-      guid.Data4[6], guid.Data4[7]);
+      "{:08X}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}", guid.Data1,
+      guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3],
+      guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
   return buffer;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -485,7 +485,7 @@ void CSelectionStreams::Update(const std::shared_ptr<CDVDInputStream>& input,
       s.width = info.width;
       s.height = info.height;
       s.codec = info.codecName;
-      s.name = StringUtils::Format("{} {}", g_localizeStrings.Get(38032).c_str(), i);
+      s.name = StringUtils::Format("{} {}", g_localizeStrings.Get(38032), i);
       Update(s);
     }
   }
@@ -3166,13 +3166,13 @@ void CVideoPlayer::GetGeneralInfo(std::string& strGeneralInfo)
     if (m_State.cache_bytes >= 0)
     {
       strBuf += StringUtils::Format(" forward:{} {:2.0f}%",
-                                    StringUtils::SizeToString(m_State.cache_bytes).c_str(),
+                                    StringUtils::SizeToString(m_State.cache_bytes),
                                     m_State.cache_level * 100);
       if (m_playSpeed == 0 || m_caching == CACHESTATE_FULL)
         strBuf += StringUtils::Format(" {} msec", DVD_TIME_TO_MSEC(m_State.cache_delay));
     }
 
-    strGeneralInfo = StringUtils::Format("Player: a/v:{: 6.3f}, {}", dDiff, strBuf.c_str());
+    strGeneralInfo = StringUtils::Format("Player: a/v:{: 6.3f}, {}", dDiff, strBuf);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -1049,8 +1049,7 @@ unsigned int CDVDRadioRDSData::DecodePTYN(uint8_t *msgElement)
   if (!m_RTPlus_GenrePresent)
   {
     std::string progTypeName = StringUtils::Format(
-        "{}: {}", g_localizeStrings.Get(pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name).c_str(),
-        m_PTYN);
+        "{}: {}", g_localizeStrings.Get(pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name), m_PTYN);
     SetRadioStyle(progTypeName);
   }
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -524,7 +524,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   InitSettings(dbSettings);
 
   std::string dbName = dbSettings.name;
-  dbName += StringUtils::Format("{}", GetSchemaVersion());
+  dbName += std::to_string(GetSchemaVersion());
   return Connect(dbName, dbSettings, false);
 }
 

--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -401,7 +401,7 @@ std::string CDatabaseQueryRule::FormatWhereClause(const std::string &negate, con
     else if (GetFieldType(m_field) == SECONDS_FIELD)
       fmt = "CAST(%s as INTEGER)";
 
-    query = StringUtils::Format(fmt.c_str(), GetField(m_field,strType).c_str());
+    query = StringUtils::Format(fmt, GetField(m_field, strType));
     query += negate + parameter;
 
     // special case for matching parameters in fields that might be either empty or NULL.

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -445,7 +445,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       // password entry and re-entry succeeded, write out the lock data
       share->m_iHasLock = LOCK_STATE_LOCKED;
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockcode", strNewPassword);
-      strNewPassword = StringUtils::Format("{}", share->m_iLockMode);
+      strNewPassword = std::to_string(share->m_iLockMode);
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockmode", strNewPassword);
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
@@ -505,7 +505,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       std::string strNewPW;
       std::string strNewLockMode;
       if (CGUIDialogLockSettings::ShowAndGetLock(share->m_iLockMode,strNewPW))
-        strNewLockMode = StringUtils::Format("{}", share->m_iLockMode);
+        strNewLockMode = std::to_string(share->m_iLockMode);
       else
         return false;
       // password ReSet and re-entry succeeded, write out the lock data

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -234,8 +234,8 @@ int CGUIDialogGamepad::ShowAndVerifyPassword(std::string& strPassword, const std
   if (0 < iRetries)
   {
     // Show a string telling user they have iRetries retries left
-    strLine2 = StringUtils::Format("{} {} {}", g_localizeStrings.Get(12342).c_str(), iRetries,
-                                   g_localizeStrings.Get(12343).c_str());
+    strLine2 = StringUtils::Format("{} {} {}", g_localizeStrings.Get(12342), iRetries,
+                                   g_localizeStrings.Get(12343));
   }
 
   // make a copy of strPassword to prevent from overwriting it later

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -366,7 +366,8 @@ void CGUIDialogMediaFilter::SetupView()
     localizedMediaId = 134;
 
   // set the heading
-  SET_CONTROL_LABEL(CONTROL_HEADING, StringUtils::Format(g_localizeStrings.Get(1275).c_str(), g_localizeStrings.Get(localizedMediaId).c_str()));
+  SET_CONTROL_LABEL(CONTROL_HEADING, StringUtils::Format(g_localizeStrings.Get(1275),
+                                                         g_localizeStrings.Get(localizedMediaId)));
 
   SET_CONTROL_LABEL(CONTROL_OKAY_BUTTON, 186);
   SET_CONTROL_LABEL(CONTROL_CLEAR_BUTTON, 192);
@@ -415,8 +416,7 @@ void CGUIDialogMediaFilter::InitializeSettings()
       }
     }
 
-    std::string settingId =
-        StringUtils::Format("filter.{}.{}", filter.mediaType.c_str(), filter.field);
+    std::string settingId = StringUtils::Format("filter.{}.{}", filter.mediaType, filter.field);
     if (filter.controlType == "edit")
     {
       CVariant data;
@@ -602,7 +602,7 @@ void CGUIDialogMediaFilter::UpdateControls()
     else
     {
       CONTROL_ENABLE(control->GetID());
-      label = StringUtils::Format(g_localizeStrings.Get(21470).c_str(), label.c_str(), size);
+      label = StringUtils::Format(g_localizeStrings.Get(21470), label, size);
     }
     SET_CONTROL_LABEL(control->GetID(), label);
   }
@@ -791,7 +791,7 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
         table = "tvshow_view";
         year = StringUtils::Format(
             "strftime(\"%%Y\", {})",
-            DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPartWhere).c_str());
+            DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPartWhere));
       }
       else if (m_mediaType == "musicvideos")
       {

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -205,7 +205,7 @@ std::string CGUIDialogMediaSource::GetUniqueMediaSourceName()
     }
     if (i < pShares->size())
       // found a match -  try next
-      strName = StringUtils::Format("{} ({})", m_name.c_str(), j++);
+      strName = StringUtils::Format("{} ({})", m_name, j++);
     else
       bConfirmed = true;
   }

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -605,9 +605,8 @@ int CGUIDialogNumeric::ShowAndVerifyPassword(std::string& strPassword, const std
   if (iRetries > 0)
   {
     // Show a string telling user they have iRetries retries left
-    strTempHeading = StringUtils::Format("{}. {} {} {}", strHeading.c_str(),
-                                         g_localizeStrings.Get(12342).c_str(), iRetries,
-                                         g_localizeStrings.Get(12343).c_str());
+    strTempHeading = StringUtils::Format("{}. {} {} {}", strHeading, g_localizeStrings.Get(12342),
+                                         iRetries, g_localizeStrings.Get(12343));
   }
 
   // make a copy of strPassword to prevent from overwriting it later

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -354,9 +354,8 @@ void CGUIDialogSelect::OnInitWindow()
   }
   m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILED_LIST : CONTROL_SIMPLE_LIST);
 
-  SET_CONTROL_LABEL(
-      CONTROL_NUMBER_OF_ITEMS,
-      StringUtils::Format("{} {}", m_vecList->Size(), g_localizeStrings.Get(127).c_str()));
+  SET_CONTROL_LABEL(CONTROL_NUMBER_OF_ITEMS,
+                    StringUtils::Format("{} {}", m_vecList->Size(), g_localizeStrings.Get(127)));
 
   if (m_multiSelection)
     EnableButton(true, 186);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -297,7 +297,7 @@ void CGUIDialogSmartPlaylistEditor::OnLimit()
     if (*limit == 0)
       dialog->Add(g_localizeStrings.Get(21428));
     else
-      dialog->Add(StringUtils::Format(g_localizeStrings.Get(21436).c_str(), *limit));
+      dialog->Add(StringUtils::Format(g_localizeStrings.Get(21436), *limit));
   }
   dialog->SetHeading(CVariant{ 21427 });
   dialog->SetSelected(selected);
@@ -414,7 +414,8 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   if (m_playlist.m_limit == 0)
     SET_CONTROL_LABEL2(CONTROL_LIMIT, g_localizeStrings.Get(21428)); // no limit
   else
-    SET_CONTROL_LABEL2(CONTROL_LIMIT, StringUtils::Format(g_localizeStrings.Get(21436).c_str(), m_playlist.m_limit));
+    SET_CONTROL_LABEL2(CONTROL_LIMIT,
+                       StringUtils::Format(g_localizeStrings.Get(21436), m_playlist.m_limit));
   int currentItem = GetSelectedItem();
   CGUIMessage msgReset(GUI_MSG_LABEL_RESET, GetID(), CONTROL_RULE_LIST);
   OnMessage(msgReset);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -358,7 +358,8 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   CGUIDialogSelect* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   pDialog->Reset();
   pDialog->SetItems(items);
-  std::string strHeading = StringUtils::Format(g_localizeStrings.Get(13401).c_str(), g_localizeStrings.Get(iLabel).c_str());
+  std::string strHeading =
+      StringUtils::Format(g_localizeStrings.Get(13401), g_localizeStrings.Get(iLabel));
   pDialog->SetHeading(CVariant{std::move(strHeading)});
   pDialog->SetMultiSelection(m_rule.m_field != FieldPlaylist && m_rule.m_field != FieldVirtualFolder);
 

--- a/xbmc/events/windows/GUIWindowEventLog.cpp
+++ b/xbmc/events/windows/GUIWindowEventLog.cpp
@@ -177,7 +177,9 @@ void CGUIWindowEventLog::UpdateButtons()
 
   EventLevel eventLevel = CViewStateSettings::GetInstance().GetEventLevel();
   // set the label of the "level" button
-  SET_CONTROL_LABEL(CONTROL_BUTTON_LEVEL, StringUtils::Format(g_localizeStrings.Get(14119).c_str(), g_localizeStrings.Get(14115 + (int)eventLevel).c_str()));
+  SET_CONTROL_LABEL(CONTROL_BUTTON_LEVEL,
+                    StringUtils::Format(g_localizeStrings.Get(14119),
+                                        g_localizeStrings.Get(14115 + (int)eventLevel)));
 
   // set the label, value and enabled state of the "level only" button
   SET_CONTROL_LABEL(CONTROL_BUTTON_LEVEL_ONLY, 14120);

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -190,38 +190,35 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
                                 !(item.IsSmartPlayList() || item.IsPlayList())))
   {
     if (!contextWindow.empty())
-      execute = StringUtils::Format("ActivateWindow({},{},return)", contextWindow.c_str(),
-                                    StringUtils::Paramify(item.GetPath()).c_str());
+      execute = StringUtils::Format("ActivateWindow({},{},return)", contextWindow,
+                                    StringUtils::Paramify(item.GetPath()));
   }
   //! @todo STRING_CLEANUP
   else if (item.IsScript() && item.GetPath().size() > 9) // script://<foo>
-    execute = StringUtils::Format("RunScript({})",
-                                  StringUtils::Paramify(item.GetPath().substr(9)).c_str());
+    execute = StringUtils::Format("RunScript({})", StringUtils::Paramify(item.GetPath().substr(9)));
   else if (item.IsAddonsPath() && item.GetPath().size() > 9) // addons://<foo>
   {
     CURL url(item.GetPath());
     if (url.GetHostName() == "install")
       execute = "installfromzip";
     else
-      execute = StringUtils::Format("RunAddon({})", url.GetFileName().c_str());
+      execute = StringUtils::Format("RunAddon({})", url.GetFileName());
   }
   else if (item.IsAndroidApp() && item.GetPath().size() > 26) // androidapp://sources/apps/<foo>
     execute = StringUtils::Format("StartAndroidActivity({})",
-                                  StringUtils::Paramify(item.GetPath().substr(26)).c_str());
+                                  StringUtils::Paramify(item.GetPath().substr(26)));
   else  // assume a media file
   {
     if (item.IsVideoDb() && item.HasVideoInfoTag())
       execute = StringUtils::Format(
-          "PlayMedia({})",
-          StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
+          "PlayMedia({})", StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath));
     else if (item.IsMusicDb() && item.HasMusicInfoTag())
-      execute = StringUtils::Format(
-          "PlayMedia({})", StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()).c_str());
+      execute = StringUtils::Format("PlayMedia({})",
+                                    StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()));
     else if (item.IsPicture())
-      execute =
-          StringUtils::Format("ShowPicture({})", StringUtils::Paramify(item.GetPath()).c_str());
+      execute = StringUtils::Format("ShowPicture({})", StringUtils::Paramify(item.GetPath()));
     else
-      execute = StringUtils::Format("PlayMedia({})", StringUtils::Paramify(item.GetPath()).c_str());
+      execute = StringUtils::Format("PlayMedia({})", StringUtils::Paramify(item.GetPath()));
   }
   return execute;
 }

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -175,7 +175,7 @@ bool CFavouritesService::IsFavourited(const CFileItem& item, int contextWindow) 
 
 std::string CFavouritesService::GetExecutePath(const CFileItem &item, int contextWindow) const
 {
-  return GetExecutePath(item, StringUtils::Format("{}", contextWindow));
+  return GetExecutePath(item, std::to_string(contextWindow));
 }
 
 std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std::string &contextWindow) const

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -873,8 +873,8 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
 
   std::string strLabel(addon->Name());
   if (CURL(path).GetHostName() == "search")
-    strLabel = StringUtils::Format(
-        "{} - {}", CAddonInfo::TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
+    strLabel = StringUtils::Format("{} - {}", CAddonInfo::TranslateType(addon->Type(), true),
+                                   addon->Name());
   item->SetLabel(strLabel);
   item->SetArt(addon->Art());
   item->SetArt("thumb", addon->Icon());
@@ -945,7 +945,7 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
       if (plugin && plugin->ProvidesSeveral())
       {
         CURL url(path);
-        std::string opt = StringUtils::Format("?content_type={}", content.c_str());
+        std::string opt = StringUtils::Format("?content_type={}", content);
         url.SetOptions(opt);
         path = url.Get();
       }

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -72,7 +72,7 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   for (size_t i=0;i<m_fctx->nb_chapters;++i)
   {
     tag=nullptr;
-    std::string chaptitle = StringUtils::Format(g_localizeStrings.Get(25010).c_str(), i+1);
+    std::string chaptitle = StringUtils::Format(g_localizeStrings.Get(25010), i + 1);
     std::string chapauthor;
     std::string chapalbum;
     while ((tag=av_dict_get(m_fctx->chapters[i]->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
@@ -99,9 +99,9 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
     else
       item->GetMusicInfoTag()->SetArtist(chapauthor);
 
-    item->SetLabel(StringUtils::Format("{0:02}. {1} - {2}",i+1,
-                   item->GetMusicInfoTag()->GetAlbum().c_str(),
-                   item->GetMusicInfoTag()->GetTitle()).c_str());
+    item->SetLabel(StringUtils::Format("{0:02}. {1} - {2}", i + 1,
+                                       item->GetMusicInfoTag()->GetAlbum(),
+                                       item->GetMusicInfoTag()->GetTitle()));
     item->m_lStartOffset = CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->start*av_q2d(m_fctx->chapters[i]->time_base));
     item->m_lEndOffset = m_fctx->chapters[i]->end*av_q2d(m_fctx->chapters[i]->time_base);
     int compare = m_fctx->duration / (AV_TIME_BASE);

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -121,10 +121,11 @@ CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const st
   int duration = (int)(title->duration / 90000);
   item->GetVideoInfoTag()->SetDuration(duration);
   item->GetVideoInfoTag()->m_iTrack = title->playlist;
-  buf = StringUtils::Format(label.c_str(), title->playlist);
+  buf = StringUtils::Format(label, title->playlist);
   item->m_strTitle = buf;
   item->SetLabel(buf);
-  chap = StringUtils::Format(g_localizeStrings.Get(25007).c_str(), title->chapter_count, StringUtils::SecondsToTimeString(duration).c_str());
+  chap = StringUtils::Format(g_localizeStrings.Get(25007), title->chapter_count,
+                             StringUtils::SecondsToTimeString(duration));
   item->SetLabel2(chap);
   item->m_dwSize = 0;
   item->SetArt("icon", "DefaultVideo.png");

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1878,7 +1878,7 @@ void CCurlFile::SetRequestHeader(const std::string& header, const std::string& v
 
 void CCurlFile::SetRequestHeader(const std::string& header, long value)
 {
-  m_requestheaders[header] = StringUtils::Format("{}", value);
+  m_requestheaders[header] = std::to_string(value);
 }
 
 std::string CCurlFile::GetURL(void)

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -55,7 +55,7 @@ bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items) const
   for (int i=0; i<(int)albums.size(); ++i)
   {
     CAlbum& album=albums[i];
-    std::string strDir = StringUtils::Format("{}{}/", BuildPath().c_str(), album.idAlbum);
+    std::string strDir = StringUtils::Format("{}{}/", BuildPath(), album.idAlbum);
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -55,7 +55,7 @@ bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items) const
   for (int i=0; i<(int)albums.size(); ++i)
   {
     CAlbum& album=albums[i];
-    std::string strDir = StringUtils::Format("{}{}/", BuildPath().c_str(), album.idAlbum);
+    std::string strDir = StringUtils::Format("{}{}/", BuildPath(), album.idAlbum);
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -52,7 +52,7 @@ bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items) const
   for (int i=0; i<(int)albums.size(); ++i)
   {
     CAlbum& album=albums[i];
-    std::string strDir = StringUtils::Format("{}{}/", BuildPath().c_str(), album.idAlbum);
+    std::string strDir = StringUtils::Format("{}{}/", BuildPath(), album.idAlbum);
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -76,7 +76,7 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
       continue;
 
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(OverviewChildren[i].label)));
-    std::string strDir = StringUtils::Format("{}/", OverviewChildren[i].id.c_str());
+    std::string strDir = StringUtils::Format("{}/", OverviewChildren[i].id);
     pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -47,7 +47,7 @@ bool CDirectoryNodeTop100::GetContent(CFileItemList& items) const
   for (const Node& node : Top100Children)
   {
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
-    std::string strDir = StringUtils::Format("{}/", node.id.c_str());
+    std::string strDir = StringUtils::Format("{}/", node.id);
     pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     items.Add(pItem);

--- a/xbmc/filesystem/MusicFileDirectory.cpp
+++ b/xbmc/filesystem/MusicFileDirectory.cpp
@@ -35,11 +35,10 @@ bool CMusicFileDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   for (int i=0; i<iStreams; ++i)
   {
-    std::string strLabel = StringUtils::Format("{} - {} {:02}", strFileName.c_str(),
-                                               g_localizeStrings.Get(554).c_str(), i + 1);
+    std::string strLabel =
+        StringUtils::Format("{} - {} {:02}", strFileName, g_localizeStrings.Get(554), i + 1);
     CFileItemPtr pItem(new CFileItem(strLabel));
-    strLabel = StringUtils::Format("{}{}-{}.{}", strPath.c_str(), strFileName.c_str(), i + 1,
-                                   m_strExt.c_str());
+    strLabel = StringUtils::Format("{}{}-{}.{}", strPath, strFileName, i + 1, m_strExt);
     pItem->SetPath(strLabel);
 
     /*

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -166,7 +166,7 @@ bool CVideoDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
   // get year
   if (params.GetYear() != -1)
   {
-    std::string strTemp = StringUtils::Format("{}", params.GetYear());
+    std::string strTemp = std::to_string(params.GetYear());
     if (!strLabel.empty())
       strLabel += " / ";
     strLabel += strTemp;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -67,7 +67,7 @@ bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
     }
 
     CVideoDbUrl itemUrl = videoUrl;
-    std::string strDir = StringUtils::Format("{}/", MovieChildren[i].id.c_str());
+    std::string strDir = StringUtils::Format("{}/", MovieChildren[i].id);
     itemUrl.AppendPath(strDir);
 
     CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), true));

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -60,7 +60,7 @@ bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
 
     CVideoDbUrl itemUrl = videoUrl;
-    std::string strDir = StringUtils::Format("{}/", node.id.c_str());
+    std::string strDir = StringUtils::Format("{}/", node.id);
     itemUrl.AppendPath(strDir);
     pItem->SetPath(itemUrl.ToString());
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -43,7 +43,8 @@ std::string CDirectoryNodeSeasons::GetLocalizedName() const
     return "";
   }
   default:
-    std::string season = StringUtils::Format(g_localizeStrings.Get(20358).c_str(), GetID()); // Season <season>
+    std::string season =
+        StringUtils::Format(g_localizeStrings.Get(20358), GetID()); // Season <season>
     return season;
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -61,7 +61,7 @@ bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
 
     CVideoDbUrl itemUrl = videoUrl;
-    std::string strDir = StringUtils::Format("{}/", node.id.c_str());
+    std::string strDir = StringUtils::Format("{}/", node.id);
     itemUrl.AppendPath(strDir);
     pItem->SetPath(itemUrl.ToString());
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -393,17 +393,15 @@ void CGameClient::NotifyError(GAME_ERROR error)
   {
     // Failed to play game
     // This game requires the following add-on: %s
-    HELPERS::ShowOKDialogText(CVariant{35210},
-                              CVariant{StringUtils::Format(g_localizeStrings.Get(35211).c_str(),
-                                                           missingResource.c_str())});
+    HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{StringUtils::Format(
+                                                   g_localizeStrings.Get(35211), missingResource)});
   }
   else
   {
     // Failed to play game
     // The emulator "%s" had an internal error.
-    HELPERS::ShowOKDialogText(
-        CVariant{35210},
-        CVariant{StringUtils::Format(g_localizeStrings.Get(35213).c_str(), Name().c_str())});
+    HELPERS::ShowOKDialogText(CVariant{35210},
+                              CVariant{StringUtils::Format(g_localizeStrings.Get(35213), Name())});
   }
 }
 

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
@@ -32,7 +32,7 @@ std::string CGUIDialogAxisDetection::GetDialogText()
     primitives.emplace_back(JOYSTICK::CJoystickTranslator::GetPrimitiveName(axis));
   }
 
-  return StringUtils::Format(dialogText.c_str(), StringUtils::Join(primitives, " | ").c_str());
+  return StringUtils::Format(dialogText, StringUtils::Join(primitives, " | "));
 }
 
 std::string CGUIDialogAxisDetection::GetDialogHeader()

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -48,7 +48,7 @@ std::string CGUIDialogIgnoreInput::GetDialogText()
                    return JOYSTICK::CJoystickTranslator::GetPrimitiveName(primitive);
                  });
 
-  return StringUtils::Format(dialogText.c_str(), StringUtils::Join(primitives, " | ").c_str());
+  return StringUtils::Format(dialogText, StringUtils::Join(primitives, " | "));
 }
 
 std::string CGUIDialogIgnoreInput::GetDialogHeader()

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -64,9 +64,9 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
     std::string strLabel;
 
     if (bWarn)
-      strLabel = StringUtils::Format(strWarn.c_str(), strFeature.c_str(), secondsRemaining);
+      strLabel = StringUtils::Format(strWarn, strFeature, secondsRemaining);
     else
-      strLabel = StringUtils::Format(strPrompt.c_str(), strFeature.c_str(), secondsRemaining);
+      strLabel = StringUtils::Format(strPrompt, strFeature, secondsRemaining);
 
     msgLabel.SetLabel(strLabel);
     CApplicationMessenger::GetInstance().SendGUIMessage(msgLabel, WINDOW_INVALID, false);

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -69,7 +69,7 @@ void CGUIAction::SetNavigation(int id)
   if (id == 0)
     return;
 
-  std::string strId = StringUtils::Format("{}", id);
+  std::string strId = std::to_string(id);
   for (auto &i : m_actions)
   {
     if (StringUtils::IsInteger(i.action) && i.condition.empty())

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1337,20 +1337,20 @@ std::string CGUIBaseContainer::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_NUM_PAGES:
-    label = StringUtils::Format("{}", (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage);
+    label = std::to_string((GetRows() + m_itemsPerPage - 1) / m_itemsPerPage);
     break;
   case CONTAINER_CURRENT_PAGE:
-    label = StringUtils::Format("{}", GetCurrentPage());
+    label = std::to_string(GetCurrentPage());
     break;
   case CONTAINER_POSITION:
-    label = StringUtils::Format("{}", GetCursor());
+    label = std::to_string(GetCursor());
     break;
   case CONTAINER_CURRENT_ITEM:
     {
       if (m_items.size() && m_items[0]->IsFileItem() && (std::static_pointer_cast<CFileItem>(m_items[0]))->IsParentFolder())
-        label = StringUtils::Format("{}", GetSelectedItem());
+        label = std::to_string(GetSelectedItem());
       else
-        label = StringUtils::Format("{}", GetSelectedItem() + 1);
+        label = std::to_string(GetSelectedItem() + 1);
     }
     break;
   case CONTAINER_NUM_ALL_ITEMS:
@@ -1358,9 +1358,9 @@ std::string CGUIBaseContainer::GetLabel(int info) const
     {
       unsigned int numItems = GetNumItems();
       if (info == CONTAINER_NUM_ITEMS && numItems && m_items[0]->IsFileItem() && (std::static_pointer_cast<CFileItem>(m_items[0]))->IsParentFolder())
-        label = StringUtils::Format("{}", numItems - 1);
+        label = std::to_string(numItems - 1);
       else
-        label = StringUtils::Format("{}", numItems);
+        label = std::to_string(numItems);
     }
     break;
   case CONTAINER_NUM_NONFOLDER_ITEMS:
@@ -1371,7 +1371,7 @@ std::string CGUIBaseContainer::GetLabel(int info) const
         if (!item->m_bIsFolder)
           numItems++;
       }
-      label = StringUtils::Format("{}", numItems);
+      label = std::to_string(numItems);
     }
     break;
   default:

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -848,7 +848,7 @@ std::string CGUIBaseContainer::GetDescription() const
   {
     CGUIListItemPtr pItem = m_items[item];
     if (pItem->m_bIsFolder)
-      strLabel = StringUtils::Format("[{}]", pItem->GetLabel().c_str());
+      strLabel = StringUtils::Format("[{}]", pItem->GetLabel());
     else
       strLabel = pItem->GetLabel();
   }

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -594,7 +594,7 @@ void CGUIControlFactory::GetInfoLabels(const TiXmlNode *pControlNode, const std:
   int labelNumber = 0;
   if (XMLUtils::GetInt(pControlNode, "number", labelNumber))
   {
-    std::string label = StringUtils::Format("{}", labelNumber);
+    std::string label = std::to_string(labelNumber);
     infoLabels.emplace_back(label);
     return; // done
   }

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -445,11 +445,11 @@ std::string CGUIControlGroupList::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_CURRENT_ITEM:
-    return StringUtils::Format("{}", GetSelectedItem());
+    return std::to_string(GetSelectedItem());
   case CONTAINER_NUM_ITEMS:
-    return StringUtils::Format("{}", GetNumItems());
+    return std::to_string(GetNumItems());
   case CONTAINER_POSITION:
-    return StringUtils::Format("{}", m_focusedPosition);
+    return std::to_string(m_focusedPosition);
   default:
     break;
   }

--- a/xbmc/guilib/GUIControlProfiler.cpp
+++ b/xbmc/guilib/GUIControlProfiler.cpp
@@ -145,7 +145,7 @@ void CGUIControlProfilerItem::SaveToXML(TiXmlElement *parent)
     xmlControl->SetAttribute("type", lpszType);
   if (m_controlID != 0)
   {
-    std::string str = StringUtils::Format("{}", m_controlID);
+    std::string str = std::to_string(m_controlID);
     xmlControl->SetAttribute("id", str.c_str());
   }
 
@@ -172,13 +172,13 @@ void CGUIControlProfilerItem::SaveToXML(TiXmlElement *parent)
     std::string val;
     TiXmlElement *elem = new TiXmlElement("rendertime");
     xmlControl->LinkEndChild(elem);
-    val = StringUtils::Format("{}", rend);
+    val = std::to_string(rend);
     TiXmlText *text = new TiXmlText(val.c_str());
     elem->LinkEndChild(text);
 
     elem = new TiXmlElement("visibletime");
     xmlControl->LinkEndChild(elem);
-    val = StringUtils::Format("{}", vis);
+    val = std::to_string(vis);
     text = new TiXmlText(val.c_str());
     elem->LinkEndChild(text);
   }
@@ -324,7 +324,7 @@ bool CGUIControlProfiler::SaveResults(void)
   doc.InsertEndChild(decl);
 
   TiXmlElement *root = new TiXmlElement("guicontrolprofiler");
-  std::string str = StringUtils::Format("{}", m_iFrameCount);
+  std::string str = std::to_string(m_iFrameCount);
   root->SetAttribute("framecount", str.c_str());
   root->SetAttribute("timeunit", "ms");
   doc.LinkEndChild(root);

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -132,8 +132,8 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName, const std::str
   }
 
   // check if we already have this font file loaded (font object could differ only by color or style)
-  std::string TTFfontName = StringUtils::Format("{}_{:f}_{:f}{}", strFilename.c_str(), newSize,
-                                                aspect, border ? "_border" : "");
+  std::string TTFfontName =
+      StringUtils::Format("{}_{:f}_{:f}{}", strFilename, newSize, aspect, border ? "_border" : "");
 
   CGUIFontTTF* pFontFile = GetFontFile(TTFfontName);
   if (!pFontFile)
@@ -226,8 +226,8 @@ void GUIFontManager::ReloadTTFFonts(void)
 
     RescaleFontSizeAndAspect(&newSize, &aspect, fontInfo.sourceRes, fontInfo.preserveAspect);
 
-    std::string TTFfontName = StringUtils::Format("{}_{:f}_{:f}{}", strFilename.c_str(), newSize,
-                                                  aspect, fontInfo.border ? "_border" : "");
+    std::string TTFfontName = StringUtils::Format("{}_{:f}_{:f}{}", strFilename, newSize, aspect,
+                                                  fontInfo.border ? "_border" : "");
     CGUIFontTTF* pFontFile = GetFontFile(TTFfontName);
     if (!pFontFile)
     {

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -208,11 +208,11 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(std::string& strPassword, const s
     strHeadingTemp = strHeading;
   else
     strHeadingTemp =
-        StringUtils::Format("{} - {} {}", g_localizeStrings.Get(12326).c_str(),
+        StringUtils::Format("{} - {} {}", g_localizeStrings.Get(12326),
                             CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
                                 CSettings::SETTING_MASTERLOCK_MAXRETRIES) -
                                 iRetries,
-                            g_localizeStrings.Get(12343).c_str());
+                            g_localizeStrings.Get(12343));
 
   std::string strUserInput;
   //! @todo GUI Setting to enable disable this feature y/n?

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -521,9 +521,9 @@ std::string CGUIPanelContainer::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_ROW:
-    return StringUtils::Format("{}", row);
+    return std::to_string(row);
   case CONTAINER_COLUMN:
-    return StringUtils::Format("{}", col);
+    return std::to_string(col);
   default:
     return CGUIBaseContainer::GetLabel(info);
   }

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -726,7 +726,7 @@ std::string CGUISliderControl::GetDescription() const
     if (m_rangeSelection)
       description = StringUtils::Format("[{}, {}]", m_intValues[0], m_intValues[1]);
     else
-      description = StringUtils::Format("{}", m_intValues[0]);
+      description = std::to_string(m_intValues[0]);
   }
   else
   {

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -456,11 +456,11 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
       if (m_bShowRange)
       {
         text = StringUtils::Format("({}/{}) {}", m_iValue + 1, (int)m_vecLabels.size(),
-                                   m_vecLabels[m_iValue].c_str());
+                                   m_vecLabels[m_iValue]);
       }
       else
       {
-        text = StringUtils::Format("{}", m_vecLabels[m_iValue].c_str());
+        text = StringUtils::Format("{}", m_vecLabels[m_iValue]);
       }
     }
     else

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -426,7 +426,7 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
     }
     else
     {
-      text = StringUtils::Format("{}", m_iValue);
+      text = std::to_string(m_iValue);
     }
   }
   else if (m_iType == SPIN_CONTROL_TYPE_PAGE)
@@ -460,7 +460,7 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
       }
       else
       {
-        text = StringUtils::Format("{}", m_vecLabels[m_iValue]);
+        text = m_vecLabels[m_iValue];
       }
     }
     else

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -111,8 +111,7 @@ const std::string CGUISpinControlEx::GetCurrentLabel() const
 
 std::string CGUISpinControlEx::GetDescription() const
 {
-  return StringUtils::Format("{} ({})", m_buttonControl.GetDescription().c_str(),
-                             GetLabel().c_str());
+  return StringUtils::Format("{} ({})", m_buttonControl.GetDescription(), GetLabel());
 }
 
 void CGUISpinControlEx::SetItemInvalid(bool invalid)

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -411,10 +411,10 @@ std::string CGUITextBox::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_NUM_PAGES:
-    label = StringUtils::Format("{}", GetNumPages());
+    label = std::to_string(GetNumPages());
     break;
   case CONTAINER_CURRENT_PAGE:
-    label = StringUtils::Format("{}", GetCurrentPage());
+    label = std::to_string(GetCurrentPage());
     break;
   default:
     break;

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -105,7 +105,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
           }
           else if (info.m_info == CONTAINER_VIEWCOUNT)
           {
-            value = StringUtils::Format("{}", window->GetViewCount());
+            value = std::to_string(window->GetViewCount());
             return true;
           }
         }
@@ -223,7 +223,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
         }
         else if (info.m_info == CONTAINER_TOTALWATCHED || info.m_info == CONTAINER_TOTALUNWATCHED)
         {
-          value = StringUtils::Format("{}", count);
+          value = std::to_string(count);
           return true;
         }
       }
@@ -316,9 +316,8 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
       value = g_localizeStrings.Get(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
       return true;
     case SYSTEM_STARTUP_WINDOW:
-      value =
-          StringUtils::Format("{}", CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-                                        CSettings::SETTING_LOOKANDFEEL_STARTUPWINDOW));
+      value = std::to_string(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_LOOKANDFEEL_STARTUPWINDOW));
       return true;
     case SYSTEM_CURRENT_CONTROL:
     case SYSTEM_CURRENT_CONTROL_ID:
@@ -330,7 +329,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
         if (control)
         {
           if (info.m_info == SYSTEM_CURRENT_CONTROL_ID)
-            value = StringUtils::Format("{}", control->GetID());
+            value = std::to_string(control->GetID());
           else if (info.m_info == SYSTEM_CURRENT_CONTROL)
             value = control->GetDescription();
           return true;
@@ -342,7 +341,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     {
       CGUIDialogProgress *bar = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
       if (bar && bar->IsDialogRunning())
-        value = StringUtils::Format("{}", bar->GetPercentage());
+        value = std::to_string(bar->GetPercentage());
       return true;
     }
 

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -43,13 +43,13 @@ std::string GetPlaylistLabel(int item, int playlistid /* = PLAYLIST_NONE */)
   {
     case PLAYLIST_LENGTH:
     {
-      return StringUtils::Format("{}", player.GetPlaylist(iPlaylist).size());
+      return std::to_string(player.GetPlaylist(iPlaylist).size());
     }
     case PLAYLIST_POSITION:
     {
       int currentSong = player.GetCurrentSong();
       if (currentSong > -1)
-        return StringUtils::Format("{}", currentSong + 1);
+        return std::to_string(currentSong + 1);
       break;
     }
     case PLAYLIST_RANDOM:

--- a/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
@@ -66,7 +66,7 @@ bool CGamesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     case RETROPLAYER_VIDEO_ROTATION:
     {
       const unsigned int rotationDegCCW = CMediaSettings::GetInstance().GetCurrentGameSettings().RotationDegCCW();
-      value = StringUtils::Format("{}", rotationDegCCW);
+      value = std::to_string(rotationDegCCW);
       return true;
     }
     default:

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -106,7 +106,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_PLAYCOUNT:
         if (tag->GetPlayCount() > 0)
         {
-          value = StringUtils::Format("{}", tag->GetPlayCount());
+          value = std::to_string(tag->GetPlayCount());
           return true;
         }
         break;
@@ -133,13 +133,13 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_DISC_NUMBER:
         if (tag->GetDiscNumber() > 0)
         {
-          value = StringUtils::Format("{}", tag->GetDiscNumber());
+          value = std::to_string(tag->GetDiscNumber());
           return true;
         }
         break;
       case MUSICPLAYER_TOTALDISCS:
       case LISTITEM_TOTALDISCS:
-        value = StringUtils::Format("{}", tag->GetTotalDiscs());
+        value = std::to_string(tag->GetTotalDiscs());
         return true;
       case MUSICPLAYER_DISC_TITLE:
       case LISTITEM_DISC_TITLE:
@@ -216,7 +216,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_USER_RATING:
         if (tag->GetUserrating() > 0)
         {
-          value = StringUtils::Format("{}", tag->GetUserrating());
+          value = std::to_string(tag->GetUserrating());
           return true;
         }
         break;
@@ -237,7 +237,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int dbId = tag->GetDatabaseId();
         if (dbId > -1)
         {
-          value = StringUtils::Format("{}", dbId);
+          value = std::to_string(dbId);
           return true;
         }
         break;
@@ -264,7 +264,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_BPM:
         if (tag->GetBPM() > 0)
         {
-          value = StringUtils::Format("{}", tag->GetBPM());
+          value = std::to_string(tag->GetBPM());
           return true;
         }
         break;
@@ -317,7 +317,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int BitRate = tag->GetBitRate();
         if (BitRate > 0)
         {
-          value = StringUtils::Format("{}", BitRate);
+          value = std::to_string(BitRate);
           return true;
         }
         break;
@@ -337,7 +337,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int channels = tag->GetNoOfChannels();
         if (channels > 0)
         {
-          value = StringUtils::Format("{}", channels);
+          value = std::to_string(channels);
           return true;
         }
         break;
@@ -434,7 +434,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBitrate = m_audioInfo.bitrate;
       if (iBitrate > 0)
       {
-        value = StringUtils::Format("{}", std::lrint(static_cast<double>(iBitrate) / 1000.0));
+        value = std::to_string(std::lrint(static_cast<double>(iBitrate) / 1000.0));
         return true;
       }
       break;
@@ -444,7 +444,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iChannels = m_audioInfo.channels;
       if (iChannels > 0)
       {
-        value = StringUtils::Format("{}", iChannels);
+        value = std::to_string(iChannels);
         return true;
       }
       break;
@@ -454,7 +454,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBPS = m_audioInfo.bitspersample;
       if (iBPS > 0)
       {
-        value = StringUtils::Format("{}", iBPS);
+        value = std::to_string(iBPS);
         return true;
       }
       break;
@@ -470,7 +470,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       break;
     }
     case MUSICPLAYER_CODEC:
-      value = StringUtils::Format("{}", m_audioInfo.codecName);
+      value = m_audioInfo.codecName;
       return true;
   }
 
@@ -511,7 +511,7 @@ bool CMusicGUIInfo::GetPartyModeLabel(std::string& value, const CGUIInfo &info) 
 
   if (iSongs >= 0)
   {
-    value = StringUtils::Format("{}", iSongs);
+    value = std::to_string(iSongs);
     return true;
   }
 
@@ -553,7 +553,7 @@ bool CMusicGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo &info) co
   }
   if (info.m_info == MUSICPLAYER_PLAYLISTPOS)
   {
-    value = StringUtils::Format("{}", index + 1);
+    value = std::to_string(index + 1);
     return true;
   }
   else if (info.m_info == MUSICPLAYER_COVER)

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -205,9 +205,9 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
           if (votes <= 0)
             value = StringUtils::FormatNumber(rating);
           else
-            value = StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
-                                        StringUtils::FormatNumber(rating).c_str(),
-                                        StringUtils::FormatNumber(votes).c_str());
+            value =
+                StringUtils::Format(g_localizeStrings.Get(20350), StringUtils::FormatNumber(rating),
+                                    StringUtils::FormatNumber(votes));
           return true;
         }
         break;
@@ -470,7 +470,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       break;
     }
     case MUSICPLAYER_CODEC:
-      value = StringUtils::Format("{}", m_audioInfo.codecName.c_str());
+      value = StringUtils::Format("{}", m_audioInfo.codecName);
       return true;
   }
 

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -287,7 +287,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       int iLevel = g_application.GetAppPlayer().GetCacheLevel();
       if (iLevel >= 0)
       {
-        value = StringUtils::Format("{}", iLevel);
+        value = std::to_string(iLevel);
         return true;
       }
       break;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -259,9 +259,9 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     {
       float speed = g_application.GetAppPlayer().GetPlaySpeed();
       if (speed != 1.0f)
-        value = StringUtils::Format(
-            "{} ({}x)", GetCurrentPlayTime(static_cast<TIME_FORMAT>(info.GetData1())).c_str(),
-            static_cast<int>(speed));
+        value = StringUtils::Format("{} ({}x)",
+                                    GetCurrentPlayTime(static_cast<TIME_FORMAT>(info.GetData1())),
+                                    static_cast<int>(speed));
       else
         value = GetCurrentPlayTime(TIME_FORMAT_GUESS);
       return true;

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -184,10 +184,10 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       if (CServiceBroker::GetWinSystem()->IsFullScreen())
         value =
             StringUtils::Format("{}x{}@{:.2f}Hz - {}", resInfo.iScreenWidth, resInfo.iScreenHeight,
-                                resInfo.fRefreshRate, g_localizeStrings.Get(244).c_str());
+                                resInfo.fRefreshRate, g_localizeStrings.Get(244));
       else
         value = StringUtils::Format("{}x{} - {}", resInfo.iScreenWidth, resInfo.iScreenHeight,
-                                    g_localizeStrings.Get(242).c_str());
+                                    g_localizeStrings.Get(242));
       return true;
     }
     case SYSTEM_BUILD_VERSION_SHORT:
@@ -255,10 +255,11 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       {
         double fTime = g_alarmClock.GetRemaining("shutdowntimer");
         if (fTime > 60.0)
-          value = StringUtils::Format(g_localizeStrings.Get(13213).c_str(),
+          value = StringUtils::Format(g_localizeStrings.Get(13213),
                                       g_alarmClock.GetRemaining("shutdowntimer") / 60.0);
         else
-          value = StringUtils::Format(g_localizeStrings.Get(13214).c_str(), g_alarmClock.GetRemaining("shutdowntimer"));
+          value = StringUtils::Format(g_localizeStrings.Get(13214),
+                                      g_alarmClock.GetRemaining("shutdowntimer"));
       }
       return true;
     case SYSTEM_PROFILENAME:
@@ -297,9 +298,9 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       return true;
     }
     case SYSTEM_GET_CORE_USAGE:
-      value = StringUtils::Format("{:4.2f}", CServiceBroker::GetCPUInfo()
-                                                 ->GetCoreInfo(std::atoi(info.GetData3().c_str()))
-                                                 .m_usagePercent);
+      value = StringUtils::Format(
+          "{:4.2f}",
+          CServiceBroker::GetCPUInfo()->GetCoreInfo(std::stoi(info.GetData3())).m_usagePercent);
       return true;
     case SYSTEM_RENDER_VENDOR:
       value = CServiceBroker::GetRenderSystem()->GetRenderVendor();

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -294,7 +294,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case SYSTEM_STEREOSCOPIC_MODE:
     {
       int iStereoMode = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE);
-      value = StringUtils::Format("{}", iStereoMode);
+      value = std::to_string(iStereoMode);
       return true;
     }
     case SYSTEM_GET_CORE_USAGE:

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -141,7 +141,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_DBID:
         if (tag->m_iDbId > -1)
         {
-          value = StringUtils::Format("{}", tag->m_iDbId);
+          value = std::to_string(tag->m_iDbId);
           return true;
         }
         break;
@@ -149,7 +149,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_TVSHOWDBID:
         if (tag->m_iIdShow > -1)
         {
-          value = StringUtils::Format("{}", tag->m_iIdShow);
+          value = std::to_string(tag->m_iIdShow);
           return true;
         }
         break;
@@ -191,7 +191,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_USER_RATING:
         if (tag->m_iUserRating > 0)
         {
-          value = StringUtils::Format("{}", tag->m_iUserRating);
+          value = std::to_string(tag->m_iUserRating);
           return true;
         }
         break;
@@ -203,7 +203,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_YEAR:
         if (tag->HasYear())
         {
-          value = StringUtils::Format("{}", tag->GetYear());
+          value = std::to_string(tag->GetYear());
           return true;
         }
         break;
@@ -245,7 +245,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
 
         if (iEpisode >= 0)
         {
-          value = StringUtils::Format("{}", iEpisode);
+          value = std::to_string(iEpisode);
           return true;
         }
         break;
@@ -254,7 +254,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_SEASON:
         if (tag->m_iSeason >= 0)
         {
-          value = StringUtils::Format("{}", tag->m_iSeason);
+          value = std::to_string(tag->m_iSeason);
           return true;
         }
         break;
@@ -278,7 +278,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_TOP250:
         if (tag->m_iTop250 > 0)
         {
-          value = StringUtils::Format("{}", tag->m_iTop250);
+          value = std::to_string(tag->m_iTop250);
           return true;
         }
         break;
@@ -321,7 +321,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_PLAYCOUNT:
         if (tag->GetPlayCount() > 0)
         {
-          value = StringUtils::Format("{}", tag->GetPlayCount());
+          value = std::to_string(tag->GetPlayCount());
           return true;
         }
         break;
@@ -342,7 +342,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_TRACKNUMBER:
         if (tag->m_iTrack > -1 )
         {
-          value = StringUtils::Format("{}", tag->m_iTrack);
+          value = std::to_string(tag->m_iTrack);
           return true;
         }
         break;
@@ -380,7 +380,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_SETID:
         if (tag->m_set.id > 0)
         {
-          value = StringUtils::Format("{}", tag->m_set.id);
+          value = std::to_string(tag->m_set.id);
           return true;
         }
         break;
@@ -409,12 +409,12 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_APPEARANCES:
         if (tag->m_relevance > -1)
         {
-          value = StringUtils::Format("{}", tag->m_relevance);
+          value = std::to_string(tag->m_relevance);
           return true;
         }
         break;
       case LISTITEM_PERCENT_PLAYED:
-        value = StringUtils::Format("{}", GetPercentPlayed(tag));
+        value = std::to_string(GetPercentPlayed(tag));
         return true;
       case LISTITEM_VIDEO_CODEC:
         value = tag->m_streamDetails.GetVideoCodec();
@@ -433,7 +433,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int iChannels = tag->m_streamDetails.GetAudioChannels();
         if (iChannels > 0)
         {
-          value = StringUtils::Format("{}", iChannels);
+          value = std::to_string(iChannels);
           return true;
         }
         break;
@@ -560,7 +560,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iChannels = m_audioInfo.channels;
       if (iChannels > 0)
       {
-        value = StringUtils::Format("{}", iChannels);
+        value = std::to_string(iChannels);
         return true;
       }
       break;
@@ -570,7 +570,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBitrate = m_audioInfo.bitrate;
       if (iBitrate > 0)
       {
-        value = StringUtils::Format("{}", std::lrint(static_cast<double>(iBitrate) / 1000.0));
+        value = std::to_string(std::lrint(static_cast<double>(iBitrate) / 1000.0));
         return true;
       }
       break;
@@ -580,7 +580,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       int iBitrate = m_videoInfo.bitrate;
       if (iBitrate > 0)
       {
-        value = StringUtils::Format("{}", std::lrint(static_cast<double>(iBitrate) / 1000.0));
+        value = std::to_string(std::lrint(static_cast<double>(iBitrate) / 1000.0));
         return true;
       }
       break;
@@ -623,7 +623,7 @@ bool CVideoGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo& info) co
   }
   if (info.m_info == VIDEOPLAYER_PLAYLISTPOS)
   {
-    value = StringUtils::Format("{}", index + 1);
+    value = std::to_string(index + 1);
     return true;
   }
   else if (info.m_info == VIDEOPLAYER_COVER)

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -178,9 +178,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
           if (rating.rating > 0.f && rating.votes == 0)
             value = StringUtils::FormatNumber(rating.rating);
           else if (rating.votes > 0)
-            value = StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
-                                        StringUtils::FormatNumber(rating.rating).c_str(),
-                                        StringUtils::FormatNumber(rating.votes).c_str());
+            value = StringUtils::Format(g_localizeStrings.Get(20350),
+                                        StringUtils::FormatNumber(rating.rating),
+                                        StringUtils::FormatNumber(rating.votes));
           else
             break;
           return true;

--- a/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
@@ -42,8 +42,8 @@ bool CWeatherGUIInfo::GetLabel(std::string& value, const CFileItem *item, int co
       return true;
     case WEATHER_TEMPERATURE:
       value = StringUtils::Format(
-          "{}{}", CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_CURRENT_TEMP).c_str(),
-          g_langInfo.GetTemperatureUnitString().c_str());
+          "{}{}", CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_CURRENT_TEMP),
+          g_langInfo.GetTemperatureUnitString());
       return true;
     case WEATHER_LOCATION:
       value = CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_LOCATION);

--- a/xbmc/input/InputCodingTableBaiduPY.cpp
+++ b/xbmc/input/InputCodingTableBaiduPY.cpp
@@ -51,7 +51,7 @@ void CInputCodingTableBaiduPY::Process()
       std::string data;
       XFILE::CCurlFile http;
       std::string strUrl;
-      strUrl = StringUtils::Format(m_url.c_str(), work.c_str(), m_api_begin, m_api_end);
+      strUrl = StringUtils::Format(m_url, work, m_api_begin, m_api_end);
 
       if (http.Get(strUrl, data))
         HandleResponse(work, data);

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -123,13 +123,12 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
 
 std::string CKeyboardLayout::GetIdentifier() const
 {
-  return StringUtils::Format("{} {}", m_language.c_str(), m_layout.c_str());
+  return StringUtils::Format("{} {}", m_language, m_layout);
 }
 
 std::string CKeyboardLayout::GetName() const
 {
-  return StringUtils::Format(g_localizeStrings.Get(311).c_str(), m_language.c_str(),
-                             m_layout.c_str());
+  return StringUtils::Format(g_localizeStrings.Get(311), m_language, m_layout);
 }
 
 std::string CKeyboardLayout::GetCharAt(unsigned int row,

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -239,7 +239,7 @@ std::string CKeyboardStat::GetKeyName(int KeyID)
   if (VKeyFound)
     keyname.append(keytable.keyname);
   else
-    keyname += StringUtils::Format("{}", keyid);
+    keyname += std::to_string(keyid);
 
   // in case this might be an universalremote keyid
   // we also print the possible corresponding obc code

--- a/xbmc/input/joysticks/JoystickTranslator.cpp
+++ b/xbmc/input/joysticks/JoystickTranslator.cpp
@@ -171,5 +171,5 @@ std::string CJoystickTranslator::GetPrimitiveName(const CDriverPrimitive& primit
       break;
   }
 
-  return StringUtils::Format(primitiveTemplate.c_str(), primitive.Index());
+  return StringUtils::Format(primitiveTemplate, primitive.Index());
 }

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -139,24 +139,24 @@ static int RunAddon(const std::vector<std::string>& params)
 
       std::string cmd;
       if (plugin->Provides(CPluginSource::VIDEO))
-        cmd = StringUtils::Format("ActivateWindow(Videos,plugin://{}{},return)", addonid.c_str(),
-                                  urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Videos,plugin://{}{},return)", addonid,
+                                  urlParameters);
       else if (plugin->Provides(CPluginSource::AUDIO))
-        cmd = StringUtils::Format("ActivateWindow(Music,plugin://{}{},return)", addonid.c_str(),
-                                  urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Music,plugin://{}{},return)", addonid,
+                                  urlParameters);
       else if (plugin->Provides(CPluginSource::EXECUTABLE))
-        cmd = StringUtils::Format("ActivateWindow(Programs,plugin://{}{},return)", addonid.c_str(),
-                                  urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Programs,plugin://{}{},return)", addonid,
+                                  urlParameters);
       else if (plugin->Provides(CPluginSource::IMAGE))
-        cmd = StringUtils::Format("ActivateWindow(Pictures,plugin://{}{},return)", addonid.c_str(),
-                                  urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Pictures,plugin://{}{},return)", addonid,
+                                  urlParameters);
       else if (plugin->Provides(CPluginSource::GAME))
-        cmd = StringUtils::Format("ActivateWindow(Games,plugin://{}{},return)", addonid.c_str(),
-                                  urlParameters.c_str());
+        cmd = StringUtils::Format("ActivateWindow(Games,plugin://{}{},return)", addonid,
+                                  urlParameters);
       else
         // Pass the script name (addonid) and all the parameters
         // (params[1] ... params[x]) separated by a comma to RunPlugin
-        cmd = StringUtils::Format("RunPlugin({})", StringUtils::Join(params, ",").c_str());
+        cmd = StringUtils::Format("RunPlugin({})", StringUtils::Join(params, ","));
       CBuiltins::GetInstance().Execute(cmd);
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT,
@@ -171,7 +171,7 @@ static int RunAddon(const std::vector<std::string>& params)
       // Pass the script name (addonid) and all the parameters
       // (params[1] ... params[x]) separated by a comma to RunScript
       CBuiltins::GetInstance().Execute(
-          StringUtils::Format("RunScript({})", StringUtils::Join(params, ",").c_str()));
+          StringUtils::Format("RunScript({})", StringUtils::Join(params, ",")));
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_GAMEDLL,
                                                     OnlyEnabled::YES))

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -207,9 +207,9 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITrans
 
   std::string cmd;
   if (params.empty())
-    cmd = StringUtils::Format("RunAddon({})", id.c_str());
+    cmd = StringUtils::Format("RunAddon({})", id);
   else
-    cmd = StringUtils::Format("RunAddon({}, {})", id.c_str(), argv.c_str());
+    cmd = StringUtils::Format("RunAddon({}, {})", id, argv);
 
   if (params["wait"].asBoolean())
     CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1029,7 +1029,7 @@ JSONRPC_STATUS CAudioLibrary::Scan(const std::string &method, ITransportLayer *t
 {
   std::string directory = parameterObject["directory"].asString();
   std::string cmd =
-      StringUtils::Format("updatelibrary(music, {}, {})", StringUtils::Paramify(directory).c_str(),
+      StringUtils::Format("updatelibrary(music, {}, {})", StringUtils::Paramify(directory),
                           parameterObject["showdialogs"].asBoolean() ? "true" : "false");
 
   CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
@@ -1040,9 +1040,8 @@ JSONRPC_STATUS CAudioLibrary::Export(const std::string &method, ITransportLayer 
 {
   std::string cmd;
   if (parameterObject["options"].isMember("path"))
-    cmd = StringUtils::Format(
-        "exportlibrary2(music, singlefile, {}, albums, albumartists)",
-        StringUtils::Paramify(parameterObject["options"]["path"].asString()).c_str());
+    cmd = StringUtils::Format("exportlibrary2(music, singlefile, {}, albums, albumartists)",
+                              StringUtils::Paramify(parameterObject["options"]["path"].asString()));
   else
   {
     cmd = "exportlibrary2(music, library, dummy, albums, albumartists";

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -695,7 +695,7 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
       {
         CLog::Log(LOGDEBUG, "JSONRPC: Value does not match extended type %s of type %s", extends.at(extendsIndex)->ID.c_str(), name.c_str());
         errorMessage = StringUtils::Format("value does not match extended type {}",
-                                           extends.at(extendsIndex)->ID.c_str());
+                                           extends.at(extendsIndex)->ID);
         errorData["message"] = errorMessage.c_str();
         return status;
       }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -954,7 +954,7 @@ JSONRPC_STATUS CVideoLibrary::Scan(const std::string &method, ITransportLayer *t
 {
   std::string directory = parameterObject["directory"].asString();
   std::string cmd =
-      StringUtils::Format("updatelibrary(video, {}, {})", StringUtils::Paramify(directory).c_str(),
+      StringUtils::Format("updatelibrary(video, {}, {})", StringUtils::Paramify(directory),
                           parameterObject["showdialogs"].asBoolean() ? "true" : "false");
 
   CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
@@ -965,9 +965,8 @@ JSONRPC_STATUS CVideoLibrary::Export(const std::string &method, ITransportLayer 
 {
   std::string cmd;
   if (parameterObject["options"].isMember("path"))
-    cmd = StringUtils::Format(
-        "exportlibrary2(video, singlefile, {})",
-        StringUtils::Paramify(parameterObject["options"]["path"].asString()).c_str());
+    cmd = StringUtils::Format("exportlibrary2(video, singlefile, {})",
+                              StringUtils::Paramify(parameterObject["options"]["path"].asString()));
   else
   {
     cmd = "exportlibrary2(video, separate, dummy";
@@ -991,11 +990,11 @@ JSONRPC_STATUS CVideoLibrary::Clean(const std::string &method, ITransportLayer *
   if (parameterObject["content"].empty())
     cmd = StringUtils::Format("cleanlibrary(video, {0}, {1})",
                               parameterObject["showdialogs"].asBoolean() ? "true" : "false",
-                              StringUtils::Paramify(directory).c_str());
+                              StringUtils::Paramify(directory));
   else
     cmd = StringUtils::Format("cleanlibrary({0}, {1}, {2})", parameterObject["content"].asString(),
                               parameterObject["showdialogs"].asBoolean() ? "true" : "false",
-                              StringUtils::Paramify(directory).c_str());
+                              StringUtils::Paramify(directory));
 
   CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -150,7 +150,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dcguard(languageHook);
       ADDON::AddonPtr addon(pAddon);
-      if (UpdateSettingInActiveDialog(id, StringUtils::Format("{}", value)))
+      if (UpdateSettingInActiveDialog(id, std::to_string(value)))
         return true;
 
       if (!addon->UpdateSettingInt(id, value))

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -91,7 +91,7 @@ namespace XBMCAddon
 
     String InfoTagVideo::getVotes()
     {
-      return StringUtils::Format("{}", infoTag->GetRating().votes);
+      return std::to_string(infoTag->GetRating().votes);
     }
 
     String InfoTagVideo::getCast()

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -434,9 +434,8 @@ namespace XBMCAddon
           StringUtils::Replace(result, "xx", "%p");
         }
         else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
-          result =
-              StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
-                                  g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
+          result = StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM),
+                                       g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM));
 
         return result;
     }

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -693,7 +693,7 @@ void CPythonInvoker::onError(const std::string& exceptionType /* = "" */,
   {
     std::string message;
     if (m_addon && !m_addon->Name().empty())
-      message = StringUtils::Format(g_localizeStrings.Get(2102).c_str(), m_addon->Name().c_str());
+      message = StringUtils::Format(g_localizeStrings.Get(2102), m_addon->Name());
     else
       message = g_localizeStrings.Get(2103);
     pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, message, g_localizeStrings.Get(2104));

--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -228,10 +228,10 @@ namespace PythonBindings
 
     if (!exceptionType.empty())
     {
-      msg += StringUtils::Format("Error Type: {}\n", exceptionType.c_str());
+      msg += StringUtils::Format("Error Type: {}\n", exceptionType);
 
       if (!exceptionValue.empty())
-        msg += StringUtils::Format("Error Contents: {}\n", exceptionValue.c_str());
+        msg += StringUtils::Format("Error Contents: {}\n", exceptionValue);
 
       if (!exceptionTraceback.empty())
         msg += exceptionTraceback;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -11696,7 +11696,7 @@ std::string CMusicDatabase::GetItemById(const std::string& itemType, int id)
   else if (StringUtils::EqualsNoCase(itemType, "sources"))
     return GetSourceById(id);
   else if (StringUtils::EqualsNoCase(itemType, "years"))
-    return StringUtils::Format("{}", id);
+    return std::to_string(id);
   else if (StringUtils::EqualsNoCase(itemType, "artists"))
     return GetArtistById(id);
   else if (StringUtils::EqualsNoCase(itemType, "albums"))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3055,8 +3055,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
     CMusicDbUrl itemUrl = baseUrl;
     std::string strFileName = record->at(song_strFileName).get_asString();
     std::string strExt = URIUtils::GetExtension(strFileName);
-    std::string path =
-        StringUtils::Format("{}{}", record->at(song_idSong).get_asInt(), strExt.c_str());
+    std::string path = StringUtils::Format("{}{}", record->at(song_idSong).get_asInt(), strExt);
     itemUrl.AppendPath(path);
     item->SetPath(itemUrl.ToString());
     item->SetDynPath(strRealPath);
@@ -3366,11 +3365,10 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& art
     {
       std::string path = StringUtils::Format("musicdb://artists/{}/", m_pDS->fv(0).get_asInt());
       CFileItemPtr pItem(new CFileItem(path, true));
-      std::string label =
-          StringUtils::Format("[{}] {}", artistLabel.c_str(), m_pDS->fv(1).get_asString().c_str());
+      std::string label = StringUtils::Format("[{}] {}", artistLabel, m_pDS->fv(1).get_asString());
       pItem->SetLabel(label);
       // sort label is stored in the title tag
-      label = StringUtils::Format("A {}", m_pDS->fv(1).get_asString().c_str());
+      label = StringUtils::Format("A {}", m_pDS->fv(1).get_asString());
       pItem->GetMusicInfoTag()->SetTitle(label);
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv(0).get_asInt(), MediaTypeArtist);
       artists.Add(pItem);
@@ -4052,11 +4050,10 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList& albu
       CAlbum album = GetAlbumFromDataset(m_pDS.get());
       std::string path = StringUtils::Format("musicdb://albums/{}/", album.idAlbum);
       CFileItemPtr pItem(new CFileItem(path, album));
-      std::string label =
-          StringUtils::Format("[{}] {}", albumLabel.c_str(), album.strAlbum.c_str());
+      std::string label = StringUtils::Format("[{}] {}", albumLabel, album.strAlbum);
       pItem->SetLabel(label);
       // sort label is stored in the title tag
-      label = StringUtils::Format("B {}", album.strAlbum.c_str());
+      label = StringUtils::Format("B {}", album.strAlbum);
       pItem->GetMusicInfoTag()->SetTitle(label);
       albums.Add(pItem);
       m_pDS->next();
@@ -5281,7 +5278,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
       CFileItemPtr pItem(new CFileItem(labelValue));
 
       CMusicDbUrl itemUrl = musicUrl;
-      std::string strDir = StringUtils::Format("{}/", labelValue.c_str());
+      std::string strDir = StringUtils::Format("{}/", labelValue);
       itemUrl.AppendPath(strDir);
       pItem->SetPath(itemUrl.ToString());
 
@@ -12096,8 +12093,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
 
   if (iFailCount > 0 && progressDialog)
     HELPERS::ShowOKDialogLines(
-        CVariant{20196},
-        CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
+        CVariant{20196}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011), iFailCount)});
 }
 
 bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* progressDialog)
@@ -12603,7 +12599,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
     // Write event log entry
     // "Importing song history {1} of {2} songs matched", total - unmatched, total)
     std::string strLine =
-        StringUtils::Format(g_localizeStrings.Get(38353).c_str(), total - unmatched, total);
+        StringUtils::Format(g_localizeStrings.Get(38353), total - unmatched, total);
     CServiceBroker::GetEventLog().Add(
         EventPtr(new CNotificationEvent(20197, strLine, EventLevel::Information)));
 

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -321,7 +321,7 @@ namespace MUSIC_UTILS
       dialog->SetHeading(CVariant{ 38023 });
       dialog->Add(g_localizeStrings.Get(38022));
       for (int i = 1; i <= 10; i++)
-        dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563).c_str(), i));
+        dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563), i));
       dialog->SetSelected(iSelected);
       dialog->Open();
 

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -62,7 +62,7 @@ void CGUIDialogVisualisationPresetList::SetVisualisation(CGUIVisualisationContro
   {
     SetUseDetails(false);
     SetMultiSelection(false);
-    SetHeading(CVariant{StringUtils::Format(g_localizeStrings.Get(13407).c_str(), m_viz->Name().c_str())});
+    SetHeading(CVariant{StringUtils::Format(g_localizeStrings.Get(13407), m_viz->Name())});
     std::vector<std::string> presets;
     if (m_viz->GetPresetList(presets))
     {

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -2229,7 +2229,7 @@ bool CMusicInfoScanner::AddLocalArtwork(std::map<std::string, std::string>& art,
       }
       else if (discnum > 0)
         // Append disc number when candidate art type (and file) not have it
-        strCandidate += StringUtils::Format("{}", discnum);
+        strCandidate += std::to_string(discnum);
 
       if (art.find(strCandidate) == art.end())
         art.insert(std::make_pair(strCandidate, artFile->GetPath()));

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1315,12 +1315,11 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
       }
       else
       {
-        CServiceBroker::GetEventLog().Add(EventPtr(
-            new CMediaLibraryEvent(MediaTypeAlbum, album.strPath, 24146,
-                                   StringUtils::Format(g_localizeStrings.Get(24147).c_str(),
-                                                       MediaTypeAlbum, album.strAlbum.c_str()),
-                                   CScraperUrl::GetThumbUrl(album.thumbURL.GetFirstUrlByType()),
-                                   CURL::GetRedacted(album.strPath), EventLevel::Warning)));
+        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
+            MediaTypeAlbum, album.strPath, 24146,
+            StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeAlbum, album.strAlbum),
+            CScraperUrl::GetThumbUrl(album.thumbURL.GetFirstUrlByType()),
+            CURL::GetRedacted(album.strPath), EventLevel::Warning)));
       }
     }
   }
@@ -1384,12 +1383,11 @@ CMusicInfoScanner::UpdateDatabaseArtistInfo(CArtist& artist,
       }
       else
       {
-        CServiceBroker::GetEventLog().Add(EventPtr(
-            new CMediaLibraryEvent(MediaTypeArtist, artist.strPath, 24146,
-                                   StringUtils::Format(g_localizeStrings.Get(24147).c_str(),
-                                                       MediaTypeArtist, artist.strArtist.c_str()),
-                                   CScraperUrl::GetThumbUrl(artist.thumbURL.GetFirstUrlByType()),
-                                   CURL::GetRedacted(artist.strPath), EventLevel::Warning)));
+        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
+            MediaTypeArtist, artist.strPath, 24146,
+            StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeArtist, artist.strArtist),
+            CScraperUrl::GetThumbUrl(artist.thumbURL.GetFirstUrlByType()),
+            CURL::GetRedacted(artist.strPath), EventLevel::Warning)));
       }
     }
   }
@@ -1445,7 +1443,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
 {
   if (m_handle)
   {
-    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20321).c_str(), info->Name().c_str()));
+    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20321), info->Name()));
     m_handle->SetText(album.GetAlbumArtistString() + " - " + album.strAlbum);
   }
 
@@ -1586,8 +1584,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
           if (pDialog)
           {
             // set the label to [relevance]  album - artist
-            std::string strTemp =
-                StringUtils::Format("[{:0.2f}]  {}", relevance, info.GetTitle2().c_str());
+            std::string strTemp = StringUtils::Format("[{:0.2f}]  {}", relevance, info.GetTitle2());
             CFileItemPtr item(new CFileItem("", false));
             item->SetLabel(strTemp);
 
@@ -1706,7 +1703,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
 {
   if (m_handle)
   {
-    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20320).c_str(), info->Name().c_str()));
+    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20320), info->Name()));
     m_handle->SetText(artist.strArtist);
   }
 
@@ -1848,7 +1845,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
             {
               std::string genres = StringUtils::Join(scraper.GetArtist(i).GetArtist().genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
               if (!genres.empty())
-                strTemp = StringUtils::Format("[{}] {}", genres.c_str(), strTemp.c_str());
+                strTemp = StringUtils::Format("[{}] {}", genres, strTemp);
             }
             item.SetLabel(strTemp);
             item.m_idepth = i; // use this to hold the index of the album in the scraper

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -1268,7 +1268,7 @@ const std::string CMusicInfoTag::GetContributorsText() const
   std::string strLabel;
   for (const auto& credit : m_musicRoles)
   {
-    strLabel += StringUtils::Format("{}\n", credit.GetArtist().c_str());
+    strLabel += StringUtils::Format("{}\n", credit.GetArtist());
   }
   return StringUtils::TrimRight(strLabel, "\n");
 }
@@ -1278,8 +1278,7 @@ const std::string CMusicInfoTag::GetContributorsAndRolesText() const
   std::string strLabel;
   for (const auto& credit : m_musicRoles)
   {
-    strLabel +=
-        StringUtils::Format("{} - {}\n", credit.GetRoleDesc().c_str(), credit.GetArtist().c_str());
+    strLabel += StringUtils::Format("{} - {}\n", credit.GetRoleDesc(), credit.GetArtist());
   }
   return StringUtils::TrimRight(strLabel, "\n");
 }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1081,9 +1081,9 @@ bool CGUIWindowMusicBase::OnSelect(int iItem)
         // ask the user if they want to play or resume
         CContextButtons choices;
         choices.Add(MUSIC_SELECT_ACTION_PLAY, 208); // 208 = Play
-        choices.Add(MUSIC_SELECT_ACTION_RESUME, StringUtils::Format(g_localizeStrings.Get(12022), // 12022 = Resume from ...
-          (*itemIt)->GetMusicInfoTag()->GetTitle().c_str()
-        ));
+        choices.Add(MUSIC_SELECT_ACTION_RESUME,
+                    StringUtils::Format(g_localizeStrings.Get(12022), // 12022 = Resume from ...
+                                        (*itemIt)->GetMusicInfoTag()->GetTitle()));
 
         auto choice = CGUIDialogContextMenu::Show(choices);
         if (choice == MUSIC_SELECT_ACTION_RESUME)

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -480,7 +480,7 @@ void CGUIWindowMusicNav::UpdateButtons()
       StringUtils::StartsWith(m_vecItems->Get(m_vecItems->Size()-1)->GetPath(), "/-1/"))
       iItems--;
   }
-  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127).c_str());
+  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   // set the filter label

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -410,8 +410,8 @@ void CGUIWindowMusicPlayList::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_BTNREPEAT, g_localizeStrings.Get(iRepeat));
 
   // Update object count label
-  std::string items = StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
-                                          g_localizeStrings.Get(127).c_str());
+  std::string items =
+      StringUtils::Format("{} {}", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   MarkPlaying();
@@ -474,7 +474,7 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
       // No music info and it's not CDDA so we'll just show the filename
       std::string str;
       str = CUtil::GetTitleFromPath(pItem->GetPath());
-      str = StringUtils::Format("{:02}. {} ", pItem->m_iprogramCount, str.c_str());
+      str = StringUtils::Format("{:02}. {} ", pItem->m_iprogramCount, str);
       pItem->SetLabel(str);
     }
   }

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -220,7 +220,7 @@ void CGUIWindowMusicPlaylistEditor::UpdateButtons()
 
   // Update object count label
   std::string items = StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
-                                          g_localizeStrings.Get(127).c_str()); // " 14 Objects"
+                                          g_localizeStrings.Get(127)); // " 14 Objects"
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 }
 
@@ -299,7 +299,7 @@ void CGUIWindowMusicPlaylistEditor::UpdatePlaylist()
 
   // indicate how many songs we have
   std::string items = StringUtils::Format("{} {}", m_playlist->Size(),
-                                          g_localizeStrings.Get(134).c_str()); // "123 Songs"
+                                          g_localizeStrings.Get(134)); // "123 Songs"
   SET_CONTROL_LABEL(CONTROL_LABEL_PLAYLIST, items);
 
   m_playlistThumbLoader.Load(*m_playlist);

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -533,14 +533,13 @@ void CAirPlayServer::CTCPClient::PushBuffer(CAirPlayServer *host, const char *bu
     const time_t ltime = time(NULL);
     char *date = asctime(gmtime(&ltime)); //Fri, 17 Dec 2010 11:18:01 GMT;
     date[strlen(date) - 1] = '\0'; // remove \n
-    response = StringUtils::Format("HTTP/1.1 {} {}\nDate: {}\r\n", status, statusMsg.c_str(), date);
+    response = StringUtils::Format("HTTP/1.1 {} {}\nDate: {}\r\n", status, statusMsg, date);
     if (!responseHeader.empty())
     {
       response += responseHeader;
     }
 
-    response =
-        StringUtils::Format("{}Content-Length: {}\r\n\r\n", response.c_str(), responseBody.size());
+    response = StringUtils::Format("{}Content-Length: {}\r\n\r\n", response, responseBody.size());
 
     if (!responseBody.empty())
     {
@@ -603,7 +602,7 @@ void CAirPlayServer::CTCPClient::ComposeReverseEvent( std::string& reverseHeader
     }
     reverseHeader = "Content-Type: text/x-apple-plist+xml\r\n";
     reverseHeader =
-        StringUtils::Format("{}Content-Length: {}\r\n", reverseHeader.c_str(), reverseBody.size());
+        StringUtils::Format("{}Content-Length: {}\r\n", reverseHeader, reverseBody.size());
     reverseHeader = StringUtils::Format("{}x-apple-session-id: {}\r\n", reverseHeader.c_str(),
                                         m_sessionId.c_str());
     m_lastEvent = state;
@@ -615,7 +614,7 @@ void CAirPlayServer::CTCPClient::ComposeAuthRequestAnswer(std::string& responseH
   int16_t random=rand();
   std::string randomStr = StringUtils::Format("{}", random);
   m_authNonce=CDigest::Calculate(CDigest::Type::MD5, randomStr);
-  responseHeader = StringUtils::Format(AUTH_REQUIRED, m_authNonce.c_str());
+  responseHeader = StringUtils::Format(AUTH_REQUIRED, m_authNonce);
   responseBody.clear();
 }
 
@@ -1150,7 +1149,8 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
   else if (uri == "/server-info")
   {
     CLog::Log(LOGDEBUG, "AIRPLAY: got request %s", uri.c_str());
-    responseBody = StringUtils::Format(SERVER_INFO, CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetMacAddress().c_str());
+    responseBody = StringUtils::Format(
+        SERVER_INFO, CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetMacAddress());
     responseHeader = "Content-Type: text/x-apple-plist+xml\r\n";
   }
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -612,7 +612,7 @@ void CAirPlayServer::CTCPClient::ComposeReverseEvent( std::string& reverseHeader
 void CAirPlayServer::CTCPClient::ComposeAuthRequestAnswer(std::string& responseHeader, std::string& responseBody)
 {
   int16_t random=rand();
-  std::string randomStr = StringUtils::Format("{}", random);
+  std::string randomStr = std::to_string(random);
   m_authNonce=CDigest::Calculate(CDigest::Type::MD5, randomStr);
   responseHeader = StringUtils::Format(AUTH_REQUIRED, m_authNonce);
   responseBody.clear();

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -594,8 +594,7 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
   if (ServerInstance->Initialize(pw))
   {
     success = true;
-    std::string appName =
-        StringUtils::Format("{}@{}", m_macAddress.c_str(), CSysInfo::GetDeviceName().c_str());
+    std::string appName = StringUtils::Format("{}@{}", m_macAddress, CSysInfo::GetDeviceName());
 
     std::vector<std::pair<std::string, std::string> > txt;
     txt.emplace_back("txtvers", "1");

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -255,7 +255,7 @@ void CGUIDialogNetworkSetup::OnProtocolChange()
       return;
     m_protocol = msg.GetParam1();
     // set defaults for the port
-    m_port = StringUtils::Format("{}", m_protocols[m_protocol].defaultPort);
+    m_port = std::to_string(m_protocols[m_protocol].defaultPort);
 
     UpdateButtons();
   }
@@ -413,7 +413,7 @@ bool CGUIDialogNetworkSetup::SetPath(const std::string &path)
   else
     m_username = url.GetUserName();
   m_password = url.GetPassWord();
-  m_port = StringUtils::Format("{}", url.GetPort());
+  m_port = std::to_string(url.GetPort());
   m_server = url.GetHostName();
   m_path = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(m_path);

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -414,7 +414,7 @@ std::vector<SOCKET> CreateTCPServerSocket(const int port, const bool bindLocal, 
   std::vector<SOCKET> sockets;
   struct addrinfo* results = nullptr;
 
-  std::string sPort = StringUtils::Format("{}", port);
+  std::string sPort = std::to_string(port);
   struct addrinfo hints = { 0 };
   hints.ai_family = PF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -75,12 +75,12 @@ static void ShowDiscoveryMessage(const char* function, const char* server_name, 
   if (new_entry)
   {
     CLog::Log(LOGINFO, "%s - Create new entry for host '%s'", function, server_name);
-    message = StringUtils::Format(LOCALIZED(13035).c_str(), server_name);
+    message = StringUtils::Format(LOCALIZED(13035), server_name);
   }
   else
   {
     CLog::Log(LOGINFO, "%s - Update existing entry for host '%s'", function, server_name);
-    message = StringUtils::Format(LOCALIZED(13034).c_str(), server_name);
+    message = StringUtils::Format(LOCALIZED(13034), server_name);
   }
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, LOCALIZED(13033), message, 4000, true, 3000);
 }
@@ -493,7 +493,7 @@ bool CWakeOnAccess::WakeUpHost(const std::string& hostName, const std::string& c
 
 bool CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
 {
-  std::string heading = StringUtils::Format(LOCALIZED(13027).c_str(), server.friendlyName.c_str());
+  std::string heading = StringUtils::Format(LOCALIZED(13027), server.friendlyName);
 
   ProgressDialogHelper dlg (heading);
 
@@ -754,7 +754,7 @@ void CWakeOnAccess::OnJobComplete(unsigned int jobID, bool success, CJob *job)
     if (IsEnabled())
     {
       const std::string& heading = LOCALIZED(13033);
-      std::string message = StringUtils::Format(LOCALIZED(13036).c_str(), host.c_str());
+      std::string message = StringUtils::Format(LOCALIZED(13036), host);
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, heading, message, 4000, true, 3000);
     }
   }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -444,7 +444,7 @@ MHD_RESULT CWebServer::FinalizeRequest(const std::shared_ptr<IHTTPRequestHandler
   // add MHD_HTTP_HEADER_CONTENT_LENGTH
   if (responseDetails.totalLength > 0)
     handler->AddResponseHeader(MHD_HTTP_HEADER_CONTENT_LENGTH,
-                               StringUtils::Format("{}", responseDetails.totalLength));
+                               std::to_string(responseDetails.totalLength));
 
   // add all headers set by the request handler
   for (const auto& it : responseDetails.headers)
@@ -768,7 +768,7 @@ MHD_RESULT CWebServer::CreateRangedMemoryDownloadResponse(
 
   // add Content-Length header
   handler->AddResponseHeader(MHD_HTTP_HEADER_CONTENT_LENGTH,
-                             StringUtils::Format("{}", static_cast<uint64_t>(result.size())));
+                             std::to_string(static_cast<uint64_t>(result.size())));
 
   // finally create the response
   return CreateMemoryDownloadResponse(request.connection, result.c_str(), result.size(), false,
@@ -928,8 +928,7 @@ MHD_RESULT CWebServer::CreateFileDownloadResponse(
       return MHD_NO;
     }
 
-    handler->AddResponseHeader(MHD_HTTP_HEADER_CONTENT_LENGTH,
-                               StringUtils::Format("{}", fileLength));
+    handler->AddResponseHeader(MHD_HTTP_HEADER_CONTENT_LENGTH, std::to_string(fileLength));
   }
 
   // set the Content-Type header

--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
@@ -375,7 +375,7 @@ std::map<std::string, std::string> CHTTPPythonWsgiInvoker::createCgiEnvironment(
   environment.insert(std::make_pair("SERVER_NAME", httpRequest->hostname));
 
   // SERVER_PORT
-  environment.insert(std::make_pair("SERVER_PORT", StringUtils::Format("{}", httpRequest->port)));
+  environment.insert(std::make_pair("SERVER_PORT", std::to_string(httpRequest->port)));
 
   // SERVER_PROTOCOL
   environment.insert(std::make_pair("SERVER_PROTOCOL", httpRequest->version));

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -250,8 +250,8 @@ protected:
       EXPECT_STREQ(expectedContent.c_str(), result.c_str());
 
       // and Content-Length
-      EXPECT_STREQ(StringUtils::Format("{}", static_cast<unsigned int>(expectedContent.size())),
-                   httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH));
+      EXPECT_STREQ(std::to_string(static_cast<unsigned int>(expectedContent.size())).c_str(),
+                   httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
 
       return;
     }

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -250,9 +250,8 @@ protected:
       EXPECT_STREQ(expectedContent.c_str(), result.c_str());
 
       // and Content-Length
-      EXPECT_STREQ(
-          StringUtils::Format("{}", static_cast<unsigned int>(expectedContent.size())).c_str(),
-          httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
+      EXPECT_STREQ(StringUtils::Format("{}", static_cast<unsigned int>(expectedContent.size())),
+                   httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH));
 
       return;
     }

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -288,10 +288,10 @@ void CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
 
     std::string buffer;
 
-    buffer = StringUtils::Format("{}", data["volume"].asInteger());
+    buffer = std::to_string(data["volume"].asInteger());
     rct->SetStateVariable("Volume", buffer.c_str());
 
-    buffer = StringUtils::Format("{}", 256 * (data["volume"].asInteger() * 60 - 60) / 100);
+    buffer = std::to_string(256 * (data["volume"].asInteger() * 60 - 60) / 100);
     rct->SetStateVariable("VolumeDb", buffer.c_str());
 
     rct->SetStateVariable("Mute", data["muted"].asBoolean() ? "1" : "0");
@@ -350,9 +350,9 @@ CUPnPRenderer::UpdateState()
         if (slideshow)
         {
           std::string index;
-          index = StringUtils::Format("{}", slideshow->NumSlides());
+          index = std::to_string(slideshow->NumSlides());
           avt->SetStateVariable("NumberOfTracks", index.c_str());
-          index = StringUtils::Format("{}", slideshow->CurrentSlide());
+          index = std::to_string(slideshow->CurrentSlide());
           avt->SetStateVariable("CurrentTrack", index.c_str());
 
         }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -181,8 +181,7 @@ CUPnPServer::PropagateUpdates()
     // only broadcast ids with modified bit set
     for (itr = m_UpdateIDs.begin(); itr != m_UpdateIDs.end(); ++itr) {
         if (itr->second.first) {
-          buffer.append(
-              StringUtils::Format("{},{},", itr->first.c_str(), itr->second.second).c_str());
+          buffer.append(StringUtils::Format("{},{},", itr->first, itr->second.second));
           itr->second.first = false;
         }
     }

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -382,7 +382,7 @@ bool CPeripheralAddon::PerformDeviceScan(PeripheralScanResults& results)
       }
 
       result.m_strDeviceName = peripheral.Name();
-      result.m_strLocation = StringUtils::Format("{}/{}", ID().c_str(), peripheral.Index());
+      result.m_strLocation = StringUtils::Format("{}/{}", ID(), peripheral.Index());
       result.m_iVendorId = peripheral.VendorID();
       result.m_iProductId = peripheral.ProductID();
       result.m_mappedType = PERIPHERAL_JOYSTICK;

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -310,11 +310,10 @@ void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& ite
     if (strVersion.empty())
       strVersion = g_localizeStrings.Get(13205);
 
-    std::string strDetails =
-        StringUtils::Format("{} {}", g_localizeStrings.Get(24051).c_str(), strVersion.c_str());
+    std::string strDetails = StringUtils::Format("{} {}", g_localizeStrings.Get(24051), strVersion);
     if (peripheral->GetBusType() == PERIPHERAL_BUS_CEC && !peripheral->GetSettingBool("enabled"))
-      strDetails = StringUtils::Format("{}: {}", g_localizeStrings.Get(126).c_str(),
-                                       g_localizeStrings.Get(13106).c_str());
+      strDetails =
+          StringUtils::Format("{}: {}", g_localizeStrings.Get(126), g_localizeStrings.Get(13106));
 
     peripheralFile->SetProperty("version", strVersion);
     peripheralFile->SetLabel2(strDetails);

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
@@ -79,5 +79,5 @@ void CPeripheralBusApplication::GetDirectory(const std::string& strPath, CFileIt
 
 std::string CPeripheralBusApplication::MakeLocation(unsigned int controllerIndex) const
 {
-  return StringUtils::Format("{}", controllerIndex);
+  return std::to_string(controllerIndex);
 }

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -62,13 +62,13 @@ CPeripheral::CPeripheral(CPeripherals& manager,
     m_strFileLocation =
         StringUtils::Format("peripherals://{}/{}_{}.dev",
                             PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
-                            scanResult.m_strLocation.c_str(), scanResult.m_iSequence);
+                            scanResult.m_strLocation, scanResult.m_iSequence);
   }
   else
   {
     m_strFileLocation = StringUtils::Format(
         "peripherals://%s/%s.dev", PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
-        scanResult.m_strLocation.c_str());
+        scanResult.m_strLocation);
   }
 }
 
@@ -150,22 +150,20 @@ bool CPeripheral::Initialise(void)
     m_strSettingsFile =
         StringUtils::Format("special://profile/peripheral_data/{}_{}.xml",
                             PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
-                            CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT).c_str());
+                            CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT));
   }
   else
   {
     // Backwards compatibility - old settings files didn't include the device name
-    m_strSettingsFile =
-        StringUtils::Format("special://profile/peripheral_data/{}_{}_{}.xml",
-                            PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
-                            m_strVendorId.c_str(), m_strProductId.c_str());
+    m_strSettingsFile = StringUtils::Format(
+        "special://profile/peripheral_data/{}_{}_{}.xml",
+        PeripheralTypeTranslator::BusTypeToString(m_mappedBusType), m_strVendorId, m_strProductId);
 
     if (!XFILE::CFile::Exists(m_strSettingsFile))
-      m_strSettingsFile =
-          StringUtils::Format("special://profile/peripheral_data/{}_{}_{}_{}.xml",
-                              PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
-                              m_strVendorId.c_str(), m_strProductId.c_str(),
-                              CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT).c_str());
+      m_strSettingsFile = StringUtils::Format(
+          "special://profile/peripheral_data/{}_{}_{}_{}.xml",
+          PeripheralTypeTranslator::BusTypeToString(m_mappedBusType), m_strVendorId, m_strProductId,
+          CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT));
   }
 
   LoadPersistedSettings();

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -67,7 +67,7 @@ CPeripheral::CPeripheral(CPeripherals& manager,
   else
   {
     m_strFileLocation = StringUtils::Format(
-        "peripherals://%s/%s.dev", PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
+        "peripherals://{}/{}.dev", PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
         scanResult.m_strLocation);
   }
 }

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -497,7 +497,7 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
         std::shared_ptr<CSettingInt> intSetting =
             std::static_pointer_cast<CSettingInt>(itr.second.m_setting);
         if (intSetting)
-          strValue = StringUtils::Format("{}", intSetting->GetValue());
+          strValue = std::to_string(intSetting->GetValue());
       }
       break;
       case SettingType::Number:
@@ -513,7 +513,7 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
         std::shared_ptr<CSettingBool> boolSetting =
             std::static_pointer_cast<CSettingBool>(itr.second.m_setting);
         if (boolSetting)
-          strValue = StringUtils::Format("{}", boolSetting->GetValue() ? 1 : 0);
+          strValue = std::to_string(boolSetting->GetValue() ? 1 : 0);
       }
       break;
       default:

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1587,7 +1587,7 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
     CLog::Log(LOGDEBUG,
               "%s - CEC capable amplifier found (%s). volume will be controlled on the amp",
               __FUNCTION__, ampName.c_str());
-    strAmpName += StringUtils::Format("{}", ampName);
+    strAmpName += ampName;
 
     // set amp present
     m_adapter->SetAudioSystemConnected(true);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -249,7 +249,7 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
 
       // display warning: incompatible libCEC
       std::string strMessage = StringUtils::Format(
-          g_localizeStrings.Get(36040).c_str(), m_cecAdapter ? m_configuration.serverVersion : -1,
+          g_localizeStrings.Get(36040), m_cecAdapter ? m_configuration.serverVersion : -1,
           CEC_LIB_SUPPORTED_VERSION);
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000),
                                             strMessage);
@@ -277,16 +277,15 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
 
 void CPeripheralCecAdapter::SetVersionInfo(const libcec_configuration& configuration)
 {
-  m_strVersionInfo =
-      StringUtils::Format("libCEC {} - firmware v{}",
-                          m_cecAdapter->VersionToString(configuration.serverVersion).c_str(),
-                          configuration.iFirmwareVersion);
+  m_strVersionInfo = StringUtils::Format("libCEC {} - firmware v{}",
+                                         m_cecAdapter->VersionToString(configuration.serverVersion),
+                                         configuration.iFirmwareVersion);
 
   // append firmware build date
   if (configuration.iFirmwareBuildDate != CEC_FW_BUILD_UNKNOWN)
   {
     CDateTime dt((time_t)configuration.iFirmwareBuildDate);
-    m_strVersionInfo += StringUtils::Format(" ({})", dt.GetAsDBDate().c_str());
+    m_strVersionInfo += StringUtils::Format(" ({})", dt.GetAsDBDate());
   }
 }
 
@@ -307,8 +306,8 @@ bool CPeripheralCecAdapter::OpenConnection(void)
 
   // scanning the CEC bus takes about 5 seconds, so display a notification to inform users that
   // we're busy
-  std::string strMessage = StringUtils::Format(g_localizeStrings.Get(21336).c_str(),
-                                               g_localizeStrings.Get(36000).c_str());
+  std::string strMessage =
+      StringUtils::Format(g_localizeStrings.Get(21336), g_localizeStrings.Get(36000));
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000),
                                         strMessage);
 
@@ -1588,7 +1587,7 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
     CLog::Log(LOGDEBUG,
               "%s - CEC capable amplifier found (%s). volume will be controlled on the amp",
               __FUNCTION__, ampName.c_str());
-    strAmpName += StringUtils::Format("{}", ampName.c_str());
+    strAmpName += StringUtils::Format("{}", ampName);
 
     // set amp present
     m_adapter->SetAudioSystemConnected(true);
@@ -1628,12 +1627,11 @@ bool CPeripheralCecAdapterUpdateThread::SetInitialConfiguration(void)
   // request the OSD name of the TV
   std::string strNotification;
   std::string tvName(m_adapter->m_cecAdapter->GetDeviceOSDName(CECDEVICE_TV));
-  strNotification =
-      StringUtils::Format("{}: {}", g_localizeStrings.Get(36016).c_str(), tvName.c_str());
+  strNotification = StringUtils::Format("{}: {}", g_localizeStrings.Get(36016), tvName);
 
   std::string strAmpName = UpdateAudioSystemStatus();
   if (!strAmpName.empty())
-    strNotification += StringUtils::Format("- {}", strAmpName.c_str());
+    strNotification += StringUtils::Format("- {}", strAmpName);
 
   m_adapter->m_bIsReady = true;
 

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
@@ -45,8 +45,8 @@ bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         continue;
       CFileItemPtr pItem(new CFileItem(i.packageName));
       pItem->m_bIsFolder = false;
-      std::string path = StringUtils::Format("androidapp://{}/{}/{}", url.GetHostName().c_str(),
-                                             dirname.c_str(), i.packageName.c_str());
+      std::string path =
+          StringUtils::Format("androidapp://{}/{}/{}", url.GetHostName(), dirname, i.packageName);
       pItem->SetPath(path);
       pItem->SetLabel(i.packageLabel);
       pItem->SetArt("thumb", path+".png");

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -27,7 +27,7 @@ static std::string PrintAxisIds(const std::vector<int>& axisIds)
     return "";
 
   if (axisIds.size() == 1)
-    return StringUtils::Format("{}", axisIds.front());
+    return std::to_string(axisIds.front());
 
   std::string strAxisIds;
   for (const auto& axisId : axisIds)
@@ -37,7 +37,7 @@ static std::string PrintAxisIds(const std::vector<int>& axisIds)
     else
       strAxisIds += " | ";
 
-    strAxisIds += StringUtils::Format("{}", axisId);
+    strAxisIds += std::to_string(axisId);
   }
   strAxisIds += "]";
 

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -326,7 +326,7 @@ PeripheralScanResults CPeripheralBusAndroid::GetInputDevices()
 
 std::string CPeripheralBusAndroid::GetDeviceLocation(int deviceId)
 {
-  return StringUtils::Format("{}{}", DeviceLocationPrefix.c_str(), deviceId);
+  return StringUtils::Format("{}{}", DeviceLocationPrefix, deviceId);
 }
 
 bool CPeripheralBusAndroid::GetDeviceId(const std::string& deviceLocation, int& deviceId)

--- a/xbmc/platform/darwin/ios-common/peripherals/PeripheralBusDarwinEmbeddedManager.mm
+++ b/xbmc/platform/darwin/ios-common/peripherals/PeripheralBusDarwinEmbeddedManager.mm
@@ -165,7 +165,7 @@
 
 - (std::string)GetDeviceLocation:(int)deviceId
 {
-  return StringUtils::Format("{}{}", parentClass->getDeviceLocationPrefix().c_str(), deviceId);
+  return StringUtils::Format("{}{}", parentClass->getDeviceLocationPrefix(), deviceId);
 }
 
 #pragma mark - Logging Utils

--- a/xbmc/platform/darwin/osx/peripherals/PeripheralBusUSB.cpp
+++ b/xbmc/platform/darwin/osx/peripherals/PeripheralBusUSB.cpp
@@ -237,8 +237,7 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
           }
         }
         if (!ttlDeviceFilePath.empty())
-          privateDataRef->result.m_strLocation =
-              StringUtils::Format("{}", ttlDeviceFilePath.c_str());
+          privateDataRef->result.m_strLocation = StringUtils::Format("{}", ttlDeviceFilePath);
         else
           privateDataRef->result.m_strLocation = StringUtils::Format("{}", locationId);
 

--- a/xbmc/platform/darwin/osx/peripherals/PeripheralBusUSB.cpp
+++ b/xbmc/platform/darwin/osx/peripherals/PeripheralBusUSB.cpp
@@ -237,9 +237,9 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
           }
         }
         if (!ttlDeviceFilePath.empty())
-          privateDataRef->result.m_strLocation = StringUtils::Format("{}", ttlDeviceFilePath);
+          privateDataRef->result.m_strLocation = ttlDeviceFilePath;
         else
-          privateDataRef->result.m_strLocation = StringUtils::Format("{}", locationId);
+          privateDataRef->result.m_strLocation = std::to_string(locationId);
 
         if (bDeviceClass == kUSBCompositeClass)
           privateDataRef->result.m_type = refCon->GetType(bInterfaceClass);

--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
@@ -182,7 +182,7 @@ void CTVOSTopShelf::SetTopShelfItems(CFileItemList& items, TVOSTopShelfItemsCate
             [](const CFileItemPtr& videoItem)
             {
               return StringUtils::Format("{} s{:02}e{:02}",
-                                         videoItem->GetVideoInfoTag()->m_strShowTitle.c_str(),
+                                         videoItem->GetVideoInfoTag()->m_strShowTitle,
                                          videoItem->GetVideoInfoTag()->m_iSeason,
                                          videoItem->GetVideoInfoTag()->m_iEpisode);
             });
@@ -214,8 +214,7 @@ void CTVOSTopShelf::RunTopShelf()
   //  check split[2] for url type (display or play)
 
   // its a bit ugly, but only way to get resume window to show
-  std::string cmd =
-      StringUtils::Format("PlayMedia({})", StringUtils::Paramify(url.c_str()).c_str());
+  std::string cmd = StringUtils::Format("PlayMedia({})", StringUtils::Paramify(url));
   KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1,
                                                                 nullptr, cmd);
 }

--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUSB.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUSB.cpp
@@ -42,7 +42,7 @@ bool CPeripheralBusUSB::PerformDeviceScan(PeripheralScanResults &results)
                                  GetType(dev->config[0].interface[0].altsetting[0].bInterfaceClass) :
                                  GetType(dev->descriptor.bDeviceClass);
 #ifdef TARGET_FREEBSD
-      result.m_strLocation = StringUtils::Format("{}", dev->filename);
+      result.m_strLocation = std::to_string(dev->filename);
 #else
       result.m_strLocation = StringUtils::Format("/bus{}/dev{}", bus->dirname, dev->filename);
 #endif

--- a/xbmc/platform/linux/storage/UDisksProvider.cpp
+++ b/xbmc/platform/linux/storage/UDisksProvider.cpp
@@ -155,8 +155,8 @@ bool CUDiskDevice::IsApproved()
 std::string CUDiskDevice::toString()
 {
   return StringUtils::Format("DeviceUDI {}: IsFileSystem {} HasFileSystem {} "
-                             "IsSystemInternal %s IsMounted %s IsRemovable %s IsPartition %s "
-                             "IsOptical %s",
+                             "IsSystemInternal {} IsMounted {} IsRemovable {} IsPartition {} "
+                             "IsOptical {}",
                              m_DeviceKitUDI, BOOL2SZ(m_isFileSystem), m_FileSystem,
                              BOOL2SZ(m_isSystemInternal), BOOL2SZ(m_isMounted),
                              BOOL2SZ(m_isRemovable), BOOL2SZ(m_isPartition), BOOL2SZ(m_isOptical));

--- a/xbmc/platform/linux/storage/UDisksProvider.cpp
+++ b/xbmc/platform/linux/storage/UDisksProvider.cpp
@@ -130,8 +130,7 @@ CMediaSource CUDiskDevice::ToMediaShare()
   if (m_Label.empty())
   {
     std::string strSize = StringUtils::SizeToString(m_PartitionSize);
-    source.strName =
-        StringUtils::Format("{} {}", strSize.c_str(), g_localizeStrings.Get(155).c_str());
+    source.strName = StringUtils::Format("{} {}", strSize, g_localizeStrings.Get(155));
   }
   else
     source.strName = m_Label;
@@ -158,7 +157,7 @@ std::string CUDiskDevice::toString()
   return StringUtils::Format("DeviceUDI {}: IsFileSystem {} HasFileSystem {} "
                              "IsSystemInternal %s IsMounted %s IsRemovable %s IsPartition %s "
                              "IsOptical %s",
-                             m_DeviceKitUDI.c_str(), BOOL2SZ(m_isFileSystem), m_FileSystem.c_str(),
+                             m_DeviceKitUDI, BOOL2SZ(m_isFileSystem), m_FileSystem,
                              BOOL2SZ(m_isSystemInternal), BOOL2SZ(m_isMounted),
                              BOOL2SZ(m_isRemovable), BOOL2SZ(m_isPartition), BOOL2SZ(m_isOptical));
 }

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -259,7 +259,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
     }
 
     if (errno == ENODEV || errno == ENOENT)
-      cError = StringUtils::Format(g_localizeStrings.Get(770).c_str(),errno);
+      cError = StringUtils::Format(g_localizeStrings.Get(770), errno);
     else
       cError = strerror(errno);
 

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -152,8 +152,7 @@ std::vector<std::string> CStorageProvider::GetDiskUsage()
   auto localfolder = ApplicationData::Current().LocalFolder().Path();
   GetDiskFreeSpaceExW(localfolder.c_str(), nullptr, &ULTotal, &ULTotalFree);
   strRet = StringUtils::Format("{}: {} MB {}", g_localizeStrings.Get(21440),
-                               (ULTotalFree.QuadPart / (1024 * 1024)),
-                               g_localizeStrings.Get(160).c_str());
+                               (ULTotalFree.QuadPart / (1024 * 1024)), g_localizeStrings.Get(160));
   result.push_back(strRet);
 
   DWORD drivesBits = GetLogicalDrives();
@@ -173,9 +172,9 @@ std::vector<std::string> CStorageProvider::GetDiskUsage()
     if (DRIVE_FIXED == GetDriveTypeA(strDrive.c_str())
       && GetDiskFreeSpaceExA((strDrive.c_str()), nullptr, &ULTotal, &ULTotalFree))
     {
-      strRet = StringUtils::Format("{} {} MB {}", strDrive.c_str(),
-                                   int(ULTotalFree.QuadPart / (1024 * 1024)),
-                                   g_localizeStrings.Get(160).c_str());
+      strRet =
+          StringUtils::Format("{} {} MB {}", strDrive, int(ULTotalFree.QuadPart / (1024 * 1024)),
+                              g_localizeStrings.Get(160));
       result.push_back(strRet);
     }
   }
@@ -244,20 +243,17 @@ void CStorageProvider::GetDrivesByType(VECSOURCES & localDrives, Drive_Types eDr
       switch (uDriveType)
       {
       case DRIVE_CDROM:
-        share.strName = StringUtils::Format("{} ({})", share.strPath.c_str(),
-                                            g_localizeStrings.Get(218).c_str());
+        share.strName = StringUtils::Format("{} ({})", share.strPath, g_localizeStrings.Get(218));
         break;
       case DRIVE_REMOVABLE:
         if (share.strName.empty())
-          share.strName = StringUtils::Format("{} ({})", g_localizeStrings.Get(437).c_str(),
-                                              share.strPath.c_str());
+          share.strName = StringUtils::Format("{} ({})", g_localizeStrings.Get(437), share.strPath);
         break;
       default:
         if (share.strName.empty())
           share.strName = share.strPath;
         else
-          share.strName =
-              StringUtils::Format("{} ({})", share.strPath.c_str(), share.strName.c_str());
+          share.strName = StringUtils::Format("{} ({})", share.strPath, share.strName);
         break;
       }
     }

--- a/xbmc/platform/win32/CPUInfoWin32.cpp
+++ b/xbmc/platform/win32/CPUInfoWin32.cpp
@@ -115,9 +115,9 @@ CCPUInfoWin32::CCPUInfoWin32()
     for (size_t i = 0; i < m_cores.size(); i++)
     {
       if (i < m_coreCounters.size() &&
-          PdhAddEnglishCounterW(
-              m_cpuQueryLoad, StringUtils::Format(L"\\Processor({})\\% Idle Time", int(i)).c_str(),
-              0, &m_coreCounters[i]) != ERROR_SUCCESS)
+          PdhAddEnglishCounterW(m_cpuQueryLoad,
+                                StringUtils::Format(L"\\Processor({})\\% Idle Time", int(i)), 0,
+                                &m_coreCounters[i]) != ERROR_SUCCESS)
         m_coreCounters[i] = nullptr;
     }
   }

--- a/xbmc/platform/win32/CPUInfoWin32.cpp
+++ b/xbmc/platform/win32/CPUInfoWin32.cpp
@@ -115,9 +115,9 @@ CCPUInfoWin32::CCPUInfoWin32()
     for (size_t i = 0; i < m_cores.size(); i++)
     {
       if (i < m_coreCounters.size() &&
-          PdhAddEnglishCounterW(m_cpuQueryLoad,
-                                StringUtils::Format(L"\\Processor({})\\% Idle Time", int(i)), 0,
-                                &m_coreCounters[i]) != ERROR_SUCCESS)
+          PdhAddEnglishCounterW(
+              m_cpuQueryLoad, StringUtils::Format(L"\\Processor({})\\% Idle Time", int(i)).c_str(),
+              0, &m_coreCounters[i]) != ERROR_SUCCESS)
         m_coreCounters[i] = nullptr;
     }
   }

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1189,7 +1189,7 @@ bool CWIN32Util::IsUsbDevice(const std::wstring &strWdrive)
   }
   return false;
 #else
-  std::wstring strWDevicePath = StringUtils::Format(L"\\\\.\\{}", strWdrive.substr(0, 2).c_str());
+  std::wstring strWDevicePath = StringUtils::Format(L"\\\\.\\{}", strWdrive.substr(0, 2));
 
   HANDLE deviceHandle = CreateFileW(
     strWDevicePath.c_str(),

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -68,7 +68,7 @@ std::string CNetworkInterfaceWin32::GetCurrentNetmask(void) const
   if (m_adapter.FirstUnicastAddress->Address.lpSockaddr->sa_family == AF_INET)
     return CNetworkBase::GetMaskByPrefixLength(m_adapter.FirstUnicastAddress->OnLinkPrefixLength);
 
-  return StringUtils::Format("{}", m_adapter.FirstUnicastAddress->OnLinkPrefixLength);
+  return std::to_string(m_adapter.FirstUnicastAddress->OnLinkPrefixLength);
 }
 
 std::string CNetworkInterfaceWin32::GetCurrentDefaultGateway(void) const

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -156,9 +156,9 @@ std::vector<std::string > CWin32StorageProvider::GetDiskUsage()
       if( DRIVE_FIXED == GetDriveType( strDrive.c_str()  ) &&
         GetDiskFreeSpaceEx( ( strDrive.c_str() ), nullptr, &ULTotal, &ULTotalFree ) )
       {
-        strRet = KODI::PLATFORM::WINDOWS::FromW(StringUtils::Format(
-            L"{} {} MB {}", strDrive.c_str(), int(ULTotalFree.QuadPart / (1024 * 1024)),
-            KODI::PLATFORM::WINDOWS::ToW(g_localizeStrings.Get(160).c_str())));
+        strRet = KODI::PLATFORM::WINDOWS::FromW(
+            StringUtils::Format(L"{} {} MB {}", strDrive, int(ULTotalFree.QuadPart / (1024 * 1024)),
+                                KODI::PLATFORM::WINDOWS::ToW(g_localizeStrings.Get(160))));
         result.push_back(strRet);
       }
       iPos += (wcslen( pcBuffer.get() + iPos) + 1 );
@@ -242,20 +242,19 @@ void CWin32StorageProvider::GetDrivesByType(VECSOURCES &localDrives, Drive_Types
           switch(uDriveType)
           {
           case DRIVE_CDROM:
-            share.strName = StringUtils::Format("{} ({})", share.strPath.c_str(),
-                                                g_localizeStrings.Get(218).c_str());
+            share.strName =
+                StringUtils::Format("{} ({})", share.strPath, g_localizeStrings.Get(218));
             break;
           case DRIVE_REMOVABLE:
             if(share.strName.empty())
-              share.strName = StringUtils::Format("{} ({})", g_localizeStrings.Get(437).c_str(),
-                                                  share.strPath.c_str());
+              share.strName =
+                  StringUtils::Format("{} ({})", g_localizeStrings.Get(437), share.strPath);
             break;
           default:
             if(share.strName.empty())
               share.strName = share.strPath;
             else
-              share.strName =
-                  StringUtils::Format("{} ({})", share.strPath.c_str(), share.strName.c_str());
+              share.strName = StringUtils::Format("{} ({})", share.strPath, share.strName);
             break;
           }
         }

--- a/xbmc/playlists/PlayListB4S.cpp
+++ b/xbmc/playlists/PlayListB4S.cpp
@@ -115,12 +115,12 @@ void CPlayListB4S::Save(const std::string& strFileName) const
   write += StringUtils::Format("<?xml version={}1.0{} encoding='UTF-8' standalone={}yes{}?>\n", 34,
                                34, 34, 34);
   write += StringUtils::Format("<WinampXML>\n");
-  write += StringUtils::Format("  <playlist num_entries=\"{0}\" label=\"{1}\">\n", m_vecItems.size(),m_strPlayListName.c_str());
+  write += StringUtils::Format("  <playlist num_entries=\"{0}\" label=\"{1}\">\n",
+                               m_vecItems.size(), m_strPlayListName);
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     const CFileItemPtr item = m_vecItems[i];
-    write += StringUtils::Format("    <entry Playstring={}file:{}{}>\n", 34,
-                                 item->GetPath().c_str(), 34);
+    write += StringUtils::Format("    <entry Playstring={}file:{}{}>\n", 34, item->GetPath(), 34);
     write += StringUtils::Format("      <Name>{}</Name>\n", item->GetLabel().c_str());
     write +=
         StringUtils::Format("      <Length>{}</Length>\n", item->GetMusicInfoTag()->GetDuration());

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -226,9 +226,8 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     CFileItemPtr item = m_vecItems[i];
     std::string strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
-    strLine =
-        StringUtils::Format("{}:{},{}\n", InfoMarker, item->GetMusicInfoTag()->GetDuration() / 1000,
-                            strDescription.c_str());
+    strLine = StringUtils::Format("{}:{},{}\n", InfoMarker,
+                                  item->GetMusicInfoTag()->GetDuration() / 1000, strDescription);
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
     if (item->m_lStartOffset != 0 || item->m_lEndOffset != 0)
@@ -239,7 +238,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     }
     std::string strFileName = ResolveURL(item);
     g_charsetConverter.utf8ToStringCharset(strFileName);
-    strLine = StringUtils::Format("{}\n", strFileName.c_str());
+    strLine = StringUtils::Format("{}\n", strFileName);
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
   }

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -210,7 +210,7 @@ void CPlayListPLS::Save(const std::string& strFileName) const
   write += StringUtils::Format("{}\n", START_PLAYLIST_MARKER);
   std::string strPlayListName=m_strPlayListName;
   g_charsetConverter.utf8ToStringCharset(strPlayListName);
-  write += StringUtils::Format("PlaylistName={}\n", strPlayListName.c_str());
+  write += StringUtils::Format("PlaylistName={}\n", strPlayListName);
 
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
@@ -219,7 +219,7 @@ void CPlayListPLS::Save(const std::string& strFileName) const
     g_charsetConverter.utf8ToStringCharset(strFileName);
     std::string strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
-    write += StringUtils::Format("File{}={}\n", i + 1, strFileName.c_str());
+    write += StringUtils::Format("File{}={}\n", i + 1, strFileName);
     write += StringUtils::Format("Title{}={}\n", i + 1, strDescription.c_str());
     write +=
         StringUtils::Format("Length{}={}\n", i + 1, item->GetMusicInfoTag()->GetDuration() / 1000);

--- a/xbmc/playlists/PlayListWPL.cpp
+++ b/xbmc/playlists/PlayListWPL.cpp
@@ -119,8 +119,7 @@ void CPlayListWPL::Save(const std::string& strFileName) const
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     CFileItemPtr item = m_vecItems[i];
-    write +=
-        StringUtils::Format("            <media src={}{}{}/>", 34, item->GetPath().c_str(), 34);
+    write += StringUtils::Format("            <media src={}{}{}/>", 34, item->GetPath(), 34);
   }
   write += StringUtils::Format("        </seq>\n");
   write += StringUtils::Format("    </body>\n");

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -171,22 +171,21 @@ void CPlayListXML::Save(const std::string& strFileName) const
     CFileItemPtr item = m_vecItems[i];
     write += StringUtils::Format("  <stream>\n" );
     write += StringUtils::Format("    <url>{}</url>", item->GetPath().c_str());
-    write += StringUtils::Format("    <name>{}</name>", item->GetLabel().c_str());
+    write += StringUtils::Format("    <name>{}</name>", item->GetLabel());
 
     if ( !item->GetProperty("language").empty() )
-      write += StringUtils::Format("    <lang>{}</lang>", item->GetProperty("language").c_str());
+      write += StringUtils::Format("    <lang>{}</lang>", item->GetProperty("language").asString());
 
     if ( !item->GetProperty("category").empty() )
-      write +=
-          StringUtils::Format("    <category>{}</category>", item->GetProperty("category").c_str());
+      write += StringUtils::Format("    <category>{}</category>",
+                                   item->GetProperty("category").asString());
 
     if ( !item->GetProperty("remotechannel").empty() )
       write += StringUtils::Format("    <channel>{}</channel>",
-                                   item->GetProperty("remotechannel").c_str());
+                                   item->GetProperty("remotechannel").asString());
 
     if (item->m_iHasLock > LOCK_STATE_NO_LOCK)
-      write +=
-          StringUtils::Format("    <lockpassword>{}<lockpassword>", item->m_strLockCode.c_str());
+      write += StringUtils::Format("    <lockpassword>{}<lockpassword>", item->m_strLockCode);
 
     write += StringUtils::Format("  </stream>\n\n" );
   }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -825,7 +825,7 @@ std::string CSmartPlaylistRule::FormatParameter(const std::string &operatorStrin
   // special-casing
   if (m_field == FieldTime || m_field == FieldAlbumDuration)
   { // translate time to seconds
-    std::string seconds = StringUtils::Format("{}", StringUtils::TimeStringToSeconds(param));
+    std::string seconds = std::to_string(StringUtils::TimeStringToSeconds(param));
     return db.PrepareSQL(operatorString.c_str(), seconds.c_str());
   }
   return CDatabaseQueryRule::FormatParameter(operatorString, param, db, strType);

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -836,8 +836,8 @@ std::string CSmartPlaylistRule::FormatLinkQuery(const char *field, const char *t
   // NOTE: no need for a PrepareSQL here, as the parameter has already been formatted
   return StringUtils::Format(
       " EXISTS (SELECT 1 FROM {}_link"
-      "         JOIN %s ON %s.%s_id=%s_link.%s_id"
-      "         WHERE %s_link.media_id=%s AND %s.name %s AND %s_link.media_type = '%s')",
+      "         JOIN {} ON {}.{}_id={}_link.{}_id"
+      "         WHERE {}_link.media_id={} AND {}.name {} AND {}_link.media_type = '{}')",
       field, table, table, table, field, table, field, mediaField, table, parameter, field,
       mediaType);
 }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -730,8 +730,8 @@ bool CSmartPlaylistRule::CanGroupMix(Field group)
 
 std::string CSmartPlaylistRule::GetLocalizedRule() const
 {
-  return StringUtils::Format("{} {} {}", GetLocalizedField(m_field).c_str(),
-                             GetLocalizedOperator(m_operator).c_str(), GetParameter().c_str());
+  return StringUtils::Format("{} {} {}", GetLocalizedField(m_field),
+                             GetLocalizedOperator(m_operator), GetParameter());
 }
 
 std::string CSmartPlaylistRule::GetVideoResolutionQuery(const std::string &parameter) const
@@ -838,8 +838,8 @@ std::string CSmartPlaylistRule::FormatLinkQuery(const char *field, const char *t
       " EXISTS (SELECT 1 FROM {}_link"
       "         JOIN %s ON %s.%s_id=%s_link.%s_id"
       "         WHERE %s_link.media_id=%s AND %s.name %s AND %s_link.media_type = '%s')",
-      field, table, table, table, field, table, field, mediaField.c_str(), table, parameter.c_str(),
-      field, mediaType.c_str());
+      field, table, table, table, field, table, field, mediaField, table, parameter, field,
+      mediaType);
 }
 
 std::string CSmartPlaylistRule::FormatYearQuery(const std::string& field,
@@ -1114,7 +1114,7 @@ std::string CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, c
           if (playlist.GetType() == strType)
           {
             if ((*it)->m_operator == CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL)
-              currentRule = StringUtils::Format("NOT ({})", playlistQuery.c_str());
+              currentRule = StringUtils::Format("NOT ({})", playlistQuery);
             else
               currentRule = playlistQuery;
           }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -475,7 +475,7 @@ bool CProfileManager::DeleteProfile(unsigned int index)
 
   const std::string& str = g_localizeStrings.Get(13201);
   dlgYesNo->SetHeading(CVariant{13200});
-  dlgYesNo->SetLine(0, CVariant{StringUtils::Format(str.c_str(), profile->getName().c_str())});
+  dlgYesNo->SetLine(0, CVariant{StringUtils::Format(str, profile->getName())});
   dlgYesNo->SetLine(1, CVariant{""});
   dlgYesNo->SetLine(2, CVariant{""});
   dlgYesNo->Open();

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -212,7 +212,7 @@ void CGUIDialogLockSettings::SetupView()
 
   // set the title
   if (m_getUser)
-    SetHeading(StringUtils::Format(g_localizeStrings.Get(20152).c_str(), CURL::Decode(m_url).c_str()));
+    SetHeading(StringUtils::Format(g_localizeStrings.Get(20152), CURL::Decode(m_url)));
   else
   {
     SetHeading(20066);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -577,8 +577,7 @@ bool CPVRManager::SetWakeupCommand()
     {
       nextEvent.GetAsTime(iWakeupTime);
 
-      std::string strExecCommand =
-          StringUtils::Format("{} {}", strWakeupCommand.c_str(), iWakeupTime);
+      std::string strExecCommand = StringUtils::Format("{} {}", strWakeupCommand, iWakeupTime);
 
       const int iReturn = system(strExecCommand.c_str());
       if (iReturn != 0)

--- a/xbmc/pvr/PVRThumbLoader.cpp
+++ b/xbmc/pvr/PVRThumbLoader.cpp
@@ -117,7 +117,7 @@ std::string CPVRThumbLoader::CreateChannelGroupThumb(const CFileItem& channelGro
     }
 
     std::string thumb = StringUtils::Format(
-        "%s?ts=%d", // append timestamp to Thumb URL to enforce texture refresh
+        "{}?ts={}", // append timestamp to Thumb URL to enforce texture refresh
         CTextureUtils::GetWrappedImageURL(channelGroupItem.GetPath(), "pvr"), std::time(nullptr));
     const std::string relativeCacheFile = CTextureCache::GetCacheFile(thumb) + ".png";
     if (CPicture::CreateTiledThumb(channelIcons, CTextureCache::GetCachedPath(relativeCacheFile)))

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -2096,7 +2096,7 @@ void CPVRClientCapabilities::InitRecordingsLifetimeValues()
     for (int i = 1; i < 366; ++i)
     {
       m_recordingsLifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999), i),
-                                              i); // "%s days"
+                                              i); // "{} days"
     }
   }
   else

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -2085,7 +2085,7 @@ void CPVRClientCapabilities::InitRecordingsLifetimeValues()
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("{}", iValue);
+        strDescr = std::to_string(iValue);
       }
       m_recordingsLifetimeValues.emplace_back(strDescr, iValue);
     }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1843,8 +1843,8 @@ void CPVRClient::cb_recording_notification(void* kodiInstance,
       return;
     }
 
-    const std::string strLine1 = StringUtils::Format(
-        g_localizeStrings.Get(bOnOff ? 19197 : 19198).c_str(), client->Name().c_str());
+    const std::string strLine1 =
+        StringUtils::Format(g_localizeStrings.Get(bOnOff ? 19197 : 19198), client->Name());
     std::string strLine2;
     if (strName)
       strLine2 = strName;
@@ -2095,9 +2095,8 @@ void CPVRClientCapabilities::InitRecordingsLifetimeValues()
     // No values given by addon, but lifetime supported. Use default values 1..365
     for (int i = 1; i < 366; ++i)
     {
-      m_recordingsLifetimeValues.emplace_back(
-          StringUtils::Format(g_localizeStrings.Get(17999).c_str(), i),
-          i); // "%s days"
+      m_recordingsLifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999), i),
+                                              i); // "%s days"
     }
   }
   else

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -322,7 +322,7 @@ bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIco
   CSingleLock lock(m_critSection);
   if (m_strIconPath != strIconPath)
   {
-    m_strIconPath = StringUtils::Format("{}", strIconPath);
+    m_strIconPath = strIconPath;
 
     m_bChanged = true;
     m_bIsUserSetIcon = bIsUserSetIcon && !m_strIconPath.empty();
@@ -638,7 +638,7 @@ bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
   {
     bool bCleanEPG = !m_strEPGScraper.empty() || strScraper.empty();
 
-    m_strEPGScraper = StringUtils::Format("{}", strScraper);
+    m_strEPGScraper = strScraper;
     m_bChanged = true;
 
     /* clear the previous EPG entries if needed */

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -67,8 +67,7 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId)
     m_iClientEncryptionSystem(channel.iEncryptionSystem)
 {
   if (m_strChannelName.empty())
-    m_strChannelName =
-        StringUtils::Format("{} {}", g_localizeStrings.Get(19029).c_str(), m_iUniqueId);
+    m_strChannelName = StringUtils::Format("{} {}", g_localizeStrings.Get(19029), m_iUniqueId);
 
   UpdateEncryptionName();
 }
@@ -323,7 +322,7 @@ bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIco
   CSingleLock lock(m_critSection);
   if (m_strIconPath != strIconPath)
   {
-    m_strIconPath = StringUtils::Format("{}", strIconPath.c_str());
+    m_strIconPath = StringUtils::Format("{}", strIconPath);
 
     m_bChanged = true;
     m_bIsUserSetIcon = bIsUserSetIcon && !m_strIconPath.empty();
@@ -338,7 +337,8 @@ bool CPVRChannel::SetChannelName(const std::string& strChannelName, bool bIsUser
   std::string strName(strChannelName);
 
   if (strName.empty())
-    strName = StringUtils::Format(g_localizeStrings.Get(19085).c_str(), m_clientChannelNumber.FormattedChannelNumber().c_str());
+    strName = StringUtils::Format(g_localizeStrings.Get(19085),
+                                  m_clientChannelNumber.FormattedChannelNumber());
 
   CSingleLock lock(m_critSection);
   if (m_strChannelName != strName)
@@ -638,7 +638,7 @@ bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
   {
     bool bCleanEPG = !m_strEPGScraper.empty() || strScraper.empty();
 
-    m_strEPGScraper = StringUtils::Format("{}", strScraper.c_str());
+    m_strEPGScraper = StringUtils::Format("{}", strScraper);
     m_bChanged = true;
 
     /* clear the previous EPG entries if needed */

--- a/xbmc/pvr/channels/PVRChannelNumber.cpp
+++ b/xbmc/pvr/channels/PVRChannelNumber.cpp
@@ -30,7 +30,7 @@ std::string CPVRChannelNumber::SortableChannelNumber() const
 std::string CPVRChannelNumber::ToString(char separator) const
 {
   if (m_iSubChannelNumber == 0)
-    return StringUtils::Format("{}", m_iChannelNumber);
+    return std::to_string(m_iChannelNumber);
   else
     return StringUtils::Format("{}{}{}", m_iChannelNumber, separator, m_iSubChannelNumber);
 }

--- a/xbmc/pvr/channels/PVRChannelsPath.cpp
+++ b/xbmc/pvr/channels/PVRChannelsPath.cpp
@@ -118,8 +118,8 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio, bool bHidden, const std::string&
     m_kind = Kind::GROUP;
 
   m_group = bHidden ? ".hidden" : strGroupName;
-  m_path = StringUtils::Format("pvr://channels/{}/{}", bRadio ? "radio" : "tv",
-                               CURL::Encode(m_group).c_str());
+  m_path =
+      StringUtils::Format("pvr://channels/{}/{}", bRadio ? "radio" : "tv", CURL::Encode(m_group));
 
   if (!m_group.empty())
     m_path.append("/");
@@ -134,8 +134,8 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio, const std::string& strGroupName)
     m_kind = Kind::GROUP;
 
   m_group = strGroupName;
-  m_path = StringUtils::Format("pvr://channels/{}/{}", bRadio ? "radio" : "tv",
-                               CURL::Encode(m_group).c_str());
+  m_path =
+      StringUtils::Format("pvr://channels/{}/{}", bRadio ? "radio" : "tv", CURL::Encode(m_group));
 
   if (!m_group.empty())
     m_path.append("/");
@@ -151,7 +151,7 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio, const std::string& strGroupName,
     m_clientID = strClientID;
     m_iChannelUID = iChannelUID;
     m_path = StringUtils::Format("pvr://channels/{}/{}/{}_{}.pvr", bRadio ? "radio" : "tv",
-                                 CURL::Encode(m_group).c_str(), m_clientID.c_str(), m_iChannelUID);
+                                 CURL::Encode(m_group), m_clientID, m_iChannelUID);
   }
 }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -131,9 +131,9 @@ bool CGUIDialogPVRChannelManager::OnActionMove(const CAction& action)
           unsigned int iNewSelect = bMoveUp ? m_iSelected - 1 : m_iSelected + 1;
           if (m_channelItems->Get(iNewSelect)->GetProperty("Number").asString() != "-")
           {
-            strNumber = StringUtils::Format("{}", m_iSelected + 1);
+            strNumber = std::to_string(m_iSelected + 1);
             m_channelItems->Get(iNewSelect)->SetProperty("Number", strNumber);
-            strNumber = StringUtils::Format("{}", iNewSelect + 1);
+            strNumber = std::to_string(iNewSelect + 1);
             m_channelItems->Get(m_iSelected)->SetProperty("Number", strNumber);
           }
           m_channelItems->Swap(iNewSelect, m_iSelected);
@@ -731,8 +731,7 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty("Icon", channel->IconPath());
     channelFile->SetProperty("EPGSource", 0);
     channelFile->SetProperty("ParentalLocked", channel->IsLocked());
-    channelFile->SetProperty("Number",
-                             StringUtils::Format("{}", member->ChannelNumber().GetChannelNumber()));
+    channelFile->SetProperty("Number", std::to_string(member->ChannelNumber().GetChannelNumber()));
 
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*channelFile);
     if (client)
@@ -869,7 +868,7 @@ void CGUIDialogPVRChannelManager::Renumber()
     pItem = m_channelItems->Get(iChannelPtr);
     if (pItem->GetProperty("ActiveChannel").asBoolean())
     {
-      strNumber = StringUtils::Format("{}", ++iNextChannelNumber);
+      strNumber = std::to_string(++iNextChannelNumber);
       pItem->SetProperty("Number", strNumber);
     }
     else

--- a/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
@@ -72,7 +72,7 @@ void CGUIDialogPVRClientPriorities::InitializeSettings()
   CServiceBroker::GetPVRManager().Clients()->GetCreatedClients(m_clients);
   for (const auto& client : m_clients)
   {
-    setting = AddEdit(group, StringUtils::Format("{}", client.second->GetID()), 13205 /* Unknown */,
+    setting = AddEdit(group, std::to_string(client.second->GetID()), 13205 /* Unknown */,
                       SettingLevel::Basic, client.second->GetPriority());
   }
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -475,7 +475,7 @@ void CGUIDialogPVRGroupManager::Update()
     }
     else
     {
-      std::string strNewLabel = StringUtils::Format("{}", g_localizeStrings.Get(19219));
+      std::string strNewLabel = g_localizeStrings.Get(19219);
       SET_CONTROL_LABEL(CONTROL_UNGROUPED_LABEL, strNewLabel);
 
       strNewLabel =

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -463,23 +463,23 @@ void CGUIDialogPVRGroupManager::Update()
 
     if (m_selectedGroup->IsInternalGroup())
     {
-      std::string strNewLabel = StringUtils::Format(
-          "{} {}", g_localizeStrings.Get(19022).c_str(),
-          m_bIsRadio ? g_localizeStrings.Get(19024).c_str() : g_localizeStrings.Get(19023).c_str());
+      std::string strNewLabel = StringUtils::Format("{} {}", g_localizeStrings.Get(19022),
+                                                    m_bIsRadio ? g_localizeStrings.Get(19024)
+                                                               : g_localizeStrings.Get(19023));
       SET_CONTROL_LABEL(CONTROL_UNGROUPED_LABEL, strNewLabel);
 
-      strNewLabel = StringUtils::Format("{} {}", g_localizeStrings.Get(19218).c_str(),
-                                        m_bIsRadio ? g_localizeStrings.Get(19024).c_str()
-                                                   : g_localizeStrings.Get(19023).c_str());
+      strNewLabel = StringUtils::Format("{} {}", g_localizeStrings.Get(19218),
+                                        m_bIsRadio ? g_localizeStrings.Get(19024)
+                                                   : g_localizeStrings.Get(19023));
       SET_CONTROL_LABEL(CONTROL_IN_GROUP_LABEL, strNewLabel);
     }
     else
     {
-      std::string strNewLabel = StringUtils::Format("{}", g_localizeStrings.Get(19219).c_str());
+      std::string strNewLabel = StringUtils::Format("{}", g_localizeStrings.Get(19219));
       SET_CONTROL_LABEL(CONTROL_UNGROUPED_LABEL, strNewLabel);
 
-      strNewLabel = StringUtils::Format("{} {}", g_localizeStrings.Get(19220).c_str(),
-                                        m_selectedGroup->GroupName().c_str());
+      strNewLabel =
+          StringUtils::Format("{} {}", g_localizeStrings.Get(19220), m_selectedGroup->GroupName());
       SET_CONTROL_LABEL(CONTROL_IN_GROUP_LABEL, strNewLabel);
     }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -131,7 +131,7 @@ void CGUIDialogPVRGuideSearch::UpdateDurationSpin()
 
   labels.emplace_back("-", EPG_SEARCH_UNSET);
   for (int i = 1; i < 12*60/5; ++i)
-    labels.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i * 5), i * 5);
+    labels.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044), i * 5), i * 5);
 
   SET_CONTROL_LABELS(CONTROL_SPIN_MIN_DURATION, m_searchFilter->GetMinimumDuration(), &labels);
 
@@ -140,7 +140,7 @@ void CGUIDialogPVRGuideSearch::UpdateDurationSpin()
 
   labels.emplace_back("-", EPG_SEARCH_UNSET);
   for (int i = 1; i < 12*60/5; ++i)
-    labels.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i * 5), i * 5);
+    labels.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044), i * 5), i * 5);
 
   SET_CONTROL_LABELS(CONTROL_SPIN_MAX_DURATION, m_searchFilter->GetMaximumDuration(), &labels);
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -131,8 +131,10 @@ bool CGUIDialogPVRRecordingSettings::OnSettingChanging(
     int iNewLifetime = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
     if (m_recording->WillBeExpiredWithNewLifetime(iNewLifetime))
     {
-      if (HELPERS::ShowYesNoDialogText(CVariant{19068}, // "Recording settings"
-                                       StringUtils::Format(g_localizeStrings.Get(19147).c_str(), iNewLifetime)) // "Setting the lifetime..."
+      if (HELPERS::ShowYesNoDialogText(
+              CVariant{19068}, // "Recording settings"
+              StringUtils::Format(g_localizeStrings.Get(19147),
+                                  iNewLifetime)) // "Setting the lifetime..."
           != HELPERS::DialogResponse::YES)
         return false;
     }
@@ -215,9 +217,9 @@ void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& sett
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(17999).c_str(),
-                                                               current) /* {} days */,
-                                           current));
+      list.insert(it, IntegerSettingOption(
+                          StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
+                          current));
     }
   }
   else

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1025,7 +1025,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format("{}", current), current));
+      list.insert(it, IntegerSettingOption(std::to_string(current), current));
     }
   }
   else
@@ -1099,7 +1099,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format("{}", current), current));
+      list.insert(it, IntegerSettingOption(std::to_string(current), current));
     }
   }
   else

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -831,8 +831,8 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   {
     const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
     const std::string channelDescription =
-        StringUtils::Format("{} {}", groupMember->ChannelNumber().FormattedChannelNumber().c_str(),
-                            channel->ChannelName().c_str());
+        StringUtils::Format("{} {}", groupMember->ChannelNumber().FormattedChannelNumber(),
+                            channel->ChannelName());
     m_channelEntries.insert({index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});
     ++index;
   }
@@ -1061,9 +1061,9 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(17999).c_str(),
-                                                               current) /* {} days */,
-                                           current));
+      list.insert(it, IntegerSettingOption(
+                          StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
+                          current));
     }
   }
   else
@@ -1164,9 +1164,9 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
     if (bInsertValue)
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(StringUtils::Format(g_localizeStrings.Get(14044).c_str(),
-                                                               current) /* {} min */,
-                                           current));
+      list.insert(it, IntegerSettingOption(
+                          StringUtils::Format(g_localizeStrings.Get(14044), current) /* {} min */,
+                          current));
     }
   }
   else

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -343,7 +343,7 @@ const std::string CPVREpgInfoTag::GetCastLabel() const
   // Note: see CVideoInfoTag::GetCast for reference implementation.
   std::string strLabel;
   for (const auto& castEntry : m_cast)
-    strLabel += StringUtils::Format("{}\n", castEntry.c_str());
+    strLabel += StringUtils::Format("{}\n", castEntry);
 
   return StringUtils::TrimRight(strLabel, "\n");
 }
@@ -573,8 +573,8 @@ std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
 
 void CPVREpgInfoTag::UpdatePath()
 {
-  m_strFileNameAndPath = StringUtils::Format("pvr://guide/{:04}/{}.epg", EpgID(),
-                                             m_startTime.GetAsDBDateTime().c_str());
+  m_strFileNameAndPath =
+      StringUtils::Format("pvr://guide/{:04}/{}.epg", EpgID(), m_startTime.GetAsDBDateTime());
 }
 
 int CPVREpgInfoTag::EpgID() const

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -326,9 +326,8 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     {
       item->IncrementProperty("watchedepisodes", 1);
     }
-    item->SetLabel2(StringUtils::Format("{} / {}",
-                                        item->GetProperty("watchedepisodes").asString().c_str(),
-                                        item->GetProperty("totalepisodes").asString().c_str()));
+    item->SetLabel2(StringUtils::Format("{} / {}", item->GetProperty("watchedepisodes").asString(),
+                                        item->GetProperty("totalepisodes").asString()));
 
     item->IncrementProperty("sizeinbytes", recording->GetSizeInBytes());
   }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1419,23 +1419,22 @@ std::string CGUIEPGGridContainer::GetLabel(int info) const
   {
   case CONTAINER_NUM_PAGES:
     if (m_channelsPerPage > 0)
-      label = StringUtils::Format("{}", (m_gridModel->ChannelItemsSize() + m_channelsPerPage - 1) /
-                                            m_channelsPerPage);
+      label = std::to_string((m_gridModel->ChannelItemsSize() + m_channelsPerPage - 1) /
+                             m_channelsPerPage);
     else
-      label = StringUtils::Format("{}", 0);
+      label = std::to_string(0);
     break;
   case CONTAINER_CURRENT_PAGE:
     if (m_channelsPerPage > 0)
-      label =
-          StringUtils::Format("{}", 1 + (m_channelCursor + m_channelOffset) / m_channelsPerPage);
+      label = std::to_string(1 + (m_channelCursor + m_channelOffset) / m_channelsPerPage);
     else
-      label = StringUtils::Format("{}", 1);
+      label = std::to_string(1);
     break;
   case CONTAINER_POSITION:
-    label = StringUtils::Format("{}", 1 + m_channelCursor + m_channelOffset);
+    label = std::to_string(1 + m_channelCursor + m_channelOffset);
     break;
   case CONTAINER_NUM_ITEMS:
-    label = StringUtils::Format("{}", m_gridModel->ChannelItemsSize());
+    label = std::to_string(m_gridModel->ChannelItemsSize());
     break;
   default:
       break;

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -542,22 +542,29 @@ namespace PVR
         switch (eAction)
         {
           case RECORD_INSTANTRECORDTIME:
-            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(), m_iInstantRecordTime)); // Record next <default duration> minutes
+            m_pDlgSelect->Add(StringUtils::Format(
+                g_localizeStrings.Get(19090),
+                m_iInstantRecordTime)); // Record next <default duration> minutes
             break;
           case RECORD_30_MINUTES:
-            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(), 30)); // Record next 30 minutes
+            m_pDlgSelect->Add(
+                StringUtils::Format(g_localizeStrings.Get(19090), 30)); // Record next 30 minutes
             break;
           case RECORD_60_MINUTES:
-            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(), 60)); // Record next 60 minutes
+            m_pDlgSelect->Add(
+                StringUtils::Format(g_localizeStrings.Get(19090), 60)); // Record next 60 minutes
             break;
           case RECORD_120_MINUTES:
-            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(), 120)); // Record next 120 minutes
+            m_pDlgSelect->Add(
+                StringUtils::Format(g_localizeStrings.Get(19090), 120)); // Record next 120 minutes
             break;
           case RECORD_CURRENT_SHOW:
-            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19091).c_str(), title.c_str())); // Record current show (<title>)
+            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19091),
+                                                  title)); // Record current show (<title>)
             break;
           case RECORD_NEXT_SHOW:
-            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19092).c_str(), title.c_str())); // Record next show (<title>)
+            m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19092),
+                                                  title)); // Record next show (<title>)
             break;
           case NONE:
           case ASK:
@@ -1164,8 +1171,9 @@ namespace PVR
     {
       int positionInSeconds = lrint(recording->GetResumePoint().timeInSeconds);
       if (positionInSeconds > 0)
-        resumeString = StringUtils::Format(g_localizeStrings.Get(12022).c_str(),
-                                           StringUtils::SecondsToTimeString(positionInSeconds, TIME_FORMAT_HH_MM_SS).c_str());
+        resumeString = StringUtils::Format(
+            g_localizeStrings.Get(12022),
+            StringUtils::SecondsToTimeString(positionInSeconds, TIME_FORMAT_HH_MM_SS));
     }
     return resumeString;
   }
@@ -1413,7 +1421,9 @@ namespace PVR
     else if (result == ParentalCheckResult::FAILED)
     {
       const std::string channelName = channel ? channel->ChannelName() : g_localizeStrings.Get(19029); // Channel
-      const std::string msg = StringUtils::Format(g_localizeStrings.Get(19035).c_str(), channelName.c_str()); // CHANNELNAME could not be played. Check the log for details.
+      const std::string msg = StringUtils::Format(
+          g_localizeStrings.Get(19035),
+          channelName); // CHANNELNAME could not be played. Check the log for details.
 
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(19166), msg); // PVR information
     }
@@ -1489,10 +1499,14 @@ namespace PVR
                "first channel of active group could also not be determined.",
                bIsRadio ? "Radio" : "TV");
 
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                          g_localizeStrings.Get(19166), // PVR information
-                                          StringUtils::Format(g_localizeStrings.Get(19035).c_str(),
-                                                              g_localizeStrings.Get(bIsRadio ? 19021 : 19020).c_str())); // Radio/TV could not be played. Check the log for details.
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Error,
+        g_localizeStrings.Get(19166), // PVR information
+        StringUtils::Format(
+            g_localizeStrings.Get(19035),
+            g_localizeStrings.Get(
+                bIsRadio ? 19021
+                         : 19020))); // Radio/TV could not be played. Check the log for details.
     return false;
   }
 
@@ -1895,9 +1909,9 @@ namespace PVR
           {
             if (cause->IsRecording())
             {
-              text = StringUtils::Format(g_localizeStrings.Get(19691).c_str(), // "PVR is currently recording...."
-                                         cause->Title().c_str(),
-                                         cause->ChannelName().c_str());
+              text = StringUtils::Format(
+                  g_localizeStrings.Get(19691), // "PVR is currently recording...."
+                  cause->Title(), cause->ChannelName());
             }
             else
             {
@@ -1914,7 +1928,7 @@ namespace PVR
               if (mins > 1)
               {
                 // "%d minutes"
-                dueStr = StringUtils::Format(g_localizeStrings.Get(19694).c_str(), mins);
+                dueStr = StringUtils::Format(g_localizeStrings.Get(19694), mins);
               }
               else
               {
@@ -1922,12 +1936,11 @@ namespace PVR
                 dueStr = g_localizeStrings.Get(19695);
               }
 
-              text = StringUtils::Format(cause->IsReminder()
-                                           ? g_localizeStrings.Get(19690).c_str() // "PVR has scheduled a reminder...."
-                                           : g_localizeStrings.Get(19692).c_str(), // "PVR will start recording...."
-                                         cause->Title().c_str(),
-                                         cause->ChannelName().c_str(),
-                                         dueStr.c_str());
+              text = StringUtils::Format(
+                  cause->IsReminder()
+                      ? g_localizeStrings.Get(19690) // "PVR has scheduled a reminder...."
+                      : g_localizeStrings.Get(19692), // "PVR will start recording...."
+                  cause->Title(), cause->ChannelName(), dueStr);
             }
           }
           else
@@ -1946,7 +1959,7 @@ namespace PVR
             if (mins > 1)
             {
               // "%d minutes"
-              dueStr = StringUtils::Format(g_localizeStrings.Get(19694).c_str(), mins);
+              dueStr = StringUtils::Format(g_localizeStrings.Get(19694), mins);
             }
             else
             {
@@ -1954,8 +1967,8 @@ namespace PVR
               dueStr = g_localizeStrings.Get(19695);
             }
 
-            text = StringUtils::Format(g_localizeStrings.Get(19693).c_str(), // "Daily wakeup is due in...."
-                                       dueStr.c_str());
+            text = StringUtils::Format(g_localizeStrings.Get(19693), // "Daily wakeup is due in...."
+                                       dueStr);
           }
 
           // Inform user about PVR being busy. Ask if user wants to powerdown anyway.

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -458,7 +458,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         }
         else if (recording->HasYear())
         {
-          strValue = StringUtils::Format("{}", recording->GetYear());
+          strValue = std::to_string(recording->GetYear());
           return true;
         }
         return false;
@@ -592,7 +592,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_YEAR:
         if (epgTag->Year() > 0)
         {
-          strValue = StringUtils::Format("{}", epgTag->Year());
+          strValue = std::to_string(epgTag->Year());
           return true;
         }
         return false;
@@ -600,7 +600,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_SEASON:
         if (epgTag->SeriesNumber() >= 0)
         {
-          strValue = StringUtils::Format("{}", epgTag->SeriesNumber());
+          strValue = std::to_string(epgTag->SeriesNumber());
           return true;
         }
         return false;
@@ -608,7 +608,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_EPISODE:
         if (epgTag->EpisodeNumber() >= 0)
         {
-          strValue = StringUtils::Format("{}", epgTag->EpisodeNumber());
+          strValue = std::to_string(epgTag->EpisodeNumber());
           return true;
         }
         return false;
@@ -640,7 +640,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_PARENTAL_RATING:
         if (epgTag->ParentalRating() > 0)
         {
-          strValue = StringUtils::Format("{}", epgTag->ParentalRating());
+          strValue = std::to_string(epgTag->ParentalRating());
           return true;
         }
         return false;
@@ -653,7 +653,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         }
         else if (epgTag->Year() > 0)
         {
-          strValue = StringUtils::Format("{}", epgTag->Year());
+          strValue = std::to_string(epgTag->Year());
           return true;
         }
         return false;
@@ -960,7 +960,7 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item, const CGUIInfo& info, 
       case RDS_ALBUM_TRACKNUMBER:
         if (tag->GetAlbumTrackNumber() > 0)
         {
-          strValue = StringUtils::Format("{}", tag->GetAlbumTrackNumber());
+          strValue = std::to_string(tag->GetAlbumTrackNumber());
           return true;
         }
         break;
@@ -980,43 +980,43 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item, const CGUIInfo& info, 
         strValue = tag->GetInfoStock();
         return true;
       case RDS_INFO_STOCK_SIZE:
-        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoStock().size()));
+        strValue = std::to_string(static_cast<int>(tag->GetInfoStock().size()));
         return true;
       case RDS_INFO_SPORT:
         strValue = tag->GetInfoSport();
         return true;
       case RDS_INFO_SPORT_SIZE:
-        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoSport().size()));
+        strValue = std::to_string(static_cast<int>(tag->GetInfoSport().size()));
         return true;
       case RDS_INFO_LOTTERY:
         strValue = tag->GetInfoLottery();
         return true;
       case RDS_INFO_LOTTERY_SIZE:
-        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoLottery().size()));
+        strValue = std::to_string(static_cast<int>(tag->GetInfoLottery().size()));
         return true;
       case RDS_INFO_WEATHER:
         strValue = tag->GetInfoWeather();
         return true;
       case RDS_INFO_WEATHER_SIZE:
-        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoWeather().size()));
+        strValue = std::to_string(static_cast<int>(tag->GetInfoWeather().size()));
         return true;
       case RDS_INFO_HOROSCOPE:
         strValue = tag->GetInfoHoroscope();
         return true;
       case RDS_INFO_HOROSCOPE_SIZE:
-        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoHoroscope().size()));
+        strValue = std::to_string(static_cast<int>(tag->GetInfoHoroscope().size()));
         return true;
       case RDS_INFO_CINEMA:
         strValue = tag->GetInfoCinema();
         return true;
       case RDS_INFO_CINEMA_SIZE:
-        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoCinema().size()));
+        strValue = std::to_string(static_cast<int>(tag->GetInfoCinema().size()));
         return true;
       case RDS_INFO_OTHER:
         strValue = tag->GetInfoOther();
         return true;
       case RDS_INFO_OTHER_SIZE:
-        strValue = StringUtils::Format("{}", static_cast<int>(tag->GetInfoOther().size()));
+        strValue = std::to_string(static_cast<int>(tag->GetInfoOther().size()));
         return true;
       case RDS_PROG_HOST:
         strValue = tag->GetProgHost();
@@ -1778,16 +1778,16 @@ void CPVRGUIInfo::UpdateBackendCache()
     m_strBackendHost = backend.host;
 
     if (backend.numChannels >= 0)
-      m_strBackendChannels = StringUtils::Format("{}", backend.numChannels);
+      m_strBackendChannels = std::to_string(backend.numChannels);
 
     if (backend.numTimers >= 0)
-      m_strBackendTimers = StringUtils::Format("{}", backend.numTimers);
+      m_strBackendTimers = std::to_string(backend.numTimers);
 
     if (backend.numRecordings >= 0)
-      m_strBackendRecordings = StringUtils::Format("{}", backend.numRecordings);
+      m_strBackendRecordings = std::to_string(backend.numRecordings);
 
     if (backend.numDeletedRecordings >= 0)
-      m_strBackendDeletedRecordings = StringUtils::Format("{}", backend.numDeletedRecordings);
+      m_strBackendDeletedRecordings = std::to_string(backend.numDeletedRecordings);
 
     m_iBackendDiskTotal = backend.diskTotal;
     m_iBackendDiskUsed = backend.diskUsed;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1580,7 +1580,8 @@ void CPVRGUIInfo::CharInfoBackendNumber(std::string& strValue) const
   size_t numBackends = m_backendProperties.size();
 
   if (numBackends > 0)
-    strValue = StringUtils::Format("{0} {1} {2}", m_iCurrentActiveClient + 1, g_localizeStrings.Get(20163).c_str(), numBackends);
+    strValue = StringUtils::Format("{0} {1} {2}", m_iCurrentActiveClient + 1,
+                                   g_localizeStrings.Get(20163), numBackends);
   else
     strValue = g_localizeStrings.Get(14023);
 }
@@ -1653,9 +1654,9 @@ void CPVRGUIInfo::CharInfoBackendDiskspace(std::string& strValue) const
 
   if (diskTotal > 0)
   {
-    strValue = StringUtils::Format(g_localizeStrings.Get(802).c_str(),
-        StringUtils::SizeToString(diskTotal - diskUsed).c_str(),
-        StringUtils::SizeToString(diskTotal).c_str());
+    strValue = StringUtils::Format(g_localizeStrings.Get(802),
+                                   StringUtils::SizeToString(diskTotal - diskUsed),
+                                   StringUtils::SizeToString(diskTotal));
   }
   else
     strValue = g_localizeStrings.Get(13205);

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -96,9 +96,9 @@ void CPVRGUITimerInfo::UpdateTimersToggle()
     if (m_iTimerInfoToggleCurrent < activeTags.size())
     {
       const std::shared_ptr<CPVRTimerInfoTag> tag = activeTags.at(m_iTimerInfoToggleCurrent);
-      strActiveTimerTitle = StringUtils::Format("{}", tag->Title().c_str());
+      strActiveTimerTitle = StringUtils::Format("{}", tag->Title());
       strActiveTimerChannelName = StringUtils::Format("{}", tag->ChannelName().c_str());
-      strActiveTimerChannelIcon = StringUtils::Format("{}", tag->ChannelIcon().c_str());
+      strActiveTimerChannelIcon = StringUtils::Format("{}", tag->ChannelIcon());
       strActiveTimerTime = StringUtils::Format(
           "{}", tag->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
     }
@@ -137,17 +137,16 @@ void CPVRGUITimerInfo::UpdateNextTimer()
   const std::shared_ptr<CPVRTimerInfoTag> timer = GetNextActiveTimer();
   if (timer)
   {
-    strNextRecordingTitle = StringUtils::Format("{}", timer->Title().c_str());
+    strNextRecordingTitle = StringUtils::Format("{}", timer->Title());
     strNextRecordingChannelName = StringUtils::Format("{}", timer->ChannelName().c_str());
-    strNextRecordingChannelIcon = StringUtils::Format("{}", timer->ChannelIcon().c_str());
+    strNextRecordingChannelIcon = StringUtils::Format("{}", timer->ChannelIcon());
     strNextRecordingTime = StringUtils::Format(
         "{}", timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
 
-    strNextTimerInfo =
-        StringUtils::Format("{} {} {} {}", g_localizeStrings.Get(19106).c_str(),
-                            timer->StartAsLocalTime().GetAsLocalizedDate(true).c_str(),
-                            g_localizeStrings.Get(19107).c_str(),
-                            timer->StartAsLocalTime().GetAsLocalizedTime("", false).c_str());
+    strNextTimerInfo = StringUtils::Format("{} {} {} {}", g_localizeStrings.Get(19106),
+                                           timer->StartAsLocalTime().GetAsLocalizedDate(true),
+                                           g_localizeStrings.Get(19107),
+                                           timer->StartAsLocalTime().GetAsLocalizedTime("", false));
   }
 
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -96,11 +96,10 @@ void CPVRGUITimerInfo::UpdateTimersToggle()
     if (m_iTimerInfoToggleCurrent < activeTags.size())
     {
       const std::shared_ptr<CPVRTimerInfoTag> tag = activeTags.at(m_iTimerInfoToggleCurrent);
-      strActiveTimerTitle = StringUtils::Format("{}", tag->Title());
-      strActiveTimerChannelName = StringUtils::Format("{}", tag->ChannelName().c_str());
-      strActiveTimerChannelIcon = StringUtils::Format("{}", tag->ChannelIcon());
-      strActiveTimerTime = StringUtils::Format(
-          "{}", tag->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
+      strActiveTimerTitle = tag->Title();
+      strActiveTimerChannelName = tag->ChannelName();
+      strActiveTimerChannelIcon = tag->ChannelIcon();
+      strActiveTimerTime = tag->StartAsLocalTime().GetAsLocalizedDateTime(false, false);
     }
   }
 
@@ -137,11 +136,10 @@ void CPVRGUITimerInfo::UpdateNextTimer()
   const std::shared_ptr<CPVRTimerInfoTag> timer = GetNextActiveTimer();
   if (timer)
   {
-    strNextRecordingTitle = StringUtils::Format("{}", timer->Title());
-    strNextRecordingChannelName = StringUtils::Format("{}", timer->ChannelName().c_str());
-    strNextRecordingChannelIcon = StringUtils::Format("{}", timer->ChannelIcon());
-    strNextRecordingTime = StringUtils::Format(
-        "{}", timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false).c_str());
+    strNextRecordingTitle = timer->Title();
+    strNextRecordingChannelName = timer->ChannelName();
+    strNextRecordingChannelIcon = timer->ChannelIcon();
+    strNextRecordingTime = timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false);
 
     strNextTimerInfo = StringUtils::Format("{} {} {} {}", g_localizeStrings.Get(19106),
                                            timer->StartAsLocalTime().GetAsLocalizedDate(true),

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -438,7 +438,7 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
   }
 
   //Old Method of identifying TV show title and subtitle using m_strDirectory and strPlotOutline (deprecated)
-  std::string strShow = StringUtils::Format("{} - ", g_localizeStrings.Get(20364).c_str());
+  std::string strShow = StringUtils::Format("{} - ", g_localizeStrings.Get(20364));
   if (StringUtils::StartsWithNoCase(m_strPlotOutline, strShow))
   {
     CLog::Log(LOGWARNING, "PVR addon provides episode name in strPlotOutline which is deprecated");

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -87,7 +87,7 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio,
 {
   std::string strDirectoryN(TrimSlashes(strDirectory));
   if (!strDirectoryN.empty())
-    strDirectoryN = StringUtils::Format("{}/", strDirectoryN.c_str());
+    strDirectoryN = StringUtils::Format("{}/", strDirectoryN);
 
   std::string strTitleN(strTitle);
   strTitleN = CURL::Encode(strTitleN);
@@ -96,32 +96,30 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio,
   if ((iSeason > -1 && iEpisode > -1 && (iSeason > 0 || iEpisode > 0)))
     strSeasonEpisodeN = StringUtils::Format("s{:02}e{:02}", iSeason, iEpisode);
   if (!strSeasonEpisodeN.empty())
-    strSeasonEpisodeN = StringUtils::Format(" {}", strSeasonEpisodeN.c_str());
+    strSeasonEpisodeN = StringUtils::Format(" {}", strSeasonEpisodeN);
 
   std::string strYearN(iYear > 0 ? StringUtils::Format(" ({})", iYear) : "");
 
   std::string strSubtitleN;
   if (!strSubtitle.empty())
   {
-    strSubtitleN = StringUtils::Format(" {}", strSubtitle.c_str());
+    strSubtitleN = StringUtils::Format(" {}", strSubtitle);
     strSubtitleN = CURL::Encode(strSubtitleN);
   }
 
   std::string strChannelNameN;
   if (!strChannelName.empty())
   {
-    strChannelNameN = StringUtils::Format(" ({})", strChannelName.c_str());
+    strChannelNameN = StringUtils::Format(" ({})", strChannelName);
     strChannelNameN = CURL::Encode(strChannelNameN);
   }
 
-  m_directoryPath =
-      StringUtils::Format("{}{}{}{}{}", strDirectoryN.c_str(), strTitleN.c_str(),
-                          strSeasonEpisodeN.c_str(), strYearN.c_str(), strSubtitleN.c_str());
+  m_directoryPath = StringUtils::Format("{}{}{}{}{}", strDirectoryN, strTitleN, strSeasonEpisodeN,
+                                        strYearN, strSubtitleN);
   m_params = StringUtils::Format(", TV{}, {}, {}.pvr", strChannelNameN.c_str(),
                                  recordingTime.GetAsSaveString().c_str(), strId.c_str());
   m_path = StringUtils::Format("pvr://recordings/{}/{}/{}{}", bRadio ? "radio" : "tv",
-                               bDeleted ? "deleted" : "active", m_directoryPath.c_str(),
-                               m_params.c_str());
+                               bDeleted ? "deleted" : "active", m_directoryPath, m_params);
 }
 
 std::string CPVRRecordingsPath::GetUnescapedDirectoryPath() const

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -161,8 +161,8 @@ void CPVRSettings::MarginTimeFiller(const SettingConstPtr& /*setting*/,
 
   for (int iValue : marginTimeValues)
   {
-    list.emplace_back(
-        StringUtils::Format(g_localizeStrings.Get(14044).c_str(), iValue) /* {} min */, iValue);
+    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044), iValue) /* {} min */,
+                      iValue);
   }
 }
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -332,36 +332,36 @@ void CPVRTimerInfoTag::UpdateSummary()
   {
     m_strSummary = StringUtils::Format(
         "{} {} {}",
-        m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString().c_str()
-                                        : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
-        g_localizeStrings.Get(19107).c_str(), // "at"
-        m_bStartAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
-                        : StartAsLocalTime().GetAsLocalizedTime("", false).c_str());
+        m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString()
+                                        : startDate, //for "Any day" set PVR_WEEKDAY_ALLDAYS
+        g_localizeStrings.Get(19107), // "at"
+        m_bStartAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
+                        : StartAsLocalTime().GetAsLocalizedTime("", false));
   }
   else if ((m_iWeekdays != PVR_WEEKDAY_NONE) || (startDate == endDate))
   {
     m_strSummary = StringUtils::Format(
         "{} {} {} {} {}",
-        m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString().c_str()
-                                        : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
-        g_localizeStrings.Get(19159).c_str(), // "from"
-        m_bStartAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
-                        : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
-        g_localizeStrings.Get(19160).c_str(), // "to"
-        m_bEndAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
-                      : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
+        m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString()
+                                        : startDate, //for "Any day" set PVR_WEEKDAY_ALLDAYS
+        g_localizeStrings.Get(19159), // "from"
+        m_bStartAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
+                        : StartAsLocalTime().GetAsLocalizedTime("", false),
+        g_localizeStrings.Get(19160), // "to"
+        m_bEndAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
+                      : EndAsLocalTime().GetAsLocalizedTime("", false));
   }
   else
   {
-    m_strSummary = StringUtils::Format(
-        "{} {} {} {} {} {}", startDate.c_str(),
-        g_localizeStrings.Get(19159).c_str(), // "from"
-        m_bStartAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
-                        : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
-        g_localizeStrings.Get(19160).c_str(), // "to"
-        endDate.c_str(),
-        m_bEndAnyTime ? g_localizeStrings.Get(19161).c_str() /* "any time" */
-                      : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
+    m_strSummary =
+        StringUtils::Format("{} {} {} {} {} {}", startDate,
+                            g_localizeStrings.Get(19159), // "from"
+                            m_bStartAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
+                                            : StartAsLocalTime().GetAsLocalizedTime("", false),
+                            g_localizeStrings.Get(19160), // "to"
+                            endDate,
+                            m_bEndAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
+                                          : EndAsLocalTime().GetAsLocalizedTime("", false));
   }
 }
 
@@ -417,8 +417,9 @@ std::string CPVRTimerInfoTag::GetStatus(bool bRadio) const
     else if ((m_iTVChildTimersConflictNOK > 0 && !bRadio) || (m_iRadioChildTimersConflictNOK > 0 && bRadio))
       strReturn = g_localizeStrings.Get(19276); // "Conflict error"
     else if ((m_iTVChildTimersActive > 0 && !bRadio) || (m_iRadioChildTimersActive > 0 && bRadio))
-      strReturn = StringUtils::Format(g_localizeStrings.Get(19255).c_str(),
-                                      bRadio ? m_iRadioChildTimersActive : m_iTVChildTimersActive); // "%d scheduled"
+      strReturn = StringUtils::Format(g_localizeStrings.Get(19255),
+                                      bRadio ? m_iRadioChildTimersActive
+                                             : m_iTVChildTimersActive); // "%d scheduled"
   }
 
   return strReturn;
@@ -691,7 +692,7 @@ std::string CPVRTimerInfoTag::ChannelName() const
   if (channeltag)
     strReturn = channeltag->ChannelName();
   else if (m_timerType && m_timerType->IsEpgBasedTimerRule())
-    strReturn = StringUtils::Format("({})", g_localizeStrings.Get(809).c_str()); // "Any channel"
+    strReturn = StringUtils::Format("({})", g_localizeStrings.Get(809)); // "Any channel"
 
   return strReturn;
 }
@@ -831,7 +832,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
   if (bInstantStart)
   {
     // "Instant recording: <summary>
-    newTimer->m_strSummary = StringUtils::Format(g_localizeStrings.Get(19093).c_str(), newTimer->Summary().c_str());
+    newTimer->m_strSummary = StringUtils::Format(g_localizeStrings.Get(19093), newTimer->Summary());
 
     // now that we have a nice summary, we can set the "special" start time value that indicates an instant recording
     newTimer->SetStartFromUTC(start);
@@ -1191,8 +1192,7 @@ std::string CPVRTimerInfoTag::GetNotificationText() const
   }
 
   if (stringID != 0)
-    return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID).c_str(),
-                               m_strTitle.c_str());
+    return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID), m_strTitle);
 
   return {};
 }
@@ -1216,8 +1216,7 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
       stringID = 19228; // Timer deleted
   }
 
-  return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID).c_str(),
-                             m_strTitle.c_str());
+  return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID), m_strTitle);
 }
 
 void CPVRTimerInfoTag::SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -419,7 +419,7 @@ std::string CPVRTimerInfoTag::GetStatus(bool bRadio) const
     else if ((m_iTVChildTimersActive > 0 && !bRadio) || (m_iRadioChildTimersActive > 0 && bRadio))
       strReturn = StringUtils::Format(g_localizeStrings.Get(19255),
                                       bRadio ? m_iRadioChildTimersActive
-                                             : m_iTVChildTimersActive); // "%d scheduled"
+                                             : m_iTVChildTimersActive); // "{} scheduled"
   }
 
   return strReturn;

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -235,7 +235,7 @@ void CPVRTimerType::InitDescription()
     ? 824  // Reminder: ...
     : 825; // Recording: ...
 
-  m_strDescription = StringUtils::Format(g_localizeStrings.Get(prefixId).c_str(), m_strDescription.c_str());
+  m_strDescription = StringUtils::Format(g_localizeStrings.Get(prefixId), m_strDescription);
 }
 
 void CPVRTimerType::InitAttributeValues(const PVR_TIMER_TYPE& type)
@@ -308,7 +308,7 @@ void CPVRTimerType::InitLifetimeValues(const PVR_TIMER_TYPE& type)
     // No values given by addon, but lifetime supported. Use default values 1..365
     for (int i = 1; i < 366; ++i)
     {
-      m_lifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999).c_str(), i),
+      m_lifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999), i),
                                     i); // "{} days"
     }
     m_iLifetimeDefault = DEFAULT_RECORDING_LIFETIME;
@@ -399,7 +399,7 @@ void CPVRTimerType::InitRecordingGroupValues(const PVR_TIMER_TYPE& type)
       {
         // No description given by addon. Create one from value.
         strDescr = StringUtils::Format("{} {}",
-                                       g_localizeStrings.Get(811).c_str(), // Recording group
+                                       g_localizeStrings.Get(811), // Recording group
                                        type.recordingGroup[i].iValue);
       }
       m_recordingGroupValues.emplace_back(strDescr, type.recordingGroup[i].iValue);

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -257,7 +257,7 @@ void CPVRTimerType::InitPriorityValues(const PVR_TIMER_TYPE& type)
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("{}", type.priorities[i].iValue);
+        strDescr = std::to_string(type.priorities[i].iValue);
       }
       m_priorityValues.emplace_back(strDescr, type.priorities[i].iValue);
     }
@@ -268,7 +268,7 @@ void CPVRTimerType::InitPriorityValues(const PVR_TIMER_TYPE& type)
   {
     // No values given by addon, but priority supported. Use default values 1..100
     for (int i = 1; i < 101; ++i)
-      m_priorityValues.emplace_back(StringUtils::Format("{}", i), i);
+      m_priorityValues.emplace_back(std::to_string(i), i);
 
     m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
   }
@@ -296,7 +296,7 @@ void CPVRTimerType::InitLifetimeValues(const PVR_TIMER_TYPE& type)
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("{}", iValue);
+        strDescr = std::to_string(iValue);
       }
       m_lifetimeValues.emplace_back(strDescr, iValue);
     }
@@ -336,7 +336,7 @@ void CPVRTimerType::InitMaxRecordingsValues(const PVR_TIMER_TYPE& type)
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("{}", type.maxRecordings[i].iValue);
+        strDescr = std::to_string(type.maxRecordings[i].iValue);
       }
       m_maxRecordingsValues.emplace_back(strDescr, type.maxRecordings[i].iValue);
     }
@@ -361,7 +361,7 @@ void CPVRTimerType::InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& typ
       if (strDescr.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("{}", type.preventDuplicateEpisodes[i].iValue);
+        strDescr = std::to_string(type.preventDuplicateEpisodes[i].iValue);
       }
       m_preventDupEpisodesValues.emplace_back(strDescr, type.preventDuplicateEpisodes[i].iValue);
     }

--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -44,7 +44,7 @@ CPVRTimersPath::CPVRTimersPath(const std::string& strPath, int iClientId, int iP
 
 CPVRTimersPath::CPVRTimersPath(bool bRadio, bool bTimerRules)
   : m_path(StringUtils::Format(
-        "pvr://timers/%s/%s", bRadio ? "radio" : "tv", bTimerRules ? "rules" : "timers")),
+        "pvr://timers/{}/{}", bRadio ? "radio" : "tv", bTimerRules ? "rules" : "timers")),
     m_bValid(true),
     m_bRoot(true),
     m_bRadio(bRadio),

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -291,20 +291,20 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
   {
     epg->ForceUpdate();
 
-    const std::string strMessage = StringUtils::Format(
-        "{}: '{}'",
-        g_localizeStrings.Get(19253).c_str(), // "Guide update scheduled for channel"
-        channel->ChannelName().c_str());
+    const std::string strMessage =
+        StringUtils::Format("{}: '{}'",
+                            g_localizeStrings.Get(19253), // "Guide update scheduled for channel"
+                            channel->ChannelName());
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
                                           g_localizeStrings.Get(19166), // "PVR information"
                                           strMessage);
   }
   else
   {
-    const std::string strMessage = StringUtils::Format(
-        "{}: '{}'",
-        g_localizeStrings.Get(19254).c_str(), // "Guide update failed for channel"
-        channel->ChannelName().c_str());
+    const std::string strMessage =
+        StringUtils::Format("{}: '{}'",
+                            g_localizeStrings.Get(19254), // "Guide update failed for channel"
+                            channel->ChannelName());
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
                                           g_localizeStrings.Get(19166), // "PVR information"
                                           strMessage);

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -686,7 +686,7 @@ std::string CDisplaySettings::GetStringFromResolution(RESOLUTION resolution, flo
     {
       return StringUtils::Format("{:05}{:05}{:09.5f}{}", info.iScreenWidth, info.iScreenHeight,
                                  refreshrate > 0.0f ? refreshrate : info.fRefreshRate,
-                                 ModeFlagsToString(info.dwFlags, true).c_str());
+                                 ModeFlagsToString(info.dwFlags, true));
     }
   }
 
@@ -725,7 +725,7 @@ void CDisplaySettings::SettingOptionsModesFiller(const std::shared_ptr<const CSe
 
       list.emplace_back(
           StringUtils::Format("{}x{}{} {:0.2f}Hz", mode.iScreenWidth, mode.iScreenHeight,
-                              ModeFlagsToString(mode.dwFlags, false).c_str(), mode.fRefreshRate),
+                              ModeFlagsToString(mode.dwFlags, false), mode.fRefreshRate),
           setting);
     }
   }
@@ -742,7 +742,8 @@ void CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller(
   list.emplace_back(g_localizeStrings.Get(13551), 0);
 
   for (int i = 1; i <= MAX_REFRESH_CHANGE_DELAY; i++)
-    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13553).c_str(), static_cast<double>(i) / 10.0), i);
+    list.emplace_back(
+        StringUtils::Format(g_localizeStrings.Get(13553), static_cast<double>(i) / 10.0), i);
 }
 
 void CDisplaySettings::SettingOptionsRefreshRatesFiller(const SettingConstPtr& setting,
@@ -799,7 +800,7 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const SettingConstPtr& se
     for (std::vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); ++resolution)
     {
       list.emplace_back(StringUtils::Format("{}x{}{}", resolution->width, resolution->height,
-                                            ModeFlagsToString(resolution->flags, false).c_str()),
+                                            ModeFlagsToString(resolution->flags, false)),
                         resolution->ResInfo_Index);
 
       resolutionInfos.insert(std::make_pair((RESOLUTION)resolution->ResInfo_Index, CDisplaySettings::GetInstance().GetResolutionInfo(resolution->ResInfo_Index)));

--- a/xbmc/settings/SettingUtils.cpp
+++ b/xbmc/settings/SettingUtils.cpp
@@ -77,8 +77,8 @@ bool CSettingUtils::ValuesToList(const std::shared_ptr<const CSettingList>& sett
   bool ret = true;
   for (const auto& value : values)
   {
-    SettingPtr settingValue = setting->GetDefinition()->Clone(
-        StringUtils::Format("{}.{}", setting->GetId().c_str(), index++));
+    SettingPtr settingValue =
+        setting->GetDefinition()->Clone(StringUtils::Format("{}.{}", setting->GetId(), index++));
     if (settingValue == NULL)
       return false;
 

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -656,8 +656,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
     std::string indentation;
     for (int index = 1; index < parentLevels; index++)
       indentation.append("  ");
-    label =
-        StringUtils::Format(g_localizeStrings.Get(168).c_str(), indentation.c_str(), label.c_str());
+    label = StringUtils::Format(g_localizeStrings.Get(168), indentation, label);
   }
 
   // create the proper controls

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -155,9 +155,9 @@ static bool GetIntegerOptions(const SettingConstPtr& setting,
         if (i == pSettingInt->GetMinimum() && control->GetMinimumLabel() > -1)
           strLabel = Localize(control->GetMinimumLabel(), localizer);
         else if (control->GetFormatLabel() > -1)
-          strLabel = StringUtils::Format(Localize(control->GetFormatLabel(), localizer).c_str(), i);
+          strLabel = StringUtils::Format(Localize(control->GetFormatLabel(), localizer), i);
         else
-          strLabel = StringUtils::Format(control->GetFormatString().c_str(), i);
+          strLabel = StringUtils::Format(control->GetFormatString(), i);
 
         options.push_back(IntegerSettingOption(strLabel, i));
       }
@@ -410,9 +410,9 @@ CGUIControlSpinExSetting::CGUIControlSpinExSetting(CGUISpinControlEx* pSpin,
         if (value == pSettingNumber->GetMinimum() && control->GetMinimumLabel() > -1)
           strLabel = Localize(control->GetMinimumLabel());
         else if (control->GetFormatLabel() > -1)
-          strLabel = StringUtils::Format(Localize(control->GetFormatLabel()).c_str(), value);
+          strLabel = StringUtils::Format(Localize(control->GetFormatLabel()), value);
         else
-          strLabel = StringUtils::Format(control->GetFormatString().c_str(), value);
+          strLabel = StringUtils::Format(control->GetFormatString(), value);
 
         m_pSpin->AddLabel(strLabel, index);
       }
@@ -1470,10 +1470,9 @@ bool CGUIControlSliderSetting::FormatText(const std::string& formatString,
   try
   {
     if (value.isDouble())
-      formattedText = StringUtils::Format(formatString.c_str(), value.asDouble());
+      formattedText = StringUtils::Format(formatString, value.asDouble());
     else
-      formattedText =
-          StringUtils::Format(formatString.c_str(), static_cast<int>(value.asInteger()));
+      formattedText = StringUtils::Format(formatString, static_cast<int>(value.asInteger()));
   }
   catch (const std::runtime_error& err)
   {
@@ -1645,13 +1644,12 @@ void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
       }
       else
       {
-        strTextLower = StringUtils::Format(valueFormat.c_str(), valueLower);
+        strTextLower = StringUtils::Format(valueFormat, valueLower);
         strTextUpper = StringUtils::Format(valueFormat.c_str(), valueUpper);
       }
 
       if (valueLower != valueUpper)
-        strText =
-            StringUtils::Format(formatString.c_str(), strTextLower.c_str(), strTextUpper.c_str());
+        strText = StringUtils::Format(formatString, strTextLower, strTextUpper);
       else
         strText = strTextLower;
       break;
@@ -1675,12 +1673,11 @@ void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
         m_pSlider->SetFloatValue((float)valueUpper, CGUISliderControl::RangeSelectorUpper);
       }
 
-      strTextLower = StringUtils::Format(valueFormat.c_str(), valueLower);
+      strTextLower = StringUtils::Format(valueFormat, valueLower);
       if (valueLower != valueUpper)
       {
-        strTextUpper = StringUtils::Format(valueFormat.c_str(), valueUpper);
-        strText =
-            StringUtils::Format(formatString.c_str(), strTextLower.c_str(), strTextUpper.c_str());
+        strTextUpper = StringUtils::Format(valueFormat, valueUpper);
+        strText = StringUtils::Format(formatString, strTextLower, strTextUpper);
       }
       else
         strText = strTextLower;

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -64,7 +64,9 @@ bool CGUIWindowSettingsScreenCalibration::OnAction(const CAction &action)
     {
       CGUIDialogYesNo* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
       pDialog->SetHeading(CVariant{20325});
-      std::string strText = StringUtils::Format(g_localizeStrings.Get(20326).c_str(), CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(m_Res[m_iCurRes]).strMode.c_str());
+      std::string strText = StringUtils::Format(
+          g_localizeStrings.Get(20326),
+          CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(m_Res[m_iCurRes]).strMode);
       pDialog->SetLine(0, CVariant{std::move(strText)});
       pDialog->SetLine(1, CVariant{20327});
       pDialog->SetChoice(0, CVariant{222});
@@ -318,8 +320,7 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
       // recenter our control...
       pControl->SetPosition((info.iWidth - pControl->GetWidth()) / 2,
                             (info.iHeight - pControl->GetHeight()) / 2);
-      strStatus =
-          StringUtils::Format("{} ({:5.3f})", g_localizeStrings.Get(275).c_str(), info.fPixelRatio);
+      strStatus = StringUtils::Format("{} ({:5.3f})", g_localizeStrings.Get(275), info.fPixelRatio);
       SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 278);
     }
   }
@@ -334,7 +335,7 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
         {
           info.Overscan.left = pControl->GetXLocation();
           info.Overscan.top = pControl->GetYLocation();
-          strStatus = StringUtils::Format("{} ({},{})", g_localizeStrings.Get(272).c_str(),
+          strStatus = StringUtils::Format("{} ({},{})", g_localizeStrings.Get(272),
                                           pControl->GetXLocation(), pControl->GetYLocation());
           SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 276);
         }
@@ -346,8 +347,7 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
           info.Overscan.bottom = pControl->GetYLocation();
           int iXOff1 = info.iWidth - pControl->GetXLocation();
           int iYOff1 = info.iHeight - pControl->GetYLocation();
-          strStatus =
-              StringUtils::Format("{} ({},{})", g_localizeStrings.Get(273).c_str(), iXOff1, iYOff1);
+          strStatus = StringUtils::Format("{} ({},{})", g_localizeStrings.Get(273), iXOff1, iYOff1);
           SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 276);
         }
         break;
@@ -355,8 +355,8 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
       case CONTROL_SUBTITLES:
         {
           info.iSubtitles = pControl->GetYLocation();
-          strStatus = StringUtils::Format("{} ({})", g_localizeStrings.Get(274).c_str(),
-                                          pControl->GetYLocation());
+          strStatus =
+              StringUtils::Format("{} ({})", g_localizeStrings.Get(274), pControl->GetYLocation());
           SET_CONTROL_LABEL(CONTROL_LABEL_ROW2, 277);
         }
         break;
@@ -370,11 +370,10 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
   std::string strText;
   if (CServiceBroker::GetWinSystem()->IsFullScreen())
     strText = StringUtils::Format("{}x{}@{:.2f} - {} | {}", info.iScreenWidth, info.iScreenHeight,
-                                  info.fRefreshRate, g_localizeStrings.Get(244).c_str(),
-                                  strStatus.c_str());
+                                  info.fRefreshRate, g_localizeStrings.Get(244), strStatus);
   else
     strText = StringUtils::Format("{}x{} - {} | {}", info.iScreenWidth, info.iScreenHeight,
-                                  g_localizeStrings.Get(242).c_str(), strStatus.c_str());
+                                  g_localizeStrings.Get(242), strStatus);
 
   SET_CONTROL_LABEL(CONTROL_LABEL_ROW1, strText);
 }

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -47,7 +47,7 @@ bool CAutorunMediaJob::DoWork()
   if (selection >= 0)
   {
     std::string strAction =
-        StringUtils::Format("ActivateWindow({}, {})", GetWindowString(selection), m_path.c_str());
+        StringUtils::Format("ActivateWindow({}, {})", GetWindowString(selection), m_path);
     CBuiltins::GetInstance().Execute(strAction);
   }
 

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -196,7 +196,7 @@ void CMediaManager::GetNetworkLocations(VECSOURCES &locations, bool autolocation
     {
       const std::string& strDevices = g_localizeStrings.Get(33040); //"% Devices"
       share.strPath = "upnp://";
-      share.strName = StringUtils::Format(strDevices.c_str(), "UPnP"); //"UPnP Devices"
+      share.strName = StringUtils::Format(strDevices, "UPnP"); //"UPnP Devices"
       locations.push_back(share);
     }
 #endif
@@ -559,8 +559,7 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
     return "";
   }
 
-  std::string strID =
-      StringUtils::Format("removable://{}_{}", info.name.c_str(), info.serial.c_str());
+  std::string strID = StringUtils::Format("removable://{}_{}", info.name, info.serial);
   CLog::Log(LOGDEBUG, "GetDiskUniqueId: Got ID %s for %s with path %s", strID.c_str(), info.type.c_str(), CURL::GetRedacted(mediaPath).c_str());
 
   return strID;

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -68,8 +68,8 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
   KODI::TIME::SystemTime stLocalTime;
   KODI::TIME::GetLocalTime(&stLocalTime);
 
-  dumpFileName = StringUtils::Format("kodi_crashlog-%s-%04d%02d%02d-%02d%02d%02d.dmp", mVersion,
-                                     stLocalTime.year, stLocalTime.month, stLocalTime.day,
+  dumpFileName = StringUtils::Format("kodi_crashlog-{}-{:04}{:02}{:02}-{:02}{:02}{:02}.dmp",
+                                     mVersion, stLocalTime.year, stLocalTime.month, stLocalTime.day,
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
@@ -167,8 +167,8 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
      pSFTA == NULL || pSGMB == NULL)
     goto cleanup;
 
-  dumpFileName = StringUtils::Format("kodi_stacktrace-%s-%04d%02d%02d-%02d%02d%02d.txt", mVersion,
-                                     stLocalTime.year, stLocalTime.month, stLocalTime.day,
+  dumpFileName = StringUtils::Format("kodi_stacktrace-{}-{:04}{:02}{:02}-{:02}{:02}{:02}.txt",
+                                     mVersion, stLocalTime.year, stLocalTime.month, stLocalTime.day,
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -68,9 +68,9 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
   KODI::TIME::SystemTime stLocalTime;
   KODI::TIME::GetLocalTime(&stLocalTime);
 
-  dumpFileName = StringUtils::Format(
-      "kodi_crashlog-%s-%04d%02d%02d-%02d%02d%02d.dmp", mVersion.c_str(), stLocalTime.year,
-      stLocalTime.month, stLocalTime.day, stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
+  dumpFileName = StringUtils::Format("kodi_crashlog-%s-%04d%02d%02d-%02d%02d%02d.dmp", mVersion,
+                                     stLocalTime.year, stLocalTime.month, stLocalTime.day,
+                                     stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
 
@@ -167,9 +167,9 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
      pSFTA == NULL || pSGMB == NULL)
     goto cleanup;
 
-  dumpFileName = StringUtils::Format(
-      "kodi_stacktrace-%s-%04d%02d%02d-%02d%02d%02d.txt", mVersion.c_str(), stLocalTime.year,
-      stLocalTime.month, stLocalTime.day, stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
+  dumpFileName = StringUtils::Format("kodi_stacktrace-%s-%04d%02d%02d-%02d%02d%02d.txt", mVersion,
+                                     stLocalTime.year, stLocalTime.month, stLocalTime.day,
+                                     stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
 

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -58,8 +58,10 @@ void CAlarmClock::Start(const std::string& strName, float n_secs, const std::str
     labelStarted = 13210;
   }
 
-  EventPtr alarmClockActivity(new CNotificationEvent(labelAlarmClock,
-    StringUtils::Format(g_localizeStrings.Get(labelStarted).c_str(), static_cast<int>(event.m_fSecs) / 60, static_cast<int>(event.m_fSecs) % 60)));
+  EventPtr alarmClockActivity(new CNotificationEvent(
+      labelAlarmClock,
+      StringUtils::Format(g_localizeStrings.Get(labelStarted), static_cast<int>(event.m_fSecs) / 60,
+                          static_cast<int>(event.m_fSecs) % 60)));
   if (bSilent)
     CServiceBroker::GetEventLog().Add(alarmClockActivity);
   else
@@ -99,7 +101,8 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
   else
   {
     float remaining = static_cast<float>(iter->second.m_fSecs) - elapsed;
-    strMessage = StringUtils::Format(g_localizeStrings.Get(13212).c_str(), static_cast<int>(remaining) / 60, static_cast<int>(remaining) % 60);
+    strMessage = StringUtils::Format(g_localizeStrings.Get(13212), static_cast<int>(remaining) / 60,
+                                     static_cast<int>(remaining) % 60);
   }
 
   if (iter->second.m_strCommand.empty() || static_cast<float>(iter->second.m_fSecs) > elapsed)

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -371,7 +371,7 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool
     // we only need to print the hex value if it's an actual EGL define
     CLog::Log(LOGDEBUG, "  {}: {}", eglAttribute.second,
               (value >= 0x3000 && value <= 0x3200) ? StringUtils::Format("{:#04x}", value)
-                                                   : StringUtils::Format("{}", value));
+                                                   : std::to_string(value));
   }
 
   return true;

--- a/xbmc/utils/Fanart.cpp
+++ b/xbmc/utils/Fanart.cpp
@@ -163,9 +163,8 @@ bool CFanart::ParseColors(const std::string &colorsIn, std::string &colorsOut)
       { // convert
         if (colorsOut.size())
           colorsOut += ",";
-        colorsOut +=
-            StringUtils::Format("FF{:2x}{:2x}{:2x}", atol(strTriplets[0].c_str()),
-                                atol(strTriplets[1].c_str()), atol(strTriplets[2].c_str()));
+        colorsOut += StringUtils::Format("FF{:2x}{:2x}{:2x}", std::stol(strTriplets[0]),
+                                         std::stol(strTriplets[1]), std::stol(strTriplets[2]));
       }
     }
   }

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -321,8 +321,8 @@ bool CFileOperationJob::CFileOperation::OnFileCallback(void* pContext, int iperc
     data->base->m_avgSpeed = StringUtils::Format("{:.1f} KB/s", avgSpeed / 1000.0f);
 
   std::string line;
-  line = StringUtils::Format("{} ({})", data->base->GetCurrentFile().c_str(),
-                             data->base->GetAverageSpeed().c_str());
+  line =
+      StringUtils::Format("{} ({})", data->base->GetCurrentFile(), data->base->GetAverageSpeed());
   data->base->SetText(line);
   return !data->base->ShouldCancel((unsigned)current, 100);
 }

--- a/xbmc/utils/HTMLUtil.cpp
+++ b/xbmc/utils/HTMLUtil.cpp
@@ -218,9 +218,9 @@ void CHTMLUtil::ConvertHTMLToW(const std::wstring& strHTML, std::wstring& strStr
     num = strStripped.substr(i, iPos-i);
     wchar_t val = (wchar_t)wcstol(num.c_str(),NULL,base);
     if (base == 10)
-      num = StringUtils::Format(L"&#{};", num.c_str());
+      num = StringUtils::Format(L"&#{};", num);
     else
-      num = StringUtils::Format(L"&#x{};", num.c_str());
+      num = StringUtils::Format(L"&#x{};", num);
 
     StringUtils::Replace(strStripped, num,std::wstring(1,val));
     iPos = strStripped.find(L"&#", iStart);

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -204,7 +204,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       if (movie->m_firstAired.IsValid())
         value = movie->m_firstAired.GetAsLocalizedDate();
       else if (movie->HasYear())
-        value = StringUtils::Format("{}", movie->GetYear());
+        value = std::to_string(movie->GetYear());
     }
     break;
   case 'F': // filename
@@ -250,10 +250,10 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = StringUtils::Format("{:.1f}", movie->GetRating().rating);
     break;
   case 'C': // programs count
-    value = StringUtils::Format("{}", item->m_iprogramCount);
+    value = std::to_string(item->m_iprogramCount);
     break;
   case 'c': // relevance
-    value = StringUtils::Format("{}", movie->m_relevance);
+    value = std::to_string(movie->m_relevance);
     break;
   case 'K':
     value = item->m_strTitle;
@@ -299,9 +299,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'V': // Playcount
     if (music)
-      value = StringUtils::Format("{}", music->GetPlayCount());
+      value = std::to_string(music->GetPlayCount());
     if (movie)
-      value = StringUtils::Format("{}", movie->GetPlayCount());
+      value = std::to_string(movie->GetPlayCount());
     break;
   case 'X': // Bitrate
     if( !item->m_bIsFolder && item->m_dwSize != 0 )
@@ -321,7 +321,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'b': // Total number of discs
     if (music)
-      value = StringUtils::Format("{}", music->GetTotalDiscs());
+      value = std::to_string(music->GetTotalDiscs());
     break;
   case 'e': // Original release date
     if (music)
@@ -343,9 +343,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'r': // userrating
     if (movie && movie->m_iUserRating != 0)
-      value = StringUtils::Format("{}", movie->m_iUserRating);
+      value = std::to_string(movie->m_iUserRating);
     if (music && music->GetUserrating() != 0)
-      value = StringUtils::Format("{}", music->GetUserrating());
+      value = std::to_string(music->GetUserrating());
     break;
   case 't': // Date Taken
     if (pic && pic->GetDateTimeTaken().IsValid())
@@ -369,7 +369,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'f': // BPM
     if (music)
-      value = StringUtils::Format("{}", music->GetBPM());
+      value = std::to_string(music->GetBPM());
     break;
   }
   if (!value.empty())

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -260,9 +260,8 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'M':
     if (movie && movie->m_iEpisode > 0)
-      value = StringUtils::Format(
-          "{} {}", movie->m_iEpisode,
-          g_localizeStrings.Get(movie->m_iEpisode == 1 ? 20452 : 20453).c_str());
+      value = StringUtils::Format("{} {}", movie->m_iEpisode,
+                                  g_localizeStrings.Get(movie->m_iEpisode == 1 ? 20452 : 20453));
     break;
   case 'E':
     if (movie && movie->m_iEpisode > 0)
@@ -310,9 +309,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
    case 'W': // Listeners
     if( !item->m_bIsFolder && music && music->GetListeners() != 0 )
-      value = StringUtils::Format(
-          "{} {}", music->GetListeners(),
-          g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455).c_str());
+      value =
+          StringUtils::Format("{} {}", music->GetListeners(),
+                              g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455));
     break;
   case 'a': // Date Added
     if (movie && movie->m_dateAdded.IsValid())

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -59,7 +59,7 @@ bool CRecentlyAddedJob::UpdateVideo()
     for (; i < items.Size(); ++i)
     {
       auto item = items.Get(i);
-      std::string value = StringUtils::Format("{}", i + 1);
+      std::string value = std::to_string(i + 1);
       std::string strRating =
           StringUtils::Format("{:.1f}", item->GetVideoInfoTag()->GetRating().rating);
 
@@ -81,7 +81,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("{}", i + 1);
+    std::string value = std::to_string(i + 1);
     home->SetProperty("LatestMovie." + value + ".Title"       , "");
     home->SetProperty("LatestMovie." + value + ".Thumb"       , "");
     home->SetProperty("LatestMovie." + value + ".Rating"      , "");
@@ -105,7 +105,7 @@ bool CRecentlyAddedJob::UpdateVideo()
       int          EpisodeSeason = item->GetVideoInfoTag()->m_iSeason;
       int          EpisodeNumber = item->GetVideoInfoTag()->m_iEpisode;
       std::string EpisodeNo = StringUtils::Format("s{:02}e{:02}", EpisodeSeason, EpisodeNumber);
-      std::string value = StringUtils::Format("{}", i + 1);
+      std::string value = std::to_string(i + 1);
       std::string strRating =
           StringUtils::Format("{:.1f}", item->GetVideoInfoTag()->GetRating().rating);
 
@@ -133,7 +133,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("{}", i + 1);
+    std::string value = std::to_string(i + 1);
     home->SetProperty("LatestEpisode." + value + ".ShowTitle"     , "");
     home->SetProperty("LatestEpisode." + value + ".EpisodeTitle"  , "");
     home->SetProperty("LatestEpisode." + value + ".Rating"        , "");
@@ -162,7 +162,7 @@ bool CRecentlyAddedJob::UpdateVideo()
     for (; i < MusicVideoItems.Size(); ++i)
     {
       auto item = MusicVideoItems.Get(i);
-      std::string value = StringUtils::Format("{}", i + 1);
+      std::string value = std::to_string(i + 1);
 
       home->SetProperty("LatestMusicVideo." + value + ".Title"       , item->GetLabel());
       home->SetProperty("LatestMusicVideo." + value + ".Year"        , item->GetVideoInfoTag()->GetYear());
@@ -180,7 +180,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("{}", i + 1);
+    std::string value = std::to_string(i + 1);
     home->SetProperty("LatestMusicVideo." + value + ".Title"       , "");
     home->SetProperty("LatestMusicVideo." + value + ".Thumb"       , "");
     home->SetProperty("LatestMusicVideo." + value + ".Year"        , "");
@@ -220,7 +220,7 @@ bool CRecentlyAddedJob::UpdateMusic()
     for (; i < musicItems.Size(); ++i)
     {
       auto item = musicItems.Get(i);
-      std::string value = StringUtils::Format("{}", i + 1);
+      std::string value = std::to_string(i + 1);
 
       std::string   strRating;
       std::string   strAlbum  = item->GetMusicInfoTag()->GetAlbum();
@@ -239,7 +239,7 @@ bool CRecentlyAddedJob::UpdateMusic()
         }
       }
 
-      strRating = StringUtils::Format("{}", item->GetMusicInfoTag()->GetUserrating());
+      strRating = std::to_string(item->GetMusicInfoTag()->GetUserrating());
 
       home->SetProperty("LatestSong." + value + ".Title"   , item->GetMusicInfoTag()->GetTitle());
       home->SetProperty("LatestSong." + value + ".Year"    , item->GetMusicInfoTag()->GetYear());
@@ -253,7 +253,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("{}", i + 1);
+    std::string value = std::to_string(i + 1);
     home->SetProperty("LatestSong." + value + ".Title"   , "");
     home->SetProperty("LatestSong." + value + ".Year"    , "");
     home->SetProperty("LatestSong." + value + ".Artist"  , "");
@@ -273,7 +273,7 @@ bool CRecentlyAddedJob::UpdateMusic()
     for (; j < albums.size(); ++j)
     {
       auto& album=albums[j];
-      std::string value = StringUtils::Format("{}", j + 1);
+      std::string value = std::to_string(j + 1);
       std::string strThumb;
       std::string strFanart;
       bool artfound = false;
@@ -305,7 +305,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   }
   for (; i < NUM_ITEMS; ++i)
   {
-    std::string value = StringUtils::Format("{}", i + 1);
+    std::string value = std::to_string(i + 1);
     home->SetProperty("LatestAlbum." + value + ".Title"   , "");
     home->SetProperty("LatestAlbum." + value + ".Year"    , "");
     home->SetProperty("LatestAlbum." + value + ".Artist"  , "");

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -548,7 +548,7 @@ void CScraperParser::ConvertJSON(std::string &string)
     int pos = reg.GetSubStart(1);
     std::string szReplace(reg.GetMatch(1));
 
-    std::string replace = StringUtils::Format("&#x{};", szReplace.c_str());
+    std::string replace = StringUtils::Format("&#x{};", szReplace);
     string.replace(string.begin()+pos-2, string.begin()+pos+4, replace);
   }
 
@@ -560,7 +560,7 @@ void CScraperParser::ConvertJSON(std::string &string)
     int pos2 = reg2.GetSubStart(2);
     std::string szHexValue(reg2.GetMatch(1));
 
-    std::string replace = StringUtils::Format("{}", strtol(szHexValue.c_str(), NULL, 16));
+    std::string replace = StringUtils::Format("{}", std::stol(szHexValue, NULL, 16));
     string.replace(string.begin()+pos1-2, string.begin()+pos2+reg2.GetSubLength(2), replace);
   }
 

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -560,7 +560,7 @@ void CScraperParser::ConvertJSON(std::string &string)
     int pos2 = reg2.GetSubStart(2);
     std::string szHexValue(reg2.GetMatch(1));
 
-    std::string replace = StringUtils::Format("{}", std::stol(szHexValue, NULL, 16));
+    std::string replace = std::to_string(std::stol(szHexValue, NULL, 16));
     string.replace(string.begin()+pos1-2, string.begin()+pos2+reg2.GetSubLength(2), replace);
   }
 

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -260,7 +260,7 @@ void CScraperUrl::AddParsedUrl(const std::string& url,
     thumb.SetAttribute("gzip", "yes");
   if (season >= 0)
   {
-    thumb.SetAttribute("season", StringUtils::Format("{}", season));
+    thumb.SetAttribute("season", std::to_string(season));
     thumb.SetAttribute("type", "season");
   }
   thumb.SetAttribute("aspect", aspect);

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -94,7 +94,7 @@ std::string ByDateAdded(SortAttribute attributes, const SortItem &values)
 
 std::string BySize(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{}", values.at(FieldSize).asInteger());
+  return std::to_string(values.at(FieldSize).asInteger());
 }
 
 std::string ByDriveType(SortAttribute attributes, const SortItem &values)
@@ -184,7 +184,7 @@ std::string ByArtistThenYear(SortAttribute attributes, const SortItem &values)
 
 std::string ByTrackNumber(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{}", (int)values.at(FieldTrackNumber).asInteger());
+  return std::to_string((int)values.at(FieldTrackNumber).asInteger());
 }
 
 std::string ByTotalDiscs(SortAttribute attributes, const SortItem& values)
@@ -197,15 +197,15 @@ std::string ByTime(SortAttribute attributes, const SortItem &values)
   std::string label;
   const CVariant &time = values.at(FieldTime);
   if (time.isInteger())
-    label = StringUtils::Format("{}", (int)time.asInteger());
+    label = std::to_string((int)time.asInteger());
   else
-    label = StringUtils::Format("{}", time.asString());
+    label = time.asString();
   return label;
 }
 
 std::string ByProgramCount(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{}", (int)values.at(FieldProgramCount).asInteger());
+  return std::to_string((int)values.at(FieldProgramCount).asInteger());
 }
 
 std::string ByPlaylistOrder(SortAttribute attributes, const SortItem &values)
@@ -231,7 +231,7 @@ std::string ByYear(SortAttribute attributes, const SortItem &values)
   if (!airDate.isNull() && !airDate.asString().empty())
     label = airDate.asString() + " ";
 
-  label += StringUtils::Format("{}", (int)values.at(FieldYear).asInteger());
+  label += std::to_string((int)values.at(FieldYear).asInteger());
 
   const CVariant &album = values.at(FieldAlbum);
   if (!album.isNull())
@@ -419,17 +419,17 @@ std::string BySubtitleLanguage(SortAttribute attributes, const SortItem &values)
 
 std::string ByBitrate(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{}", values.at(FieldBitrate).asInteger());
+  return std::to_string(values.at(FieldBitrate).asInteger());
 }
 
 std::string ByListeners(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{}", values.at(FieldListeners).asInteger());
+  return std::to_string(values.at(FieldListeners).asInteger());
 }
 
 std::string ByRandom(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{}", CUtil::GetRandomNumber());
+  return std::to_string(CUtil::GetRandomNumber());
 }
 
 std::string ByChannel(SortAttribute attributes, const SortItem &values)
@@ -454,7 +454,7 @@ std::string ByDateTaken(SortAttribute attributes, const SortItem &values)
 
 std::string ByRelevance(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{}", (int)values.at(FieldRelevance).asInteger());
+  return std::to_string((int)values.at(FieldRelevance).asInteger());
 }
 
 std::string ByInstallDate(SortAttribute attributes, const SortItem &values)

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -56,13 +56,13 @@ std::string ByFile(SortAttribute attributes, const SortItem &values)
 {
   CURL url(values.at(FieldPath).asString());
 
-  return StringUtils::Format("{} {}", url.GetFileNameWithoutPath().c_str(),
+  return StringUtils::Format("{} {}", url.GetFileNameWithoutPath(),
                              values.at(FieldStartOffset).asInteger());
 }
 
 std::string ByPath(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{} {}", values.at(FieldPath).asString().c_str(),
+  return StringUtils::Format("{} {}", values.at(FieldPath).asString(),
                              values.at(FieldStartOffset).asInteger());
 }
 
@@ -71,14 +71,14 @@ std::string ByLastPlayed(SortAttribute attributes, const SortItem &values)
   if (attributes & SortAttributeIgnoreLabel)
     return values.at(FieldLastPlayed).asString();
 
-  return StringUtils::Format("{} {}", values.at(FieldLastPlayed).asString().c_str(),
-                             ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldLastPlayed).asString(),
+                             ByLabel(attributes, values));
 }
 
 std::string ByPlaycount(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldPlaycount).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByDate(SortAttribute attributes, const SortItem &values)
@@ -88,7 +88,7 @@ std::string ByDate(SortAttribute attributes, const SortItem &values)
 
 std::string ByDateAdded(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{} {}", values.at(FieldDateAdded).asString().c_str(),
+  return StringUtils::Format("{} {}", values.at(FieldDateAdded).asString(),
                              (int)values.at(FieldId).asInteger());
 }
 
@@ -100,7 +100,7 @@ std::string BySize(SortAttribute attributes, const SortItem &values)
 std::string ByDriveType(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldDriveType).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByTitle(SortAttribute attributes, const SortItem &values)
@@ -117,8 +117,8 @@ std::string ByAlbum(SortAttribute attributes, const SortItem &values)
   if (attributes & SortAttributeIgnoreArticle)
     album = SortUtils::RemoveArticles(album);
 
-  std::string label = StringUtils::Format(
-      "{} {}", album.c_str(), ArrayToString(attributes, values.at(FieldArtist)).c_str());
+  std::string label =
+      StringUtils::Format("{} {}", album, ArrayToString(attributes, values.at(FieldArtist)));
 
   const CVariant &track = values.at(FieldTrackNumber);
   if (!track.isNull())
@@ -199,7 +199,7 @@ std::string ByTime(SortAttribute attributes, const SortItem &values)
   if (time.isInteger())
     label = StringUtils::Format("{}", (int)time.asInteger());
   else
-    label = StringUtils::Format("{}", time.asString().c_str());
+    label = StringUtils::Format("{}", time.asString());
   return label;
 }
 
@@ -279,25 +279,25 @@ std::string BySortTitle(SortAttribute attributes, const SortItem &values)
 std::string ByRating(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{:f} {}", values.at(FieldRating).asFloat(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByUserRating(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", static_cast<int>(values.at(FieldUserRating).asInteger()),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByVotes(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldVotes).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByTop250(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldTop250).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByMPAA(SortAttribute attributes, const SortItem &values)
@@ -335,7 +335,7 @@ std::string ByEpisodeNumber(SortAttribute attributes, const SortItem &values)
   if (title.empty())
     title = ByLabel(attributes, values);
 
-  return StringUtils::Format("{} {}", num, title.c_str());
+  return StringUtils::Format("{} {}", num, title);
 }
 
 std::string BySeason(SortAttribute attributes, const SortItem &values)
@@ -345,19 +345,19 @@ std::string BySeason(SortAttribute attributes, const SortItem &values)
   if (!specialSeason.isNull())
     season = (int)specialSeason.asInteger();
 
-  return StringUtils::Format("{} {}", season, ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", season, ByLabel(attributes, values));
 }
 
 std::string ByNumberOfEpisodes(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldNumberOfEpisodes).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByNumberOfWatchedEpisodes(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldNumberOfWatchedEpisodes).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByTvShowStatus(SortAttribute attributes, const SortItem &values)
@@ -378,43 +378,43 @@ std::string ByProductionCode(SortAttribute attributes, const SortItem &values)
 std::string ByVideoResolution(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldVideoResolution).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByVideoCodec(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{} {}", values.at(FieldVideoCodec).asString().c_str(),
-                             ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldVideoCodec).asString(),
+                             ByLabel(attributes, values));
 }
 
 std::string ByVideoAspectRatio(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{:.3f} {}", values.at(FieldVideoAspectRatio).asFloat(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByAudioChannels(SortAttribute attributes, const SortItem &values)
 {
   return StringUtils::Format("{} {}", (int)values.at(FieldAudioChannels).asInteger(),
-                             ByLabel(attributes, values).c_str());
+                             ByLabel(attributes, values));
 }
 
 std::string ByAudioCodec(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{} {}", values.at(FieldAudioCodec).asString().c_str(),
-                             ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldAudioCodec).asString(),
+                             ByLabel(attributes, values));
 }
 
 std::string ByAudioLanguage(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{} {}", values.at(FieldAudioLanguage).asString().c_str(),
-                             ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldAudioLanguage).asString(),
+                             ByLabel(attributes, values));
 }
 
 std::string BySubtitleLanguage(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("{} {}", values.at(FieldSubtitleLanguage).asString().c_str(),
-                             ByLabel(attributes, values).c_str());
+  return StringUtils::Format("{} {}", values.at(FieldSubtitleLanguage).asString(),
+                             ByLabel(attributes, values));
 }
 
 std::string ByBitrate(SortAttribute attributes, const SortItem &values)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1393,13 +1393,13 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
 
   std::string strHMS;
   if (format == TIME_FORMAT_SECS)
-    strHMS = StringUtils::Format("{}", lSeconds);
+    strHMS = std::to_string(lSeconds);
   else if (format == TIME_FORMAT_MINS)
-    strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(lSeconds) / 60.0f));
+    strHMS = std::to_string(lrintf(static_cast<float>(lSeconds) / 60.0f));
   else if (format == TIME_FORMAT_HOURS)
-    strHMS = StringUtils::Format("{}", lrintf(static_cast<float>(lSeconds) / 3600.0f));
+    strHMS = std::to_string(lrintf(static_cast<float>(lSeconds) / 3600.0f));
   else if (format & TIME_FORMAT_M)
-    strHMS += StringUtils::Format("{}", lSeconds % 3600 / 60);
+    strHMS += std::to_string(lSeconds % 3600 / 60);
   else
   {
     int hh = lSeconds / 3600;
@@ -1412,7 +1412,7 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
     if (format & TIME_FORMAT_HH)
       strHMS += StringUtils::Format("{:02}", hh);
     else if (format & TIME_FORMAT_H)
-      strHMS += StringUtils::Format("{}", hh);
+      strHMS += std::to_string(hh);
     if (format & TIME_FORMAT_MM)
       strHMS += StringUtils::Format(strHMS.empty() ? "{:02}" : ":{:02}", mm);
     if (format & TIME_FORMAT_SS)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1792,7 +1792,7 @@ std::string StringUtils::FormatFileSize(uint64_t bytes)
 {
   const std::array<std::string, 6> units{{"B", "kB", "MB", "GB", "TB", "PB"}};
   if (bytes < 1000)
-    return Format("%" PRIu64 "B", bytes);
+    return Format("{}B", bytes);
 
   size_t i = 0;
   double value = static_cast<double>(bytes);

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -357,19 +357,18 @@ std::string CSysInfoJob::GetSystemUpTime(bool bTotalUptime)
   SystemUpTime(iInputMinutes,iMinutes, iHours, iDays);
   if (iDays > 0)
   {
-    strSystemUptime = StringUtils::Format(
-        "{} {}, {} {}, {} {}", iDays, g_localizeStrings.Get(12393).c_str(), iHours,
-        g_localizeStrings.Get(12392).c_str(), iMinutes, g_localizeStrings.Get(12391).c_str());
+    strSystemUptime =
+        StringUtils::Format("{} {}, {} {}, {} {}", iDays, g_localizeStrings.Get(12393), iHours,
+                            g_localizeStrings.Get(12392), iMinutes, g_localizeStrings.Get(12391));
   }
   else if (iDays == 0 && iHours >= 1 )
   {
-    strSystemUptime =
-        StringUtils::Format("{} {}, {} {}", iHours, g_localizeStrings.Get(12392).c_str(), iMinutes,
-                            g_localizeStrings.Get(12391).c_str());
+    strSystemUptime = StringUtils::Format("{} {}, {} {}", iHours, g_localizeStrings.Get(12392),
+                                          iMinutes, g_localizeStrings.Get(12391));
   }
   else if (iDays == 0 && iHours == 0 &&  iMinutes >= 0)
   {
-    strSystemUptime = StringUtils::Format("{} {}", iMinutes, g_localizeStrings.Get(12391).c_str());
+    strSystemUptime = StringUtils::Format("{} {}", iMinutes, g_localizeStrings.Get(12391));
   }
   return strSystemUptime;
 }
@@ -1041,19 +1040,19 @@ std::string CSysInfo::GetHddSpaceInfo(int& percent, int drive, bool shortText)
       switch(drive)
       {
       case SYSTEM_FREE_SPACE:
-        strRet = StringUtils::Format("{} MB {}", totalFree, g_localizeStrings.Get(160).c_str());
+        strRet = StringUtils::Format("{} MB {}", totalFree, g_localizeStrings.Get(160));
         break;
       case SYSTEM_USED_SPACE:
-        strRet = StringUtils::Format("{} MB {}", totalUsed, g_localizeStrings.Get(20162).c_str());
+        strRet = StringUtils::Format("{} MB {}", totalUsed, g_localizeStrings.Get(20162));
         break;
       case SYSTEM_TOTAL_SPACE:
-        strRet = StringUtils::Format("{} MB {}", total, g_localizeStrings.Get(20161).c_str());
+        strRet = StringUtils::Format("{} MB {}", total, g_localizeStrings.Get(20161));
         break;
       case SYSTEM_FREE_SPACE_PERCENT:
-        strRet = StringUtils::Format("{} % {}", percentFree, g_localizeStrings.Get(160).c_str());
+        strRet = StringUtils::Format("{} % {}", percentFree, g_localizeStrings.Get(160));
         break;
       case SYSTEM_USED_SPACE_PERCENT:
-        strRet = StringUtils::Format("{} % {}", percentused, g_localizeStrings.Get(20162).c_str());
+        strRet = StringUtils::Format("{} % {}", percentused, g_localizeStrings.Get(20162));
         break;
       }
     }
@@ -1222,7 +1221,7 @@ std::string CSysInfo::GetDeviceName()
   {
     std::string hostname("[unknown]");
     CServiceBroker::GetNetwork().GetHostName(hostname);
-    return StringUtils::Format("{} ({})", friendlyName.c_str(), hostname.c_str());
+    return StringUtils::Format("{} ({})", friendlyName, hostname);
   }
 
   return friendlyName;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -726,8 +726,8 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
 #elif defined(TARGET_FREEBSD) || defined(TARGET_DARWIN)
   osNameVer = GetOsName() + " " + GetOsVersion();
 #elif defined(TARGET_ANDROID)
-  osNameVer = GetOsName() + " " + GetOsVersion() + " API level " +
-              StringUtils::Format("{}", CJNIBuild::SDK_INT);
+  osNameVer =
+      GetOsName() + " " + GetOsVersion() + " API level " + std::to_string(CJNIBuild::SDK_INT);
 #elif defined(TARGET_LINUX)
   osNameVer = getValueFromOs_release("PRETTY_NAME");
   if (osNameVer.empty())
@@ -1205,7 +1205,7 @@ std::string CSysInfo::GetUserAgent()
   }
 #endif
 
-  result += " App_Bitness/" + StringUtils::Format("{}", GetXbmcBitness());
+  result += " App_Bitness/" + std::to_string(GetXbmcBitness());
 
   std::string fullVer(CSysInfo::GetVersion());
   StringUtils::Replace(fullVer, ' ', '-');

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -287,13 +287,13 @@ TiXmlNode* XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const s
 
 TiXmlNode* XMLUtils::SetInt(TiXmlNode* pRootNode, const char *strTag, int value)
 {
-  std::string strValue = StringUtils::Format("{}", value);
+  std::string strValue = std::to_string(value);
   return SetString(pRootNode, strTag, strValue);
 }
 
 void XMLUtils::SetLong(TiXmlNode* pRootNode, const char *strTag, long value)
 {
-  std::string strValue = StringUtils::Format("{}", value);
+  std::string strValue = std::to_string(value);
   SetString(pRootNode, strTag, strValue);
 }
 

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -71,7 +71,7 @@ bool CPlayerController::OnAction(const CAction &action)
           if (info.name.length() == 0)
             sub = lang;
           else
-            sub = StringUtils::Format("{} - {}", lang.c_str(), info.name.c_str());
+            sub = StringUtils::Format("{} - {}", lang, info.name);
         }
         else
           sub = g_localizeStrings.Get(1223);
@@ -118,7 +118,7 @@ bool CPlayerController::OnAction(const CAction &action)
           if (info.name.length() == 0)
             sub = lang;
           else
-            sub = StringUtils::Format("{} - {}", lang.c_str(), info.name.c_str());
+            sub = StringUtils::Format("{} - {}", lang, info.name);
         }
         else
           sub = g_localizeStrings.Get(1223);
@@ -218,7 +218,7 @@ bool CPlayerController::OnAction(const CAction &action)
         if (info.name.empty())
           aud = lan;
         else
-          aud = StringUtils::Format("{} - {}", lan.c_str(), info.name.c_str());
+          aud = StringUtils::Format("{} - {}", lan, info.name);
         std::string caption = g_localizeStrings.Get(460);
         caption += StringUtils::Format(" ({}/{})", currentAudio + 1, audioStreamCount);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, aud, DisplTime, false, MsgTime);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -951,7 +951,7 @@ int CVideoDatabase::AddFile(const std::string& strFileNameAndPath,
 
     std::string strPlaycount = "NULL";
     if (playcount > 0)
-      strPlaycount = StringUtils::Format("{}", playcount);
+      strPlaycount = std::to_string(playcount);
     std::string strLastPlayed = "NULL";
     if (lastPlayed.IsValid())
       strLastPlayed = "'" + lastPlayed.GetAsDBDateTime() + "'";
@@ -6571,7 +6571,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
       if (!isAlbum)
       {
         itemUrl.AddOption("albumid", idMVideo);
-        path += StringUtils::Format("{}", idMVideo);
+        path += std::to_string(idMVideo);
 
         strSQL = PrepareSQL(
             "SELECT type, url FROM art WHERE media_id = %i AND media_type = 'musicvideo'",
@@ -7040,7 +7040,7 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
           // check path
           if (g_passwordManager.IsDatabasePathUnlocked(m_pDS->fv("path.strPath").get_asString(),*CMediaSourceSettings::GetInstance().GetSources("video")))
           {
-            std::string year = StringUtils::Format("{}", lYear);
+            std::string year = std::to_string(lYear);
             if (idContent == VIDEODB_CONTENT_MOVIES || idContent == VIDEODB_CONTENT_MUSICVIDEOS)
               mapYears.insert(std::pair<int, std::pair<std::string,int> >(lYear, std::pair<std::string,int>(year,m_pDS->fv(2).get_asInt())));
             else
@@ -7083,7 +7083,7 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
           if (time.IsValid())
           {
             lYear = time.GetYear();
-            strLabel = StringUtils::Format("{}", lYear);
+            strLabel = std::to_string(lYear);
           }
         }
         if (lYear == 0)
@@ -7404,7 +7404,7 @@ std::string CVideoDatabase::GetItemById(const std::string &itemType, int id)
   if (StringUtils::EqualsNoCase(itemType, "genres"))
     return GetGenreById(id);
   else if (StringUtils::EqualsNoCase(itemType, "years"))
-    return StringUtils::Format("{}", id);
+    return std::to_string(id);
   else if (StringUtils::EqualsNoCase(itemType, "actors") ||
            StringUtils::EqualsNoCase(itemType, "directors") ||
            StringUtils::EqualsNoCase(itemType, "artists"))
@@ -7519,7 +7519,7 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
         CFileItemPtr pItem(new CFileItem(movie));
 
         CVideoDbUrl itemUrl = videoUrl;
-        std::string path = StringUtils::Format("{}", movie.m_iDbId);
+        std::string path = std::to_string(movie.m_iDbId);
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
         pItem->SetDynPath(movie.m_strFileNameAndPath);
@@ -7765,7 +7765,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
                                      record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_ID).get_asInt(),
                                      episode.m_iSeason, idEpisode);
         else
-          path = StringUtils::Format("{}", idEpisode);
+          path = std::to_string(idEpisode);
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
         pItem->SetDynPath(episode.m_strFileNameAndPath);
@@ -8532,7 +8532,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(0).get_asString()));
-      std::string strDir = StringUtils::Format("{}", m_pDS->fv(1).get_asInt());
+      std::string strDir = std::to_string(m_pDS->fv(1).get_asInt());
       pItem->SetPath("videodb://musicvideos/titles/"+ strDir);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
@@ -8667,7 +8667,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
         CFileItemPtr item(new CFileItem(musicvideo));
 
         CVideoDbUrl itemUrl = videoUrl;
-        std::string path = StringUtils::Format("{}", record->at(0).get_asInt());
+        std::string path = std::to_string(record->at(0).get_asInt());
         itemUrl.AppendPath(path);
         item->SetPath(itemUrl.ToString());
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8502,7 +8502,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
       return;
 
     strSQL = StringUtils::Format("SELECT DISTINCT"
-                                 "  musicvideo.c%02d,"
+                                 "  musicvideo.c{:02},"
                                  "  musicvideo.idMVideo,"
                                  "  path.strPath"
                                  " FROM"
@@ -8510,7 +8510,8 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
                                  " JOIN files ON"
                                  "  files.idFile=musicvideo.idFile"
                                  " JOIN path ON"
-                                 "  path.idPath=files.idPath", VIDEODB_ID_MUSICVIDEO_ALBUM);
+                                 "  path.idPath=files.idPath",
+                                 VIDEODB_ID_MUSICVIDEO_ALBUM);
     if (!strSearch.empty())
       strSQL += PrepareSQL(" WHERE musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_ALBUM, strSearch.c_str());
 
@@ -9483,18 +9484,21 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     }
 
     CLog::Log(LOGDEBUG, LOGDATABASE, "%s: Cleaning path table", __FUNCTION__);
-    sql = StringUtils::Format("DELETE FROM path "
-                                "WHERE (strContent IS NULL OR strContent = '') "
-                                  "AND (strSettings IS NULL OR strSettings = '') "
-                                  "AND (strHash IS NULL OR strHash = '') "
-                                  "AND (exclude IS NULL OR exclude != 1) "
-                                  "AND (idParentPath IS NULL OR NOT EXISTS (SELECT 1 FROM (SELECT idPath FROM path) as parentPath WHERE parentPath.idPath = path.idParentPath)) " // MySQL only fix (#5007)
-                                  "AND NOT EXISTS (SELECT 1 FROM files WHERE files.idPath = path.idPath) "
-                                  "AND NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idPath = path.idPath) "
-                                  "AND NOT EXISTS (SELECT 1 FROM movie WHERE movie.c%02d = path.idPath) "
-                                  "AND NOT EXISTS (SELECT 1 FROM episode WHERE episode.c%02d = path.idPath) "
-                                  "AND NOT EXISTS (SELECT 1 FROM musicvideo WHERE musicvideo.c%02d = path.idPath)"
-                , VIDEODB_ID_PARENTPATHID, VIDEODB_ID_EPISODE_PARENTPATHID, VIDEODB_ID_MUSICVIDEO_PARENTPATHID );
+    sql = StringUtils::Format(
+        "DELETE FROM path "
+        "WHERE (strContent IS NULL OR strContent = '') "
+        "AND (strSettings IS NULL OR strSettings = '') "
+        "AND (strHash IS NULL OR strHash = '') "
+        "AND (exclude IS NULL OR exclude != 1) "
+        "AND (idParentPath IS NULL OR NOT EXISTS (SELECT 1 FROM (SELECT idPath FROM path) as "
+        "parentPath WHERE parentPath.idPath = path.idParentPath)) " // MySQL only fix (#5007)
+        "AND NOT EXISTS (SELECT 1 FROM files WHERE files.idPath = path.idPath) "
+        "AND NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idPath = path.idPath) "
+        "AND NOT EXISTS (SELECT 1 FROM movie WHERE movie.c{:02} = path.idPath) "
+        "AND NOT EXISTS (SELECT 1 FROM episode WHERE episode.c{:02} = path.idPath) "
+        "AND NOT EXISTS (SELECT 1 FROM musicvideo WHERE musicvideo.c{:02} = path.idPath)",
+        VIDEODB_ID_PARENTPATHID, VIDEODB_ID_EPISODE_PARENTPATHID,
+        VIDEODB_ID_MUSICVIDEO_PARENTPATHID);
     m_pDS->exec(sql);
 
     CLog::Log(LOGDEBUG, LOGDATABASE, "%s: Cleaning genre table", __FUNCTION__);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2180,7 +2180,7 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason, CVideoInfoTag& details, bool al
       if (season == 0)
         name = g_localizeStrings.Get(20381);
       else
-        name = StringUtils::Format(g_localizeStrings.Get(20358).c_str(), season);
+        name = StringUtils::Format(g_localizeStrings.Get(20358), season);
     }
 
     details.m_strTitle = name;
@@ -6312,7 +6312,7 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir, CFileItemList& 
       extFilter.group.clear();
       extFilter.order.clear();
     }
-    strSQL = StringUtils::Format(strSQL.c_str(), !extFilter.fields.empty() ? extFilter.fields.c_str() : "*");
+    strSQL = StringUtils::Format(strSQL, !extFilter.fields.empty() ? extFilter.fields : "*");
 
     CVideoDbUrl videoUrl;
     if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
@@ -6518,7 +6518,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
       extFilter.group.clear();
       extFilter.order.clear();
     }
-    strSQL = StringUtils::Format(strSQL.c_str(), !extFilter.fields.empty() ? extFilter.fields.c_str() : "*");
+    strSQL = StringUtils::Format(strSQL, !extFilter.fields.empty() ? extFilter.fields : "*");
 
     if (!BuildSQL(videoUrl.ToString(), strSQL, extFilter, strSQL, videoUrl))
       return false;
@@ -6808,7 +6808,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir, CFileItemList& 
       extFilter.group.clear();
       extFilter.order.clear();
     }
-    strSQL = StringUtils::Format(strSQL.c_str(), !extFilter.fields.empty() ? extFilter.fields.c_str() : "*");
+    strSQL = StringUtils::Format(strSQL, !extFilter.fields.empty() ? extFilter.fields : "*");
 
     CVideoDbUrl videoUrl;
     if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
@@ -7222,7 +7222,7 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
           if (iSeason == 0)
             strLabel = g_localizeStrings.Get(20381);
           else
-            strLabel = StringUtils::Format(g_localizeStrings.Get(20358).c_str(), iSeason);
+            strLabel = StringUtils::Format(g_localizeStrings.Get(20358), iSeason);
         }
         CFileItemPtr pItem(new CFileItem(strLabel));
 
@@ -9574,7 +9574,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
   if (mediaType == MediaTypeMovie)
   {
     idField = "idMovie";
-    parentPathIdField = StringUtils::Format("{}.c{:02}", table.c_str(), VIDEODB_ID_PARENTPATHID);
+    parentPathIdField = StringUtils::Format("{}.c{:02}", table, VIDEODB_ID_PARENTPATHID);
   }
   else if (mediaType == MediaTypeEpisode)
   {
@@ -9585,8 +9585,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
   else if (mediaType == MediaTypeMusicVideo)
   {
     idField = "idMVideo";
-    parentPathIdField =
-        StringUtils::Format("{}.c{:02}", table.c_str(), VIDEODB_ID_MUSICVIDEO_PARENTPATHID);
+    parentPathIdField = StringUtils::Format("{}.c{:02}", table, VIDEODB_ID_MUSICVIDEO_PARENTPATHID);
   }
   else
     return cleanedIDs;
@@ -9650,7 +9649,8 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
             {
               CURL sourceUrl(sourcePath);
               pDialog->SetHeading(CVariant{15012});
-              pDialog->SetText(CVariant{StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str())});
+              pDialog->SetText(CVariant{StringUtils::Format(g_localizeStrings.Get(15013),
+                                                            sourceUrl.GetWithoutUserDetails())});
               pDialog->SetChoice(0, CVariant{15015});
               pDialog->SetChoice(1, CVariant{15014});
               pDialog->Open();
@@ -9706,8 +9706,8 @@ void CVideoDatabase::DumpToDummyFiles(const std::string &path)
       for (int i = 0; i < episodes.Size(); i++)
       {
         CVideoInfoTag *tag = episodes[i]->GetVideoInfoTag();
-        std::string episode = StringUtils::Format("{}.s{:02}e{:02}.avi", showName.c_str(),
-                                                  tag->m_iSeason, tag->m_iEpisode);
+        std::string episode =
+            StringUtils::Format("{}.s{:02}e{:02}.avi", showName, tag->m_iSeason, tag->m_iEpisode);
         // and make a file
         std::string episodePath = URIUtils::AddFileToFolder(TVFolder, episode);
         CFile file;
@@ -9724,7 +9724,7 @@ void CVideoDatabase::DumpToDummyFiles(const std::string &path)
   for (int i = 0; i < items.Size(); i++)
   {
     CVideoInfoTag *tag = items[i]->GetVideoInfoTag();
-    std::string movie = StringUtils::Format("{}.avi", tag->m_strTitle.c_str());
+    std::string movie = StringUtils::Format("{}.avi", tag->m_strTitle);
     CFile file;
     if (file.OpenForWrite(URIUtils::AddFileToFolder(moviePath, movie)))
       file.Close();
@@ -10292,7 +10292,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     progress->Close();
 
   if (iFailCount > 0)
-    HELPERS::ShowOKDialogText(CVariant{647}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
+    HELPERS::ShowOKDialogText(
+        CVariant{647}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011), iFailCount)});
 }
 
 void CVideoDatabase::ExportActorThumbs(const std::string &strDir, const CVideoInfoTag &tag, bool singleFiles, bool overwrite /*=false*/)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -281,7 +281,7 @@ namespace VIDEO
       if (m_handle)
       {
         int str = content == CONTENT_MOVIES ? 20317:20318;
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str).c_str(), info->Name().c_str()));
+        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str), info->Name()));
       }
 
       std::string fastHash;
@@ -329,7 +329,7 @@ namespace VIDEO
     else if (content == CONTENT_TVSHOWS)
     {
       if (m_handle)
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
+        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319), info->Name()));
 
       if (foundDirectly && !settings.parent_name_root)
       {
@@ -480,9 +480,10 @@ namespace VIDEO
         else if (info2->Content() == CONTENT_MUSICVIDEOS)
           mediaType = MediaTypeMusicVideo;
         CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
-          mediaType, pItem->GetPath(), 24145,
-          StringUtils::Format(g_localizeStrings.Get(24147).c_str(), mediaType.c_str(), URIUtils::GetFileName(pItem->GetPath()).c_str()),
-          pItem->GetArt("thumb"), CURL::GetRedacted(pItem->GetPath()), EventLevel::Warning)));
+            mediaType, pItem->GetPath(), 24145,
+            StringUtils::Format(g_localizeStrings.Get(24147), mediaType,
+                                URIUtils::GetFileName(pItem->GetPath())),
+            pItem->GetArt("thumb"), CURL::GetRedacted(pItem->GetPath()), EventLevel::Warning)));
       }
 
       pURL = NULL;
@@ -1315,9 +1316,8 @@ namespace VIDEO
 
     if (showInfo && content == CONTENT_TVSHOWS)
     {
-      strTitle =
-          StringUtils::Format("{} - {}x{} - {}", showInfo->m_strTitle.c_str(),
-                              movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle.c_str());
+      strTitle = StringUtils::Format("{} - {}x{} - {}", showInfo->m_strTitle,
+                                     movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle);
     }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", TranslateContent(content), CURL::GetRedacted(pItem->GetPath()));

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -818,7 +818,7 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
   {
     // seasons with a custom name/title need special handling as they should be sorted by season number
     if (m_type == MediaTypeSeason && !m_strSortTitle.empty())
-      sortable[FieldSortTitle] = StringUtils::Format(g_localizeStrings.Get(20358).c_str(), m_iSeason);
+      sortable[FieldSortTitle] = StringUtils::Format(g_localizeStrings.Get(20358), m_iSeason);
     else
       sortable[FieldSortTitle] = m_strSortTitle;
     break;
@@ -946,10 +946,10 @@ const std::string CVideoInfoTag::GetCast(bool bIncludeRole /*= false*/) const
   {
     std::string character;
     if (it->strRole.empty() || !bIncludeRole)
-      character = StringUtils::Format("{}\n", it->strName.c_str());
+      character = StringUtils::Format("{}\n", it->strName);
     else
-      character = StringUtils::Format("{} {} {}\n", it->strName.c_str(),
-                                      g_localizeStrings.Get(20347).c_str(), it->strRole.c_str());
+      character =
+          StringUtils::Format("{} {} {}\n", it->strName, g_localizeStrings.Get(20347), it->strRole);
     strLabel += character;
   }
   return StringUtils::TrimRight(strLabel, "\n");
@@ -1629,8 +1629,8 @@ void CVideoInfoTag::SetEpisodeGuide(std::string episodeGuide)
   if (StringUtils::StartsWith(episodeGuide, "<episodeguide"))
     m_strEpisodeGuide = Trim(std::move(episodeGuide));
   else
-    m_strEpisodeGuide = StringUtils::Format("<episodeguide>{}</episodeguide>",
-                                            Trim(std::move(episodeGuide)).c_str());
+    m_strEpisodeGuide =
+        StringUtils::Format("<episodeguide>{}</episodeguide>", Trim(std::move(episodeGuide)));
 }
 
 void CVideoInfoTag::SetStatus(std::string status)

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -707,7 +707,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["plotoutline"] = m_strPlotOutline;
   value["plot"] = m_strPlot;
   value["title"] = m_strTitle;
-  value["votes"] = StringUtils::Format("{}", GetRating().votes);
+  value["votes"] = std::to_string(GetRating().votes);
   value["studio"] = m_studio;
   value["trailer"] = m_strTrailer;
   value["cast"] = CVariant(CVariant::VariantTypeArray);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -758,7 +758,7 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     // add audio language properties
     for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
-      std::string index = StringUtils::Format("{}", i);
+      std::string index = std::to_string(i);
       item.SetProperty("AudioChannels." + index, details.GetAudioChannels(i));
       item.SetProperty("AudioCodec."    + index, details.GetAudioCodec(i).c_str());
       item.SetProperty("AudioLanguage." + index, details.GetAudioLanguage(i).c_str());
@@ -767,7 +767,7 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     // add subtitle language properties
     for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
-      std::string index = StringUtils::Format("{}", i);
+      std::string index = std::to_string(i);
       item.SetProperty("SubtitleLanguage." + index, details.GetSubtitleLanguage(i).c_str());
     }
   }

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -73,21 +73,21 @@ void CGUIDialogAudioSettings::FrameMove()
 std::string CGUIDialogAudioSettings::FormatDelay(float value, float interval)
 {
   if (fabs(value) < 0.5f * interval)
-    return StringUtils::Format(g_localizeStrings.Get(22003).c_str(), 0.0);
+    return StringUtils::Format(g_localizeStrings.Get(22003), 0.0);
   if (value < 0)
-    return StringUtils::Format(g_localizeStrings.Get(22004).c_str(), fabs(value));
+    return StringUtils::Format(g_localizeStrings.Get(22004), fabs(value));
 
-  return StringUtils::Format(g_localizeStrings.Get(22005).c_str(), value);
+  return StringUtils::Format(g_localizeStrings.Get(22005), value);
 }
 
 std::string CGUIDialogAudioSettings::FormatDecibel(float value)
 {
-  return StringUtils::Format(g_localizeStrings.Get(14054).c_str(), value);
+  return StringUtils::Format(g_localizeStrings.Get(14054), value);
 }
 
 std::string CGUIDialogAudioSettings::FormatPercentAsDecibel(float value)
 {
-  return StringUtils::Format(g_localizeStrings.Get(14054).c_str(), CAEUtil::PercentToGain(value));
+  return StringUtils::Format(g_localizeStrings.Get(14054), CAEUtil::PercentToGain(value));
 }
 
 void CGUIDialogAudioSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
@@ -334,7 +334,7 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(const SettingConstPtr& se
     if (info.name.length() == 0)
       info.name = strUnknown;
 
-    strItem = StringUtils::Format(strFormat, strLanguage.c_str(), info.name.c_str(), info.channels);
+    strItem = StringUtils::Format(strFormat, strLanguage, info.name, info.channels);
 
     strItem += FormatFlags(info.flags);
     strItem += StringUtils::Format(" ({}/{})", i + 1, audioStreamCount);
@@ -362,11 +362,11 @@ std::string CGUIDialogAudioSettings::SettingFormatterDelay(
   float fStep = step.asFloat();
 
   if (fabs(fValue) < 0.5f * fStep)
-    return StringUtils::Format(g_localizeStrings.Get(22003).c_str(), 0.0);
+    return StringUtils::Format(g_localizeStrings.Get(22003), 0.0);
   if (fValue < 0)
-    return StringUtils::Format(g_localizeStrings.Get(22004).c_str(), fabs(fValue));
+    return StringUtils::Format(g_localizeStrings.Get(22004), fabs(fValue));
 
-  return StringUtils::Format(g_localizeStrings.Get(22005).c_str(), fValue);
+  return StringUtils::Format(g_localizeStrings.Get(22005), fValue);
 }
 
 std::string CGUIDialogAudioSettings::SettingFormatterPercentAsDecibel(
@@ -383,7 +383,7 @@ std::string CGUIDialogAudioSettings::SettingFormatterPercentAsDecibel(
   if (control->GetFormatLabel() > -1)
     formatString = g_localizeStrings.Get(control->GetFormatLabel());
 
-  return StringUtils::Format(formatString.c_str(), CAEUtil::PercentToGain(value.asFloat()));
+  return StringUtils::Format(formatString, CAEUtil::PercentToGain(value.asFloat()));
 }
 
 std::string CGUIDialogAudioSettings::FormatFlags(StreamFlags flags)

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -342,7 +342,7 @@ void CGUIDialogSubtitleSettings::SubtitleStreamsOptionFiller(
     if (info.name.length() == 0)
       strItem = strLanguage;
     else
-      strItem = StringUtils::Format("{} - {}", strLanguage.c_str(), info.name.c_str());
+      strItem = StringUtils::Format("{} - {}", strLanguage, info.name);
 
     strItem += FormatFlags(info.flags);
     strItem += StringUtils::Format(" ({}/{})", i + 1, subtitleStreamCount);
@@ -372,11 +372,11 @@ std::string CGUIDialogSubtitleSettings::SettingFormatterDelay(
   float fStep = step.asFloat();
 
   if (fabs(fValue) < 0.5f * fStep)
-    return StringUtils::Format(g_localizeStrings.Get(22003).c_str(), 0.0);
+    return StringUtils::Format(g_localizeStrings.Get(22003), 0.0);
   if (fValue < 0)
-    return StringUtils::Format(g_localizeStrings.Get(22004).c_str(), fabs(fValue));
+    return StringUtils::Format(g_localizeStrings.Get(22004), fabs(fValue));
 
-  return StringUtils::Format(g_localizeStrings.Get(22005).c_str(), fValue);
+  return StringUtils::Format(g_localizeStrings.Get(22005), fValue);
 }
 
 std::string CGUIDialogSubtitleSettings::FormatFlags(StreamFlags flags)

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -393,7 +393,7 @@ void CGUIDialogSubtitles::UpdateStatus(STATUS status)
       break;
     case SEARCH_COMPLETE:
       if (!m_subtitles->IsEmpty())
-        label = StringUtils::Format(g_localizeStrings.Get(24108).c_str(), m_subtitles->Size());
+        label = StringUtils::Format(g_localizeStrings.Get(24108), m_subtitles->Size());
       else
         label = g_localizeStrings.Get(24109);
       break;
@@ -504,8 +504,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
 
     // construct subtitle path
     std::string strSubExt = URIUtils::GetExtension(strUrl);
-    std::string strSubName =
-        StringUtils::Format("{}.{}{}", strFileName.c_str(), strSubLang.c_str(), strSubExt.c_str());
+    std::string strSubName = StringUtils::Format("{}.{}{}", strFileName, strSubLang, strSubExt);
 
     // Handle URL encoding:
     std::string strDownloadFile = URIUtils::ChangeBasePath(strCurrentFilePath, strSubName, strDownloadPath);
@@ -552,8 +551,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
         strUrl = URIUtils::ReplaceExtension(strUrl, ".idx");
         if(CFile::Exists(strUrl))
         {
-          std::string strSubNameIdx =
-              StringUtils::Format("{}.{}.idx", strFileName.c_str(), strSubLang.c_str());
+          std::string strSubNameIdx = StringUtils::Format("{}.{}.idx", strFileName, strSubLang);
           // Handle URL encoding:
           strDestFile = URIUtils::ChangeBasePath(strCurrentFilePath, strSubNameIdx, strDestPath);
           CFile::Copy(strUrl, strDestFile);

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -213,7 +213,7 @@ void CGUIDialogVideoBookmarks::UpdateItem(unsigned int chapterIdx)
 
   if (itemPos < m_vecItems->Size())
   {
-    std::string time = StringUtils::Format("chapter://{}/{}", m_filePath.c_str(), chapterIdx);
+    std::string time = StringUtils::Format("chapter://{}/{}", m_filePath, chapterIdx);
     std::string cachefile = CTextureCache::GetInstance().GetCachedPath(CTextureCache::GetInstance().GetCacheFile(time) + ".jpg");
     if (XFILE::CFile::Exists(cachefile))
     {
@@ -247,13 +247,13 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   {
     std::string bookmarkTime;
     if (m_bookmarks[i].type == CBookmark::EPISODE)
-      bookmarkTime = StringUtils::Format(
-          "{} {} {} {}", g_localizeStrings.Get(20373).c_str(), m_bookmarks[i].seasonNumber,
-          g_localizeStrings.Get(20359).c_str(), m_bookmarks[i].episodeNumber);
+      bookmarkTime = StringUtils::Format("{} {} {} {}", g_localizeStrings.Get(20373),
+                                         m_bookmarks[i].seasonNumber, g_localizeStrings.Get(20359),
+                                         m_bookmarks[i].episodeNumber);
     else
       bookmarkTime = StringUtils::SecondsToTimeString((long)m_bookmarks[i].timeInSeconds, TIME_FORMAT_HH_MM_SS);
 
-    CFileItemPtr item(new CFileItem(StringUtils::Format(g_localizeStrings.Get(299).c_str(), i+1)));
+    CFileItemPtr item(new CFileItem(StringUtils::Format(g_localizeStrings.Get(299), i + 1)));
     item->SetLabel2(bookmarkTime);
     item->SetArt("thumb", m_bookmarks[i].thumbNailImage);
     item->SetProperty("resumepoint", m_bookmarks[i].timeInSeconds);
@@ -274,12 +274,12 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
     if (chapterName.empty() ||
         StringUtils::StartsWithNoCase(chapterName, time) ||
         StringUtils::IsNaturalNumber(chapterName))
-      chapterName = StringUtils::Format(g_localizeStrings.Get(25010).c_str(), i);
+      chapterName = StringUtils::Format(g_localizeStrings.Get(25010), i);
 
     CFileItemPtr item(new CFileItem(chapterName));
     item->SetLabel2(time);
 
-    std::string chapterPath = StringUtils::Format("chapter://{}/{}", m_filePath.c_str(), i);
+    std::string chapterPath = StringUtils::Format("chapter://{}/{}", m_filePath, i);
     std::string cachefile = CTextureCache::GetInstance().GetCachedPath(CTextureCache::GetInstance().GetCacheFile(chapterPath)+".jpg");
     if (XFILE::CFile::Exists(cachefile))
       item->SetArt("thumb", cachefile);
@@ -500,9 +500,9 @@ bool CGUIDialogVideoBookmarks::AddEpisodeBookmark()
     CContextButtons choices;
     for (unsigned int i=0; i < episodes.size(); ++i)
     {
-      std::string strButton = StringUtils::Format(
-          "{} {}, {} {}", g_localizeStrings.Get(20373).c_str(), episodes[i].m_iSeason,
-          g_localizeStrings.Get(20359).c_str(), episodes[i].m_iEpisode);
+      std::string strButton =
+          StringUtils::Format("{} {}, {} {}", g_localizeStrings.Get(20373), episodes[i].m_iSeason,
+                              g_localizeStrings.Get(20359), episodes[i].m_iEpisode);
       choices.Add(i, strButton);
     }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1157,7 +1157,7 @@ void CGUIDialogVideoInfo::OnSetUserrating() const
     dialog->SetHeading(CVariant{ 38023 });
     dialog->Add(g_localizeStrings.Get(38022));
     for (int i = 1; i <= 10; i++)
-      dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563).c_str(), i));
+      dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563), i));
 
     dialog->SetSelected(m_movieItem->GetVideoInfoTag()->m_iUserRating);
 
@@ -1177,9 +1177,8 @@ void CGUIDialogVideoInfo::PlayTrailer()
   item.SetPath(m_movieItem->GetVideoInfoTag()->m_strTrailer);
   *item.GetVideoInfoTag() = *m_movieItem->GetVideoInfoTag();
   item.GetVideoInfoTag()->m_streamDetails.Reset();
-  item.GetVideoInfoTag()->m_strTitle =
-      StringUtils::Format("{} ({})", m_movieItem->GetVideoInfoTag()->m_strTitle.c_str(),
-                          g_localizeStrings.Get(20410).c_str());
+  item.GetVideoInfoTag()->m_strTitle = StringUtils::Format(
+      "{} ({})", m_movieItem->GetVideoInfoTag()->m_strTitle, g_localizeStrings.Get(20410));
   item.SetArt(m_movieItem->GetArt());
   item.GetVideoInfoTag()->m_iDbId = -1;
   item.GetVideoInfoTag()->m_iFileId = -1;
@@ -1312,7 +1311,9 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
     {
       const std::string &mediaType = videoUrl.GetItemType();
 
-      buttons.Add(CONTEXT_BUTTON_TAGS_ADD_ITEMS, StringUtils::Format(g_localizeStrings.Get(20460).c_str(), GetLocalizedVideoType(mediaType).c_str()));
+      buttons.Add(
+          CONTEXT_BUTTON_TAGS_ADD_ITEMS,
+          StringUtils::Format(g_localizeStrings.Get(20460), GetLocalizedVideoType(mediaType)));
       buttons.Add(CONTEXT_BUTTON_TAGS_REMOVE_ITEMS, StringUtils::Format(g_localizeStrings.Get(20461).c_str(), GetLocalizedVideoType(mediaType).c_str()));
     }
   }
@@ -1548,7 +1549,8 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
   }
   else
   {
-    pDialog->SetLine(0, CVariant{StringUtils::Format(g_localizeStrings.Get(433).c_str(), item->GetLabel().c_str())});
+    pDialog->SetLine(0,
+                     CVariant{StringUtils::Format(g_localizeStrings.Get(433), item->GetLabel())});
     pDialog->SetLine(1, CVariant{""});
   }
   pDialog->SetLine(2, CVariant{""});
@@ -1782,12 +1784,12 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
       }
     }
     // add clear item
-    std::string strClear = StringUtils::Format(g_localizeStrings.Get(20467).c_str(), currentSetLabel.c_str());
+    std::string strClear = StringUtils::Format(g_localizeStrings.Get(20467), currentSetLabel);
     CFileItemPtr clearItem(new CFileItem(strClear));
     clearItem->GetVideoInfoTag()->m_iDbId = -1; // -1 will be used to clear set
     listItems.AddFront(clearItem, 0);
     // add keep current set item
-    std::string strKeep = StringUtils::Format(g_localizeStrings.Get(20469).c_str(), currentSetLabel.c_str());
+    std::string strKeep = StringUtils::Format(g_localizeStrings.Get(20469), currentSetLabel);
     CFileItemPtr keepItem(new CFileItem(strKeep));
     keepItem->GetVideoInfoTag()->m_iDbId = currentSetId;
     listItems.AddFront(keepItem, 1);
@@ -1936,7 +1938,7 @@ bool CGUIDialogVideoInfo::AddItemsToTag(const CFileItemPtr &tagItem)
 
   CFileItemList items;
   std::string localizedType = GetLocalizedVideoType(mediaType);
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464).c_str(), localizedType.c_str());
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType);
   if (!GetItemsForTag(strLabel, mediaType, items, tagItem->GetVideoInfoTag()->m_iDbId))
     return true;
 
@@ -1969,7 +1971,7 @@ bool CGUIDialogVideoInfo::RemoveItemsFromTag(const CFileItemPtr &tagItem)
 
   CFileItemList items;
   std::string localizedType = GetLocalizedVideoType(mediaType);
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464).c_str(), localizedType.c_str());
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType);
   if (!GetItemsForTag(strLabel, mediaType, items, tagItem->GetVideoInfoTag()->m_iDbId, false))
     return true;
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -491,7 +491,7 @@ void CGUIDialogVideoSettings::VideoStreamsOptionFiller(
     if (!info.name.empty())
     {
       if (!strLanguage.empty())
-        strItem = StringUtils::Format("{} - {}", strLanguage.c_str(), info.name.c_str());
+        strItem = StringUtils::Format("{} - {}", strLanguage, info.name);
       else
         strItem = info.name;
     }
@@ -503,8 +503,7 @@ void CGUIDialogVideoSettings::VideoStreamsOptionFiller(
     if (info.codecName.empty())
       strItem += StringUtils::Format(" ({}x{}", info.width, info.height);
     else
-      strItem +=
-          StringUtils::Format(" ({}, {}x{}", info.codecName.c_str(), info.width, info.height);
+      strItem += StringUtils::Format(" ({}, {}x{}", info.codecName, info.width, info.height);
 
     if (info.bitrate)
       strItem += StringUtils::Format(", {} bps)", info.bitrate);

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -162,7 +162,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     // if we don't have an url or need to refresh anyway do the web search
     if (!hasDetails && (needsRefresh || !scraperUrl.HasUrls()))
     {
-      SetTitle(StringUtils::Format(g_localizeStrings.Get(197).c_str(), scraper->Name().c_str()));
+      SetTitle(StringUtils::Format(g_localizeStrings.Get(197), scraper->Name()));
       SetText(itemTitle);
       SetProgress(0);
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -321,7 +321,7 @@ void CGUIWindowFullScreen::FrameMove()
       const auto& vs = g_application.GetAppPlayer().GetVideoSettings();
       int sId = CViewModeSettings::GetViewModeStringIndex(vs.m_ViewMode);
       const std::string& strMode = g_localizeStrings.Get(sId);
-      std::string strInfo = StringUtils::Format("{} : {}", strTitle.c_str(), strMode.c_str());
+      std::string strInfo = StringUtils::Format("{} : {}", strTitle, strMode);
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW1);
       msg.SetLabel(strInfo);
       OnMessage(msg);
@@ -334,15 +334,13 @@ void CGUIWindowFullScreen::FrameMove()
       float xscale = (float)res.iScreenWidth  / (float)res.iWidth;
       float yscale = (float)res.iScreenHeight / (float)res.iHeight;
 
-      std::string strSizing = StringUtils::Format(g_localizeStrings.Get(245).c_str(),
-                                                 (int)info.SrcRect.Width(),
-                                                 (int)info.SrcRect.Height(),
-                                                 (int)(info.DestRect.Width() * xscale),
-                                                 (int)(info.DestRect.Height() * yscale),
-                                                 CDisplaySettings::GetInstance().GetZoomAmount(),
-                                                 info.videoAspectRatio*CDisplaySettings::GetInstance().GetPixelRatio(),
-                                                 CDisplaySettings::GetInstance().GetPixelRatio(),
-                                                 CDisplaySettings::GetInstance().GetVerticalShift());
+      std::string strSizing = StringUtils::Format(
+          g_localizeStrings.Get(245), (int)info.SrcRect.Width(), (int)info.SrcRect.Height(),
+          (int)(info.DestRect.Width() * xscale), (int)(info.DestRect.Height() * yscale),
+          CDisplaySettings::GetInstance().GetZoomAmount(),
+          info.videoAspectRatio * CDisplaySettings::GetInstance().GetPixelRatio(),
+          CDisplaySettings::GetInstance().GetPixelRatio(),
+          CDisplaySettings::GetInstance().GetVerticalShift());
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW2);
       msg.SetLabel(strSizing);
       OnMessage(msg);
@@ -351,13 +349,13 @@ void CGUIWindowFullScreen::FrameMove()
     {
       std::string strStatus;
       if (CServiceBroker::GetWinSystem()->IsFullScreen())
-        strStatus = StringUtils::Format(
-            "{} {}x{}@{:.2f}Hz - {}", g_localizeStrings.Get(13287).c_str(), res.iScreenWidth,
-            res.iScreenHeight, res.fRefreshRate, g_localizeStrings.Get(244).c_str());
+        strStatus = StringUtils::Format("{} {}x{}@{:.2f}Hz - {}", g_localizeStrings.Get(13287),
+                                        res.iScreenWidth, res.iScreenHeight, res.fRefreshRate,
+                                        g_localizeStrings.Get(244));
       else
-        strStatus = StringUtils::Format("{} {}x{} - {}", g_localizeStrings.Get(13287).c_str(),
-                                        res.iScreenWidth, res.iScreenHeight,
-                                        g_localizeStrings.Get(242).c_str());
+        strStatus =
+            StringUtils::Format("{} {}x{} - {}", g_localizeStrings.Get(13287), res.iScreenWidth,
+                                res.iScreenHeight, g_localizeStrings.Get(242));
 
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW3);
       msg.SetLabel(strStatus);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -786,11 +786,14 @@ std::string CGUIWindowVideoBase::GetResumeString(const CFileItem &item)
   GetResumeItemOffset(&item, startOffset, startPart);
   if (startOffset > 0)
   {
-    resumeString = StringUtils::Format(g_localizeStrings.Get(12022).c_str(),
-        StringUtils::SecondsToTimeString(static_cast<long>(CUtil::ConvertMilliSecsToSecsInt(startOffset)), TIME_FORMAT_HH_MM_SS).c_str());
+    resumeString =
+        StringUtils::Format(g_localizeStrings.Get(12022),
+                            StringUtils::SecondsToTimeString(
+                                static_cast<long>(CUtil::ConvertMilliSecsToSecsInt(startOffset)),
+                                TIME_FORMAT_HH_MM_SS));
     if (startPart > 0)
     {
-      std::string partString = StringUtils::Format(g_localizeStrings.Get(23051).c_str(), startPart);
+      std::string partString = StringUtils::Format(g_localizeStrings.Get(23051), startPart);
       resumeString += " (" + partString + ")";
     }
   }
@@ -961,7 +964,7 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
   CDirectory::GetDirectory(path, parts, "", DIR_FLAG_DEFAULTS);
 
   for (int i = 0; i < parts.Size(); i++)
-    parts[i]->SetLabel(StringUtils::Format(g_localizeStrings.Get(23051).c_str(), i+1));
+    parts[i]->SetLabel(StringUtils::Format(g_localizeStrings.Get(23051), i + 1));
 
   CGUIDialogSelect* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -664,7 +664,7 @@ void CGUIWindowVideoNav::UpdateButtons()
       StringUtils::StartsWith(m_vecItems->Get(m_vecItems->Size()-1)->GetPath(), "/-1/"))
       iItems--;
   }
-  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127).c_str());
+  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   // set the filter label
@@ -829,7 +829,7 @@ void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)
       return;
 
     pDialog->SetHeading(CVariant{432});
-    std::string strLabel = StringUtils::Format(g_localizeStrings.Get(433).c_str(),pItem->GetLabel().c_str());
+    std::string strLabel = StringUtils::Format(g_localizeStrings.Get(433), pItem->GetLabel());
     pDialog->SetLine(1, CVariant{std::move(strLabel)});
     pDialog->SetLine(2, CVariant{""});
     pDialog->Open();
@@ -1141,14 +1141,14 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
 
     if (!videodb.GetSingleValue("tag", "tag.tag_id", videodb.PrepareSQL("tag.name = '%s' AND tag.tag_id IN (SELECT tag_link.tag_id FROM tag_link WHERE tag_link.media_type = '%s')", strTag.c_str(), mediaType.c_str())).empty())
     {
-      std::string strError = StringUtils::Format(g_localizeStrings.Get(20463).c_str(), strTag.c_str());
+      std::string strError = StringUtils::Format(g_localizeStrings.Get(20463), strTag);
       HELPERS::ShowOKDialogText(CVariant{20462}, CVariant{std::move(strError)});
       return true;
     }
 
     int idTag = videodb.AddTag(strTag);
     CFileItemList items;
-    std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464).c_str(), localizedType.c_str());
+    std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType);
     if (CGUIDialogVideoInfo::GetItemsForTag(strLabel, mediaType, items, idTag))
     {
       for (int index = 0; index < items.Size(); index++)

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -316,8 +316,8 @@ void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
   {
     IGUIContainer *view = static_cast<IGUIContainer*>(m_visibleViews[i]);
-    std::string label = StringUtils::Format(g_localizeStrings.Get(534).c_str(),
-                                            view->GetLabel().c_str()); // View: {}
+    std::string label = StringUtils::Format(g_localizeStrings.Get(534),
+                                            view->GetLabel()); // View: {}
     labels.emplace_back(std::move(label), i);
   }
   CGUIMessage msg(GUI_MSG_SET_LABELS, m_parentWindow, m_viewAsControl, m_currentView);
@@ -325,8 +325,7 @@ void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg, m_parentWindow);
 
   // otherwise it's just a normal button
-  std::string label =
-      StringUtils::Format(g_localizeStrings.Get(534).c_str(), viewLabel.c_str()); // View: {}
+  std::string label = StringUtils::Format(g_localizeStrings.Get(534), viewLabel); // View: {}
   CGUIMessage msgSet(GUI_MSG_LABEL_SET, m_parentWindow, m_viewAsControl);
   msgSet.SetLabel(label);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msgSet, m_parentWindow);

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -203,11 +203,12 @@ void CWeatherJob::SetFromProperties()
     else
     {
       LocalizeOverviewToken(direction);
-      m_info.currentWind = StringUtils::Format(g_localizeStrings.Get(434).c_str(),
-                                               direction.c_str(), (int)speed.To(g_langInfo.GetSpeedUnit()), g_langInfo.GetSpeedUnitString().c_str());
+      m_info.currentWind = StringUtils::Format(g_localizeStrings.Get(434), direction,
+                                               (int)speed.To(g_langInfo.GetSpeedUnit()),
+                                               g_langInfo.GetSpeedUnitString());
     }
     std::string windspeed = StringUtils::Format("{} {}", (int)speed.To(g_langInfo.GetSpeedUnit()),
-                                                g_langInfo.GetSpeedUnitString().c_str());
+                                                g_langInfo.GetSpeedUnitString());
     window->SetProperty("Current.WindSpeed",windspeed);
     FormatTemperature(m_info.currentDewPoint,
                       strtod(window->GetProperty("Current.DewPoint").asString().c_str(), nullptr));
@@ -215,7 +216,7 @@ void CWeatherJob::SetFromProperties()
       m_info.currentHumidity.clear();
     else
       m_info.currentHumidity =
-          StringUtils::Format("{}%", window->GetProperty("Current.Humidity").asString().c_str());
+          StringUtils::Format("{}%", window->GetProperty("Current.Humidity").asString());
     m_info.location = window->GetProperty("Current.Location").asString();
     for (int i=0;i<NUM_DAYS;++i)
     {

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -60,7 +60,7 @@ bool CWeatherJob::DoWork()
   std::vector<std::string> argv;
   argv.push_back(addon->LibPath());
 
-  std::string strSetting = StringUtils::Format("{}", m_location);
+  std::string strSetting = std::to_string(m_location);
   argv.push_back(strSetting);
 
   // Download our weather

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -60,7 +60,7 @@ void CWinSystemBase::UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std:
   newRes.iHeight = height;
   newRes.iScreenWidth = width;
   newRes.iScreenHeight = height;
-  newRes.strMode = StringUtils::Format("{}: {}x{}", output.c_str(), width, height);
+  newRes.strMode = StringUtils::Format("{}: {}x{}", output, width, height);
   if (refreshRate > 1)
     newRes.strMode += StringUtils::Format(" @ {:.2f}Hz", refreshRate);
   if (dwFlags & D3DPRESENTFLAG_INTERLACED)

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -409,8 +409,7 @@ void CWinSystemX11::UpdateResolutions()
 
       CLog::Log(LOGINFO, "Pixel Ratio: %f", res.fPixelRatio);
 
-      res.strMode =
-          StringUtils::Format("{}: {} @ {:.2f}Hz", out->name.c_str(), mode.name.c_str(), mode.hz);
+      res.strMode = StringUtils::Format("{}: {} @ {:.2f}Hz", out->name, mode.name, mode.hz);
       res.strOutput    = out->name;
       res.strId        = mode.id;
       res.iSubtitles   = (int)(0.965*mode.h);

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -66,7 +66,7 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
   {
     cmd  = getenv("KODI_BIN_HOME");
     cmd += "/" + appname + "-xrandr";
-    cmd = StringUtils::Format("{} -q --screen {}", cmd.c_str(), screennum);
+    cmd = StringUtils::Format("{} -q --screen {}", cmd, screennum);
   }
 
   FILE* file = popen(cmd.c_str(),"r");
@@ -156,8 +156,7 @@ bool CXRandR::TurnOffOutput(const std::string& name)
   {
     cmd  = getenv("KODI_BIN_HOME");
     cmd += "/" + appname + "-xrandr";
-    cmd = StringUtils::Format("{} --screen {} --output {} --off", cmd.c_str(), output->screen,
-                              name.c_str());
+    cmd = StringUtils::Format("{} --screen {} --output {} --off", cmd, output->screen, name);
   }
 
   int status = system(cmd.c_str());

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -83,7 +83,7 @@ static void fetchDisplayModes()
         s_hasModeApi = true;
 
         CLog::Log(LOGDEBUG, "CAndroidUtils: current mode: %d: %dx%d@%f", m.getModeId(), m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
-        s_res_cur_displayMode.strId = StringUtils::Format("{}", m.getModeId());
+        s_res_cur_displayMode.strId = std::to_string(m.getModeId());
         s_res_cur_displayMode.iWidth = s_res_cur_displayMode.iScreenWidth = m.getPhysicalWidth();
         s_res_cur_displayMode.iHeight = s_res_cur_displayMode.iScreenHeight = m.getPhysicalHeight();
         s_res_cur_displayMode.fRefreshRate = m.getRefreshRate();
@@ -102,7 +102,7 @@ static void fetchDisplayModes()
           CLog::Log(LOGDEBUG, "CAndroidUtils: available mode: %d: %dx%d@%f", m.getModeId(), m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
 
           RESOLUTION_INFO res;
-          res.strId = StringUtils::Format("{}", m.getModeId());
+          res.strId = std::to_string(m.getModeId());
           res.iWidth = res.iScreenWidth = m.getPhysicalWidth();
           res.iHeight = res.iScreenHeight = m.getPhysicalHeight();
           res.fRefreshRate = m.getRefreshRate();

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -963,8 +963,8 @@ void CWinSystemWin32::UpdateResolutions()
     res.iScreenWidth = res.iWidth;
     res.iScreenHeight = res.iHeight;
     res.iSubtitles = (int)(0.965 * res.iHeight);
-    res.strMode = StringUtils::Format("{}: {}x{} @ {:.2f}Hz", monitorName.c_str(), res.iWidth,
-                                      res.iHeight, res.fRefreshRate);
+    res.strMode = StringUtils::Format("{}: {}x{} @ {:.2f}Hz", monitorName, res.iWidth, res.iHeight,
+                                      res.fRefreshRate);
     GetGfxContext().ResetOverscan(res);
     res.strOutput = strOutput;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -215,7 +215,7 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
 
   if (action.GetID() >= ACTION_FILTER_SMS2 && action.GetID() <= ACTION_FILTER_SMS9)
   {
-    std::string filter = StringUtils::Format("{}", action.GetID() - ACTION_FILTER_SMS2 + 2);
+    std::string filter = std::to_string(action.GetID() - ACTION_FILTER_SMS2 + 2);
     CGUIMessage message(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_FILTER_ITEMS, 1); // 1 for append
     message.SetStringParam(filter);
     OnMessage(message);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -616,13 +616,13 @@ void CGUIMediaWindow::UpdateButtons()
     else
       CONTROL_ENABLE(CONTROL_BTNSORTBY);
 
-    std::string sortLabel = StringUtils::Format(g_localizeStrings.Get(550).c_str(),
-                                                g_localizeStrings.Get(m_guiState->GetSortMethodLabel()).c_str());
+    std::string sortLabel = StringUtils::Format(
+        g_localizeStrings.Get(550), g_localizeStrings.Get(m_guiState->GetSortMethodLabel()));
     SET_CONTROL_LABEL(CONTROL_BTNSORTBY, sortLabel);
   }
 
-  std::string items = StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
-                                          g_localizeStrings.Get(127).c_str());
+  std::string items =
+      StringUtils::Format("{} {}", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   SET_CONTROL_LABEL2(CONTROL_BTN_FILTER, GetProperty("filter").asString());

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -105,14 +105,14 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     StringUtils::ToLower(lcAppName);
 #if !defined(TARGET_POSIX)
     info = StringUtils::Format("LOG: {}{}.log\nMEM: {}/{} KB - FPS: {:2.1f} fps\nCPU: {}{}",
-                               CSpecialProtocol::TranslatePath("special://logpath").c_str(),
-                               lcAppName.c_str(), stat.availPhys / 1024, stat.totalPhys / 1024,
+                               CSpecialProtocol::TranslatePath("special://logpath"), lcAppName,
+                               stat.availPhys / 1024, stat.totalPhys / 1024,
                                CServiceBroker::GetGUI()
                                    ->GetInfoManager()
                                    .GetInfoProviders()
                                    .GetSystemInfoProvider()
                                    .GetFPS(),
-                               strCores.c_str(), profiling.c_str());
+                               strCores, profiling);
 #else
     double dCPU = m_resourceCounter.GetCPUUsage();
     std::string ucAppName = lcAppName;
@@ -120,14 +120,14 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     info = StringUtils::Format("LOG: {}{}.log\n"
                                "MEM: %" PRIu64 "/%" PRIu64 " KB - FPS: %2.1f fps\n"
                                "CPU: %s (CPU-%s %4.2f%%%s)",
-                               CSpecialProtocol::TranslatePath("special://logpath").c_str(),
-                               lcAppName.c_str(), stat.availPhys / 1024, stat.totalPhys / 1024,
+                               CSpecialProtocol::TranslatePath("special://logpath"), lcAppName,
+                               stat.availPhys / 1024, stat.totalPhys / 1024,
                                CServiceBroker::GetGUI()
                                    ->GetInfoManager()
                                    .GetInfoProviders()
                                    .GetSystemInfoProvider()
                                    .GetFPS(),
-                               strCores.c_str(), ucAppName.c_str(), dCPU, profiling.c_str());
+                               strCores, ucAppName, dCPU, profiling);
 #endif
   }
 
@@ -163,7 +163,7 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
       if (control)
         info += StringUtils::Format(
             "Focused: {} ({})", control->GetID(),
-            CGUIControlFactory::TranslateControlType(control->GetControlType()).c_str());
+            CGUIControlFactory::TranslateControlType(control->GetControlType()));
     }
   }
 

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -118,8 +118,8 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     std::string ucAppName = lcAppName;
     StringUtils::ToUpper(ucAppName);
     info = StringUtils::Format("LOG: {}{}.log\n"
-                               "MEM: %" PRIu64 "/%" PRIu64 " KB - FPS: %2.1f fps\n"
-                               "CPU: %s (CPU-%s %4.2f%%%s)",
+                               "MEM: {}/{} KB - FPS: {:2.1f} fps\n"
+                               "CPU: {} (CPU-{} {:4.2f}%{})",
                                CSpecialProtocol::TranslatePath("special://logpath"), lcAppName,
                                stat.availPhys / 1024, stat.totalPhys / 1024,
                                CServiceBroker::GetGUI()

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -432,11 +432,11 @@ void CGUIWindowFileManager::UpdateItemCounts()
     }
     std::string items;
     if (selectedCount > 0)
-      items = StringUtils::Format("{}/{} {} ({})", selectedCount, totalCount,
-                                  g_localizeStrings.Get(127).c_str(),
-                                  StringUtils::SizeToString(selectedSize).c_str());
+      items =
+          StringUtils::Format("{}/{} {} ({})", selectedCount, totalCount,
+                              g_localizeStrings.Get(127), StringUtils::SizeToString(selectedSize));
     else
-      items = StringUtils::Format("{} {}", totalCount, g_localizeStrings.Get(127).c_str());
+      items = StringUtils::Format("{} {}", totalCount, g_localizeStrings.Get(127));
     SET_CONTROL_LABEL(CONTROL_NUMFILES_LEFT + i, items);
   }
 }

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -151,7 +151,8 @@ void CGUIWindowLoginScreen::FrameMove()
 
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, profileManager->GetNumberOfProfiles());
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114), m_iSelectedItem + 1,
+                                             profileManager->GetNumberOfProfiles());
   SET_CONTROL_LABEL(CONTROL_LABEL_SELECTED_PROFILE,strLabel);
   CGUIWindow::FrameMove();
 }
@@ -202,7 +203,7 @@ void CGUIWindowLoginScreen::Update()
     if (profile->getDate().empty())
       strLabel = g_localizeStrings.Get(20113);
     else
-      strLabel = StringUtils::Format(g_localizeStrings.Get(20112).c_str(), profile->getDate().c_str());
+      strLabel = StringUtils::Format(g_localizeStrings.Get(20112), profile->getDate());
 
     item->SetLabel2(strLabel);
     item->SetArt("thumb", profile->getThumb());

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -241,7 +241,8 @@ void CGUIWindowSystemInfo::ResetLabels()
 
 void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label, int info)
 {
-  std::string tmpStr = StringUtils::Format(format, g_localizeStrings.Get(label).c_str(),
-      CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info).c_str());
+  std::string tmpStr =
+      StringUtils::Format(format, g_localizeStrings.Get(label),
+                          CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info));
   SET_CONTROL_LABEL(id, tmpStr);
 }


### PR DESCRIPTION
This is a follow up to #19684 

I've done a few things. The first commit is an automated cleanup of `.c_str()` usage from `StringUtils::Format` calls. This is done by the following:
```
sed -i "${FILE}" \
-e ':a
    /StringUtils::Format(/{
      :line
      s/.c_str()//g
      /);/!{
        N
        bline
      }
      N
    }'
```

The weird sed syntax is so I don't have to use `;` line breaks and so that I can make sure I match multiline calls.

The following commits prefixed with `[SQUASH]` are commits I made manually to fix the build. I may need more of these depending on what jenkins says.

I've also included a commit to remove redundant usage of `StringUtils::Format` and simplified it to use std::to_string() where applicable. This was an automated commit using
```
sed -i "${FILE}" -E \
-e '/StringUtils::Format\("\{\}",/{
      /fmt::ptr/b
      s/StringUtils::Format\("\{\}", (.*)\)/std::to_string\(\1\)/g
    }'
```

I've also included a manual commit after his that fixes the build after the `std::to_string` changes as some methods return a `std::string` already!

It's amazing to me after years of refactoring that some of the boilerplate can be removed completely.