### PR TITLE
Improvements for add-on settings

### DIFF
--- a/system/settings/android.xml
+++ b/system/settings/android.xml
@@ -23,8 +23,8 @@
               <option label="37030">9999</option> <!-- unlimited -->
             </options>
           </constraints>
-        <control type="spinner" format="string" />
-        <control type="edit" format="integer" />
+          <control type="spinner" format="string" />
+          <control type="edit" format="integer" />
         </setting>
       </group>
     </category>

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -15,7 +15,7 @@
     </category>
     <category id="discs">
       <group id="3">
-      <visible>false</visible>
+        <visible>false</visible>
       </group>
     </category>
   </section>

--- a/system/settings/darwin_tvos.xml
+++ b/system/settings/darwin_tvos.xml
@@ -147,8 +147,8 @@
           <visible>false</visible>
         </setting>
         <setting id="audiooutput.supportdtshdcpudecoding" type="boolean">
-            <default>false</default>
-            <visible>false</visible>
+          <default>false</default>
+          <visible>false</visible>
         </setting>
       </group>
     </category>

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -43,7 +43,7 @@
             <dependency type="enable">
               <condition setting="videoplayer.usevdpau" operator="is">true</condition> <!-- USE VDPAU -->
             </dependency>
-           </dependencies>
+          </dependencies>
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.usevdpauvc1" type="boolean" parent="videoplayer.usevdpau" label="13445" help="13446">
@@ -55,7 +55,7 @@
             <dependency type="enable">
               <condition setting="videoplayer.usevdpau" operator="is">true</condition> <!-- USE VDPAU -->
             </dependency>
-           </dependencies>
+          </dependencies>
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.usevaapi" type="boolean" label="13426" help="36156">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -442,9 +442,9 @@
           <control type="toggle" />
         </setting>
         <setting id="slideshow.highqualitydownscaling" type="boolean" label="36619" help="36620">
-            <level>1</level>
-            <default>false</default>
-            <control type="toggle" />
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -771,7 +771,7 @@
         <setting id="musiclibrary.exportfolder" type="string" label="38305" help="">
           <level>4</level>
           <default></default>
-		  <constraints>
+          <constraints>
             <allowempty>true</allowempty>
           </constraints>
         </setting>
@@ -789,11 +789,11 @@
         </setting>
         <setting id="musiclibrary.exportartwork" type="boolean" label="" help="">
           <level>4</level>
-		  <default>false</default>
+          <default>false</default>
         </setting>
         <setting id="musiclibrary.exportskipnfo" type="boolean" label="" help="">
           <level>4</level>
-		  <default>false</default>
+          <default>false</default>
         </setting>
         <setting id="musiclibrary.import" type="action" label="14249" help="36263">
           <level>2</level>
@@ -993,7 +993,7 @@
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
-         </setting>
+        </setting>
       </group>
       <group id="4" label="39123">
         <!-- Hidden setting indicating video art settings have been migrated from old advancedsettings.xml format-->
@@ -1296,7 +1296,7 @@
             <allowempty>true</allowempty>
             <allownewoption>true</allownewoption>
           </constraints>
-		  <dependencies>
+          <dependencies>
             <dependency type="enable" setting="musiclibrary.artworklevel" operator="!is">3</dependency>
           </dependencies>
           <control type="list" format="string">
@@ -1307,9 +1307,9 @@
           <level>1</level>
           <default>false</default>
           <control type="toggle" />
-		  <dependencies>
+          <dependencies>
             <dependency type="enable" setting="musiclibrary.artworklevel" operator="!is">3</dependency>
-          </dependencies>		  
+          </dependencies>
         </setting>
       </group>
       <group id="4" label="128">
@@ -1923,7 +1923,7 @@
         </setting>
       </group>
       <group id="2" label="1259">
-      <requirement>HAS_ZEROCONF</requirement>
+        <requirement>HAS_ZEROCONF</requirement>
         <setting id="services.zeroconf" type="boolean" label="1260" help="36342">
           <level>1</level>
           <default>true</default>
@@ -1931,7 +1931,7 @@
         </setting>
       </group>
       <group id="3">
-      <requirement>HAS_ZEROCONF</requirement>
+        <requirement>HAS_ZEROCONF</requirement>
         <setting id="services.deviceuuid" type="string">
           <visible>false</visible>
           <level>1</level>
@@ -1945,7 +1945,7 @@
     </category>
     <category id="control" label="14223" help="36327">
       <group id="1" label="33101">
-      <requirement>HAS_WEB_SERVER</requirement>
+        <requirement>HAS_WEB_SERVER</requirement>
         <setting id="services.webserver" type="boolean" label="263" help="36328">
           <level>1</level>
           <default>false</default>
@@ -2057,7 +2057,7 @@
           <default>false</default>
           <dependencies>
             <dependency type="enable">
-                <condition setting="services.esenabled" operator="is">true</condition>
+              <condition setting="services.esenabled" operator="is">true</condition>
             </dependency>
           </dependencies>
           <control type="toggle" />
@@ -2249,7 +2249,7 @@
           <control type="toggle" />
           <dependencies>
             <dependency type="enable">
-                <condition setting="smb.maxprotocol" operator="is">1</condition>
+              <condition setting="smb.maxprotocol" operator="is">1</condition>
             </dependency>
           </dependencies>
         </setting>
@@ -2831,7 +2831,7 @@
           <default>resource.uisounds.kodi</default>
           <dependencies>
             <dependency type="enable" setting="audiooutput.guisoundmode" operator="!is">0</dependency>
-          </dependencies>          
+          </dependencies>
           <constraints>
             <addontype>kodi.resource.uisounds</addontype>
             <allowempty>true</allowempty>

--- a/system/settings/win10.xml
+++ b/system/settings/win10.xml
@@ -31,12 +31,12 @@
       </group>
     </category>
   </section>
-  <section id="pvr" >
+  <section id="pvr">
     <category id="pvrpowermanagement">
-        <setting id="pvrpowermanagement.setwakeupcmd">
-          <default></default>
-          <visible>false</visible>
-        </setting>
+      <setting id="pvrpowermanagement.setwakeupcmd">
+        <default></default>
+        <visible>false</visible>
+      </setting>
     </category>
   </section>
   <section id="games">

--- a/system/settings/windows.xml
+++ b/system/settings/windows.xml
@@ -49,9 +49,9 @@
           <level>3</level>
           <default>false</default>
           <control type="toggle" />
-      </setting>
-    </group>
-  </category>
+        </setting>
+      </group>
+    </category>
   </section>
   <section id="interface">
     <category id="regional">

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -196,6 +196,15 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
       }
     }
   }
+  else if (m_format == "file")
+  {
+    bool useThumbs = false;
+    if (XMLUtils::GetBoolean(node, "usethumbs", useThumbs))
+      m_useImageThumbs = useThumbs;
+    bool useFileDirectories = false;
+    if (XMLUtils::GetBoolean(node, "treatasfolder", useFileDirectories))
+      m_useFileDirectories = useFileDirectories;
+  }
 
   return true;
 }

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -56,6 +56,8 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
   {
     // get writable
     XMLUtils::GetBoolean(constraints, "writable", m_writable);
+    // get hide extensions
+    XMLUtils::GetBoolean(constraints, "hideextensions", m_hideExtension);
 
     // get sources
     auto sources = constraints->FirstChild("sources");

--- a/xbmc/settings/lib/ISetting.cpp
+++ b/xbmc/settings/lib/ISetting.cpp
@@ -46,7 +46,14 @@ bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   return m_requirementCondition.Deserialize(requirementNode);
 }
 
-bool ISetting::DeserializeIdentification(const TiXmlNode *node, std::string &identification)
+bool ISetting::DeserializeIdentification(const TiXmlNode* node, std::string& identification)
+{
+  return DeserializeIdentificationFromAttribute(node, SETTING_XML_ATTR_ID, identification);
+}
+
+bool ISetting::DeserializeIdentificationFromAttribute(const TiXmlNode* node,
+                                                      const std::string& attribute,
+                                                      std::string& identification)
 {
   if (node == nullptr)
     return false;
@@ -55,11 +62,11 @@ bool ISetting::DeserializeIdentification(const TiXmlNode *node, std::string &ide
   if (element == nullptr)
     return false;
 
-  auto idAttribute = element->Attribute(SETTING_XML_ATTR_ID);
-  if (idAttribute == nullptr || strlen(idAttribute) <= 0)
+  auto idAttribute = element->Attribute(attribute);
+  if (idAttribute == nullptr || idAttribute->empty())
     return false;
 
-  identification = idAttribute;
+  identification = *idAttribute;
   return true;
 }
 

--- a/xbmc/settings/lib/ISetting.h
+++ b/xbmc/settings/lib/ISetting.h
@@ -114,6 +114,18 @@ public:
   static bool DeserializeIdentification(const TiXmlNode *node, std::string &identification);
 
 protected:
+  /*!
+   \brief Deserializes the given XML node to retrieve a setting object's identifier from the given attribute.
+
+   \param node XML node containing a setting object's identifier
+   \param attribute Attribute which contains the setting object's identifier
+   \param identification Will contain the deserialized setting object's identifier
+   \return True if a setting object's identifier was deserialized, false otherwise
+   */
+  static bool DeserializeIdentificationFromAttribute(const TiXmlNode* node,
+                                                     const std::string& attribute,
+                                                     std::string& identification);
+
   std::string m_id;
   CSettingsManager *m_settingsManager;
 

--- a/xbmc/settings/lib/ISetting.h
+++ b/xbmc/settings/lib/ISetting.h
@@ -114,6 +114,7 @@ public:
   static bool DeserializeIdentification(const TiXmlNode *node, std::string &identification);
 
 protected:
+  static constexpr int DefaultLabel = -1;
   /*!
    \brief Deserializes the given XML node to retrieve a setting object's identifier from the given attribute.
 
@@ -131,7 +132,7 @@ protected:
 
 private:
   bool m_visible = true;
-  int m_label = -1;
+  int m_label = DefaultLabel;
   int m_help = -1;
   bool m_meetsRequirements = true;
   CSettingRequirement m_requirementCondition;

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -68,19 +68,15 @@ bool DeserializeOptionsSort(const TiXmlElement* optionsElement, SettingOptionsSo
 
 Logger CSetting::s_logger;
 
-CSetting::CSetting(const std::string& id,
-                   CSettingsManager* settingsManager /* = nullptr */,
-                   const std::string& name /* = "CSetting" */)
+CSetting::CSetting(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
   : ISetting(id, settingsManager)
 {
   if (s_logger == nullptr)
-    s_logger = CServiceBroker::GetLogging().GetLogger(name);
+    s_logger = CServiceBroker::GetLogging().GetLogger("CSetting");
 }
 
-CSetting::CSetting(const std::string& id,
-                   const CSetting& setting,
-                   const std::string& name /* = "CSetting" */)
-  : CSetting(id, setting.m_settingsManager, name)
+CSetting::CSetting(const std::string& id, const CSetting& setting)
+  : CSetting(id, setting.m_settingsManager)
 {
   Copy(setting);
 }
@@ -342,17 +338,22 @@ void CSetting::Copy(const CSetting &setting)
   m_changed = setting.m_changed;
 }
 
+Logger CSettingList::s_logger;
+
 CSettingList::CSettingList(const std::string& id,
                            std::shared_ptr<CSetting> settingDefinition,
                            CSettingsManager* settingsManager /* = nullptr */)
-  : CSetting(id, settingsManager, "CSettingList"), m_definition(std::move(settingDefinition))
-{ }
+  : CSetting(id, settingsManager), m_definition(std::move(settingDefinition))
+{
+  if (s_logger == nullptr)
+    s_logger = CServiceBroker::GetLogging().GetLogger("CSettingList");
+}
 
 CSettingList::CSettingList(const std::string& id,
                            std::shared_ptr<CSetting> settingDefinition,
                            int label,
                            CSettingsManager* settingsManager /* = nullptr */)
-  : CSetting(id, settingsManager, "CSettingList"), m_definition(std::move(settingDefinition))
+  : CSettingList(id, settingDefinition, settingsManager)
 {
   SetLabel(label);
 }
@@ -656,12 +657,15 @@ std::string CSettingList::toString(const SettingList &values) const
   return StringUtils::Join(strValues, m_delimiter);
 }
 
+Logger CSettingBool::s_logger;
+
 CSettingBool::CSettingBool(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingBool")
-{ }
+  : CSettingBool(id, DefaultLabel, DefaultValue, settingsManager)
+{
+}
 
 CSettingBool::CSettingBool(const std::string& id, const CSettingBool& setting)
-  : CTraitedSetting(id, setting, "CSettingBool")
+  : CSettingBool(id, setting.m_settingsManager)
 {
   copy(setting);
 }
@@ -670,9 +674,12 @@ CSettingBool::CSettingBool(const std::string& id,
                            int label,
                            bool value,
                            CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingBool"), m_value(value), m_default(value)
+  : CTraitedSetting(id, settingsManager), m_value(value), m_default(value)
 {
   SetLabel(label);
+
+  if (s_logger == nullptr)
+    s_logger = CServiceBroker::GetLogging().GetLogger("CSettingBool");
 }
 
 SettingPtr CSettingBool::Clone(const std::string &id) const
@@ -798,12 +805,14 @@ bool CSettingBool::fromString(const std::string &strValue, bool &value) const
   return false;
 }
 
+Logger CSettingInt::s_logger;
+
 CSettingInt::CSettingInt(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingInt")
+  : CSettingInt(id, DefaultLabel, DefaultValue, settingsManager)
 { }
 
 CSettingInt::CSettingInt(const std::string& id, const CSettingInt& setting)
-  : CTraitedSetting(id, setting, "CSettingInt")
+  : CSettingInt(id, setting.m_settingsManager)
 {
   copy(setting);
 }
@@ -812,7 +821,7 @@ CSettingInt::CSettingInt(const std::string& id,
                          int label,
                          int value,
                          CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingInt"), m_value(value), m_default(value)
+  : CSettingInt(id, label, value, DefaultMin, DefaultStep, DefaultMax, settingsManager)
 {
   SetLabel(label);
 }
@@ -824,7 +833,7 @@ CSettingInt::CSettingInt(const std::string& id,
                          int step,
                          int maximum,
                          CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingInt"),
+  : CTraitedSetting(id, settingsManager),
     m_value(value),
     m_default(value),
     m_min(minimum),
@@ -832,6 +841,9 @@ CSettingInt::CSettingInt(const std::string& id,
     m_max(maximum)
 {
   SetLabel(label);
+
+  if (s_logger == nullptr)
+    s_logger = CServiceBroker::GetLogging().GetLogger("CSettingInt");
 }
 
 CSettingInt::CSettingInt(const std::string& id,
@@ -839,12 +851,9 @@ CSettingInt::CSettingInt(const std::string& id,
                          int value,
                          const TranslatableIntegerSettingOptions& options,
                          CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingInt"),
-    m_value(value),
-    m_default(value),
-    m_translatableOptions(options)
+  : CSettingInt(id, label, value, settingsManager)
 {
-  SetLabel(label);
+  SetTranslatableOptions(options);
 }
 
 SettingPtr CSettingInt::Clone(const std::string &id) const
@@ -1144,13 +1153,15 @@ bool CSettingInt::fromString(const std::string &strValue, int &value)
   return true;
 }
 
+Logger CSettingNumber::s_logger;
+
 CSettingNumber::CSettingNumber(const std::string& id,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingNumber")
+  : CSettingNumber(id, DefaultLabel, DefaultValue, settingsManager)
 { }
 
 CSettingNumber::CSettingNumber(const std::string& id, const CSettingNumber& setting)
-  : CTraitedSetting(id, setting, "CSettingNumber")
+  : CSettingNumber(id, setting.m_settingsManager)
 {
   copy(setting);
 }
@@ -1159,11 +1170,8 @@ CSettingNumber::CSettingNumber(const std::string& id,
                                int label,
                                float value,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingNumber"),
-    m_value(static_cast<double>(value)),
-    m_default(static_cast<double>(value))
+  : CSettingNumber(id, label, value, DefaultMin, DefaultStep, DefaultMax, settingsManager)
 {
-  SetLabel(label);
 }
 
 CSettingNumber::CSettingNumber(const std::string& id,
@@ -1173,7 +1181,7 @@ CSettingNumber::CSettingNumber(const std::string& id,
                                float step,
                                float maximum,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingNumber"),
+  : CTraitedSetting(id, settingsManager),
     m_value(static_cast<double>(value)),
     m_default(static_cast<double>(value)),
     m_min(static_cast<double>(minimum)),
@@ -1181,6 +1189,9 @@ CSettingNumber::CSettingNumber(const std::string& id,
     m_max(static_cast<double>(maximum))
 {
   SetLabel(label);
+
+  if (s_logger == nullptr)
+    s_logger = CServiceBroker::GetLogging().GetLogger("CSettingNumber");
 }
 
 SettingPtr CSettingNumber::Clone(const std::string &id) const
@@ -1344,13 +1355,16 @@ bool CSettingNumber::fromString(const std::string &strValue, double &value)
   return true;
 }
 
+const CSettingString::Value CSettingString::DefaultValue;
+Logger CSettingString::s_logger;
+
 CSettingString::CSettingString(const std::string& id,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingString")
+  : CSettingString(id, DefaultLabel, DefaultValue, settingsManager)
 { }
 
 CSettingString::CSettingString(const std::string& id, const CSettingString& setting)
-  : CTraitedSetting(id, setting, "CSettingString")
+  : CSettingString(id, setting.m_settingsManager)
 {
   copy(setting);
 }
@@ -1359,9 +1373,12 @@ CSettingString::CSettingString(const std::string& id,
                                int label,
                                const std::string& value,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager, "CSettingString"), m_value(value), m_default(value)
+  : CTraitedSetting(id, settingsManager), m_value(value), m_default(value)
 {
   SetLabel(label);
+
+  if (s_logger == nullptr)
+    s_logger = CServiceBroker::GetLogging().GetLogger("CSettingString");
 }
 
 SettingPtr CSettingString::Clone(const std::string &id) const
@@ -1611,22 +1628,29 @@ void CSettingString::copy(const CSettingString &setting)
   m_dynamicOptions = setting.m_dynamicOptions;
 }
 
+Logger CSettingAction::s_logger;
+
 CSettingAction::CSettingAction(const std::string& id,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CSetting(id, settingsManager, "CSettingAction")
+  : CSettingAction(id, DefaultLabel, settingsManager)
 { }
 
 CSettingAction::CSettingAction(const std::string& id,
                                int label,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CSetting(id, settingsManager, "CSettingAction")
+  : CSetting(id, settingsManager)
 {
   SetLabel(label);
+
+  if (s_logger == nullptr)
+    s_logger = CServiceBroker::GetLogging().GetLogger("CSettingAction");
 }
 
 CSettingAction::CSettingAction(const std::string& id, const CSettingAction& setting)
-  : CSetting(id, setting, "CSettingAction"), m_data(setting.m_data)
-{ }
+  : CSettingAction(id, setting.m_settingsManager)
+{
+  copy(setting);
+}
 
 SettingPtr CSettingAction::Clone(const std::string &id) const
 {
@@ -1653,4 +1677,12 @@ bool CSettingAction::Deserialize(const TiXmlNode *node, bool update /* = false *
   m_data = XMLUtils::GetString(node, SETTING_XML_ELM_DATA);
 
   return true;
+}
+
+void CSettingAction::copy(const CSettingAction& setting)
+{
+  CSetting::Copy(setting);
+
+  CExclusiveLock lock(m_critical);
+  m_data = setting.m_data;
 }

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -283,6 +283,24 @@ void CSetting::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
   m_callback->OnSettingAction(setting);
 }
 
+bool CSetting::DeserializeIdentification(const TiXmlNode* node,
+                                         std::string& identification,
+                                         bool& isReference)
+{
+  isReference = false;
+
+  // first check if we can simply retrieve the setting's identifier
+  if (ISetting::DeserializeIdentification(node, identification))
+    return true;
+
+  // otherwise try to retrieve a reference to another setting's identifier
+  if (!DeserializeIdentificationFromAttribute(node, SETTING_XML_ATTR_REFERENCE, identification))
+    return false;
+
+  isReference = true;
+  return true;
+}
+
 bool CSetting::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
                                const char* oldSettingId,
                                const TiXmlNode* oldSettingNode)

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -95,6 +95,19 @@ public:
   // implementation of ISettingCallback
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
 
+  /*!
+   \brief Deserializes the given XML node to retrieve a setting object's identifier and
+          whether the setting is a reference to another setting or not.
+
+   \param node XML node containing a setting object's identifier
+   \param identification Will contain the deserialized setting object's identifier
+   \param isReference Whether the setting is a reference to the setting with the determined identifier
+   \return True if a setting object's identifier was deserialized, false otherwise
+   */
+  static bool DeserializeIdentification(const TiXmlNode* node,
+                                        std::string& identification,
+                                        bool& isReference);
+
 protected:
   // implementation of ISettingCallback
   bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override;

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -47,10 +47,8 @@ class CSetting : public ISetting,
                  public std::enable_shared_from_this<CSetting>
 {
 public:
-  CSetting(const std::string& id,
-           CSettingsManager* settingsManager = nullptr,
-           const std::string& name = "CSetting");
-  CSetting(const std::string& id, const CSetting& setting, const std::string& name = "CSetting");
+  CSetting(const std::string& id, CSettingsManager* settingsManager = nullptr);
+  CSetting(const std::string& id, const CSetting& setting);
   ~CSetting() override = default;
 
   virtual std::shared_ptr<CSetting> Clone(const std::string &id) const = 0;
@@ -138,6 +136,7 @@ protected:
 
   std::string m_referencedId;
 
+private:
   static Logger s_logger;
 };
 
@@ -153,16 +152,10 @@ public:
   static SettingType Type() { return TSettingType; }
 
 protected:
-  CTraitedSetting(const std::string& id,
-                  CSettingsManager* settingsManager = nullptr,
-                  const std::string& name = "CTraitedSetting")
-    : CSetting(id, settingsManager, name)
+  CTraitedSetting(const std::string& id, CSettingsManager* settingsManager = nullptr)
+    : CSetting(id, settingsManager)
   { }
-  CTraitedSetting(const std::string& id,
-                  const CTraitedSetting& setting,
-                  const std::string& name = "CTraitedSetting")
-    : CSetting(id, setting, name)
-  { }
+  CTraitedSetting(const std::string& id, const CTraitedSetting& setting) : CSetting(id, setting) {}
   ~CTraitedSetting() override = default;
 };
 
@@ -223,6 +216,8 @@ protected:
   std::string m_delimiter = "|";
   int m_minimumItems = 0;
   int m_maximumItems = -1;
+
+  static Logger s_logger;
 };
 
 /*!
@@ -255,11 +250,15 @@ public:
   void SetDefault(bool value);
 
 private:
+  static constexpr Value DefaultValue = false;
+
   void copy(const CSettingBool &setting);
   bool fromString(const std::string &strValue, bool &value) const;
 
-  bool m_value = false;
-  bool m_default = false;
+  bool m_value = DefaultValue;
+  bool m_default = DefaultValue;
+
+  static Logger s_logger;
 };
 
 /*!
@@ -323,14 +322,19 @@ public:
   void SetOptionsSort(SettingOptionsSort optionsSort) { m_optionsSort = optionsSort; }
 
 private:
+  static constexpr Value DefaultValue = 0;
+  static constexpr Value DefaultMin = DefaultValue;
+  static constexpr Value DefaultStep = 1;
+  static constexpr Value DefaultMax = DefaultValue;
+
   void copy(const CSettingInt &setting);
   static bool fromString(const std::string &strValue, int &value);
 
-  int m_value = 0;
-  int m_default = 0;
-  int m_min = 0;
-  int m_step = 1;
-  int m_max = 0;
+  int m_value = DefaultValue;
+  int m_default = DefaultValue;
+  int m_min = DefaultMin;
+  int m_step = DefaultStep;
+  int m_max = DefaultMax;
   TranslatableIntegerSettingOptions m_translatableOptions;
   IntegerSettingOptions m_options;
   std::string m_optionsFillerName;
@@ -338,6 +342,8 @@ private:
   void *m_optionsFillerData = nullptr;
   IntegerSettingOptions m_dynamicOptions;
   SettingOptionsSort m_optionsSort = SettingOptionsSort::NoSorting;
+
+  static Logger s_logger;
 };
 
 /*!
@@ -379,14 +385,21 @@ public:
   void SetMaximum(double maximum) { m_max = maximum; }
 
 private:
+  static constexpr Value DefaultValue = 0.0;
+  static constexpr Value DefaultMin = DefaultValue;
+  static constexpr Value DefaultStep = 1.0;
+  static constexpr Value DefaultMax = DefaultValue;
+
   virtual void copy(const CSettingNumber &setting);
   static bool fromString(const std::string &strValue, double &value);
 
-  double m_value = 0.0;
-  double m_default = 0.0;
-  double m_min = 0.0;
-  double m_step = 1.0;
-  double m_max = 0.0;
+  double m_value = DefaultValue;
+  double m_default = DefaultValue;
+  double m_min = DefaultMin;
+  double m_step = DefaultStep;
+  double m_max = DefaultMax;
+
+  static Logger s_logger;
 };
 
 /*!
@@ -445,6 +458,8 @@ public:
   void SetOptionsSort(SettingOptionsSort optionsSort) { m_optionsSort = optionsSort; }
 
 protected:
+  static const Value DefaultValue;
+
   virtual void copy(const CSettingString &setting);
 
   std::string m_value;
@@ -458,6 +473,8 @@ protected:
   void *m_optionsFillerData = nullptr;
   StringSettingOptions m_dynamicOptions;
   SettingOptionsSort m_optionsSort = SettingOptionsSort::NoSorting;
+
+  static Logger s_logger;
 };
 
 /*!
@@ -494,5 +511,9 @@ public:
   void SetData(const std::string& data) { m_data = data; }
 
 protected:
+  virtual void copy(const CSettingAction& setting);
+
   std::string m_data;
+
+  static Logger s_logger;
 };

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -49,6 +49,7 @@
 #define SETTING_XML_ELM_DATA "data"
 
 #define SETTING_XML_ATTR_ID "id"
+#define SETTING_XML_ATTR_REFERENCE "ref"
 #define SETTING_XML_ATTR_LABEL "label"
 #define SETTING_XML_ATTR_HELP "help"
 #define SETTING_XML_ATTR_TYPE "type"

--- a/xbmc/settings/lib/SettingSection.cpp
+++ b/xbmc/settings/lib/SettingSection.cpp
@@ -97,7 +97,8 @@ bool CSettingGroup::Deserialize(const TiXmlNode *node, bool update /* = false */
   while (settingElement != nullptr)
   {
     std::string settingId;
-    if (CSetting::DeserializeIdentification(settingElement, settingId))
+    bool isReference;
+    if (CSetting::DeserializeIdentification(settingElement, settingId, isReference))
     {
       auto settingIt = std::find_if(m_settings.begin(), m_settings.end(),
         [&settingId](const SettingPtr& setting)
@@ -126,10 +127,20 @@ bool CSettingGroup::Deserialize(const TiXmlNode *node, bool update /* = false */
 
       if (setting == nullptr)
         s_logger->error("unable to create new setting \"{}\"", settingId);
-      else if (!setting->Deserialize(settingElement, update))
-        s_logger->warn("unable to read setting \"{}\"", settingId);
-      else if (!update)
-        addISetting(settingElement, setting, m_settings);
+      else
+      {
+        if (!setting->Deserialize(settingElement, update))
+          s_logger->warn("unable to read setting \"{}\"", settingId);
+        else
+        {
+          // if the setting is a reference turn it into one
+          if (isReference)
+            setting->MakeReference();
+
+          if (!update)
+            addISetting(settingElement, setting, m_settings);
+        }
+      }
     }
 
     settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);

--- a/xbmc/settings/lib/SettingSection.cpp
+++ b/xbmc/settings/lib/SettingSection.cpp
@@ -97,7 +97,7 @@ bool CSettingGroup::Deserialize(const TiXmlNode *node, bool update /* = false */
   while (settingElement != nullptr)
   {
     std::string settingId;
-    if (CSettingCategory::DeserializeIdentification(settingElement, settingId))
+    if (CSetting::DeserializeIdentification(settingElement, settingId))
     {
       auto settingIt = std::find_if(m_settings.begin(), m_settings.end(),
         [&settingId](const SettingPtr& setting)


### PR DESCRIPTION
## Description
This PR adds the following improvements / missing features from the old add-on settings system to the new one:
* `<hideextensions>` for `path` / `CSettingPath` settings
* `<usethumbs>` for `string` / `CSettingString` settings using the `file` format
* `<treatasfolder>` for `string` / `CSettingString` settings using the `file` format
* support for referencing existing settings from other categories / sections. This is now possible by using **`ref="some_setting_id"`** instead of `id="some_setting_id"` to create a reference to the setting with the id `some_setting_id`. Beware that the setting definition still has to be valid so you can't just drop mandatory properties of the setting. But the original and the reference setting will share their value.

## Motivation and context
Up until now these features only worked as part of the automatic conversion from old add-on settings system but it didn't work when directly using the new add-on settings system.

## How has this been tested?
Manually.

## What is the effect on users?
Add-on developers can now use the features listed above when writing the settings of their add-on in the new settings system / format.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed