### PR TITLE
[Windows] Fix: crash when the monitor is turned off and Kodi goes to another monitor

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -446,6 +446,7 @@ bool CWinSystemWin32::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
               res.iWidth, res.iHeight, res.fRefreshRate,
              (res.dwFlags & D3DPRESENTFLAG_INTERLACED) ? "i" : "");
 
+  // oldMonitor may be NULL if it's powered off or not available due windows settings
   MONITOR_DETAILS* oldMonitor = GetDisplayDetails(m_hMonitor);
   MONITOR_DETAILS* newMonitor = GetDisplayDetails(res.strOutput);
 
@@ -453,10 +454,11 @@ bool CWinSystemWin32::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
   bool changeScreen = false;   // display is changed
   bool stereoChange = IsStereoEnabled() != (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() == RENDER_STEREO_MODE_HARDWAREBASED);
 
-  if ( m_nWidth != res.iWidth || m_nHeight != res.iHeight  || m_fRefreshRate != res.fRefreshRate ||
-      oldMonitor->hMonitor != newMonitor->hMonitor || stereoChange || m_bFirstResChange)
+  if (m_nWidth != res.iWidth || m_nHeight != res.iHeight || m_fRefreshRate != res.fRefreshRate ||
+      !oldMonitor || oldMonitor->hMonitor != newMonitor->hMonitor || stereoChange ||
+      m_bFirstResChange)
   {
-    if (oldMonitor->hMonitor != newMonitor->hMonitor)
+    if (!oldMonitor || oldMonitor->hMonitor != newMonitor->hMonitor)
       changeScreen = true;
     forceChange = true;
   }


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/19768


## What is the effect on users?
Fix crash when Kodi switches from monitor due hardware config changed or monitor is turned off.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
