### PR TITLE
[threads] convert to use std::chrono

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -212,6 +212,7 @@ using namespace KODI::MESSAGING;
 using namespace ActiveAE;
 
 using namespace XbmcThreads;
+using namespace std::chrono_literals;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
@@ -625,7 +626,7 @@ bool CApplication::Initialize()
 
   std::string localizedStr = g_localizeStrings.Get(24150);
   int iDots = 1;
-  while (!event.WaitMSec(1000))
+  while (!event.WaitMSec(1000ms))
   {
     if (databaseManager.IsUpgrading())
       CServiceBroker::GetRenderSystem()->ShowSplash(std::string(iDots, ' ') + localizedStr + std::string(iDots, '.'));
@@ -669,7 +670,7 @@ bool CApplication::Initialize()
             CJob::PRIORITY_DEDICATED);
         localizedStr = g_localizeStrings.Get(24151);
         iDots = 1;
-        while (!event.WaitMSec(1000))
+        while (!event.WaitMSec(1000ms))
         {
           CServiceBroker::GetRenderSystem()->ShowSplash(std::string(iDots, ' ') + localizedStr +
                                                         std::string(iDots, '.'));

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -626,7 +626,7 @@ bool CApplication::Initialize()
 
   std::string localizedStr = g_localizeStrings.Get(24150);
   int iDots = 1;
-  while (!event.WaitMSec(1000ms))
+  while (!event.Wait(1000ms))
   {
     if (databaseManager.IsUpgrading())
       CServiceBroker::GetRenderSystem()->ShowSplash(std::string(iDots, ' ') + localizedStr + std::string(iDots, '.'));
@@ -670,7 +670,7 @@ bool CApplication::Initialize()
             CJob::PRIORITY_DEDICATED);
         localizedStr = g_localizeStrings.Get(24151);
         iDots = 1;
-        while (!event.WaitMSec(1000ms))
+        while (!event.Wait(1000ms))
         {
           CServiceBroker::GetRenderSystem()->ShowSplash(std::string(iDots, ' ') + localizedStr +
                                                         std::string(iDots, '.'));

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -49,6 +49,7 @@ using namespace XFILE;
 using namespace PLAYLIST;
 using namespace MEDIA_DETECT;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
@@ -488,7 +489,7 @@ void CAutorun::HandleAutorun()
     return ;
   }
 
-  if (mediadetect.m_evAutorun.WaitMSec(0))
+  if (mediadetect.m_evAutorun.WaitMSec(0ms))
   {
     ExecuteAutorun();
     mediadetect.m_evAutorun.Reset();

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -489,7 +489,7 @@ void CAutorun::HandleAutorun()
     return ;
   }
 
-  if (mediadetect.m_evAutorun.WaitMSec(0ms))
+  if (mediadetect.m_evAutorun.Wait(0ms))
   {
     ExecuteAutorun();
     mediadetect.m_evAutorun.Reset();

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -23,6 +23,7 @@
 #include "utils/log.h"
 
 using namespace XFILE;
+using namespace std::chrono_literals;
 
 CTextureCache &CTextureCache::GetInstance()
 {
@@ -152,7 +153,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
   // wait for currently processing job to end.
   while (true)
   {
-    m_completeEvent.WaitMSec(1000);
+    m_completeEvent.WaitMSec(1000ms);
     {
       CSingleLock lock(m_processingSection);
       if (m_processinglist.find(url) == m_processinglist.end())

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -153,7 +153,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
   // wait for currently processing job to end.
   while (true)
   {
-    m_completeEvent.WaitMSec(1000ms);
+    m_completeEvent.Wait(1000ms);
     {
       CSingleLock lock(m_processingSection);
       if (m_processinglist.find(url) == m_processinglist.end())

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -31,6 +31,8 @@
 #include <iterator>
 #include <vector>
 
+using namespace std::chrono_literals;
+
 namespace ADDON
 {
 
@@ -165,7 +167,7 @@ void CRepositoryUpdater::OnTimeout()
       CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW)
   {
     CLog::Log(LOGDEBUG,"CRepositoryUpdater: busy playing. postponing scheduled update");
-    m_timer.RestartAsync(2 * 60 * 1000);
+    m_timer.RestartAsync(2min);
     return;
   }
 
@@ -240,7 +242,7 @@ void CRepositoryUpdater::ScheduleUpdate()
               nextCheck.GetAsLocalizedDateTime(), delta / 1000);
   }
 
-  if (!m_timer.Start(delta))
+  if (!m_timer.Start(std::chrono::milliseconds(delta)))
     CLog::Log(LOGERROR,"CRepositoryUpdater: failed to start timer");
 }
 }

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -40,10 +40,16 @@
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
 std::shared_ptr<ADDON::CSkinInfo> g_SkinInfo;
+
+namespace
+{
+constexpr auto DELAY = 500ms;
+}
 
 namespace ADDON
 {
@@ -58,8 +64,6 @@ public:
   void OnTimeout() override;
   void TriggerSave();
 private:
-  static constexpr int DELAY = 500;
-
   CAddon &m_addon;
   CTimer m_timer;
 };

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -1431,7 +1431,7 @@ bool CGUIAddonWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
 void CGUIAddonWindow::WaitForActionEvent(unsigned int timeout)
 {
-  m_actionEvent.WaitMSec(std::chrono::milliseconds(timeout));
+  m_actionEvent.Wait(std::chrono::milliseconds(timeout));
   m_actionEvent.Reset();
 }
 

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -1431,7 +1431,7 @@ bool CGUIAddonWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
 void CGUIAddonWindow::WaitForActionEvent(unsigned int timeout)
 {
-  m_actionEvent.WaitMSec(timeout);
+  m_actionEvent.WaitMSec(std::chrono::milliseconds(timeout));
   m_actionEvent.Reset();
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1102,7 +1102,7 @@ void CActiveAE::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
+    else if (m_outMsgEvent.Wait(std::chrono::milliseconds(m_extTimeout)))
     {
       m_extTimeout = timer.MillisLeft();
       continue;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1102,7 +1102,7 @@ void CActiveAE::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(m_extTimeout))
+    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
     {
       m_extTimeout = timer.MillisLeft();
       continue;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -13,6 +13,7 @@
 #include "cores/AudioEngine/Interfaces/AESound.h"
 #include "cores/AudioEngine/Interfaces/AEStream.h"
 #include "guilib/DispResource.h"
+#include "threads/SystemClock.h"
 #include "threads/Thread.h"
 
 #include <list>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -660,7 +660,7 @@ void CActiveAESink::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(m_extTimeout))
+    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
     {
       m_extTimeout = timer.MillisLeft();
       continue;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -23,6 +23,7 @@
 
 using namespace AE;
 using namespace ActiveAE;
+using namespace std::chrono_literals;
 
 CActiveAESink::CActiveAESink(CEvent *inMsgEvent) :
   CThread("AESink"),
@@ -377,10 +378,9 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
         {
         case CSinkDataProtocol::SAMPLE:
           CSampleBuffer *samples;
-          int timeout;
           samples = *((CSampleBuffer**)msg->data);
-          timeout = 1000*samples->pkt->nb_samples/samples->pkt->config.sample_rate;
-          CThread::Sleep(timeout);
+          CThread::Sleep(std::chrono::milliseconds(1000 * samples->pkt->nb_samples /
+                                                   samples->pkt->config.sample_rate));
           msg->Reply(CSinkDataProtocol::RETURNSAMPLE, &samples, sizeof(CSampleBuffer*));
           m_extTimeout = 0;
           return;
@@ -708,7 +708,7 @@ void CActiveAESink::EnumerateSinkList(bool force, std::string driver)
   while (m_sinkInfoList.empty() && c_retry > 0)
   {
     CLog::Log(LOGINFO, "No Devices found - retry: {}", c_retry);
-    CThread::Sleep(1500);
+    CThread::Sleep(1500ms);
     c_retry--;
     // retry the enumeration
     CAESinkFactory::EnumerateEx(m_sinkInfoList, true, driver);
@@ -1030,7 +1030,8 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
     written = m_sink->AddPackets(buffer, maxFrames, totalFrames - frames);
     if (written == 0)
     {
-      CThread::Sleep(500 * m_sinkFormat.m_frames / m_sinkFormat.m_sampleRate);
+      CThread::Sleep(
+          std::chrono::milliseconds(500 * m_sinkFormat.m_frames / m_sinkFormat.m_sampleRate));
       retry++;
       if (retry > 4)
       {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -660,7 +660,7 @@ void CActiveAESink::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
+    else if (m_outMsgEvent.Wait(std::chrono::milliseconds(m_extTimeout)))
     {
       m_extTimeout = timer.MillisLeft();
       continue;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -13,6 +13,7 @@
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/Interfaces/AESink.h"
 #include "threads/Event.h"
+#include "threads/SystemClock.h"
 #include "threads/Thread.h"
 #include "utils/ActorProtocol.h"
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -344,7 +344,7 @@ unsigned int CActiveAEStream::AddData(const uint8_t* const *data, unsigned int o
         break;
       }
     }
-    if (!m_inMsgEvent.WaitMSec(200ms))
+    if (!m_inMsgEvent.Wait(200ms))
       break;
   }
   return copied;
@@ -452,7 +452,7 @@ void CActiveAEStream::Drain(bool wait)
     else if (!wait)
       return;
 
-    m_inMsgEvent.WaitMSec(std::chrono::milliseconds(timer.MillisLeft()));
+    m_inMsgEvent.Wait(std::chrono::milliseconds(timer.MillisLeft()));
   }
   CLog::Log(LOGERROR, "CActiveAEStream::Drain - timeout out");
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -15,6 +15,7 @@
 #include "utils/log.h"
 
 using namespace ActiveAE;
+using namespace std::chrono_literals;
 
 CActiveAEStream::CActiveAEStream(AEAudioFormat *format, unsigned int streamid, CActiveAE *ae)
 {
@@ -343,7 +344,7 @@ unsigned int CActiveAEStream::AddData(const uint8_t* const *data, unsigned int o
         break;
       }
     }
-    if (!m_inMsgEvent.WaitMSec(200))
+    if (!m_inMsgEvent.WaitMSec(200ms))
       break;
   }
   return copied;
@@ -451,7 +452,7 @@ void CActiveAEStream::Drain(bool wait)
     else if (!wait)
       return;
 
-    m_inMsgEvent.WaitMSec(timer.MillisLeft());
+    m_inMsgEvent.WaitMSec(std::chrono::milliseconds(timer.MillisLeft()));
   }
   CLog::Log(LOGERROR, "CActiveAEStream::Drain - timeout out");
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
@@ -14,6 +14,7 @@
 #include "cores/AudioEngine/Utils/AERingBuffer.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "threads/Condition.h"
+#include "threads/SystemClock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -229,7 +230,7 @@ unsigned int CAAudioUnitSink::write(uint8_t *data, unsigned int frames)
     // we are using a timer here for being sure for timeouts
     // condvar can be woken spuriously as signaled
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(mutex, timeout);
+    condVar.wait(mutex, std::chrono::milliseconds(timeout));
     if (!m_started && timer.IsTimePast())
     {
       CLog::Log(LOGERROR, "{} engine didn't start in {} ms!", __FUNCTION__, timeout);
@@ -254,7 +255,7 @@ void CAAudioUnitSink::drain()
   {
     CSingleLock lock(mutex);
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(mutex, timeout);
+    condVar.wait(mutex, std::chrono::milliseconds(timeout));
 
     bytes = m_buffer->GetReadSize();
     // if we timeout and don't

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -14,6 +14,7 @@
 #include "cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h"
 #include "cores/AudioEngine/Sinks/osx/CoreAudioHardware.h"
 #include "cores/AudioEngine/Utils/AERingBuffer.h"
+#include "threads/SystemClock.h"
 #include "utils/MemUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
@@ -428,7 +429,7 @@ unsigned int CAESinkDARWINOSX::AddPackets(uint8_t **data, unsigned int frames, u
     // we are using a timer here for being sure for timeouts
     // condvar can be woken spuriously as signaled
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(mutex, timeout);
+    condVar.wait(mutex, std::chrono::milliseconds(timeout));
     if (!m_started && timer.IsTimePast())
     {
       CLog::Log(LOGERROR, "{} engine didn't start in {} ms!", __FUNCTION__, timeout);
@@ -455,7 +456,7 @@ void CAESinkDARWINOSX::Drain()
   {
     CSingleLock lock(mutex);
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(mutex, timeout);
+    condVar.wait(mutex, std::chrono::milliseconds(timeout));
 
     bytes = m_buffer->GetReadSize();
     // if we timeout and don't

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -14,6 +14,7 @@
 #include "cores/AudioEngine/Utils/AERingBuffer.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "threads/Condition.h"
+#include "threads/SystemClock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -365,7 +366,7 @@ unsigned int CAAudioUnitSink::write(uint8_t* data, unsigned int frames, unsigned
     // we are using a timer here for beeing sure for timeouts
     // condvar can be woken spuriously as signaled
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(mutex, timeout);
+    condVar.wait(mutex, std::chrono::milliseconds(timeout));
     if (!m_started && timer.IsTimePast())
     {
       CLog::Log(LOGERROR, "{} engine didn't start in {} ms!", __FUNCTION__, timeout);
@@ -391,7 +392,7 @@ void CAAudioUnitSink::drain()
   {
     CSingleLock lock(mutex);
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(mutex, timeout);
+    condVar.wait(mutex, std::chrono::milliseconds(timeout));
 
     bytes = m_buffer->GetReadSize();
     // if we timeout and do not consume bytes,

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -12,6 +12,7 @@
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "threads/CriticalSection.h"
+#include "threads/SystemClock.h"
 #include "threads/Thread.h"
 
 #include <atomic>

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cores/AudioEngine/Sinks/osx/CoreAudioStream.h"
+#include "threads/SystemClock.h"
 
 #include <list>
 #include <string>

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
@@ -12,6 +12,8 @@
 #include "cores/AudioEngine/Sinks/darwin/CoreAudioHelpers.h"
 #include "utils/log.h"
 
+using namespace std::chrono_literals;
+
 CCoreAudioStream::CCoreAudioStream()
 {
   m_OriginalVirtualFormat.mFormatID = 0;
@@ -290,7 +292,7 @@ bool CCoreAudioStream::SetVirtualFormat(AudioStreamBasicDescription* pDesc)
                 (uint)m_StreamId, StreamDescriptionToString(checkVirtualFormat, formatString));
       break;
     }
-    m_virtual_format_event.WaitMSec(100);
+    m_virtual_format_event.WaitMSec(100ms);
   }
   return true;
 }
@@ -383,7 +385,7 @@ bool CCoreAudioStream::SetPhysicalFormat(AudioStreamBasicDescription* pDesc)
                 (uint)m_StreamId, StreamDescriptionToString(checkPhysicalFormat, formatString));
       break;
     }
-    m_physical_format_event.WaitMSec(100);
+    m_physical_format_event.WaitMSec(100ms);
   }
 
   return true;

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
@@ -292,7 +292,7 @@ bool CCoreAudioStream::SetVirtualFormat(AudioStreamBasicDescription* pDesc)
                 (uint)m_StreamId, StreamDescriptionToString(checkVirtualFormat, formatString));
       break;
     }
-    m_virtual_format_event.WaitMSec(100ms);
+    m_virtual_format_event.Wait(100ms);
   }
   return true;
 }
@@ -385,7 +385,7 @@ bool CCoreAudioStream::SetPhysicalFormat(AudioStreamBasicDescription* pDesc)
                 (uint)m_StreamId, StreamDescriptionToString(checkPhysicalFormat, formatString));
       break;
     }
-    m_physical_format_event.WaitMSec(100ms);
+    m_physical_format_event.Wait(100ms);
   }
 
   return true;

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -44,6 +44,7 @@
 #define DEFAULT_PLAYCOUNT_MIN_TIME 10
 
 using namespace XFILE;
+using namespace std::chrono_literals;
 
 #if defined(TARGET_WINDOWS_DESKTOP)
 extern HWND g_hWnd;
@@ -296,7 +297,7 @@ void CExternalPlayer::Process()
   XbmcThreads::EndTime timer(2000);
   while (!timer.IsTimePast() && !CServiceBroker::GetActiveAE()->IsSuspended())
   {
-    CThread::Sleep(50);
+    CThread::Sleep(50ms);
   }
   if (timer.IsTimePast())
   {

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -14,8 +14,12 @@
 
 using namespace KODI;
 using namespace RETRO;
+using namespace std::chrono_literals;
 
-#define AUTOSAVE_DURATION_SECS 10 // Auto-save every 10 seconds
+namespace
+{
+constexpr auto AUTOSAVE_DURATION_SECS = 10s; // Auto-save every 10 seconds
+}
 
 CRetroPlayerAutoSave::CRetroPlayerAutoSave(IAutoSaveCallback& callback,
                                            GAME::CGameSettings& settings)
@@ -39,7 +43,7 @@ void CRetroPlayerAutoSave::Process()
 
   while (!m_bStop)
   {
-    CThread::Sleep(AUTOSAVE_DURATION_SECS * 1000);
+    CThread::Sleep(AUTOSAVE_DURATION_SECS);
 
     if (m_bStop)
       break;

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -64,7 +64,7 @@ void CGameLoop::Process(void)
     if (m_speedFactor == 0.0)
     {
       m_lastFrameMs = 0.0;
-      m_sleepEvent.WaitMSec(5000ms);
+      m_sleepEvent.Wait(5000ms);
     }
     else
     {
@@ -90,7 +90,7 @@ void CGameLoop::Process(void)
       // Sleep at least 1 ms to avoid sleeping forever
       while (sleepTimeMs > 1.0)
       {
-        m_sleepEvent.WaitMSec(std::chrono::milliseconds(static_cast<unsigned int>(sleepTimeMs)));
+        m_sleepEvent.Wait(std::chrono::milliseconds(static_cast<unsigned int>(sleepTimeMs)));
 
         if (m_bStop)
           break;

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -13,6 +13,7 @@
 
 using namespace KODI;
 using namespace RETRO;
+using namespace std::chrono_literals;
 
 #define DEFAULT_FPS 60 // In case fps is 0 (shouldn't happen)
 #define FOREVER_MS (7 * 24 * 60 * 60 * 1000) // 1 week is large enough
@@ -63,7 +64,7 @@ void CGameLoop::Process(void)
     if (m_speedFactor == 0.0)
     {
       m_lastFrameMs = 0.0;
-      m_sleepEvent.WaitMSec(5000);
+      m_sleepEvent.WaitMSec(5000ms);
     }
     else
     {
@@ -89,7 +90,7 @@ void CGameLoop::Process(void)
       // Sleep at least 1 ms to avoid sleeping forever
       while (sleepTimeMs > 1.0)
       {
-        m_sleepEvent.WaitMSec(static_cast<unsigned int>(sleepTimeMs));
+        m_sleepEvent.WaitMSec(std::chrono::milliseconds(static_cast<unsigned int>(sleepTimeMs)));
 
         if (m_bStop)
           break;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -144,7 +144,7 @@ void CMediaCodecVideoBuffer::Set(int bufferId, int textureId,
 
 bool CMediaCodecVideoBuffer::WaitForFrame(int millis)
 {
-  return m_frameready->WaitMSec(millis);
+  return m_frameready->WaitMSec(std::chrono::milliseconds(millis));
 }
 
 void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTime, CMediaCodecVideoBufferPool* pool)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -144,7 +144,7 @@ void CMediaCodecVideoBuffer::Set(int bufferId, int textureId,
 
 bool CMediaCodecVideoBuffer::WaitForFrame(int millis)
 {
-  return m_frameready->WaitMSec(std::chrono::milliseconds(millis));
+  return m_frameready->Wait(std::chrono::milliseconds(millis));
 }
 
 void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTime, CMediaCodecVideoBufferPool* pool)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -1373,7 +1373,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   {
     lock.Leave();
     // wait app device restoration
-    m_event.WaitMSec(2000ms);
+    m_event.Wait(2000ms);
     lock.Enter();
 
     // still in lost state after 2sec

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -38,6 +38,7 @@
 
 using namespace DXVA;
 using namespace Microsoft::WRL;
+using namespace std::chrono_literals;
 
 DEFINE_GUID(DXVADDI_Intel_ModeH264_A,      0x604F8E64,0x4951,0x4c54,0x88,0xFE,0xAB,0xD2,0x5C,0x15,0xB3,0xD6);
 DEFINE_GUID(DXVADDI_Intel_ModeH264_C,      0x604F8E66,0x4951,0x4c54,0x88,0xFE,0xAB,0xD2,0x5C,0x15,0xB3,0xD6);
@@ -1372,7 +1373,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   {
     lock.Leave();
     // wait app device restoration
-    m_event.WaitMSec(2000);
+    m_event.WaitMSec(2000ms);
     lock.Enter();
 
     // still in lost state after 2sec

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -49,6 +49,8 @@ extern "C" {
 #endif
 
 using namespace VAAPI;
+using namespace std::chrono_literals;
+
 #define NUM_RENDER_PICS 7
 
 constexpr auto SETTING_VIDEOPLAYER_USEVAAPI = "videoplayer.usevaapi";
@@ -964,7 +966,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame
       }
     }
 
-    if (!m_inMsgEvent.WaitMSec(2000))
+    if (!m_inMsgEvent.WaitMSec(2000ms))
       break;
   }
 
@@ -988,7 +990,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   if (state == VAAPI_LOST)
   {
     CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI::Check waiting for display reset event");
-    if (!m_DisplayEvent.WaitMSec(4000))
+    if (!m_DisplayEvent.WaitMSec(4000ms))
     {
       CLog::Log(LOGERROR, "VAAPI::Check - device didn't reset in reasonable time");
       state = VAAPI_RESET;
@@ -1852,7 +1854,7 @@ void COutput::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(m_extTimeout))
+    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
     {
       continue;
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -966,7 +966,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame
       }
     }
 
-    if (!m_inMsgEvent.WaitMSec(2000ms))
+    if (!m_inMsgEvent.Wait(2000ms))
       break;
   }
 
@@ -990,7 +990,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   if (state == VAAPI_LOST)
   {
     CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI::Check waiting for display reset event");
-    if (!m_DisplayEvent.WaitMSec(4000ms))
+    if (!m_DisplayEvent.Wait(4000ms))
     {
       CLog::Log(LOGERROR, "VAAPI::Check - device didn't reset in reasonable time");
       state = VAAPI_RESET;
@@ -1854,7 +1854,7 @@ void COutput::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
+    else if (m_outMsgEvent.Wait(std::chrono::milliseconds(m_extTimeout)))
     {
       continue;
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -32,6 +32,8 @@
 
 using namespace Actor;
 using namespace VDPAU;
+using namespace std::chrono_literals;
+
 #define NUM_RENDER_PICS 7
 #define NUM_CROP_PIX 3
 
@@ -773,7 +775,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   if (state == VDPAU_LOST)
   {
     CLog::Log(LOGINFO, "CVDPAU::Check waiting for display reset event");
-    if (!m_DisplayEvent.WaitMSec(4000))
+    if (!m_DisplayEvent.WaitMSec(4000ms))
     {
       CLog::Log(LOGERROR, "CVDPAU::Check - device didn't reset in reasonable time");
       state = VDPAU_RESET;
@@ -1226,7 +1228,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext *avctx, AVFrame *pFrame
       }
     }
 
-    if (!m_inMsgEvent.WaitMSec(2000))
+    if (!m_inMsgEvent.WaitMSec(2000ms))
       break;
   }
 
@@ -1899,7 +1901,7 @@ void CMixer::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(m_extTimeout))
+    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
     {
       continue;
     }
@@ -3132,7 +3134,7 @@ void COutput::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(m_extTimeout))
+    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
     {
       continue;
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -775,7 +775,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   if (state == VDPAU_LOST)
   {
     CLog::Log(LOGINFO, "CVDPAU::Check waiting for display reset event");
-    if (!m_DisplayEvent.WaitMSec(4000ms))
+    if (!m_DisplayEvent.Wait(4000ms))
     {
       CLog::Log(LOGERROR, "CVDPAU::Check - device didn't reset in reasonable time");
       state = VDPAU_RESET;
@@ -1228,7 +1228,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext *avctx, AVFrame *pFrame
       }
     }
 
-    if (!m_inMsgEvent.WaitMSec(2000ms))
+    if (!m_inMsgEvent.Wait(2000ms))
       break;
   }
 
@@ -1901,7 +1901,7 @@ void CMixer::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
+    else if (m_outMsgEvent.Wait(std::chrono::milliseconds(m_extTimeout)))
     {
       continue;
     }
@@ -3134,7 +3134,7 @@ void COutput::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.WaitMSec(std::chrono::milliseconds(m_extTimeout)))
+    else if (m_outMsgEvent.Wait(std::chrono::milliseconds(m_extTimeout)))
     {
       continue;
     }

--- a/xbmc/cores/VideoPlayer/DVDMessage.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessage.cpp
@@ -63,7 +63,7 @@ bool CDVDMsgGeneralSynchronize::Wait(unsigned int milliseconds, unsigned int sou
   while (m_p->reached != m_p->sources)
   {
     milliseconds = std::min(m_p->timeout.MillisLeft(), timeout.MillisLeft());
-    if (m_p->condition.wait(lock, milliseconds))
+    if (m_p->condition.wait(lock, std::chrono::milliseconds(milliseconds)))
       continue;
 
     if (m_p->timeout.IsTimePast())

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -205,7 +205,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
       lock.Leave();
 
       // wait for a new message
-      if (!m_hEvent.WaitMSec(iTimeoutInMilliSeconds))
+      if (!m_hEvent.WaitMSec(std::chrono::milliseconds(iTimeoutInMilliSeconds)))
         return MSGQ_TIMEOUT;
 
       lock.Enter();

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -205,7 +205,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
       lock.Leave();
 
       // wait for a new message
-      if (!m_hEvent.WaitMSec(std::chrono::milliseconds(iTimeoutInMilliSeconds)))
+      if (!m_hEvent.Wait(std::chrono::milliseconds(iTimeoutInMilliSeconds)))
         return MSGQ_TIMEOUT;
 
       lock.Enter();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -72,6 +72,7 @@
 #include <iterator>
 
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 //------------------------------------------------------------------------------
 // selection streams
@@ -656,7 +657,7 @@ CVideoPlayer::~CVideoPlayer()
 
   while (m_outboundEvents->IsProcessing())
   {
-    CThread::Sleep(10);
+    CThread::Sleep(10ms);
   }
 }
 
@@ -1329,7 +1330,7 @@ void CVideoPlayer::Process()
     // check display lost
     if (m_displayLost)
     {
-      CThread::Sleep(50);
+      CThread::Sleep(50ms);
       continue;
     }
 
@@ -1414,7 +1415,7 @@ void CVideoPlayer::Process()
           m_pDemuxer->SetSpeed(DVD_PLAYSPEED_PAUSE);
         m_demuxerSpeed = DVD_PLAYSPEED_PAUSE;
       }
-      CThread::Sleep(10);
+      CThread::Sleep(10ms);
       continue;
     }
 
@@ -1484,7 +1485,7 @@ void CVideoPlayer::Process()
       // input stream asked us to just retry
       if(next == CDVDInputStream::NEXTSTREAM_RETRY)
       {
-        CThread::Sleep(100);
+        CThread::Sleep(100ms);
         continue;
       }
 
@@ -1506,7 +1507,7 @@ void CVideoPlayer::Process()
       if (m_VideoPlayerAudio->HasData() ||
           m_VideoPlayerVideo->HasData())
       {
-        CThread::Sleep(100);
+        CThread::Sleep(100ms);
         continue;
       }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -29,6 +29,8 @@
 #include <iomanip>
 #include <math.h>
 
+using namespace std::chrono_literals;
+
 class CDVDMsgAudioCodecChange : public CDVDMsg
 {
 public:
@@ -277,7 +279,7 @@ void CVideoPlayerAudio::Process()
         }
       }
       if (timeout == 0)
-        CThread::Sleep(10);
+        CThread::Sleep(10ms);
 
       continue;
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -14,6 +14,7 @@
 #include "DVDStreamInfo.h"
 #include "IVideoPlayer.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "threads/SystemClock.h"
 #include "threads/Thread.h"
 #include "utils/BitstreamStats.h"
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -26,6 +26,8 @@
 #include <numeric>
 #include <sstream>
 
+using namespace std::chrono_literals;
+
 class CDVDMsgVideoCodecChange : public CDVDMsg
 {
 public:
@@ -885,7 +887,7 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
       if (inputPts >= renderPts)
       {
         m_rewindStalled = true;
-        CThread::Sleep(50);
+        CThread::Sleep(50ms);
       }
       return OUTPUT_DROPPED;
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -150,7 +150,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
     m_presentevent.notifyAll();
   }
 
-  if (!m_stateEvent.WaitMSec(1000ms))
+  if (!m_stateEvent.Wait(1000ms))
   {
     CLog::Log(LOGWARNING, "CRenderManager::Configure - timeout waiting for configure");
     CSingleLock lock(m_statelock);
@@ -359,7 +359,7 @@ void CRenderManager::PreInit()
   {
     m_initEvent.Reset();
     CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_PREINIT);
-    if (!m_initEvent.WaitMSec(2000ms))
+    if (!m_initEvent.Wait(2000ms))
     {
       CLog::Log(LOGERROR, "{} - timed out waiting for renderer to preinit", __FUNCTION__);
     }
@@ -388,7 +388,7 @@ void CRenderManager::UnInit()
   {
     m_initEvent.Reset();
     CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_UNINIT);
-    if (!m_initEvent.WaitMSec(2000ms))
+    if (!m_initEvent.Wait(2000ms))
     {
       CLog::Log(LOGERROR, "{} - timed out waiting for renderer to uninit", __FUNCTION__);
     }
@@ -451,7 +451,7 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
     CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_FLUSH);
     if (wait)
     {
-      if (!m_flushEvent.WaitMSec(1000ms))
+      if (!m_flushEvent.Wait(1000ms))
       {
         CLog::Log(LOGERROR, "{} - timed out waiting for renderer to flush", __FUNCTION__);
         return false;
@@ -568,7 +568,7 @@ bool CRenderManager::RenderCaptureGetPixels(unsigned int captureId, unsigned int
       millis = 1000;
 
     CSingleExit exitlock(m_captCritSect);
-    if (!it->second->GetEvent().WaitMSec(std::chrono::milliseconds(millis)))
+    if (!it->second->GetEvent().Wait(std::chrono::milliseconds(millis)))
     {
       m_captureWaitCounter--;
       return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -32,6 +32,7 @@
 #include "../VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 void CRenderManager::CClockSync::Reset()
 {
@@ -122,7 +123,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
         m_forceNext = false;
         return false;
       }
-      m_presentevent.wait(lock, endtime.MillisLeft());
+      m_presentevent.wait(lock, std::chrono::milliseconds(endtime.MillisLeft()));
     }
     m_forceNext = false;
   }
@@ -149,7 +150,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
     m_presentevent.notifyAll();
   }
 
-  if (!m_stateEvent.WaitMSec(1000))
+  if (!m_stateEvent.WaitMSec(1000ms))
   {
     CLog::Log(LOGWARNING, "CRenderManager::Configure - timeout waiting for configure");
     CSingleLock lock(m_statelock);
@@ -264,7 +265,7 @@ void CRenderManager::FrameWait(int ms)
   XbmcThreads::EndTime timeout(ms);
   CSingleLock lock(m_presentlock);
   while(m_presentstep == PRESENT_IDLE && !timeout.IsTimePast())
-    m_presentevent.wait(lock, timeout.MillisLeft());
+    m_presentevent.wait(lock, std::chrono::milliseconds(timeout.MillisLeft()));
 }
 
 bool CRenderManager::IsPresenting()
@@ -358,7 +359,7 @@ void CRenderManager::PreInit()
   {
     m_initEvent.Reset();
     CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_PREINIT);
-    if (!m_initEvent.WaitMSec(2000))
+    if (!m_initEvent.WaitMSec(2000ms))
     {
       CLog::Log(LOGERROR, "{} - timed out waiting for renderer to preinit", __FUNCTION__);
     }
@@ -387,7 +388,7 @@ void CRenderManager::UnInit()
   {
     m_initEvent.Reset();
     CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_UNINIT);
-    if (!m_initEvent.WaitMSec(2000))
+    if (!m_initEvent.WaitMSec(2000ms))
     {
       CLog::Log(LOGERROR, "{} - timed out waiting for renderer to uninit", __FUNCTION__);
     }
@@ -450,7 +451,7 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
     CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_FLUSH);
     if (wait)
     {
-      if (!m_flushEvent.WaitMSec(1000))
+      if (!m_flushEvent.WaitMSec(1000ms))
       {
         CLog::Log(LOGERROR, "{} - timed out waiting for renderer to flush", __FUNCTION__);
         return false;
@@ -567,7 +568,7 @@ bool CRenderManager::RenderCaptureGetPixels(unsigned int captureId, unsigned int
       millis = 1000;
 
     CSingleExit exitlock(m_captCritSect);
-    if (!it->second->GetEvent().WaitMSec(millis))
+    if (!it->second->GetEvent().WaitMSec(std::chrono::milliseconds(millis)))
     {
       m_captureWaitCounter--;
       return false;
@@ -999,7 +1000,7 @@ bool CRenderManager::AddVideoPicture(const VideoPicture& picture, volatile std::
     XbmcThreads::EndTime endtime(200);
     while (m_presentstep == PRESENT_READY)
     {
-      m_presentevent.wait(lock, 20);
+      m_presentevent.wait(lock, 20ms);
       if(endtime.IsTimePast() || bStop)
       {
         if (!bStop)
@@ -1064,10 +1065,10 @@ int CRenderManager::WaitForBuffer(volatile std::atomic_bool&bStop, int timeout)
     else
       presenttime = clock + 0.02;
 
-    int sleeptime = static_cast<int>((presenttime - clock) * 1000);
-    if (sleeptime < 0)
-      sleeptime = 0;
-    sleeptime = std::min(sleeptime, 20);
+    auto sleeptime = std::chrono::milliseconds(static_cast<int>((presenttime - clock) * 1000));
+    if (sleeptime < 0ms)
+      sleeptime = 0ms;
+    sleeptime = std::min(sleeptime, 20ms);
     m_presentevent.wait(lock, sleeptime);
     DiscardBuffer();
     return 0;
@@ -1076,7 +1077,7 @@ int CRenderManager::WaitForBuffer(volatile std::atomic_bool&bStop, int timeout)
   XbmcThreads::EndTime endtime(timeout);
   while(m_free.empty())
   {
-    m_presentevent.wait(lock, std::min(50, timeout));
+    m_presentevent.wait(lock, std::min(50ms, std::chrono::milliseconds(timeout)));
     if (endtime.IsTimePast() || bStop)
     {
       return -1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -15,6 +15,7 @@
 #include "cores/VideoSettings.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
+#include "threads/SystemClock.h"
 #include "utils/Geometry.h"
 #include "windowing/Resolution.h"
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -532,7 +532,7 @@ bool PAPlayer::CloseFile(bool reopen)
     while (m_jobCounter > 0)
     {
       lock.Leave();
-      m_jobEvent.WaitMSec(100ms);
+      m_jobEvent.Wait(100ms);
       lock.Enter();
     }
   }
@@ -542,7 +542,7 @@ bool PAPlayer::CloseFile(bool reopen)
 
 void PAPlayer::Process()
 {
-  if (!m_startEvent.WaitMSec(100ms))
+  if (!m_startEvent.Wait(100ms))
   {
     CLog::Log(LOGDEBUG, "PAPlayer::Process - Failed to receive start event");
     return;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -22,11 +22,13 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "threads/SystemClock.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
 #include "video/Bookmark.h"
 
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 #define TIME_TO_CACHE_NEXT_FILE 5000 /* 5 seconds before end of song, start caching the next song */
 #define FAST_XFADE_TIME           80 /* 80 milliseconds */
@@ -530,7 +532,7 @@ bool PAPlayer::CloseFile(bool reopen)
     while (m_jobCounter > 0)
     {
       lock.Leave();
-      m_jobEvent.WaitMSec(100);
+      m_jobEvent.WaitMSec(100ms);
       lock.Enter();
     }
   }
@@ -540,7 +542,7 @@ bool PAPlayer::CloseFile(bool reopen)
 
 void PAPlayer::Process()
 {
-  if (!m_startEvent.WaitMSec(100))
+  if (!m_startEvent.WaitMSec(100ms))
   {
     CLog::Log(LOGDEBUG, "PAPlayer::Process - Failed to receive start event");
     return;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -92,7 +92,7 @@ void PAPlayer::SoftStart(bool wait/* = false */)
   {
     /* wait for them to fade in */
     lock.Leave();
-    CThread::Sleep(FAST_XFADE_TIME);
+    CThread::Sleep(std::chrono::milliseconds(FAST_XFADE_TIME));
     lock.Enter();
 
     /* be sure they have faded in */
@@ -106,7 +106,7 @@ void PAPlayer::SoftStart(bool wait/* = false */)
         {
           lock.Leave();
           wait = true;
-          CThread::Sleep(1);
+          CThread::Sleep(1ms);
           lock.Enter();
           break;
         }
@@ -141,7 +141,7 @@ void PAPlayer::SoftStop(bool wait/* = false */, bool close/* = true */)
 
     /* wait for them to fade out */
     lock.Leave();
-    CThread::Sleep(FAST_XFADE_TIME);
+    CThread::Sleep(std::chrono::milliseconds(FAST_XFADE_TIME));
     lock.Enter();
 
     /* be sure they have faded out */
@@ -155,7 +155,7 @@ void PAPlayer::SoftStop(bool wait/* = false */, bool close/* = true */)
         {
           lock.Leave();
           wait = true;
-          CThread::Sleep(1);
+          CThread::Sleep(1ms);
           lock.Enter();
           break;
         }
@@ -361,7 +361,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
     }
 
     /* yield our time so that the main PAP thread doesn't stall */
-    CThread::Sleep(1);
+    CThread::Sleep(1ms);
   }
 
   // set m_upcomingCrossfadeMS depending on type of file and user settings
@@ -506,7 +506,7 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
       break;
 
     /* yield our time so that the main PAP thread doesn't stall */
-    CThread::Sleep(1);
+    CThread::Sleep(1ms);
   }
 
   CLog::Log(LOGINFO, "PAPlayer::PrepareStream - Ready");
@@ -564,7 +564,7 @@ void PAPlayer::Process()
     // if none of our streams wants at least 10ms of data, we sleep
     if (freeBufferTime < 0.01)
     {
-      CThread::Sleep(10);
+      CThread::Sleep(10ms);
     }
 
     if (m_newForcedPlayerTime != -1)

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -76,7 +76,7 @@ bool CGUIDialogBusy::Wait(IRunnable *runnable, unsigned int displaytime, bool al
 bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 100 */, bool allowCancel /* = true */)
 {
   bool cancelled = false;
-  if (!event.WaitMSec(std::chrono::milliseconds(displaytime)))
+  if (!event.Wait(std::chrono::milliseconds(displaytime)))
   {
     // throw up the progress
     CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
@@ -89,7 +89,7 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
 
       dialog->Open();
 
-      while (!event.WaitMSec(1ms))
+      while (!event.Wait(1ms))
       {
         dialog->ProcessRenderLoop(false);
         if (allowCancel && dialog->IsCanceled())

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -15,6 +15,8 @@
 #include "threads/IRunnable.h"
 #include "threads/Thread.h"
 
+using namespace std::chrono_literals;
+
 #define PROGRESS_CONTROL 10
 
 class CBusyWaiter : public CThread
@@ -74,7 +76,7 @@ bool CGUIDialogBusy::Wait(IRunnable *runnable, unsigned int displaytime, bool al
 bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 100 */, bool allowCancel /* = true */)
 {
   bool cancelled = false;
-  if (!event.WaitMSec(displaytime))
+  if (!event.WaitMSec(std::chrono::milliseconds(displaytime)))
   {
     // throw up the progress
     CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
@@ -87,7 +89,7 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
 
       dialog->Open();
 
-      while(!event.WaitMSec(1))
+      while (!event.WaitMSec(1ms))
       {
         dialog->ProcessRenderLoop(false);
         if (allowCancel && dialog->IsCanceled())

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -21,6 +21,7 @@
 
 
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const std::string& strHeader, const std::string& strMsg) : CThread("GUIDialogCache"),
   m_strHeader(strHeader),
@@ -133,7 +134,7 @@ void CGUIDialogCache::Process()
         m_pDlg->Progress();
         if( bSentCancel )
         {
-          CThread::Sleep(10);
+          CThread::Sleep(10ms);
           continue;
         }
 
@@ -151,7 +152,7 @@ void CGUIDialogCache::Process()
       }
     }
 
-    CThread::Sleep(10);
+    CThread::Sleep(10ms);
   }
 }
 

--- a/xbmc/dialogs/GUIDialogMediaFilter.h
+++ b/xbmc/dialogs/GUIDialogMediaFilter.h
@@ -60,7 +60,7 @@ protected:
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
   bool Save() override { return true; }
-  unsigned int GetDelayMs() const override { return 500; }
+  std::chrono::milliseconds GetDelayMs() const override { return std::chrono::milliseconds(500); }
 
   // specialization of CGUIDialogSettingsManualBase
   void SetupView() override;

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -195,7 +195,7 @@ void CGUIDialogProgress::ShowProgressBar(bool bOnOff)
 bool CGUIDialogProgress::Wait(int progresstime /*= 10*/)
 {
   CEvent m_done;
-  while (!m_done.WaitMSec(std::chrono::milliseconds(progresstime)) && m_active && !IsCanceled())
+  while (!m_done.Wait(std::chrono::milliseconds(progresstime)) && m_active && !IsCanceled())
     Progress();
 
   return !IsCanceled();
@@ -203,7 +203,7 @@ bool CGUIDialogProgress::Wait(int progresstime /*= 10*/)
 
 bool CGUIDialogProgress::WaitOnEvent(CEvent& event)
 {
-  while (!event.WaitMSec(1ms))
+  while (!event.Wait(1ms))
   {
     if (IsCanceled())
       return false;

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -17,6 +17,8 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+using namespace std::chrono_literals;
+
 CGUIDialogProgress::CGUIDialogProgress(void)
     : CGUIDialogBoxBase(WINDOW_DIALOG_PROGRESS, "DialogConfirm.xml")
 {
@@ -193,7 +195,7 @@ void CGUIDialogProgress::ShowProgressBar(bool bOnOff)
 bool CGUIDialogProgress::Wait(int progresstime /*= 10*/)
 {
   CEvent m_done;
-  while (!m_done.WaitMSec(progresstime) && m_active && !IsCanceled())
+  while (!m_done.WaitMSec(std::chrono::milliseconds(progresstime)) && m_active && !IsCanceled())
     Progress();
 
   return !IsCanceled();
@@ -201,7 +203,7 @@ bool CGUIDialogProgress::Wait(int progresstime /*= 10*/)
 
 bool CGUIDialogProgress::WaitOnEvent(CEvent& event)
 {
-  while (!event.WaitMSec(1))
+  while (!event.WaitMSec(1ms))
   {
     if (IsCanceled())
       return false;

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -186,7 +186,7 @@ int64_t CSimpleFileCache::WaitForData(unsigned int iMinAvail, unsigned int iMill
     if (iAvail >= iMinAvail)
       return iAvail;
 
-    if (!m_hDataAvailEvent->WaitMSec(endTime.MillisLeft()))
+    if (!m_hDataAvailEvent->WaitMSec(std::chrono::milliseconds(endTime.MillisLeft())))
       return CACHE_RC_TIMEOUT;
   }
   return GetAvailableRead();

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -186,7 +186,7 @@ int64_t CSimpleFileCache::WaitForData(unsigned int iMinAvail, unsigned int iMill
     if (iAvail >= iMinAvail)
       return iAvail;
 
-    if (!m_hDataAvailEvent->WaitMSec(std::chrono::milliseconds(endTime.MillisLeft())))
+    if (!m_hDataAvailEvent->Wait(std::chrono::milliseconds(endTime.MillisLeft())))
       return CACHE_RC_TIMEOUT;
   }
   return GetAvailableRead();

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -15,6 +15,7 @@
 #include <string.h>
 
 using namespace XFILE;
+using namespace std::chrono_literals;
 
 CCircularCache::CCircularCache(size_t front, size_t back)
  : CCacheStrategy()
@@ -194,7 +195,7 @@ int64_t CCircularCache::WaitForData(unsigned int minimum, unsigned int millis)
   while (!IsEndOfInput() && avail < minimum && !endtime.IsTimePast() )
   {
     lock.Leave();
-    m_written.WaitMSec(50); // may miss the deadline. shouldn't be a problem.
+    m_written.WaitMSec(50ms); // may miss the deadline. shouldn't be a problem.
     lock.Enter();
     avail = m_end - m_cur;
   }

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -195,7 +195,7 @@ int64_t CCircularCache::WaitForData(unsigned int minimum, unsigned int millis)
   while (!IsEndOfInput() && avail < minimum && !endtime.IsTimePast() )
   {
     lock.Leave();
-    m_written.WaitMSec(50ms); // may miss the deadline. shouldn't be a problem.
+    m_written.Wait(50ms); // may miss the deadline. shouldn't be a problem.
     lock.Enter();
     avail = m_end - m_cur;
   }

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 
 using namespace XFILE;
+using namespace std::chrono_literals;
 
 #define TIME_TO_BUSY_DIALOG 500
 
@@ -91,13 +92,13 @@ public:
 
   bool Wait(unsigned int timeout)
   {
-    return m_result->m_event.WaitMSec(timeout);
+    return m_result->m_event.WaitMSec(std::chrono::milliseconds(timeout));
   }
 
   bool GetDirectory(CFileItemList& list)
   {
     /* if it was not finished or failed, return failure */
-    if(!m_result->m_event.WaitMSec(0) || !m_result->m_result)
+    if (!m_result->m_event.WaitMSec(0ms) || !m_result->m_result)
     {
       list.Clear();
       return false;

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -92,13 +92,13 @@ public:
 
   bool Wait(unsigned int timeout)
   {
-    return m_result->m_event.WaitMSec(std::chrono::milliseconds(timeout));
+    return m_result->m_event.Wait(std::chrono::milliseconds(timeout));
   }
 
   bool GetDirectory(CFileItemList& list)
   {
     /* if it was not finished or failed, return failure */
-    if (!m_result->m_event.WaitMSec(0ms) || !m_result->m_result)
+    if (!m_result->m_event.Wait(0ms) || !m_result->m_result)
     {
       list.Clear();
       return false;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -252,7 +252,7 @@ void CFileCache::Process()
     m_fileSize = m_source.GetLength();
 
     // check for seek events
-    if (m_seekEvent.WaitMSec(0ms))
+    if (m_seekEvent.Wait(0ms))
     {
       m_seekEvent.Reset();
       int64_t cacheMaxPos = m_pCache->CachedDataEndPosIfSeekTo(m_seekPos);
@@ -302,7 +302,7 @@ void CFileCache::Process()
       if (limiter.Rate(m_writePos) < m_writeRate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheReadFactor)
         break;
 
-      if (m_seekEvent.WaitMSec(100ms))
+      if (m_seekEvent.Wait(100ms))
       {
         if (!m_bStop)
           m_seekEvent.Set();
@@ -322,7 +322,7 @@ void CFileCache::Process()
     if (maxWrite < maxSourceRead)
     {
       // Wait until sufficient cache write space is available
-      m_pCache->m_space.WaitMSec(5ms);
+      m_pCache->m_space.Wait(5ms);
       continue;
     }
 
@@ -338,7 +338,7 @@ void CFileCache::Process()
                   __FUNCTION__, m_sourcePath, iRead);
 
         // Wait a bit:
-        if (m_seekEvent.WaitMSec(2000ms))
+        if (m_seekEvent.Wait(2000ms))
         {
           if (!m_bStop)
             m_seekEvent.Set(); // hack so that later we realize seek is needed
@@ -395,13 +395,13 @@ void CFileCache::Process()
       }
       else if (iWrite == 0)
       {
-        m_pCache->m_space.WaitMSec(5ms);
+        m_pCache->m_space.Wait(5ms);
       }
 
       iTotalWrite += iWrite;
 
       // check if seek was asked. otherwise if cache is full we'll freeze.
-      if (m_seekEvent.WaitMSec(0ms))
+      if (m_seekEvent.Wait(0ms))
       {
         if (!m_bStop)
           m_seekEvent.Set(); // make sure we get the seek event later.
@@ -535,7 +535,7 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     m_seekPos = std::min(iTarget, std::max((int64_t)0, m_fileSize - m_chunkSize));
 
     m_seekEvent.Set();
-    while (!m_seekEnded.WaitMSec(100ms))
+    while (!m_seekEnded.Wait(100ms))
     {
       // SeekEnded will never be set if FileCache thread is not running
       if (!CThread::IsRunning())

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -33,6 +33,7 @@
 #endif
 
 using namespace XFILE;
+using namespace std::chrono_literals;
 
 class CWriteRate
 {
@@ -251,7 +252,7 @@ void CFileCache::Process()
     m_fileSize = m_source.GetLength();
 
     // check for seek events
-    if (m_seekEvent.WaitMSec(0))
+    if (m_seekEvent.WaitMSec(0ms))
     {
       m_seekEvent.Reset();
       int64_t cacheMaxPos = m_pCache->CachedDataEndPosIfSeekTo(m_seekPos);
@@ -301,7 +302,7 @@ void CFileCache::Process()
       if (limiter.Rate(m_writePos) < m_writeRate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheReadFactor)
         break;
 
-      if (m_seekEvent.WaitMSec(100))
+      if (m_seekEvent.WaitMSec(100ms))
       {
         if (!m_bStop)
           m_seekEvent.Set();
@@ -321,7 +322,7 @@ void CFileCache::Process()
     if (maxWrite < maxSourceRead)
     {
       // Wait until sufficient cache write space is available
-      m_pCache->m_space.WaitMSec(5);
+      m_pCache->m_space.WaitMSec(5ms);
       continue;
     }
 
@@ -337,7 +338,7 @@ void CFileCache::Process()
                   __FUNCTION__, m_sourcePath, iRead);
 
         // Wait a bit:
-        if (m_seekEvent.WaitMSec(2000))
+        if (m_seekEvent.WaitMSec(2000ms))
         {
           if (!m_bStop)
             m_seekEvent.Set(); // hack so that later we realize seek is needed
@@ -394,13 +395,13 @@ void CFileCache::Process()
       }
       else if (iWrite == 0)
       {
-        m_pCache->m_space.WaitMSec(5);
+        m_pCache->m_space.WaitMSec(5ms);
       }
 
       iTotalWrite += iWrite;
 
       // check if seek was asked. otherwise if cache is full we'll freeze.
-      if (m_seekEvent.WaitMSec(0))
+      if (m_seekEvent.WaitMSec(0ms))
       {
         if (!m_bStop)
           m_seekEvent.Set(); // make sure we get the seek event later.
@@ -534,7 +535,7 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     m_seekPos = std::min(iTarget, std::max((int64_t)0, m_fileSize - m_chunkSize));
 
     m_seekEvent.Set();
-    while (!m_seekEnded.WaitMSec(100))
+    while (!m_seekEnded.WaitMSec(100ms))
     {
       // SeekEnded will never be set if FileCache thread is not running
       if (!CThread::IsRunning())

--- a/xbmc/filesystem/PipesManager.cpp
+++ b/xbmc/filesystem/PipesManager.cpp
@@ -11,9 +11,7 @@
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 
-#ifndef min
-#define min(a,b) ((a) < (b) ? (a) : (b))
-#endif
+#include <algorithm>
 
 using namespace XFILE;
 
@@ -103,7 +101,7 @@ int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
   int nResult = 0;
   if (!IsEmpty())
   {
-    int nToRead = min((int)m_buffer.getMaxReadSize(), nMaxSize);
+    int nToRead = std::min(static_cast<int>(m_buffer.getMaxReadSize()), nMaxSize);
     m_buffer.ReadData(buf, nToRead);
     nResult = nToRead;
   }
@@ -129,7 +127,7 @@ int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
       for (size_t l=0; l<m_listeners.size(); l++)
         m_listeners[l]->OnPipeUnderFlow();
 
-      bHasData = m_readEvent.WaitMSec(min(200,nMillisLeft));
+      bHasData = m_readEvent.WaitMSec(std::min(200, nMillisLeft));
       nMillisLeft -= 200;
     } while (!bHasData && nMillisLeft > 0 && !m_bEof);
 
@@ -141,7 +139,7 @@ int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
 
     if (bHasData)
     {
-      int nToRead = min((int)m_buffer.getMaxReadSize(), nMaxSize);
+      int nToRead = std::min(static_cast<int>(m_buffer.getMaxReadSize()), nMaxSize);
       m_buffer.ReadData(buf, nToRead);
       nResult = nToRead;
     }

--- a/xbmc/filesystem/PipesManager.cpp
+++ b/xbmc/filesystem/PipesManager.cpp
@@ -96,7 +96,7 @@ int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
   }
 
   while (!m_bReadyForRead && !m_bEof)
-    m_readEvent.WaitMSec(100ms);
+    m_readEvent.Wait(100ms);
 
   int nResult = 0;
   if (!IsEmpty())
@@ -127,7 +127,7 @@ int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
       for (size_t l=0; l<m_listeners.size(); l++)
         m_listeners[l]->OnPipeUnderFlow();
 
-      bHasData = m_readEvent.WaitMSec(std::min(200ms, nMillisLeft));
+      bHasData = m_readEvent.Wait(std::min(200ms, nMillisLeft));
       nMillisLeft -= 200ms;
     } while (!bHasData && nMillisLeft > 0ms && !m_bEof);
 
@@ -171,7 +171,7 @@ bool Pipe::Write(const char *buf, int nSize, int nWaitMillis)
         m_listeners[l]->OnPipeOverFlow();
 
       bool bClear = nWaitMillis < 0 ? m_writeEvent.Wait()
-                                    : m_writeEvent.WaitMSec(std::chrono::milliseconds(nWaitMillis));
+                                    : m_writeEvent.Wait(std::chrono::milliseconds(nWaitMillis));
       lock.Enter();
       if (bClear && (int)m_buffer.getMaxWriteSize() >= nSize)
       {

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -346,7 +346,7 @@ void CShoutcastFile::Process()
         if (m_cacheReader->GetPosition() < front.first) // tagpos
         {
           CSingleExit ex(m_tagSection);
-          CThread::Sleep(20);
+          CThread::Sleep(20ms);
         }
         else
         {

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -34,6 +34,7 @@
 using namespace XFILE;
 using namespace MUSIC_INFO;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 CShoutcastFile::CShoutcastFile() :
   IFile(), CThread("ShoutcastFile")
@@ -336,7 +337,7 @@ void CShoutcastFile::Process()
 {
   while (!m_bStop)
   {
-    if (m_tagChange.WaitMSec(500))
+    if (m_tagChange.WaitMSec(500ms))
     {
       CSingleLock lock(m_tagSection);
       while (!m_bStop && !m_tags.empty())

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -337,7 +337,7 @@ void CShoutcastFile::Process()
 {
   while (!m_bStop)
   {
-    if (m_tagChange.WaitMSec(500ms))
+    if (m_tagChange.Wait(500ms))
     {
       CSingleLock lock(m_tagSection);
       while (!m_bStop && !m_tags.empty())

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -17,6 +17,7 @@
 
 using namespace KODI;
 using namespace GAME;
+using namespace std::chrono_literals;
 
 CGUIFeatureButton::CGUIFeatureButton(const CGUIButtonControl& buttonTemplate,
                                      IConfigurationWizard* wizard,
@@ -72,7 +73,7 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
     CApplicationMessenger::GetInstance().SendGUIMessage(msgLabel, WINDOW_INVALID, false);
 
     waitEvent.Reset();
-    bInterrupted = waitEvent.WaitMSec(1000); // Wait 1 second
+    bInterrupted = waitEvent.WaitMSec(1000ms); // Wait 1 second
 
     if (bInterrupted)
       break;

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -73,7 +73,7 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
     CApplicationMessenger::GetInstance().SendGUIMessage(msgLabel, WINDOW_INVALID, false);
 
     waitEvent.Reset();
-    bInterrupted = waitEvent.WaitMSec(1000ms); // Wait 1 second
+    bInterrupted = waitEvent.Wait(1000ms); // Wait 1 second
 
     if (bInterrupted)
       break;

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -25,12 +25,18 @@
 
 using namespace KODI;
 using namespace GAME;
+using namespace std::chrono_literals;
+
+namespace
+{
 
 #define ESC_KEY_CODE 27
 #define SKIPPING_DETECTION_MS 200
 
 // Duration to wait for axes to neutralize after mapping is finished
-#define POST_MAPPING_WAIT_TIME_MS (5 * 1000)
+constexpr auto POST_MAPPING_WAIT_TIME_MS = 5000ms;
+
+} // namespace
 
 CGUIConfigurationWizard::CGUIConfigurationWizard()
   : CThread("GUIConfigurationWizard"), m_actionMap(new KEYBOARD::CKeymapActionMap)
@@ -185,7 +191,7 @@ void CGUIConfigurationWizard::Process(void)
     if (bInMotion)
     {
       CLog::Log(LOGDEBUG, "Configuration wizard: waiting {}ms for axes to neutralize",
-                POST_MAPPING_WAIT_TIME_MS);
+                POST_MAPPING_WAIT_TIME_MS.count());
       m_motionlessEvent.WaitMSec(POST_MAPPING_WAIT_TIME_MS);
     }
   }

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -192,7 +192,7 @@ void CGUIConfigurationWizard::Process(void)
     {
       CLog::Log(LOGDEBUG, "Configuration wizard: waiting {}ms for axes to neutralize",
                 POST_MAPPING_WAIT_TIME_MS.count());
-      m_motionlessEvent.WaitMSec(POST_MAPPING_WAIT_TIME_MS);
+      m_motionlessEvent.Wait(POST_MAPPING_WAIT_TIME_MS);
     }
   }
 

--- a/xbmc/guilib/GUIKeyboard.h
+++ b/xbmc/guilib/GUIKeyboard.h
@@ -64,7 +64,7 @@ class CGUIKeyboard : public ITimerCallback
     void startAutoCloseTimer(unsigned int autoCloseMs)
     {
       if ( autoCloseMs > 0 )
-        m_idleTimer.Start(autoCloseMs, false);
+        m_idleTimer.Start(std::chrono::milliseconds(autoCloseMs), false);
     }
 
     void resetAutoCloseTimer()

--- a/xbmc/input/InputCodingTableBaiduPY.cpp
+++ b/xbmc/input/InputCodingTableBaiduPY.cpp
@@ -37,7 +37,7 @@ void CInputCodingTableBaiduPY::Process()
   m_initialized = true;
   while (!m_bStop) // Make sure we don't exit the thread
   {
-    AbortableWait(m_Event, -1); // Wait for work to appear
+    AbortableWait(m_Event); // Wait for work to appear
     while (!m_bStop) // Process all queued work before going back to wait on the event
     {
       CSingleLock lock(m_CS);

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -16,11 +16,16 @@
 
 #include <algorithm>
 
-#define RUMBLE_TEST_DURATION_MS 1000 // Per motor
-#define RUMBLE_NOTIFICATION_DURATION_MS 300
+using namespace std::chrono_literals;
+
+namespace
+{
+constexpr auto RUMBLE_TEST_DURATION_MS = 1000ms; // Per motor
+constexpr auto RUMBLE_NOTIFICATION_DURATION_MS = 300ms;
 
 // From game.controller.default profile
 #define WEAK_MOTOR_NAME "rightmotor"
+} // namespace
 
 using namespace KODI;
 using namespace JOYSTICK;

--- a/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
@@ -17,9 +17,11 @@
 #include <algorithm>
 #include <cmath>
 
+using namespace std::chrono_literals;
+
 namespace
 {
-constexpr int TOUCH_HOLD_TIMEOUT = 500;
+constexpr auto TOUCH_HOLD_TIMEOUT = 500ms;
 }
 
 CGenericTouchInputHandler::CGenericTouchInputHandler() : m_holdTimer(new CTimer(this))

--- a/xbmc/interfaces/generic/RunningScriptObserver.cpp
+++ b/xbmc/interfaces/generic/RunningScriptObserver.cpp
@@ -10,6 +10,8 @@
 
 #include "interfaces/generic/ScriptInvocationManager.h"
 
+using namespace std::chrono_literals;
+
 CRunningScriptObserver::CRunningScriptObserver(int scriptId, CEvent& evt)
   : m_scriptId(scriptId), m_event(evt), m_stopEvent(true), m_thread(this, "ScriptObs")
 {
@@ -30,7 +32,7 @@ void CRunningScriptObserver::Run()
       m_event.Set();
       break;
     }
-  } while (!m_stopEvent.WaitMSec(20));
+  } while (!m_stopEvent.WaitMSec(20ms));
 }
 
 void CRunningScriptObserver::Abort()

--- a/xbmc/interfaces/generic/RunningScriptObserver.cpp
+++ b/xbmc/interfaces/generic/RunningScriptObserver.cpp
@@ -32,7 +32,7 @@ void CRunningScriptObserver::Run()
       m_event.Set();
       break;
     }
-  } while (!m_stopEvent.WaitMSec(20ms));
+  } while (!m_stopEvent.Wait(20ms));
 }
 
 void CRunningScriptObserver::Abort()

--- a/xbmc/interfaces/generic/ScriptRunner.cpp
+++ b/xbmc/interfaces/generic/ScriptRunner.cpp
@@ -126,7 +126,7 @@ bool CScriptRunner::WaitOnScriptResult(int scriptId,
   // keep the render loop alive
   if (g_application.IsCurrentThread())
   {
-    if (!m_scriptDone.WaitMSec(20ms))
+    if (!m_scriptDone.Wait(20ms))
     {
       // observe the script until it's finished while showing the busy dialog
       CRunningScriptObserver scriptObs(scriptId, m_scriptDone);
@@ -148,13 +148,13 @@ bool CScriptRunner::WaitOnScriptResult(int scriptId,
   {
     // wait for the script to finish or be cancelled
     while (!IsCancelled() && CScriptInvocationManager::GetInstance().IsRunning(scriptId) &&
-           !m_scriptDone.WaitMSec(20ms))
+           !m_scriptDone.Wait(20ms))
       ;
 
     // give the script 30 seconds to exit before we attempt to stop it
     XbmcThreads::EndTime timer(30000);
     while (!timer.IsTimePast() && CScriptInvocationManager::GetInstance().IsRunning(scriptId) &&
-           !m_scriptDone.WaitMSec(20ms))
+           !m_scriptDone.Wait(20ms))
       ;
   }
 

--- a/xbmc/interfaces/generic/ScriptRunner.cpp
+++ b/xbmc/interfaces/generic/ScriptRunner.cpp
@@ -22,6 +22,8 @@
 
 #include <vector>
 
+using namespace std::chrono_literals;
+
 ADDON::AddonPtr CScriptRunner::GetAddon() const
 {
   return m_addon;
@@ -124,7 +126,7 @@ bool CScriptRunner::WaitOnScriptResult(int scriptId,
   // keep the render loop alive
   if (g_application.IsCurrentThread())
   {
-    if (!m_scriptDone.WaitMSec(20))
+    if (!m_scriptDone.WaitMSec(20ms))
     {
       // observe the script until it's finished while showing the busy dialog
       CRunningScriptObserver scriptObs(scriptId, m_scriptDone);
@@ -146,13 +148,13 @@ bool CScriptRunner::WaitOnScriptResult(int scriptId,
   {
     // wait for the script to finish or be cancelled
     while (!IsCancelled() && CScriptInvocationManager::GetInstance().IsRunning(scriptId) &&
-           !m_scriptDone.WaitMSec(20))
+           !m_scriptDone.WaitMSec(20ms))
       ;
 
     // give the script 30 seconds to exit before we attempt to stop it
     XbmcThreads::EndTime timer(30000);
     while (!timer.IsTimePast() && CScriptInvocationManager::GetInstance().IsRunning(scriptId) &&
-           !m_scriptDone.WaitMSec(20))
+           !m_scriptDone.WaitMSec(20ms))
       ;
   }
 

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -48,7 +48,7 @@ namespace XBMCAddon
         {
           DelayedCallGuard dg(languageHook);
           unsigned int t = std::min(endTime.MillisLeft(), 100u);
-          if (abortEvent.WaitMSec(std::chrono::milliseconds(t)))
+          if (abortEvent.Wait(std::chrono::milliseconds(t)))
             return true;
         }
         if (languageHook)

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -8,6 +8,8 @@
 
 #include "Monitor.h"
 
+#include "threads/SystemClock.h"
+
 #include <algorithm>
 #include <math.h>
 
@@ -46,7 +48,7 @@ namespace XBMCAddon
         {
           DelayedCallGuard dg(languageHook);
           unsigned int t = std::min(endTime.MillisLeft(), 100u);
-          if (abortEvent.WaitMSec(t))
+          if (abortEvent.WaitMSec(std::chrono::milliseconds(t)))
             return true;
         }
         if (languageHook)

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -385,9 +385,8 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       // DO NOT MAKE THIS A DELAYED CALL!!!!
-      bool ret = languageHook == NULL
-                     ? m_actionEvent.WaitMSec(std::chrono::milliseconds(milliseconds))
-                     : languageHook->WaitForEvent(m_actionEvent, milliseconds);
+      bool ret = languageHook == NULL ? m_actionEvent.Wait(std::chrono::milliseconds(milliseconds))
+                                      : languageHook->WaitForEvent(m_actionEvent, milliseconds);
       if (ret)
         m_actionEvent.Reset();
       return ret;

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -385,7 +385,9 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       // DO NOT MAKE THIS A DELAYED CALL!!!!
-      bool ret = languageHook == NULL ? m_actionEvent.WaitMSec(milliseconds) : languageHook->WaitForEvent(m_actionEvent,milliseconds);
+      bool ret = languageHook == NULL
+                     ? m_actionEvent.WaitMSec(std::chrono::milliseconds(milliseconds))
+                     : languageHook->WaitForEvent(m_actionEvent, milliseconds);
       if (ret)
         m_actionEvent.Reset();
       return ret;

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -60,6 +60,7 @@ extern "C" FILE* fopen_utf8(const char* _Filename, const char* _Mode);
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 #define PythonModulesSize sizeof(PythonModules) / sizeof(PythonModule)
 
@@ -495,7 +496,7 @@ bool CPythonInvoker::stop(bool abort)
       lock.Leave();
 
     XbmcThreads::EndTime timeout(PYTHON_SCRIPT_TIMEOUT);
-    while (!m_stoppedEvent.WaitMSec(15))
+    while (!m_stoppedEvent.WaitMSec(15ms))
     {
       if (timeout.IsTimePast())
       {

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -496,7 +496,7 @@ bool CPythonInvoker::stop(bool abort)
       lock.Leave();
 
     XbmcThreads::EndTime timeout(PYTHON_SCRIPT_TIMEOUT);
-    while (!m_stoppedEvent.WaitMSec(15ms))
+    while (!m_stoppedEvent.Wait(15ms))
     {
       if (timeout.IsTimePast())
       {

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -622,7 +622,7 @@ bool XBPython::WaitForEvent(CEvent& hEvent, unsigned int milliseconds)
 {
   // wait for either this event our our global event
   XbmcThreads::CEventGroup eventGroup{&hEvent, &m_globalEvent};
-  CEvent* ret = eventGroup.wait(milliseconds);
+  CEvent* ret = eventGroup.wait(std::chrono::milliseconds(milliseconds));
   if (ret)
     m_globalEvent.Reset();
   return ret != NULL;

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -41,7 +41,7 @@ CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay) : CThre
 
 void CDelayedMessage::Process()
 {
-  CThread::Sleep(m_delay);
+  CThread::Sleep(std::chrono::milliseconds(m_delay));
 
   if (!m_bStop)
     CApplicationMessenger::GetInstance().PostMsg(m_msg.dwMessage, m_msg.param1, m_msg.param1, m_msg.lpVoid, m_msg.strParam, m_msg.params);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1948,7 +1948,7 @@ void CMusicInfoScanner::ScannerWait(unsigned int milliseconds)
   if (milliseconds > 10)
   {
     CEvent m_StopEvent;
-    m_StopEvent.WaitMSec(milliseconds);
+    m_StopEvent.WaitMSec(std::chrono::milliseconds(milliseconds));
   }
   else
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1948,7 +1948,7 @@ void CMusicInfoScanner::ScannerWait(unsigned int milliseconds)
   if (milliseconds > 10)
   {
     CEvent m_StopEvent;
-    m_StopEvent.WaitMSec(std::chrono::milliseconds(milliseconds));
+    m_StopEvent.Wait(std::chrono::milliseconds(milliseconds));
   }
   else
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/xbmc/music/infoscanner/MusicInfoScraper.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScraper.cpp
@@ -13,6 +13,7 @@
 
 using namespace MUSIC_GRABBER;
 using namespace ADDON;
+using namespace std::chrono_literals;
 
 CMusicInfoScraper::CMusicInfoScraper(const ADDON::ScraperPtr &scraper) : CThread("MusicInfoScraper")
 {
@@ -121,7 +122,7 @@ void CMusicInfoScraper::LoadArtistInfo()
 
 bool CMusicInfoScraper::Completed()
 {
-  return Join(10);
+  return Join(10ms);
 }
 
 bool CMusicInfoScraper::Succeeded()

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -44,6 +44,7 @@
 
 using namespace KODI::MESSAGING;
 using KODI::UTILITY::CDigest;
+using namespace std::chrono_literals;
 
 #ifdef TARGET_WINDOWS
 #define close closesocket
@@ -363,7 +364,7 @@ void CAirPlayServer::Process()
     if (res < 0)
     {
       CLog::Log(LOGERROR, "AIRPLAY Server: Select failed");
-      CThread::Sleep(1000);
+      CThread::Sleep(1000ms);
       Initialize();
     }
     else if (res > 0)
@@ -406,7 +407,7 @@ void CAirPlayServer::Process()
             CLog::Log(LOGERROR, "AIRPLAY Server: Accept of new connection failed: {}", errno);
             if (EBADF == errno)
             {
-              CThread::Sleep(1000);
+              CThread::Sleep(1000ms);
               Initialize();
               break;
             }

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -57,6 +57,7 @@
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 CAirTunesServer *CAirTunesServer::ServerInstance = NULL;
 std::string CAirTunesServer::m_macAddress;
@@ -227,7 +228,7 @@ void CAirTunesServer::Process()
     if (m_streamStarted)
       SetupRemoteControl();// check for remote controls
 
-    m_processActions.WaitMSec(1000);// timeout for being able to stop
+    m_processActions.WaitMSec(1000ms); // timeout for being able to stop
     std::list<CAction> currentActions;
     {
       CSingleLock lock(m_actionQueueLock);// copy and clear the source queue
@@ -414,12 +415,12 @@ void CAirTunesServer::InformPlayerAboutPlayTimes()
     unsigned int position = m_cachedCurrentTime - m_cachedStartTime;
     duration /= m_sampleRate;
     position /= m_sampleRate;
-  
+
     if (g_application.GetAppPlayer().IsPlaying())
     {
       g_application.GetAppPlayer().SetTime(position * 1000);
       g_application.GetAppPlayer().SetTotalTime(duration * 1000);
-      
+
       // reset play times now that we have informed the player
       m_cachedEndTime = 0;
       m_cachedCurrentTime = 0;
@@ -494,7 +495,7 @@ void  CAirTunesServer::AudioOutputFunctions::audio_process(void *cls, void *sess
 {
   XFILE::CPipeFile *pipe=(XFILE::CPipeFile *)cls;
   pipe->Write(buffer, buflen);
-  
+
   // in case there are some play times cached that are not yet sent to the player - do it here
   InformPlayerAboutPlayTimes();
 }

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -228,7 +228,7 @@ void CAirTunesServer::Process()
     if (m_streamStarted)
       SetupRemoteControl();// check for remote controls
 
-    m_processActions.WaitMSec(1000ms); // timeout for being able to stop
+    m_processActions.Wait(1000ms); // timeout for being able to stop
     std::list<CAction> currentActions;
     {
       CSingleLock lock(m_actionQueueLock);// copy and clear the source queue

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -31,6 +31,7 @@ using namespace EVENTSERVER;
 using namespace EVENTPACKET;
 using namespace EVENTCLIENT;
 using namespace SOCKETS;
+using namespace std::chrono_literals;
 
 /************************************************************************/
 /* CEventServer                                                         */
@@ -134,7 +135,7 @@ void CEventServer::Process()
   {
     Run();
     if (!m_bStop)
-      CThread::Sleep(1000);
+      CThread::Sleep(1000ms);
   }
 }
 

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -23,6 +23,8 @@
 #include "websocket/WebSocketManager.h"
 #include "Network.h"
 
+using namespace std::chrono_literals;
+
 #if defined(TARGET_WINDOWS) || defined(HAVE_LIBBLUETOOTH)
 static const char     bt_service_name[] = "XBMC JSON-RPC";
 static const char     bt_service_desc[] = "Interface for XBMC remote control over bluetooth";
@@ -123,7 +125,7 @@ void CTCPServer::Process()
     if (res < 0)
     {
       CLog::Log(LOGERROR, "JSONRPC Server: Select failed");
-      CThread::Sleep(1000);
+      CThread::Sleep(1000ms);
       Initialize();
     }
     else if (res > 0)
@@ -189,7 +191,7 @@ void CTCPServer::Process()
             CLog::Log(LOGERROR, "JSONRPC Server: Accept of new connection failed: {}", errno);
             if (EBADF == errno)
             {
-              CThread::Sleep(1000);
+              CThread::Sleep(1000ms);
               Initialize();
               break;
             }

--- a/xbmc/network/UdpClient.cpp
+++ b/xbmc/network/UdpClient.cpp
@@ -20,6 +20,8 @@
 
 #include <arpa/inet.h>
 
+using namespace std::chrono_literals;
+
 #define UDPCLIENT_DEBUG_LEVEL LOGDEBUG
 
 CUdpClient::CUdpClient(void) : CThread("UDPClient")
@@ -130,7 +132,7 @@ bool CUdpClient::Send(struct sockaddr_in aAddress, unsigned char* pMessage, DWOR
 
 void CUdpClient::Process()
 {
-  CThread::Sleep(2000);
+  CThread::Sleep(2000ms);
 
   CLog::Log(UDPCLIENT_DEBUG_LEVEL, "UDPCLIENT: Listening.");
 

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -350,7 +350,7 @@ bool CZeroconfBrowserMDNS::doResolveService(CZeroconfBrowser::ZeroconfService& f
   // when using the embedded mdns service the call to DNSServiceProcessResult
   // above will not block until the resolving was finished - instead we have to
   // wait for resolve to return or timeout
-  m_resolved_event.WaitMSec(std::chrono::duration<double, std::milli>(f_timeout * 1000));
+  m_resolved_event.Wait(std::chrono::duration<double, std::milli>(f_timeout * 1000));
 #endif //HAS_MDNS_EMBEDDED
   fr_service = m_resolving_service;
 
@@ -386,7 +386,7 @@ bool CZeroconfBrowserMDNS::doResolveService(CZeroconfBrowser::ZeroconfService& f
     // wait for resolve to return or timeout
     // give it 2 secs for resolving (resolving in mdns is cached and queued
     // in timeslices off 1 sec
-    m_addrinfo_event.WaitMSec(2000ms);
+    m_addrinfo_event.Wait(2000ms);
 #endif //HAS_MDNS_EMBEDDED
     fr_service = m_resolving_service;
 

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -24,8 +24,9 @@
 #include "platform/win32/WIN32Util.h"
 #endif //TARGET_WINDOWS
 
-extern HWND g_hWnd;
+using namespace std::chrono_literals;
 
+extern HWND g_hWnd;
 
 CZeroconfBrowserMDNS::CZeroconfBrowserMDNS()
 {
@@ -349,7 +350,7 @@ bool CZeroconfBrowserMDNS::doResolveService(CZeroconfBrowser::ZeroconfService& f
   // when using the embedded mdns service the call to DNSServiceProcessResult
   // above will not block until the resolving was finished - instead we have to
   // wait for resolve to return or timeout
-  m_resolved_event.WaitMSec(f_timeout * 1000);
+  m_resolved_event.WaitMSec(std::chrono::duration<double, std::milli>(f_timeout * 1000));
 #endif //HAS_MDNS_EMBEDDED
   fr_service = m_resolving_service;
 
@@ -385,7 +386,7 @@ bool CZeroconfBrowserMDNS::doResolveService(CZeroconfBrowser::ZeroconfService& f
     // wait for resolve to return or timeout
     // give it 2 secs for resolving (resolving in mdns is cached and queued
     // in timeslices off 1 sec
-    m_addrinfo_event.WaitMSec(2000);
+    m_addrinfo_event.WaitMSec(2000ms);
 #endif //HAS_MDNS_EMBEDDED
     fr_service = m_resolving_service;
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -38,6 +38,7 @@
 using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
+using namespace std::chrono_literals;
 
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.player")
 
@@ -190,7 +191,7 @@ CUPnPPlayer::~CUPnPPlayer()
 
 static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime& timeout, CGUIDialogBusy*& dialog)
 {
-  if(event.WaitMSec(0))
+  if (event.WaitMSec(0ms))
     return NPT_SUCCESS;
 
   if (!CGUIDialogBusy::WaitOnEvent(event))
@@ -418,7 +419,8 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
                                                          , file.GetPath().c_str()
                                                          , (const char*)tmp
                                                          , m_delegate), failed);
-  if(!m_delegate->m_resevent.WaitMSec(10000)) goto failed;
+  if (!m_delegate->m_resevent.WaitMSec(10000ms))
+    goto failed;
   NPT_CHECK_LABEL_WARNING(m_delegate->m_resstatus, failed);
   return true;
 
@@ -435,7 +437,8 @@ bool CUPnPPlayer::CloseFile(bool reopen)
     NPT_CHECK_LABEL(m_control->Stop(m_delegate->m_device
                                   , m_delegate->m_instance
                                   , m_delegate), failed);
-    if(!m_delegate->m_resevent.WaitMSec(10000)) goto failed;
+    if (!m_delegate->m_resevent.WaitMSec(10000ms))
+      goto failed;
     NPT_CHECK_LABEL(m_delegate->m_resstatus, failed);
   }
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -191,7 +191,7 @@ CUPnPPlayer::~CUPnPPlayer()
 
 static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime& timeout, CGUIDialogBusy*& dialog)
 {
-  if (event.WaitMSec(0ms))
+  if (event.Wait(0ms))
     return NPT_SUCCESS;
 
   if (!CGUIDialogBusy::WaitOnEvent(event))
@@ -419,7 +419,7 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
                                                          , file.GetPath().c_str()
                                                          , (const char*)tmp
                                                          , m_delegate), failed);
-  if (!m_delegate->m_resevent.WaitMSec(10000ms))
+  if (!m_delegate->m_resevent.Wait(10000ms))
     goto failed;
   NPT_CHECK_LABEL_WARNING(m_delegate->m_resstatus, failed);
   return true;
@@ -437,7 +437,7 @@ bool CUPnPPlayer::CloseFile(bool reopen)
     NPT_CHECK_LABEL(m_control->Stop(m_delegate->m_device
                                   , m_delegate->m_instance
                                   , m_delegate), failed);
-    if (!m_delegate->m_resevent.WaitMSec(10000ms))
+    if (!m_delegate->m_resevent.Wait(10000ms))
       goto failed;
     NPT_CHECK_LABEL(m_delegate->m_resstatus, failed);
   }

--- a/xbmc/peripherals/EventScanner.cpp
+++ b/xbmc/peripherals/EventScanner.cpp
@@ -151,7 +151,7 @@ void CEventScanner::Process()
     auto waitTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(nextScan - now);
 
     if (!m_bStop && waitTimeMs.count() > 0)
-      m_scanEvent.WaitMSec(waitTimeMs);
+      m_scanEvent.Wait(waitTimeMs);
   }
 }
 

--- a/xbmc/peripherals/EventScanner.cpp
+++ b/xbmc/peripherals/EventScanner.cpp
@@ -151,7 +151,7 @@ void CEventScanner::Process()
     auto waitTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(nextScan - now);
 
     if (!m_bStop && waitTimeMs.count() > 0)
-      m_scanEvent.WaitMSec(waitTimeMs.count());
+      m_scanEvent.WaitMSec(waitTimeMs);
   }
 }
 

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -222,7 +222,7 @@ void CPeripheralBus::Process(void)
       break;
 
     if (!m_bStop)
-      m_triggerEvent.WaitMSec(m_iRescanTime);
+      m_triggerEvent.Wait(m_iRescanTime);
   }
 }
 

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -17,8 +17,12 @@
 #include "utils/log.h"
 
 using namespace PERIPHERALS;
+using namespace std::chrono_literals;
 
-#define PERIPHERAL_DEFAULT_RESCAN_INTERVAL 5000
+namespace
+{
+constexpr auto PERIPHERAL_DEFAULT_RESCAN_INTERVAL = 5000ms;
+}
 
 CPeripheralBus::CPeripheralBus(const std::string& threadname,
                                CPeripherals& manager,

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -190,7 +190,7 @@ protected:
   virtual bool PerformDeviceScan(PeripheralScanResults& results) = 0;
 
   PeripheralVector m_peripherals;
-  int m_iRescanTime;
+  std::chrono::milliseconds m_iRescanTime;
   bool m_bNeedsPolling; /*!< true when this bus needs to be polled for new devices, false when it
                            uses callbacks to notify this bus of changed */
   CPeripherals& m_manager;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -31,6 +31,7 @@ using namespace MESSAGING;
 using namespace PERIPHERALS;
 using namespace CEC;
 using namespace ANNOUNCEMENT;
+using namespace std::chrono_literals;
 
 #define CEC_LIB_SUPPORTED_VERSION LIBCEC_VERSION_TO_UINT(4, 0, 0)
 
@@ -1555,7 +1556,7 @@ bool CPeripheralCecAdapterUpdateThread::WaitReady(void)
   {
     powerStatus = m_adapter->m_cecAdapter->GetDevicePowerStatus(waitFor);
     if (powerStatus != CEC_POWER_STATUS_ON)
-      bContinue = !m_event.WaitMSec(1000);
+      bContinue = !m_event.WaitMSec(1000ms);
   }
 
   return powerStatus == CEC_POWER_STATUS_ON;
@@ -1663,7 +1664,7 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
   while (!m_bStop)
   {
     // update received
-    if (bUpdate || m_event.WaitMSec(500))
+    if (bUpdate || m_event.WaitMSec(500ms))
     {
       if (m_bStop)
         return;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -327,7 +327,7 @@ bool CPeripheralCecAdapter::OpenConnection(void)
             CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000), g_localizeStrings.Get(36012));
       bConnectionFailedDisplayed = true;
 
-      CThread::Sleep(10000);
+      CThread::Sleep(10000ms);
     }
   }
 
@@ -378,7 +378,7 @@ void CPeripheralCecAdapter::Process(void)
       ProcessStandbyDevices();
 
     if (!m_bStop)
-      CThread::Sleep(5);
+      CThread::Sleep(5ms);
   }
 
   m_queryThread->StopThread(true);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1556,7 +1556,7 @@ bool CPeripheralCecAdapterUpdateThread::WaitReady(void)
   {
     powerStatus = m_adapter->m_cecAdapter->GetDevicePowerStatus(waitFor);
     if (powerStatus != CEC_POWER_STATUS_ON)
-      bContinue = !m_event.WaitMSec(1000ms);
+      bContinue = !m_event.Wait(1000ms);
   }
 
   return powerStatus == CEC_POWER_STATUS_ON;
@@ -1664,7 +1664,7 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
   while (!m_bStop)
   {
     // update received
-    if (bUpdate || m_event.WaitMSec(500ms))
+    if (bUpdate || m_event.Wait(500ms))
     {
       if (m_bStop)
         return;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -43,6 +43,7 @@
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 #define MAX_ZOOM_FACTOR                     10
 #define MAX_PICTURE_SIZE             2048*2048
@@ -91,7 +92,7 @@ void CBackgroundPicLoader::Process()
   unsigned int count = 0;
   while (!m_bStop)
   { // loop around forever, waiting for the app to call LoadPic
-    if (AbortableWait(m_loadPic,10) == WAIT_SIGNALED)
+    if (AbortableWait(m_loadPic, 10ms) == WAIT_SIGNALED)
     {
       if (m_pCallback)
       {

--- a/xbmc/platform/android/activity/JNIXBMCMainView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMainView.cpp
@@ -111,7 +111,7 @@ void CJNIXBMCMainView::surfaceDestroyed(CJNISurfaceHolder holder)
 
 bool CJNIXBMCMainView::waitForSurface(unsigned int millis)
 {
-  return m_surfaceCreated.WaitMSec(millis);
+  return m_surfaceCreated.WaitMSec(std::chrono::milliseconds(millis));
 }
 
 bool CJNIXBMCMainView::isCreated() const

--- a/xbmc/platform/android/activity/JNIXBMCMainView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMainView.cpp
@@ -111,7 +111,7 @@ void CJNIXBMCMainView::surfaceDestroyed(CJNISurfaceHolder holder)
 
 bool CJNIXBMCMainView::waitForSurface(unsigned int millis)
 {
-  return m_surfaceCreated.WaitMSec(std::chrono::milliseconds(millis));
+  return m_surfaceCreated.Wait(std::chrono::milliseconds(millis));
 }
 
 bool CJNIXBMCMainView::isCreated() const

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
@@ -115,7 +115,7 @@ void CJNIXBMCVideoView::surfaceDestroyed(CJNISurfaceHolder holder)
 
 bool CJNIXBMCVideoView::waitForSurface(unsigned int millis)
 {
-  return m_surfaceCreated.WaitMSec(millis);
+  return m_surfaceCreated.WaitMSec(std::chrono::milliseconds(millis));
 }
 
 void CJNIXBMCVideoView::add()

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
@@ -115,7 +115,7 @@ void CJNIXBMCVideoView::surfaceDestroyed(CJNISurfaceHolder holder)
 
 bool CJNIXBMCVideoView::waitForSurface(unsigned int millis)
 {
-  return m_surfaceCreated.WaitMSec(std::chrono::milliseconds(millis));
+  return m_surfaceCreated.Wait(std::chrono::milliseconds(millis));
 }
 
 void CJNIXBMCVideoView::add()

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -107,6 +107,7 @@
 using namespace KODI::MESSAGING;
 using namespace ANNOUNCEMENT;
 using namespace jni;
+using namespace std::chrono_literals;
 
 template<class T, void(T::*fn)()>
 void* thread_run(void* obj)
@@ -607,7 +608,7 @@ void CXBMCApp::SetRefreshRate(float rate)
   runNativeOnUiThread(SetRefreshRateCallback, variant);
   if (g_application.IsInitialized())
   {
-    m_displayChangeEvent.WaitMSec(5000);
+    m_displayChangeEvent.WaitMSec(5000ms);
     if (m_hdmiSource && g_application.GetAppPlayer().IsPlaying())
       dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->InitiateModeChange();
   }
@@ -635,7 +636,7 @@ void CXBMCApp::SetDisplayMode(int mode, float rate)
   runNativeOnUiThread(SetDisplayModeCallback, variant);
   if (g_application.IsInitialized())
   {
-    m_displayChangeEvent.WaitMSec(5000);
+    m_displayChangeEvent.WaitMSec(5000ms);
     if (m_hdmiSource && g_application.GetAppPlayer().IsPlaying())
       dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->InitiateModeChange();
   }
@@ -1331,7 +1332,7 @@ float CXBMCApp::GetFrameLatencyMs()
 
 bool CXBMCApp::WaitVSync(unsigned int milliSeconds)
 {
-  return m_vsyncEvent.WaitMSec(milliSeconds);
+  return m_vsyncEvent.WaitMSec(std::chrono::milliseconds(milliSeconds));
 }
 
 bool CXBMCApp::GetMemoryInfo(long& availMem, long& totalMem)

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -608,7 +608,7 @@ void CXBMCApp::SetRefreshRate(float rate)
   runNativeOnUiThread(SetRefreshRateCallback, variant);
   if (g_application.IsInitialized())
   {
-    m_displayChangeEvent.WaitMSec(5000ms);
+    m_displayChangeEvent.Wait(5000ms);
     if (m_hdmiSource && g_application.GetAppPlayer().IsPlaying())
       dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->InitiateModeChange();
   }
@@ -636,7 +636,7 @@ void CXBMCApp::SetDisplayMode(int mode, float rate)
   runNativeOnUiThread(SetDisplayModeCallback, variant);
   if (g_application.IsInitialized())
   {
-    m_displayChangeEvent.WaitMSec(5000ms);
+    m_displayChangeEvent.Wait(5000ms);
     if (m_hdmiSource && g_application.GetAppPlayer().IsPlaying())
       dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->InitiateModeChange();
   }
@@ -1332,7 +1332,7 @@ float CXBMCApp::GetFrameLatencyMs()
 
 bool CXBMCApp::WaitVSync(unsigned int milliSeconds)
 {
-  return m_vsyncEvent.WaitMSec(std::chrono::milliseconds(milliSeconds));
+  return m_vsyncEvent.Wait(std::chrono::milliseconds(milliSeconds));
 }
 
 bool CXBMCApp::GetMemoryInfo(long& availMem, long& totalMem)

--- a/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
@@ -109,7 +109,8 @@ bool CZeroconfBrowserAndroid::doResolveService(CZeroconfBrowser::ZeroconfService
   CZeroconfBrowserAndroidResolve resolver;
   m_manager.resolveService(service, resolver);
 
-  if (!resolver.m_resolutionDone.WaitMSec(f_timeout * 1000))
+  if (!resolver.m_resolutionDone.WaitMSec(
+          std::chrono::duration<double, std::milli>(f_timeout * 1000)))
   {
     CLog::Log(LOGERROR, "ZeroconfBrowserAndroid: DNSServiceResolve Timeout error");
     return false;

--- a/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
@@ -109,8 +109,7 @@ bool CZeroconfBrowserAndroid::doResolveService(CZeroconfBrowser::ZeroconfService
   CZeroconfBrowserAndroidResolve resolver;
   m_manager.resolveService(service, resolver);
 
-  if (!resolver.m_resolutionDone.WaitMSec(
-          std::chrono::duration<double, std::milli>(f_timeout * 1000)))
+  if (!resolver.m_resolutionDone.Wait(std::chrono::duration<double, std::milli>(f_timeout * 1000)))
   {
     CLog::Log(LOGERROR, "ZeroconfBrowserAndroid: DNSServiceResolve Timeout error");
     return false;

--- a/xbmc/platform/darwin/ios-common/DarwinEmbedKeyboardView.mm
+++ b/xbmc/platform/darwin/ios-common/DarwinEmbedKeyboardView.mm
@@ -96,7 +96,7 @@ static CEvent keyboardFinishedEvent;
   });
 
   // we are waiting on the user finishing the keyboard
-  while (!keyboardFinishedEvent.WaitMSec(500ms))
+  while (!keyboardFinishedEvent.Wait(500ms))
   {
   }
 }

--- a/xbmc/platform/darwin/ios-common/DarwinEmbedKeyboardView.mm
+++ b/xbmc/platform/darwin/ios-common/DarwinEmbedKeyboardView.mm
@@ -19,6 +19,8 @@
 #include "platform/darwin/tvos/XBMCController.h"
 #endif
 
+using namespace std::chrono_literals;
+
 static CEvent keyboardFinishedEvent;
 
 @implementation KeyboardView
@@ -94,7 +96,7 @@ static CEvent keyboardFinishedEvent;
   });
 
   // we are waiting on the user finishing the keyboard
-  while (!keyboardFinishedEvent.WaitMSec(500))
+  while (!keyboardFinishedEvent.WaitMSec(500ms))
   {
   }
 }

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -174,7 +174,7 @@ static CEvent screenChangeEvent;
   if([NSThread currentThread] != [NSThread mainThread])
   {
     [self performSelectorOnMainThread:@selector(changeScreenSelector:) withObject:dict  waitUntilDone:YES];
-    screenChangeEvent.WaitMSec(30000ms);
+    screenChangeEvent.Wait(30000ms);
   }
   else
   {

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -26,6 +26,8 @@
 #include <objc/runtime.h>
 #include <sys/resource.h>
 
+using namespace std::chrono_literals;
+
 const CGFloat timeSwitchingToExternalSecs = 6.0;
 const CGFloat timeSwitchingToInternalSecs = 2.0;
 const CGFloat timeFadeSecs                = 2.0;
@@ -172,7 +174,7 @@ static CEvent screenChangeEvent;
   if([NSThread currentThread] != [NSThread mainThread])
   {
     [self performSelectorOnMainThread:@selector(changeScreenSelector:) withObject:dict  waitUntilDone:YES];
-    screenChangeEvent.WaitMSec(30000);
+    screenChangeEvent.WaitMSec(30000ms);
   }
   else
   {

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -21,6 +21,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+using namespace std::chrono_literals;
+
 CLirc::CLirc() : CThread("Lirc")
 {
 }
@@ -52,7 +54,7 @@ void CLirc::Process()
     throw std::runtime_error("CSettings needs to exist before starting CLirc");
 
   while (!settings->IsLoaded())
-    CThread::Sleep(1000);
+    CThread::Sleep(1000ms);
 
   m_profileId = settingsComponent->GetProfileManager()->GetCurrentProfileId();
   m_irTranslator.Load("Lircmap.xml");
@@ -72,7 +74,7 @@ void CLirc::Process()
       if (!CheckDaemon())
       {
         CSingleExit lock(m_critSection);
-        CThread::Sleep(1000);
+        CThread::Sleep(1000ms);
         continue;
       }
 
@@ -80,7 +82,7 @@ void CLirc::Process()
       if (m_fd <= 0)
       {
         CSingleExit lock(m_critSection);
-        CThread::Sleep(1000);
+        CThread::Sleep(1000ms);
         continue;
       }
     }
@@ -92,7 +94,7 @@ void CLirc::Process()
       if (ret < 0)
       {
         lirc_deinit();
-        CThread::Sleep(1000);
+        CThread::Sleep(1000ms);
         break;
       }
       if (code != nullptr)

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -307,7 +307,7 @@ void CLibInputKeyboard::ProcessKey(libinput_event_keyboard *e)
       m_repeatRate = data->second.at(1);
       m_repeatTimer.Stop(true);
       m_repeatEvent = event;
-      m_repeatTimer.Start(data->second.at(0), false);
+      m_repeatTimer.Start(std::chrono::milliseconds(data->second.at(0)), false);
     }
   }
   else
@@ -340,7 +340,7 @@ XBMCKey CLibInputKeyboard::XBMCKeyForKeysym(xkb_keysym_t sym, uint32_t scancode)
 
 void CLibInputKeyboard::KeyRepeatTimeout()
 {
-  m_repeatTimer.RestartAsync(m_repeatRate);
+  m_repeatTimer.RestartAsync(std::chrono::milliseconds(m_repeatRate));
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)

--- a/xbmc/platform/linux/network/zeroconf/ZeroconfBrowserAvahi.cpp
+++ b/xbmc/platform/linux/network/zeroconf/ZeroconfBrowserAvahi.cpp
@@ -167,7 +167,7 @@ bool CZeroconfBrowserAvahi::doResolveService ( CZeroconfBrowser::ZeroconfService
   } // end of this block releases lock of eventloop
 
   //wait for resolve to return or timeout
-  m_resolved_event.WaitMSec(f_timeout*1000);
+  m_resolved_event.WaitMSec(std::chrono::duration<double, std::milli>(f_timeout * 1000));
   {
     ScopedEventLoopBlock lock ( mp_poll );
     fr_service = m_resolving_service;

--- a/xbmc/platform/linux/network/zeroconf/ZeroconfBrowserAvahi.cpp
+++ b/xbmc/platform/linux/network/zeroconf/ZeroconfBrowserAvahi.cpp
@@ -167,7 +167,7 @@ bool CZeroconfBrowserAvahi::doResolveService ( CZeroconfBrowser::ZeroconfService
   } // end of this block releases lock of eventloop
 
   //wait for resolve to return or timeout
-  m_resolved_event.WaitMSec(std::chrono::duration<double, std::milli>(f_timeout * 1000));
+  m_resolved_event.Wait(std::chrono::duration<double, std::milli>(f_timeout * 1000));
   {
     ScopedEventLoopBlock lock ( mp_poll );
     fr_service = m_resolving_service;

--- a/xbmc/platform/win10/peripherals/PeripheralBusUSB.cpp
+++ b/xbmc/platform/win10/peripherals/PeripheralBusUSB.cpp
@@ -18,6 +18,7 @@ const static GUID USB_DISK_GUID = { 0x53F56307, 0xB6BF, 0x11D0, { 0x94, 0xF2, 0x
 const static GUID USB_NIC_GUID = { 0xAD498944, 0x762F, 0x11D0, { 0x8D, 0xCB, 0x00, 0xC0, 0x4F, 0xC3, 0x35, 0x8C } };
 
 using namespace PERIPHERALS;
+using namespace std::chrono_literals;
 
 // Only to avoid endless loops while scanning for devices
 #define MAX_BUS_DEVICES 2000
@@ -26,7 +27,7 @@ CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals &manager) :
     CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   /* device removals aren't always triggering OnDeviceRemoved events, so poll for changes every 5 seconds to be sure we don't miss anything */
-  m_iRescanTime = 5000;
+  m_iRescanTime = 5000ms;
 }
 
 bool CPeripheralBusUSB::PerformDeviceScan(PeripheralScanResults &results)

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -19,6 +19,8 @@
 
 #include <WS2tcpip.h>
 
+using namespace std::chrono_literals;
+
 #define IRSS_PORT 24000
 #define IRSS_MAP_FILENAME "IRSSmap.xml"
 
@@ -81,7 +83,7 @@ void CIRServerSuite::Process()
       if (logging)
         CLog::LogF(LOGINFO, "failed to connect to irss, will keep retrying every 5 seconds");
 
-      if (AbortableWait(m_event, 5000) == WAIT_SIGNALED)
+      if (AbortableWait(m_event, 5000ms) == WAIT_SIGNALED)
         break;
 
       logging = false;

--- a/xbmc/platform/win32/peripherals/PeripheralBusUSB.cpp
+++ b/xbmc/platform/win32/peripherals/PeripheralBusUSB.cpp
@@ -20,6 +20,7 @@ const static GUID USB_DISK_GUID = { 0x53F56307, 0xB6BF, 0x11D0, { 0x94, 0xF2, 0x
 const static GUID USB_NIC_GUID = { 0xAD498944, 0x762F, 0x11D0, { 0x8D, 0xCB, 0x00, 0xC0, 0x4F, 0xC3, 0x35, 0x8C } };
 
 using namespace PERIPHERALS;
+using namespace std::chrono_literals;
 
 // Only to avoid endless loops while scanning for devices
 #define MAX_BUS_DEVICES 2000
@@ -28,7 +29,7 @@ CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
     CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   /* device removals aren't always triggering OnDeviceRemoved events, so poll for changes every 5 seconds to be sure we don't miss anything */
-  m_iRescanTime = 5000;
+  m_iRescanTime = 5000ms;
 }
 
 bool CPeripheralBusUSB::PerformDeviceScan(PeripheralScanResults &results)

--- a/xbmc/platform/win32/powermanagement/Win32PowerSyscall.cpp
+++ b/xbmc/platform/win32/powermanagement/Win32PowerSyscall.cpp
@@ -46,7 +46,7 @@ void CWin32PowerStateWorker::Process(void)
 {
   while (!m_bStop)
   {
-    if (AbortableWait(m_queryEvent, -1) == WAIT_SIGNALED)
+    if (AbortableWait(m_queryEvent) == WAIT_SIGNALED)
     {
       PowerManagement(m_state.load());
       m_state.exchange(POWERSTATE_NONE);

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -18,6 +18,8 @@
 #include <cstdlib>
 #include <string>
 
+using namespace std::chrono_literals;
+
 namespace PVR
 {
 
@@ -54,7 +56,7 @@ void CPVRChannelNumberInputHandler::OnTimeout()
     if (m_timer.IsRunning())
       m_label.erase();
     else
-      m_timer.Start(500);
+      m_timer.Start(500ms);
   }
 }
 
@@ -132,7 +134,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter
   }
 
   if (!m_timer.IsRunning())
-    m_timer.Start(m_iDelay);
+    m_timer.Start(std::chrono::milliseconds(m_iDelay));
   else
     m_timer.Restart();
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -44,6 +44,7 @@
 
 using namespace PVR;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 namespace PVR
 {
@@ -485,7 +486,7 @@ void CPVRManager::Process()
   while (!LoadComponents(progressHandler) && IsInitialising())
   {
     CLog::Log(LOGWARNING, "PVR Manager failed to load data, retrying");
-    CThread::Sleep(1000);
+    CThread::Sleep(1000ms);
 
     if (progressHandler && progressTimeout.IsTimePast())
     {
@@ -625,7 +626,7 @@ bool CPVRManager::LoadComponents(CPVRGUIProgressHandler* progressHandler)
 {
   /* load at least one client */
   while (IsInitialising() && m_addons && !m_addons->HasCreatedClients())
-    CThread::Sleep(50);
+    CThread::Sleep(50ms);
 
   if (!IsInitialising() || !m_addons->HasCreatedClients())
     return false;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -89,7 +89,7 @@ public:
 
   bool WaitForJobs(unsigned int milliSeconds)
   {
-    return m_triggerEvent.WaitMSec(std::chrono::milliseconds(milliSeconds));
+    return m_triggerEvent.Wait(std::chrono::milliseconds(milliSeconds));
   }
 
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -89,7 +89,7 @@ public:
 
   bool WaitForJobs(unsigned int milliSeconds)
   {
-    return m_triggerEvent.WaitMSec(milliSeconds);
+    return m_triggerEvent.WaitMSec(std::chrono::milliseconds(milliSeconds));
   }
 
 

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -146,7 +146,7 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item
         m_lastWatchedUpdateTimer->Stop(true);
 
       m_lastWatchedUpdateTimer.reset(new CLastWatchedUpdateTimer(*this, channel, CDateTime::GetUTCDateTime()));
-      m_lastWatchedUpdateTimer->Start(iLastWatchedDelay);
+      m_lastWatchedUpdateTimer->Start(std::chrono::milliseconds(iLastWatchedDelay));
     }
     else
     {

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -29,6 +29,8 @@
 #include <utility>
 #include <vector>
 
+using namespace std::chrono_literals;
+
 namespace PVR
 {
 
@@ -432,7 +434,7 @@ void CPVREpgContainer::Process()
       iLastSave = iNow;
     }
 
-    CThread::Sleep(1000);
+    CThread::Sleep(1000ms);
   }
 
   // store data on exit

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -22,6 +22,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
+#include "threads/SystemClock.h"
 #include "utils/log.h"
 
 #include <memory>

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -19,6 +19,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
+#include "threads/SystemClock.h"
 #include "utils/Job.h"
 #include "utils/JobManager.h"
 #include "utils/XTimeUtils.h"

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
@@ -18,6 +18,8 @@
 #include <cmath>
 #include <string>
 
+using namespace std::chrono_literals;
+
 namespace PVR
 {
   CPVRGUIProgressHandler::CPVRGUIProgressHandler(const std::string& strTitle)
@@ -86,8 +88,8 @@ namespace PVR
         progressHandle->SetText(strText);
       }
 
-      CThread::Sleep(
-          100); // Intentionally ignore some changes that come in too fast. Humans cannot read as fast as Mr. Data ;-)
+      // Intentionally ignore some changes that come in too fast. Humans cannot read as fast as Mr. Data ;-)
+      CThread::Sleep(100ms);
     }
 
     progressHandle->MarkFinished();

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -46,6 +46,7 @@
 
 using namespace PVR;
 using namespace KODI::GUILIB::GUIINFO;
+using namespace std::chrono_literals;
 
 CPVRGUIInfo::CPVRGUIInfo() : CThread("PVRGUIInfo")
 {
@@ -185,7 +186,7 @@ void CPVRGUIInfo::Process()
       iLoop = 0;
 
     if (!m_bStop)
-      CThread::Sleep(500);
+      CThread::Sleep(500ms);
   }
 }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -32,6 +32,12 @@
 #include <vector>
 
 using namespace PVR;
+using namespace std::chrono_literals;
+
+namespace
+{
+constexpr auto MAX_NOTIFICATION_DELAY = 10s;
+}
 
 bool CPVRTimersContainer::UpdateFromClient(const std::shared_ptr<CPVRTimerInfoTag>& timer)
 {
@@ -165,14 +171,12 @@ bool CPVRTimers::LoadFromDatabase()
 
 void CPVRTimers::Process()
 {
-  static const unsigned int MAX_NOTIFICATION_DELAY = 10; // secs
-
   while (!m_bStop)
   {
     // update all timers not owned by a client (e.g. reminders)
-    UpdateEntries(MAX_NOTIFICATION_DELAY);
+    UpdateEntries(MAX_NOTIFICATION_DELAY.count());
 
-    CThread::Sleep(MAX_NOTIFICATION_DELAY * 1000);
+    CThread::Sleep(MAX_NOTIFICATION_DELAY);
   }
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -48,6 +48,7 @@
 
 using namespace KODI::MESSAGING;
 using namespace PVR;
+using namespace std::chrono_literals;
 
 CGUIWindowPVRGuideBase::CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string& xmlFile)
   : CGUIWindowPVRBase(bRadio, id, xmlFile), m_bChannelSelectionRestored(false)
@@ -911,11 +912,11 @@ void CPVRRefreshTimelineItemsThread::Process()
 
       iLastEpgItemsCount = iCurrentEpgItemsCount;
 
-      m_ready.WaitMSec(1000); // boosted update cycle
+      m_ready.WaitMSec(1000ms); // boosted update cycle
     }
     else
     {
-      m_ready.WaitMSec(5000); // normal update cycle
+      m_ready.WaitMSec(5000ms); // normal update cycle
     }
 
     m_ready.Reset();

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -912,11 +912,11 @@ void CPVRRefreshTimelineItemsThread::Process()
 
       iLastEpgItemsCount = iCurrentEpgItemsCount;
 
-      m_ready.WaitMSec(1000ms); // boosted update cycle
+      m_ready.Wait(1000ms); // boosted update cycle
     }
     else
     {
-      m_ready.WaitMSec(5000ms); // normal update cycle
+      m_ready.Wait(5000ms); // normal update cycle
     }
 
     m_ready.Reset();

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -39,6 +39,7 @@ using namespace KODI;
 using namespace DirectX;
 using namespace DirectX::PackedVector;
 using namespace Microsoft::WRL;
+using namespace std::chrono_literals;
 
 CRenderSystemDX::CRenderSystemDX() : CRenderSystemBase()
   , m_interlaced(false)
@@ -285,7 +286,7 @@ void CRenderSystemDX::PresentRender(bool rendered, bool videoLayer)
     timer.Set(5);
     while (!m_decodingTimer.IsTimePast() && !timer.IsTimePast())
     {
-      m_decodingEvent.wait(lock, 1);
+      m_decodingEvent.wait(lock, 1ms);
     }
   }
 

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -12,6 +12,7 @@
 #include "rendering/RenderSystem.h"
 #include "threads/Condition.h"
 #include "threads/CriticalSection.h"
+#include "threads/SystemClock.h"
 #include "utils/Color.h"
 
 #include <wrl/client.h>

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -90,7 +90,7 @@ protected:
   virtual int GetSettingLevel() const { return 0; }
   virtual std::shared_ptr<CSettingSection> GetSection() = 0;
   virtual std::shared_ptr<CSetting> GetSetting(const std::string& settingId) = 0;
-  virtual unsigned int GetDelayMs() const { return 1500; }
+  virtual std::chrono::milliseconds GetDelayMs() const { return std::chrono::milliseconds(1500); }
   virtual std::string GetLocalizedString(uint32_t labelId) const;
 
   virtual bool OnOkay()

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -33,6 +33,7 @@
 
 using namespace XFILE;
 using namespace MEDIA_DETECT;
+using namespace std::chrono_literals;
 
 CCriticalSection CDetectDVDMedia::m_muReadingMedia;
 CEvent CDetectDVDMedia::m_evAutorun;
@@ -74,17 +75,17 @@ void CDetectDVDMedia::Process()
   {
     if (g_application.GetAppPlayer().IsPlayingVideo())
     {
-      CThread::Sleep(10000);
+      CThread::Sleep(10000ms);
     }
     else
     {
       UpdateDvdrom();
       m_bStartup = false;
-      CThread::Sleep(2000);
+      CThread::Sleep(2000ms);
       if ( m_bAutorun )
       {
-        CThread::Sleep(
-            1500); // Media in drive, wait 1.5s more to be sure the device is ready for playback
+        // Media in drive, wait 1.5s more to be sure the device is ready for playback
+        CThread::Sleep(1500ms);
         m_evAutorun.Set();
         m_bAutorun = false;
       }
@@ -138,7 +139,7 @@ void CDetectDVDMedia::UpdateDvdrom()
           CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
           CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
           // Do we really need sleep here? This will fix: [ 1530771 ] "Open tray" problem
-          // CThread::Sleep(6000);
+          // CThread::Sleep(6000ms);
           return ;
         }
         break;

--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -13,6 +13,8 @@
 #include <algorithm>
 #include <limits>
 
+using namespace std::chrono_literals;
+
 void CEvent::addGroup(XbmcThreads::CEventGroup* group)
 {
   CSingleLock lock(groupListMutex);
@@ -108,7 +110,7 @@ namespace XbmcThreads
       if (milliseconds == std::numeric_limits<unsigned int>::max())
         condVar.wait(mutex);
       else
-        condVar.wait(mutex,milliseconds);
+        condVar.wait(mutex, std::chrono::milliseconds(milliseconds));
     } // at this point the CEventGroup::mutex is reacquired
     numWaits--;
 
@@ -119,7 +121,7 @@ namespace XbmcThreads
       if (signaled)
         // This acquires and releases the CEvent::mutex. This is fine since the
         //  CEventGroup::mutex is already being held
-        signaled->WaitMSec(0); // reset the event if needed
+        signaled->WaitMSec(0ms); // reset the event if needed
       signaled = nullptr;  // clear the signaled if all the waiters are gone
     }
     return ret;

--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -70,61 +70,7 @@ namespace XbmcThreads
    */
   CEvent* CEventGroup::wait()
   {
-    return wait(std::numeric_limits<unsigned int>::max());
-  }
-
-  /**
-   * This will block until any one of the CEvents in the group are
-   * signaled or the timeout is reached. If an event is signaled then
-   * it will return a pointer to that CEvent, otherwise it will return
-   * NULL.
-   */
-  // locking is ALWAYS done in this order:
-  //  CEvent::groupListMutex -> CEventGroup::mutex -> CEvent::mutex
-  //
-  // Notice that this method doesn't grab the CEvent::groupListMutex at all. This
-  // is fine. It just grabs the CEventGroup::mutex and THEN the individual
-  // CEvent::mutex's
-  CEvent* CEventGroup::wait(unsigned int milliseconds)
-  {
-    CSingleLock lock(mutex); // grab CEventGroup::mutex
-    numWaits++;
-
-    // ==================================================
-    // This block checks to see if any child events are
-    // signaled and sets 'signaled' to the first one it
-    // finds.
-    // ==================================================
-    signaled = nullptr;
-    for (auto* cur : events)
-    {
-      CSingleLock lock2(cur->mutex);
-      if (cur->signaled)
-        signaled = cur;
-    }
-    // ==================================================
-
-    if(!signaled)
-    {
-      // both of these release the CEventGroup::mutex
-      if (milliseconds == std::numeric_limits<unsigned int>::max())
-        condVar.wait(mutex);
-      else
-        condVar.wait(mutex, std::chrono::milliseconds(milliseconds));
-    } // at this point the CEventGroup::mutex is reacquired
-    numWaits--;
-
-    // signaled should have been set by a call to CEventGroup::Set
-    CEvent* ret = signaled;
-    if (numWaits == 0)
-    {
-      if (signaled)
-        // This acquires and releases the CEvent::mutex. This is fine since the
-        //  CEventGroup::mutex is already being held
-        signaled->Wait(0ms); // reset the event if needed
-      signaled = nullptr;  // clear the signaled if all the waiters are gone
-    }
-    return ret;
+    return wait(std::chrono::milliseconds::max());
   }
 
   CEventGroup::CEventGroup(std::initializer_list<CEvent*> eventsList)

--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -121,7 +121,7 @@ namespace XbmcThreads
       if (signaled)
         // This acquires and releases the CEvent::mutex. This is fine since the
         //  CEventGroup::mutex is already being held
-        signaled->WaitMSec(0ms); // reset the event if needed
+        signaled->Wait(0ms); // reset the event if needed
       signaled = nullptr;  // clear the signaled if all the waiters are gone
     }
     return ret;

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -18,7 +18,7 @@
 // forward declare the CEventGroup
 namespace XbmcThreads
 {
-  class CEventGroup;
+class CEventGroup;
 }
 
 
@@ -55,20 +55,36 @@ class CEvent
   void removeGroup(XbmcThreads::CEventGroup* group);
 
   // helper for the two wait methods
-  inline bool prepReturn() { bool ret = signaled; if (!manualReset && numWaits == 0) signaled = false; return ret; }
+  inline bool prepReturn()
+  {
+    bool ret = signaled;
+    if (!manualReset && numWaits == 0)
+      signaled = false;
+    return ret;
+  }
 
   CEvent(const CEvent&) = delete;
   CEvent& operator=(const CEvent&) = delete;
 
 public:
-  inline CEvent(bool manual = false, bool signaled_ = false) :
-    manualReset(manual), signaled(signaled_), condVar(actualCv,signaled) {}
+  inline CEvent(bool manual = false, bool signaled_ = false)
+    : manualReset(manual), signaled(signaled_), condVar(actualCv, signaled)
+  {
+  }
 
-  inline void Reset() { CSingleLock lock(mutex); signaled = false; }
+  inline void Reset()
+  {
+    CSingleLock lock(mutex);
+    signaled = false;
+  }
   void Set();
 
   /** Returns true if Event has been triggered and not reset, false otherwise. */
-  inline bool Signaled() { CSingleLock lock(mutex); return signaled; }
+  inline bool Signaled()
+  {
+    CSingleLock lock(mutex);
+    return signaled;
+  }
 
   /**
    * This will wait up to 'milliSeconds' milliseconds for the Event
@@ -91,110 +107,127 @@ public:
    * it will return false. Otherwise it will return false.
    */
   inline bool Wait()
-  { CSingleLock lock(mutex); numWaits++; condVar.wait(mutex); numWaits--; return prepReturn(); }
+  {
+    CSingleLock lock(mutex);
+    numWaits++;
+    condVar.wait(mutex);
+    numWaits--;
+    return prepReturn();
+  }
 
   /**
    * This is mostly for testing. It allows a thread to make sure there are
    *  the right amount of other threads waiting.
    */
-  inline int getNumWaits() { CSingleLock lock(mutex); return numWaits; }
-
+  inline int getNumWaits()
+  {
+    CSingleLock lock(mutex);
+    return numWaits;
+  }
 };
 
 namespace XbmcThreads
 {
-  /**
+/**
    * CEventGroup is a means of grouping CEvents to wait on them together.
    * It is equivalent to WaitOnMultipleObject that returns when "any" Event
    * in the group signaled.
    */
-  class CEventGroup
+class CEventGroup
+{
+  std::vector<CEvent*> events;
+  CEvent* signaled{};
+  XbmcThreads::ConditionVariable actualCv;
+  XbmcThreads::TightConditionVariable<CEvent*&> condVar{actualCv, signaled};
+  CCriticalSection mutex;
+
+  unsigned int numWaits{0};
+
+  // This is ONLY called from CEvent::Set.
+  inline void Set(CEvent* child)
   {
-    std::vector<CEvent*> events;
-    CEvent* signaled{};
-    XbmcThreads::ConditionVariable actualCv;
-    XbmcThreads::TightConditionVariable<CEvent*&> condVar{actualCv, signaled};
-    CCriticalSection mutex;
+    CSingleLock l(mutex);
+    signaled = child;
+    condVar.notifyAll();
+  }
 
-    unsigned int numWaits{0};
+  friend class ::CEvent;
 
-    // This is ONLY called from CEvent::Set.
-    inline void Set(CEvent* child) { CSingleLock l(mutex); signaled = child; condVar.notifyAll(); }
+  CEventGroup(const CEventGroup&) = delete;
+  CEventGroup& operator=(const CEventGroup&) = delete;
 
-    friend class ::CEvent;
-
-    CEventGroup(const CEventGroup&) = delete;
-    CEventGroup& operator=(const CEventGroup&) = delete;
-
-  public:
-    /**
+public:
+  /**
      * Create a CEventGroup from a number of CEvents.
      */
-    CEventGroup(std::initializer_list<CEvent*> events);
+  CEventGroup(std::initializer_list<CEvent*> events);
 
-    ~CEventGroup();
+  ~CEventGroup();
 
-    /**
+  /**
      * This will block until any one of the CEvents in the group are
      * signaled at which point a pointer to that CEvents will be
      * returned.
      */
-    CEvent* wait();
+  CEvent* wait();
 
-    // locking is ALWAYS done in this order:
-    //  CEvent::groupListMutex -> CEventGroup::mutex -> CEvent::mutex
-    //
-    // Notice that this method doesn't grab the CEvent::groupListMutex at all. This
-    // is fine. It just grabs the CEventGroup::mutex and THEN the individual
-    // CEvent::mutex's
-    template<typename Rep, typename Period>
-    CEvent* wait(std::chrono::duration<Rep, Period> duration)
+  // locking is ALWAYS done in this order:
+  //  CEvent::groupListMutex -> CEventGroup::mutex -> CEvent::mutex
+  //
+  // Notice that this method doesn't grab the CEvent::groupListMutex at all. This
+  // is fine. It just grabs the CEventGroup::mutex and THEN the individual
+  // CEvent::mutex's
+  template<typename Rep, typename Period>
+  CEvent* wait(std::chrono::duration<Rep, Period> duration)
+  {
+    CSingleLock lock(mutex); // grab CEventGroup::mutex
+    numWaits++;
+
+    // ==================================================
+    // This block checks to see if any child events are
+    // signaled and sets 'signaled' to the first one it
+    // finds.
+    // ==================================================
+    signaled = nullptr;
+    for (auto* cur : events)
     {
-      CSingleLock lock(mutex); // grab CEventGroup::mutex
-      numWaits++;
-
-      // ==================================================
-      // This block checks to see if any child events are
-      // signaled and sets 'signaled' to the first one it
-      // finds.
-      // ==================================================
-      signaled = nullptr;
-      for (auto* cur : events)
-      {
-        CSingleLock lock2(cur->mutex);
-        if (cur->signaled)
-          signaled = cur;
-      }
-      // ==================================================
-
-      if (!signaled)
-      {
-        // both of these release the CEventGroup::mutex
-        if (duration == std::chrono::duration<Rep, Period>::max())
-          condVar.wait(mutex);
-        else
-          condVar.wait(mutex, duration);
-      } // at this point the CEventGroup::mutex is reacquired
-      numWaits--;
-
-      // signaled should have been set by a call to CEventGroup::Set
-      CEvent* ret = signaled;
-      if (numWaits == 0)
-      {
-        if (signaled)
-          // This acquires and releases the CEvent::mutex. This is fine since the
-          //  CEventGroup::mutex is already being held
-          signaled->Wait(std::chrono::duration<Rep, Period>::zero()); // reset the event if needed
-        signaled = nullptr; // clear the signaled if all the waiters are gone
-      }
-      return ret;
+      CSingleLock lock2(cur->mutex);
+      if (cur->signaled)
+        signaled = cur;
     }
+    // ==================================================
 
-    /**
+    if (!signaled)
+    {
+      // both of these release the CEventGroup::mutex
+      if (duration == std::chrono::duration<Rep, Period>::max())
+        condVar.wait(mutex);
+      else
+        condVar.wait(mutex, duration);
+    } // at this point the CEventGroup::mutex is reacquired
+    numWaits--;
+
+    // signaled should have been set by a call to CEventGroup::Set
+    CEvent* ret = signaled;
+    if (numWaits == 0)
+    {
+      if (signaled)
+        // This acquires and releases the CEvent::mutex. This is fine since the
+        //  CEventGroup::mutex is already being held
+        signaled->Wait(std::chrono::duration<Rep, Period>::zero()); // reset the event if needed
+      signaled = nullptr; // clear the signaled if all the waiters are gone
+    }
+    return ret;
+  }
+
+  /**
      * This is mostly for testing. It allows a thread to make sure there are
      *  the right amount of other threads waiting.
      */
-    inline int getNumWaits() { CSingleLock lock(mutex); return numWaits; }
-
-  };
-}
+  inline int getNumWaits()
+  {
+    CSingleLock lock(mutex);
+    return numWaits;
+  }
+};
+} // namespace XbmcThreads

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -21,16 +21,17 @@ namespace XbmcThreads
 class CEventGroup;
 }
 
-
 /**
- * This is an Event class built from a ConditionVariable. The Event adds the state
- * that the condition is gating as well as the mutex/lock.
+ * @brief This is an Event class built from a ConditionVariable. The Event adds the state
+ *        that the condition is gating as well as the mutex/lock.
  *
- * This Event can be 'interruptible' (even though there is only a single place
- * in the code that uses this behavior).
+ *        This Event can be 'interruptible' (even though there is only a single place
+ *        in the code that uses this behavior).
  *
- * This class manages 'spurious returns' from the condition variable.
+ *        This class manages 'spurious returns' from the condition variable.
+ *
  */
+
 class CEvent
 {
   bool manualReset;
@@ -79,7 +80,10 @@ public:
   }
   void Set();
 
-  /** Returns true if Event has been triggered and not reset, false otherwise. */
+  /**
+   * @brief Returns true if Event has been triggered and not reset, false otherwise.
+   *
+   */
   inline bool Signaled()
   {
     CSingleLock lock(mutex);
@@ -87,9 +91,10 @@ public:
   }
 
   /**
-   * This will wait up to 'milliSeconds' milliseconds for the Event
-   *  to be triggered. The method will return 'true' if the Event
-   *  was triggered. Otherwise it will return false.
+   * @brief This will wait up to 'duration' for the Event to be
+   *        triggered. The method will return 'true' if the Event
+   *        was triggered. Otherwise it will return false.
+   *
    */
   template<typename Rep, typename Period>
   inline bool Wait(std::chrono::duration<Rep, Period> duration)
@@ -102,9 +107,10 @@ public:
   }
 
   /**
-   * This will wait for the Event to be triggered. The method will return
-   * 'true' if the Event was triggered. If it was either interrupted
-   * it will return false. Otherwise it will return false.
+   * @brief This will wait for the Event to be triggered. The method will return
+   *        'true' if the Event was triggered. If it was either interrupted
+   *        it will return false. Otherwise it will return false.
+   *
    */
   inline bool Wait()
   {
@@ -116,8 +122,9 @@ public:
   }
 
   /**
-   * This is mostly for testing. It allows a thread to make sure there are
-   *  the right amount of other threads waiting.
+   * @brief This is mostly for testing. It allows a thread to make sure there are
+   *        the right amount of other threads waiting.
+   *
    */
   inline int getNumWaits()
   {
@@ -129,10 +136,11 @@ public:
 namespace XbmcThreads
 {
 /**
-   * CEventGroup is a means of grouping CEvents to wait on them together.
-   * It is equivalent to WaitOnMultipleObject that returns when "any" Event
-   * in the group signaled.
-   */
+ * @brief  CEventGroup is a means of grouping CEvents to wait on them together.
+ *         It is equivalent to WaitOnMultipleObject that returns when "any" Event
+ *         in the group signaled.
+ *
+ */
 class CEventGroup
 {
   std::vector<CEvent*> events;
@@ -158,25 +166,29 @@ class CEventGroup
 
 public:
   /**
-     * Create a CEventGroup from a number of CEvents.
-     */
+   * @brief Create a CEventGroup from a number of CEvents.
+   *
+   */
   CEventGroup(std::initializer_list<CEvent*> events);
 
   ~CEventGroup();
 
   /**
-     * This will block until any one of the CEvents in the group are
-     * signaled at which point a pointer to that CEvents will be
-     * returned.
-     */
+   * @brief This will block until any one of the CEvents in the group are
+   *        signaled at which point a pointer to that CEvents will be
+   *        returned.
+   *
+   */
   CEvent* wait();
 
-  // locking is ALWAYS done in this order:
-  //  CEvent::groupListMutex -> CEventGroup::mutex -> CEvent::mutex
-  //
-  // Notice that this method doesn't grab the CEvent::groupListMutex at all. This
-  // is fine. It just grabs the CEventGroup::mutex and THEN the individual
-  // CEvent::mutex's
+  /**
+   * @brief locking is ALWAYS done in this order:
+   *        CEvent::groupListMutex -> CEventGroup::mutex -> CEvent::mutex
+   *
+   *        Notice that this method doesn't grab the CEvent::groupListMutex at all. This
+   *        is fine. It just grabs the CEventGroup::mutex and THEN the individual
+   *
+   */
   template<typename Rep, typename Period>
   CEvent* wait(std::chrono::duration<Rep, Period> duration)
   {
@@ -221,9 +233,10 @@ public:
   }
 
   /**
-     * This is mostly for testing. It allows a thread to make sure there are
-     *  the right amount of other threads waiting.
-     */
+   * @brief This is mostly for testing. It allows a thread to make sure there are
+   *        the right amount of other threads waiting.
+   *
+   */
   inline int getNumWaits()
   {
     CSingleLock lock(mutex);

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -76,7 +76,7 @@ public:
    *  was triggered. Otherwise it will return false.
    */
   template<typename Rep, typename Period>
-  inline bool WaitMSec(std::chrono::duration<Rep, Period> duration)
+  inline bool Wait(std::chrono::duration<Rep, Period> duration)
   {
     CSingleLock lock(mutex);
     numWaits++;

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -75,8 +75,15 @@ public:
    *  to be triggered. The method will return 'true' if the Event
    *  was triggered. Otherwise it will return false.
    */
-  inline bool WaitMSec(unsigned int milliSeconds)
-  { CSingleLock lock(mutex); numWaits++; condVar.wait(mutex,milliSeconds); numWaits--; return prepReturn(); }
+  template<typename Rep, typename Period>
+  inline bool WaitMSec(std::chrono::duration<Rep, Period> duration)
+  {
+    CSingleLock lock(mutex);
+    numWaits++;
+    condVar.wait(mutex, duration);
+    numWaits--;
+    return prepReturn();
+  }
 
   /**
    * This will wait for the Event to be triggered. The method will return

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -230,14 +230,6 @@ void CThread::TermHandler()
 {
 }
 
-void CThread::Sleep(unsigned int milliseconds)
-{
-  if (milliseconds > 10 && IsCurrentThread())
-    m_StopEvent.Wait(std::chrono::milliseconds(milliseconds));
-  else
-    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
-}
-
 bool CThread::Join(unsigned int milliseconds)
 {
   CSingleLock l(m_CriticalSection);

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -233,7 +233,7 @@ void CThread::TermHandler()
 void CThread::Sleep(unsigned int milliseconds)
 {
   if (milliseconds > 10 && IsCurrentThread())
-    m_StopEvent.WaitMSec(milliseconds);
+    m_StopEvent.WaitMSec(std::chrono::milliseconds(milliseconds));
   else
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -233,7 +233,7 @@ void CThread::TermHandler()
 void CThread::Sleep(unsigned int milliseconds)
 {
   if (milliseconds > 10 && IsCurrentThread())
-    m_StopEvent.WaitMSec(std::chrono::milliseconds(milliseconds));
+    m_StopEvent.Wait(std::chrono::milliseconds(milliseconds));
   else
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -200,7 +200,7 @@ void CThread::StopThread(bool bWait /*= true*/)
   if (lthread != nullptr && bWait && !IsCurrentThread())
   {
     lock.Leave();
-    if (!Join(0xFFFFFFFF)) // eh?
+    if (!Join(std::chrono::milliseconds::max())) // eh?
       lthread->join();
     m_thread = nullptr;
   }
@@ -230,7 +230,7 @@ void CThread::TermHandler()
 {
 }
 
-bool CThread::Join(unsigned int milliseconds)
+bool CThread::Join(std::chrono::milliseconds duration)
 {
   CSingleLock l(m_CriticalSection);
   std::thread* lthread = m_thread;
@@ -241,7 +241,7 @@ bool CThread::Join(unsigned int milliseconds)
 
     {
       CSingleExit exit(m_CriticalSection); // don't hold the thread lock while we're waiting
-      std::future_status stat = m_future.wait_for(std::chrono::milliseconds(milliseconds));
+      std::future_status stat = m_future.wait_for(duration);
       if (stat != std::future_status::ready)
         return false;
     }

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -85,7 +85,8 @@ protected:
   inline WaitResponse AbortableWait(CEvent& event, int timeoutMillis = -1 /* indicates wait forever*/)
   {
     XbmcThreads::CEventGroup group{&event, &m_StopEvent};
-    CEvent* result = timeoutMillis < 0 ? group.wait() : group.wait(timeoutMillis);
+    CEvent* result =
+        timeoutMillis < 0 ? group.wait() : group.wait(std::chrono::milliseconds(timeoutMillis));
     return  result == &event ? WAIT_SIGNALED :
       (result == NULL ? WAIT_TIMEDOUT : WAIT_INTERRUPTED);
   }

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -36,7 +36,16 @@ public:
   CThread(IRunnable* pRunnable, const char* ThreadName);
   virtual ~CThread();
   void Create(bool bAutoDelete = false);
-  void Sleep(unsigned int milliseconds);
+
+  template<typename Rep, typename Period>
+  void Sleep(std::chrono::duration<Rep, Period> duration)
+  {
+    if (duration > std::chrono::milliseconds(10) && IsCurrentThread())
+      m_StopEvent.Wait(duration);
+    else
+      std::this_thread::sleep_for(duration);
+  }
+
   bool IsAutoDelete() const;
   virtual void StopThread(bool bWait = true);
   bool IsRunning() const;

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -91,11 +91,13 @@ protected:
    *  stop is called on the thread the wait will return with a response
    *  indicating what happened.
    */
-  inline WaitResponse AbortableWait(CEvent& event, int timeoutMillis = -1 /* indicates wait forever*/)
+  inline WaitResponse AbortableWait(CEvent& event,
+                                    std::chrono::milliseconds duration =
+                                        std::chrono::milliseconds(-1) /* indicates wait forever*/)
   {
     XbmcThreads::CEventGroup group{&event, &m_StopEvent};
     CEvent* result =
-        timeoutMillis < 0 ? group.wait() : group.wait(std::chrono::milliseconds(timeoutMillis));
+        duration < std::chrono::milliseconds::zero() ? group.wait() : group.wait(duration);
     return  result == &event ? WAIT_SIGNALED :
       (result == NULL ? WAIT_TIMEDOUT : WAIT_INTERRUPTED);
   }

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -51,7 +51,7 @@ public:
   bool IsRunning() const;
 
   bool IsCurrentThread() const;
-  bool Join(unsigned int milliseconds);
+  bool Join(std::chrono::milliseconds duration);
 
   inline static const std::thread::id GetCurrentThreadId()
   {

--- a/xbmc/threads/Timer.cpp
+++ b/xbmc/threads/Timer.cpp
@@ -10,11 +10,10 @@
 
 #include <algorithm>
 
+using namespace std::chrono_literals;
+
 CTimer::CTimer(std::function<void()> const& callback)
-  : CThread("Timer"),
-    m_callback(callback),
-    m_timeout(std::chrono::milliseconds(0)),
-    m_interval(false)
+  : CThread("Timer"), m_callback(callback), m_timeout(0ms), m_interval(false)
 { }
 
 CTimer::CTimer(ITimerCallback *callback)
@@ -26,12 +25,12 @@ CTimer::~CTimer()
   Stop(true);
 }
 
-bool CTimer::Start(uint32_t timeout, bool interval /* = false */)
+bool CTimer::Start(std::chrono::milliseconds timeout, bool interval /* = false */)
 {
-  if (m_callback == NULL || timeout == 0 || IsRunning())
+  if (m_callback == NULL || timeout == 0ms || IsRunning())
     return false;
 
-  m_timeout = std::chrono::milliseconds(timeout);
+  m_timeout = timeout;
   m_interval = interval;
 
   Create();
@@ -50,10 +49,10 @@ bool CTimer::Stop(bool wait /* = false */)
   return true;
 }
 
-void CTimer::RestartAsync(uint32_t timeout)
+void CTimer::RestartAsync(std::chrono::milliseconds timeout)
 {
-  m_timeout = std::chrono::milliseconds(timeout);
-  m_endTime = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+  m_timeout = timeout;
+  m_endTime = std::chrono::steady_clock::now() + timeout;
   m_eventTimeout.Set();
 }
 
@@ -64,8 +63,7 @@ bool CTimer::Restart()
 
   Stop(true);
 
-  //! @todo: fix method to use std::chrono::milliseconds
-  return Start(m_timeout.count(), m_interval);
+  return Start(m_timeout, m_interval);
 }
 
 float CTimer::GetElapsedSeconds() const

--- a/xbmc/threads/Timer.cpp
+++ b/xbmc/threads/Timer.cpp
@@ -94,7 +94,7 @@ void CTimer::Process()
     // wait the necessary time
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(m_endTime - currentTime);
 
-    if (!m_eventTimeout.WaitMSec(duration.count()))
+    if (!m_eventTimeout.WaitMSec(duration))
     {
       currentTime = std::chrono::steady_clock::now();
       if (m_endTime <= currentTime)

--- a/xbmc/threads/Timer.cpp
+++ b/xbmc/threads/Timer.cpp
@@ -94,7 +94,7 @@ void CTimer::Process()
     // wait the necessary time
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(m_endTime - currentTime);
 
-    if (!m_eventTimeout.WaitMSec(duration))
+    if (!m_eventTimeout.Wait(duration))
     {
       currentTime = std::chrono::steady_clock::now();
       if (m_endTime <= currentTime)

--- a/xbmc/threads/Timer.h
+++ b/xbmc/threads/Timer.h
@@ -29,10 +29,10 @@ public:
   explicit CTimer(std::function<void()> const& callback);
   ~CTimer() override;
 
-  bool Start(uint32_t timeout, bool interval = false);
+  bool Start(std::chrono::milliseconds timeout, bool interval = false);
   bool Stop(bool wait = false);
   bool Restart();
-  void RestartAsync(uint32_t timeout);
+  void RestartAsync(std::chrono::milliseconds timeout);
 
   bool IsRunning() const { return CThread::IsRunning(); }
 

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -41,19 +41,23 @@ public:
 class timed_waiter : public IRunnable
 {
   CEvent& event;
-  unsigned int waitTime;
+  std::chrono::milliseconds waitTime;
+
 public:
   int& result;
 
   volatile bool waiting;
 
-  timed_waiter(CEvent& o, int& flag, int waitTimeMillis) : event(o), waitTime(waitTimeMillis), result(flag), waiting(false) {}
+  timed_waiter(CEvent& o, int& flag, std::chrono::milliseconds waitTimeMillis)
+    : event(o), waitTime(waitTimeMillis), result(flag), waiting(false)
+  {
+  }
 
   void Run() override
   {
     waiting = true;
     result = 0;
-    result = event.Wait(std::chrono::milliseconds(waitTime)) ? 1 : -1;
+    result = event.Wait(waitTime) ? 1 : -1;
     waiting = false;
   }
 };
@@ -129,7 +133,7 @@ TEST(TestEvent, TimedWaits)
 {
   CEvent event;
   int result1 = 10;
-  timed_waiter w1(event,result1,100);
+  timed_waiter w1(event, result1, 100ms);
   thread waitThread1(w1);
 
   EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
@@ -147,7 +151,7 @@ TEST(TestEvent, TimedWaitsTimeout)
 {
   CEvent event;
   int result1 = 10;
-  timed_waiter w1(event,result1,50);
+  timed_waiter w1(event, result1, 50ms);
   thread waitThread1(w1);
 
   EXPECT_TRUE(waitForWaiters(event, 1, 100ms));

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -95,7 +95,7 @@ TEST(TestEvent, General)
 
   event.Set();
 
-  EXPECT_TRUE(waitThread.timed_join(10000));
+  EXPECT_TRUE(waitThread.timed_join(10000ms));
 
   EXPECT_TRUE(result);
 }
@@ -117,8 +117,8 @@ TEST(TestEvent, TwoWaits)
 
   event.Set();
 
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-  EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
+  EXPECT_TRUE(waitThread2.timed_join(10000ms));
 
   EXPECT_TRUE(result1);
   EXPECT_TRUE(result2);
@@ -138,7 +138,7 @@ TEST(TestEvent, TimedWaits)
 
   event.Set();
 
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
 
   EXPECT_TRUE(result1 == 1);
 }
@@ -154,7 +154,7 @@ TEST(TestEvent, TimedWaitsTimeout)
 
   EXPECT_TRUE(result1 == 0);
 
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
 
   EXPECT_TRUE(result1 == -1);
 }
@@ -189,8 +189,8 @@ TEST(TestEvent, Group)
 
   event1.Set();
 
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-  EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
+  EXPECT_TRUE(waitThread3.timed_join(10000ms));
   std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
@@ -202,8 +202,7 @@ TEST(TestEvent, Group)
 
   event2.Set();
 
-  EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
-
+  EXPECT_TRUE(waitThread2.timed_join(10000ms));
 }
 
 /* Test disabled for now, because it deadlocks
@@ -238,8 +237,8 @@ TEST(TestEvent, GroupLimitedGroupScope)
 
     event1.Set();
 
-    EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-    EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
+    EXPECT_TRUE(waitThread1.timed_join(10000ms));
+    EXPECT_TRUE(waitThread3.timed_join(10000ms));
     std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(result1);
@@ -291,9 +290,9 @@ TEST(TestEvent, TwoGroups)
 
   event1.Set();
 
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-  EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
-  EXPECT_TRUE(waitThread4.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
+  EXPECT_TRUE(waitThread3.timed_join(10000ms));
+  EXPECT_TRUE(waitThread4.timed_join(10000ms));
   std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
@@ -307,7 +306,7 @@ TEST(TestEvent, TwoGroups)
 
   event2.Set();
 
-  EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread2.timed_join(10000ms));
 }
 
 TEST(TestEvent, AutoResetBehavior)
@@ -334,7 +333,7 @@ TEST(TestEvent, ManualReset)
 
   event.Set();
 
-  EXPECT_TRUE(waitThread.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread.timed_join(10000ms));
 
   EXPECT_TRUE(result);
 
@@ -378,8 +377,8 @@ TEST(TestEvent, GroupChildSet)
   thread waitThread3(w3);
 
   EXPECT_TRUE(waitForWaiters(event2, 1, 10000ms));
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-  EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
+  EXPECT_TRUE(waitThread3.timed_join(10000ms));
   std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
@@ -390,7 +389,7 @@ TEST(TestEvent, GroupChildSet)
 
   event2.Set();
 
-  EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread2.timed_join(10000ms));
 }
 
 TEST(TestEvent, GroupChildSet2)
@@ -412,8 +411,8 @@ TEST(TestEvent, GroupChildSet2)
   thread waitThread3(w3);
 
   EXPECT_TRUE(waitForWaiters(event2, 1, 10000ms));
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-  EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
+  EXPECT_TRUE(waitThread3.timed_join(10000ms));
   std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
@@ -424,7 +423,7 @@ TEST(TestEvent, GroupChildSet2)
 
   event2.Set();
 
-  EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread2.timed_join(10000ms));
 }
 
 TEST(TestEvent, GroupWaitResetsChild)
@@ -445,7 +444,7 @@ TEST(TestEvent, GroupWaitResetsChild)
 
   event2.Set();
 
-  EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread3.timed_join(10000ms));
 
   EXPECT_TRUE(!w3.waiting);
   EXPECT_TRUE(w3.result == &event2);
@@ -485,7 +484,7 @@ TEST(TestEvent, GroupTimedWait)
   EXPECT_TRUE(w3.result == NULL);
 
   // this should end given the wait is for only 50 millis
-  EXPECT_TRUE(waitThread3.timed_join(MILLIS(200)));
+  EXPECT_TRUE(waitThread3.timed_join(200ms));
 
   EXPECT_TRUE(!w3.waiting);
   EXPECT_TRUE(w3.result == NULL);
@@ -500,8 +499,8 @@ TEST(TestEvent, GroupTimedWait)
 
   event1.Set();
 
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-  EXPECT_TRUE(waitThread4.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
+  EXPECT_TRUE(waitThread4.timed_join(10000ms));
   std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
@@ -512,7 +511,7 @@ TEST(TestEvent, GroupTimedWait)
 
   event2.Set();
 
-  EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread2.timed_join(10000ms));
 }
 
 #define TESTNUM 100000l
@@ -583,7 +582,7 @@ template <class W> void RunMassEventTest(std::vector<std::shared_ptr<W>>& m, boo
 
   for(size_t i=0; i<NUMTHREADS; i++)
   {
-    EXPECT_TRUE(t[i]->timed_join(MILLIS(10000)));
+    EXPECT_TRUE(t[i]->timed_join(10000ms));
   }
 
   for(size_t i=0; i<NUMTHREADS; i++)

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -191,7 +191,7 @@ TEST(TestEvent, Group)
 
   EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
-  SleepMillis(10);
+  std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
   EXPECT_TRUE(!w1.waiting);
@@ -240,7 +240,7 @@ TEST(TestEvent, GroupLimitedGroupScope)
 
     EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
     EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
-    SleepMillis(10);
+    std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(result1);
     EXPECT_TRUE(!w1.waiting);
@@ -252,7 +252,7 @@ TEST(TestEvent, GroupLimitedGroupScope)
 
   event2.Set();
 
-  SleepMillis(50); // give thread 2 a chance to exit
+  std::this_thread::sleep_for(50ms); // give thread 2 a chance to exit
 }*/
 
 TEST(TestEvent, TwoGroups)
@@ -294,7 +294,7 @@ TEST(TestEvent, TwoGroups)
   EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread4.timed_join(MILLIS(10000)));
-  SleepMillis(10);
+  std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
   EXPECT_TRUE(!w1.waiting);
@@ -380,7 +380,7 @@ TEST(TestEvent, GroupChildSet)
   EXPECT_TRUE(waitForWaiters(event2,1,10000));
   EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
-  SleepMillis(10);
+  std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
   EXPECT_TRUE(!result2);
@@ -414,7 +414,7 @@ TEST(TestEvent, GroupChildSet2)
   EXPECT_TRUE(waitForWaiters(event2,1,10000));
   EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
-  SleepMillis(10);
+  std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
   EXPECT_TRUE(!result2);
@@ -502,7 +502,7 @@ TEST(TestEvent, GroupTimedWait)
 
   EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread4.timed_join(MILLIS(10000)));
-  SleepMillis(10);
+  std::this_thread::sleep_for(10ms);
 
   EXPECT_TRUE(result1);
   EXPECT_TRUE(!result2);
@@ -572,7 +572,7 @@ template <class W> void RunMassEventTest(std::vector<std::shared_ptr<W>>& m, boo
     EXPECT_TRUE(waitForWaiters(*g_event,NUMTHREADS,10000));
   }
 
-  SleepMillis(100);// give them a little more time
+  std::this_thread::sleep_for(100ms); // give them a little more time
 
   for(size_t i=0; i<NUMTHREADS; i++)
   {

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -75,7 +75,7 @@ public:
     if (timeout == -1)
       result = event.wait();
     else
-      result = event.wait((unsigned int)timeout);
+      result = event.wait(std::chrono::milliseconds(timeout));
     waiting = false;
   }
 };
@@ -471,7 +471,7 @@ TEST(TestEvent, GroupTimedWait)
   EXPECT_TRUE(waitForWaiters(event1,1,10000));
   EXPECT_TRUE(waitForWaiters(event2,1,10000));
 
-  EXPECT_TRUE(group.wait(20) == NULL); // waited ... got nothing
+  EXPECT_TRUE(group.wait(20ms) == NULL); // waited ... got nothing
 
   group_wait w3(group,50);
   thread waitThread3(w3);

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -14,6 +14,7 @@
 #include <stdio.h>
 
 using namespace XbmcThreads;
+using namespace std::chrono_literals;
 
 //=============================================================================
 // Helper classes
@@ -52,7 +53,7 @@ public:
   {
     waiting = true;
     result = 0;
-    result = event.WaitMSec(waitTime) ? 1 : -1;
+    result = event.WaitMSec(std::chrono::milliseconds(waitTime)) ? 1 : -1;
     waiting = false;
   }
 };
@@ -313,11 +314,11 @@ TEST(TestEvent, AutoResetBehavior)
 {
   CEvent event;
 
-  EXPECT_TRUE(!event.WaitMSec(1));
+  EXPECT_TRUE(!event.WaitMSec(1ms));
 
   event.Set(); // event will remain signaled if there are no waits
 
-  EXPECT_TRUE(event.WaitMSec(1));
+  EXPECT_TRUE(event.WaitMSec(1ms));
 }
 
 TEST(TestEvent, ManualReset)
@@ -338,23 +339,23 @@ TEST(TestEvent, ManualReset)
   EXPECT_TRUE(result);
 
   // with manual reset, the state should remain signaled
-  EXPECT_TRUE(event.WaitMSec(1));
+  EXPECT_TRUE(event.WaitMSec(1ms));
 
   event.Reset();
 
-  EXPECT_TRUE(!event.WaitMSec(1));
+  EXPECT_TRUE(!event.WaitMSec(1ms));
 }
 
 TEST(TestEvent, InitVal)
 {
   CEvent event(false,true);
-  EXPECT_TRUE(event.WaitMSec(50));
+  EXPECT_TRUE(event.WaitMSec(50ms));
 }
 
 TEST(TestEvent, SimpleTimeout)
 {
   CEvent event;
-  EXPECT_TRUE(!event.WaitMSec(50));
+  EXPECT_TRUE(!event.WaitMSec(50ms));
 }
 
 TEST(TestEvent, GroupChildSet)
@@ -449,7 +450,7 @@ TEST(TestEvent, GroupWaitResetsChild)
   EXPECT_TRUE(!w3.waiting);
   EXPECT_TRUE(w3.result == &event2);
   // event2 should have been reset.
-  EXPECT_TRUE(event2.WaitMSec(1) == false);
+  EXPECT_TRUE(event2.WaitMSec(1ms) == false);
 }
 
 TEST(TestEvent, GroupTimedWait)
@@ -553,7 +554,8 @@ public:
   {
     waiting = true;
     AtomicGuard g(&g_mutex);
-    while ((result = event.WaitMSec(0)) == false);
+    while ((result = event.WaitMSec(0ms)) == false)
+      ;
     waiting = false;
   }
 };

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -89,7 +89,7 @@ TEST(TestEvent, General)
   waiter w1(event,result);
   thread waitThread(w1);
 
-  EXPECT_TRUE(waitForWaiters(event,1,10000));
+  EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
 
   EXPECT_TRUE(!result);
 
@@ -110,7 +110,7 @@ TEST(TestEvent, TwoWaits)
   thread waitThread1(w1);
   thread waitThread2(w2);
 
-  EXPECT_TRUE(waitForWaiters(event,2,10000));
+  EXPECT_TRUE(waitForWaiters(event, 2, 10000ms));
 
   EXPECT_TRUE(!result1);
   EXPECT_TRUE(!result2);
@@ -132,7 +132,7 @@ TEST(TestEvent, TimedWaits)
   timed_waiter w1(event,result1,100);
   thread waitThread1(w1);
 
-  EXPECT_TRUE(waitForWaiters(event,1,10000));
+  EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
 
   EXPECT_TRUE(result1 == 0);
 
@@ -150,7 +150,7 @@ TEST(TestEvent, TimedWaitsTimeout)
   timed_waiter w1(event,result1,50);
   thread waitThread1(w1);
 
-  EXPECT_TRUE(waitForWaiters(event,1,100));
+  EXPECT_TRUE(waitForWaiters(event, 1, 100ms));
 
   EXPECT_TRUE(result1 == 0);
 
@@ -177,9 +177,9 @@ TEST(TestEvent, Group)
   thread waitThread2(w2);
   thread waitThread3(w3);
 
-  EXPECT_TRUE(waitForWaiters(event1,1,10000));
-  EXPECT_TRUE(waitForWaiters(event2,1,10000));
-  EXPECT_TRUE(waitForWaiters(group,1,10000));
+  EXPECT_TRUE(waitForWaiters(event1, 1, 10000ms));
+  EXPECT_TRUE(waitForWaiters(event2, 1, 10000ms));
+  EXPECT_TRUE(waitForWaiters(group, 1, 10000ms));
 
   EXPECT_TRUE(!result1);
   EXPECT_TRUE(!result2);
@@ -226,9 +226,9 @@ TEST(TestEvent, GroupLimitedGroupScope)
     thread waitThread2(w2);
     thread waitThread3(w3);
 
-    EXPECT_TRUE(waitForWaiters(event1,1,10000));
-    EXPECT_TRUE(waitForWaiters(event2,1,10000));
-    EXPECT_TRUE(waitForWaiters(group,1,10000));
+    EXPECT_TRUE(waitForWaiters(event1,1,10000ms));
+    EXPECT_TRUE(waitForWaiters(event2,1,10000ms));
+    EXPECT_TRUE(waitForWaiters(group,1,10000ms));
 
     EXPECT_TRUE(!result1);
     EXPECT_TRUE(!result2);
@@ -276,10 +276,10 @@ TEST(TestEvent, TwoGroups)
   thread waitThread3(w3);
   thread waitThread4(w4);
 
-  EXPECT_TRUE(waitForWaiters(event1,1,10000));
-  EXPECT_TRUE(waitForWaiters(event2,1,10000));
-  EXPECT_TRUE(waitForWaiters(group1,1,10000));
-  EXPECT_TRUE(waitForWaiters(group2,1,10000));
+  EXPECT_TRUE(waitForWaiters(event1, 1, 10000ms));
+  EXPECT_TRUE(waitForWaiters(event2, 1, 10000ms));
+  EXPECT_TRUE(waitForWaiters(group1, 1, 10000ms));
+  EXPECT_TRUE(waitForWaiters(group2, 1, 10000ms));
 
   EXPECT_TRUE(!result1);
   EXPECT_TRUE(!result2);
@@ -328,7 +328,7 @@ TEST(TestEvent, ManualReset)
   waiter w1(event,result);
   thread waitThread(w1);
 
-  EXPECT_TRUE(waitForWaiters(event,1,10000));
+  EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
 
   EXPECT_TRUE(!result);
 
@@ -377,7 +377,7 @@ TEST(TestEvent, GroupChildSet)
   thread waitThread2(w2);
   thread waitThread3(w3);
 
-  EXPECT_TRUE(waitForWaiters(event2,1,10000));
+  EXPECT_TRUE(waitForWaiters(event2, 1, 10000ms));
   EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
   std::this_thread::sleep_for(10ms);
@@ -411,7 +411,7 @@ TEST(TestEvent, GroupChildSet2)
   thread waitThread2(w2);
   thread waitThread3(w3);
 
-  EXPECT_TRUE(waitForWaiters(event2,1,10000));
+  EXPECT_TRUE(waitForWaiters(event2, 1, 10000ms));
   EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
   EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
   std::this_thread::sleep_for(10ms);
@@ -438,7 +438,7 @@ TEST(TestEvent, GroupWaitResetsChild)
 
   thread waitThread3(w3);
 
-  EXPECT_TRUE(waitForWaiters(group,1,10000));
+  EXPECT_TRUE(waitForWaiters(group, 1, 10000ms));
 
   EXPECT_TRUE(w3.waiting);
   EXPECT_TRUE(w3.result == NULL);
@@ -468,15 +468,15 @@ TEST(TestEvent, GroupTimedWait)
   thread waitThread1(w1);
   thread waitThread2(w2);
 
-  EXPECT_TRUE(waitForWaiters(event1,1,10000));
-  EXPECT_TRUE(waitForWaiters(event2,1,10000));
+  EXPECT_TRUE(waitForWaiters(event1, 1, 10000ms));
+  EXPECT_TRUE(waitForWaiters(event2, 1, 10000ms));
 
   EXPECT_TRUE(group.wait(20ms) == NULL); // waited ... got nothing
 
   group_wait w3(group,50);
   thread waitThread3(w3);
 
-  EXPECT_TRUE(waitForWaiters(group,1,10000));
+  EXPECT_TRUE(waitForWaiters(group, 1, 10000ms));
 
   EXPECT_TRUE(!result1);
   EXPECT_TRUE(!result2);
@@ -493,7 +493,7 @@ TEST(TestEvent, GroupTimedWait)
   group_wait w4(group,50);
   thread waitThread4(w4);
 
-  EXPECT_TRUE(waitForWaiters(group,1,10000));
+  EXPECT_TRUE(waitForWaiters(group, 1, 10000ms));
 
   EXPECT_TRUE(w4.waiting);
   EXPECT_TRUE(w4.result == NULL);
@@ -566,10 +566,10 @@ template <class W> void RunMassEventTest(std::vector<std::shared_ptr<W>>& m, boo
   for(size_t i=0; i<NUMTHREADS; i++)
     t[i].reset(new thread(*m[i]));
 
-  EXPECT_TRUE(waitForThread(g_mutex,NUMTHREADS,10000));
+  EXPECT_TRUE(waitForThread(g_mutex, NUMTHREADS, 10000ms));
   if (canWaitOnEvent)
   {
-    EXPECT_TRUE(waitForWaiters(*g_event,NUMTHREADS,10000));
+    EXPECT_TRUE(waitForWaiters(*g_event, NUMTHREADS, 10000ms));
   }
 
   std::this_thread::sleep_for(100ms); // give them a little more time

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -53,7 +53,7 @@ public:
   {
     waiting = true;
     result = 0;
-    result = event.WaitMSec(std::chrono::milliseconds(waitTime)) ? 1 : -1;
+    result = event.Wait(std::chrono::milliseconds(waitTime)) ? 1 : -1;
     waiting = false;
   }
 };
@@ -314,11 +314,11 @@ TEST(TestEvent, AutoResetBehavior)
 {
   CEvent event;
 
-  EXPECT_TRUE(!event.WaitMSec(1ms));
+  EXPECT_TRUE(!event.Wait(1ms));
 
   event.Set(); // event will remain signaled if there are no waits
 
-  EXPECT_TRUE(event.WaitMSec(1ms));
+  EXPECT_TRUE(event.Wait(1ms));
 }
 
 TEST(TestEvent, ManualReset)
@@ -339,23 +339,23 @@ TEST(TestEvent, ManualReset)
   EXPECT_TRUE(result);
 
   // with manual reset, the state should remain signaled
-  EXPECT_TRUE(event.WaitMSec(1ms));
+  EXPECT_TRUE(event.Wait(1ms));
 
   event.Reset();
 
-  EXPECT_TRUE(!event.WaitMSec(1ms));
+  EXPECT_TRUE(!event.Wait(1ms));
 }
 
 TEST(TestEvent, InitVal)
 {
   CEvent event(false,true);
-  EXPECT_TRUE(event.WaitMSec(50ms));
+  EXPECT_TRUE(event.Wait(50ms));
 }
 
 TEST(TestEvent, SimpleTimeout)
 {
   CEvent event;
-  EXPECT_TRUE(!event.WaitMSec(50ms));
+  EXPECT_TRUE(!event.Wait(50ms));
 }
 
 TEST(TestEvent, GroupChildSet)
@@ -450,7 +450,7 @@ TEST(TestEvent, GroupWaitResetsChild)
   EXPECT_TRUE(!w3.waiting);
   EXPECT_TRUE(w3.result == &event2);
   // event2 should have been reset.
-  EXPECT_TRUE(event2.WaitMSec(1ms) == false);
+  EXPECT_TRUE(event2.Wait(1ms) == false);
 }
 
 TEST(TestEvent, GroupTimedWait)
@@ -554,7 +554,7 @@ public:
   {
     waiting = true;
     AtomicGuard g(&g_mutex);
-    while ((result = event.WaitMSec(0ms)) == false)
+    while ((result = event.Wait(0ms)) == false)
       ;
     waiting = false;
   }

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -65,21 +65,26 @@ public:
 class group_wait : public IRunnable
 {
   CEventGroup& event;
-  int timeout;
+  std::chrono::milliseconds timeout;
+
 public:
   CEvent* result;
   bool waiting;
 
-  group_wait(CEventGroup& o) : event(o), timeout(-1), result(NULL), waiting(false) {}
-  group_wait(CEventGroup& o, int timeout_) : event(o), timeout(timeout_), result(NULL), waiting(false) {}
+  group_wait(CEventGroup& o) : event(o), timeout(-1ms), result(NULL), waiting(false) {}
+
+  group_wait(CEventGroup& o, std::chrono::milliseconds timeout_)
+    : event(o), timeout(timeout_), result(NULL), waiting(false)
+  {
+  }
 
   void Run() override
   {
     waiting = true;
-    if (timeout == -1)
+    if (timeout == -1ms)
       result = event.wait();
     else
-      result = event.wait(std::chrono::milliseconds(timeout));
+      result = event.wait(timeout);
     waiting = false;
   }
 };
@@ -476,7 +481,7 @@ TEST(TestEvent, GroupTimedWait)
 
   EXPECT_TRUE(group.wait(20ms) == NULL); // waited ... got nothing
 
-  group_wait w3(group,50);
+  group_wait w3(group, 50ms);
   thread waitThread3(w3);
 
   EXPECT_TRUE(waitForWaiters(group, 1, 10000ms));
@@ -493,7 +498,7 @@ TEST(TestEvent, GroupTimedWait)
   EXPECT_TRUE(!w3.waiting);
   EXPECT_TRUE(w3.result == NULL);
 
-  group_wait w4(group,50);
+  group_wait w4(group, 50ms);
   thread waitThread4(w4);
 
   EXPECT_TRUE(waitForWaiters(group, 1, 10000ms));

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -76,14 +76,8 @@ public:
   inline thread(thread& other) : f(other.f), cthread(other.cthread) { other.f = NULL; other.cthread = NULL; }
   inline thread& operator=(thread& other) { f = other.f; other.f = NULL; cthread = other.cthread; other.cthread = NULL; return *this; }
 
-  void join()
-  {
-    cthread->Join(static_cast<unsigned int>(-1));
-  }
+  void join() { cthread->Join(std::chrono::milliseconds::max()); }
 
-  bool timed_join(unsigned int millis)
-  {
-    return cthread->Join(millis);
-  }
+  bool timed_join(unsigned int millis) { return cthread->Join(std::chrono::milliseconds(millis)); }
 };
 

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -12,8 +12,6 @@
 
 #include <gtest/gtest.h>
 
-#define MILLIS(x) x
-
 template<class E>
 inline static bool waitForWaiters(E& event, int numWaiters, std::chrono::milliseconds duration)
 {
@@ -80,6 +78,6 @@ public:
 
   void join() { cthread->Join(std::chrono::milliseconds::max()); }
 
-  bool timed_join(unsigned int millis) { return cthread->Join(std::chrono::milliseconds(millis)); }
+  bool timed_join(std::chrono::milliseconds duration) { return cthread->Join(duration); }
 };
 

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -14,21 +14,26 @@
 
 #define MILLIS(x) x
 
-template<class E> inline static bool waitForWaiters(E& event, int numWaiters, int milliseconds)
+template<class E>
+inline static bool waitForWaiters(E& event, int numWaiters, std::chrono::milliseconds duration)
 {
-  for( int i = 0; i < milliseconds; i++)
+  for (auto i = std::chrono::milliseconds::zero(); i < duration; i++)
   {
     if (event.getNumWaits() == numWaiters)
       return true;
+
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+
   return false;
 }
 
-inline static bool waitForThread(std::atomic<long>& mutex, int numWaiters, int milliseconds)
+inline static bool waitForThread(std::atomic<long>& mutex,
+                                 int numWaiters,
+                                 std::chrono::milliseconds duration)
 {
   CCriticalSection sec;
-  for( int i = 0; i < milliseconds; i++)
+  for (auto i = std::chrono::milliseconds::zero(); i < duration; i++)
   {
     if (mutex == (long)numWaiters)
       return true;
@@ -36,8 +41,10 @@ inline static bool waitForThread(std::atomic<long>& mutex, int numWaiters, int m
     {
       CSingleLock tmplock(sec); // kick any memory syncs
     }
+
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+
   return false;
 }
 

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -14,18 +14,13 @@
 
 #define MILLIS(x) x
 
-inline static void SleepMillis(unsigned int millis)
-{
-  std::this_thread::sleep_for(std::chrono::milliseconds(millis));
-}
-
 template<class E> inline static bool waitForWaiters(E& event, int numWaiters, int milliseconds)
 {
   for( int i = 0; i < milliseconds; i++)
   {
     if (event.getNumWaits() == numWaiters)
       return true;
-    SleepMillis(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return false;
 }
@@ -41,7 +36,7 @@ inline static bool waitForThread(std::atomic<long>& mutex, int numWaiters, int m
     {
       CSingleLock tmplock(sec); // kick any memory syncs
     }
-    SleepMillis(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return false;
 }

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -14,6 +14,8 @@
 
 #include <stdio.h>
 
+using namespace std::chrono_literals;
+
 //=============================================================================
 // Helper classes
 //=============================================================================
@@ -76,7 +78,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   thread waitThread1(l2); // try to get an exclusive lock
 
   EXPECT_TRUE(waitForThread(mutex,1,10000));
-  SleepMillis(10);  // still need to give it a chance to move ahead
+  std::this_thread::sleep_for(10ms); // still need to give it a chance to move ahead
 
   EXPECT_TRUE(!l2.haslock);  // this thread is waiting ...
   EXPECT_TRUE(!l2.obtainedlock);  // this thread is waiting ...
@@ -85,7 +87,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   locker<CSharedLock> l3(sec,&mutex,&event);
   thread waitThread3(l3); // try to get a shared lock
   EXPECT_TRUE(waitForThread(mutex,2,10000));
-  SleepMillis(10);
+  std::this_thread::sleep_for(10ms);
   EXPECT_TRUE(l3.haslock);
 
   event.Set();
@@ -134,14 +136,14 @@ TEST(TestSharedSection, TwoCase)
     thread waitThread2(l2); // thread should block
 
     EXPECT_TRUE(waitForThread(mutex,1,10000));
-    SleepMillis(10);
+    std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(!l2.haslock);
 
     lock.Leave();
 
     EXPECT_TRUE(waitForWaiters(event,1,10000));
-    SleepMillis(10);
+    std::this_thread::sleep_for(10ms);
     EXPECT_TRUE(l2.haslock);
 
     event.Set();
@@ -164,7 +166,7 @@ TEST(TestMultipleSharedSection, General)
     thread waitThread1(l1);
 
     EXPECT_TRUE(waitForThread(mutex,1,10000));
-    SleepMillis(10);
+    std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(l1.haslock);
 
@@ -185,7 +187,7 @@ TEST(TestMultipleSharedSection, General)
     thread waitThread4(l5);
 
     EXPECT_TRUE(waitForThread(mutex,4,10000));
-    SleepMillis(10);
+    std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(!l2.haslock);
     EXPECT_TRUE(!l3.haslock);

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -77,7 +77,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   locker<CExclusiveLock> l2(sec,&mutex);
   thread waitThread1(l2); // try to get an exclusive lock
 
-  EXPECT_TRUE(waitForThread(mutex,1,10000));
+  EXPECT_TRUE(waitForThread(mutex, 1, 10000ms));
   std::this_thread::sleep_for(10ms); // still need to give it a chance to move ahead
 
   EXPECT_TRUE(!l2.haslock);  // this thread is waiting ...
@@ -86,7 +86,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   // now try and get a SharedLock
   locker<CSharedLock> l3(sec,&mutex,&event);
   thread waitThread3(l3); // try to get a shared lock
-  EXPECT_TRUE(waitForThread(mutex,2,10000));
+  EXPECT_TRUE(waitForThread(mutex, 2, 10000ms));
   std::this_thread::sleep_for(10ms);
   EXPECT_TRUE(l3.haslock);
 
@@ -122,7 +122,7 @@ TEST(TestSharedSection, TwoCase)
     CSharedLock lock(sec);
     thread waitThread1(l1);
 
-    EXPECT_TRUE(waitForWaiters(event,1,10000));
+    EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
     EXPECT_TRUE(l1.haslock);
 
     event.Set();
@@ -135,14 +135,14 @@ TEST(TestSharedSection, TwoCase)
     CExclusiveLock lock(sec); // get exclusive lock
     thread waitThread2(l2); // thread should block
 
-    EXPECT_TRUE(waitForThread(mutex,1,10000));
+    EXPECT_TRUE(waitForThread(mutex, 1, 10000ms));
     std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(!l2.haslock);
 
     lock.Leave();
 
-    EXPECT_TRUE(waitForWaiters(event,1,10000));
+    EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
     std::this_thread::sleep_for(10ms);
     EXPECT_TRUE(l2.haslock);
 
@@ -165,7 +165,7 @@ TEST(TestMultipleSharedSection, General)
     CSharedLock lock(sec);
     thread waitThread1(l1);
 
-    EXPECT_TRUE(waitForThread(mutex,1,10000));
+    EXPECT_TRUE(waitForThread(mutex, 1, 10000ms));
     std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(l1.haslock);
@@ -186,7 +186,7 @@ TEST(TestMultipleSharedSection, General)
     thread waitThread3(l4);
     thread waitThread4(l5);
 
-    EXPECT_TRUE(waitForThread(mutex,4,10000));
+    EXPECT_TRUE(waitForThread(mutex, 4, 10000ms));
     std::this_thread::sleep_for(10ms);
 
     EXPECT_TRUE(!l2.haslock);
@@ -196,7 +196,7 @@ TEST(TestMultipleSharedSection, General)
 
     lock.Leave();
 
-    EXPECT_TRUE(waitForWaiters(event,4,10000));
+    EXPECT_TRUE(waitForWaiters(event, 4, 10000ms));
 
     EXPECT_TRUE(l2.haslock);
     EXPECT_TRUE(l3.haslock);

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -91,7 +91,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   EXPECT_TRUE(l3.haslock);
 
   event.Set();
-  EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread3.timed_join(10000ms));
 
   // l3 should have released.
   EXPECT_TRUE(!l3.haslock);
@@ -103,7 +103,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   // let it go
   l1.Leave(); // the last shared lock leaves.
 
-  EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
+  EXPECT_TRUE(waitThread1.timed_join(10000ms));
 
   EXPECT_TRUE(l2.obtainedlock);  // the exclusive lock was captured
   EXPECT_TRUE(!l2.haslock);  // ... but it doesn't have it anymore
@@ -127,7 +127,7 @@ TEST(TestSharedSection, TwoCase)
 
     event.Set();
 
-    EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
+    EXPECT_TRUE(waitThread1.timed_join(10000ms));
   }
 
   locker<CSharedLock> l2(sec,&mutex,&event);
@@ -148,7 +148,7 @@ TEST(TestSharedSection, TwoCase)
 
     event.Set();
 
-    EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
+    EXPECT_TRUE(waitThread2.timed_join(10000ms));
   }
 }
 
@@ -172,7 +172,7 @@ TEST(TestMultipleSharedSection, General)
 
     event.Set();
 
-    EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
+    EXPECT_TRUE(waitThread1.timed_join(10000ms));
   }
 
   locker<CSharedLock> l2(sec,&mutex,&event);
@@ -205,10 +205,10 @@ TEST(TestMultipleSharedSection, General)
 
     event.Set();
 
-    EXPECT_TRUE(waitThread1.timed_join(MILLIS(10000)));
-    EXPECT_TRUE(waitThread2.timed_join(MILLIS(10000)));
-    EXPECT_TRUE(waitThread3.timed_join(MILLIS(10000)));
-    EXPECT_TRUE(waitThread4.timed_join(MILLIS(10000)));
+    EXPECT_TRUE(waitThread1.timed_join(10000ms));
+    EXPECT_TRUE(waitThread2.timed_join(10000ms));
+    EXPECT_TRUE(waitThread3.timed_join(10000ms));
+    EXPECT_TRUE(waitThread4.timed_join(10000ms));
   }
 }
 

--- a/xbmc/utils/ActorProtocol.cpp
+++ b/xbmc/utils/ActorProtocol.cpp
@@ -235,7 +235,7 @@ bool Protocol::SendOutMessageSync(
   msg->event->Reset();
   SendOutMessage(signal, data, size, msg);
 
-  if (!msg->event->WaitMSec(std::chrono::milliseconds(timeout)))
+  if (!msg->event->Wait(std::chrono::milliseconds(timeout)))
   {
     const CSingleLock lock(criticalSection);
     if (msg->replyMessage)
@@ -266,7 +266,7 @@ bool Protocol::SendOutMessageSync(int signal, Message **retMsg, int timeout, CPa
   msg->event->Reset();
   SendOutMessage(signal, payload, msg);
 
-  if (!msg->event->WaitMSec(std::chrono::milliseconds(timeout)))
+  if (!msg->event->Wait(std::chrono::milliseconds(timeout)))
   {
     const CSingleLock lock(criticalSection);
     if (msg->replyMessage)

--- a/xbmc/utils/ActorProtocol.cpp
+++ b/xbmc/utils/ActorProtocol.cpp
@@ -235,7 +235,7 @@ bool Protocol::SendOutMessageSync(
   msg->event->Reset();
   SendOutMessage(signal, data, size, msg);
 
-  if (!msg->event->WaitMSec(timeout))
+  if (!msg->event->WaitMSec(std::chrono::milliseconds(timeout)))
   {
     const CSingleLock lock(criticalSection);
     if (msg->replyMessage)
@@ -266,7 +266,7 @@ bool Protocol::SendOutMessageSync(int signal, Message **retMsg, int timeout, CPa
   msg->event->Reset();
   SendOutMessage(signal, payload, msg);
 
-  if (!msg->event->WaitMSec(timeout))
+  if (!msg->event->WaitMSec(std::chrono::milliseconds(timeout)))
   {
     const CSingleLock lock(criticalSection);
     if (msg->replyMessage)

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 CAlarmClock::CAlarmClock() : CThread("AlarmClock")
 {
@@ -145,7 +146,7 @@ void CAlarmClock::Process()
         else
           strLast = iter->first;
     }
-    CThread::Sleep(100);
+    CThread::Sleep(100ms);
   }
 }
 

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -373,7 +373,7 @@ CJob *CJobManager::GetNextJob(const CJobWorker *worker)
       return job;
     // no jobs are left - sleep for 30 seconds to allow new jobs to come in
     lock.Leave();
-    bool newJob = m_jobEvent.WaitMSec(30000ms);
+    bool newJob = m_jobEvent.Wait(30000ms);
     lock.Enter();
     if (!newJob)
       break;

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -16,6 +16,8 @@
 #include <functional>
 #include <stdexcept>
 
+using namespace std::chrono_literals;
+
 bool CJob::ShouldCancel(unsigned int progress, unsigned int total) const
 {
   if (m_callback)
@@ -371,7 +373,7 @@ CJob *CJobManager::GetNextJob(const CJobWorker *worker)
       return job;
     // no jobs are left - sleep for 30 seconds to allow new jobs to come in
     lock.Leave();
-    bool newJob = m_jobEvent.WaitMSec(30000);
+    bool newJob = m_jobEvent.WaitMSec(30000ms);
     lock.Enter();
     if (!newJob)
       break;

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -29,6 +29,7 @@
 #define RSS_COLOR_CHANNEL   2
 
 using namespace XFILE;
+using namespace std::chrono_literals;
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -167,7 +168,7 @@ void CRssReader::Process()
             break;
           }
           else if (nRetries > 0)
-            CThread::Sleep(5000); // Network problems? Retry, but not immediately.
+            CThread::Sleep(5000ms); // Network problems? Retry, but not immediately.
           else
             CLog::Log(LOGERROR, "Unable to obtain rss feed: {}", strUrl);
         }

--- a/xbmc/utils/test/TestBitstreamStats.cpp
+++ b/xbmc/utils/test/TestBitstreamStats.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+using namespace std::chrono_literals;
+
 #define BITS (256 * 8)
 #define BYTES (256)
 
@@ -37,7 +39,7 @@ TEST(TestBitstreamStats, General)
   {
     a.AddSampleBits(1);
     i++;
-    t.Sleep(1);
+    t.Sleep(1ms);
   }
   a.CalculateBitrate();
   EXPECT_GT(a.GetBitrate(), 0.0);
@@ -48,7 +50,7 @@ TEST(TestBitstreamStats, General)
   while (i <= BYTES)
   {
     a.AddSampleBytes(1);
-    t.Sleep(2);
+    t.Sleep(2ms);
     i++;
   }
   a.CalculateBitrate();

--- a/xbmc/utils/test/TestStopwatch.cpp
+++ b/xbmc/utils/test/TestStopwatch.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+using namespace std::chrono_literals;
+
 class CTestStopWatchThread : public CThread
 {
 public:
@@ -46,7 +48,7 @@ TEST(TestStopWatch, ElapsedTime)
   CStopWatch a;
   CTestStopWatchThread thread;
   a.Start();
-  thread.Sleep(1);
+  thread.Sleep(1ms);
   EXPECT_GT(a.GetElapsedSeconds(), 0.0f);
   EXPECT_GT(a.GetElapsedMilliseconds(), 0.0f);
 }
@@ -56,9 +58,9 @@ TEST(TestStopWatch, Reset)
   CStopWatch a;
   CTestStopWatchThread thread;
   a.StartZero();
-  thread.Sleep(2);
+  thread.Sleep(2ms);
   EXPECT_GT(a.GetElapsedMilliseconds(), 1);
-  thread.Sleep(3);
+  thread.Sleep(3ms);
   a.Reset();
   EXPECT_LT(a.GetElapsedMilliseconds(), 5);
 }

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -16,6 +16,7 @@
 
 using namespace VIDEO;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 #ifndef __GNUC__
 #pragma warning (disable:4018)
@@ -122,7 +123,7 @@ int CVideoInfoDownloader::FindMovie(const std::string &movieTitle, int movieYear
         CloseThread();
         return 0;
       }
-      CThread::Sleep(1);
+      CThread::Sleep(1ms);
     }
     // transfer to our movielist
     m_movieList.swap(movieList);
@@ -171,7 +172,7 @@ bool CVideoInfoDownloader::GetDetails(const CScraperUrl &url,
         CloseThread();
         return false;
       }
-      CThread::Sleep(1);
+      CThread::Sleep(1ms);
     }
     movieDetails = m_movieDetails;
     CloseThread();
@@ -206,7 +207,7 @@ bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
         CloseThread();
         return false;
       }
-      CThread::Sleep(1);
+      CThread::Sleep(1ms);
     }
     movieDetails = m_movieDetails;
     CloseThread();
@@ -241,7 +242,7 @@ bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
         CloseThread();
         return false;
       }
-      CThread::Sleep(1);
+      CThread::Sleep(1ms);
     }
     movieDetails = m_episode;
     CloseThread();

--- a/xbmc/windowing/X11/OSScreenSaverX11.cpp
+++ b/xbmc/windowing/X11/OSScreenSaverX11.cpp
@@ -10,6 +10,8 @@
 
 #include <cassert>
 
+using namespace std::chrono_literals;
+
 COSScreenSaverX11::COSScreenSaverX11(Display* dpy)
 : m_dpy(dpy), m_screensaverResetTimer(std::bind(&COSScreenSaverX11::ResetScreenSaver, this))
 {
@@ -20,7 +22,7 @@ void COSScreenSaverX11::Inhibit()
 {
   // disallow the screensaver by periodically calling XResetScreenSaver(),
   // for some reason setting a 0 timeout with XSetScreenSaver doesn't work with gnome
-  m_screensaverResetTimer.Start(5000, true);
+  m_screensaverResetTimer.Start(5000ms, true);
 }
 
 void COSScreenSaverX11::Uninhibit()

--- a/xbmc/windowing/android/WinEventsAndroid.cpp
+++ b/xbmc/windowing/android/WinEventsAndroid.cpp
@@ -123,7 +123,7 @@ void CWinEventsAndroid::Process()
   while (!m_bStop)
   {
     // run a 10ms (timeout) wait cycle
-    CThread::Sleep(timeout);
+    CThread::Sleep(std::chrono::milliseconds(timeout));
 
     CSingleLock lock(m_lasteventCond);
 

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -40,6 +40,7 @@
 #include <EGL/eglplatform.h>
 
 using namespace KODI;
+using namespace std::chrono_literals;
 
 CWinSystemAndroid::CWinSystemAndroid()
 {
@@ -220,12 +221,13 @@ void CWinSystemAndroid::OnTimeout()
 
 void CWinSystemAndroid::InitiateModeChange()
 {
-  int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-                  "videoscreen.delayrefreshchange") *
-              100;
+  auto delay =
+      std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                    "videoscreen.delayrefreshchange") *
+                                100);
 
-  if (delay < 2000)
-    delay = 2000;
+  if (delay < 2000ms)
+    delay = 2000ms;
   m_dispResetTimer->Stop();
   m_dispResetTimer->Start(delay);
 

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -11,6 +11,7 @@
 #include "VideoLayerBridge.h"
 #include "drm/DRMUtils.h"
 #include "threads/CriticalSection.h"
+#include "threads/SystemClock.h"
 #include "windowing/WinSystem.h"
 
 #include "platform/linux/input/LibInputHandler.h"

--- a/xbmc/windowing/osx/VideoSyncOsx.mm
+++ b/xbmc/windowing/osx/VideoSyncOsx.mm
@@ -21,6 +21,8 @@
 #include <QuartzCore/CVDisplayLink.h>
 #include <unistd.h>
 
+using namespace std::chrono_literals;
+
 bool CVideoSyncOsx::Setup(PUPDATECLOCK func)
 {
   CLog::Log(LOGDEBUG, "CVideoSyncOsx::{} setting up OSX", __FUNCTION__);
@@ -82,7 +84,7 @@ void CVideoSyncOsx::OnLostDisplay()
   if (!m_displayLost)
   {
     m_displayLost = true;
-    m_lostEvent.WaitMSec(1000);
+    m_lostEvent.WaitMSec(1000ms);
   }
 }
 

--- a/xbmc/windowing/osx/VideoSyncOsx.mm
+++ b/xbmc/windowing/osx/VideoSyncOsx.mm
@@ -84,7 +84,7 @@ void CVideoSyncOsx::OnLostDisplay()
   if (!m_displayLost)
   {
     m_displayLost = true;
-    m_lostEvent.WaitMSec(1000ms);
+    m_lostEvent.Wait(1000ms);
   }
 }
 

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "threads/CriticalSection.h"
+#include "threads/SystemClock.h"
 #include "threads/Timer.h"
 #include "windowing/WinSystem.h"
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -59,6 +59,7 @@
 using namespace KODI;
 using namespace MESSAGING;
 using namespace WINDOWING;
+using namespace std::chrono_literals;
 
 //------------------------------------------------------------------------------------------
 // special object-c class for handling the NSWindowDidMoveNotification callback.
@@ -171,7 +172,7 @@ NSOpenGLContext* CWinSystemOSXImpl::m_lastOwnedContext = nil;
 // but no device reset for 3 secs
 // a timeout fires the reset callback
 // (for ensuring that e.x. AE isn't stuck)
-#define LOST_DEVICE_TIMEOUT_MS 3000
+constexpr auto LOST_DEVICE_TIMEOUT_MS = 3000ms;
 static NSWindow* blankingWindows[MAX_DISPLAYS];
 
 //------------------------------------------------------------------------------------------

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -46,13 +46,15 @@
 #import <OpenGLES/ES2/glext.h>
 #import <QuartzCore/CADisplayLink.h>
 
+using namespace std::chrono_literals;
+
 #define CONST_HDMI "HDMI"
 
 // if there was a devicelost callback
 // but no device reset for 3 secs
 // a timeout fires the reset callback
 // (for ensuring that e.x. AE isn't stuck)
-constexpr uint32_t LOST_DEVICE_TIMEOUT_MS{3000};
+constexpr auto LOST_DEVICE_TIMEOUT_MS{3000ms};
 
 // TVOSDisplayLinkCallback is defined in the lower part of the file
 @interface TVOSDisplayLinkCallback : NSObject

--- a/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
@@ -131,7 +131,7 @@ void CInputProcessorKeyboard::ConvertAndSendKey(std::uint32_t scancode, bool pre
     // Update/Set key
     m_keyToRepeat = event;
     // Start timer with initial delay
-    m_keyRepeatTimer.Start(m_keyRepeatDelay, false);
+    m_keyRepeatTimer.Start(std::chrono::milliseconds(m_keyRepeatDelay), false);
   }
   else
   {
@@ -160,7 +160,7 @@ XBMC_Event CInputProcessorKeyboard::SendKey(unsigned char scancode, XBMCKey key,
 void CInputProcessorKeyboard::KeyRepeatTimeout()
 {
   // Reset ourselves
-  m_keyRepeatTimer.RestartAsync(m_keyRepeatInterval);
+  m_keyRepeatTimer.RestartAsync(std::chrono::milliseconds(m_keyRepeatInterval));
   // Simulate repeat: Key up and down
   XBMC_Event event = m_keyToRepeat;
   event.type = XBMC_KEYUP;

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -56,6 +56,7 @@
 using namespace KODI::WINDOWING;
 using namespace KODI::WINDOWING::WAYLAND;
 using namespace std::placeholders;
+using namespace std::chrono_literals;
 
 namespace
 {
@@ -1400,7 +1401,7 @@ void CWinSystemWayland::PrepareFramePresentation()
     // while it is minimized (since the wait needs to be interrupted for that).
     // -> Use Wait with timeout here so we can maintain a reasonable frame rate
     //    even when the window is not visible and we do not get any frame callbacks.
-    if (m_frameCallbackEvent.WaitMSec(50))
+    if (m_frameCallbackEvent.WaitMSec(50ms))
     {
       // Only reset frame callback object a callback was received so a
       // new one is not requested continuously

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -1401,7 +1401,7 @@ void CWinSystemWayland::PrepareFramePresentation()
     // while it is minimized (since the wait needs to be interrupted for that).
     // -> Use Wait with timeout here so we can maintain a reasonable frame rate
     //    even when the window is not visible and we do not get any frame callbacks.
-    if (m_frameCallbackEvent.WaitMSec(50ms))
+    if (m_frameCallbackEvent.Wait(50ms))
     {
       // Only reset frame callback object a callback was received so a
       // new one is not requested continuously

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -75,6 +75,7 @@
 
 using namespace ADDON;
 using namespace KODI::MESSAGING;
+using namespace std::chrono_literals;
 
 namespace
 {
@@ -2275,7 +2276,7 @@ bool CGUIMediaWindow::WaitGetDirectoryItems(CGetDirectoryItems &items)
       m_updateEvent.Set();
     }, nullptr, CJob::PRIORITY_NORMAL);
 
-    while (!m_updateEvent.WaitMSec(1))
+    while (!m_updateEvent.WaitMSec(1ms))
     {
       if (!ProcessRenderLoop(false))
         break;
@@ -2295,7 +2296,7 @@ void CGUIMediaWindow::CancelUpdateItems()
   {
     m_rootDir.CancelDirectory();
     m_updateAborted = true;
-    if (!m_updateEvent.WaitMSec(5000))
+    if (!m_updateEvent.WaitMSec(5000ms))
     {
       CLog::Log(LOGERROR, "CGUIMediaWindow::CancelUpdateItems - error cancel update");
     }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -2276,7 +2276,7 @@ bool CGUIMediaWindow::WaitGetDirectoryItems(CGetDirectoryItems &items)
       m_updateEvent.Set();
     }, nullptr, CJob::PRIORITY_NORMAL);
 
-    while (!m_updateEvent.WaitMSec(1ms))
+    while (!m_updateEvent.Wait(1ms))
     {
       if (!ProcessRenderLoop(false))
         break;
@@ -2296,7 +2296,7 @@ void CGUIMediaWindow::CancelUpdateItems()
   {
     m_rootDir.CancelDirectory();
     m_updateAborted = true;
-    if (!m_updateEvent.WaitMSec(5000ms))
+    if (!m_updateEvent.Wait(5000ms))
     {
       CLog::Log(LOGERROR, "CGUIMediaWindow::CancelUpdateItems - error cancel update");
     }


### PR DESCRIPTION
This PR aims to convert xbmc/threads to completely use `std::chrono`. This is so that we can stop mixing types and use `std::chrono::duration` for any timeouts, sleeps, etc.

I could probably have broken this up into a few smaller PR's but considering it's all related I figured I would make one PR with ~500 changed lines.

The major benefit of this PR (and `std::chrono` in general) is that you don't have to guess (or suffix variable names) to know they duration.

Using `std::chrono_literals` allows specifying a duration directly, ie. `50ms`, `10s`, `2min`, `200ns`, etc. This makes it obvious what the duration is.

I've used templates in a couple of places (it wasn't really necessary) to allow using various `std::chrono::durations` with various types. So now it should be possible to use `CThread::Sleep` with `20s`, `2min`, etc (and possibly even fractional values, ~~though that isn't tested~~ EDIT: see zeroconf for `double` value).

~~There is likely a couple places I didn't adjust so I'll have to wait for jenkins to make some final changes.~~

I decided to run clang-format on Event.h entirely as it wanted to format most of the file anyways with the documentation changes. So be sure to look at the diff with whitespace changes off `?w=1`, [here is a quick link to help with that](https://github.com/xbmc/xbmc/pull/19780/files?w=1).

There are some places where `#defines` we being used to hardcode a duration, I typically handled these with a `constexpr` in an anonymous namespace. I didn't adjust the variable name however as some use a duration suffix (I can change this if desired).

There is likely still a bit of boilerplate from outside classes using these new interfaces but I didn't want to clutter this PR any more and will make future PR's to help convert other areas to use `std::chrono::duration's`.

The initial commit to `PipesManager` is required as to use `std::min` as in later commits `std::min` can be used with `std::chrono::duration`.