### PR TITLE
[PVR] CFileItem: Add fallbacks to channel icon and default images to …

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -177,11 +177,18 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag,
 
   if (!tag->Icon().empty())
     SetArt("icon", tag->Icon());
-  else if (groupMember)
+  else
   {
-    const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
+    std::shared_ptr<CPVRChannel> channel;
+    if (groupMember)
+      channel = groupMember->Channel();
+
     if (channel && !channel->IconPath().empty())
       SetArt("icon", channel->IconPath());
+    else if (tag->IsRadio())
+      SetArt("icon", "DefaultAudio.png");
+    else
+      SetArt("icon", "DefaultTVShows.png");
   }
 
   FillMusicInfoTag(groupMember, tag);
@@ -230,8 +237,16 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
 
   // Set art
   if (!record->m_strIconPath.empty())
-  {
     SetArt("icon", record->m_strIconPath);
+  else
+  {
+    const std::shared_ptr<CPVRChannel> channel = record->Channel();
+    if (channel && !channel->IconPath().empty())
+      SetArt("icon", channel->IconPath());
+    else if (record->IsRadio())
+      SetArt("icon", "DefaultAudio.png");
+    else
+      SetArt("icon", "DefaultTVShows.png");
   }
 
   if (!record->m_strThumbnailPath.empty())
@@ -255,6 +270,10 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
 
   if (!timer->ChannelIcon().empty())
     SetArt("icon", timer->ChannelIcon());
+  else if (timer->m_bIsRadio)
+    SetArt("icon", "DefaultAudio.png");
+  else
+    SetArt("icon", "DefaultTVShows.png");
 
   FillInMimeType(false);
 }


### PR DESCRIPTION
…EPG, timer and recording items, like we already had for channels.

People complaining in the forum about ugly icons in the new Estuary Recordings window layout. Those will appear if the related PVR add-on does not set an icon for recordings. (`SetIonPath(...)`)

Before:
![screenshot00002](https://user-images.githubusercontent.com/3226626/118231096-e5e0c200-b48e-11eb-8898-ef579d2a6225.png)

After:

![screenshot00003](https://user-images.githubusercontent.com/3226626/118231093-e4af9500-b48e-11eb-8375-908d9db4eb16.png)

Runtime-tested on macOS, latest Kodi master.

@phunkyfish pleaes
