### PR TITLE
[gui] fix on-screen debug info for posix platforms

### DIFF
--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -105,29 +105,29 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     StringUtils::ToLower(lcAppName);
 #if !defined(TARGET_POSIX)
     info = StringUtils::Format("LOG: {}{}.log\nMEM: {}/{} KB - FPS: {:2.1f} fps\nCPU: {}{}",
-                               CSpecialProtocol::TranslatePath("special://logpath").c_str(),
+                               CSpecialProtocol::TranslatePath("special://logpath"),
                                lcAppName.c_str(), stat.availPhys / 1024, stat.totalPhys / 1024,
                                CServiceBroker::GetGUI()
                                    ->GetInfoManager()
                                    .GetInfoProviders()
                                    .GetSystemInfoProvider()
                                    .GetFPS(),
-                               strCores.c_str(), profiling.c_str());
+                               strCores, profiling);
 #else
     double dCPU = m_resourceCounter.GetCPUUsage();
     std::string ucAppName = lcAppName;
     StringUtils::ToUpper(ucAppName);
     info = StringUtils::Format("LOG: {}{}.log\n"
-                               "MEM: %" PRIu64 "/%" PRIu64 " KB - FPS: %2.1f fps\n"
-                               "CPU: %s (CPU-%s %4.2f%%%s)",
-                               CSpecialProtocol::TranslatePath("special://logpath").c_str(),
-                               lcAppName.c_str(), stat.availPhys / 1024, stat.totalPhys / 1024,
+                               "MEM: {}/{} KB - FPS: {:2.1f} fps\n"
+                               "CPU: {} (CPU-{} {:4.2f}%){}",
+                               CSpecialProtocol::TranslatePath("special://logpath"), lcAppName,
+                               stat.availPhys / 1024, stat.totalPhys / 1024,
                                CServiceBroker::GetGUI()
                                    ->GetInfoManager()
                                    .GetInfoProviders()
                                    .GetSystemInfoProvider()
                                    .GetFPS(),
-                               strCores.c_str(), ucAppName.c_str(), dCPU, profiling.c_str());
+                               strCores, ucAppName, dCPU, profiling);
 #endif
   }
 


### PR DESCRIPTION
## Description
follow up to https://github.com/xbmc/xbmc/pull/19684

on-screen debug info format string for posix was missed and a few `c_str()` conversions are removed

## How has this been tested?
debian buster

## Screenshots (if appropriate):
**before:**
![ugly](https://user-images.githubusercontent.com/58829855/118398913-f04fb700-b65a-11eb-998f-4011a3cdc6ae.png)

**after:**
![nice](https://user-images.githubusercontent.com/58829855/118398930-fc3b7900-b65a-11eb-99d5-25c352da16f5.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
