### PR TITLE
VideoPlayer: MediaCodec - Add av1 hw decoding

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=e9517e0f4efccd07667eec163449853bea8d5e5e
+VERSION=7b3e6a3be0e4f3c704016c44eeb37b5f026d6b9a
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -56,7 +56,6 @@
 
 #include "system.h"
 
-
 static const char* XMEDIAFORMAT_KEY_ROTATION = "rotation-degrees";
 static const char* XMEDIAFORMAT_KEY_SLICE = "slice-height";
 static const char* XMEDIAFORMAT_KEY_CROP_LEFT = "crop-left";
@@ -588,6 +587,27 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
 
       m_mime = "video/wvc1";
       m_formatname = "amc-vc1";
+      break;
+    }
+    case AV_CODEC_ID_AV1:
+    {
+      switch (hints.profile)
+      {
+        case FF_PROFILE_AV1_MAIN:
+          profile = CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain8;
+          break;
+        case FF_PROFILE_AV1_HIGH:
+        case FF_PROFILE_AV1_PROFESSIONAL:
+          goto FAIL;
+          break;
+        default:
+          break;
+      }
+      m_mime = "video/av01";
+      m_formatname = "amc-av1";
+      free(m_hints.extradata);
+      m_hints.extradata = nullptr;
+      m_hints.extrasize = 0;
       break;
     }
     default:


### PR DESCRIPTION
Add support for AV1 hardware decoding via
AndroidMediaCodec.

Needs: https://github.com/xbmc/libandroidjni/pull/24

## How has this been tested?
Tested on Amlogic S905X4 (Mecool KM6)

## What is the effect on users?
Stutterfree AV1 video.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
