### PR TITLE
[Music][Backport]Fix MySQL problem with fetching artist discography

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2096,58 +2096,67 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
        but SQLite not support updatable joins.
     */
     m_pDS->exec("CREATE TABLE tempDisco "
-                "(strAlbum TEXT, iYear INTEGER, mbid TEXT, idAlbum INTEGER)");
+                "(strAlbum TEXT, strYear VARCHAR(4), mbid TEXT, idAlbum INTEGER)");
+    m_pDS->exec("CREATE TABLE tempAlbum "
+                "(strAlbum TEXT, strYear VARCHAR(4), mbid TEXT, idAlbum INTEGER)");
 
     std::string strSQL;
-    strSQL = PrepareSQL("INSERT INTO tempDisco(strAlbum, iYear, mbid, idAlbum) "
-                        "SELECT strAlbum, CAST(discography.strYear AS INTEGER) AS iYear, "
+    strSQL = PrepareSQL("INSERT INTO tempDisco(strAlbum, strYear, mbid, idAlbum) "
+                        "SELECT strAlbum, SUBSTR(discography.strYear, 1, 4) AS strYear, "
                         "strReleaseGroupMBID, NULL "
                         "FROM discography WHERE idArtist = %i",
                         idArtist);
     m_pDS->exec(strSQL);
 
-    // Match albums on release group mbid, if multi-releases then first used
-    strSQL = "UPDATE tempDisco SET idAlbum = (SELECT album.idAlbum FROM album "
-             "WHERE album.strReleaseGroupMBID = tempDisco.mbid "
-             "AND album.strReleaseGroupMBID IS NOT NULL)";
-    m_pDS->exec(strSQL);
-    // Match remaining to albums by artist on title and year
-    strSQL = PrepareSQL("UPDATE tempDisco SET idAlbum = (SELECT album.idAlbum FROM album "
-                        "JOIN album_artist ON album_artist.idAlbum = album.idAlbum "
-                        "WHERE album_artist.idArtist = %i "
-                        "AND NOT EXISTS(SELECT 1 FROM tempDisco AS td "
-                        "WHERE td.idAlbum = album.idAlbum) "
-                        "AND CAST(strOrigReleaseDate AS INTEGER) = tempDisco.iYear "
-                        "AND album.strAlbum = tempDisco.strAlbum) "
-                        "WHERE tempDisco.idAlbum is NULL",
+    strSQL = PrepareSQL("INSERT INTO tempAlbum(strAlbum, strYear, mbid, idAlbum) "
+                        "SELECT strAlbum, SUBSTR(strOrigReleaseDate, 1, 4) AS strYear, "
+                        "strReleaseGroupMBID, album.idAlbum "
+                        "FROM album JOIN album_artist ON album_artist.idAlbum = album.idAlbum "
+                        "WHERE idArtist = %i",
                         idArtist);
-    m_pDS->exec(strSQL);
-    // Match remaining to albums by artist on title only
-    strSQL = PrepareSQL("UPDATE tempDisco SET idAlbum = (SELECT album.idAlbum FROM album "
-                        "JOIN album_artist ON album_artist.idAlbum = album.idAlbum "
-                        "WHERE album_artist.idArtist = %i "
-                        "AND NOT EXISTS(SELECT 1 FROM tempDisco AS td "
-                        "WHERE td.idAlbum = album.idAlbum) "
-                        "AND album.strAlbum = tempDisco.strAlbum) "
-                        "WHERE tempDisco.idAlbum is NULL",
-                        idArtist);
-    m_pDS->exec(strSQL);
-    // Use year from album table, when matched by name only it could be different
-    strSQL = PrepareSQL("UPDATE tempDisco "
-                        "SET iYear = (SELECT CAST(album.strOrigReleaseDate AS INTEGER) FROM album "
-                        "WHERE album.idAlbum = tempDisco.idAlbum) "
-                        "WHERE tempDisco.idAlbum > 0");
     m_pDS->exec(strSQL);
 
-    // Combine distinctly with albums by artist that are not in discography
-    strSQL =
-        PrepareSQL("SELECT strAlbum, iYear, idAlbum FROM tempDisco "
-                   "UNION "
-                   "SELECT strAlbum, CAST(strOrigReleaseDate AS INTEGER) AS iYear, album.idAlbum "
-                   "FROM album JOIN album_artist ON album_artist.idAlbum = album.idAlbum "
-                   "WHERE album_artist.idArtist = %i "
-                   "ORDER BY iYear, strAlbum, idAlbum",
-                   idArtist);
+    // Match albums on release group mbid, if multi-releases then first used
+    // Only use albums credited to this artist
+    strSQL = "UPDATE tempDisco SET idAlbum = (SELECT tempAlbum.idAlbum FROM tempAlbum "
+             "WHERE tempAlbum.mbid = tempDisco.mbid AND tempAlbum.mbid IS NOT NULL)";
+    m_pDS->exec(strSQL);
+    //Delete matched albums
+    strSQL = "DELETE FROM tempAlbum "
+             "WHERE EXISTS(SELECT 1 FROM tempDisco WHERE tempDisco.idAlbum = tempAlbum.idAlbum)";
+    m_pDS->exec(strSQL);
+
+    // Match remaining to albums by artist on title and year
+    strSQL = "UPDATE tempDisco SET idAlbum = (SELECT idAlbum FROM tempAlbum "
+             "WHERE tempAlbum.strAlbum = tempDisco.strAlbum "
+             "AND tempAlbum.strYear = tempDisco.strYear) "
+             "WHERE tempDisco.idAlbum is NULL";
+    m_pDS->exec(strSQL);
+    //Delete matched albums
+    strSQL = "DELETE FROM tempAlbum "
+      "WHERE EXISTS(SELECT 1 FROM tempDisco WHERE tempDisco.idAlbum = tempAlbum.idAlbum)";
+    m_pDS->exec(strSQL);
+
+    // Match remaining to albums by artist on title only
+    strSQL = "UPDATE tempDisco SET idAlbum = (SELECT idAlbum FROM tempAlbum "
+             "WHERE tempAlbum.strAlbum = tempDisco.strAlbum) "
+             "WHERE tempDisco.idAlbum is NULL";
+    m_pDS->exec(strSQL);
+    // Use year from album table, when matched by title only as it could be different
+    strSQL = "UPDATE tempDisco SET strYear = (SELECT strYear FROM tempAlbum "
+             "WHERE tempAlbum.idAlbum = tempDisco.idAlbum) "
+             "WHERE EXISTS(SELECT 1 FROM tempAlbum WHERE tempAlbum.idAlbum = tempDisco.idAlbum)";
+    m_pDS->exec(strSQL);
+    //Delete matched albums
+    strSQL = "DELETE FROM tempAlbum "
+             "WHERE EXISTS(SELECT 1 FROM tempDisco WHERE tempDisco.idAlbum = tempAlbum.idAlbum)";
+    m_pDS->exec(strSQL);
+
+    // Combine distinctly with any remaining unmatched albums by artist
+    strSQL = "SELECT strAlbum, strYear, idAlbum FROM tempDisco "
+             "UNION "
+             "SELECT strAlbum, strYear, idAlbum FROM tempAlbum "
+             "ORDER BY strYear, strAlbum, idAlbum";
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -2167,7 +2176,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
       if (!strAlbum.empty())
       {
           CFileItemPtr pItem(new CFileItem(strAlbum));
-          pItem->SetLabel2(m_pDS->fv("iYear").get_asString());
+          pItem->SetLabel2(m_pDS->fv("strYear").get_asString());
           pItem->GetMusicInfoTag()->SetDatabaseId(idAlbum, MediaTypeAlbum);
           items.Add(pItem);
       }
@@ -2177,12 +2186,14 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
     // cleanup
     m_pDS->close();
     m_pDS->exec("DROP TABLE tempDisco");
+    m_pDS->exec("DROP TABLE tempAlbum");
 
     return true;
   }
   catch (...)
   {
     m_pDS->exec("DROP TABLE tempDisco");
+    m_pDS->exec("DROP TABLE tempAlbum");
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
   }
   return false;


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/19840

Artist discography as displayed on the artist info dialog, a combination of the albums in their library and list scraped from remote sites, was showing empty for some users with a client/server set-up and _certain versions_ of MySQL/MariaDB.

The vagaries of MySQL/MariaDB and differences between versions strike again! The SQL used to generate the discography listing works perfectly in some versions e.g. MySQL 5.7 and MariaDB v10.4.17 and 10.5, but fails on others e.g. MariaDB 10.0.38.

There are two SQL issues:
- Using `CAST` to convert an ISO date-string YYYY-MM-DD (or possibly partial) to integer year raises an error when the string is empty or not just YYYY rather than a warning and return `0` (as SQLite does). This produces MySQL Error 1292 - Truncated incorrect INTEGER value.
 - Attempting to check for and exclude already matched albums in the disography using a subquery raises error 1093 - Can't specify target table for update in FROM clause.

Solution, constent across SQLite and MySQL/MariaDB, is to
a) Work with year as a YYYY string not an integer
b) Use a second temp table for the list of unmatched albums not subqueries.