### PR TITLE
StringUtils: fix dynamic precision in FormatFileSize

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1802,8 +1802,7 @@ std::string StringUtils::FormatFileSize(uint64_t bytes)
     value /= 1024.0;
   }
   unsigned int decimals = value < 9.995 ? 2 : (value < 99.95 ? 1 : 0);
-  auto frmt = "%." + Format("%u", decimals) + "f%s";
-  return Format(frmt.c_str(), value, units[i].c_str());
+  return Format("{:.{}f}{}", value, decimals, units[i]);
 }
 
 const std::locale& StringUtils::GetOriginalLocale() noexcept


### PR DESCRIPTION
I missed one!

This updates the last (I hope) `StringUtils::Format` call to use the new style. This takes advantage of libfmts ability to nest format modifiers as we want to have a dynamic precision. Cool!

