### PR TITLE
Expose various hardware blending modes to the skinning engine

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -753,6 +753,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   std::string altLabel;
   std::string strLabel2;
   std::string action;
+  std::string blendMode;
 
   int focusPosition = 0;
   int scrollTime = 200;
@@ -1068,6 +1069,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   XMLUtils::GetString(pControlNode, "action", action);
 
+  XMLUtils::GetString(pControlNode, "blendmode", blendMode);
+
   /////////////////////////////////////////////////////////////////////////////
   // Instantiate a new control using the properties gathered above
   //
@@ -1320,6 +1323,50 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       icontrol->SetInfo(textureFile);
       icontrol->SetAspectRatio(aspect);
       icontrol->SetCrossFade(fadeTime);
+
+      //basic blending modes. should be supported by virtually all GPUs.
+      // t = texture
+      // b = buffer
+
+      // t + b
+      if (blendMode == "add") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADD);
+      // t - b
+      else if (blendMode == "subtract") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_SUBTRACT);
+      // b - t
+      else if (blendMode == "reversesubtract") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_REVERSE_SUBTRACT);
+      // t * b
+      else if (blendMode == "multiply") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_MULTIPLY);
+      // t * b + t * b
+      else if (blendMode == "2xmultiply") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_2X_MULTIPLY);
+      // min(t, b)
+      else if (blendMode == "darken") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_DARKEN);
+      // max(t, b)
+      else if (blendMode == "lighten") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_LIGHTEN);
+
+      //advanced blending modes, only available with OGL 4, GLES 2 and VK. might be unsupported.
+      else if (blendMode == "advancedmultiply") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_MULTIPLY);
+      else if (blendMode == "advancedscreen") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_SCREEN);
+      else if (blendMode == "advancedoverlay") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_OVERLAY);
+      else if (blendMode == "advanceddarken") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_DARKEN);
+      else if (blendMode == "advancedlighten") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_LIGHTEN);
+      else if (blendMode == "advancedcolordodge") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_COLORDODGE);
+      else if (blendMode == "advancedcolorburn") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_COLORBURN);
+      else if (blendMode == "advanceddifference") 
+        icontrol->SetBlendMode(IMAGE_BLENDMODE_ADVANCED_DIFFERENCE);
     }
     break;
   case CGUIControl::GUICONTROL_MULTI_IMAGE:

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -385,6 +385,41 @@ void CGUIImage::SetInfo(const GUIINFO::CGUIInfoLabel &info)
     m_texture->SetFileName(m_info.GetLabel(0));
 }
 
+void CGUIImage::SetBlendMode(IMAGE_BLENDMODE blendMode)
+{
+  if (blendMode == IMAGE_BLENDMODE_ADD)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADD);
+  else if (blendMode == IMAGE_BLENDMODE_REVERSE_SUBTRACT)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_REVERSE_SUBTRACT);
+  else if (blendMode == IMAGE_BLENDMODE_SUBTRACT)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_SUBTRACT);
+  else if (blendMode == IMAGE_BLENDMODE_MULTIPLY)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_MULTIPLY);
+  else if (blendMode == IMAGE_BLENDMODE_2X_MULTIPLY)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_2X_MULTIPLY);
+  else if (blendMode == IMAGE_BLENDMODE_DARKEN)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_DARKEN);
+  else if (blendMode == IMAGE_BLENDMODE_LIGHTEN)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_LIGHTEN);
+
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_MULTIPLY)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_MULTIPLY);
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_SCREEN)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_SCREEN);
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_OVERLAY)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_OVERLAY);
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_DARKEN)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_DARKEN);
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_LIGHTEN)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_LIGHTEN);
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_COLORDODGE)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_COLORDODGE);
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_COLORBURN)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_COLORBURN);
+  else if (blendMode == IMAGE_BLENDMODE_ADVANCED_DIFFERENCE)
+    m_texture->SetBlendMode(TEXTURE_BLENDMODE_ADVANCED_DIFFERENCE);
+}
+
 unsigned char CGUIImage::GetFadeLevel(unsigned int time) const
 {
   float amount = (float)time / m_crossFadeTime;

--- a/xbmc/guilib/GUIImage.dox
+++ b/xbmc/guilib/GUIImage.dox
@@ -26,6 +26,7 @@ position, size, transparency and contents of the image to be displayed.
       <bordersize>5</bordersize>
       <texture>$INFO[MusicPlayer.Cover]</texture>
       <aspectratio>keep</aspectratio>
+      <blendmode>add</blendmode>
 </control>
 ~~~~~~~~~~~~~
 
@@ -71,6 +72,7 @@ important, as `xml` tags are case-sensitive.
 | info          | Specifies the information that this image control is presenting. Kodi will select the texture to use based on this tag. [See here for more information](http://kodi.wiki/view/InfoLabels).
 | fadetime      | This specifies a crossfade time that will be used whenever the underlying <b>`<texture>`</b> filename changes. The previous image will be held until the new image is ready, and then they will be crossfaded. This is particularly useful for a large thumbnail image showing the focused item in a list, or for fanart or other large backdrops.
 | background    | For images inside a container, you can specify background="true" to load the textures in a background worker thread. [See here for additional information about background loading](http://kodi.wiki/view/Background_Image_Loader).
+| blendmode     | Sets the texture blending mode. Available modes are add (default), subtract, reversesubtract, multiply, 2xmultiply, lighten and darken.
 
 
 --------------------------------------------------------------------------------

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -19,6 +19,26 @@
 
 #include <vector>
 
+enum IMAGE_BLENDMODE
+{
+  IMAGE_BLENDMODE_NONE = 0,
+  IMAGE_BLENDMODE_ADD,
+  IMAGE_BLENDMODE_SUBTRACT,
+  IMAGE_BLENDMODE_REVERSE_SUBTRACT,
+  IMAGE_BLENDMODE_MULTIPLY,
+  IMAGE_BLENDMODE_2X_MULTIPLY,
+  IMAGE_BLENDMODE_DARKEN,
+  IMAGE_BLENDMODE_LIGHTEN,
+  IMAGE_BLENDMODE_ADVANCED_MULTIPLY,
+  IMAGE_BLENDMODE_ADVANCED_SCREEN,
+  IMAGE_BLENDMODE_ADVANCED_OVERLAY,
+  IMAGE_BLENDMODE_ADVANCED_DARKEN,
+  IMAGE_BLENDMODE_ADVANCED_LIGHTEN,
+  IMAGE_BLENDMODE_ADVANCED_COLORDODGE,
+  IMAGE_BLENDMODE_ADVANCED_COLORBURN,
+  IMAGE_BLENDMODE_ADVANCED_DIFFERENCE,
+};
+
 /*!
  \ingroup controls
  \brief
@@ -78,6 +98,7 @@ public:
   void SetPosition(float posX, float posY) override;
   std::string GetDescription() const override;
   void SetCrossFade(unsigned int time);
+  void SetBlendMode(IMAGE_BLENDMODE blendMode);
 
   const std::string& GetFileName() const;
   float GetTextureWidth() const;
@@ -109,5 +130,7 @@ protected:
   unsigned int m_crossFadeTime;
   unsigned int m_currentFadeTime;
   unsigned int m_lastRenderTime;
+
+  IMAGE_BLENDMODE m_blendMode = IMAGE_BLENDMODE_ADD;
 };
 

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -23,6 +23,25 @@
 #define ASPECT_ALIGN_MASK    3
 #define ASPECT_ALIGNY_MASK  ~3
 
+enum TEXTURE_BLENDMODE
+{
+  TEXTURE_BLENDMODE_ADD = 0,
+  TEXTURE_BLENDMODE_SUBTRACT,
+  TEXTURE_BLENDMODE_REVERSE_SUBTRACT,
+  TEXTURE_BLENDMODE_MULTIPLY,
+  TEXTURE_BLENDMODE_2X_MULTIPLY,
+  TEXTURE_BLENDMODE_DARKEN,
+  TEXTURE_BLENDMODE_LIGHTEN,
+  TEXTURE_BLENDMODE_ADVANCED_MULTIPLY,
+  TEXTURE_BLENDMODE_ADVANCED_SCREEN,
+  TEXTURE_BLENDMODE_ADVANCED_OVERLAY,
+  TEXTURE_BLENDMODE_ADVANCED_DARKEN,
+  TEXTURE_BLENDMODE_ADVANCED_LIGHTEN,
+  TEXTURE_BLENDMODE_ADVANCED_COLORDODGE,
+  TEXTURE_BLENDMODE_ADVANCED_COLORBURN,
+  TEXTURE_BLENDMODE_ADVANCED_DIFFERENCE,
+};
+
 class CAspectRatio
 {
 public:
@@ -90,6 +109,7 @@ public:
   bool SetFileName(const std::string &filename);
   void SetUseCache(const bool useCache = true);
   bool SetAspectRatio(const CAspectRatio &aspect);
+  void SetBlendMode(TEXTURE_BLENDMODE blendMode) { m_blendMode = blendMode; };
 
   const std::string& GetFileName() const { return m_info.filename; };
   float GetTextureWidth() const { return m_frameWidth; };
@@ -174,4 +194,6 @@ protected:
 
   CTextureArray m_diffuse;
   CTextureArray m_texture;
+
+  TEXTURE_BLENDMODE m_blendMode = TEXTURE_BLENDMODE_ADD;
 };

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -80,15 +80,89 @@ void CGUITextureGL::Begin(UTILS::Color color)
     }
   }
 
-  if (hasAlpha)
+  if (hasAlpha || m_blendMode != TEXTURE_BLENDMODE_ADD)
   {
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+    if (m_blendMode == TEXTURE_BLENDMODE_ADD)
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_SUBTRACT)
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_SUBTRACT, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_REVERSE_SUBTRACT)
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_REVERSE_SUBTRACT, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_MULTIPLY)
+    {
+      glBlendFuncSeparate(GL_ZERO, GL_SRC_COLOR, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_2X_MULTIPLY)
+    {
+      glBlendFuncSeparate(GL_DST_COLOR, GL_SRC_COLOR, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_DARKEN)
+    {
+      glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_MIN, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_LIGHTEN)
+    {
+      glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_MAX, GL_FUNC_ADD);
+    }
+
+    //needs a shader with the proper layout qualifier
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_MULTIPLY)
+    {
+      glBlendEquation(GL_MULTIPLY_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_SCREEN)
+    {
+      glBlendEquation(GL_SCREEN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_OVERLAY)
+    {
+      glBlendEquation(GL_OVERLAY_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_DARKEN)
+    {
+      glBlendEquation(GL_DARKEN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_LIGHTEN)
+    {
+      glBlendEquation(GL_LIGHTEN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_COLORDODGE)
+    {
+      glBlendEquation(GL_COLORDODGE_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_COLORBURN)
+    {
+      glBlendEquation(GL_COLORBURN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_DIFFERENCE)
+    {
+      glBlendEquation(GL_DIFFERENCE_KHR);
+    }
+    else
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
     glEnable(GL_BLEND);
   }
   else
   {
     glDisable(GL_BLEND);
   }
+
   m_packedVertices.clear();
   m_idx.clear();
 }

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -89,15 +89,89 @@ void CGUITextureGLES::Begin(UTILS::Color color)
     }
   }
 
-  if ( hasAlpha )
+  if (hasAlpha || m_blendMode != TEXTURE_BLENDMODE_ADD)
   {
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
-    glEnable( GL_BLEND );
+    if (m_blendMode == TEXTURE_BLENDMODE_ADD)
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_SUBTRACT)
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_SUBTRACT, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_REVERSE_SUBTRACT)
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_REVERSE_SUBTRACT, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_MULTIPLY)
+    {
+      glBlendFuncSeparate(GL_ZERO, GL_SRC_COLOR, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_2X_MULTIPLY)
+    {
+      glBlendFuncSeparate(GL_DST_COLOR, GL_SRC_COLOR, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_DARKEN)
+    {
+      glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_MIN, GL_FUNC_ADD);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_LIGHTEN)
+    {
+      glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ZERO, GL_ONE);
+      glBlendEquationSeparate(GL_MAX, GL_FUNC_ADD);
+    }
+
+    //needs a shader with the proper layout qualifier
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_MULTIPLY)
+    {
+      glBlendEquation(GL_MULTIPLY_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_SCREEN)
+    {
+      glBlendEquation(GL_SCREEN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_OVERLAY)
+    {
+      glBlendEquation(GL_OVERLAY_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_DARKEN)
+    {
+      glBlendEquation(GL_DARKEN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_LIGHTEN)
+    {
+      glBlendEquation(GL_LIGHTEN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_COLORDODGE)
+    {
+      glBlendEquation(GL_COLORDODGE_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_COLORBURN)
+    {
+      glBlendEquation(GL_COLORBURN_KHR);
+    }
+    else if (m_blendMode == TEXTURE_BLENDMODE_ADVANCED_DIFFERENCE)
+    {
+      glBlendEquation(GL_DIFFERENCE_KHR);
+    }
+    else
+    {
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+      glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    }
+    glEnable(GL_BLEND);
   }
   else
   {
     glDisable(GL_BLEND);
   }
+
   m_packedVertices.clear();
 }
 


### PR DESCRIPTION
## Description
This PR adds various blending options to our skinning engine, enabling our skin devs to employ more interesting effects.

For now it is OpenGL exclusive, but I'm planning to port it to OpenGL ES. DirectX would have to be covered by someone with experience in the field (maybe @thexai?). 

The advanced blending options (like "advancedscreen") would need small additions to the shader(s). On the OGL side, it needs GL_KHR_blend_equation_advanced to work. Otherwise, shader trickery would be needed. I'm curious if this can be done in DX.

## Motivation and context
More GUI effects are always nice to have :).

## How has this been tested?
I've tested it on my RX 570. I expect it to work the same on all relatively recent (<10 year old) hardware.

## What is the effect on users?
None if the skin doesn't use it. If an unsupported blend mode is used, it should reverse to the default "add".

## Screenshots (if appropriate):
![kodi_blending](https://user-images.githubusercontent.com/30039775/118358088-8dd4b900-b57d-11eb-8bee-330d0e7518bf.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
