### PR TITLE
[Cleanup][Music]Remove trailing whitespaces

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -144,7 +144,7 @@ CDatabase::DatasetLayout::DatasetLayout(size_t totalfields)
 }
 
 void CDatabase::DatasetLayout::SetField(int fieldNo, const std::string &strField, bool bOutput /*= false*/)
-{  
+{
   if (fieldNo >= 0 && fieldNo < static_cast<int>(m_fields.size()))
   {
     m_fields[fieldNo].strField = strField;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -46,7 +46,7 @@ public:
     std::string limit;
   };
 
-  
+
   typedef struct DatasetFieldInfo {
     DatasetFieldInfo(bool fetch, bool output, int recno)
       : fetch(fetch),

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -63,7 +63,7 @@ JSONRPC_STATUS CAudioLibrary::GetProperties(const std::string &method, ITranspor
       property = (int)BLANKARTIST_ID;
     else if (propertyName == "librarylastupdated")
       property = musicdatabase.GetLibraryLastUpdated();
-    else if (propertyName == "librarylastcleaned")  
+    else if (propertyName == "librarylastcleaned")
       property = musicdatabase.GetLibraryLastCleaned();
     else if (propertyName == "artistlinksupdated")
       property = musicdatabase.GetArtistLinksUpdated();
@@ -251,8 +251,8 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
   std::set<std::string> fields;
   if (parameterObject.isMember("properties") && parameterObject["properties"].isArray())
   {
-    for (CVariant::const_iterator_array field = parameterObject["properties"].begin_array(); 
-      field != parameterObject["properties"].end_array(); field++)
+    for (CVariant::const_iterator_array field = parameterObject["properties"].begin_array();
+         field != parameterObject["properties"].end_array(); field++)
       fields.insert(field->asString());
   }
 
@@ -477,7 +477,7 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
 
   int start, end;
   HandleLimits(parameterObject, result, total, start, end);
-  
+
   return OK;
 }
 
@@ -617,7 +617,7 @@ JSONRPC_STATUS CAudioLibrary::GetGenres(const std::string &method, ITransportLay
   std::set<std::string> additionalProperties;
   if (CheckForAdditionalProperties(parameterObject["properties"], checkProperties, additionalProperties))
     sourcesneeded = (additionalProperties.find("sourceid") != additionalProperties.end());
-   
+
   CFileItemList items;
   if (!musicdatabase.GetGenresJSON(items, sourcesneeded))
     return InternalError;
@@ -1317,7 +1317,7 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalSongDetails(const CVariant &parameter
       }
     }
     if (additionalProperties.find("sourceid") != additionalProperties.end())
-    {      
+    {
       musicdatabase.GetSourcesBySong(item->GetMusicInfoTag()->GetDatabaseId(), item->GetPath(), item.get());
     }
     if (item->GetMusicInfoTag()->GetAlbumId() > 0)

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -516,7 +516,7 @@ bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
       strReleaseDate = StringUtils::Format("{:04}", year);
   }
   XMLUtils::GetString(album, "originalreleasedate", strOrigReleaseDate);
-  
+
   const TiXmlElement* rElement = album->FirstChildElement("rating");
   if (rElement)
   {
@@ -655,7 +655,7 @@ bool CAlbum::Save(TiXmlNode *node, const std::string &tag, const std::string& st
     userrating->ToElement()->SetAttribute("max", 10);
 
   XMLUtils::SetInt(album,           "votes", iVotes);
-  
+
   for (const auto& artistCredit : artistCredits)
   {
     // add an <albumArtistCredits> tag

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -946,8 +946,8 @@ private:
   \param sortAttributes the sort attributes e.g. SortAttributeIgnoreArticle
   \param strField original name or title field that articles could be removed from
   \param strSortField sort name or title field to be used instead of original (when data not null)
-  \return SQL string e.g. 
-  CASE WHEN strArtistSort IS NOT NULL THEN strArtistSort    
+  \return SQL string e.g.
+  CASE WHEN strArtistSort IS NOT NULL THEN strArtistSort
   WHEN strField LIKE 'the ' OR strField LIKE 'the_' ESCAPE '_' THEN SUBSTR(strArtist, 5)
   ELSE strField
   END AS strAlias
@@ -960,14 +960,14 @@ private:
   /*! \brief Build SQL for sorting field naturally and case insensitvely (in SQLite).
   \param strField field name
   \param sortOrder the sort order
-  \return SQL string e.g.   
-  CASE WHEN CAST(strTitle AS INTEGER) = 0 THEN 100000000 
+  \return SQL string e.g.
+  CASE WHEN CAST(strTitle AS INTEGER) = 0 THEN 100000000
   ELSE CAST(strTitle AS INTEGER) END DESC, strTitle COLLATE NOCASE DESC
   */
   std::string AlphanumericSortSQL(const std::string& strField, const SortOrder& sortOrder);
 
   /*! \brief Checks that source table matches sources.xml
-  returns true when they do 
+  returns true when they do
   */
   bool CheckSources(VECSOURCES& sources);
 

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -165,10 +165,10 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if ((pItem->m_bIsFolder && !pItem->IsAudio()) || 
-      pItem->IsPlayList() || pItem->IsSmartPlayList() ||
-      StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
-      StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") ||
+  if ((pItem->m_bIsFolder && !pItem->IsAudio()) || //
+      pItem->IsPlayList() || pItem->IsSmartPlayList() || //
+      StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") || //
+      StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") || //
       pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsMusicDb()))
     return false;
 
@@ -206,7 +206,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
       MAPSONGS::iterator it = m_songsMap.find(pItem->GetPath()); // Find file in song map
       if (it != m_songsMap.end() && it->second.size() == 1)
       {
-        // Have we loaded this item from database before, 
+        // Have we loaded this item from database before,
         // and even if it has a cuesheet it has only one song
         pItem->GetMusicInfoTag()->SetSong(it->second[0]);
         if (!it->second[0].strThumb.empty())

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -151,7 +151,7 @@ bool CMusicThumbLoader::FillThumb(CFileItem &item, bool folderThumbs /* = true *
 
 bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
 {
-  /* Called for any item with MusicInfoTag and no art. 
+  /* Called for any item with MusicInfoTag and no art.
      Items on Genres, Sources and Roles nodes have ID (although items on Years
      node do not) so check for song/album/artist specifically.
      Non-library songs (file view) can also have MusicInfoTag but no ID or type
@@ -159,9 +159,9 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
   bool artfound(false);
   std::vector<ArtForThumbLoader> art;
   CMusicInfoTag &tag = *item.GetMusicInfoTag();
-  if (tag.GetDatabaseId() > -1 && (tag.GetType() == MediaTypeSong || 
-      tag.GetType() == MediaTypeAlbum || 
-      tag.GetType() == MediaTypeArtist))
+  if (tag.GetDatabaseId() > -1 &&
+      (tag.GetType() == MediaTypeSong || tag.GetType() == MediaTypeAlbum ||
+       tag.GetType() == MediaTypeArtist))
   {
     // Item in music library, fetch the art
     m_musicDatabase->Open();
@@ -174,15 +174,15 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
 
     m_musicDatabase->Close();
   }
-  else if (!tag.GetArtist().empty() && 
-    (tag.GetType() == MediaTypeNone || tag.GetType() == MediaTypeSong))
+  else if (!tag.GetArtist().empty() &&
+           (tag.GetType() == MediaTypeNone || tag.GetType() == MediaTypeSong))
   {
-    /* 
+    /*
     Could be non-library song - has musictag but no ID or type (may have
     thumb already). Try to fetch both song artist(s) and album artist(s) art by
     artist name, e.g. "artist.thumb", "artist.fanart", "artist.clearlogo",
     "artist.banner", "artist1.thumb", "artist1.fanart", "artist1.clearlogo",
-    "artist1.banner", "albumartist.thumb", "albumartist.fanart" etc. 
+    "artist1.banner", "albumartist.thumb", "albumartist.fanart" etc.
     Set fanart as fallback.
     */
     CSong song;
@@ -262,7 +262,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
       }
       artfound = !art.empty();
       m_musicDatabase->Close();
-    }    
+    }
   }
 
   if (artfound)

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -279,7 +279,7 @@ void CSong::Clear()
   iBitRate = 0;
   iSampleRate = 0;
   iChannels =  0;
-  
+
   replayGain = ReplayGain();
 }
 const std::vector<std::string> CSong::GetArtist() const

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1089,7 +1089,7 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const std::string &p
   if (albums.size() == 1)
   {
     CFileItem album(path, true);
-    /* 
+    /*
      If we are scanning a directory served over http(s) the root directory for an album will set
      IsInternetStream to true which prevents scanning it for art.  As we can't reach this point
      without having read some tags (and tags are not read from streams) we can safely check for
@@ -1335,7 +1335,7 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
     bool overridetags = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_OVERRIDETAGS);
     // Remove art accidentally set by the Python scraper, it only provides URLs of possible artwork
     // Art is selected later applying whitelist and other art preferences
-    albumInfo.GetAlbum().art.clear(); 
+    albumInfo.GetAlbum().art.clear();
     album.MergeScrapedAlbum(albumInfo.GetAlbum(), overridetags);
     m_musicDatabase.UpdateAlbum(album);
     albumInfo.SetLoaded(true);

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -184,7 +184,7 @@ protected:
   /*! \brief Add art for an artist
   This scans the given folder for local art and/or applies the first available art of each type
   from the possibile art URLs previously scraped. Art is added to any already stored by previous
-  scanning etc.The art types processed are determined by whitelist and other art settings. 
+  scanning etc.The art types processed are determined by whitelist and other art settings.
   When usealllocalart is enabled then all local image files are applied as art (providing name is
   valid for an art type), and then the URL list of remote art is checked adding the first available
   image of each art type not yet in the art map.
@@ -203,9 +203,9 @@ protected:
   The art types processed are determined by whitelist and other art settings. When usealllocalart is
   enabled then all local image files are applied as art (providing name is valid for an art type),
   and then the URL list of remote art is checked adding the first available image of each art type
-  not yet in the art map. 
-  Art found is saved in the album structure and the music database. The images found are cached. 
-  \param artist [in/out] an album, the art is set 
+  not yet in the art map.
+  Art found is saved in the album structure and the music database. The images found are cached.
+  \param artist [in/out] an album, the art is set
   \return true when art is added
   */
   bool AddAlbumArtwork(CAlbum& album);

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -161,7 +161,7 @@ const std::string &CMusicInfoTag::GetType() const
 }
 
 int CMusicInfoTag::GetYear() const
-{  
+{
   return atoi(GetYearString().c_str());
 }
 

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1333,7 +1333,7 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
     tag.SetNoOfChannels(file->audioProperties()->channels());
     tag.SetSampleRate(file->audioProperties()->sampleRate());
   }
-  
+
   if (asf)
     ParseTag(asf, art, tag);
   if (id3v1)

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -49,7 +49,7 @@ public:
 
   /*! \brief Once a music source is added, store source in library, and prompt
   the user to scan this folder into the library
-  \param oldName the original music source name 
+  \param oldName the original music source name
   \param source details of the music source (just added or edited)
   */
   static void OnAssignContent(const std::string& oldName, const CMediaSource& source);

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -77,7 +77,7 @@ bool CGUIWindowMusicPlaylistEditor::OnAction(const CAction &action)
 bool CGUIWindowMusicPlaylistEditor::OnClick(int iItem, const std::string& player /* = "" */)
 {
   if (iItem < 0 || iItem >= m_vecItems->Size()) return false;
-  CFileItemPtr item = m_vecItems->Get(iItem);  
+  CFileItemPtr item = m_vecItems->Get(iItem);
 
   // Expand .m3u files in sources list when clicked on regardless of <playlistasfolders>
   if (item->IsFileFolder(EFILEFOLDER_MASK_ONBROWSE))

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -889,7 +889,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
         field = GetField(FieldOrigYear, strType);
       else
         field = GetField(m_field, strType);
-      query = FormatYearQuery(field, param, parameter);      
+      query = FormatYearQuery(field, param, parameter);
     }
   }
   else if (strType == "albums")

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -130,7 +130,7 @@ void CGUIDialogLibExportSettings::OnSettingChanged(const std::shared_ptr<const C
     if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS) && (m_settings.m_skipnfo && !m_settings.m_artwork))
     {
       m_settings.m_artwork = true;
-      m_settingArt->SetValue(true);     
+      m_settingArt->SetValue(true);
     }
     UpdateToggles();
   }
@@ -145,8 +145,8 @@ void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CS
 
   const std::string &settingId = setting->GetId();
 
-  if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER && 
-      !m_settings.IsToLibFolders() && !m_settings.IsArtistFoldersOnly())
+  if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER && !m_settings.IsToLibFolders() &&
+      !m_settings.IsArtistFoldersOnly())
   {
     VECSOURCES shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
@@ -298,8 +298,8 @@ void CGUIDialogLibExportSettings::UpdateToggles()
 }
 
 void CGUIDialogLibExportSettings::UpdateDescription()
-{ 
-  if (m_settings.IsToLibFolders())  
+{
+  if (m_settings.IsToLibFolders())
   {
     // Destination button is description of what to library means
     SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, "");
@@ -383,7 +383,7 @@ void CGUIDialogLibExportSettings::InitializeSettings()
   }
   else
    items = m_settings.GetExportItems();
-  
+
   AddList(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ITEMS, 38306, SettingLevel::Basic, items, entries, 133, 1);
 
   if (m_settings.IsToLibFolders() || m_settings.IsSeparateFiles())

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -247,11 +247,11 @@ std::string ByYear(SortAttribute attributes, const SortItem &values)
 }
 
 std::string ByOrigDate(SortAttribute attributes, const SortItem& values)
-{  
+{
   std::string label;
   label = values.at(FieldOrigDate).asString();
 
-  const CVariant &album = values.at(FieldAlbum); 
+  const CVariant& album = values.at(FieldAlbum);
   if (!album.isNull())
     label += " " + SortUtils::RemoveArticles(album.asString());
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1072,10 +1072,10 @@ int64_t StringUtils::AlphaNumericCompare(const wchar_t* left, const wchar_t* rig
     // alphanumeric ascii, rather than some being mixed between the numbers and letters, and
     // above all other unicode letters, symbols and punctuation.
     // (Locale collation of these chars varies across platforms)
-    lsym = (lc >= 32 && lc < L'0') || (lc > L'9' && lc < L'A') || 
-           (lc > L'Z' && lc < L'a') || (lc > L'z' && lc < 128);
-    rsym = (rc >= 32 && rc < L'0') || (rc > L'9' && rc < L'A') || 
-           (rc > L'Z' && rc < L'a') || (rc > L'z' && rc < 128);
+    lsym = (lc >= 32 && lc < L'0') || (lc > L'9' && lc < L'A') || (lc > L'Z' && lc < L'a') ||
+           (lc > L'z' && lc < 128);
+    rsym = (rc >= 32 && rc < L'0') || (rc > L'9' && rc < L'A') || (rc > L'Z' && rc < L'a') ||
+           (rc > L'z' && rc < 128);
     if (lsym && !rsym)
       return -1;
     if (!lsym && rsym)
@@ -1086,7 +1086,7 @@ int64_t StringUtils::AlphaNumericCompare(const wchar_t* left, const wchar_t* rig
         return lc - rc;
       else
       { // Same symbol advance to next wchar
-        l++; 
+        l++;
         r++;
         continue;
       }


### PR DESCRIPTION
Remove trailing whitespaces, mostly in comment lines, from music related code.
There is no functional impact of these changes.

Cleaing up the code that I may have littered with whitespace not caught by my dev env settings. 
Done in one go rather than have lines that are otherwise uneffected by a PR altered by it because of differences in dev env settings.

