### PR TITLE
CGUIFontCache: use std::chrono and some other changes

### DIFF
--- a/xbmc/guilib/GUIFontCache.cpp
+++ b/xbmc/guilib/GUIFontCache.cpp
@@ -12,6 +12,13 @@
 #include <stdint.h>
 #include <vector>
 
+using namespace std::chrono_literals;
+
+namespace
+{
+constexpr auto FONT_CACHE_TIME_LIMIT = 1000ms;
+}
+
 template<class Position, class Value>
 class CGUIFontCacheImpl
 {
@@ -19,14 +26,14 @@ class CGUIFontCacheImpl
   {
     using HashMap = std::multimap<size_t, CGUIFontCacheEntry<Position, Value>*>;
     using HashIter = typename HashMap::iterator;
-    using AgeMap = std::multimap<size_t, HashIter>;
+    using AgeMap = std::multimap<std::chrono::steady_clock::time_point, HashIter>;
 
     ~EntryList() { Flush(); }
     HashIter Insert(size_t hash, CGUIFontCacheEntry<Position, Value>* v)
     {
       auto r(hashMap.insert(typename HashMap::value_type(hash, v)));
       if (r->second)
-        ageMap.insert(typename AgeMap::value_type(r->second->m_lastUsedMillis, r));
+        ageMap.insert(typename AgeMap::value_type(r->second->m_lastUsed, r));
 
       return r;
     }
@@ -52,16 +59,16 @@ class CGUIFontCacheImpl
 
       return hashMap.end();
     }
-    void UpdateAge(HashIter it, size_t millis)
+    void UpdateAge(HashIter it, std::chrono::steady_clock::time_point now)
     {
-      auto range = ageMap.equal_range(it->second->m_lastUsedMillis);
+      auto range = ageMap.equal_range(it->second->m_lastUsed);
       for (auto ageit = range.first; ageit != range.second; ++ageit)
       {
         if (ageit->second == it)
         {
           ageMap.erase(ageit);
-          ageMap.insert(typename AgeMap::value_type(millis, it));
-          it->second->m_lastUsedMillis = millis;
+          ageMap.insert(typename AgeMap::value_type(now, it));
+          it->second->m_lastUsed = now;
           return;
         }
       }
@@ -83,7 +90,7 @@ public:
                 uint32_t alignment,
                 float maxPixelWidth,
                 bool scrolling,
-                unsigned int nowMillis,
+                std::chrono::steady_clock::time_point now,
                 bool& dirtyCache);
   void Flush();
 };
@@ -98,7 +105,7 @@ CGUIFontCacheEntry<Position, Value>::~CGUIFontCacheEntry()
 
 template<class Position, class Value>
 void CGUIFontCacheEntry<Position, Value>::Assign(const CGUIFontCacheKey<Position>& key,
-                                                 unsigned int nowMillis)
+                                                 std::chrono::steady_clock::time_point now)
 {
   m_key.m_pos = key.m_pos;
   m_key.m_colors.assign(key.m_colors.begin(), key.m_colors.end());
@@ -109,7 +116,7 @@ void CGUIFontCacheEntry<Position, Value>::Assign(const CGUIFontCacheKey<Position
   m_matrix = key.m_matrix;
   m_key.m_scaleX = key.m_scaleX;
   m_key.m_scaleY = key.m_scaleY;
-  m_lastUsedMillis = nowMillis;
+  m_lastUsed = now;
   m_value.clear();
 }
 
@@ -133,13 +140,13 @@ Value& CGUIFontCache<Position, Value>::Lookup(const CGraphicContext& context,
                                               uint32_t alignment,
                                               float maxPixelWidth,
                                               bool scrolling,
-                                              unsigned int nowMillis,
+                                              std::chrono::steady_clock::time_point now,
                                               bool& dirtyCache)
 {
   if (!m_impl)
     m_impl = new CGUIFontCacheImpl<Position, Value>(this);
 
-  return m_impl->Lookup(context, pos, colors, text, alignment, maxPixelWidth, scrolling, nowMillis,
+  return m_impl->Lookup(context, pos, colors, text, alignment, maxPixelWidth, scrolling, now,
                         dirtyCache);
 }
 
@@ -151,7 +158,7 @@ Value& CGUIFontCacheImpl<Position, Value>::Lookup(const CGraphicContext& context
                                                   uint32_t alignment,
                                                   float maxPixelWidth,
                                                   bool scrolling,
-                                                  unsigned int nowMillis,
+                                                  std::chrono::steady_clock::time_point now,
                                                   bool& dirtyCache)
 {
   const CGUIFontCacheKey<Position> key(pos, const_cast<std::vector<UTILS::COLOR::Color>&>(colors),
@@ -165,21 +172,25 @@ Value& CGUIFontCacheImpl<Position, Value>::Lookup(const CGraphicContext& context
     // Cache miss
     dirtyCache = true;
     CGUIFontCacheEntry<Position, Value>* entry = nullptr;
-    if (!m_list.ageMap.empty() &&
-        (nowMillis - m_list.ageMap.begin()->first) > FONT_CACHE_TIME_LIMIT)
+
+    if (!m_list.ageMap.empty())
     {
-      entry = m_list.ageMap.begin()->second->second;
-      m_list.hashMap.erase(m_list.ageMap.begin()->second);
-      m_list.ageMap.erase(m_list.ageMap.begin());
+      const auto duration =
+          std::chrono::duration_cast<std::chrono::milliseconds>(now - m_list.ageMap.begin()->first);
+      if (duration > FONT_CACHE_TIME_LIMIT)
+      {
+        entry = m_list.ageMap.begin()->second->second;
+        m_list.hashMap.erase(m_list.ageMap.begin()->second);
+        m_list.ageMap.erase(m_list.ageMap.begin());
+      }
     }
 
     // add new entry
     CGUIFontCacheHash<Position> hashgen;
     if (!entry)
-      entry = new CGUIFontCacheEntry<Position, Value>(*m_parent, key, nowMillis);
+      entry = new CGUIFontCacheEntry<Position, Value>(*m_parent, key, now);
     else
-      entry->Assign(key, nowMillis);
-
+      entry->Assign(key, now);
     return m_list.Insert(hashgen(key), entry)->second->m_value;
   }
   else
@@ -190,7 +201,7 @@ Value& CGUIFontCacheImpl<Position, Value>::Lookup(const CGraphicContext& context
     pos.UpdateWithOffsets(i->second->m_key.m_pos, scrolling);
 
     // Update time in entry and move to the back of the list
-    m_list.UpdateAge(i, nowMillis);
+    m_list.UpdateAge(i, now);
 
     dirtyCache = false;
 
@@ -224,7 +235,7 @@ template CGUIFontCacheStaticValue& CGUIFontCache<
                                       uint32_t,
                                       float,
                                       bool,
-                                      unsigned int,
+                                      std::chrono::steady_clock::time_point,
                                       bool&);
 template void CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Flush();
 
@@ -242,7 +253,7 @@ template CGUIFontCacheDynamicValue& CGUIFontCache<
                                        uint32_t,
                                        float,
                                        bool,
-                                       unsigned int,
+                                       std::chrono::steady_clock::time_point,
                                        bool&);
 template void CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Flush();
 

--- a/xbmc/guilib/GUIFontCache.cpp
+++ b/xbmc/guilib/GUIFontCache.cpp
@@ -122,15 +122,12 @@ void CGUIFontCacheEntry<Position, Value>::Assign(const CGUIFontCacheKey<Position
 
 template<class Position, class Value>
 CGUIFontCache<Position, Value>::CGUIFontCache(CGUIFontTTF& font)
-  : m_impl(new CGUIFontCacheImpl<Position, Value>(this)), m_font(font)
+  : m_impl(std::make_unique<CGUIFontCacheImpl<Position, Value>>(this)), m_font(font)
 {
 }
 
 template<class Position, class Value>
-CGUIFontCache<Position, Value>::~CGUIFontCache()
-{
-  delete m_impl;
-}
+CGUIFontCache<Position, Value>::~CGUIFontCache() = default;
 
 template<class Position, class Value>
 Value& CGUIFontCache<Position, Value>::Lookup(const CGraphicContext& context,
@@ -144,7 +141,7 @@ Value& CGUIFontCache<Position, Value>::Lookup(const CGraphicContext& context,
                                               bool& dirtyCache)
 {
   if (!m_impl)
-    m_impl = new CGUIFontCacheImpl<Position, Value>(this);
+    m_impl = std::make_unique<CGUIFontCacheImpl<Position, Value>>(this);
 
   return m_impl->Lookup(context, pos, colors, text, alignment, maxPixelWidth, scrolling, now,
                         dirtyCache);

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -143,7 +143,7 @@ struct CGUIFontCacheKeysMatch
 template<class Position, class Value>
 class CGUIFontCache
 {
-  CGUIFontCacheImpl<Position, Value>* m_impl;
+  std::unique_ptr<CGUIFontCacheImpl<Position, Value>> m_impl;
 
   CGUIFontCache(const CGUIFontCache<Position, Value>&) = delete;
   const CGUIFontCache<Position, Value>& operator=(const CGUIFontCache<Position, Value>&) = delete;

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -18,13 +18,13 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cstddef>
 #include <cstring>
 #include <memory>
 #include <stdint.h>
 #include <vector>
 
-constexpr unsigned int FONT_CACHE_TIME_LIMIT = 1000;
 constexpr float FONT_CACHE_DIST_LIMIT = 0.01f;
 
 class CGraphicContext;
@@ -77,12 +77,12 @@ struct CGUIFontCacheEntry
   const CGUIFontCache<Position, Value>& m_cache;
   CGUIFontCacheKey<Position> m_key;
   TransformMatrix m_matrix;
-  unsigned int m_lastUsedMillis;
+  std::chrono::steady_clock::time_point m_lastUsed;
   Value m_value;
 
   CGUIFontCacheEntry(const CGUIFontCache<Position, Value>& cache,
                      const CGUIFontCacheKey<Position>& key,
-                     unsigned int nowMillis)
+                     std::chrono::steady_clock::time_point now)
     : m_cache(cache),
       m_key(key.m_pos,
             *new std::vector<UTILS::COLOR::Color>,
@@ -93,7 +93,7 @@ struct CGUIFontCacheEntry
             m_matrix,
             key.m_scaleX,
             key.m_scaleY),
-      m_lastUsedMillis(nowMillis)
+      m_lastUsed(now)
   {
     m_key.m_colors.assign(key.m_colors.begin(), key.m_colors.end());
     m_key.m_text.assign(key.m_text.begin(), key.m_text.end());
@@ -102,7 +102,7 @@ struct CGUIFontCacheEntry
 
   ~CGUIFontCacheEntry();
 
-  void Assign(const CGUIFontCacheKey<Position>& key, unsigned int nowMillis);
+  void Assign(const CGUIFontCacheKey<Position>& key, std::chrono::steady_clock::time_point now);
 };
 
 template<class Position>
@@ -162,7 +162,7 @@ public:
                 uint32_t alignment,
                 float maxPixelWidth,
                 bool scrolling,
-                unsigned int nowMillis,
+                std::chrono::steady_clock::time_point now,
                 bool& dirtyCache);
   void Flush();
 };

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -378,14 +378,14 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
   CVertexBuffer& vertexBuffer =
       hardwareClipping
           ? m_dynamicCache.Lookup(context, dynamicPos, colors, text, alignment, maxPixelWidth,
-                                  scrolling, XbmcThreads::SystemClockMillis(), dirtyCache)
+                                  scrolling, std::chrono::steady_clock::now(), dirtyCache)
           : unusedVertexBuffer;
   std::shared_ptr<std::vector<SVertex>> tempVertices = std::make_shared<std::vector<SVertex>>();
   std::shared_ptr<std::vector<SVertex>>& vertices =
       hardwareClipping ? tempVertices
                        : static_cast<std::shared_ptr<std::vector<SVertex>>&>(m_staticCache.Lookup(
                              context, staticPos, colors, text, alignment, maxPixelWidth, scrolling,
-                             XbmcThreads::SystemClockMillis(), dirtyCache));
+                             std::chrono::steady_clock::now(), dirtyCache));
   if (dirtyCache)
   {
     // save the origin, which is scaled separately
@@ -540,7 +540,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
     {
       CVertexBuffer& vertexBuffer =
           m_dynamicCache.Lookup(context, dynamicPos, colors, text, rawAlignment, maxPixelWidth,
-                                scrolling, XbmcThreads::SystemClockMillis(), dirtyCache);
+                                scrolling, std::chrono::steady_clock::now(), dirtyCache);
       CVertexBuffer newVertexBuffer = CreateVertexBuffer(*tempVertices);
       vertexBuffer = newVertexBuffer;
       m_vertexTrans.emplace_back(0, 0, 0, &vertexBuffer, context.GetClipRegion());
@@ -548,7 +548,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
     else
     {
       m_staticCache.Lookup(context, staticPos, colors, text, rawAlignment, maxPixelWidth, scrolling,
-                           XbmcThreads::SystemClockMillis(), dirtyCache) =
+                           std::chrono::steady_clock::now(), dirtyCache) =
           *static_cast<CGUIFontCacheStaticValue*>(&tempVertices);
       /* Append the new vertices to the set collected since the first Begin() call */
       m_vertex.insert(m_vertex.end(), tempVertices->begin(), tempVertices->end());


### PR DESCRIPTION
I wanted to separate this from #19808 as it's a bit more involved and includes some other changes.

1) use `std::chrono::steady_clock::time_point` for the font cache check. The old implementation used `SystemClockMillis` which was just a wrapper anyways.
2) ~~directly initialize the cache item from the key. I'm not 100% sure about this one as it seems the old way would use a pointer to point to the key item, this update simplifies the logic but will make a copy (like the other items do already?). If desired I can drop this change.~~
3) a small safety update to use a `unique_ptr`
4) another saftey update to use a `unique_ptr`

clang-format did some heavy adjustments so it's likely easier looking at each commit individually.