### PR TITLE
[Windows] Fix: crash if WS-Discovery receives partial or malformed list of properties from network devices

### DIFF
--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -433,15 +433,16 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
   do
   {
     DWORD resCount = -1;
-    DWORD bufSize = buf.size();
-    result = WNetEnumResourceW(netEnum, &resCount, buf.get(), &bufSize);
+    size_t bufSize = buf.size();
+    result = WNetEnumResourceW(netEnum, &resCount, buf.get(), reinterpret_cast<LPDWORD>(&bufSize));
     if (result == NO_ERROR)
     {
       if (bufSize > buf.size())
       { // buffer is too small
         buf.allocate(bufSize); // discard buffer content and extend the buffer
         bufSize = buf.size();
-        result = WNetEnumResourceW(netEnum, &resCount, buf.get(), &bufSize);
+        result =
+            WNetEnumResourceW(netEnum, &resCount, buf.get(), reinterpret_cast<LPDWORD>(&bufSize));
         if (result != NO_ERROR || bufSize > buf.size())
           errorFlag = true; // hardly ever happens
       }

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -62,8 +62,19 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
 
   if (list && address)
   {
-    const std::wstring type(list->Next->Element->LocalName);
     const std::wstring addr(address);
+    std::wstring type(L"Unspecified");
+    WSD_NAME_LIST* pList = list; // first element of list
+
+    do
+    {
+      if (pList->Element && pList->Element->LocalName)
+        type = std::wstring(pList->Element->LocalName);
+      if (pList->Next)
+        pList = pList->Next; // next element of list
+      else
+        pList = nullptr; // end of list
+    } while (type != L"Computer" && pList != nullptr);
 
     CLog::Log(LOGDEBUG,
               "[WS-Discovery]: HELLO packet received: device type = '{}', device address = '{}'",
@@ -234,7 +245,7 @@ void CWSDiscoverySupport::Terminate()
 {
   if (m_initialized)
   {
-    CLog::Log(LOGINFO, "[WS-Discovery]: terminate...");
+    CLog::Log(LOGINFO, "[WS-Discovery]: terminating");
     m_initialized = false;
   }
   if (m_provider)

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -62,8 +62,8 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
 
   if (list && address)
   {
-    std::wstring type(list->Next->Element->LocalName);
-    std::wstring addr(address);
+    const std::wstring type(list->Next->Element->LocalName);
+    const std::wstring addr(address);
 
     CLog::Log(LOGDEBUG,
               "[WS-Discovery]: HELLO packet received: device type = '{}', device address = '{}'",
@@ -72,9 +72,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
     // filter Printers and other devices that are not "Computers"
     if (type == L"Computer")
     {
-      std::wstring addr(address);
       const std::wstring ip = addr.substr(0, addr.find(L":", 0));
-
       auto it = std::find(m_serversIPs.begin(), m_serversIPs.end(), ip);
 
       // inserts server IP if not exist in list
@@ -102,7 +100,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* 
 
   if (address)
   {
-    std::wstring addr(address);
+    const std::wstring addr(address);
 
     CLog::Log(LOGDEBUG, "[WS-Discovery]: BYE packet received: device address = '{}'", FromW(addr));
 
@@ -268,7 +266,7 @@ std::vector<std::wstring> CWSDiscoverySupport::GetServersIPs()
   return m_sink->GetServersIPs();
 }
 
-std::wstring CWSDiscoverySupport::ResolveHostName(const std::wstring serverIP)
+std::wstring CWSDiscoverySupport::ResolveHostName(const std::wstring& serverIP)
 {
   std::wstring hostName = serverIP;
 

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.h
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.h
@@ -56,7 +56,7 @@ public:
   bool ThereAreServers();
   std::vector<std::wstring> GetServersIPs();
 
-  static std::wstring ResolveHostName(const std::wstring serverIP);
+  static std::wstring ResolveHostName(const std::wstring& serverIP);
 
 private:
   bool m_initialized = false;


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/19801 and https://github.com/xbmc/xbmc/pull/19660

The second is need because because WS-Discovery code on master branch is already patched to remove c++ warnings so in this way is same code master/Matrix now.


## What is the effect on users?
Fixes startup crash if WS-Discovery receives partial or malformed list of properties from network devices.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
