### PR TITLE
[interfaces/legacy] add Settings and make it accessible through xbmc.Addon().getSettings()

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -350,13 +350,16 @@ bool CAddon::SettingsToXML(CXBMCTinyXML &doc) const
   return true;
 }
 
-CAddonSettings* CAddon::GetSettings() const
+std::shared_ptr<CAddonSettings> CAddon::GetSettings()
 {
   // initialize addon settings if necessary
   if (m_settings == nullptr)
+  {
     m_settings = std::make_shared<CAddonSettings>(enable_shared_from_this::shared_from_this());
+    LoadSettings(false);
+  }
 
-  return m_settings.get();
+  return m_settings;
 }
 
 std::string CAddon::LibPath() const

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -224,7 +224,7 @@ public:
   */
   bool GetSettingString(const std::string& key, std::string& value) override;
 
-  CAddonSettings* GetSettings() const override;
+  std::shared_ptr<CAddonSettings> GetSettings() override;
 
   /*! \brief get the required version of a dependency.
    \param dependencyID the addon ID of the dependency.

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -76,7 +76,7 @@ namespace ADDON
     virtual bool GetSettingInt(const std::string& key, int& value) = 0;
     virtual bool GetSettingNumber(const std::string& key, double& value) = 0;
     virtual bool GetSettingString(const std::string& key, std::string& value) = 0;
-    virtual CAddonSettings* GetSettings() const =0;
+    virtual std::shared_ptr<CAddonSettings> GetSettings() = 0;
     virtual const std::vector<DependencyInfo> &GetDependencies() const =0;
     virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;
     virtual bool MeetsVersion(const AddonVersion& versionMin,

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
+#include "addons/settings/AddonSettings.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -77,6 +78,11 @@ namespace XBMCAddon
     String Addon::getLocalizedString(int id)
     {
       return g_localizeStrings.GetAddonString(pAddon->ID(), id);
+    }
+
+    Settings* Addon::getSettings()
+    {
+      return new Settings(pAddon->GetSettings());
     }
 
     String Addon::getSetting(const char* id)

--- a/xbmc/interfaces/legacy/Addon.h
+++ b/xbmc/interfaces/legacy/Addon.h
@@ -11,6 +11,7 @@
 #include "AddonClass.h"
 #include "AddonString.h"
 #include "Exception.h"
+#include "Settings.h"
 #include "addons/IAddon.h"
 
 namespace XBMCAddon
@@ -99,6 +100,32 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getSettings() }
+      ///-----------------------------------------------------------------------
+      /// Returns a wrapper around the addon's settings.
+      ///
+      /// @return                        `Settings` wrapper
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// settings = self.Addon.getSettings()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      getSettings(...);
+#else
+      Settings* getSettings();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
       /// @brief \python_func{ xbmcaddon.Addon([id]).getSetting(id) }
       /// Returns the value of a setting as string.
       ///
@@ -138,6 +165,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.getBool()** instead.
       ///
       ///
       /// **Example:**
@@ -166,6 +194,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.getInt()** instead.
       ///
       ///
       /// **Example:**
@@ -194,6 +223,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.getNumber()** instead.
       ///
       ///
       /// **Example:**
@@ -222,6 +252,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.getString()** instead.
       ///
       ///
       /// **Example:**
@@ -283,6 +314,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.setBool()** instead.
       ///
       ///
       /// **Example:**
@@ -314,6 +346,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.setInt()** instead.
       ///
       ///
       /// **Example:**
@@ -345,6 +378,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.setNumber()** instead.
       ///
       ///
       /// **Example:**
@@ -376,6 +410,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// @python_v18
       /// New function added.
+      /// @python_v20 Deprecated. Use **Settings.setString()** instead.
       ///
       ///
       /// **Example:**

--- a/xbmc/interfaces/legacy/CMakeLists.txt
+++ b/xbmc/interfaces/legacy/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES AddonCallback.cpp
             Monitor.cpp
             Player.cpp
             PlayList.cpp
+            Settings.cpp
             String.cpp
             Window.cpp
             WindowDialog.cpp
@@ -61,6 +62,7 @@ set(HEADERS Addon.h
             Player.h
             PlayList.h
             RenderCapture.h
+            Settings.h
             Stat.h
             swighelper.h
             Tuple.h

--- a/xbmc/interfaces/legacy/Settings.cpp
+++ b/xbmc/interfaces/legacy/Settings.cpp
@@ -1,0 +1,235 @@
+/*
+ *  Copyright (C) 2017-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Settings.h"
+
+#include "settings/SettingsBase.h"
+#include "settings/lib/Setting.h"
+
+#include <algorithm>
+#include <functional>
+
+namespace XBMCAddon
+{
+namespace xbmcaddon
+{
+
+template<class TSetting>
+bool GetSettingValue(std::shared_ptr<CSettingsBase> settings,
+                     const std::string& key,
+                     typename TSetting::Value& value)
+{
+  if (key.empty() || !settings->IsLoaded())
+    return false;
+
+  auto setting = settings->GetSetting(key);
+  if (setting == nullptr || setting->GetType() != TSetting::Type())
+    return false;
+
+  value = std::static_pointer_cast<TSetting>(setting)->GetValue();
+  return true;
+}
+
+template<class TSetting>
+bool GetSettingValueList(std::shared_ptr<CSettingsBase> settings,
+                         const std::string& key,
+                         std::function<typename TSetting::Value(CVariant)> transform,
+                         std::vector<typename TSetting::Value>& values)
+{
+  if (key.empty() || !settings->IsLoaded())
+    return false;
+
+  auto setting = settings->GetSetting(key);
+  if (setting == nullptr || setting->GetType() != SettingType::List ||
+      std::static_pointer_cast<CSettingList>(setting)->GetElementType() != TSetting::Type())
+    return false;
+
+  const auto variantValues = settings->GetList(key);
+  std::transform(variantValues.begin(), variantValues.end(), std::back_inserter(values), transform);
+  return true;
+}
+
+template<class TSetting>
+bool SetSettingValue(std::shared_ptr<CSettingsBase> settings,
+                     const std::string& key,
+                     typename TSetting::Value value)
+{
+  if (key.empty() || !settings->IsLoaded())
+    return false;
+
+  // try to get the setting
+  auto setting = settings->GetSetting(key);
+  if (setting == nullptr || setting->GetType() != TSetting::Type())
+    return false;
+
+  return std::static_pointer_cast<TSetting>(setting)->SetValue(value);
+}
+
+template<class TSetting>
+bool SetSettingValueList(std::shared_ptr<CSettingsBase> settings,
+                         const std::string& key,
+                         const std::vector<typename TSetting::Value>& values)
+{
+  if (key.empty() || !settings->IsLoaded())
+    return false;
+
+  // try to get the setting
+  auto setting = settings->GetSetting(key);
+  if (setting == nullptr || setting->GetType() != SettingType::List ||
+      std::static_pointer_cast<CSettingList>(setting)->GetElementType() != TSetting::Type())
+    return false;
+
+  std::vector<CVariant> variantValues;
+  std::transform(values.begin(), values.end(), std::back_inserter(variantValues),
+                 [](typename TSetting::Value value) { return CVariant(value); });
+
+  return settings->SetList(key, variantValues);
+}
+
+Settings::Settings(std::shared_ptr<CSettingsBase> settings) : settings(settings)
+{
+}
+
+bool Settings::getBool(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  bool value = false;
+  if (!GetSettingValue<CSettingBool>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"boolean\" for \"%s\"", id);
+
+  return value;
+}
+
+int Settings::getInt(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  int value = 0;
+  if (!GetSettingValue<CSettingInt>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"integer\" for \"%s\"", id);
+
+  return value;
+}
+
+double Settings::getNumber(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  double value = 0.0;
+  if (!GetSettingValue<CSettingNumber>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"number\" for \"%s\"", id);
+
+  return value;
+}
+
+String Settings::getString(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  std::string value;
+  if (!GetSettingValue<CSettingString>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"string\" for \"%s\"", id);
+
+  return value;
+}
+
+std::vector<bool> Settings::getBoolList(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  const auto transform = [](CVariant value) { return value.asBoolean(); };
+  std::vector<bool> values;
+  if (!GetSettingValueList<CSettingBool>(settings, id, transform, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[boolean]\" for \"%s\"", id);
+
+  return values;
+}
+
+std::vector<int> Settings::getIntList(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  const auto transform = [](CVariant value) { return value.asInteger32(); };
+  std::vector<int> values;
+  if (!GetSettingValueList<CSettingInt>(settings, id, transform, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[integer]\" for \"%s\"", id);
+
+  return values;
+}
+
+std::vector<double> Settings::getNumberList(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  const auto transform = [](CVariant value) { return value.asDouble(); };
+  std::vector<double> values;
+  if (!GetSettingValueList<CSettingNumber>(settings, id, transform, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[number]\" for \"%s\"", id);
+
+  return values;
+}
+
+std::vector<String> Settings::getStringList(const char* id) throw(XBMCAddon::WrongTypeException)
+{
+  const auto transform = [](CVariant value) { return value.asString(); };
+  std::vector<std::string> values;
+  if (!GetSettingValueList<CSettingString>(settings, id, transform, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[string]\" for \"%s\"", id);
+
+  return values;
+}
+
+void Settings::setBool(const char* id, bool value) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValue<CSettingBool>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"boolean\" for \"%s\"", id);
+  settings->Save();
+}
+
+void Settings::setInt(const char* id, int value) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValue<CSettingInt>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"integer\" for \"%s\"", id);
+  settings->Save();
+}
+
+void Settings::setNumber(const char* id, double value) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValue<CSettingNumber>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"number\" for \"%s\"", id);
+  settings->Save();
+}
+
+void Settings::setString(const char* id, const String& value) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValue<CSettingString>(settings, id, value))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"string\" for \"%s\"", id);
+  settings->Save();
+}
+
+void Settings::setBoolList(const char* id,
+                           const std::vector<bool>& values) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValueList<CSettingBool>(settings, id, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[boolean]\" for \"%s\"", id);
+  settings->Save();
+}
+
+void Settings::setIntList(const char* id,
+                          const std::vector<int>& values) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValueList<CSettingInt>(settings, id, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[integer]\" for \"%s\"", id);
+  settings->Save();
+}
+
+void Settings::setNumberList(const char* id,
+                             const std::vector<double>& values) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValueList<CSettingNumber>(settings, id, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[number]\" for \"%s\"", id);
+  settings->Save();
+}
+
+void Settings::setStringList(const char* id,
+                             const std::vector<String>& values) throw(XBMCAddon::WrongTypeException)
+{
+  if (!SetSettingValueList<CSettingString>(settings, id, values))
+    throw XBMCAddon::WrongTypeException("Invalid setting type \"list[string]\" for \"%s\"", id);
+  settings->Save();
+}
+
+} // namespace xbmcaddon
+} // namespace XBMCAddon

--- a/xbmc/interfaces/legacy/Settings.h
+++ b/xbmc/interfaces/legacy/Settings.h
@@ -1,0 +1,518 @@
+/*
+ *  Copyright (C) 2017-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "commons/Exception.h"
+#include "interfaces/legacy/AddonClass.h"
+#include "interfaces/legacy/AddonString.h"
+#include "interfaces/legacy/Exception.h"
+#include "interfaces/legacy/Tuple.h"
+#include "settings/lib/SettingDefinitions.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class CSettingsBase;
+
+namespace XBMCAddon
+{
+namespace xbmcaddon
+{
+
+XBMCCOMMONS_STANDARD_EXCEPTION(SettingCallbacksNotSupportedException);
+
+//
+/// \defgroup python_settings Settings
+/// \ingroup python_settings
+/// @{
+/// @brief **Add-on settings**
+///
+/// \python_class{ Settings() }
+///
+/// This wrapper provides access to the settings specific to an add-on.
+/// It supports reading and writing specific setting values.
+///
+///-----------------------------------------------------------------------
+/// @python_v20 New class added.
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.py}
+/// ...
+/// settings = xbmc.Addon('id').getSettings()
+/// ...
+/// ~~~~~~~~~~~~~
+class Settings : public AddonClass
+{
+public:
+#if !defined SWIG && !defined DOXYGEN_SHOULD_SKIP_THIS
+  std::shared_ptr<CSettingsBase> settings;
+#endif
+
+#ifndef SWIG
+  Settings(std::shared_ptr<CSettingsBase> settings);
+#endif
+
+  virtual ~Settings() = default;
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getBool(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as a boolean.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       bool - Setting as a boolean
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// enabled = settings.getBool('enabled')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getBool(...);
+#else
+  bool getBool(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getInt(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as an integer.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       integer - Setting as an integer
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// max = settings.getInt('max')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getInt(...);
+#else
+  int getInt(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getNumber(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as a floating point number.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       float - Setting as a floating point number
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// max = settings.getNumber('max')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getNumber(...);
+#else
+  double getNumber(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getString(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as a unicode string.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       string - Setting as a unicode string
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// apikey = settings.getString('apikey')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getString(...);
+#else
+  String getString(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getBoolList(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as a list of booleans.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       list - Setting as a list of booleans
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// enabled = settings.getBoolList('enabled')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getBoolList(...);
+#else
+  std::vector<bool> getBoolList(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getIntList(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as a list of integers.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       list - Setting as a list of integers
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// ids = settings.getIntList('ids')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getIntList(...);
+#else
+  std::vector<int> getIntList(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getNumberList(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as a list of floating point numbers.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       list - Setting as a list of floating point numbers
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// max = settings.getNumberList('max')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getNumberList(...);
+#else
+  std::vector<double> getNumberList(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ getStringList(id) }
+  ///-----------------------------------------------------------------------
+  /// Returns the value of a setting as a list of unicode strings.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @return                       list - Setting as a list of unicode strings
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// views = settings.getStringList('views')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  getStringList(...);
+#else
+  std::vector<String> getStringList(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setBool(id, value) }
+  ///-----------------------------------------------------------------------
+  /// Sets the value of a setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param value                  bool - value of the setting.
+  /// @return                       bool - True if the value of the setting was set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setBool(id='enabled', value=True)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setBool(...);
+#else
+  void setBool(const char* id, bool value) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setInt(id, value) }
+  ///-----------------------------------------------------------------------
+  /// Sets the value of a setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param value                  integer - value of the setting.
+  /// @return                       bool - True if the value of the setting was set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setInt(id='max', value=5)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setInt(...);
+#else
+  void setInt(const char* id, int value) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setNumber(id, value) }
+  ///-----------------------------------------------------------------------
+  /// Sets the value of a setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param value                  float - value of the setting.
+  /// @return                       bool - True if the value of the setting was set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setNumber(id='max', value=5.5)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setNumber(...);
+#else
+  void setNumber(const char* id, double value) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setString(id, value) }
+  ///-----------------------------------------------------------------------
+  /// Sets the value of a setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param value                  string or unicode - value of the setting.
+  /// @return                       bool - True if the value of the setting was set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setString(id='username', value='teamkodi')
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setString(...);
+#else
+  void setString(const char* id, const String& value) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setBoolList(id, values) }
+  ///-----------------------------------------------------------------------
+  /// Sets the boolean values of a list setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param values                 list of boolean - values of the setting.
+  /// @return                       bool - True if the values of the setting were set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setBoolList(id='enabled', values=[ True, False ])
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setBoolList(...);
+#else
+  void setBoolList(const char* id,
+                   const std::vector<bool>& values) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setIntList(id, value) }
+  ///-----------------------------------------------------------------------
+  /// Sets the integer values of a list setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param values                 list of int - values of the setting.
+  /// @return                       bool - True if the values of the setting were set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setIntList(id='max', values=[ 5, 23 ])
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setIntList(...);
+#else
+  void setIntList(const char* id,
+                  const std::vector<int>& values) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setNumberList(id, value) }
+  ///-----------------------------------------------------------------------
+  /// Sets the floating point values of a list setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param values                 list of float - values of the setting.
+  /// @return                       bool - True if the values of the setting were set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setNumberList(id='max', values=[ 5.5, 5.8 ])
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setNumberList(...);
+#else
+  void setNumberList(const char* id,
+                     const std::vector<double>& values) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_settings
+  /// @brief \python_func{ setStringList(id, value) }
+  ///-----------------------------------------------------------------------
+  /// Sets the string values of a list setting.
+  ///
+  /// @param id                     string - id of the setting that the module needs to access.
+  /// @param values                 list of string or unicode - values of the setting.
+  /// @return                       bool - True if the values of the setting were set, false otherwise
+  ///
+  ///
+  /// @note You can use the above as keywords for arguments.
+  ///
+  ///
+  ///-----------------------------------------------------------------------
+  /// @python_v20 New function added.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// settings.setStringList(id='username', values=[ 'team', 'kodi' ])
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setStringList(...);
+#else
+  void setStringList(const char* id,
+                     const std::vector<String>& values) throw(XBMCAddon::WrongTypeException);
+#endif
+};
+
+} // namespace xbmcaddon
+} // namespace XBMCAddon

--- a/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
@@ -14,6 +14,7 @@
 #endif
 
 #include "interfaces/legacy/Addon.h"
+#include "interfaces/legacy/Settings.h"
 
 using namespace XBMCAddon;
 using namespace xbmcaddon;
@@ -32,4 +33,5 @@ using namespace xbmcaddon;
 %include "interfaces/legacy/AddonString.h"
 
 %include "interfaces/legacy/Addon.h"
+%include "interfaces/legacy/Settings.h"
 


### PR DESCRIPTION
## Description
This PR adds a new `Settings` class to the Python interface which supports typed getters and setters for settings of an add-on. The add-on specific settings object can be retrieved using `xbmc.Addon().getSettings()`. 

## Motivation and context
Right now the main advantage of this settings wrapper object is that it also offers getters and setters for list settings by returning / expecting an `std::vector<>` instead of having to use `xbmc.Addon().setSetting()` with a stringified list of values. For my media import work I have already extended it to support some callbacks like for action settings when the user clicks on the setting or providing callbacks for dynamic setting values. Right now this is only available for media import add-ons but I plan to extend this to all python add-ons which will allow a much more interactive way of providing add-on settings.

## How has this been tested?
As part of my media import work.

## What is the effect on users?
Add-on developers will have access to a cleaner interface to interact with the settings of their add-ons.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
