### PR TITLE
Fix audio passthrough at display lost/reset events

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -20,6 +20,7 @@ struct DemuxPacket;
 class CDVDMsg
 {
 public:
+  // clang-format off
   enum Message
   {
     NONE = 1000,
@@ -52,6 +53,7 @@ public:
     PLAYER_ABORT,
     PLAYER_REPORT_STATE,
     PLAYER_FRAME_ADVANCE,
+    PLAYER_DISPLAY_RESET,           // report display reset event
 
     // demuxer related messages
     DEMUXER_PACKET,                 // data packet
@@ -65,6 +67,7 @@ public:
     SUBTITLE_CLUTCHANGE,
     SUBTITLE_ADDFILE
   };
+  // clang-format on
 
   explicit CDVDMsg(Message msg)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4936,6 +4936,7 @@ void CVideoPlayer::OnResetDisplay()
   m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, false), 1);
   m_clock.Pause(false);
   m_displayLost = false;
+  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_DISPLAY_RESET), 1);
 }
 
 void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -405,8 +405,11 @@ void CVideoPlayerAudio::Process()
       {
         onlyPrioMsgs = true;
       }
-
-    } // demuxer packet
+    }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_DISPLAY_RESET))
+    {
+      m_displayReset = true;
+    }
   }
 }
 
@@ -452,6 +455,17 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
     if (m_processInfo.IsRealtimeStream() && m_synctype != SYNC_RESAMPLE)
     {
       m_synctype = SYNC_RESAMPLE;
+      if (SwitchCodecIfNeeded())
+      {
+        audioframe.nb_frames = 0;
+        return false;
+      }
+    }
+
+    // Display reset event has occurred
+    // See if we should enable passthrough
+    if (m_displayReset)
+    {
       if (SwitchCodecIfNeeded())
       {
         audioframe.nb_frames = 0;
@@ -596,7 +610,13 @@ bool CVideoPlayerAudio::AcceptsData() const
 
 bool CVideoPlayerAudio::SwitchCodecIfNeeded()
 {
-  CLog::Log(LOGDEBUG, "CVideoPlayerAudio: stream props changed, checking for passthrough");
+  if (m_displayReset)
+    CLog::Log(LOGINFO, "CVideoPlayerAudio: display reset occurred, checking for passthrough");
+  else
+    CLog::Log(LOGDEBUG, "CVideoPlayerAudio: stream props changed, checking for passthrough");
+
+  m_displayReset = false;
+
   bool allowpassthrough = !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
   if (m_processInfo.IsRealtimeStream() || m_synctype == SYNC_RESAMPLE)
     allowpassthrough = false;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -107,5 +107,7 @@ protected:
 
   mutable CCriticalSection m_info_section;
   SInfo            m_info;
+
+  bool m_displayReset = false;
 };
 


### PR DESCRIPTION
## Description
Fix audio passthrough at display lost/reset events. 

Fixes https://github.com/xbmc/xbmc/issues/15490


## Motivation and context
I have relied on @FernetMenta's comments to implement this. My systems are not affected by this issue.

> This is a scenario that hasn't been considered in the code. In other words it was working by chance in earlier versions. VideoPlayerAudio checks passthrough capabilities at the time it opens a stream. This can happen at every time, not just at start of playback.
> The mentioned commit introduced no error, it just brought an already existing issue to surface. A audio device change can happen at every time. VideoPlayerAudio needs to re-evaluate passthrough capabilities after a device change and act accordingly.


## How has this been tested?
Tested on RTX 2060 SUPER + Denon AVR-X1600H
and Intel NUC8i3BEK + Denon AVR-X1600H

Although these systems are unaffected and has passthrough audio before and after this PR. 
Kodi log shows the code runs as expected: display reset event triggers re-evaluates passthrough capabilities.

One user affected by this has confirmed that PR fixes the issue:
https://github.com/xbmc/xbmc/issues/15490#issuecomment-838569965

More tests to confirm issue is fixed ~would be desirable...~ two users have already confirmed that it works.

## What is the effect on users?
Fixes missing passthrough audio when Adjust Display Refresh Rate at Start/Stop is enabled.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
