### PR TITLE
[PVR] Refactor and fix load and update of channel groups.

### DIFF
--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -18,6 +18,7 @@ namespace PVR
 {
   class CPVRChannel;
   class CPVRChannelGroup;
+  class CPVRChannelGroupMember;
   class CPVRChannelGroups;
   class CPVRClient;
   class CPVRTimerInfoTag;
@@ -109,6 +110,14 @@ namespace PVR
     bool DeleteChannels();
 
     /*!
+     * @brief Get channels from the database.
+     * @param bRadio Whether to fetch radio or TV channels.
+     * @param results The container for the channels.
+     * @return The number of channels loaded.
+     */
+    int Get(bool bRadio, std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results);
+
+    /*!
      * @brief Add or update a channel entry in the database
      * @param channel The channel to persist.
      * @param bCommit queue only or queue and commit
@@ -123,12 +132,17 @@ namespace PVR
      */
     bool QueueDeleteQuery(const CPVRChannel& channel);
 
+    //@}
+
+    /*! @name Channel group member methods */
+    //@{
+
     /*!
-     * @brief Get the list of channels from the database
-     * @param results The channel group to store the results in.
-     * @return The amount of channels that were added.
+     * @brief Remove a channel group member entry from the database
+     * @param groupMember The group member to remove.
+     * @return True if the member was removed, false otherwise.
      */
-    int Get(CPVRChannelGroup& results);
+    bool QueueDeleteQuery(const CPVRChannelGroupMember& groupMember);
 
     //@}
 
@@ -142,18 +156,11 @@ namespace PVR
     bool DeleteChannelGroups();
 
     /*!
-     * @brief Delete a channel group from the database.
+     * @brief Delete a channel group and all its members from the database.
      * @param group The group to delete.
      * @return True if the group was deleted successfully, false otherwise.
      */
     bool Delete(const CPVRChannelGroup& group);
-
-    /*!
-     * @brief Remove all channel members of the given group from the database
-     * @param iGroupID The id of the group.
-     * @return True if all channel members were removed, false otherwise.
-     */
-    bool QueueDeleteChannelGroupMembersQuery(int iGroupID);
 
     /*!
      * @brief Get the channel groups.
@@ -165,10 +172,9 @@ namespace PVR
     /*!
      * @brief Add the group members to a group.
      * @param group The group to get the channels for.
-     * @param allGroup The "all channels group" matching param group's 'IsRadio' property.
      * @return The amount of channels that were added.
      */
-    int Get(CPVRChannelGroup& group, const CPVRChannelGroup& allGroup);
+    int Get(CPVRChannelGroup& group);
 
     /*!
      * @brief Add or update a channel group entry in the database.
@@ -253,20 +259,11 @@ namespace PVR
     void UpdateTables(int version) override;
     int GetMinSchemaVersion() const override { return 11; }
 
-    bool DeleteChannelsFromGroup(const CPVRChannelGroup& group, const std::vector<int>& channelsToDelete);
-
-    bool GetCurrentGroupMembers(const CPVRChannelGroup& group, std::vector<int>& members);
-    bool RemoveStaleChannelsFromGroup(const CPVRChannelGroup& group);
-
     bool PersistGroupMembers(const CPVRChannelGroup& group);
 
     bool PersistChannels(CPVRChannelGroup& group);
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup& group);
-    void InsertChannelIntoGroup(const std::shared_ptr<CPVRChannel>& channel,
-                                CPVRChannelGroup& group);
-
-    int GetClientIdByChannelId(int iChannelId);
 
     CCriticalSection m_critSection;
   };

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -532,9 +532,11 @@ public:
   /*!
    * @brief Request the list of all group members from the backend.
    * @param group The group to get the members for.
+   * @param groupMembers The container for the group members.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetChannelGroupMembers(CPVRChannelGroup* group);
+  PVR_ERROR GetChannelGroupMembers(
+      CPVRChannelGroup* group, std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
 
   //@}
   /** @name PVR channel methods */
@@ -549,11 +551,11 @@ public:
 
   /*!
    * @brief Request the list of all channels from the backend.
-   * @param channels The channel group to add the channels to.
    * @param bRadio True to get the radio channels, false to get the TV channels.
+   * @param channels The container for the channels.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetChannels(CPVRChannelGroup& channels, bool bRadio);
+  PVR_ERROR GetChannels(bool bRadio, std::vector<std::shared_ptr<CPVRChannel>>& channels);
 
   //@}
   /** @name PVR recording methods */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -543,11 +543,16 @@ PVR_ERROR CPVRClients::SetEPGMaxFutureDays(int iFutureDays)
   });
 }
 
-PVR_ERROR CPVRClients::GetChannels(CPVRChannelGroupInternal* group, std::vector<int>& failedClients)
+PVR_ERROR CPVRClients::GetChannels(bool bRadio,
+                                   std::vector<std::shared_ptr<CPVRChannel>>& channels,
+                                   std::vector<int>& failedClients)
 {
-  return ForCreatedClients(__FUNCTION__, [group](const std::shared_ptr<CPVRClient>& client) {
-    return client->GetChannels(*group, group->IsRadio());
-  }, failedClients);
+  return ForCreatedClients(
+      __FUNCTION__,
+      [bRadio, &channels](const std::shared_ptr<CPVRClient>& client) {
+        return client->GetChannels(bRadio, channels);
+      },
+      failedClients);
 }
 
 PVR_ERROR CPVRClients::GetChannelGroups(CPVRChannelGroups* groups, std::vector<int>& failedClients)
@@ -557,11 +562,17 @@ PVR_ERROR CPVRClients::GetChannelGroups(CPVRChannelGroups* groups, std::vector<i
   }, failedClients);
 }
 
-PVR_ERROR CPVRClients::GetChannelGroupMembers(CPVRChannelGroup* group, std::vector<int>& failedClients)
+PVR_ERROR CPVRClients::GetChannelGroupMembers(
+    CPVRChannelGroup* group,
+    std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
+    std::vector<int>& failedClients)
 {
-  return ForCreatedClients(__FUNCTION__, [group](const std::shared_ptr<CPVRClient>& client) {
-    return client->GetChannelGroupMembers(group);
-  }, failedClients);
+  return ForCreatedClients(
+      __FUNCTION__,
+      [group, &groupMembers](const std::shared_ptr<CPVRClient>& client) {
+        return client->GetChannelGroupMembers(group, groupMembers);
+      },
+      failedClients);
 }
 
 std::vector<std::shared_ptr<CPVRClient>> CPVRClients::GetClientsSupportingChannelScan() const

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -255,11 +255,14 @@ namespace PVR
 
     /*!
      * @brief Get all channels from backends.
-     * @param group The container to store the channels in.
+     * @param bRadio Whether to fetch radio or TV channels.
+     * @param channels The container to store the channels.
      * @param failedClients in case of errors will contain the ids of the clients for which the channels could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the channels were fetched successfully, last error otherwise.
      */
-    PVR_ERROR GetChannels(CPVRChannelGroupInternal* group, std::vector<int>& failedClients);
+    PVR_ERROR GetChannels(bool bRadio,
+                          std::vector<std::shared_ptr<CPVRChannel>>& channels,
+                          std::vector<int>& failedClients);
 
     /*!
      * @brief Get all channel groups from backends.
@@ -272,10 +275,14 @@ namespace PVR
     /*!
      * @brief Get all group members of a channel group.
      * @param group The group to get the member for.
+     * @param groupMembers The container for the group members.
      * @param failedClients in case of errors will contain the ids of the clients for which the channel group members could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the channel group members were fetched successfully, last error otherwise.
      */
-    PVR_ERROR GetChannelGroupMembers(CPVRChannelGroup* group, std::vector<int>& failedClients);
+    PVR_ERROR GetChannelGroupMembers(
+        CPVRChannelGroup* group,
+        std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
+        std::vector<int>& failedClients);
 
     /*!
      * @brief Get a list of clients providing a channel scan dialog.

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -49,7 +49,7 @@ namespace PVR
     //@{
 
     /*!
-     * @brief Delete this channel from the database and delete the corresponding EPG table if it exists.
+     * @brief Delete this channel from the database.
      * @return True if it was deleted successfully, false otherwise.
      */
     bool QueueDelete();

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -13,6 +13,7 @@
 #include "utils/ISortable.h"
 
 #include <memory>
+#include <string>
 
 namespace PVR
 {
@@ -26,12 +27,9 @@ class CPVRChannelGroupMember : public ISerializable, public ISortable
 public:
   CPVRChannelGroupMember() : m_bChanged(false) {}
 
-  CPVRChannelGroupMember(const std::shared_ptr<CPVRChannel>& channel,
+  CPVRChannelGroupMember(int iGroupID,
                          const std::string& groupName,
-                         const CPVRChannelNumber& channelNumber,
-                         int iClientPriority,
-                         int iOrder,
-                         const CPVRChannelNumber& clientChannelNumber);
+                         const std::shared_ptr<CPVRChannel>& channel);
 
   virtual ~CPVRChannelGroupMember() = default;
 
@@ -42,6 +40,10 @@ public:
   void ToSortable(SortItem& sortable, Field field) const override;
 
   std::shared_ptr<CPVRChannel> Channel() const { return m_channel; }
+  void SetChannel(const std::shared_ptr<CPVRChannel>& channel);
+
+  int GroupID() const { return m_iGroupID; }
+  void SetGroupID(int iGroupID);
 
   const std::string& Path() const { return m_path; }
   void SetGroupName(const std::string& groupName);
@@ -61,7 +63,17 @@ public:
   bool NeedsSave() const { return m_bChanged; }
   void SetSaved() { m_bChanged = false; }
 
+  /*!
+   * @brief Delete this group member from the database.
+   * @return True if it was deleted successfully, false otherwise.
+   */
+  bool QueueDelete();
+
 private:
+  int m_iGroupID = -1;
+  int m_iClientID = -1;
+  int m_iChannelUID = -1;
+  bool m_bIsRadio = false;
   std::shared_ptr<CPVRChannel> m_channel;
   std::string m_path;
   CPVRChannelNumber m_channelNumber; // the channel number this channel has in the group

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -837,11 +837,11 @@ void CGUIDialogPVRChannelManager::SaveList()
   }
 
   group->SortAndRenumber();
-  group->Persist();
   m_bContainsChanges = false;
   SetItemsUnchanged();
   auto channelGroups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio);
-  channelGroups->PropagateChannelNumbersAndPersist();
+  channelGroups->UpdateChannelNumbersFromAllChannelsGroup();
+  channelGroups->PersistAll();
   pDlgProgress->Close();
 }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -146,7 +146,10 @@ bool CGUIDialogPVRGroupManager::ActionButtonDeleteGroup(CGUIMessage& message)
     if (pDialog->IsConfirmed())
     {
       ClearSelectedGroupsThumbnail();
-      if (CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)->DeleteGroup(*m_selectedGroup))
+      if (CServiceBroker::GetPVRManager()
+              .ChannelGroups()
+              ->Get(m_bIsRadio)
+              ->DeleteGroup(m_selectedGroup))
         Update();
     }
 


### PR DESCRIPTION
This PR (hopefully) simplifies the  loading and updating logic of channel groups, channel group members and channels. It contains larger refactoring as well as fixes for issues I discovered while working on the refactoring.

I runtime-tested the changes very carefully on macOS and Android, but it might be very well the case that some regressions slipped in.

Sorry, @phunkyfish I was. not able to separate the changes into smaller logically separated commits. I hope you can do the review anyway.