### PR TITLE
[PVR] Fix wrong search window opened when executing 'Find similar' on a timer item.

### DIFF
--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -59,7 +59,7 @@ namespace PVR
     }
     else if (m_item->IsPVRTimer())
     {
-      const std::shared_ptr<CPVRChannel> channel =m_item->GetPVRTimerInfoTag()->Channel();
+      const std::shared_ptr<CPVRChannel> channel = m_item->GetPVRTimerInfoTag()->Channel();
       if (channel)
         return channel->GetEPGNext();
     }
@@ -146,6 +146,10 @@ namespace PVR
     else if (m_item->IsPVRRecording())
     {
       return m_item->GetPVRRecordingInfoTag()->IsRadio();
+    }
+    else if (m_item->IsPVRTimer())
+    {
+      return m_item->GetPVRTimerInfoTag()->m_bIsRadio;
     }
     else
     {


### PR DESCRIPTION
1) Open TV or Radio timer window
2) Select "Find similar" from any item's context menu
=> Log entry: `ERROR <general>: IsRadio: Unsupported item type!`

<img width="1518" alt="Screenshot 2021-05-13 at 10 32 51" src="https://user-images.githubusercontent.com/3226626/118104882-fe43d480-b3db-11eb-8cb4-1132343dc53b.png">

... resulting in always the TV search window being opened and never the radio search window...

<img width="906" alt="Screenshot 2021-05-13 at 10 34 53" src="https://user-images.githubusercontent.com/3226626/118104893-013ec500-b3dc-11eb-97da-b9ce2dea5ada.png">

Runtime-tested on macOS, latest Kodi master.

@phunkyfish for review?