### PR TITLE
[PVR] Cleanup: Get rid of static member CPVRChannelGroup::EmptyMember.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -134,8 +134,7 @@ namespace
 void CFileItem::FillMusicInfoTag(const std::shared_ptr<CPVRChannelGroupMember>& groupMember,
                                  const std::shared_ptr<CPVREpgInfoTag>& tag)
 {
-  if (groupMember && groupMember->Channel() && groupMember->Channel()->IsRadio() &&
-      !HasMusicInfoTag())
+  if (groupMember && groupMember->Channel()->IsRadio() && !HasMusicInfoTag())
   {
     CMusicInfoTag* musictag = GetMusicInfoTag(); // create (!) the music tag.
 

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -743,7 +743,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
 
     const std::shared_ptr<CPVRChannelGroupMember> groupMember =
         CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(channel);
-    if (!groupMember || !groupMember->Channel())
+    if (!groupMember)
       return InvalidParams;
 
     if (!CServiceBroker::GetPVRManager().GUIActions()->PlayMedia(

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -76,11 +76,6 @@ namespace PVR
     bool operator ==(const CPVRChannelGroup& right) const;
     bool operator !=(const CPVRChannelGroup& right) const;
 
-    /**
-     * Empty group member
-     */
-    static std::shared_ptr<CPVRChannelGroupMember> EmptyMember;
-
     /*!
      * @brief Query the events available for CEventStream
      */
@@ -443,11 +438,9 @@ namespace PVR
     /*!
      * @brief Get a channel group member given its storage id.
      * @param id The storage id (a pair of client id and unique channel id).
-     * @return A reference to the group member or an empty group member if it wasn't found.
+     * @return The channel group member or nullptr if it wasn't found.
      */
-    std::shared_ptr<CPVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id);
-    const std::shared_ptr<CPVRChannelGroupMember>& GetByUniqueID(
-        const std::pair<int, int>& id) const;
+    std::shared_ptr<CPVRChannelGroupMember> GetByUniqueID(const std::pair<int, int>& id) const;
 
     bool SetHidden(bool bHidden);
     bool IsHidden() const;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -86,8 +86,8 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupInternal::UpdateFromClient(
     int iOrder)
 {
   CSingleLock lock(m_critSection);
-  const std::shared_ptr<CPVRChannelGroupMember>& realMember = GetByUniqueID(channel->StorageId());
-  if (realMember->Channel())
+  const std::shared_ptr<CPVRChannelGroupMember> realMember = GetByUniqueID(channel->StorageId());
+  if (realMember)
   {
     realMember->Channel()->UpdateFromClient(channel);
     return realMember->Channel();
@@ -119,8 +119,8 @@ bool CPVRChannelGroupInternal::AddToGroup(const std::shared_ptr<CPVRChannel>& ch
   CSingleLock lock(m_critSection);
 
   /* get the group member, because we need the channel ID in this group, and the channel from this group */
-  std::shared_ptr<CPVRChannelGroupMember>& groupMember = GetByUniqueID(channel->StorageId());
-  if (!groupMember->Channel())
+  const std::shared_ptr<CPVRChannelGroupMember> groupMember = GetByUniqueID(channel->StorageId());
+  if (!groupMember)
     return bReturn;
 
   bool bSort = false;
@@ -233,9 +233,10 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup& chan
   for (auto& newMemberPair : channels.m_members)
   {
     /* check whether this channel is present in this container */
-    std::shared_ptr<CPVRChannelGroupMember>& existingMember = GetByUniqueID(newMemberPair.first);
-    const std::shared_ptr<CPVRChannelGroupMember>& newMember = newMemberPair.second;
-    if (existingMember->Channel())
+    const std::shared_ptr<CPVRChannelGroupMember> existingMember =
+        GetByUniqueID(newMemberPair.first);
+    const std::shared_ptr<CPVRChannelGroupMember> newMember = newMemberPair.second;
+    if (existingMember)
     {
       /* if it's present, update the current tag */
       if (existingMember->Channel()->UpdateFromClient(newMember->Channel()))

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -79,17 +79,14 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
   int iSelectedChannel = EPG_SEARCH_UNSET;
   for (const auto& groupMember : groupMembers)
   {
-    if (groupMember->Channel())
-    {
-      labels.emplace_back(std::make_pair(groupMember->Channel()->ChannelName(), iIndex));
-      m_channelNumbersMap.insert(std::make_pair(iIndex, groupMember->ChannelNumber()));
+    labels.emplace_back(std::make_pair(groupMember->Channel()->ChannelName(), iIndex));
+    m_channelNumbersMap.insert(std::make_pair(iIndex, groupMember->ChannelNumber()));
 
-      if (iSelectedChannel == EPG_SEARCH_UNSET &&
-          groupMember->ChannelNumber() == m_searchFilter->GetChannelNumber())
-        iSelectedChannel = iIndex;
+    if (iSelectedChannel == EPG_SEARCH_UNSET &&
+        groupMember->ChannelNumber() == m_searchFilter->GetChannelNumber())
+      iSelectedChannel = iIndex;
 
-      ++iIndex;
-    }
+    ++iIndex;
   }
 
   SET_CONTROL_LABELS(CONTROL_SPIN_CHANNELS, iSelectedChannel, &labels);

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1523,7 +1523,7 @@ namespace PVR
         return false;
 
       groupMember = channels.front();
-      if (!groupMember || !groupMember->Channel())
+      if (!groupMember)
         return false;
     }
 


### PR DESCRIPTION
Cleanup: Get rid of static member CPVRChannelGroup::EmptyMember. Nothing more to say.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish another one for you...