### PR TITLE
CDVDMsg: remove use of IDVDResourceCounted and use as a shared_ptr

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDMessage.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessage.cpp
@@ -43,6 +43,8 @@ CDVDMsgGeneralSynchronize::CDVDMsgGeneralSynchronize(unsigned int timeout, unsig
 
 CDVDMsgGeneralSynchronize::~CDVDMsgGeneralSynchronize()
 {
+  m_p->condition.notifyAll();
+
   delete m_p;
 }
 
@@ -80,17 +82,6 @@ bool CDVDMsgGeneralSynchronize::Wait(unsigned int milliseconds, unsigned int sou
 void CDVDMsgGeneralSynchronize::Wait(std::atomic<bool>& abort, unsigned int source)
 {
   while(!Wait(100, source) && !abort);
-}
-
-long CDVDMsgGeneralSynchronize::Release()
-{
-  CSingleLock lock(m_p->section);
-  long count = --m_refs;
-  m_p->condition.notifyAll();
-  lock.Leave();
-  if (count == 0)
-    delete this;
-  return count;
 }
 
 /**

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "DVDResource.h"
 #include "FileItem.h"
 #include "cores/IPlayer.h"
 
@@ -18,7 +17,7 @@
 
 struct DemuxPacket;
 
-class CDVDMsg : public IDVDResourceCounted<CDVDMsg>
+class CDVDMsg
 {
 public:
   enum Message
@@ -72,7 +71,7 @@ public:
     m_message = msg;
   }
 
-  ~CDVDMsg() override = default;
+  virtual ~CDVDMsg() = default;
 
   /**
    * checks for message type
@@ -85,11 +84,6 @@ public:
   inline Message GetMessageType()
   {
     return m_message;
-  }
-
-  long GetNrOfReferences()
-  {
-    return m_refs;
   }
 
 private:
@@ -113,7 +107,6 @@ class CDVDMsgGeneralSynchronize : public CDVDMsg
 public:
   CDVDMsgGeneralSynchronize(unsigned int timeout, unsigned int sources);
  ~CDVDMsgGeneralSynchronize() override;
-  long Release() override;
 
   // waits until all threads waiting, released the object
   // if abort is set somehow
@@ -132,6 +125,9 @@ public:
     : CDVDMsg(type)
     , m_value(value)
   {}
+
+  ~CDVDMsgType() override = default;
+
   operator T() { return m_value; }
   T m_value;
 };
@@ -150,6 +146,8 @@ class CDVDMsgPlayerSetAudioStream : public CDVDMsg
 {
 public:
   explicit CDVDMsgPlayerSetAudioStream(int streamId) : CDVDMsg(PLAYER_SET_AUDIOSTREAM) { m_streamId = streamId; }
+  ~CDVDMsgPlayerSetAudioStream() override = default;
+
   int GetStreamId() { return m_streamId; }
 private:
   int m_streamId;
@@ -159,6 +157,8 @@ class CDVDMsgPlayerSetVideoStream : public CDVDMsg
 {
 public:
   explicit CDVDMsgPlayerSetVideoStream(int streamId) : CDVDMsg(PLAYER_SET_VIDEOSTREAM) { m_streamId = streamId; }
+  ~CDVDMsgPlayerSetVideoStream() override = default;
+
   int GetStreamId() const { return m_streamId; }
 private:
   int m_streamId;
@@ -168,6 +168,8 @@ class CDVDMsgPlayerSetSubtitleStream : public CDVDMsg
 {
 public:
   explicit CDVDMsgPlayerSetSubtitleStream(int streamId) : CDVDMsg(PLAYER_SET_SUBTITLESTREAM) { m_streamId = streamId; }
+  ~CDVDMsgPlayerSetSubtitleStream() override = default;
+
   int GetStreamId() { return m_streamId; }
 private:
   int m_streamId;
@@ -177,6 +179,8 @@ class CDVDMsgPlayerSetState : public CDVDMsg
 {
 public:
   explicit CDVDMsgPlayerSetState(const std::string& state) : CDVDMsg(PLAYER_SET_STATE), m_state(state) {}
+  ~CDVDMsgPlayerSetState() override = default;
+
   std::string GetState() { return m_state; }
 private:
   std::string m_state;
@@ -199,6 +203,8 @@ public:
   explicit CDVDMsgPlayerSeek(CDVDMsgPlayerSeek::CMode mode) : CDVDMsg(PLAYER_SEEK),
     m_mode(mode)
   {}
+  ~CDVDMsgPlayerSeek() override = default;
+
   double GetTime() { return m_mode.time; }
   bool GetRelative() { return m_mode.relative; }
   bool GetBackward() { return m_mode.backward; }
@@ -218,6 +224,7 @@ class CDVDMsgPlayerSeekChapter : public CDVDMsg
       : CDVDMsg(PLAYER_SEEK_CHAPTER)
       , m_iChapter(iChapter)
     {}
+    ~CDVDMsgPlayerSeekChapter() override = default;
 
     int GetChapter() const { return m_iChapter; }
 
@@ -239,6 +246,7 @@ public:
   : CDVDMsg(PLAYER_SETSPEED)
   , m_params(params)
   {}
+  ~CDVDMsgPlayerSetSpeed() override = default;
 
   int GetSpeed() const { return m_params.m_speed; }
   bool IsTempo() const { return m_params.m_isTempo; }
@@ -262,6 +270,7 @@ public:
   : CDVDMsg(PLAYER_OPENFILE)
   , m_params(params)
   {}
+  ~CDVDMsgOpenFile() override = default;
 
   CFileItem& GetItem() { return m_params.m_item; }
   CPlayerOptions& GetOptions() { return m_params.m_options; }
@@ -293,6 +302,7 @@ class CDVDMsgDemuxerReset : public CDVDMsg
 {
 public:
   CDVDMsgDemuxerReset() : CDVDMsg(DEMUXER_RESET)  {}
+  ~CDVDMsgDemuxerReset() override = default;
 };
 
 
@@ -314,6 +324,7 @@ class CDVDMsgSubtitleClutChange : public CDVDMsg
 {
 public:
   explicit CDVDMsgSubtitleClutChange(uint8_t* data) : CDVDMsg(SUBTITLE_CLUTCHANGE) { memcpy(m_data, data, 16*4); }
+  ~CDVDMsgSubtitleClutChange() override = default;
+
   uint8_t m_data[16][4];
-private:
 };

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -19,9 +19,9 @@
 
 struct DVDMessageListItem
 {
-  DVDMessageListItem(CDVDMsg* msg, int prio)
+  DVDMessageListItem(std::shared_ptr<CDVDMsg> msg, int prio)
   {
-    message = msg->Acquire();
+    message = std::move(msg);
     priority = prio;
   }
   DVDMessageListItem()
@@ -30,15 +30,11 @@ struct DVDMessageListItem
     priority = 0;
   }
   DVDMessageListItem(const DVDMessageListItem&) = delete;
- ~DVDMessageListItem()
-  {
-    if(message)
-      message->Release();
-  }
+  ~DVDMessageListItem() = default;
 
   DVDMessageListItem& operator=(const DVDMessageListItem&) = delete;
 
-  CDVDMsg* message;
+  std::shared_ptr<CDVDMsg> message;
   int priority;
 };
 
@@ -65,16 +61,18 @@ public:
   void Abort();
   void End();
 
-  MsgQueueReturnCode Put(CDVDMsg* pMsg, int priority = 0);
-  MsgQueueReturnCode PutBack(CDVDMsg* pMsg, int priority = 0);
+  MsgQueueReturnCode Put(std::shared_ptr<CDVDMsg> pMsg, int priority = 0);
+  MsgQueueReturnCode PutBack(std::shared_ptr<CDVDMsg> pMsg, int priority = 0);
 
   /**
    * msg,       message type from DVDMessage.h
    * timeout,   timeout in msec
    * priority,  minimum priority to get, outputs returned packets priority
    */
-  MsgQueueReturnCode Get(CDVDMsg** pMsg, unsigned int iTimeoutInMilliSeconds, int &priority);
-  MsgQueueReturnCode Get(CDVDMsg** pMsg, unsigned int iTimeoutInMilliSeconds)
+  MsgQueueReturnCode Get(std::shared_ptr<CDVDMsg>& pMsg,
+                         unsigned int iTimeoutInMilliSeconds,
+                         int& priority);
+  MsgQueueReturnCode Get(std::shared_ptr<CDVDMsg>& pMsg, unsigned int iTimeoutInMilliSeconds)
   {
     int priority = 0;
     return Get(pMsg, iTimeoutInMilliSeconds, priority);
@@ -98,8 +96,7 @@ public:
   bool IsDataBased() const;
 
 private:
-
-  MsgQueueReturnCode Put(CDVDMsg* pMsg, int priority, bool front);
+  MsgQueueReturnCode Put(std::shared_ptr<CDVDMsg> pMsg, int priority, bool front);
   void UpdateTimeFront();
   void UpdateTimeBack();
 

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -39,7 +39,7 @@ public:
   virtual ~IDVDStreamPlayer() = default;
   virtual bool OpenStream(CDVDStreamInfo hint) = 0;
   virtual void CloseStream(bool bWaitForBuffers) = 0;
-  virtual void SendMessage(CDVDMsg* pMsg, int priority = 0) = 0;
+  virtual void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) = 0;
   virtual void FlushMessages() = 0;
   virtual bool IsInited() const = 0;
   virtual bool AcceptsData() const = 0;
@@ -82,7 +82,7 @@ public:
   bool AcceptsData() const override = 0;
   virtual bool HasData() const = 0;
   bool IsInited() const override = 0;
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) override = 0;
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override = 0;
   virtual void EnableSubtitle(bool bEnable) = 0;
   virtual bool IsSubtitleEnabled() = 0;
   virtual double GetSubtitleDelay() = 0;
@@ -111,7 +111,7 @@ public:
   virtual bool HasData() const = 0;
   virtual int  GetLevel() const = 0;
   bool IsInited() const override = 0;
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) override = 0;
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override = 0;
   virtual void SetVolume(float fVolume) {};
   virtual void SetMute(bool bOnOff) {};
   virtual void SetDynamicRangeCompression(long drc) = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -670,7 +670,7 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
     params.m_item = file;
     params.m_options = options;
     params.m_item.SetMimeTypeForInternetFile();
-    m_messenger.Put(new CDVDMsgOpenFile(params), 1);
+    m_messenger.Put(std::make_shared<CDVDMsgOpenFile>(params), 1);
 
     return true;
   }
@@ -1490,7 +1490,7 @@ void CVideoPlayer::Process()
 
       if (m_CurrentVideo.inited)
       {
-        m_VideoPlayerVideo->SendMessage(new CDVDMsg(CDVDMsg::VIDEO_DRAIN));
+        m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::VIDEO_DRAIN));
       }
 
       m_CurrentAudio.inited = false;
@@ -1652,7 +1652,7 @@ void CVideoPlayer::ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket)
     drop = true;
   }
 
-  m_VideoPlayerAudio->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
   m_CurrentAudio.packets++;
 }
 
@@ -1676,7 +1676,7 @@ void CVideoPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
   if (CheckSceneSkip(m_CurrentVideo))
     drop = true;
 
-  m_VideoPlayerVideo->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
   m_CurrentVideo.packets++;
 }
 
@@ -1693,7 +1693,7 @@ void CVideoPlayer::ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket)
   if (CheckSceneSkip(m_CurrentSubtitle))
     drop = true;
 
-  m_VideoPlayerSubtitle->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_VideoPlayerSubtitle->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
 
   if(m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
     m_VideoPlayerSubtitle->UpdateOverlayInfo(std::static_pointer_cast<CDVDInputStreamNavigator>(m_pInputStream), LIBDVDNAV_BUTTON_NORMAL);
@@ -1712,7 +1712,7 @@ void CVideoPlayer::ProcessTeletextData(CDemuxStream* pStream, DemuxPacket* pPack
   if (CheckSceneSkip(m_CurrentTeletext))
     drop = true;
 
-  m_VideoPlayerTeletext->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_VideoPlayerTeletext->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
 }
 
 void CVideoPlayer::ProcessRadioRDSData(CDemuxStream* pStream, DemuxPacket* pPacket)
@@ -1728,7 +1728,7 @@ void CVideoPlayer::ProcessRadioRDSData(CDemuxStream* pStream, DemuxPacket* pPack
   if (CheckSceneSkip(m_CurrentRadioRDS))
     drop = true;
 
-  m_VideoPlayerRadioRDS->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_VideoPlayerRadioRDS->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
 }
 
 bool CVideoPlayer::GetCachingTimes(double& level, double& delay, double& offset)
@@ -1887,7 +1887,7 @@ void CVideoPlayer::HandlePlaySpeed()
             mode.backward = false;
             mode.accurate = true;
             mode.sync = true;
-            m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+            m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
           }
         }
       }
@@ -1933,7 +1933,8 @@ void CVideoPlayer::HandlePlaySpeed()
     {
       m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_INSYNC;
       m_CurrentAudio.avsync = CCurrentStream::AV_SYNC_NONE;
-      m_VideoPlayerAudio->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, m_clock.GetClock()), 1);
+      m_VideoPlayerAudio->SendMessage(
+          std::make_shared<CDVDMsgDouble>(CDVDMsg::GENERAL_RESYNC, m_clock.GetClock()), 1);
     }
     else if (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_WAITSYNC &&
              (m_CurrentVideo.avsync == CCurrentStream::AV_SYNC_CONT ||
@@ -1941,7 +1942,8 @@ void CVideoPlayer::HandlePlaySpeed()
     {
       m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_INSYNC;
       m_CurrentVideo.avsync = CCurrentStream::AV_SYNC_NONE;
-      m_VideoPlayerVideo->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, m_clock.GetClock()), 1);
+      m_VideoPlayerVideo->SendMessage(
+          std::make_shared<CDVDMsgDouble>(CDVDMsg::GENERAL_RESYNC, m_clock.GetClock()), 1);
     }
     else if (video && audio)
     {
@@ -1994,8 +1996,10 @@ void CVideoPlayer::HandlePlaySpeed()
       m_CurrentAudio.avsync = CCurrentStream::AV_SYNC_NONE;
       m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_INSYNC;
       m_CurrentVideo.avsync = CCurrentStream::AV_SYNC_NONE;
-      m_VideoPlayerAudio->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, clock), 1);
-      m_VideoPlayerVideo->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, clock), 1);
+      m_VideoPlayerAudio->SendMessage(
+          std::make_shared<CDVDMsgDouble>(CDVDMsg::GENERAL_RESYNC, clock), 1);
+      m_VideoPlayerVideo->SendMessage(
+          std::make_shared<CDVDMsgDouble>(CDVDMsg::GENERAL_RESYNC, clock), 1);
       SetCaching(CACHESTATE_DONE);
       UpdatePlayState(0);
 
@@ -2108,7 +2112,7 @@ void CVideoPlayer::HandlePlaySpeed()
             mode.restore = false;
             mode.trickplay = true;
             mode.sync = false;
-            m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+            m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
           }
         }
       }
@@ -2340,7 +2344,7 @@ void CVideoPlayer::CheckAutoSceneSkip()
       mode.restore = true;
       mode.trickplay = false;
       mode.sync = true;
-      m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+      m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
     }
   }
   else if (cut.action == EDL::Action::COMM_BREAK)
@@ -2368,7 +2372,7 @@ void CVideoPlayer::CheckAutoSceneSkip()
         mode.restore = false;
         mode.trickplay = false;
         mode.sync = true;
-        m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+        m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
       }
     }
   }
@@ -2382,10 +2386,9 @@ void CVideoPlayer::SynchronizeDemuxer()
   if(!m_messenger.IsInited())
     return;
 
-  CDVDMsgGeneralSynchronize* message = new CDVDMsgGeneralSynchronize(500, SYNCSOURCE_PLAYER);
-  m_messenger.Put(message->Acquire());
+  auto message = std::make_shared<CDVDMsgGeneralSynchronize>(500, SYNCSOURCE_PLAYER);
+  m_messenger.Put(message);
   message->Wait(m_bStop, 0);
-  message->Release();
 }
 
 IDVDStreamPlayer* CVideoPlayer::GetStreamPlayer(unsigned int target)
@@ -2403,7 +2406,7 @@ IDVDStreamPlayer* CVideoPlayer::GetStreamPlayer(unsigned int target)
   return NULL;
 }
 
-void CVideoPlayer::SendPlayerMessage(CDVDMsg* pMsg, unsigned int target)
+void CVideoPlayer::SendPlayerMessage(std::shared_ptr<CDVDMsg> pMsg, unsigned int target)
 {
   IDVDStreamPlayer* player = GetStreamPlayer(target);
   if(player)
@@ -2487,14 +2490,14 @@ void CVideoPlayer::OnExit()
 
 void CVideoPlayer::HandleMessages()
 {
-  CDVDMsg* pMsg;
+  std::shared_ptr<CDVDMsg> pMsg = nullptr;
 
-  while (m_messenger.Get(&pMsg, 0) == MSGQ_OK)
+  while (m_messenger.Get(pMsg, 0) == MSGQ_OK)
   {
     if (pMsg->IsType(CDVDMsg::PLAYER_OPENFILE) &&
         m_messenger.GetPacketCount(CDVDMsg::PLAYER_OPENFILE) == 0)
     {
-      CDVDMsgOpenFile &msg(*static_cast<CDVDMsgOpenFile*>(pMsg));
+      CDVDMsgOpenFile& msg(*std::static_pointer_cast<CDVDMsgOpenFile>(pMsg));
 
       IPlayerCallback *cb = &m_callback;
       CFileItem fileItem(m_item);
@@ -2545,12 +2548,11 @@ void CVideoPlayer::HandleMessages()
         m_messenger.GetPacketCount(CDVDMsg::PLAYER_SEEK) == 0 &&
         m_messenger.GetPacketCount(CDVDMsg::PLAYER_SEEK_CHAPTER) == 0)
     {
-      CDVDMsgPlayerSeek &msg(*static_cast<CDVDMsgPlayerSeek*>(pMsg));
+      CDVDMsgPlayerSeek& msg(*std::static_pointer_cast<CDVDMsgPlayerSeek>(pMsg));
 
       if (!m_State.canseek)
       {
         m_processInfo->SetStateSeeking(false);
-        pMsg->Release();
         continue;
       }
 
@@ -2564,7 +2566,6 @@ void CVideoPlayer::HandleMessages()
             !msg.GetAccurate())
         {
           m_processInfo->SetStateSeeking(false);
-          pMsg->Release();
           continue;
         }
       }
@@ -2643,7 +2644,7 @@ void CVideoPlayer::HandleMessages()
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
       SetCaching(CACHESTATE_FLUSH);
 
-      CDVDMsgPlayerSeekChapter &msg(*static_cast<CDVDMsgPlayerSeekChapter*>(pMsg));
+      CDVDMsgPlayerSeekChapter& msg(*std::static_pointer_cast<CDVDMsgPlayerSeekChapter>(pMsg));
       double start = DVD_NOPTS_VALUE;
       int offset = 0;
 
@@ -2682,7 +2683,7 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_AUDIOSTREAM))
     {
-      CDVDMsgPlayerSetAudioStream* pMsg2 = static_cast<CDVDMsgPlayerSetAudioStream*>(pMsg);
+      auto pMsg2 = std::static_pointer_cast<CDVDMsgPlayerSetAudioStream>(pMsg);
 
       SelectionStream& st = m_SelectionStreams.Get(STREAM_AUDIO, pMsg2->GetStreamId());
       if(st.source != STREAM_SOURCE_NONE)
@@ -2700,7 +2701,7 @@ void CVideoPlayer::HandleMessages()
             mode.accurate = true;
             mode.trickplay = true;
             mode.sync = true;
-            m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+            m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
           }
         }
         else
@@ -2715,13 +2716,13 @@ void CVideoPlayer::HandleMessages()
           mode.accurate = true;
           mode.trickplay = true;
           mode.sync = true;
-          m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+          m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
         }
       }
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_VIDEOSTREAM))
     {
-      CDVDMsgPlayerSetVideoStream* pMsg2 = static_cast<CDVDMsgPlayerSetVideoStream*>(pMsg);
+      auto pMsg2 = std::static_pointer_cast<CDVDMsgPlayerSetVideoStream>(pMsg);
 
       SelectionStream& st = m_SelectionStreams.Get(STREAM_VIDEO, pMsg2->GetStreamId());
       if (st.source != STREAM_SOURCE_NONE)
@@ -2739,7 +2740,7 @@ void CVideoPlayer::HandleMessages()
             mode.accurate = true;
             mode.trickplay = true;
             mode.sync = true;
-            m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+            m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
           }
         }
         else
@@ -2752,13 +2753,13 @@ void CVideoPlayer::HandleMessages()
           mode.accurate = true;
           mode.trickplay = true;
           mode.sync = true;
-          m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+          m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
         }
       }
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_SUBTITLESTREAM))
     {
-      CDVDMsgPlayerSetSubtitleStream* pMsg2 = static_cast<CDVDMsgPlayerSetSubtitleStream*>(pMsg);
+      auto pMsg2 = std::static_pointer_cast<CDVDMsgPlayerSetSubtitleStream>(pMsg);
 
       SelectionStream& st = m_SelectionStreams.Get(STREAM_SUBTITLE, pMsg2->GetStreamId());
       if(st.source != STREAM_SOURCE_NONE)
@@ -2781,12 +2782,12 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_SUBTITLESTREAM_VISIBLE))
     {
-      CDVDMsgBool* pValue = static_cast<CDVDMsgBool*>(pMsg);
+      auto pValue = std::static_pointer_cast<CDVDMsgBool>(pMsg);
       SetSubtitleVisibleInternal(pValue->m_value);
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_PROGRAM))
     {
-      CDVDMsgInt* msg = static_cast<CDVDMsgInt*>(pMsg);
+      auto msg = std::static_pointer_cast<CDVDMsgInt>(pMsg);
       if (m_pDemuxer)
       {
         m_pDemuxer->SetProgram(msg->m_value);
@@ -2798,7 +2799,7 @@ void CVideoPlayer::HandleMessages()
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
       SetCaching(CACHESTATE_FLUSH);
 
-      CDVDMsgPlayerSetState* pMsgPlayerSetState = static_cast<CDVDMsgPlayerSetState*>(pMsg);
+      auto pMsgPlayerSetState = std::static_pointer_cast<CDVDMsgPlayerSetState>(pMsg);
 
       if (std::shared_ptr<CDVDInputStream::IMenus> ptr = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream))
       {
@@ -2818,7 +2819,7 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
-      int speed = static_cast<CDVDMsgPlayerSetSpeed*>(pMsg)->GetSpeed();
+      int speed = std::static_pointer_cast<CDVDMsgPlayerSetSpeed>(pMsg)->GetSpeed();
 
       // correct our current clock, as it would start going wrong otherwise
       if (m_State.timestamp > 0)
@@ -2866,10 +2867,10 @@ void CVideoPlayer::HandleMessages()
         mode.accurate = true;
         mode.trickplay = true;
         mode.sync = true;
-        m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+        m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
       }
 
-      if (static_cast<CDVDMsgPlayerSetSpeed*>(pMsg)->IsTempo())
+      if (std::static_pointer_cast<CDVDMsgPlayerSetSpeed>(pMsg)->IsTempo())
         m_processInfo->SetTempo(static_cast<float>(speed) / DVD_PLAYSPEED_NORMAL);
       else
         m_processInfo->SetSpeed(static_cast<float>(speed) / DVD_PLAYSPEED_NORMAL);
@@ -2888,17 +2889,17 @@ void CVideoPlayer::HandleMessages()
     {
       if (m_playSpeed == DVD_PLAYSPEED_PAUSE)
       {
-        int frames = static_cast<CDVDMsgInt*>(pMsg)->m_value;
+        int frames = std::static_pointer_cast<CDVDMsgInt>(pMsg)->m_value;
         double time = DVD_TIME_BASE / static_cast<double>(m_processInfo->GetVideoFps()) * frames;
         m_processInfo->SetFrameAdvance(true);
         m_clock.Advance(time);
       }
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_GUI_ACTION))
-      OnAction(static_cast<CDVDMsgType<CAction>*>(pMsg)->m_value);
+      OnAction(std::static_pointer_cast<CDVDMsgType<CAction>>(pMsg)->m_value);
     else if (pMsg->IsType(CDVDMsg::PLAYER_STARTED))
     {
-      SStartMsg& msg = static_cast<CDVDMsgType<SStartMsg>*>(pMsg)->m_value;
+      SStartMsg& msg = std::static_pointer_cast<CDVDMsgType<SStartMsg>>(pMsg)->m_value;
       if (msg.player == VideoPlayer_AUDIO)
       {
         m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_WAITSYNC;
@@ -2917,7 +2918,7 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_REPORT_STATE))
     {
-      SStateMsg& msg = static_cast<CDVDMsgType<SStateMsg>*>(pMsg)->m_value;
+      SStateMsg& msg = std::static_pointer_cast<CDVDMsgType<SStateMsg>>(pMsg)->m_value;
       if (msg.player == VideoPlayer_AUDIO)
       {
         m_CurrentAudio.syncState = msg.syncState;
@@ -2931,7 +2932,7 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::SUBTITLE_ADDFILE))
     {
-      int id = AddSubtitleFile(static_cast<CDVDMsgType<std::string>*>(pMsg)->m_value);
+      int id = AddSubtitleFile(std::static_pointer_cast<CDVDMsgType<std::string>>(pMsg)->m_value);
       if (id >= 0)
       {
         SetSubtitle(id);
@@ -2940,7 +2941,7 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
     {
-      if (static_cast<CDVDMsgGeneralSynchronize*>(pMsg)->Wait(100, SYNCSOURCE_PLAYER))
+      if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100, SYNCSOURCE_PLAYER))
         CLog::Log(LOGDEBUG, "CVideoPlayer - CDVDMsg::GENERAL_SYNCHRONIZE");
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_AVCHANGE))
@@ -2960,8 +2961,6 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_UPDATE_STREAM_DETAILS))
       m_UpdateStreamDetails = true;
-
-    pMsg->Release();
   }
 }
 
@@ -3010,7 +3009,7 @@ void CVideoPlayer::SetPlaySpeed(int speed)
   if (IsPlaying())
   {
     CDVDMsgPlayerSetSpeed::SpeedParams params = { speed, false };
-    m_messenger.Put(new CDVDMsgPlayerSetSpeed(params));
+    m_messenger.Put(std::make_shared<CDVDMsgPlayerSetSpeed>(params));
   }
   else
   {
@@ -3126,7 +3125,7 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   mode.trickplay = false;
   mode.sync = true;
 
-  m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
   SynchronizeDemuxer();
   if (seekTarget < 0)
     seekTarget = 0;
@@ -3160,7 +3159,7 @@ bool CVideoPlayer::SeekScene(bool bPlus)
     mode.trickplay = false;
     mode.sync = true;
 
-    m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+    m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
     SynchronizeDemuxer();
     return true;
   }
@@ -3254,7 +3253,8 @@ bool CVideoPlayer::GetSubtitleVisible()
 
 void CVideoPlayer::SetSubtitleVisible(bool bVisible)
 {
-  m_messenger.Put(new CDVDMsgBool(CDVDMsg::PLAYER_SET_SUBTITLESTREAM_VISIBLE, bVisible));
+  m_messenger.Put(
+      std::make_shared<CDVDMsgBool>(CDVDMsg::PLAYER_SET_SUBTITLESTREAM_VISIBLE, bVisible));
   m_processInfo->UpdateVideoSettings().SetSubtitleVisible(bVisible);
 }
 
@@ -3303,7 +3303,7 @@ void CVideoPlayer::SeekTime(int64_t iTime)
   mode.trickplay = false;
   mode.sync = true;
 
-  m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
   SynchronizeDemuxer();
   m_callback.OnPlayBackSeek(iTime, seekOffset);
 }
@@ -3320,7 +3320,7 @@ bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
   mode.trickplay = false;
   mode.sync = true;
 
-  m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
   m_processInfo->SetStateSeeking(true);
 
   m_callback.OnPlayBackSeek(abstime, iTime);
@@ -3381,7 +3381,7 @@ void CVideoPlayer::SetTempo(float tempo)
   {
     int speed = tempo * DVD_PLAYSPEED_NORMAL;
     CDVDMsgPlayerSetSpeed::SpeedParams params = { speed, true };
-    m_messenger.Put(new CDVDMsgPlayerSetSpeed(params));
+    m_messenger.Put(std::make_shared<CDVDMsgPlayerSetSpeed>(params));
 
     m_processInfo->SetNewTempo(tempo);
   }
@@ -3393,7 +3393,7 @@ void CVideoPlayer::FrameAdvance(int frames)
   if (currentSpeed != DVD_PLAYSPEED_PAUSE)
     return;
 
-  m_messenger.Put(new CDVDMsgInt(CDVDMsg::PLAYER_FRAME_ADVANCE, frames));
+  m_messenger.Put(std::make_shared<CDVDMsgInt>(CDVDMsg::PLAYER_FRAME_ADVANCE, frames));
 }
 
 bool CVideoPlayer::SupportsTempo()
@@ -3549,18 +3549,19 @@ bool CVideoPlayer::OpenAudioStream(CDVDStreamInfo& hint, bool reset)
     if (!player->OpenStream(hint))
       return false;
 
-    player->SendMessage(new CDVDMsgBool(CDVDMsg::GENERAL_PAUSE, m_displayLost), 1);
+    player->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, m_displayLost), 1);
 
     static_cast<IDVDStreamPlayerAudio*>(player)->SetSpeed(m_streamPlayerSpeed);
     m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_STARTING;
     m_CurrentAudio.packets = 0;
   }
   else if (reset)
-    player->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET), 0);
+    player->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_RESET), 0);
 
   m_HasAudio = true;
 
-  static_cast<IDVDStreamPlayerAudio*>(player)->SendMessage(new CDVDMsg(CDVDMsg::PLAYER_REQUEST_STATE), 1);
+  static_cast<IDVDStreamPlayerAudio*>(player)->SendMessage(
+      std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_REQUEST_STATE), 1);
 
   return true;
 }
@@ -3640,7 +3641,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     if (!player->OpenStream(hint))
       return false;
 
-    player->SendMessage(new CDVDMsgBool(CDVDMsg::GENERAL_PAUSE, m_displayLost), 1);
+    player->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, m_displayLost), 1);
 
     // look for any EDL files
     m_Edl.Clear();
@@ -3655,11 +3656,12 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     m_CurrentVideo.packets = 0;
   }
   else if (reset)
-    player->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET), 0);
+    player->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_RESET), 0);
 
   m_HasVideo = true;
 
-  static_cast<IDVDStreamPlayerVideo*>(player)->SendMessage(new CDVDMsg(CDVDMsg::PLAYER_REQUEST_STATE), 1);
+  static_cast<IDVDStreamPlayerVideo*>(player)->SendMessage(
+      std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_REQUEST_STATE), 1);
 
   // open CC demuxer if video is mpeg2
   if ((hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_H264) && !m_pCCDemuxer)
@@ -3832,11 +3834,11 @@ void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
       m_playSpeed == DVD_PLAYSPEED_PAUSE)
   {
     // make sure players are properly flushed, should put them in stalled state
-    CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(1000, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);
-    m_VideoPlayerAudio->SendMessage(msg->Acquire(), 1);
-    m_VideoPlayerVideo->SendMessage(msg->Acquire(), 1);
+    auto msg =
+        std::make_shared<CDVDMsgGeneralSynchronize>(1000, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);
+    m_VideoPlayerAudio->SendMessage(msg, 1);
+    m_VideoPlayerVideo->SendMessage(msg, 1);
     msg->Wait(m_bStop, 0);
-    msg->Release();
 
     // purge any pending PLAYER_STARTED messages
     m_messenger.Flush(CDVDMsg::PLAYER_STARTED);
@@ -3873,7 +3875,7 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
       m_overlayContainer.ProcessAndAddOverlayIfValid(static_cast<CDVDOverlay*>(pData));
       break;
     case BD_EVENT_PLAYLIST_STOP:
-      m_messenger.Put(new CDVDMsg(CDVDMsg::GENERAL_FLUSH));
+      m_messenger.Put(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_FLUSH));
       break;
     case BD_EVENT_AUDIO_STREAM:
       m_dvd.iSelectedAudioStream = *static_cast<int*>(pData);
@@ -3997,7 +3999,8 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
       break;
     case DVDNAV_SPU_CLUT_CHANGE:
       {
-        m_VideoPlayerSubtitle->SendMessage(new CDVDMsgSubtitleClutChange((uint8_t*)pData));
+        m_VideoPlayerSubtitle->SendMessage(
+            std::make_shared<CDVDMsgSubtitleClutChange>((uint8_t*)pData));
       }
       break;
     case DVDNAV_SPU_STREAM_CHANGE:
@@ -4051,7 +4054,8 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
         //Force an aspect ratio that is set in the dvdheaders if available
         m_CurrentVideo.hint.aspect = static_cast<double>(pStream->GetVideoAspectRatio());
         if( m_VideoPlayerVideo->IsInited() )
-          m_VideoPlayerVideo->SendMessage(new CDVDMsgDouble(CDVDMsg::VIDEO_SET_ASPECT, m_CurrentVideo.hint.aspect));
+          m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgDouble>(
+              CDVDMsg::VIDEO_SET_ASPECT, m_CurrentVideo.hint.aspect));
 
         m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NAV);
         m_SelectionStreams.Update(m_pInputStream, m_pDemuxer.get());
@@ -4134,12 +4138,15 @@ void CVideoPlayer::GetVideoResolution(unsigned int &width, unsigned int &height)
 bool CVideoPlayer::OnAction(const CAction &action)
 {
 #define THREAD_ACTION(action) \
-  do { \
-    if (!IsCurrentThread()) { \
-      m_messenger.Put(new CDVDMsgType<CAction>(CDVDMsg::GENERAL_GUI_ACTION, action)); \
+  do \
+  { \
+    if (!IsCurrentThread()) \
+    { \
+      m_messenger.Put( \
+          std::make_shared<CDVDMsgType<CAction>>(CDVDMsg::GENERAL_GUI_ACTION, action)); \
       return true; \
     } \
-  } while(false)
+  } while (false)
 
   std::shared_ptr<CDVDInputStream::IMenus> pMenus = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream);
   if (pMenus)
@@ -4213,7 +4220,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
         THREAD_ACTION(action);
         CLog::Log(LOGDEBUG, " - pushed next in menu, stream will decide");
         if (pMenus->CanSeek() && GetChapterCount() > 0 && GetChapter() < GetChapterCount())
-          m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter() + 1));
+          m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() + 1));
         else
           pMenus->OnNext();
 
@@ -4223,7 +4230,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
         THREAD_ACTION(action);
         CLog::Log(LOGDEBUG, " - pushed prev in menu, stream will decide");
         if (pMenus->CanSeek() && GetChapterCount() > 0 && GetChapter() > 0)
-          m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter() - 1));
+          m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() - 1));
         else
           pMenus->OnPrevious();
 
@@ -4337,7 +4344,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
     case ACTION_NEXT_ITEM:
       if (GetChapter() > 0 && GetChapter() < GetChapterCount())
       {
-        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter() + 1));
+        m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() + 1));
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
         return true;
       }
@@ -4348,7 +4355,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
     case ACTION_PREV_ITEM:
       if (GetChapter() > 0)
       {
-        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter() - 1));
+        m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() - 1));
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
         return true;
       }
@@ -4415,7 +4422,7 @@ std::string CVideoPlayer::GetPlayerState()
 
 bool CVideoPlayer::SetPlayerState(const std::string& state)
 {
-  m_messenger.Put(new CDVDMsgPlayerSetState(state));
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSetState>(state));
   return true;
 }
 
@@ -4450,7 +4457,7 @@ int CVideoPlayer::SeekChapter(int iChapter)
       return 0;
 
     // Seek to the chapter.
-    m_messenger.Put(new CDVDMsgPlayerSeekChapter(iChapter));
+    m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(iChapter));
     SynchronizeDemuxer();
   }
 
@@ -4468,7 +4475,8 @@ int64_t CVideoPlayer::GetChapterPos(int chapterIdx)
 
 void CVideoPlayer::AddSubtitle(const std::string& strSubPath)
 {
-  m_messenger.Put(new CDVDMsgType<std::string>(CDVDMsg::SUBTITLE_ADDFILE, strSubPath));
+  m_messenger.Put(
+      std::make_shared<CDVDMsgType<std::string>>(CDVDMsg::SUBTITLE_ADDFILE, strSubPath));
 }
 
 bool CVideoPlayer::IsCaching() const
@@ -4872,7 +4880,7 @@ bool CVideoPlayer::RenderCaptureGetPixels(unsigned int captureId, unsigned int m
 
 void CVideoPlayer::VideoParamsChange()
 {
-  m_messenger.Put(new CDVDMsg(CDVDMsg::PLAYER_AVCHANGE));
+  m_messenger.Put(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_AVCHANGE));
 }
 
 void CVideoPlayer::GetDebugInfo(std::string &audio, std::string &video, std::string &general)
@@ -4911,8 +4919,8 @@ void CVideoPlayer::UpdateVideoRender(bool video)
 void CVideoPlayer::OnLostDisplay()
 {
   CLog::Log(LOGINFO, "VideoPlayer: OnLostDisplay received");
-  m_VideoPlayerAudio->SendMessage(new CDVDMsgBool(CDVDMsg::GENERAL_PAUSE, true), 1);
-  m_VideoPlayerVideo->SendMessage(new CDVDMsgBool(CDVDMsg::GENERAL_PAUSE, true), 1);
+  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, true), 1);
+  m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, true), 1);
   m_clock.Pause(true);
   m_displayLost = true;
   FlushRenderer();
@@ -4924,8 +4932,8 @@ void CVideoPlayer::OnResetDisplay()
     return;
 
   CLog::Log(LOGINFO, "VideoPlayer: OnResetDisplay received");
-  m_VideoPlayerAudio->SendMessage(new CDVDMsgBool(CDVDMsg::GENERAL_PAUSE, false), 1);
-  m_VideoPlayerVideo->SendMessage(new CDVDMsgBool(CDVDMsg::GENERAL_PAUSE, false), 1);
+  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, false), 1);
+  m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, false), 1);
   m_clock.Pause(false);
   m_displayLost = false;
 }
@@ -5047,7 +5055,7 @@ int CVideoPlayer::GetVideoStream() const
 
 void CVideoPlayer::SetVideoStream(int iStream)
 {
-  m_messenger.Put(new CDVDMsgPlayerSetVideoStream(iStream));
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSetVideoStream>(iStream));
   m_processInfo->UpdateVideoSettings().SetVideoStream(iStream);
   SynchronizeDemuxer();
 }
@@ -5096,7 +5104,7 @@ int CVideoPlayer::GetAudioStream()
 
 void CVideoPlayer::SetAudioStream(int iStream)
 {
-  m_messenger.Put(new CDVDMsgPlayerSetAudioStream(iStream));
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSetAudioStream>(iStream));
   m_processInfo->UpdateVideoSettings().SetAudioStream(iStream);
   SynchronizeDemuxer();
 }
@@ -5129,7 +5137,7 @@ void CVideoPlayer::GetSubtitleStreamInfo(int index, SubtitleStreamInfo &info)
 
 void CVideoPlayer::SetSubtitle(int iStream)
 {
-  m_messenger.Put(new CDVDMsgPlayerSetSubtitleStream(iStream));
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSetSubtitleStream>(iStream));
   m_processInfo->UpdateVideoSettings().SetSubtitleStream(iStream);
 }
 
@@ -5154,7 +5162,7 @@ int CVideoPlayer::GetPrograms(std::vector<ProgramInfo>& programs)
 
 void CVideoPlayer::SetProgram(int progId)
 {
-  m_messenger.Put(new CDVDMsgInt(CDVDMsg::PLAYER_SET_PROGRAM, progId));
+  m_messenger.Put(std::make_shared<CDVDMsgInt>(CDVDMsg::PLAYER_SET_PROGRAM, progId));
 }
 
 int CVideoPlayer::GetProgramsCount()
@@ -5165,5 +5173,5 @@ int CVideoPlayer::GetProgramsCount()
 
 void CVideoPlayer::SetUpdateStreamDetails()
 {
-  m_messenger.Put(new CDVDMsg(CDVDMsg::PLAYER_SET_UPDATE_STREAM_DETAILS));
+  m_messenger.Put(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_SET_UPDATE_STREAM_DETAILS));
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -416,7 +416,7 @@ protected:
   void UpdateCorrection(DemuxPacket* pkt, double correction);
   void UpdateTimestamps(CCurrentStream& current, DemuxPacket* pPacket);
   IDVDStreamPlayer* GetStreamPlayer(unsigned int player);
-  void SendPlayerMessage(CDVDMsg* pMsg, unsigned int target);
+  void SendPlayerMessage(std::shared_ptr<CDVDMsg> pMsg, unsigned int target);
 
   bool ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream);
   bool IsValidStream(CCurrentStream& stream);

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -42,7 +42,10 @@ public:
   bool HasData() const override { return m_messageQueue.GetDataSize() > 0; }
   int  GetLevel() const override { return m_messageQueue.GetLevel(); }
   bool IsInited() const override { return m_messageQueue.IsInited(); }
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) override { m_messageQueue.Put(pMsg, priority); }
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override
+  {
+    m_messageQueue.Put(pMsg, priority);
+  }
   void FlushMessages() override { m_messageQueue.Flush(); }
 
   void SetDynamicRangeCompression(long drc) override { m_audioSink.SetDynamicRangeCompression(drc); }

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -628,9 +628,9 @@ void CDVDRadioRDSData::Process()
 
   while (!m_bStop)
   {
-    CDVDMsg* pMsg;
+    std::shared_ptr<CDVDMsg> pMsg;
     int iPriority = (m_speed == DVD_PLAYSPEED_PAUSE) ? 1 : 0;
-    MsgQueueReturnCode ret = m_messageQueue.Get(&pMsg, 2000, iPriority);
+    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2000, iPriority);
 
     if (ret == MSGQ_TIMEOUT)
     {
@@ -648,20 +648,19 @@ void CDVDRadioRDSData::Process()
     {
       CSingleLock lock(m_critSection);
 
-      DemuxPacket* pPacket = static_cast<CDVDMsgDemuxerPacket*>(pMsg)->GetPacket();
+      DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
 
       ProcessUECP(pPacket->pData, pPacket->iSize);
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
-      m_speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
+      m_speed = std::static_pointer_cast<CDVDMsgInt>(pMsg)->m_value;
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH)
           || pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
       ResetRDSCache();
     }
-    pMsg->Release();
   }
 }
 
@@ -673,7 +672,7 @@ void CDVDRadioRDSData::Flush()
   /* and any demux packet that has been taken out of queue need to */
   /* be disposed of before we flush */
   m_messageQueue.Flush();
-  m_messageQueue.Put(new CDVDMsg(CDVDMsg::GENERAL_FLUSH));
+  m_messageQueue.Put(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_FLUSH));
 }
 
 void CDVDRadioRDSData::OnExit()

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
@@ -49,7 +49,11 @@ public:
   // waits until all available data has been rendered
   void WaitForBuffers() { m_messageQueue.WaitUntilEmpty(); }
   bool AcceptsData() const override { return !m_messageQueue.IsFull(); }
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) override { if(m_messageQueue.IsInited()) m_messageQueue.Put(pMsg, priority); }
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override
+  {
+    if (m_messageQueue.IsInited())
+      m_messageQueue.Put(pMsg, priority);
+  }
   void FlushMessages() override { m_messageQueue.Flush(); }
   bool IsInited() const override { return true; }
   bool IsStalled() const override { return true; }

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -35,16 +35,16 @@ CVideoPlayerSubtitle::~CVideoPlayerSubtitle()
 
 void CVideoPlayerSubtitle::Flush()
 {
-  SendMessage(new CDVDMsg(CDVDMsg::GENERAL_FLUSH), 0);
+  SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_FLUSH), 0);
 }
 
-void CVideoPlayerSubtitle::SendMessage(CDVDMsg* pMsg, int priority)
+void CVideoPlayerSubtitle::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority)
 {
   CSingleLock lock(m_section);
 
   if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
   {
-    CDVDMsgDemuxerPacket* pMsgDemuxerPacket = static_cast<CDVDMsgDemuxerPacket*>(pMsg);
+    auto pMsgDemuxerPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg);
     DemuxPacket* pPacket = pMsgDemuxerPacket->GetPacket();
 
     if (m_pOverlayCodec)
@@ -76,7 +76,7 @@ void CVideoPlayerSubtitle::SendMessage(CDVDMsg* pMsg, int priority)
   }
   else if( pMsg->IsType(CDVDMsg::SUBTITLE_CLUTCHANGE) )
   {
-    CDVDMsgSubtitleClutChange* pData = static_cast<CDVDMsgSubtitleClutChange*>(pMsg);
+    auto pData = std::static_pointer_cast<CDVDMsgSubtitleClutChange>(pMsg);
     for (int i = 0; i < 16; i++)
     {
       uint8_t* color = m_dvdspus.m_clut[i];
@@ -113,8 +113,6 @@ void CVideoPlayerSubtitle::SendMessage(CDVDMsg* pMsg, int priority)
 
     m_lastPts = DVD_NOPTS_VALUE;
   }
-
-  pMsg->Release();
 }
 
 bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filename)

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.h
@@ -38,7 +38,7 @@ public:
   }
 
   bool AcceptsData() const override;
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) override;
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override;
   void FlushMessages() override {}
   bool OpenStream(CDVDStreamInfo hints) override { return OpenStream(hints, hints.filename); }
   bool OpenStream(CDVDStreamInfo &hints, std::string& filename);

--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
@@ -227,9 +227,9 @@ void CDVDTeletextData::Process()
 
   while (!m_bStop)
   {
-    CDVDMsg* pMsg;
+    std::shared_ptr<CDVDMsg> pMsg;
     int iPriority = (m_speed == DVD_PLAYSPEED_PAUSE) ? 1 : 0;
-    MsgQueueReturnCode ret = m_messageQueue.Get(&pMsg, 2000, iPriority);
+    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2000, iPriority);
 
     if (ret == MSGQ_TIMEOUT)
     {
@@ -247,7 +247,7 @@ void CDVDTeletextData::Process()
     {
       CSingleLock lock(m_critSection);
 
-      DemuxPacket* pPacket = static_cast<CDVDMsgDemuxerPacket*>(pMsg)->GetPacket();
+      DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
       uint8_t *Datai       = pPacket->pData;
       int rows             = (pPacket->iSize - 1) / 46;
 
@@ -625,14 +625,13 @@ void CDVDTeletextData::Process()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
-      m_speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
+      m_speed = std::static_pointer_cast<CDVDMsgInt>(pMsg)->m_value;
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH)
           || pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
       ResetTeletextCache();
     }
-    pMsg->Release();
   }
 }
 
@@ -649,7 +648,7 @@ void CDVDTeletextData::Flush()
   /* and any demux packet that has been taken out of queue need to */
   /* be disposed of before we flush */
   m_messageQueue.Flush();
-  m_messageQueue.Put(new CDVDMsg(CDVDMsg::GENERAL_FLUSH));
+  m_messageQueue.Put(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_FLUSH));
 }
 
 void CDVDTeletextData::Decode_p2829(unsigned char *vtxt_row, TextExtData_t **ptExtData)

--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.h
@@ -29,7 +29,11 @@ public:
   // waits until all available data has been rendered
   void WaitForBuffers() { m_messageQueue.WaitUntilEmpty(); }
   bool AcceptsData() const override { return !m_messageQueue.IsFull(); }
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) override { if(m_messageQueue.IsInited()) m_messageQueue.Put(pMsg, priority); }
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override
+  {
+    if (m_messageQueue.IsInited())
+      m_messageQueue.Put(pMsg, priority);
+  }
   void FlushMessages() override { m_messageQueue.Flush(); }
   bool IsInited() const override { return true; }
   bool IsStalled() const override { return true; }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -58,7 +58,7 @@ public:
   bool AcceptsData() const override;
   bool HasData() const override;
   bool IsInited() const override;
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) override;
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override;
   void FlushMessages() override;
 
   void EnableSubtitle(bool bEnable) override { m_bRenderSubs = bEnable; }
@@ -91,8 +91,10 @@ protected:
   void Process() override;
 
   bool ProcessDecoderOutput(double &frametime, double &pts);
-  void SendMessageBack(CDVDMsg* pMsg, int priority = 0);
-  MsgQueueReturnCode GetMessage(CDVDMsg** pMsg, unsigned int iTimeoutInMilliSeconds, int &priority);
+  void SendMessageBack(std::shared_ptr<CDVDMsg> pMsg, int priority = 0);
+  MsgQueueReturnCode GetMessage(std::shared_ptr<CDVDMsg>& pMsg,
+                                unsigned int iTimeoutInMilliSeconds,
+                                int& priority);
 
   EOutputState OutputPicture(const VideoPicture* src);
   void ProcessOverlays(const VideoPicture* pSource, double pts);


### PR DESCRIPTION
This removes our manually reference counting with built in reference counting done by `shared_ptr` (not that I believe there was any issues the old way).

Most of the changes are straight forward the only thing I'm unsure about is `~CDVDMsgGeneralSynchronize`  as I'm not sure if I need the locks when calling `m_p->condition.notifyAll()`

Some brief playback tests didn't show any issues.