### PR TITLE
add precision modifier as it's invalid without it

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1531,7 +1531,7 @@ std::string StringUtils::SizeToString(int64_t size)
   }
 
   if (!i)
-    strLabel = StringUtils::Format("{:.f} B", s);
+    strLabel = StringUtils::Format("{:.2f} B", s);
   else if (i == ARRAY_SIZE(prefixes))
   {
     if (s >= 1000.0)

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -437,6 +437,10 @@ TEST(TestStringUtils, SizeToString)
   ref = "2.00 GB";
   var = StringUtils::SizeToString(2147483647);
   EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "0.00 B";
+  var = StringUtils::SizeToString(0);
+  EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 
 TEST(TestStringUtils, EmptyString)


### PR DESCRIPTION
This fixes #19839 

This was just part of the scripted conversion but it seems libfmt needs to have a precision modifier present.

```
terminate called after throwing an instance of 'fmt::v7::format_error'
  what():  missing precision specifier
```

Searching the code this seems to be the only place it's used. I'm not exactly sure what the behaviour was supposed to be (or if it was even valid). I made it 2 decimal places as that seems ok to me, other opinions are welcome.