### PR TITLE
[PVR] Fix wrong 'all channels' label in radio guide search dialog.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10481,12 +10481,13 @@ msgctxt "#19215"
 msgid "Reminders"
 msgstr ""
 
-#. used by several skins
+#. label for 'all channels' value for 'channels' selector control in pvr radio guide search dialog
+#: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19216"
 msgid "All radio channels"
 msgstr ""
 
-#. label for 'all channels' value for 'channels' selector control in pvr guide search dialog
+#. label for 'all channels' value for 'channels' selector control in pvr TV guide search dialog
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19217"
 msgid "All TV channels"

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -58,7 +58,10 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
   int iChannelGroup = GetSpinValue(CONTROL_SPIN_GROUPS);
 
   std::vector< std::pair<std::string, int> > labels;
-  labels.emplace_back(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET);
+  if (m_searchFilter->IsRadio())
+    labels.emplace_back(g_localizeStrings.Get(19216), EPG_SEARCH_UNSET); // All radio channels
+  else
+    labels.emplace_back(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET); // All TV channels
 
   std::shared_ptr<CPVRChannelGroup> group;
   if (iChannelGroup == EPG_SEARCH_UNSET)


### PR DESCRIPTION
1) Open the Radio guide search window
2) Select "Search..." 
=> search dialog opens, channels selector label read "All TV channels", not "All radio channels".

<img width="1680" alt="Screenshot 2021-05-13 at 10 37 52" src="https://user-images.githubusercontent.com/3226626/118105635-eae53900-b3dc-11eb-948f-a87b98608946.png">

Runtime-tested on macOS, latest kodi master.

@phunkyfish you already know what I what to ask, right? ;-)
