### PR TITLE
[PVR] Fix typo in CPVRPlaybackState::ReInit 

### DIFF
--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -99,7 +99,7 @@ void CPVRPlaybackState::ReInit()
   if (!m_activeGroupTV)
     m_activeGroupTV = groupsTV->GetGroupAll();
   if (!m_activeGroupRadio)
-    m_activeGroupTV = groupsRadio->GetGroupAll();
+    m_activeGroupRadio = groupsRadio->GetGroupAll();
 }
 
 void CPVRPlaybackState::Clear()


### PR DESCRIPTION
… which may lead to init of active tv group with radio 'all channels' group and no init of active radio group.

Fallout from #19722 , sorry for that.

@phunkyfish for review? The typo should be pretty obvious.
