### PR TITLE
[addons] refactor cstring handling in addon info builder

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -109,10 +109,6 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
    * - CDateTime lastUsed;
    * - std::string origin;
    */
-  const char* cstring; /* "C" string point where parts from TinyXML becomes
-                          stored, is used as this to prevent double use of
-                          calls and to prevent not wanted "C++" throws if
-                          std::string want to become set with nullptr! */
 
   if (!StringUtils::EqualsNoCase(element->Value(), "addon"))
   {
@@ -127,14 +123,13 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
    *        version="???"
    *        provider-name="???">
    */
-  cstring = element->Attribute("id");
-  addon->m_id = cstring ? cstring : "";
-  cstring = element->Attribute("name");
-  addon->m_name = cstring ? cstring : "";
-  cstring = element->Attribute("version");
-  addon->m_version = AddonVersion(cstring ? cstring : "");
-  cstring = element->Attribute("provider-name");
-  addon->m_author = cstring ? cstring : "";
+  addon->m_id = StringUtils::CreateFromCString(element->Attribute("id"));
+  addon->m_name = StringUtils::CreateFromCString(element->Attribute("name"));
+  addon->m_author = StringUtils::CreateFromCString(element->Attribute("provider-name"));
+
+  const std::string version = StringUtils::CreateFromCString(element->Attribute("version"));
+  addon->m_version = AddonVersion(version);
+
   if (addon->m_id.empty() || addon->m_version.empty())
   {
     CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: file '{}' doesn't contain required values on <addon ... > id='{}', version='{}'",
@@ -161,8 +156,8 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
   const TiXmlElement* backwards = element->FirstChildElement("backwards-compatibility");
   if (backwards)
   {
-    cstring = backwards->Attribute("abi");
-    addon->m_minversion = AddonVersion(cstring ? cstring : "");
+    const std::string minVersion = StringUtils::CreateFromCString(backwards->Attribute("abi"));
+    addon->m_minversion = AddonVersion(minVersion);
   }
 
   /*
@@ -176,16 +171,17 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
   {
     for (const TiXmlElement* child = requires->FirstChildElement("import"); child != nullptr; child = child->NextSiblingElement("import"))
     {
-      cstring = child->Attribute("addon");
-      if (cstring)
+      if (child->Attribute("addon"))
       {
-        const char* versionMin = child->Attribute("minversion");
-        const char* version = child->Attribute("version");
+        const std::string minVersion =
+            StringUtils::CreateFromCString(child->Attribute("minversion"));
+        const std::string version = StringUtils::CreateFromCString(child->Attribute("version"));
+
         bool optional = false;
         child->QueryBoolAttribute("optional", &optional);
 
-        addon->m_dependencies.emplace_back(cstring, AddonVersion(versionMin), AddonVersion(version),
-                                           optional);
+        addon->m_dependencies.emplace_back(child->Attribute("addon"), AddonVersion(minVersion),
+                                           AddonVersion(version), optional);
       }
     }
   }
@@ -211,8 +207,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
    */
   for (const TiXmlElement* child = element->FirstChildElement("extension"); child != nullptr; child = child->NextSiblingElement("extension"))
   {
-    cstring = child->Attribute("point");
-    std::string point = cstring ? cstring : "";
+    const std::string point = StringUtils::CreateFromCString(child->Attribute("point"));
 
     if (point == "kodi.addon.metadata" || point == "xbmc.addon.metadata")
     {
@@ -468,13 +463,7 @@ bool CAddonInfoBuilder::ParseXMLTypes(CAddonType& addonType,
 
 bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt, const TiXmlElement* element)
 {
-  const char* cstring; /* "C" string point where parts from TinyXML becomes
-                          stored, is used as this to prevent double use of
-                          calls and to prevent not wanted "C++" throws if
-                          std::string want to become set with nullptr! */
-
-  cstring = element->Attribute("point");
-  addonExt.m_point = cstring ? cstring : "";
+  addonExt.m_point = StringUtils::CreateFromCString(element->Attribute("point"));
 
   EXT_VALUE extension;
   const TiXmlAttribute* attribute = element->FirstAttribute();
@@ -483,27 +472,24 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt, const TiXm
     std::string name = attribute->Name();
     if (name != "point")
     {
-      cstring = attribute->Value();
-      if (cstring)
+      const std::string value = StringUtils::CreateFromCString(attribute->Value());
+      if (!value.empty())
       {
-        std::string value = cstring;
         name = "@" + name;
-        extension.push_back(std::make_pair(name, SExtValue(value)));
+        extension.emplace_back(std::make_pair(name, SExtValue(value)));
       }
     }
     attribute = attribute->Next();
   }
   if (!extension.empty())
-    addonExt.m_values.push_back(std::pair<std::string, EXT_VALUE>("", std::move(extension)));
+    addonExt.m_values.emplace_back(std::pair<std::string, EXT_VALUE>("", std::move(extension)));
 
   const TiXmlElement* childElement = element->FirstChildElement();
   while (childElement)
   {
-    cstring = childElement->Value();
-    if (cstring)
+    const std::string id = StringUtils::CreateFromCString(childElement->Value());
+    if (!id.empty())
     {
-      std::string id = cstring;
-
       EXT_VALUE extension;
       const TiXmlAttribute* attribute = childElement->FirstAttribute();
       while (attribute)
@@ -511,10 +497,9 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt, const TiXm
         std::string name = attribute->Name();
         if (name != "point")
         {
-          cstring = attribute->Value();
-          if (cstring)
+          const std::string value = StringUtils::CreateFromCString(attribute->Value());
+          if (!value.empty())
           {
-            std::string value = cstring;
             name = id + "@" + name;
             extension.push_back(std::make_pair(name, SExtValue(value)));
           }
@@ -522,16 +507,17 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt, const TiXm
         attribute = attribute->Next();
       }
 
-      cstring = childElement->GetText();
-      if (cstring)
+      const std::string childElementText = StringUtils::CreateFromCString(childElement->GetText());
+
+      if (!childElementText.empty())
       {
-        extension.push_back(std::make_pair(id, SExtValue(cstring)));
+        extension.push_back(std::make_pair(id, SExtValue(childElementText)));
       }
 
       if (!extension.empty())
         addonExt.m_values.push_back(std::make_pair(id, std::move(extension)));
 
-      if (!cstring)
+      if (childElementText.empty())
       {
         const TiXmlElement* childSubElement = childElement->FirstChildElement();
         if (childSubElement)

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -368,7 +368,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
 
       CAddonType addonType(type);
       if (ParseXMLTypes(addonType, addon, child))
-        addon->m_types.push_back(std::move(addonType));
+        addon->m_types.emplace_back(std::move(addonType));
     }
   }
 
@@ -379,7 +379,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
   if (addon->m_types.empty())
   {
     CAddonType addonType(ADDON_UNKNOWN);
-    addon->m_types.push_back(std::move(addonType));
+    addon->m_types.emplace_back(std::move(addonType));
   }
 
   addon->m_mainType = addon->m_types[0].Type();
@@ -501,7 +501,7 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt, const TiXm
           if (!value.empty())
           {
             name = id + "@" + name;
-            extension.push_back(std::make_pair(name, SExtValue(value)));
+            extension.emplace_back(std::make_pair(name, SExtValue(value)));
           }
         }
         attribute = attribute->Next();
@@ -511,11 +511,11 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt, const TiXm
 
       if (!childElementText.empty())
       {
-        extension.push_back(std::make_pair(id, SExtValue(childElementText)));
+        extension.emplace_back(std::make_pair(id, SExtValue(childElementText)));
       }
 
       if (!extension.empty())
-        addonExt.m_values.push_back(std::make_pair(id, std::move(extension)));
+        addonExt.m_values.emplace_back(std::make_pair(id, std::move(extension)));
 
       if (childElementText.empty())
       {
@@ -524,7 +524,7 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt, const TiXm
         {
           CAddonExtensions subElement;
           if (ParseXMLExtension(subElement, childElement))
-            addonExt.m_children.push_back(std::make_pair(id, std::move(subElement)));
+            addonExt.m_children.emplace_back(std::make_pair(id, std::move(subElement)));
         }
       }
     }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1843,3 +1843,8 @@ const std::locale& StringUtils::GetOriginalLocale() noexcept
 {
   return g_langInfo.GetOriginalLocale();
 }
+
+std::string StringUtils::CreateFromCString(const char* cstr)
+{
+  return cstr != nullptr ? std::string(cstr) : std::string();
+}

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -375,6 +375,13 @@ public:
    */
   static std::string FormatFileSize(uint64_t bytes);
 
+  /*! \brief Converts a cstring pointer (const char*) to a std::string.
+             In case nullptr is passed the result is an empty string.
+      \param cstr the const pointer to char
+      \return the resulting std::string or ""
+   */
+  static std::string CreateFromCString(const char* cstr);
+
 private:
   /*!
    * Wrapper for CLangInfo::GetOriginalLocale() which allows us to


### PR DESCRIPTION
## Description
introduces `std::string StringUtils::StringOrEmpty(const char*)` which returns an empty string if `nullptr` is passed in. suggestions for a better naming are welcome. addon info builder was refactored afterwards to use this method.

replaced `vector.push_back()` with `.emplace_back()`

## How has this been tested?
about a week of live testing. nothing bad spotted

## What is the effect on users?
none
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@AlwinEsch you may want to test it