### PR TITLE
[PVR] Remove CFileItem ctor taking an CPVRChannel, thus only channel …

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -112,7 +112,6 @@ public:
   explicit CFileItem(const MUSIC_INFO::CMusicInfoTag& music);
   explicit CFileItem(const CVideoInfoTag& movie);
   explicit CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
-  explicit CFileItem(const std::shared_ptr<PVR::CPVRChannel>& channel);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRChannelGroupMember>& channelGroupMember);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRRecording>& record);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRTimerInfoTag>& timer);
@@ -292,16 +291,6 @@ public:
     return m_epgInfoTag;
   }
 
-  inline bool HasPVRChannelInfoTag() const
-  {
-    return m_pvrChannelInfoTag.get() != NULL;
-  }
-
-  inline const std::shared_ptr<PVR::CPVRChannel> GetPVRChannelInfoTag() const
-  {
-    return m_pvrChannelInfoTag;
-  }
-
   inline bool HasPVRChannelGroupMemberInfoTag() const
   {
     return m_pvrChannelGroupMemberInfoTag.get() != nullptr;
@@ -311,6 +300,9 @@ public:
   {
     return m_pvrChannelGroupMemberInfoTag;
   }
+
+  bool HasPVRChannelInfoTag() const;
+  const std::shared_ptr<PVR::CPVRChannel> GetPVRChannelInfoTag() const;
 
   inline bool HasPVRRecordingInfoTag() const
   {
@@ -605,7 +597,6 @@ private:
   MUSIC_INFO::CMusicInfoTag* m_musicInfoTag;
   CVideoInfoTag* m_videoInfoTag;
   std::shared_ptr<PVR::CPVREpgInfoTag> m_epgInfoTag;
-  std::shared_ptr<PVR::CPVRChannel> m_pvrChannelInfoTag;
   std::shared_ptr<PVR::CPVRRecording> m_pvrRecordingInfoTag;
   std::shared_ptr<PVR::CPVRTimerInfoTag> m_pvrTimerInfoTag;
   std::shared_ptr<PVR::CPVRChannelGroupMember> m_pvrChannelGroupMemberInfoTag;

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -10,26 +10,28 @@
 
 #include "Application.h"
 #include "FileItem.h"
-#include "ServiceBroker.h"
-#include "filesystem/Directory.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
 #include "PartyModeManager.h"
 #include "PlayListPlayer.h"
 #include "SeekHandler.h"
+#include "ServiceBroker.h"
+#include "filesystem/Directory.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannel.h"
+#include "pvr/guilib/PVRGUIActions.h"
+#include "pvr/recordings/PVRRecording.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
-#include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "view/GUIViewState.h"
+#include "utils/log.h"
 #include "video/windows/GUIWindowVideoBase.h"
-#include "pvr/channels/PVRChannel.h"
-#include "pvr/recordings/PVRRecording.h"
+#include "view/GUIViewState.h"
 
 #include <math.h>
 
@@ -357,10 +359,19 @@ static int PlayerControl(const std::vector<std::string>& params)
 
     if (channel)
     {
-      CFileItem playItem(channel);
+      const std::shared_ptr<PVR::CPVRChannelGroupMember> groupMember =
+          CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(channel);
+      if (!groupMember)
+      {
+        CLog::Log(LOGERROR, "ResumeLiveTv could not obtain channel group member for channel: {}",
+                  channel->ChannelName());
+        return false;
+      }
+
+      CFileItem playItem(groupMember);
       if (!g_application.PlayMedia(playItem, "", channel->IsRadio() ? PLAYLIST_MUSIC : PLAYLIST_VIDEO))
       {
-        CLog::Log(LOGERROR, "ResumeLiveTv could not play channel: %s", channel->ChannelName().c_str());
+        CLog::Log(LOGERROR, "ResumeLiveTv could not play channel: {}", channel->ChannelName());
         return false;
       }
     }

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -144,7 +144,7 @@ JSONRPC_STATUS CPVROperations::GetChannelDetails(const std::string &method, ITra
     return InvalidParams;
 
   const std::shared_ptr<CPVRChannelGroupMember> groupMember =
-      CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(CFileItem(channel));
+      CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(channel);
   if (!groupMember)
     return InvalidParams;
 

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -742,7 +742,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
       return InvalidParams;
 
     const std::shared_ptr<CPVRChannelGroupMember> groupMember =
-        CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(CFileItem(channel));
+        CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(channel);
     if (!groupMember || !groupMember->Channel())
       return InvalidParams;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -295,14 +295,15 @@ namespace PVR
      * @return The requested channel group member or nullptr.
      */
     std::shared_ptr<CPVRChannelGroupMember> GetLastPlayedChannelGroupMember(
-        int iCurrentChannel) const;
+        int iCurrentChannel = -1) const;
 
     /*!
-     * @brief Get a channel given it's active channel number
+     * @brief Get a channel group member given it's active channel number
      * @param channelNumber The channel number.
-     * @return The channel or nullptr if it wasn't found.
+     * @return The channel group member or nullptr if it wasn't found.
      */
-    std::shared_ptr<CPVRChannel> GetByChannelNumber(const CPVRChannelNumber& channelNumber) const;
+    std::shared_ptr<CPVRChannelGroupMember> GetByChannelNumber(
+        const CPVRChannelNumber& channelNumber) const;
 
     /*!
      * @brief Get the channel number in this group of the given channel.
@@ -319,18 +320,20 @@ namespace PVR
     CPVRChannelNumber GetClientChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const;
 
     /*!
-     * @brief Get the next channel in this group.
-     * @param channel The current channel.
-     * @return The channel or nullptr if it wasn't found.
+     * @brief Get the next channel group member in this group.
+     * @param groupMember The current channel group member.
+     * @return The channel group member or nullptr if it wasn't found.
      */
-    std::shared_ptr<CPVRChannel> GetNextChannel(const std::shared_ptr<CPVRChannel>& channel) const;
+    std::shared_ptr<CPVRChannelGroupMember> GetNextChannelGroupMember(
+        const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
 
     /*!
-     * @brief Get the previous channel in this group.
-     * @param channel The current channel.
-     * @return The channel or nullptr if it wasn't found.
+     * @brief Get the previous channel group member in this group.
+     * @param groupMember The current channel group member.
+     * @return The channel group member or nullptr if it wasn't found.
      */
-    std::shared_ptr<CPVRChannel> GetPreviousChannel(const std::shared_ptr<CPVRChannel>& channel) const;
+    std::shared_ptr<CPVRChannelGroupMember> GetPreviousChannelGroupMember(
+        const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
 
     /*!
      * @brief Get a channel given it's channel ID.

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -125,14 +125,16 @@ void CPVRChannelGroups::SortGroups()
   }
 }
 
-std::shared_ptr<CPVRChannel> CPVRChannelGroups::GetByPath(const CPVRChannelsPath& path) const
+std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroups::GetChannelGroupMemberByPath(
+    const CPVRChannelsPath& path) const
 {
   if (path.IsChannel())
   {
     const std::shared_ptr<CPVRChannelGroup> group = GetByName(path.GetGroupName());
     if (group)
-      return group->GetByUniqueID(path.GetChannelUID(),
-                                  CServiceBroker::GetPVRManager().Clients()->GetClientId(path.GetClientID()));
+      return group->GetByUniqueID(
+          {CServiceBroker::GetPVRManager().Clients()->GetClientId(path.GetClientID()),
+           path.GetChannelUID()});
   }
 
   return {};

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -64,11 +64,12 @@ namespace PVR
     bool UpdateFromClient(const CPVRChannelGroup& group) { return Update(group, true); }
 
     /*!
-     * @brief Get a channel given its path
-     * @param strPath The path to the channel
-     * @return The channel, or nullptr if not found
+     * @brief Get a channel group member given its path
+     * @param strPath The path to the channel group member
+     * @return The channel group member, or nullptr if not found
      */
-    std::shared_ptr<CPVRChannel> GetByPath(const CPVRChannelsPath& path) const;
+    std::shared_ptr<CPVRChannelGroupMember> GetChannelGroupMemberByPath(
+        const CPVRChannelsPath& path) const;
 
     /*!
      * @brief Get a pointer to a channel group given its ID.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -9,6 +9,7 @@
 #include "PVRChannelGroupsContainer.h"
 
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "threads/SingleLock.h"
@@ -113,11 +114,21 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelForEpgTag(con
   return Get(epgTag->IsRadio())->GetGroupAll()->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID());
 }
 
-std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByPath(const std::string& strPath) const
+std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroupsContainer::GetChannelGroupMemberByPath(
+    const std::string& strPath) const
 {
   const CPVRChannelsPath path(strPath);
   if (path.IsValid())
-    return Get(path.IsRadio())->GetByPath(path);
+    return Get(path.IsRadio())->GetChannelGroupMemberByPath(path);
+
+  return {};
+}
+
+std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByPath(const std::string& strPath) const
+{
+  const std::shared_ptr<CPVRChannelGroupMember> groupMember = GetChannelGroupMemberByPath(strPath);
+  if (groupMember)
+    return groupMember->Channel();
 
   return {};
 }
@@ -137,14 +148,17 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByUniqueID(int iUniq
   return channel;
 }
 
-std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetLastPlayedChannel() const
+std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroupsContainer::
+    GetLastPlayedChannelGroupMember() const
 {
-  std::shared_ptr<CPVRChannel> channelTV = m_groupsTV->GetGroupAll()->GetLastPlayedChannel();
-  std::shared_ptr<CPVRChannel> channelRadio = m_groupsRadio->GetGroupAll()->GetLastPlayedChannel();
+  std::shared_ptr<CPVRChannelGroupMember> channelTV =
+      m_groupsTV->GetGroupAll()->GetLastPlayedChannelGroupMember();
+  std::shared_ptr<CPVRChannelGroupMember> channelRadio =
+      m_groupsRadio->GetGroupAll()->GetLastPlayedChannelGroupMember();
 
-  if (!channelTV ||
-      (channelRadio && channelRadio->LastWatched() > channelTV->LastWatched()))
-     return channelRadio;
+  if (!channelTV || (channelRadio &&
+                     channelRadio->Channel()->LastWatched() > channelTV->Channel()->LastWatched()))
+    return channelRadio;
 
   return channelTV;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -16,6 +16,7 @@ namespace PVR
 {
   class CPVRChannel;
   class CPVRChannelGroup;
+  class CPVRChannelGroupMember;
   class CPVRChannelGroups;
   class CPVREpgInfoTag;
 
@@ -130,6 +131,14 @@ namespace PVR
     std::shared_ptr<CPVRChannel> GetByPath(const std::string& strPath) const;
 
     /*!
+     * @brief Get a channel group member given it's path.
+     * @param strPath The path.
+     * @return The channel group member or nullptr if it wasn't found.
+     */
+    std::shared_ptr<CPVRChannelGroupMember> GetChannelGroupMemberByPath(
+        const std::string& strPath) const;
+
+    /*!
      * @brief Get a channel given it's channel ID from all containers.
      * @param iUniqueChannelId The unique channel id on the client.
      * @param iClientID The ID of the client.
@@ -138,10 +147,10 @@ namespace PVR
     std::shared_ptr<CPVRChannel> GetByUniqueID(int iUniqueChannelId, int iClientID) const;
 
     /*!
-     * @brief Get the channel that was played last.
-     * @return The requested channel or nullptr.
+     * @brief Get the channel group member that was played last.
+     * @return The requested channel group member or nullptr.
      */
-    std::shared_ptr<CPVRChannel> GetLastPlayedChannel() const;
+    std::shared_ptr<CPVRChannelGroupMember> GetLastPlayedChannelGroupMember() const;
 
     /*!
      * @brief The group that was played last and optionally contains the given channel.

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -253,13 +253,14 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
           CServiceBroker::GetPVRManager().PlaybackState();
       const std::shared_ptr<CPVRChannelGroup> activeGroup =
           playbackState->GetActiveChannelGroup(playbackState->IsPlayingRadio());
-      const std::shared_ptr<CPVRChannel> channel =
+      const std::shared_ptr<CPVRChannelGroupMember> groupMember =
           activeGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));
 
-      if (!channel)
+      if (!groupMember)
         return false;
 
-      CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(std::make_shared<CFileItem>(channel), false);
+      CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(
+          std::make_shared<CFileItem>(groupMember), false);
       return true;
     }
 

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -37,6 +37,7 @@ namespace PVR
     SUCCESS
   };
 
+  class CPVRChannel;
   class CPVRChannelGroupMember;
   class CPVRRecording;
   class CPVRStreamProperties;
@@ -398,6 +399,15 @@ namespace PVR
      * @param iThreshold the value in seconds to trigger seek to start of current event instead of start of previous event.
      */
     void SeekBackward(unsigned int iThreshold);
+
+    /*!
+     * @brief Get a channel group member for the given channel, either from the currently active
+     * group or if not found there, from the 'all channels' group.
+     * @param cahnnel the channel.
+     * @return the group member or nullptr if not found.
+     */
+    std::shared_ptr<CPVRChannelGroupMember> GetChannelGroupMember(
+        const std::shared_ptr<CPVRChannel>& channel) const;
 
     /*!
      * @brief Get a channel group member for the given item, either from the currently active group

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
@@ -20,7 +20,7 @@ namespace PVR
     INSTANT_OR_DELAYED_SWITCH // switch according to SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT
   };
 
-  class CPVRChannel;
+  class CPVRChannelGroupMember;
 
   class CPVRGUIChannelNavigator
   {
@@ -72,10 +72,10 @@ namespace PVR
     void ToggleInfo();
 
     /*!
-     * @brief Set a new playing channel and show the channel info OSD for the new channel.
-     * @param channel The new playing channel
+     * @brief Set a new playing channel group member and show the channel info OSD for the new channel.
+     * @param groupMember The new playing channel group member
      */
-    void SetPlayingChannel(const std::shared_ptr<CPVRChannel>& channel);
+    void SetPlayingChannel(const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
 
     /*!
      * @brief Clear the currently playing channel and hide the channel info OSD.
@@ -84,18 +84,19 @@ namespace PVR
 
   private:
     /*!
-     * @brief Get next or previous channel of the playing channel group, relative to the currently selected channel.
-     * @param bNext True to get the next channel, false to get the previous channel.
+     * @brief Get next or previous channel group member of the playing channel group, relative to the currently selected channel group member.
+     * @param bNext True to get the next channel group member, false to get the previous channel group member.
      * @param return The channel or nullptr if not found.
      */
-    std::shared_ptr<CPVRChannel> GetNextOrPrevChannel(bool bNext);
+    std::shared_ptr<CPVRChannelGroupMember> GetNextOrPrevChannel(bool bNext);
 
     /*!
-     * @brief Select a given channel, display channel info OSD, switch according to given switch mode.
-     * @param item The channel to select.
+     * @brief Select a given channel group member, display channel info OSD, switch according to given switch mode.
+     * @param groupMember The channel group member to select.
      * @param eSwitchMode The channel switch mode.
      */
-    void SelectChannel(const std::shared_ptr<CPVRChannel>& channel, ChannelSwitchMode eSwitchMode);
+    void SelectChannel(const std::shared_ptr<CPVRChannelGroupMember>& groupMember,
+                       ChannelSwitchMode eSwitchMode);
 
     /*!
      * @brief Show the channel info OSD.
@@ -104,8 +105,8 @@ namespace PVR
     void ShowInfo(bool bForce);
 
     mutable CCriticalSection m_critSection;
-    std::shared_ptr<CPVRChannel> m_playingChannel;
-    std::shared_ptr<CPVRChannel> m_currentChannel;
+    std::shared_ptr<CPVRChannelGroupMember> m_playingChannel;
+    std::shared_ptr<CPVRChannelGroupMember> m_currentChannel;
     int m_iChannelEntryJobId = -1;
     int m_iChannelInfoJobId = -1;
   };


### PR DESCRIPTION
Next one on the journey to refactor the channel/channelgroups implementation of the PVR component:

Remove CFileItem ctor taking an CPVRChannel, thus only channel group member items can be created to represent channels at GUI, ensuring all group member data are always available at GUI, not just the channel 'core' data'

Runtime-tested (as always) on macOS and Android.

@phunkyfish I hope you find some time for a review?

