### PR TITLE
[PVR][GUI] Hide context menu items not relevant to the associated client

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -602,6 +602,10 @@ namespace PVR
 
     bool PVRClientMenuHook::IsVisible(const CFileItem& item) const
     {
+      const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
+      if (!client || m_hook.GetAddonId() != client->ID())
+        return false;
+
       if (m_hook.IsAllHook())
         return !item.m_bIsFolder && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER);
       else if (m_hook.IsEpgHook())

--- a/xbmc/pvr/addons/PVRClientMenuHooks.cpp
+++ b/xbmc/pvr/addons/PVRClientMenuHooks.cpp
@@ -77,6 +77,11 @@ bool CPVRClientMenuHook::IsSettingsHook() const
   return m_hook->category == PVR_MENUHOOK_SETTING;
 }
 
+std::string CPVRClientMenuHook::GetAddonId() const
+{
+  return m_addonId;
+}
+
 unsigned int CPVRClientMenuHook::GetId() const
 {
   return m_hook->iHookId;

--- a/xbmc/pvr/addons/PVRClientMenuHooks.h
+++ b/xbmc/pvr/addons/PVRClientMenuHooks.h
@@ -35,6 +35,7 @@ namespace PVR
     bool IsDeletedRecordingHook() const;
     bool IsSettingsHook() const;
 
+    std::string GetAddonId() const;
     unsigned int GetId() const;
     unsigned int GetLabelId() const;
     std::string GetLabel() const;


### PR DESCRIPTION
## Description
When multiple PVR clients are active a superset of all context menus defined by those PVR clients will be shown to the user for any PVR item.  For example:

PVR client A implements three Channel-level context menu items
PVR client B implements one Channel-level context menu item

If the user right-clicks on any Channel item, all four of those context menu items will be displayed.  Selecting an item that isn't defined by the associated client has no effect, so this is pretty benign (borderline cosmetic?) but I think it could be considered a bug if multiple clients defined the same context menu item -- the user has no way to know which one is the right one to select.

## Motivation and context
I noticed this a while ago doing some side-by-side testing with pvr.hdhomerun and a third-party PVR addon and didn't see it as that big of a deal.  However, when testing multiple addons that have vastly different capabilities, like a "thick" TV and a "thin" Radio addon it became pretty apparent.

## How has this been tested?
Tested on Windows x64 (Desktop) against master branch current as of 2021.05.10.  Primarily tested by having two addons installed, one of which defines many context menu items, one defines none, and checking various context menu points to make sure they are filtering the way I expected.

## What is the effect on users?
My opinion is that this makes the system a little cleaner for the end user, hiding menu items that don't apply to the selected item in the GUI.  Again, there was no ill effect I found if they selected a non-applicable item, but there was also no feedback that the item did nothing.

## Screenshots (if appropriate):
Here is an example of a Radio channel context menu showing items that are defined by a separate addon.  Selecting any of these items will do nothing:

![before](https://user-images.githubusercontent.com/706055/117845163-4b923b80-b24e-11eb-8166-9e1f4c592000.png)

After the change, and having the other addon move some channels into Radio, providing a mixture of channels from multiple addons, right-clicking on a channel from the radio addon shows the expected minimal context menu, while right-clicking on a channel from the other addon shows the expected full context menu with EPG, timers, the three custom items, etc, etc:

![after-1](https://user-images.githubusercontent.com/706055/117845256-5fd63880-b24e-11eb-80d8-38154c7cc2ae.png)
![after-2](https://user-images.githubusercontent.com/706055/117845598-b5aae080-b24e-11eb-8b34-55fcdadd1700.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
