### PR TITLE
[addons] move operations for class AddonVersion

### DIFF
--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -27,16 +27,20 @@ namespace ADDON
   class AddonVersion
   {
   public:
-    AddonVersion(const AddonVersion& other) { *this = other; }
-    explicit AddonVersion(const std::string& version);
     explicit AddonVersion(const char* version = nullptr);
+    explicit AddonVersion(const std::string& version);
+
+    AddonVersion(const AddonVersion& other) = default;
+    AddonVersion(AddonVersion&& other) = default;
+    AddonVersion& operator=(const AddonVersion& other) = default;
+    AddonVersion& operator=(AddonVersion&& other) = default;
+
     virtual ~AddonVersion() = default;
 
     int Epoch() const { return mEpoch; }
     const std::string &Upstream() const { return mUpstream; }
     const std::string &Revision() const { return mRevision; }
 
-    AddonVersion& operator=(const AddonVersion& other);
     bool operator< (const AddonVersion& other) const;
     bool operator> (const AddonVersion& other) const;
     bool operator<=(const AddonVersion& other) const;
@@ -56,6 +60,4 @@ namespace ADDON
 
     static int CompareComponent(const char *a, const char *b);
   };
-
-  inline AddonVersion& AddonVersion::operator=(const AddonVersion& other) = default;
 }

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.h
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.h
@@ -56,8 +56,7 @@ public:
     }
     void SetPath(std::string path) { m_addonInfo->m_path = std::move(path); }
     void SetLibName(std::string libname) { m_addonInfo->m_libname = std::move(libname); }
-    void SetVersion(const AddonVersion& version) { m_addonInfo->m_version = version; }
-    void SetMinVersion(const AddonVersion& minversion) { m_addonInfo->m_minversion = minversion; }
+    void SetVersion(AddonVersion version) { m_addonInfo->m_version = std::move(version); }
     void SetDependencies(std::vector<DependencyInfo> dependencies) { m_addonInfo->m_dependencies = std::move(dependencies); }
     void SetExtrainfo(InfoMap extrainfo)
     {


### PR DESCRIPTION
## Description
clang-tidy removed unavailable rvalue casts for the AddonVersion class. so let's provide it with (default) move operations and clean the header a little.

## How has this been tested?
debian buster. i didn't benchmark but logged ~1500 calls to the assignment operator while starting up and checking for addon-updates. so i think it's just worth doing it.

## What is the effect on users?
none

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
