### PR TITLE
[maintenance] make CDVDFactoryCodec and CPlayerCoreConfig use smart pointers

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -58,7 +58,7 @@ void CApplicationPlayer::CreatePlayer(const CPlayerCoreFactory &factory, const s
   if (!m_pPlayer)
   {
     CDataCacheCore::GetInstance().Reset();
-    m_pPlayer.reset(factory.CreatePlayer(player, callback));
+    m_pPlayer = factory.CreatePlayer(player, callback);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -93,9 +93,9 @@ CDVDAudioCodecAndroidMediaCodec::~CDVDAudioCodecAndroidMediaCodec()
   Dispose();
 }
 
-CDVDAudioCodec* CDVDAudioCodecAndroidMediaCodec::Create(CProcessInfo &processInfo)
+std::unique_ptr<CDVDAudioCodec> CDVDAudioCodecAndroidMediaCodec::Create(CProcessInfo& processInfo)
 {
-  return new CDVDAudioCodecAndroidMediaCodec(processInfo);
+  return std::make_unique<CDVDAudioCodecAndroidMediaCodec>(processInfo);
 }
 
 bool CDVDAudioCodecAndroidMediaCodec::Register()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
@@ -31,7 +31,7 @@ public:
   ~CDVDAudioCodecAndroidMediaCodec() override;
 
   // registration
-  static CDVDAudioCodec* Create(CProcessInfo &processInfo);
+  static std::unique_ptr<CDVDAudioCodec> Create(CProcessInfo& processInfo);
   static bool Register();
 
   // required overrides

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -241,7 +241,7 @@ std::unique_ptr<CDVDAudioCodec> CDVDFactoryCodec::CreateAudioCodecHW(const std::
 // Overlay
 //------------------------------------------------------------------------------
 
-CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
+std::unique_ptr<CDVDOverlayCodec> CDVDFactoryCodec::CreateOverlayCodec(CDVDStreamInfo& hint)
 {
   std::unique_ptr<CDVDOverlayCodec> pCodec;
   CDVDCodecOptions options;
@@ -250,44 +250,28 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
   {
     case AV_CODEC_ID_TEXT:
     case AV_CODEC_ID_SUBRIP:
-      pCodec.reset(new CDVDOverlayCodecText());
-      if (pCodec->Open(hint, options))
-      {
-        return pCodec.release();
-      }
+      pCodec = std::make_unique<CDVDOverlayCodecText>();
       break;
 
     case AV_CODEC_ID_SSA:
     case AV_CODEC_ID_ASS:
-      pCodec.reset(new CDVDOverlayCodecSSA());
-      if (pCodec->Open(hint, options))
-      {
-        return pCodec.release();
-      }
-
-      pCodec.reset(new CDVDOverlayCodecText());
-      if (pCodec->Open(hint, options))
-      {
-        return pCodec.release();
-      }
+      pCodec = std::make_unique<CDVDOverlayCodecSSA>();
       break;
 
+      //! @todo: this seems unused?
+      pCodec = std::make_unique<CDVDOverlayCodecText>();
+
     case AV_CODEC_ID_MOV_TEXT:
-      pCodec.reset(new CDVDOverlayCodecTX3G());
-      if (pCodec->Open(hint, options))
-      {
-        return pCodec.release();
-      }
+      pCodec = std::make_unique<CDVDOverlayCodecTX3G>();
       break;
 
     default:
-      pCodec.reset(new CDVDOverlayCodecFFmpeg());
-      if (pCodec->Open(hint, options))
-      {
-        return pCodec.release();
-      }
+      pCodec = std::make_unique<CDVDOverlayCodecFFmpeg>();
       break;
   }
+
+  if (pCodec->Open(hint, options))
+    return pCodec;
 
   return nullptr;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -258,9 +258,6 @@ std::unique_ptr<CDVDOverlayCodec> CDVDFactoryCodec::CreateOverlayCodec(CDVDStrea
       pCodec = std::make_unique<CDVDOverlayCodecSSA>();
       break;
 
-      //! @todo: this seems unused?
-      pCodec = std::make_unique<CDVDOverlayCodecText>();
-
     case AV_CODEC_ID_MOV_TEXT:
       pCodec = std::make_unique<CDVDOverlayCodecTX3G>();
       break;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -34,7 +34,8 @@ using CreateHWVideoCodec =
     std::function<std::unique_ptr<CDVDVideoCodec>(CProcessInfo& processInfo)>;
 using CreateHWAccel = std::function<IHardwareDecoder*(
     CDVDStreamInfo& hint, CProcessInfo& processInfo, AVPixelFormat fmt)>;
-typedef std::unique_ptr<CDVDAudioCodec> (*CreateHWAudioCodec)(CProcessInfo& processInfo);
+using CreateHWAudioCodec =
+    std::function<std::unique_ptr<CDVDAudioCodec>(CProcessInfo& processInfo)>;
 
 class CDVDFactoryCodec
 {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
+#include "cores/VideoPlayer/Process/ProcessInfo.h"
 
 #include <map>
 #include <string>
@@ -29,15 +29,15 @@ class CDVDStreamInfo;
 class CDVDCodecOption;
 class CDVDCodecOptions;
 
-typedef CDVDVideoCodec* (*CreateHWVideoCodec)(CProcessInfo &processInfo);
+typedef std::unique_ptr<CDVDVideoCodec> (*CreateHWVideoCodec)(CProcessInfo& processInfo);
 typedef IHardwareDecoder* (*CreateHWAccel)(CDVDStreamInfo &hint, CProcessInfo &processInfo, AVPixelFormat fmt);
 typedef CDVDAudioCodec* (*CreateHWAudioCodec)(CProcessInfo &processInfo);
 
 class CDVDFactoryCodec
 {
 public:
-  static CDVDVideoCodec* CreateVideoCodec(CDVDStreamInfo &hint,
-                                          CProcessInfo &processInfo);
+  static std::unique_ptr<CDVDVideoCodec> CreateVideoCodec(CDVDStreamInfo& hint,
+                                                          CProcessInfo& processInfo);
 
   static IHardwareDecoder* CreateVideoCodecHWAccel(const std::string& id,
                                                    CDVDStreamInfo& hint,
@@ -62,7 +62,8 @@ public:
 
 
 protected:
-  static CDVDVideoCodec* CreateVideoCodecHW(const std::string& id, CProcessInfo& processInfo);
+  static std::unique_ptr<CDVDVideoCodec> CreateVideoCodecHW(const std::string& id,
+                                                            CProcessInfo& processInfo);
   static CDVDAudioCodec* CreateAudioCodecHW(const std::string& id, CProcessInfo& processInfo);
 
   static std::map<std::string, CreateHWVideoCodec> m_hwVideoCodecs;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -31,7 +31,7 @@ class CDVDCodecOptions;
 
 typedef std::unique_ptr<CDVDVideoCodec> (*CreateHWVideoCodec)(CProcessInfo& processInfo);
 typedef IHardwareDecoder* (*CreateHWAccel)(CDVDStreamInfo &hint, CProcessInfo &processInfo, AVPixelFormat fmt);
-typedef CDVDAudioCodec* (*CreateHWAudioCodec)(CProcessInfo &processInfo);
+typedef std::unique_ptr<CDVDAudioCodec> (*CreateHWAudioCodec)(CProcessInfo& processInfo);
 
 class CDVDFactoryCodec
 {
@@ -44,9 +44,11 @@ public:
                                                    CProcessInfo& processInfo,
                                                    AVPixelFormat fmt);
 
-  static CDVDAudioCodec* CreateAudioCodec(CDVDStreamInfo &hint, CProcessInfo &processInfo,
-                                          bool allowpassthrough, bool allowdtshddecode,
-                                          CAEStreamInfo::DataType ptStreamType);
+  static std::unique_ptr<CDVDAudioCodec> CreateAudioCodec(CDVDStreamInfo& hint,
+                                                          CProcessInfo& processInfo,
+                                                          bool allowpassthrough,
+                                                          bool allowdtshddecode,
+                                                          CAEStreamInfo::DataType ptStreamType);
 
   static CDVDOverlayCodec* CreateOverlayCodec(CDVDStreamInfo &hint);
 
@@ -64,7 +66,8 @@ public:
 protected:
   static std::unique_ptr<CDVDVideoCodec> CreateVideoCodecHW(const std::string& id,
                                                             CProcessInfo& processInfo);
-  static CDVDAudioCodec* CreateAudioCodecHW(const std::string& id, CProcessInfo& processInfo);
+  static std::unique_ptr<CDVDAudioCodec> CreateAudioCodecHW(const std::string& id,
+                                                            CProcessInfo& processInfo);
 
   static std::map<std::string, CreateHWVideoCodec> m_hwVideoCodecs;
   static std::map<std::string, CreateHWAccel> m_hwAccels;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -50,7 +50,7 @@ public:
                                                           bool allowdtshddecode,
                                                           CAEStreamInfo::DataType ptStreamType);
 
-  static CDVDOverlayCodec* CreateOverlayCodec(CDVDStreamInfo &hint);
+  static std::unique_ptr<CDVDOverlayCodec> CreateOverlayCodec(CDVDStreamInfo& hint);
 
   static void RegisterHWVideoCodec(const std::string& id, CreateHWVideoCodec createFunc);
   static void ClearHWVideoCodecs();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -32,7 +32,8 @@ class CDVDCodecOptions;
 
 using CreateHWVideoCodec =
     std::function<std::unique_ptr<CDVDVideoCodec>(CProcessInfo& processInfo)>;
-typedef IHardwareDecoder* (*CreateHWAccel)(CDVDStreamInfo &hint, CProcessInfo &processInfo, AVPixelFormat fmt);
+using CreateHWAccel = std::function<IHardwareDecoder*(
+    CDVDStreamInfo& hint, CProcessInfo& processInfo, AVPixelFormat fmt)>;
 typedef std::unique_ptr<CDVDAudioCodec> (*CreateHWAudioCodec)(CProcessInfo& processInfo);
 
 class CDVDFactoryCodec

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -11,6 +11,7 @@
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -29,7 +30,8 @@ class CDVDStreamInfo;
 class CDVDCodecOption;
 class CDVDCodecOptions;
 
-typedef std::unique_ptr<CDVDVideoCodec> (*CreateHWVideoCodec)(CProcessInfo& processInfo);
+using CreateHWVideoCodec =
+    std::function<std::unique_ptr<CDVDVideoCodec>(CProcessInfo& processInfo)>;
 typedef IHardwareDecoder* (*CreateHWAccel)(CDVDStreamInfo &hint, CProcessInfo &processInfo, AVPixelFormat fmt);
 typedef std::unique_ptr<CDVDAudioCodec> (*CreateHWAudioCodec)(CProcessInfo& processInfo);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -20,7 +20,6 @@
 CDVDOverlayCodecText::CDVDOverlayCodecText() : CDVDOverlayCodec("Text Subtitle Decoder")
 {
   m_pOverlay = NULL;
-  m_bIsSSA = false;
 }
 
 CDVDOverlayCodecText::~CDVDOverlayCodecText()
@@ -31,11 +30,9 @@ CDVDOverlayCodecText::~CDVDOverlayCodecText()
 
 bool CDVDOverlayCodecText::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
-  m_bIsSSA = (hints.codec == AV_CODEC_ID_SSA);
-  if(hints.codec == AV_CODEC_ID_TEXT || hints.codec == AV_CODEC_ID_SSA)
+  if (hints.codec == AV_CODEC_ID_TEXT || hints.codec == AV_CODEC_ID_SUBRIP)
     return true;
-  if(hints.codec == AV_CODEC_ID_SUBRIP)
-    return true;
+
   return false;
 }
 
@@ -63,20 +60,6 @@ int CDVDOverlayCodecText::Decode(DemuxPacket *pPacket)
   start = (char*)data;
   end   = (char*)data + size;
   p     = (char*)data;
-
-  if (m_bIsSSA)
-  {
-    // currently just skip the prefixed ssa fields (8 fields)
-    int nFieldCount = 8;
-    while (nFieldCount > 0 && start < end)
-    {
-      if (*start == ',')
-        nFieldCount--;
-
-      start++;
-      p++;
-    }
-  }
 
   CDVDSubtitleTagSami TagConv;
   bool Taginit = TagConv.Init();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
@@ -25,6 +25,5 @@ public:
   CDVDOverlay* GetOverlay() override;
 
 private:
-  bool             m_bIsSSA;
   CDVDOverlayText* m_pOverlay;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -344,9 +344,9 @@ CDVDVideoCodecAndroidMediaCodec::~CDVDVideoCodecAndroidMediaCodec()
   }
 }
 
-CDVDVideoCodec* CDVDVideoCodecAndroidMediaCodec::Create(CProcessInfo &processInfo)
+std::unique_ptr<CDVDVideoCodec> CDVDVideoCodecAndroidMediaCodec::Create(CProcessInfo& processInfo)
 {
-  return new CDVDVideoCodecAndroidMediaCodec(processInfo);
+  return std::make_unique<CDVDVideoCodecAndroidMediaCodec>(processInfo);
 }
 
 bool CDVDVideoCodecAndroidMediaCodec::Register()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -118,7 +118,7 @@ public:
   ~CDVDVideoCodecAndroidMediaCodec() override;
 
   // registration
-  static CDVDVideoCodec* Create(CProcessInfo& processInfo);
+  static std::unique_ptr<CDVDVideoCodec> Create(CProcessInfo& processInfo);
   static bool Register();
 
   // required overrides

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -86,11 +86,12 @@ CDVDVideoCodecDRMPRIME::~CDVDVideoCodecDRMPRIME()
   avcodec_free_context(&m_pCodecContext);
 }
 
-CDVDVideoCodec* CDVDVideoCodecDRMPRIME::Create(CProcessInfo& processInfo)
+std::unique_ptr<CDVDVideoCodec> CDVDVideoCodecDRMPRIME::Create(CProcessInfo& processInfo)
 {
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           CSettings::SETTING_VIDEOPLAYER_USEPRIMEDECODER))
-    return new CDVDVideoCodecDRMPRIME(processInfo);
+    return std::make_unique<CDVDVideoCodecDRMPRIME>(processInfo);
+
   return nullptr;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -20,7 +20,7 @@ public:
   explicit CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo);
   ~CDVDVideoCodecDRMPRIME() override;
 
-  static CDVDVideoCodec* Create(CProcessInfo& processInfo);
+  static std::unique_ptr<CDVDVideoCodec> Create(CProcessInfo& processInfo);
   static void Register();
 
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -185,7 +185,6 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
 
   if (nVideoStream != -1)
   {
-    CDVDVideoCodec *pVideoCodec;
     std::unique_ptr<CProcessInfo> pProcessInfo(CProcessInfo::CreateInstance());
     std::vector<AVPixelFormat> pixFmts;
     pixFmts.push_back(AV_PIX_FMT_YUV420P);
@@ -194,7 +193,8 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
     CDVDStreamInfo hint(*pDemuxer->GetStream(demuxerId, nVideoStream), true);
     hint.codecOptions = CODEC_FORCE_SOFTWARE;
 
-    pVideoCodec = CDVDFactoryCodec::CreateVideoCodec(hint, *pProcessInfo);
+    std::unique_ptr<CDVDVideoCodec> pVideoCodec =
+        CDVDFactoryCodec::CreateVideoCodec(hint, *pProcessInfo);
 
     if (pVideoCodec)
     {
@@ -282,7 +282,6 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
           CLog::Log(LOGDEBUG,"%s - decode failed in %s after %d packets.", __FUNCTION__, redactPath.c_str(), packetsTried);
         }
       }
-      delete pVideoCodec;
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -64,7 +64,7 @@ protected:
 
   bool ProcessDecoderOutput(DVDAudioFrame &audioframe);
   void UpdatePlayerInfo();
-  void OpenStream(CDVDStreamInfo &hints, CDVDAudioCodec* codec);
+  void OpenStream(CDVDStreamInfo& hints, std::unique_ptr<CDVDAudioCodec> codec);
   //! Switch codec if needed. Called when the sample rate gotten from the
   //! codec changes, in which case we may want to switch passthrough on/off.
   bool SwitchCodecIfNeeded();

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -149,7 +149,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
   if(hints.codec == AV_CODEC_ID_DVD_SUBTITLE && filename == "dvd")
     return true;
 
-  m_pOverlayCodec.reset(CDVDFactoryCodec::CreateOverlayCodec(hints));
+  m_pOverlayCodec = CDVDFactoryCodec::CreateOverlayCodec(hints);
   if(m_pOverlayCodec)
     return true;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -96,7 +96,7 @@ protected:
 
   EOutputState OutputPicture(const VideoPicture* src);
   void ProcessOverlays(const VideoPicture* pSource, double pts);
-  void OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec);
+  void OpenStream(CDVDStreamInfo& hint, std::unique_ptr<CDVDVideoCodec> codec);
 
   void ResetFrameRateCalc();
   void CalcFrameRate();
@@ -131,7 +131,7 @@ protected:
   CDVDMessageQueue m_messageQueue;
   CDVDMessageQueue& m_messageParent;
   CDVDStreamInfo m_hints;
-  CDVDVideoCodec* m_pVideoCodec;
+  std::unique_ptr<CDVDVideoCodec> m_pVideoCodec;
   CPtsTracker m_ptsTracker;
   std::list<DVDMessageListItem> m_packets;
   CDroppingStats m_droppingStats;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -290,11 +290,7 @@ void VideoPlayerCodec::DeInit()
     throw std::runtime_error("m_pInputStream reference count is greater than 1");
   m_pInputStream.reset();
 
-  if (m_pAudioCodec != NULL)
-  {
-    delete m_pAudioCodec;
-    m_pAudioCodec = NULL;
-  }
+  m_pAudioCodec.reset();
 
   delete m_pResampler;
   m_pResampler = NULL;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -43,7 +43,7 @@ private:
 
   CDVDDemux* m_pDemuxer;
   std::shared_ptr<CDVDInputStream> m_pInputStream;
-  CDVDAudioCodec* m_pAudioCodec;
+  std::unique_ptr<CDVDAudioCodec> m_pAudioCodec;
 
   std::string m_strContentType;
   std::string m_strFileName;

--- a/xbmc/cores/playercorefactory/PlayerCoreConfig.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreConfig.h
@@ -67,50 +67,46 @@ public:
     return m_bPlaysVideo;
   }
 
-  IPlayer* CreatePlayer(IPlayerCallback& callback) const
+  std::shared_ptr<IPlayer> CreatePlayer(IPlayerCallback& callback) const
   {
-    IPlayer* pPlayer;
+    std::shared_ptr<IPlayer> player;
+
     if (m_type.compare("video") == 0)
     {
-      pPlayer = new CVideoPlayer(callback);
+      player = std::make_shared<CVideoPlayer>(callback);
     }
     else if (m_type.compare("music") == 0)
     {
-      pPlayer = new PAPlayer(callback);
+      player = std::make_shared<PAPlayer>(callback);
     }
     else if (m_type.compare("game") == 0)
     {
-      pPlayer = new KODI::RETRO::CRetroPlayer(callback);
+      player = std::make_shared<KODI::RETRO::CRetroPlayer>(callback);
     }
     else if (m_type.compare("external") == 0)
     {
-      pPlayer = new CExternalPlayer(callback);
+      player = std::make_shared<CExternalPlayer>(callback);
     }
 
 #if defined(HAS_UPNP)
     else if (m_type.compare("remote") == 0)
     {
-      pPlayer = new UPNP::CUPnPPlayer(callback, m_id.c_str());
+      player = std::make_shared<UPNP::CUPnPPlayer>(callback, m_id.c_str());
     }
 #endif
     else
       return nullptr;
 
-    if (!pPlayer)
+    if (!player)
       return nullptr;
 
-    pPlayer->m_name = m_name;
-    pPlayer->m_type = m_type;
+    player->m_name = m_name;
+    player->m_type = m_type;
 
-    if (pPlayer->Initialize(m_config.get()))
-    {
-      return pPlayer;
-    }
-    else
-    {
-      delete pPlayer;
-      return nullptr;
-    }
+    if (player->Initialize(m_config.get()))
+      return player;
+
+    return nullptr;
   }
 
   std::string m_name;

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -51,7 +51,8 @@ void CPlayerCoreFactory::OnSettingsLoaded()
   LoadConfiguration(m_profileManager.GetUserDataItem(PLAYERCOREFACTORY_XML), false);
 }
 
-IPlayer* CPlayerCoreFactory::CreatePlayer(const std::string& nameId, IPlayerCallback& callback) const
+std::shared_ptr<IPlayer> CPlayerCoreFactory::CreatePlayer(const std::string& nameId,
+                                                          IPlayerCallback& callback) const
 {
   CSingleLock lock(m_section);
   size_t idx = GetPlayerIndex(nameId);

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -37,7 +37,7 @@ public:
 
   void OnSettingsLoaded() override;
 
-  IPlayer* CreatePlayer(const std::string& nameId, IPlayerCallback& callback) const;
+  std::shared_ptr<IPlayer> CreatePlayer(const std::string& nameId, IPlayerCallback& callback) const;
   void GetPlayers(const CFileItem& item, std::vector<std::string>&players) const;   //Players supporting the specified file
   void GetPlayers(std::vector<std::string>&players, bool audio, bool video) const;  //All audio players and/or video players
   void GetPlayers(std::vector<std::string>&players) const;                          //All players


### PR DESCRIPTION
For some reason we use create a `unique_ptr` just to release it again. This PR allows creating a `unique_ptr` for a given codec. This involves some `std::move` semantics.

I've also included a commit to make CreatePlayer return a `shared_ptr` (as that's what it's being used as anyways).

I've also included a few simple commits to allow using `std::function` which is more readable than the typedefs (IMO).

I've tested this with VAAPI but it may need testing on the other HW decoder platforms.