### PR TITLE
MysqlDatabase: remove unused variable

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -519,8 +519,6 @@ long MysqlDatabase::nextid(const char* sname) {
     }
     else
     {
-      MYSQL_ROW row = mysql_fetch_row(res);
-      //id = (int)row[0];
       id = -1;
       unsigned long *lengths;
       lengths = mysql_fetch_lengths(res);


### PR DESCRIPTION
This fixes a newly introduced warning for `unused variable 'row'`.

https://jenkins.kodi.tv/job/Android-X86/lastFailedBuild/clang/source.18c3d9cd-7bd0-412d-96fd-fafea69ad6f7/#522