### PR TITLE
CLog: allow spdlog to do the formatting

### DIFF
--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -155,9 +155,9 @@ private:
                                                   const char* format,
                                                   Args&&... args)
   {
-    GetInstance().FormatAndLogInternal(
-        level, StringUtils::Format("{0:s}: {1:s}", functionName, format).c_str(),
-        std::forward<Args>(args)...);
+    GetInstance().FormatAndLogInternal(level,
+                                       StringUtils::Format("{0:s}: {1:s}", functionName, format),
+                                       std::forward<Args>(args)...);
   }
 
   template<typename... Args>
@@ -166,24 +166,20 @@ private:
                                                   const wchar_t* format,
                                                   Args&&... args)
   {
-    GetInstance().FormatAndLogInternal(
-        level, StringUtils::Format(L"{0:s}: {1:s}", functionName, format).c_str(),
-        std::forward<Args>(args)...);
+    GetInstance().FormatAndLogInternal(level,
+                                       StringUtils::Format(L"{0:s}: {1:s}", functionName, format),
+                                       std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
+  template<typename... Args>
   inline void FormatAndLogInternal(spdlog::level::level_enum level,
-                                   const Char* format,
+                                   std::string format,
                                    Args&&... args)
   {
-    // TODO: for now we manually format the messages to support both python- and printf-style formatting.
-    //       this can be removed once all log messages have been adjusted to python-style formatting
-    auto logString = StringUtils::Format(format, std::forward<Args>(args)...);
-
     // fixup newline alignment, number of spaces should equal prefix length
-    StringUtils::Replace(logString, "\n", "\n                                                   ");
+    StringUtils::Replace(format, "\n", "\n                                                   ");
 
-    m_defaultLogger->log(level, std::move(logString));
+    m_defaultLogger->log(level, format, std::forward<Args>(args)...);
   }
 
   Logger CreateLogger(const std::string& loggerName);

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -62,14 +62,14 @@ public:
 
   Logger GetLogger(const std::string& loggerName);
 
-  template<typename Char, typename... Args>
-  static inline void Log(int level, const Char* format, Args&&... args)
+  template<typename... Args>
+  static inline void Log(int level, const char* format, Args&&... args)
   {
     Log(MapLogLevel(level), format, std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
-  static inline void Log(int level, uint32_t component, const Char* format, Args&&... args)
+  template<typename... Args>
+  static inline void Log(int level, uint32_t component, const char* format, Args&&... args)
   {
     if (!GetInstance().CanLogComponent(component))
       return;
@@ -77,16 +77,16 @@ public:
     Log(level, format, std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
-  static inline void Log(spdlog::level::level_enum level, const Char* format, Args&&... args)
+  template<typename... Args>
+  static inline void Log(spdlog::level::level_enum level, const char* format, Args&&... args)
   {
     GetInstance().FormatAndLogInternal(level, format, std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
+  template<typename... Args>
   static inline void Log(spdlog::level::level_enum level,
                          uint32_t component,
-                         const Char* format,
+                         const char* format,
                          Args&&... args)
   {
     if (!GetInstance().CanLogComponent(component))
@@ -95,18 +95,18 @@ public:
     Log(level, format, std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
+  template<typename... Args>
   static inline void LogFunction(int level,
                                  const char* functionName,
-                                 const Char* format,
+                                 const char* format,
                                  Args&&... args)
   {
     LogFunction(MapLogLevel(level), functionName, format, std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
+  template<typename... Args>
   static inline void LogFunction(
-      int level, const char* functionName, uint32_t component, const Char* format, Args&&... args)
+      int level, const char* functionName, uint32_t component, const char* format, Args&&... args)
   {
     if (!GetInstance().CanLogComponent(component))
       return;
@@ -114,10 +114,10 @@ public:
     LogFunction(level, functionName, format, std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
+  template<typename... Args>
   static inline void LogFunction(spdlog::level::level_enum level,
                                  const char* functionName,
-                                 const Char* format,
+                                 const char* format,
                                  Args&&... args)
   {
     if (functionName == nullptr || strlen(functionName) == 0)
@@ -127,11 +127,11 @@ public:
                                                  std::forward<Args>(args)...);
   }
 
-  template<typename Char, typename... Args>
+  template<typename... Args>
   static inline void LogFunction(spdlog::level::level_enum level,
                                  const char* functionName,
                                  uint32_t component,
-                                 const Char* format,
+                                 const char* format,
                                  Args&&... args)
   {
     if (!GetInstance().CanLogComponent(component))
@@ -157,17 +157,6 @@ private:
   {
     GetInstance().FormatAndLogInternal(level,
                                        StringUtils::Format("{0:s}: {1:s}", functionName, format),
-                                       std::forward<Args>(args)...);
-  }
-
-  template<typename... Args>
-  static inline void FormatAndLogFunctionInternal(spdlog::level::level_enum level,
-                                                  const char* functionName,
-                                                  const wchar_t* format,
-                                                  Args&&... args)
-  {
-    GetInstance().FormatAndLogInternal(level,
-                                       StringUtils::Format(L"{0:s}: {1:s}", functionName, format),
                                        std::forward<Args>(args)...);
   }
 


### PR DESCRIPTION
This does two things:
1) Allows passing `std::string` instead of `const char*` to `StringUtils::FormatAndLogInternal`.
2) Makes spdlog do the formatting internally (via libfmt).

I'm not sure if this can be optimised more. I'm just using a simple `std::string` because we call `StringUtils::Replace` which requires the `std::string` to be `non-const`. This would be nice to be templated so it can also accept `std::wstring` but I can't seem to get it to compile as I get something similar to:
```
git/xbmc/xbmc/utils/log.h:180:26: error: cannot bind non-const lvalue reference of type ‘std::string&’ {aka ‘std::__cxx11::basic_string<char>&’} to an rvalue of type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
  180 |     StringUtils::Replace(format, "\n", "\n                                                   ");
      |                          ^~~~~~
```

suggestions?