### PR TITLE
[DXVA2] Fix: check if HDR10 RGB limited range is supported by video driver

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -205,20 +205,30 @@ bool CProcessorHD::InitProcessor()
     }
   }
 
-  // Check if HLG color space conversion is supported by driver
   ComPtr<ID3D11VideoProcessorEnumerator1> pEnumerator1;
 
   if (SUCCEEDED(m_pEnumerator.As(&pEnumerator1)))
   {
     DXGI_FORMAT format = DX::Windowing()->GetBackBuffer().GetFormat();
     BOOL supported = 0;
-    HRESULT hr = pEnumerator1->CheckVideoProcessorFormatConversion(
+    HRESULT hr;
+
+    // Check if HLG color space conversion is supported by driver
+    hr = pEnumerator1->CheckVideoProcessorFormatConversion(
         DXGI_FORMAT_P010, DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020, format,
         DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709, &supported);
     m_bSupportHLG = SUCCEEDED(hr) && !!supported;
+
+    // Check if HDR10 RGB limited range output is supported by driver
+    hr = pEnumerator1->CheckVideoProcessorFormatConversion(
+        DXGI_FORMAT_P010, DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020, format,
+        DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020, &supported);
+    m_bSupportHDR10Limited = SUCCEEDED(hr) && !!supported;
   }
 
   CLog::LogF(LOGDEBUG, "HLG color space conversion is{}supported.", m_bSupportHLG ? " " : " NOT ");
+  CLog::LogF(LOGDEBUG, "HDR10 RGB limited range output is{}supported.",
+             m_bSupportHDR10Limited ? " " : " NOT ");
 
   return true;
 }
@@ -410,7 +420,7 @@ DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceSource(CRenderBuffer* view,
   return DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P709;
 }
 
-DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceTarget(CRenderBuffer* view)
+DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceTarget(CRenderBuffer* view, bool supportHDR)
 {
   DXGI_COLOR_SPACE_TYPE color;
 
@@ -424,8 +434,16 @@ DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceTarget(CRenderBuffer* view)
   if (view->primaries == AVCOL_PRI_BT2020 && (view->color_transfer == AVCOL_TRC_SMPTE2084 ||
                                               view->color_transfer == AVCOL_TRC_ARIB_STD_B67))
   {
-    color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
-                                               : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+    if (supportHDR)
+    {
+      color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
+                                                 : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+    }
+    else
+    {
+      color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020
+                                                 : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020;
+    }
   }
 
   return color;
@@ -538,9 +556,12 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
   ComPtr<ID3D11VideoContext1> videoCtx1;
   if (SUCCEEDED(m_pVideoContext.As(&videoCtx1)))
   {
+    bool supportHDR = DX::Windowing()->IsHDROutput() &&
+                      (m_bSupportHDR10Limited || !DX::Windowing()->UseLimitedColor());
+
     const DXGI_COLOR_SPACE_TYPE sourceColor =
-        GetDXGIColorSpaceSource(views[2], DX::Windowing()->IsHDROutput(), m_bSupportHLG);
-    const DXGI_COLOR_SPACE_TYPE targetColor = GetDXGIColorSpaceTarget(views[2]);
+        GetDXGIColorSpaceSource(views[2], supportHDR, m_bSupportHLG);
+    const DXGI_COLOR_SPACE_TYPE targetColor = GetDXGIColorSpaceTarget(views[2], supportHDR);
 
     videoCtx1->VideoProcessorSetStreamColorSpace1(m_pVideoProcessor.Get(), DEFAULT_STREAM_INDEX,
                                                   sourceColor);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -49,7 +49,7 @@ public:
   void OnDestroyDevice(bool) override { CSingleLock lock(m_section); UnInit(); }
 
   static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(CRenderBuffer* view, bool supportHDR, bool supportHLG);
-  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(CRenderBuffer* view);
+  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(CRenderBuffer* view, bool supportHDR);
 
 protected:
   bool ReInit();
@@ -69,6 +69,7 @@ protected:
   D3D11_VIDEO_PROCESSOR_CAPS m_vcaps = {};
   D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps = {};
   bool m_bSupportHLG = false;
+  bool m_bSupportHDR10Limited = false;
 
   struct ProcAmpInfo
   {


### PR DESCRIPTION
## Description
Fix: check if HDR10 RGB limited range is supported by video driver (don't assume it's always supported)

## Motivation and context
Some drivers supports `DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020` as output for YUV to RGB color space conversion although may not support  `DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020`. Latest is used if source is HDR10 and Kodi is configured with limited range output.

This may cause problems if is used HDR10 video source + DXVA2 + limited range output + HDR passthrough.

Fix consists on check color space conversion with `CheckVideoProcessorFormatConversion` and if is not supported use alternative color spaces for input and output: `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020` and `DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020`.  These color spaces are compatible because are same BT.2020 matrix and don't care if transfer is PQ or gamma for YUV to RGB conversion only. Video Processor does not use HDR metadata in pass-through mode, only is used for color space and video range transformations.


## How has this been tested?
Runtime tested on Intel NUC8i3BEK and Nvidia RTX 2060. 
Tested correct black level using **full-full-full** chain and **limited-full-limited** chain.


## What is the effect on users?
Fixes possible incorrect black level or even no picture with HDR10 video source + DXVA2 + limited range output + HDR passthrough


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
