### PR TITLE
[PVR] Remove CPVRChannel::*Path methods, make them available at CPVRC…

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -131,9 +131,11 @@ namespace
   }
 } // unnamed namespace
 
-void CFileItem::FillMusicInfoTag(const std::shared_ptr<CPVRChannel>& channel, const std::shared_ptr<CPVREpgInfoTag>& tag)
+void CFileItem::FillMusicInfoTag(const std::shared_ptr<CPVRChannelGroupMember>& groupMember,
+                                 const std::shared_ptr<CPVREpgInfoTag>& tag)
 {
-  if (channel && channel->IsRadio() && !HasMusicInfoTag())
+  if (groupMember && groupMember->Channel() && groupMember->Channel()->IsRadio() &&
+      !HasMusicInfoTag())
   {
     CMusicInfoTag* musictag = GetMusicInfoTag(); // create (!) the music tag.
 
@@ -149,7 +151,7 @@ void CFileItem::FillMusicInfoTag(const std::shared_ptr<CPVRChannel>& channel, co
       musictag->SetTitle(g_localizeStrings.Get(19055)); // no information available
     }
 
-    musictag->SetURL(channel->Path());
+    musictag->SetURL(groupMember->Path());
     musictag->SetLoaded(true);
   }
 }
@@ -173,16 +175,16 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag,
   if (!groupMember)
     groupMember = CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(*this);
 
-  std::shared_ptr<CPVRChannel> channel;
-  if (groupMember)
-    channel = groupMember->Channel();
-
   if (!tag->Icon().empty())
     SetArt("icon", tag->Icon());
-  else if (channel && !channel->IconPath().empty())
-    SetArt("icon", channel->IconPath());
+  else if (groupMember)
+  {
+    const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
+    if (channel && !channel->IconPath().empty())
+      SetArt("icon", channel->IconPath());
+  }
 
-  FillMusicInfoTag(channel, tag);
+  FillMusicInfoTag(groupMember, tag);
   FillInMimeType(false);
 }
 
@@ -195,7 +197,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
 
   m_pvrChannelGroupMemberInfoTag = channelGroupMember;
 
-  m_strPath = channel->Path();
+  m_strPath = channelGroupMember->Path();
   m_bIsFolder = false;
 
   SetLabel(channel->ChannelName());
@@ -208,10 +210,10 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
     SetArt("icon", "DefaultTVShows.png");
 
   SetProperty("channelid", channel->ChannelID());
-  SetProperty("path", channel->Path());
+  SetProperty("path", channelGroupMember->Path());
   SetArt("thumb", channel->IconPath());
 
-  FillMusicInfoTag(channel, epgNow);
+  FillMusicInfoTag(channelGroupMember, epgNow);
   FillInMimeType(false);
 }
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -584,7 +584,8 @@ private:
   /*!
    \brief If given channel is radio, fill item's music tag from given epg tag and channel info.
    */
-  void FillMusicInfoTag(const std::shared_ptr<PVR::CPVRChannel>& channel, const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
+  void FillMusicInfoTag(const std::shared_ptr<PVR::CPVRChannelGroupMember>& groupMember,
+                        const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
 
   std::string m_strPath;            ///< complete path to item
   std::string m_strDynPath;

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -344,7 +344,7 @@ bool CPVRDatabase::QueueDeleteQuery(const CPVRChannel& channel)
 void CPVRDatabase::InsertChannelIntoGroup(const std::shared_ptr<CPVRChannel>& channel,
                                           CPVRChannelGroup& group)
 {
-  auto newMember = std::make_shared<CPVRChannelGroupMember>();
+  const auto newMember = std::make_shared<CPVRChannelGroupMember>();
   newMember->m_channel = channel;
   newMember->m_channelNumber = {
       static_cast<unsigned int>(m_pDS->fv("iChannelNumber").get_asInt()),
@@ -353,6 +353,7 @@ void CPVRDatabase::InsertChannelIntoGroup(const std::shared_ptr<CPVRChannel>& ch
       static_cast<unsigned int>(m_pDS->fv("iClientChannelNumber").get_asInt()),
       static_cast<unsigned int>(m_pDS->fv("iClientSubChannelNumber").get_asInt())};
   newMember->m_iOrder = static_cast<int>(m_pDS->fv("iOrder").get_asInt());
+  newMember->SetGroupName(group.GroupName());
 
   group.m_sortedMembers.emplace_back(newMember);
   group.m_members.insert(std::make_pair(channel->StorageId(), newMember));

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -14,7 +14,6 @@
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
-#include "pvr/channels/PVRChannelsPath.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
@@ -379,12 +378,6 @@ bool CPVRChannel::SetLastWatched(time_t iLastWatched)
   return false;
 }
 
-bool CPVRChannel::IsEmpty() const
-{
-  CSingleLock lock(m_critSection);
-  return m_strFileNameAndPath.empty();
-}
-
 /********** Client related channel methods **********/
 
 bool CPVRChannel::SetClientID(int iClientId)
@@ -399,18 +392,6 @@ bool CPVRChannel::SetClientID(int iClientId)
   }
 
   return false;
-}
-
-void CPVRChannel::UpdatePath(const std::string& channelGroup)
-{
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
-  if (client)
-  {
-    CSingleLock lock(m_critSection);
-    const std::string strFileNameAndPath = CPVRChannelsPath(m_bIsRadio, channelGroup, client->ID(), m_iUniqueId);
-    if (m_strFileNameAndPath != strFileNameAndPath)
-      m_strFileNameAndPath = strFileNameAndPath;
-  }
 }
 
 std::string CPVRChannel::GetEncryptionName(int iCaid)
@@ -756,12 +737,6 @@ std::string CPVRChannel::MimeType() const
 {
   CSingleLock lock(m_critSection);
   return m_strMimeType;
-}
-
-std::string CPVRChannel::Path() const
-{
-  CSingleLock lock(m_critSection);
-  return m_strFileNameAndPath;
 }
 
 bool CPVRChannel::IsEncrypted() const

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -192,12 +192,6 @@ namespace PVR
     bool SetLastWatched(time_t iLastWatched);
 
     /*!
-     * @brief True if this channel has no file or stream name
-     * @return True if this channel has no file or stream name
-     */
-    bool IsEmpty() const;
-
-    /*!
      * @brief Check whether this channel has unpersisted data changes.
      * @return True if this channel has changes to persist, false otherwise
      */
@@ -258,20 +252,8 @@ namespace PVR
      */
     std::string MimeType() const;
 
-    /*!
-     * @brief The path in the XBMC VFS to be used by PVRManager to open and read the stream.
-     * @return The path in the XBMC VFS to be used by PVRManager to open and read the stream.
-     */
-    std::string Path() const;
-
     // ISortable implementation
     void ToSortable(SortItem& sortable, Field field) const override;
-
-    /*!
-     * @brief Update the channel path
-     * @param channelGroup The (new) name of the group this channel belongs to
-     */
-    void UpdatePath(const std::string& channelGroup);
 
     /*!
      * @return Storage id for this channel in CPVRChannelGroup
@@ -500,7 +482,6 @@ namespace PVR
     std::string m_strClientChannelName; /*!< the name of this channel on the client */
     std::string
         m_strMimeType; /*!< the stream input type based mime type, see @ref https://www.iana.org/assignments/media-types/media-types.xhtml#video */
-    std::string m_strFileNameAndPath; /*!< the filename to be used by PVRManager to open and read the stream */
     int m_iClientEncryptionSystem = -1; /*!< the encryption system used by this channel. 0 for FreeToAir, -1 for unknown */
     std::string m_strClientEncryptionName; /*!< the name of the encryption system used by this channel */
     int m_iClientOrder = 0; /*!< the order from this channels group member */

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -706,8 +706,8 @@ bool CPVRChannelGroup::AddToGroup(const std::shared_ptr<CPVRChannel>& channel, c
       if (!clientChannelNumber.IsValid())
         clientChannelNumberToUse = realMember->ClientChannelNumber();
 
-      auto newMember = std::make_shared<CPVRChannelGroupMember>(
-          realMember->Channel(),
+      const auto newMember = std::make_shared<CPVRChannelGroupMember>(
+          realMember->Channel(), GroupName(),
           CPVRChannelNumber(iChannelNumber, channelNumber.GetSubChannelNumber()),
           realMember->ClientPriority(), iOrder, clientChannelNumberToUse);
       m_sortedMembers.emplace_back(newMember);

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -76,7 +76,7 @@ void CPVRChannelGroupInternal::UpdateChannelPaths()
     if (groupMemberPair.second->Channel()->IsHidden())
       ++m_iHiddenChannels;
     else
-      groupMemberPair.second->Channel()->UpdatePath(GroupName());
+      groupMemberPair.second->SetGroupName(GroupName());
   }
 }
 
@@ -94,9 +94,8 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupInternal::UpdateFromClient(
   }
   else
   {
-    channel->UpdatePath(GroupName());
-    auto newMember = std::make_shared<CPVRChannelGroupMember>(channel, CPVRChannelNumber(), 0,
-                                                              iOrder, clientChannelNumber);
+    const auto newMember = std::make_shared<CPVRChannelGroupMember>(
+        channel, GroupName(), CPVRChannelNumber(), 0, iOrder, clientChannelNumber);
     m_sortedMembers.emplace_back(newMember);
     m_members.insert(std::make_pair(channel->StorageId(), newMember));
 

--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -8,11 +8,32 @@
 
 #include "PVRChannelGroupMember.h"
 
+#include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClient.h"
+#include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelsPath.h"
 #include "utils/DatabaseUtils.h"
 #include "utils/SortUtils.h"
 #include "utils/Variant.h"
 
 using namespace PVR;
+
+CPVRChannelGroupMember::CPVRChannelGroupMember(const std::shared_ptr<CPVRChannel>& channel,
+                                               const std::string& groupName,
+                                               const CPVRChannelNumber& channelNumber,
+                                               int iClientPriority,
+                                               int iOrder,
+                                               const CPVRChannelNumber& clientChannelNumber)
+  : m_channel(channel),
+    m_channelNumber(channelNumber),
+    m_clientChannelNumber(clientChannelNumber),
+    m_iClientPriority(iClientPriority),
+    m_iOrder(iOrder)
+{
+  // init m_path
+  SetGroupName(groupName);
+}
 
 void CPVRChannelGroupMember::Serialize(CVariant& value) const
 {
@@ -33,6 +54,14 @@ void CPVRChannelGroupMember::ToSortable(SortItem& sortable, Field field) const
     else
       sortable[FieldClientChannelOrder] = m_clientChannelNumber.SortableChannelNumber();
   }
+}
+
+void CPVRChannelGroupMember::SetGroupName(const std::string& groupName)
+{
+  const std::shared_ptr<CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_channel->ClientID());
+  if (client)
+    m_path = CPVRChannelsPath(m_channel->IsRadio(), groupName, client->ID(), m_channel->UniqueID());
 }
 
 void CPVRChannelGroupMember::SetChannelNumber(const CPVRChannelNumber& channelNumber)

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -27,17 +27,11 @@ public:
   CPVRChannelGroupMember() : m_bChanged(false) {}
 
   CPVRChannelGroupMember(const std::shared_ptr<CPVRChannel>& channel,
+                         const std::string& groupName,
                          const CPVRChannelNumber& channelNumber,
                          int iClientPriority,
                          int iOrder,
-                         const CPVRChannelNumber& clientChannelNumber)
-    : m_channel(channel),
-      m_channelNumber(channelNumber),
-      m_clientChannelNumber(clientChannelNumber),
-      m_iClientPriority(iClientPriority),
-      m_iOrder(iOrder)
-  {
-  }
+                         const CPVRChannelNumber& clientChannelNumber);
 
   virtual ~CPVRChannelGroupMember() = default;
 
@@ -48,6 +42,9 @@ public:
   void ToSortable(SortItem& sortable, Field field) const override;
 
   std::shared_ptr<CPVRChannel> Channel() const { return m_channel; }
+
+  const std::string& Path() const { return m_path; }
+  void SetGroupName(const std::string& groupName);
 
   const CPVRChannelNumber& ChannelNumber() const { return m_channelNumber; }
   void SetChannelNumber(const CPVRChannelNumber& channelNumber);
@@ -66,6 +63,7 @@ public:
 
 private:
   std::shared_ptr<CPVRChannel> m_channel;
+  std::string m_path;
   CPVRChannelNumber m_channelNumber; // the channel number this channel has in the group
   CPVRChannelNumber
       m_clientChannelNumber; // the client channel number this channel has in the group

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1355,7 +1355,7 @@ bool CGUIEPGGridContainer::OnMouseWheel(char wheel, const CPoint& point)
   return true;
 }
 
-std::shared_ptr<CPVRChannel> CGUIEPGGridContainer::GetSelectedChannel() const
+std::shared_ptr<CPVRChannelGroupMember> CGUIEPGGridContainer::GetSelectedChannelGroupMember() const
 {
   CFileItemPtr fileItem;
   {
@@ -1364,10 +1364,10 @@ std::shared_ptr<CPVRChannel> CGUIEPGGridContainer::GetSelectedChannel() const
       fileItem = m_gridModel->GetChannelItem(m_channelCursor + m_channelOffset);
   }
 
-  if (fileItem && fileItem->HasPVRChannelInfoTag())
-    return fileItem->GetPVRChannelInfoTag();
+  if (fileItem)
+    return fileItem->GetPVRChannelGroupMemberInfoTag();
 
-  return std::shared_ptr<CPVRChannel>();
+  return {};
 }
 
 CDateTime CGUIEPGGridContainer::GetSelectedDate() const

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -30,6 +30,7 @@ class CGUIListItemLayout;
 namespace PVR
 {
   class CPVRChannel;
+  class CPVRChannelGroupMember;
   class CPVRChannelNumber;
 
   class CGUIEPGGridContainerModel;
@@ -71,7 +72,7 @@ namespace PVR
     std::string GetLabel(int info) const override;
 
     std::shared_ptr<CFileItem> GetSelectedGridItem(int offset = 0) const;
-    std::shared_ptr<CPVRChannel> GetSelectedChannel() const;
+    std::shared_ptr<CPVRChannelGroupMember> GetSelectedChannelGroupMember() const;
     CDateTime GetSelectedDate() const;
 
     void LoadLayout(TiXmlElement* layout);

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -12,7 +12,6 @@
 #include "ServiceBroker.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgInfoTag.h"

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -2255,7 +2255,7 @@ namespace PVR
       // if preselect playing channel is activated, return the path of the playing channel, if any.
       const std::shared_ptr<CPVRChannel> playingChannel = mgr.PlaybackState()->GetPlayingChannel();
       if (playingChannel && playingChannel->IsRadio() == bRadio)
-        return playingChannel->Path();
+        return GetChannelGroupMember(playingChannel)->Path();
 
       const std::shared_ptr<CPVREpgInfoTag> playingTag = mgr.PlaybackState()->GetPlayingEpgTag();
       if (playingTag && playingTag->IsRadio() == bRadio)
@@ -2263,7 +2263,7 @@ namespace PVR
         const std::shared_ptr<CPVRChannel> channel =
             mgr.ChannelGroups()->GetChannelForEpgTag(playingTag);
         if (channel)
-          return channel->Path();
+          return GetChannelGroupMember(channel)->Path();
       }
     }
 
@@ -2406,7 +2406,7 @@ namespace PVR
     if (groupMember)
     {
       m_channelNavigator.SetPlayingChannel(groupMember);
-      SetSelectedItemPath(groupMember->Channel()->IsRadio(), groupMember->Channel()->Path());
+      SetSelectedItemPath(groupMember->Channel()->IsRadio(), groupMember->Path());
     }
   }
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1429,7 +1429,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
     case VIDEOPLAYER_HAS_INFO:
       if (item->IsPVRChannel())
       {
-        bValue = !item->GetPVRChannelInfoTag()->IsEmpty();
+        bValue = !item->GetPVRChannelInfoTag()->ChannelName().empty();
         return true;
       }
       break;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -26,6 +26,7 @@
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRChannelsPath.h"
 #include "pvr/epg/EpgChannelData.h"
@@ -193,9 +194,11 @@ void CGUIWindowPVRGuideBase::UpdateSelectedItemPath()
   CGUIEPGGridContainer* epgGridContainer = GetGridControl();
   if (epgGridContainer)
   {
-    std::shared_ptr<CPVRChannel> channel(epgGridContainer->GetSelectedChannel());
-    if (channel)
-      CServiceBroker::GetPVRManager().GUIActions()->SetSelectedItemPath(m_bRadio, channel->Path());
+    const std::shared_ptr<CPVRChannelGroupMember> groupMember =
+        epgGridContainer->GetSelectedChannelGroupMember();
+    if (groupMember)
+      CServiceBroker::GetPVRManager().GUIActions()->SetSelectedItemPath(m_bRadio,
+                                                                        groupMember->Path());
   }
 }
 


### PR DESCRIPTION
…hannelGroupMember. Paths are group specific!

Same reason as with #19699, but needed some rounds of refactoring before it could be done.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish you're the right person for the review... ;-)