### PR TITLE
[jenkins][defaultenv] bump xcode version to 11.3.1 for ios/osx

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -20,10 +20,10 @@ DEPLOYED_BINARY_ADDONS="-e /addons"
 #$XBMC_PLATFORM_DIR matches the platform subdirs!
 case $XBMC_PLATFORM_DIR in
   ios)
-    DEFAULT_SDK_VERSION=12.2
+    DEFAULT_SDK_VERSION=13.2
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
-    DEFAULT_XCODE_APP="Xcode10.2.app"
+    DEFAULT_XCODE_APP="Xcode11.3.1.app"
     ;;
 
   tvos)
@@ -34,10 +34,10 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   osx64)
-    DEFAULT_SDK_VERSION=10.14
+    DEFAULT_SDK_VERSION=10.15
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
-    DEFAULT_XCODE_APP="Xcode10.2.app"
+    DEFAULT_XCODE_APP="Xcode11.3.1.app"
     ;;
 
   android)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -883,7 +883,7 @@ void CDVDInputStreamBluray::OverlayCallbackARGB(const struct bd_argb_overlay_s *
   /* uncompress and draw bitmap */
   if (ov->argb && ov->cmd == BD_ARGB_OVERLAY_DRAW)
   {
-    SOverlay overlay(new CDVDOverlayImage(), std::ptr_fun(CDVDOverlay::Release));
+    SOverlay overlay(new CDVDOverlayImage(), [](CDVDOverlay* ov) { CDVDOverlay::Release(ov); });
 
     overlay->palette_colors = 0;
     overlay->palette        = nullptr;


### PR DESCRIPTION
## Description
Bumps used xcode to 11.3.1 for ios and osx inline with existing tvos

Xcode 11.3.1 is the last version with a minimum system requirement that isnt Catalina 10.15
(minreq: MacOS 10.14.4). To go further, we would need to update all jenkins mac slaves to
Catalina.

No minimum target change, so no effect on end user.

## Motivation and context


## How has this been tested?


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
