### PR TITLE
[Favourites][cmake] explicitly set header file

### DIFF
--- a/xbmc/favourites/CMakeLists.txt
+++ b/xbmc/favourites/CMakeLists.txt
@@ -4,6 +4,6 @@ set(SOURCES ContextMenus.cpp
 
 set(HEADERS ContextMenus.h
             GUIDialogFavourites.h
-            FavouritesService)
+            FavouritesService.h)
 
 core_add_library(favourites)


### PR DESCRIPTION
## Description
fixes the following warning

CMake Warning (dev) at CMakeLists.txt:309 (add_library):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:

    /xbmc/favourites/FavouritesService.cpp
This warning is for project developers.  Use -Wno-dev to suppress it.

## Motivation and context
stumbled across this

## How has this been tested?
build on osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
