### PR TITLE
[Windows] Fix: crash if WS-Discovery receives partial or malformed list of properties from network devices

### DIFF
--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -62,8 +62,19 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
 
   if (list && address)
   {
-    const std::wstring type(list->Next->Element->LocalName);
     const std::wstring addr(address);
+    std::wstring type(L"Unspecified");
+    WSD_NAME_LIST* pList = list; // first element of list
+
+    do
+    {
+      if (pList->Element && pList->Element->LocalName)
+        type = std::wstring(pList->Element->LocalName);
+      if (pList->Next)
+        pList = pList->Next; // next element of list
+      else
+        pList = nullptr; // end of list
+    } while (type != L"Computer" && pList != nullptr);
 
     CLog::Log(LOGDEBUG,
               "[WS-Discovery]: HELLO packet received: device type = '{}', device address = '{}'",
@@ -234,7 +245,7 @@ void CWSDiscoverySupport::Terminate()
 {
   if (m_initialized)
   {
-    CLog::Log(LOGINFO, "[WS-Discovery]: terminate...");
+    CLog::Log(LOGINFO, "[WS-Discovery]: terminating");
     m_initialized = false;
   }
   if (m_provider)


### PR DESCRIPTION
## Description
Fix: crash if WS-Discovery receives partial or malformed list of properties from network devices.

Fixes https://github.com/xbmc/xbmc/issues/19778

## Motivation and context
Some simple devices does not send valid "Next" element that tells "device type name"  i.e. Computer, printer, etc.
First level LocalName is always "Device" string so is need access to second level to find string "Computer".

Anyway for computers is mandatory send the second level so if is missing, packet can be discarded because is not of interest (to identify PC's or NAS devices).

**EDIT:** Updated with more elaborated method: is iterated over all elements of list to find "Computer" description in any position or ends when next element is NULL. Also are logged all found devices even exotic ones as "NetworkVideoTransmitter".

See: https://github.com/xbmc/xbmc/issues/19778#issuecomment-848036608


## How has this been tested?
Runtime tested

## What is the effect on users?
Fixes startup crash if WS-Discovery receives partial or malformed list of properties from network devices.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
