### PR TITLE
[PVR] CFileItem optimization: Add a ctor taking an EPG tag and a channel group member.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -154,7 +154,12 @@ void CFileItem::FillMusicInfoTag(const std::shared_ptr<CPVRChannel>& channel, co
   }
 }
 
-CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
+CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag) : CFileItem(tag, {})
+{
+}
+
+CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag,
+                     const std::shared_ptr<PVR::CPVRChannelGroupMember>& groupMemberIn)
 {
   Initialize();
 
@@ -164,8 +169,13 @@ CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
   SetLabel(GetEpgTagTitle(tag));
   m_dateTime = tag->StartAsLocalTime();
 
-  const std::shared_ptr<CPVRChannel> channel =
-      CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
+  std::shared_ptr<CPVRChannelGroupMember> groupMember = groupMemberIn;
+  if (!groupMember)
+    groupMember = CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(*this);
+
+  std::shared_ptr<CPVRChannel> channel;
+  if (groupMember)
+    channel = groupMember->Channel();
 
   if (!tag->Icon().empty())
     SetArt("icon", tag->Icon());

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -112,6 +112,8 @@ public:
   explicit CFileItem(const MUSIC_INFO::CMusicInfoTag& music);
   explicit CFileItem(const CVideoInfoTag& movie);
   explicit CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
+  CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag,
+            const std::shared_ptr<PVR::CPVRChannelGroupMember>& groupMember);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRChannelGroupMember>& channelGroupMember);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRRecording>& record);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRTimerInfoTag>& timer);

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -41,7 +41,8 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateGapItem(int iChannel
 {
   const std::shared_ptr<CPVRChannel> channel = m_channelItems[iChannel]->GetPVRChannelInfoTag();
   const std::shared_ptr<CPVREpgInfoTag> gapTag = channel->CreateEPGGapTag(m_gridStart, m_gridEnd);
-  return std::make_shared<CFileItem>(gapTag);
+  return std::make_shared<CFileItem>(gapTag,
+                                     m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
 }
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CGUIEPGGridContainerModel::GetEPGTimeline(
@@ -170,7 +171,8 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateEpgTags(int iChannel
     if (GetFirstEventBlock(tag) > GetLastEventBlock(tag))
       continue;
 
-    const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(tag);
+    const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(
+        tag, m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
     if (!result && IsEventMemberOfBlock(tag, iBlock))
       result = item;
 
@@ -262,7 +264,8 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetEpgTagsBefore(EpgTags& 
       if (GetFirstEventBlock(*it) > GetLastEventBlock(*it))
         continue;
 
-      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(*it);
+      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(
+          *it, m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
       if (!result && IsEventMemberOfBlock(*it, iBlock))
         result = item;
 
@@ -324,7 +327,8 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetEpgTagsAfter(EpgTags& e
       if (GetFirstEventBlock(*it) > GetLastEventBlock(*it))
         continue;
 
-      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(*it);
+      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(
+          *it, m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
       if (!result && IsEventMemberOfBlock(*it, iBlock))
         result = item;
 
@@ -564,7 +568,8 @@ bool CGUIEPGGridContainerModel::FreeProgrammeMemory(int firstChannel,
           if (GetFirstEventBlock(tag) > GetLastEventBlock(tag))
             continue;
 
-          epgTags.tags.emplace_back(std::make_shared<CFileItem>(tag));
+          epgTags.tags.emplace_back(std::make_shared<CFileItem>(
+              tag, m_channelItems[i]->GetPVRChannelGroupMemberInfoTag()));
         }
       }
     }


### PR DESCRIPTION
… If calling code already knows the member there is not need to obtain it a second time (quite expensive) in the CFileItem ctor. Speeds up opening the Guide window.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish for review?