### PR TITLE
[Windows] Fix crash when Kodi is moved to another monitor with different video adapter

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -140,6 +140,10 @@ void CWinSystemWin32DX::OnMove(int x, int y)
   if (newMonitor != m_hMonitor)
   {
     MONITOR_DETAILS* details = GetDisplayDetails(newMonitor);
+
+    if (!details)
+      return;
+
     CDisplaySettings::GetInstance().SetMonitor(KODI::PLATFORM::WINDOWS::FromW(details->MonitorNameW));
     m_deviceResources->SetMonitor(newMonitor);
     m_hMonitor = newMonitor;


### PR DESCRIPTION
## Description
Fix crash when Kodi is moved to another monitor with different video adapter due to hardware changed.

Fixes https://github.com/xbmc/xbmc/issues/15295 (if is not already fixed by https://github.com/xbmc/xbmc/pull/19768)

## Motivation and context
This is very similar to https://github.com/xbmc/xbmc/pull/19768. This time are different monitors and different video adapters.

## How has this been tested?
System with internal video adapter Intel 630 and Nvidia adapter and is configured with two monitors (Intel primary and desktop extended to monitor 2 (Nvidia). Kodi is running on monitor 2 (Nvidia).

Changed Windows display settings to one monitor (Intel) while Kodi is running on Nvidia. Kodi switches at monitor 1 and when is restored full screen crashes.

The root cause is that method `CWinSystemWin32DX::OnMove(int x, int y)` is called two times:

**Call 1**
current_monitor = Nvidia
new_monitor = Intel
m_monitor = new_monitor;   ---> at this time Kodi knows that is at Intel monitor. All right.

**Call 2** (because Kodi interprets NULL monitor as new monitor again)
current_monitor = Intel 
new_monitor  = NULL
m_monitor = NULL;  --> crash

Without fix crash by access to null pointer.
With fix is discarded this second call. 

## What is the effect on users?
Fix crash when Kodi switches from monitor due hardware config changed and new monitor is on another video adapter.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
