### PR TITLE
[PVR] Separate GUI from core: Get rid of 'selected group' functionality in core code

### DIFF
--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -191,17 +191,17 @@ public:
   bool CanRecordOnPlayingChannel() const;
 
   /*!
-   * @brief Set the current playing group, used to load the right channel.
+   * @brief Set the active channel group.
    * @param group The new group.
    */
-  void SetPlayingGroup(const std::shared_ptr<CPVRChannelGroup>& group);
+  void SetActiveChannelGroup(const std::shared_ptr<CPVRChannelGroup>& group);
 
   /*!
-   * @brief Get the current playing group, used to load the right channel.
-   * @param bRadio True to get the current radio group, false to get the current TV group.
+   * @brief Get the active channel group.
+   * @param bRadio True to get the active radio group, false to get the active TV group.
    * @return The current group or the group containing all channels if it's not set.
    */
-  std::shared_ptr<CPVRChannelGroup> GetPlayingGroup(bool bRadio) const;
+  std::shared_ptr<CPVRChannelGroup> GetActiveChannelGroup(bool bRadio) const;
 
   /*!
    * @brief Get current playback time for the given channel, taking timeshifting and playing
@@ -222,10 +222,10 @@ public:
 
 private:
   /*!
-   * @brief Set the playing group to the first group the channel is in if the given channel is not part of the current playing group
+   * @brief Set the active group to the first group the channel is in if the given channel is not part of the current active group
    * @param channel The channel
    */
-  void SetPlayingGroup(const std::shared_ptr<CPVRChannel>& channel);
+  void SetActiveChannelGroup(const std::shared_ptr<CPVRChannel>& channel);
 
   /*!
    * @brief Updates the last watched timestamps of the channel and group which are currently playing.
@@ -245,8 +245,8 @@ private:
   std::string m_strPlayingRecordingUniqueId;
   int m_playingEpgTagChannelUniqueId = -1;
   unsigned int m_playingEpgTagUniqueId = 0;
-  std::shared_ptr<CPVRChannelGroup> m_playingGroupTV;
-  std::shared_ptr<CPVRChannelGroup> m_playingGroupRadio;
+  std::shared_ptr<CPVRChannelGroup> m_activeGroupTV;
+  std::shared_ptr<CPVRChannelGroup> m_activeGroupRadio;
 
   class CLastWatchedUpdateTimer;
   std::unique_ptr<CLastWatchedUpdateTimer> m_lastWatchedUpdateTimer;

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -245,6 +245,8 @@ private:
   std::string m_strPlayingRecordingUniqueId;
   int m_playingEpgTagChannelUniqueId = -1;
   unsigned int m_playingEpgTagUniqueId = 0;
+  std::shared_ptr<CPVRChannelGroup> m_playingGroupTV;
+  std::shared_ptr<CPVRChannelGroup> m_playingGroupRadio;
 
   class CLastWatchedUpdateTimer;
   std::unique_ptr<CLastWatchedUpdateTimer> m_lastWatchedUpdateTimer;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -466,6 +466,17 @@ namespace PVR
      */
     bool UpdateChannelNumbersFromAllChannelsGroup();
 
+    /*!
+     * @brief Whether this group is deleted.
+     * @return True, if deleted, false otherwise.
+     */
+    bool IsDeleted() const { return m_bDeleted; }
+
+    /*!
+     * @brief Mark this group as deleted.
+     */
+    void SetDeleted() { m_bDeleted = true; }
+
   protected:
     /*!
      * @brief Init class
@@ -557,5 +568,6 @@ namespace PVR
 
     std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
     CPVRChannelsPath m_path;
+    bool m_bDeleted = false;
   };
 }

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -150,18 +150,6 @@ namespace PVR
     std::shared_ptr<CPVRChannelGroup> GetNextGroup(const CPVRChannelGroup& group) const;
 
     /*!
-     * @brief Get the group that is currently selected in the UI.
-     * @return The selected group.
-     */
-    std::shared_ptr<CPVRChannelGroup> GetSelectedGroup() const;
-
-    /*!
-     * @brief Change the selected group.
-     * @param selectedGroup The group to select.
-     */
-    void SetSelectedGroup(const std::shared_ptr<CPVRChannelGroup>& selectedGroup);
-
-    /*!
      * @brief Add a group to this container.
      * @param strName The name of the group.
      * @return True if the group was added, false otherwise.
@@ -231,7 +219,6 @@ namespace PVR
     void RemoveFromAllGroups(const std::shared_ptr<CPVRChannel>& channel);
 
     bool m_bRadio; /*!< true if this is a container for radio channels, false if it is for tv channels */
-    std::shared_ptr<CPVRChannelGroup> m_selectedGroup; /*!< the group that's currently selected in the UI */
     std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups; /*!< the groups in this container */
     mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClientsForChannelGroups;

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -122,11 +122,6 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByPath(const std::st
   return {};
 }
 
-std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupsContainer::GetSelectedGroup(bool bRadio) const
-{
-  return Get(bRadio)->GetSelectedGroup();
-}
-
 std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByUniqueID(int iUniqueChannelId, int iClientID) const
 {
   std::shared_ptr<CPVRChannel> channel;

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -130,13 +130,6 @@ namespace PVR
     std::shared_ptr<CPVRChannel> GetByPath(const std::string& strPath) const;
 
     /*!
-     * @brief Get the group that is currently selected in the UI.
-     * @param bRadio True to get the selected radio group, false to get the selected TV group.
-     * @return The selected group.
-     */
-    std::shared_ptr<CPVRChannelGroup> GetSelectedGroup(bool bRadio) const;
-
-    /*!
      * @brief Get a channel given it's channel ID from all containers.
      * @param iUniqueChannelId The unique channel id on the client.
      * @param iClientID The ID of the client.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -127,7 +127,7 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction& action)
       const std::shared_ptr<CPVRChannelGroup> nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP
                                                         ? groups->GetNextGroup(*m_group)
                                                         : groups->GetPreviousGroup(*m_group);
-      CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(nextGroup);
+      CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(nextGroup);
       m_group = nextGroup;
       Init();
       Update();
@@ -171,7 +171,8 @@ void CGUIDialogPVRChannelsOSD::Update()
   const std::shared_ptr<CPVRChannel> channel = pvrMgr.PlaybackState()->GetPlayingChannel();
   if (channel)
   {
-    const std::shared_ptr<CPVRChannelGroup> group = pvrMgr.PlaybackState()->GetPlayingGroup(channel->IsRadio());
+    const std::shared_ptr<CPVRChannelGroup> group =
+        pvrMgr.PlaybackState()->GetActiveChannelGroup(channel->IsRadio());
     if (group)
     {
       const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -455,7 +455,7 @@ void CGUIDialogPVRGroupManager::Update()
   if (m_selectedGroup)
   {
     /* set this group in the pvrmanager, so it becomes the selected group in other dialogs too */
-    CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(m_selectedGroup);
+    CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(m_selectedGroup);
     SET_CONTROL_LABEL(CONTROL_CURRENT_GROUP_LABEL, m_selectedGroup->GroupName());
     SET_CONTROL_SELECTED(GetID(), BUTTON_HIDE_GROUP, m_selectedGroup->IsHidden());
 

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -251,10 +251,10 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
 
       const std::shared_ptr<CPVRPlaybackState> playbackState =
           CServiceBroker::GetPVRManager().PlaybackState();
-      const std::shared_ptr<CPVRChannelGroup> playingGroup =
-          playbackState->GetPlayingGroup(playbackState->IsPlayingRadio());
+      const std::shared_ptr<CPVRChannelGroup> activeGroup =
+          playbackState->GetActiveChannelGroup(playbackState->IsPlayingRadio());
       const std::shared_ptr<CPVRChannel> channel =
-          playingGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));
+          activeGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));
 
       if (!channel)
         return false;

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -249,9 +249,12 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
       int iChannelNumber = static_cast<int>(action.GetAmount(0));
       int iSubChannelNumber = static_cast<int>(action.GetAmount(1));
 
-      const std::shared_ptr<CPVRChannel> currentChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
-      const std::shared_ptr<CPVRChannelGroup> selectedGroup = CServiceBroker::GetPVRManager().ChannelGroups()->Get(currentChannel->IsRadio())->GetSelectedGroup();
-      const std::shared_ptr<CPVRChannel> channel = selectedGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));
+      const std::shared_ptr<CPVRPlaybackState> playbackState =
+          CServiceBroker::GetPVRManager().PlaybackState();
+      const std::shared_ptr<CPVRChannelGroup> playingGroup =
+          playbackState->GetPlayingGroup(playbackState->IsPlayingRadio());
+      const std::shared_ptr<CPVRChannel> channel =
+          playingGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));
 
       if (!channel)
         return false;

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1455,7 +1455,8 @@ namespace PVR
     else
     {
       // if we don't, find the active channel group of the demanded type and play it's first channel
-      const std::shared_ptr<CPVRChannelGroup> channelGroup = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(bIsRadio);
+      const std::shared_ptr<CPVRChannelGroup> channelGroup =
+          CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bIsRadio);
       if (channelGroup)
       {
         // try to start playback of first channel in this group
@@ -1509,7 +1510,7 @@ namespace PVR
     }
 
     CLog::Log(LOGINFO, "PVR is starting playback of channel '{}'", channel->ChannelName());
-    CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(group);
+    CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(group);
     return SwitchToChannel(std::make_shared<CFileItem>(channel), true);
   }
 
@@ -2334,7 +2335,8 @@ namespace PVR
       {
         // first, try whether the channel is contained in the active channel group
         std::shared_ptr<CPVRChannelGroup> group =
-            CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(channel->IsRadio());
+            CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(
+                channel->IsRadio());
         if (group)
           groupMember = group->GetByUniqueID(channel->StorageId());
 
@@ -2431,11 +2433,11 @@ namespace PVR
       {
         bool bRadio = playingChannel->IsRadio();
         const std::shared_ptr<CPVRChannelGroup> group =
-            CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(bRadio);
+            CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bRadio);
 
         if (channelNumber != group->GetChannelNumber(playingChannel))
         {
-          // channel number present in playing group?
+          // channel number present in active group?
           std::shared_ptr<CPVRChannel> channel = group->GetByChannelNumber(channelNumber);
 
           if (!channel)
@@ -2449,7 +2451,8 @@ namespace PVR
               if (channel)
               {
                 // switch channel group
-                CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(currentGroup);
+                CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(
+                    currentGroup);
                 break;
               }
             }
@@ -2478,7 +2481,7 @@ namespace PVR
         const std::shared_ptr<CPVRChannelGroup> group = CServiceBroker::GetPVRManager().ChannelGroups()->GetPreviousPlayedGroup();
         if (group)
         {
-          CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(group);
+          CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(group);
           const std::shared_ptr<CPVRChannelGroupMember> groupMember =
               group->GetLastPlayedChannelGroupMember(playingChannel->ChannelID());
           if (groupMember)

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -120,7 +120,8 @@ namespace PVR
 
     if (bPlayingTV || bPlayingRadio)
     {
-      const std::shared_ptr<CPVRChannelGroup> group = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(bPlayingRadio);
+      const std::shared_ptr<CPVRChannelGroup> group =
+          CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bPlayingRadio);
       if (group)
       {
         CSingleLock lock(m_critSection);

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -246,8 +246,10 @@ void CPVRGUIInfo::UpdateMisc()
   const bool bCanRecordPlayingChannel = bStarted && state->CanRecordOnPlayingChannel();
   const bool bIsRecordingPlayingChannel = bStarted && state->IsRecordingOnPlayingChannel();
   const bool bIsPlayingActiveRecording = bStarted && state->IsPlayingActiveRecording();
-  const std::string strPlayingTVGroup = (bStarted && bIsPlayingTV) ? state->GetPlayingGroup(false)->GroupName() : "";
-  const std::string strPlayingRadioGroup = (bStarted && bIsPlayingRadio) ? state->GetPlayingGroup(true)->GroupName() : "";
+  const std::string strPlayingTVGroup =
+      (bStarted && bIsPlayingTV) ? state->GetActiveChannelGroup(false)->GroupName() : "";
+  const std::string strPlayingRadioGroup =
+      (bStarted && bIsPlayingRadio) ? state->GetActiveChannelGroup(true)->GroupName() : "";
 
   CSingleLock lock(m_critSection);
   m_strPlayingClientName = strPlayingClientName;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -352,7 +352,7 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
         case PVREvent::ChannelGroupsInvalidated:
         {
           std::shared_ptr<CPVRChannelGroup> group =
-              CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(m_bRadio);
+              CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(m_bRadio);
           m_channelGroupsSelector->Initialize(this, m_bRadio);
           m_channelGroupsSelector->SelectChannelGroup(group);
           SetChannelGroup(std::move(group));
@@ -450,13 +450,13 @@ bool CGUIWindowPVRBase::InitChannelGroup()
   std::shared_ptr<CPVRChannelGroup> group;
   if (m_channelGroupPath.empty())
   {
-    group = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(m_bRadio);
+    group = CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(m_bRadio);
   }
   else
   {
     group = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bRadio)->GetGroupByPath(m_channelGroupPath);
     if (group)
-      CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(group);
+      CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(group);
     else
       CLog::LogF(LOGERROR, "Found no {} channel group with path '{}'!", m_bRadio ? "radio" : "TV",
                  m_vecItems->GetPath());
@@ -505,7 +505,7 @@ void CGUIWindowPVRBase::SetChannelGroup(std::shared_ptr<CPVRChannelGroup> &&grou
 
   if (updateChannelGroup)
   {
-    CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(updateChannelGroup);
+    CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(updateChannelGroup);
     Update(GetDirectoryPath());
   }
 }


### PR DESCRIPTION
'Selected group' is a GUI concept and thus implementation belongs not into PVR core. This PR moved 'selected group' code up to PVR GUI layer.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish more stuff you could review. 