### PR TITLE
[Xbox] Fix: 4K resolutions infos reported as 1080p

### DIFF
--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -283,13 +283,22 @@ bool CWIN32Util::XBMCShellExecute(const std::string &strPath, bool bWaitForScrip
 std::string CWIN32Util::GetResInfoString()
 {
 #ifdef TARGET_WINDOWS_STORE
-  auto displayInfo = DisplayInformation::GetForCurrentView();
-
-  return StringUtils::Format("Desktop Resolution: {}x{}", displayInfo.ScreenWidthInRawPixels(),
-                             displayInfo.ScreenHeightInRawPixels());
+  auto hdmiInfo = HdmiDisplayInformation::GetForCurrentView();
+  if (hdmiInfo) // Xbox
+  {
+    auto mode = hdmiInfo.GetCurrentDisplayMode();
+    return StringUtils::Format(
+        "Desktop Resolution: {}x{} {}Bit at {:.2f}Hz", mode.ResolutionWidthInRawPixels(),
+        mode.ResolutionHeightInRawPixels(), mode.BitsPerPixel(), mode.RefreshRate());
+  }
+  else // Windows 10 UWP
+  {
+    auto info = DisplayInformation::GetForCurrentView();
+    return StringUtils::Format("Desktop Resolution: {}x{}", info.ScreenWidthInRawPixels(),
+                               info.ScreenHeightInRawPixels());
+  }
 #else
-  DEVMODE devmode;
-  ZeroMemory(&devmode, sizeof(devmode));
+  DEVMODE devmode = {};
   devmode.dmSize = sizeof(devmode);
   EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devmode);
   return StringUtils::Format("Desktop Resolution: {}x{} {}Bit at {}Hz", devmode.dmPelsWidth,

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -477,6 +477,10 @@ void CWinSystemWin10::GetConnectedDisplays(std::vector<MONITOR_DETAILS>& outputs
       if (hdmiInfo != nullptr)
       {
         auto currentMode = hdmiInfo.GetCurrentDisplayMode();
+        // On Xbox, 4K resolutions only are reported by HdmiDisplayInformation API
+        // so ScreenHeight & ScreenWidth are updated with info provided here
+        md.ScreenHeight = currentMode.ResolutionHeightInRawPixels();
+        md.ScreenWidth = currentMode.ResolutionWidthInRawPixels();
         md.RefreshRate = currentMode.RefreshRate();
         md.Bpp = currentMode.BitsPerPixel();
       }


### PR DESCRIPTION
## Description
Fix: 4K resolutions infos reported as 1080p

## Motivation and context
`DisplayInformation::GetForCurrentView()` does not report 4K capabilities on Xbox even if current video mode is 4K:

From some logs:
```
2021-05-02 09:30:41.086 T:1136     INFO <general>: Running on Microsoft Xbox Series X with WINDOWS 10.0.19041.7339, kernel: WINDOWS x86 64-bit version 10.0.19041.7339
2021-05-02 09:30:41.086 T:1136     INFO <general>: FFmpeg version/source: 4.3.2-Kodi
2021-05-02 09:30:41.086 T:1136     INFO <general>: Host CPU: Unknown, 8 cores available
2021-05-02 09:30:41.086 T:1136     INFO <general>: System has 5.0 GB of RAM installed
2021-05-02 09:30:41.088 T:1136     INFO <general>: Desktop Resolution: 1920x1080
```

On the other hand, `HdmiDisplayInformation::GetForCurrentView()` returns correct infos on Xbox

In `CWIN32Util::GetResInfoString()` is not critical because only is used to get logging string, however, in `WinSystemWin10.cpp`  it is critical because this information is used to create the main window and all `DeviceResources`. Then never is used true 4K resolution even if HDMI output is 4K.

Also I think other issues as crash when "Adjust Display Refresh Rate" is enabled are related to this.

## How has this been tested?


## What is the effect on users?
Fix: 4K resolutions infos reported as 1080p and other related issues.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
