### PR TITLE
[Matrix][PVR] Fix wrong search window opened when executing 'Find similar' on a timer item.

### DIFF
--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -59,7 +59,7 @@ namespace PVR
     }
     else if (m_item->IsPVRTimer())
     {
-      const std::shared_ptr<CPVRChannel> channel =m_item->GetPVRTimerInfoTag()->Channel();
+      const std::shared_ptr<CPVRChannel> channel = m_item->GetPVRTimerInfoTag()->Channel();
       if (channel)
         return channel->GetEPGNext();
     }
@@ -142,6 +142,10 @@ namespace PVR
     else if (m_item->IsPVRRecording())
     {
       return m_item->GetPVRRecordingInfoTag()->IsRadio();
+    }
+    else if (m_item->IsPVRTimer())
+    {
+      return m_item->GetPVRTimerInfoTag()->m_bIsRadio;
     }
     else
     {


### PR DESCRIPTION
Backport of #19733 

@phunkyfish here we go...