### PR TITLE
DynamicDLL: fix bugs in macro pairs which define and resolve functions with function pointers as parameters.

### DIFF
--- a/xbmc/DynamicDll.h
+++ b/xbmc/DynamicDll.h
@@ -112,8 +112,8 @@ public: \
     typedef result (linkage * name##_METHOD) args; \
   public: \
     union { \
-      name##_METHOD name; \
-      void*         name##_ptr; \
+      name##_METHOD m_##name; \
+      void*         m_##name##_ptr; \
     };
 
 #define DEFINE_METHOD_LINKAGE_BASE(result, linkage, name, args, args2) \
@@ -365,7 +365,7 @@ public: \
     return false;
 
 #define RESOLVE_METHOD_FP(method) \
-  if (!m_dll->ResolveExport( #method , & method##_ptr )) \
+  if (!m_dll->ResolveExport( #method , & m_##method##_ptr )) \
     return false;
 
 
@@ -385,8 +385,8 @@ public: \
    m_dll->ResolveExport( #method , & m_##method##_ptr, false );
 
 #define RESOLVE_METHOD_OPTIONAL_FP(method) \
-   method##_ptr = NULL; \
-   m_dll->ResolveExport( #method , & method##_ptr, false );
+   m_##method##_ptr = NULL; \
+   m_dll->ResolveExport( #method , & m_##method##_ptr, false );
 
 
 


### PR DESCRIPTION
## Description
The macros define the "method pointers" (the functions which are dynamically loaded) with wrong names. This is what the patches are fixing.

The `##` preprocessor directive concatenates two words. For instance:
```
#define macro(funny) name_##funny m_##funny
```
results in `name_huhu m_huhu` when calles as `macro(huhu)`

And the `#` preprocessor directive makes a string out of a macro parameter, so
```
#define macro(funny) #funny
```
results in `char *x = "huhu";` when called as `char *x = macro(huhu);`.

The bug was that the resulting function name is `name` instead of `m_name`. There're other macros which expect that a function name starts with `m_` which wasn't true for functions with function pointer parameters.

## Motivation and context

Fixes issues when using libraries with function pointers as parameters

## How has this been tested?

This has been tested on Kodi v19.x on OSMC Linux on Vero 4K/4K+ platforms

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
