### PR TITLE
changed: Reset subtitle delay when changing subtitle (fixes #19752)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2760,6 +2760,8 @@ void CVideoPlayer::HandleMessages()
           CloseStream(m_CurrentSubtitle, false);
           OpenStream(m_CurrentSubtitle, st.demuxerId, st.id, st.source);
         }
+        // Reset delay when changing subtitles
+        SetSubTitleDelay(0);
       }
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_SUBTITLESTREAM_VISIBLE))


### PR DESCRIPTION
Makes sense to me. Keeping delay for a different subtitle is useless imo.