### PR TITLE
more std::chrono conversion

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1136,19 +1136,17 @@ bool CApplication::LoadSkin(const std::string& skinID)
 
   g_localizeStrings.LoadSkinStrings(langPath, settings->GetString(CSettings::SETTING_LOCALE_LANGUAGE));
 
-
-  int64_t start;
-  start = CurrentHostCounter();
+  const auto start = std::chrono::steady_clock::now();
 
   CLog::Log(LOGINFO, "  load new skin...");
 
   // Load custom windows
   LoadCustomWindows();
 
-  int64_t end, freq;
-  end = CurrentHostCounter();
-  freq = CurrentHostFrequency();
-  CLog::Log(LOGDEBUG, "Load Skin XML: {:.2f}ms", 1000.f * (end - start) / freq);
+  const auto end = std::chrono::steady_clock::now();
+  std::chrono::duration<double, std::milli> duration = end - start;
+
+  CLog::Log(LOGDEBUG, "Load Skin XML: {:.2f} ms", duration.count());
 
   CLog::Log(LOGINFO, "  initialize new skin...");
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(this);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1572,11 +1572,10 @@ void CUtil::GetSkinThemes(std::vector<std::string>& vecTheme)
 void CUtil::InitRandomSeed()
 {
   // Init random seed
-  int64_t now;
-  now = CurrentHostCounter();
-  unsigned int seed = (unsigned int)now;
-  //  CLog::Log(LOGDEBUG, "{} - Initializing random seed with {}", __FUNCTION__, seed);
-  srand(seed);
+  auto now = std::chrono::steady_clock::now();
+  auto seed = now.time_since_epoch();
+
+  srand(static_cast<unsigned int>(seed.count()));
 }
 
 #if defined(TARGET_POSIX) && !defined(TARGET_DARWIN_TVOS)

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -339,8 +339,7 @@ const CTextureArray& CGUITextureManager::Load(const std::string& strTextureName,
   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
 #ifdef _DEBUG_TEXTURES
-  int64_t start;
-  start = CurrentHostCounter();
+  const auto start = std::chrono::steady_clock::now();
 #endif
 
   if (bundle >= 0 && StringUtils::EndsWithNoCase(strPath, ".gif"))
@@ -463,12 +462,10 @@ const CTextureArray& CGUITextureManager::Load(const std::string& strTextureName,
   m_vecTextures.push_back(pMap);
 
 #ifdef _DEBUG_TEXTURES
-  int64_t end, freq;
-  end = CurrentHostCounter();
-  freq = CurrentHostFrequency();
-  char temp[200];
-  sprintf(temp, "Load %s: %.1fms%s\n", strPath.c_str(), 1000.f * (end - start) / freq, (bundle >= 0) ? " (bundled)" : "");
-  OutputDebugString(temp);
+  const auto end = std::chrono::steady_clock::now();
+  const std::chrono::duration<double, std::milli> duration = end - start;
+  CLog::Log(LOGDEBUG, "Load {}: {:.3f} ms {}", strPath, duration.count(),
+            (bundle >= 0) ? "(bundled)" : "");
 #endif
 
   return pMap->GetTexture();

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -1425,13 +1425,14 @@ void CWinSystemWayland::FinishFramePresentation()
 {
   ProcessMessages();
 
-  m_frameStartTime = CurrentHostCounter();
+  m_frameStartTime = std::chrono::steady_clock::now();
 }
 
 float CWinSystemWayland::GetFrameLatencyAdjustment()
 {
-  std::int64_t now{CurrentHostCounter()};
-  return static_cast<float> (now - m_frameStartTime) / CurrentHostFrequency() * 1000.0f;
+  const auto now = std::chrono::steady_clock::now();
+  const std::chrono::duration<float, std::milli> duration = now - m_frameStartTime;
+  return duration.count();
 }
 
 float CWinSystemWayland::GetDisplayLatency()

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -21,6 +21,7 @@
 #include "windowing/WinSystem.h"
 
 #include <atomic>
+#include <chrono>
 #include <ctime>
 #include <list>
 #include <map>
@@ -242,7 +243,8 @@ private:
   static constexpr int LATENCY_MOVING_AVERAGE_SIZE{30};
   std::atomic<float> m_latencyMovingAverage;
   CSignalHandlerList<PresentationFeedbackHandler> m_presentationFeedbackHandlers;
-  std::int64_t m_frameStartTime{};
+
+  std::chrono::steady_clock::time_point m_frameStartTime{};
 
   // IDispResource
   // -------------


### PR DESCRIPTION
This moves some logic from using `CurrentHostCounter` to `std::chrono`. This help unify the implementations that require timing between two time points.

There is still more to change but this covers some of the simple stuff.

The `wayland` change and the `srand` change are the only functional changes. The rest is just for logging.