### PR TITLE
[addons] add function for removing orphaned dependencies recursively

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21180,7 +21180,37 @@ msgctxt "#36637"
 msgid "Note that add-ons installed from zip (excluding served repositories) will not auto-update and must be manually updated. Would you like to proceed?"
 msgstr ""
 
-#empty strings from id 36638 to 36898
+#. Menuitem at "Settings -> System -> Add-ons"
+#: ./system/settings/settings.xml
+msgctxt "#36638"
+msgid "Remove all orphaned dependencies"
+msgstr ""
+
+#. Description of setting with label #36638 "Remove all orphaned dependencies"
+#: system/settings/settings.xml
+msgctxt "#36639"
+msgid "Remove all modules and support libraries that have been automatically installed as a dependency to other add-ons and are in an orphaned state."
+msgstr ""
+
+#. Dialog caption
+#: xbmc/addons/AddonSystemSettings.cpp
+msgctxt "#36640"
+msgid "Orphaned dependencies"
+msgstr ""
+
+#. Dialog text if orphaned dependencies were found and removed
+#: xbmc/addons/AddonSystemSettings.cpp
+msgctxt "#36641"
+msgid "The following orphaned dependency add-ons were removed from your system: {0:s}."
+msgstr ""
+
+#. Dialog text if no more orphaned dependencies left on the system
+#: xbmc/addons/AddonSystemSettings.cpp
+msgctxt "#36642"
+msgid "No orphaned dependency add-ons to remove."
+msgstr ""
+
+#empty strings from id 36643 to 36898
 
 #. Description of setting with label #729 "Enable SSL"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3252,6 +3252,10 @@
           <level>2</level>
           <control type="button" format="action" />
         </setting>
+        <setting id="addons.removeorphaneddependencies" type="action" label="36638" help="36639">
+          <level>2</level>
+          <control type="button" format="action" />
+        </setting>
         <setting id="addons.showrunning" type="action" label="24994" help="36614">
           <level>2</level>
           <control type="button" format="action" />

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -726,10 +726,9 @@ bool CAddonInstallJob::DoWork()
     // we only do pinning/unpinning for non-zip installs and not system origin
     if (!m_addon->Origin().empty() && m_addon->Origin() != ORIGIN_SYSTEM)
     {
-      std::vector<std::shared_ptr<IAddon>> compatibleVersions;
-
       // get all compatible versions of an addon-id regardless of their origin
-      CServiceBroker::GetAddonMgr().GetCompatibleVersions(m_addon->ID(), compatibleVersions);
+      std::vector<std::shared_ptr<IAddon>> compatibleVersions =
+          CServiceBroker::GetAddonMgr().GetCompatibleVersions(m_addon->ID());
 
       // find the latest version for the origin we installed from
       AddonVersion latestVersion; // initializes to 0.0.0

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -26,40 +26,40 @@ namespace ADDON
 
 class CAddonDatabase;
 
-enum class BackgroundJob
+enum class BackgroundJob : bool
 {
-  YES,
-  NO,
+  YES = true,
+  NO = false,
 };
 
-enum class ModalJob
+enum class ModalJob : bool
 {
-  YES,
-  NO,
+  YES = true,
+  NO = false,
 };
 
-enum class AutoUpdateJob
+enum class AutoUpdateJob : bool
 {
-  YES,
-  NO,
+  YES = true,
+  NO = false,
 };
 
-enum class DependencyJob
+enum class DependencyJob : bool
 {
-  YES,
-  NO,
+  YES = true,
+  NO = false,
 };
 
-enum class InstallModalPrompt
+enum class InstallModalPrompt : bool
 {
-  PROMPT,
-  NO_PROMPT,
+  PROMPT = true,
+  NO_PROMPT = false,
 };
 
-enum class AllowCheckForUpdates
+enum class AllowCheckForUpdates : bool
 {
-  YES,
-  NO,
+  YES = true,
+  NO = false,
 };
 
 class CAddonInstaller : public IJobCallback

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -101,6 +101,19 @@ public:
   bool InstallOrUpdateDependency(const ADDON::AddonPtr& dependsId,
                                  const ADDON::RepositoryPtr& repo);
 
+  /*! \brief Remove a single dependency from the system
+   \param dependsId the dependency to remove
+   \return true on successful uninstall, false on failure.
+   */
+  bool RemoveDependency(const std::shared_ptr<IAddon>& dependsId) const;
+
+  /*!
+   * \brief Removes all orphaned dependency add-ons recursively. Removal may orphan further
+   *        dependencies, so loop until no orphaned is left on the system
+   * \return Names of dependencies that have effectively been removed
+   */
+  std::vector<std::string> RemoveOrphanedDepsRecursively() const;
+
   /*! \brief Installs a vector of addons
    *  \param addons the list of addons to install
    *  \param wait if the method should wait for all the DoInstall jobs to finish or if it should return right away

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -62,6 +62,12 @@ enum class AllowCheckForUpdates : bool
   NO = false,
 };
 
+enum class RecurseOrphaned : bool
+{
+  YES = true,
+  NO = false,
+};
+
 class CAddonInstaller : public IJobCallback
 {
 public:
@@ -286,12 +292,14 @@ public:
   CAddonUnInstallJob(const ADDON::AddonPtr &addon, bool removeData);
 
   bool DoWork() override;
+  void SetRecurseOrphaned(RecurseOrphaned recurseOrphaned) { m_recurseOrphaned = recurseOrphaned; };
 
 private:
   void ClearFavourites();
 
   ADDON::AddonPtr m_addon;
   bool m_removeData;
+  RecurseOrphaned m_recurseOrphaned = RecurseOrphaned::YES;
 };
 
 }; // namespace ADDON

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -255,41 +255,42 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAdd
   return result;
 }
 
-bool CAddonMgr::GetAddonsWithAvailableUpdate(
-    std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const
+std::map<std::string, CAddonWithUpdate> CAddonMgr::GetAddonsWithAvailableUpdate() const
 {
   CSingleLock lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   std::vector<std::shared_ptr<IAddon>> installed;
+  std::map<std::string, CAddonWithUpdate> result;
   CAddonRepos addonRepos(*this);
 
   addonRepos.LoadAddonsFromDatabase(m_database);
   GetAddonsForUpdate(installed);
-  addonRepos.BuildAddonsWithUpdateList(installed, addonsWithUpdate);
+  addonRepos.BuildAddonsWithUpdateList(installed, result);
 
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
   CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__, duration.count());
 
-  return true;
+  return result;
 }
 
-bool CAddonMgr::GetCompatibleVersions(
-    const std::string& addonId, std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const
+std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetCompatibleVersions(
+    const std::string& addonId) const
 {
   CSingleLock lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   CAddonRepos addonRepos(*this);
+  std::vector<std::shared_ptr<IAddon>> result;
   addonRepos.LoadAddonsFromDatabase(m_database, addonId);
-  addonRepos.BuildCompatibleVersionsList(compatibleVersions);
+  addonRepos.BuildCompatibleVersionsList(result);
 
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
   CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__, duration.count());
 
-  return true;
+  return result;
 }
 
 bool CAddonMgr::HasAvailableUpdates()
@@ -299,27 +300,27 @@ bool CAddonMgr::HasAvailableUpdates()
 
 bool CAddonMgr::GetAddonsForUpdate(VECADDONS& addons) const
 {
-  return GetAddonsInternal(ADDON_UNKNOWN, addons, true, true);
+  return GetAddonsInternal(ADDON_UNKNOWN, addons, OnlyEnabled::YES, CheckIncompatible::YES);
 }
 
 bool CAddonMgr::GetAddons(VECADDONS& addons) const
 {
-  return GetAddonsInternal(ADDON_UNKNOWN, addons, true);
+  return GetAddonsInternal(ADDON_UNKNOWN, addons, OnlyEnabled::YES, CheckIncompatible::NO);
 }
 
 bool CAddonMgr::GetAddons(VECADDONS& addons, const TYPE& type)
 {
-  return GetAddonsInternal(type, addons, true);
+  return GetAddonsInternal(type, addons, OnlyEnabled::YES, CheckIncompatible::NO);
 }
 
 bool CAddonMgr::GetInstalledAddons(VECADDONS& addons)
 {
-  return GetAddonsInternal(ADDON_UNKNOWN, addons, false);
+  return GetAddonsInternal(ADDON_UNKNOWN, addons, OnlyEnabled::NO, CheckIncompatible::NO);
 }
 
 bool CAddonMgr::GetInstalledAddons(VECADDONS& addons, const TYPE& type)
 {
-  return GetAddonsInternal(type, addons, false);
+  return GetAddonsInternal(type, addons, OnlyEnabled::NO, CheckIncompatible::NO);
 }
 
 bool CAddonMgr::GetDisabledAddons(VECADDONS& addons)
@@ -405,8 +406,8 @@ bool CAddonMgr::FindInstallableById(const std::string& addonId, AddonPtr& result
 
 bool CAddonMgr::GetAddonsInternal(const TYPE& type,
                                   VECADDONS& addons,
-                                  bool onlyEnabled,
-                                  bool checkIncompatible) const
+                                  OnlyEnabled onlyEnabled,
+                                  CheckIncompatible checkIncompatible) const
 {
   CSingleLock lock(m_critSection);
 
@@ -415,9 +416,9 @@ bool CAddonMgr::GetAddonsInternal(const TYPE& type,
     if (type != ADDON_UNKNOWN && !addonInfo.second->HasType(type))
       continue;
 
-    if (onlyEnabled &&
-        ((!checkIncompatible && IsAddonDisabled(addonInfo.second->ID())) ||
-         (checkIncompatible &&
+    if (onlyEnabled == OnlyEnabled::YES &&
+        ((checkIncompatible == CheckIncompatible::NO && IsAddonDisabled(addonInfo.second->ID())) ||
+         (checkIncompatible == CheckIncompatible::YES &&
           IsAddonDisabledExcept(addonInfo.second->ID(), AddonDisabledReason::INCOMPATIBLE))))
       continue;
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -160,6 +160,15 @@ namespace ADDON
     /*! Returns true if there is any addon with available updates, otherwise false */
     bool HasAvailableUpdates();
 
+    /*!
+     * \brief Checks if the passed in addon is an orphaned dependency
+     * \param addon the add-on/dependency to check
+     * \param allAddons vector of all installed add-ons
+     * \return true or false
+     */
+    bool IsOrphaned(const std::shared_ptr<IAddon>& addon,
+                    const std::vector<std::shared_ptr<IAddon>>& allAddons) const;
+
     /*! \brief Checks for new / updated add-ons
      \return True if everything went ok, false otherwise
      */
@@ -541,6 +550,12 @@ namespace ADDON
      * \return number of available updates
      */
     const std::string& GetLastAvailableUpdatesCountAsString() const;
+
+    /*!
+     * \brief returns a vector with all found orphaned dependencies.
+     * \return the vector
+     */
+    std::vector<std::shared_ptr<IAddon>> GetOrphanedDependencies() const;
 
   private:
     CAddonMgr& operator=(CAddonMgr const&) = delete;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -26,7 +26,7 @@ namespace ADDON
 
   const std::string ADDON_PYTHON_EXT           = "*.py";
 
-  enum class AllowCheckForUpdates;
+  enum class AllowCheckForUpdates : bool;
 
   enum class AddonCheckType
   {
@@ -41,6 +41,12 @@ namespace ADDON
   };
 
   enum class OnlyEnabledRootAddon : bool
+  {
+    YES = true,
+    NO = false,
+  };
+
+  enum class CheckIncompatible : bool
   {
     YES = true,
     NO = false,
@@ -517,20 +523,16 @@ namespace ADDON
     /*!
      * \brief Retrieves list of outdated addons as well as their related
      *        available updates and stores them into map.
-     * \param[out] addonsWithUpdate target map
-     * \return true or false
+     * \return map of outdated addons with their update
      */
-    bool GetAddonsWithAvailableUpdate(
-        std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const;
+    std::map<std::string, CAddonWithUpdate> GetAddonsWithAvailableUpdate() const;
 
     /*!
      * \brief Retrieves list of compatible addon versions of all origins
      * \param[in] addonId addon to look up
-     * \param[out] compatibleVersions target vector to be filled
-     * \return true or false
+     * \return vector containing compatible addon versions
      */
-    bool GetCompatibleVersions(const std::string& addonId,
-                               std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const;
+    std::vector<std::shared_ptr<IAddon>> GetCompatibleVersions(const std::string& addonId) const;
 
     /*!
      * \brief Return number of available updates formatted as string
@@ -557,8 +559,8 @@ namespace ADDON
 
     bool GetAddonsInternal(const TYPE& type,
                            VECADDONS& addons,
-                           bool onlyEnabled,
-                           bool checkIncompatible = false) const;
+                           OnlyEnabled onlyEnabled,
+                           CheckIncompatible checkIncompatible) const;
 
     bool EnableSingle(const std::string& id);
 

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -9,10 +9,13 @@
 #include "AddonSystemSettings.h"
 
 #include "ServiceBroker.h"
+#include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -56,6 +59,23 @@ void CAddonSystemSettings::OnSettingAction(const std::shared_ptr<const CSetting>
   {
     std::vector<std::string> params{"addons://running/", "return"};
     CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_ADDON_BROWSER, params);
+  }
+  else if (setting->GetId() == CSettings::SETTING_ADDONS_REMOVE_ORPHANED_DEPENDENCIES)
+  {
+    using namespace KODI::MESSAGING::HELPERS;
+
+    const auto removedItems = CAddonInstaller::GetInstance().RemoveOrphanedDepsRecursively();
+    if (removedItems.size() > 0)
+    {
+      const auto message =
+          StringUtils::Format(g_localizeStrings.Get(36641), StringUtils::Join(removedItems, ", "));
+
+      ShowOKDialogText(CVariant{36640}, CVariant{message}); // "following orphaned were removed..."
+    }
+    else
+    {
+      ShowOKDialogText(CVariant{36640}, CVariant{36642}); // "no orphaned found / removed"
+    }
   }
 }
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -328,16 +328,15 @@ void CGUIDialogAddonInfo::OnSelectVersion()
   const std::string& processAddonId = m_item->GetAddonInfo()->ID();
   EntryPoint entryPoint = m_localAddon ? EntryPoint::UPDATE : EntryPoint::INSTALL;
 
-  std::vector<std::shared_ptr<IAddon>> compatibleVersions;
-  std::vector<std::pair<AddonVersion, std::string>> versions;
-
   // get all compatible versions of an addon-id regardless of their origin
-  CServiceBroker::GetAddonMgr().GetCompatibleVersions(processAddonId, compatibleVersions);
+  std::vector<std::shared_ptr<IAddon>> compatibleVersions =
+      CServiceBroker::GetAddonMgr().GetCompatibleVersions(processAddonId);
 
+  std::vector<std::pair<AddonVersion, std::string>> versions;
   versions.reserve(compatibleVersions.size());
+
   for (const auto& compatibleVersion : compatibleVersions)
-    versions.emplace_back(
-        std::make_pair(compatibleVersion->Version(), compatibleVersion->Origin()));
+    versions.emplace_back(compatibleVersion->Version(), compatibleVersion->Origin());
 
   CAddonDatabase database;
   database.Open();

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -144,21 +144,6 @@ static bool IsUserInstalled(const AddonPtr& addon)
   return !CAddonType::IsDependencyType(addon->MainType());
 }
 
-static bool IsOrphaned(const AddonPtr& addon, const VECADDONS& all)
-{
-  if (CServiceBroker::GetAddonMgr().IsSystemAddon(addon->ID()) || IsUserInstalled(addon))
-    return false;
-
-  for (const AddonPtr& other : all)
-  {
-    const auto& deps = other->GetDependencies();
-    auto it = std::find_if(deps.begin(), deps.end(), [&](const DependencyInfo& dep){ return dep.id == addon->ID(); });
-    if (it != deps.end())
-      return false;
-  }
-  return true;
-}
-
 // Creates categories from addon types, if we have any addons with that type.
 static void GenerateTypeListing(const CURL& path, const std::set<TYPE>& types,
     const VECADDONS& addons, CFileItemList& items)
@@ -482,7 +467,7 @@ static void DependencyAddons(const CURL& path, CFileItemList &items)
   std::set<std::string> orphaned;
   for (const auto& addon : deps)
   {
-    if (IsOrphaned(addon, all))
+    if (CServiceBroker::GetAddonMgr().IsOrphaned(addon, all))
       orphaned.insert(addon->ID());
   }
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -793,9 +793,8 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
                                             CFileItemList& items,
                                             const std::string& label)
 {
-  std::map<std::string, CAddonWithUpdate> addonsWithUpdate;
-
-  CServiceBroker::GetAddonMgr().GetAddonsWithAvailableUpdate(addonsWithUpdate);
+  std::map<std::string, CAddonWithUpdate> addonsWithUpdate =
+      CServiceBroker::GetAddonMgr().GetAddonsWithAvailableUpdate();
 
   items.ClearItems();
   items.SetContent("addons");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -433,6 +433,7 @@ constexpr const char* CSettings::SETTING_ADDONS_SHOW_RUNNING;
 constexpr const char* CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES;
 constexpr const char* CSettings::SETTING_ADDONS_UPDATEMODE;
 constexpr const char* CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES;
+constexpr const char* CSettings::SETTING_ADDONS_REMOVE_ORPHANED_DEPENDENCIES;
 constexpr const char* CSettings::SETTING_GENERAL_ADDONFOREIGNFILTER;
 constexpr const char* CSettings::SETTING_GENERAL_ADDONBROKENFILTER;
 constexpr const char* CSettings::SETTING_SOURCE_VIDEOS;
@@ -1051,6 +1052,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_ADDONS_SHOW_RUNNING);
   settingSet.insert(CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES);
+  settingSet.insert(CSettings::SETTING_ADDONS_REMOVE_ORPHANED_DEPENDENCIES);
   settingSet.insert(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES);
   GetSettingsManager()->RegisterCallback(&ADDON::CAddonSystemSettings::GetInstance(), settingSet);
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -435,6 +435,8 @@ public:
   static constexpr auto SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES = "addons.unknownsources";
   static constexpr auto SETTING_ADDONS_UPDATEMODE = "addons.updatemode";
   static constexpr auto SETTING_ADDONS_MANAGE_DEPENDENCIES = "addons.managedependencies";
+  static constexpr auto SETTING_ADDONS_REMOVE_ORPHANED_DEPENDENCIES =
+      "addons.removeorphaneddependencies";
   static constexpr auto SETTING_GENERAL_ADDONFOREIGNFILTER = "general.addonforeignfilter";
   static constexpr auto SETTING_GENERAL_ADDONBROKENFILTER = "general.addonbrokenfilter";
   static constexpr auto SETTING_SOURCE_VIDEOS = "source.videos";


### PR DESCRIPTION
## Description

**Commit 1**
add-ons cleanup: replace bool default argument with enum class. the underlying data type for existing enum classes is changed to bool where appropiate

**Commit 2**
let's remove orphaned dependencies recursively. function located at `Settings -> System -> Add-ons`

**Commit 3**
uninstall of an add-on now removes any orphaned dependencies by default

## How has this been tested?
debian buster - tested with install/uninstall of skin `Aeon Nox: SILVO` which leaves several depends in an orphaned state

## What is the effect on users?
ability to batch clean orphaned dependencies

## Screenshots (if appropriate):
![screenshot00000](https://user-images.githubusercontent.com/58829855/120649957-9c780700-c47d-11eb-878d-67176bc9ea76.png)

![screenshot00001](https://user-images.githubusercontent.com/58829855/120650014-a7cb3280-c47d-11eb-9a72-f6d616b88cc6.png)

![screenshot00002](https://user-images.githubusercontent.com/58829855/120650082-b7e31200-c47d-11eb-8e59-8e533b91a697.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

maybe @phunkyfish has time / mood for a review?