### PR TITLE
[Addons] Allow uninstalling optional system addons

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -887,8 +887,8 @@ bool CAddonMgr::CanAddonBeDisabled(const std::string& ID)
     return false;
 
   CSingleLock lock(m_critSection);
-  // Non-optional system add-ons can not be disabled
-  if (IsSystemAddon(ID) && !IsOptionalSystemAddon(ID))
+  // Required system add-ons can not be disabled
+  if (IsRequiredSystemAddon(ID))
     return false;
 
   AddonPtr localAddon;
@@ -960,16 +960,26 @@ bool CAddonMgr::CanAddonBeInstalled(const AddonPtr& addon)
 
 bool CAddonMgr::CanUninstall(const AddonPtr& addon)
 {
-  return addon && !IsSystemAddon(addon->ID()) && CanAddonBeDisabled(addon->ID()) &&
-         !StringUtils::StartsWith(addon->Path(),
-                                  CSpecialProtocol::TranslatePath("special://xbmc/addons"));
+  return addon && CanAddonBeDisabled(addon->ID()) && !IsBundledAddon(addon->ID());
+}
+
+bool CAddonMgr::IsBundledAddon(const std::string& id)
+{
+  return XFILE::CDirectory::Exists(
+             CSpecialProtocol::TranslatePath("special://xbmc/addons/" + id + "/")) ||
+         XFILE::CDirectory::Exists(
+             CSpecialProtocol::TranslatePath("special://xbmcbin/addons/" + id + "/"));
 }
 
 bool CAddonMgr::IsSystemAddon(const std::string& id)
 {
+  return IsOptionalSystemAddon(id) || IsRequiredSystemAddon(id);
+}
+
+bool CAddonMgr::IsRequiredSystemAddon(const std::string& id)
+{
   CSingleLock lock(m_critSection);
-  return IsOptionalSystemAddon(id) ||
-         std::find(m_systemAddons.begin(), m_systemAddons.end(), id) != m_systemAddons.end();
+  return std::find(m_systemAddons.begin(), m_systemAddons.end(), id) != m_systemAddons.end();
 }
 
 bool CAddonMgr::IsOptionalSystemAddon(const std::string& id)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -292,6 +292,14 @@ namespace ADDON
     bool CanUninstall(const AddonPtr& addon);
 
     /*!
+     * @brief Checks whether an addon is a bundled addon
+     *
+     * @param[in] id id of the addon
+     * @return true if addon is bundled addon, false otherwise.
+     */
+    bool IsBundledAddon(const std::string& id);
+
+    /*!
      * @brief Checks whether an addon is a system addon
      *
      * @param[in] id id of the addon
@@ -299,7 +307,15 @@ namespace ADDON
      */
     bool IsSystemAddon(const std::string& id);
 
-   /*!
+    /*!
+     * @brief Checks whether an addon is a required system addon
+     *
+     * @param[in] id id of the addon
+     * @return true if addon is a required system addon, false otherwise.
+     */
+    bool IsRequiredSystemAddon(const std::string& id);
+
+    /*!
      * @brief Checks whether an addon is an optional system addon
      *
      * @param[in] id id of the addon
@@ -445,7 +461,7 @@ namespace ADDON
      * \brief Check whether an addon has been disabled with a special reason.
      * \param ID id of the addon
      * \param disabledReason reason we want to check for (NONE, USER, INCOMPATIBLE, PERMANENT_FAILURE)
-     * \return true or false 
+     * \return true or false
      */
     bool IsAddonDisabledWithReason(const std::string& ID, AddonDisabledReason disabledReason) const;
 


### PR DESCRIPTION
## Description
Allow uninstall non-built in optional system add-ons (eg. inputstream.adaptive)
https://github.com/xbmc/xbmc/blob/master/system/addon-manifest.xml 

## Motivation and context
Currently option system add-ons installed can not be uninstalled.

## How has this been tested?
Windows x64 and Android arm8
confirming that inputstream.adaptive can be uninstalled after installing via repo

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

This isn't a "big deal" so don't think a backport would be required.
But can create if wanted