### PR TITLE
[osx] fix warning for Applicationwillterminate -Wnonnull

### DIFF
--- a/xbmc/platform/darwin/osx/SDLMain.mm
+++ b/xbmc/platform/darwin/osx/SDLMain.mm
@@ -220,27 +220,11 @@ static void setupWindowMenu(void)
   CFRelease(url2);
 }
 
+// Doesnt currently get called. Keep in case we fix the root cause
 - (void) applicationWillTerminate: (NSNotification *) note
 {
-  [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self
-    name:NSWorkspaceDidMountNotification object:nil];
-
-  [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self
-    name:NSWorkspaceDidUnmountNotification object:nil];
-
-  NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-
-  [center removeObserver:self name:MediaKeyPower object:nil];
-  [center removeObserver:self name:MediaKeySoundMute object:nil];
-  [center removeObserver:self name:MediaKeySoundUp object:nil];
-  [center removeObserver:self name:MediaKeySoundDown object:nil];
-  [center removeObserver:self name:MediaKeyPlayPauseNotification object:nil];
-  [center removeObserver:self name:MediaKeyFastNotification object:nil];
-  [center removeObserver:self name:MediaKeyRewindNotification object:nil];
-  [center removeObserver:self name:MediaKeyNextNotification object:nil];
-  [center removeObserver:self name:MediaKeyPreviousNotification object:nil];
-
-  [[HotKeyController sharedController] disableTap];
+  // disabled as currently main() explicitly calls this.
+  // [self appshutdownCleanup];
 }
 
 - (void) applicationWillResignActive:(NSNotification *) note
@@ -266,6 +250,32 @@ static void setupWindowMenu(void)
   {
     // empty
   }
+}
+
+- (void)appshutdownCleanup
+{
+  [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self
+                                                                name:NSWorkspaceDidMountNotification
+                                                              object:nil];
+
+  [[[NSWorkspace sharedWorkspace] notificationCenter]
+      removeObserver:self
+                name:NSWorkspaceDidUnmountNotification
+              object:nil];
+
+  NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
+
+  [center removeObserver:self name:MediaKeyPower object:nil];
+  [center removeObserver:self name:MediaKeySoundMute object:nil];
+  [center removeObserver:self name:MediaKeySoundUp object:nil];
+  [center removeObserver:self name:MediaKeySoundDown object:nil];
+  [center removeObserver:self name:MediaKeyPlayPauseNotification object:nil];
+  [center removeObserver:self name:MediaKeyFastNotification object:nil];
+  [center removeObserver:self name:MediaKeyRewindNotification object:nil];
+  [center removeObserver:self name:MediaKeyNextNotification object:nil];
+  [center removeObserver:self name:MediaKeyPreviousNotification object:nil];
+
+  [[HotKeyController sharedController] disableTap];
 }
 
 // Called after the internal event loop has started running.
@@ -558,7 +568,7 @@ int main(int argc, char *argv[])
     status = SDL_main(gArgc, gArgv);
     SDL_Quit();
 
-    [xbmc_delegate applicationWillTerminate:NULL];
+    [xbmc_delegate appshutdownCleanup];
 
     return status;
   }


### PR DESCRIPTION
## Description
applicationWillTerminate shouldnt technically be required to be explicitly called.
However it is also optional, and can be disabled (by default in xcode 11) to not be called
at all when app is shut down (NSSupportsSuddenTermination info.plist)

Just implement and use a standard method called after SDL_Quit

Fixes a warning for -Wnonnull

## Motivation and context


## How has this been tested?
runtime on OSX. shuts down clean, still removes the observers.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
