### PR TITLE
Fix dependency build on macOS.

### DIFF
--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -71,10 +71,10 @@ CPPFLAGS=@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/incl
 FFMPEG_CONFIGURE_OPTIONS=@ffmpeg_options@
 
 
-PATH:=@prefix@/@tool_dir@/bin:$(PATH)
 ifneq (@use_build_toolchain@,)
   PATH:=@use_build_toolchain@/bin:@use_build_toolchain@/usr/bin:$(PATH)
 endif
+PATH:=@prefix@/@tool_dir@/bin:$(PATH)
 LD_FOR_BUILD=@LD_FOR_BUILD@
 ifneq (@use_ccache@,yes)
   CC_FOR_BUILD=@CC_FOR_BUILD@


### PR DESCRIPTION
PATH should include the target install directory before anything else.

Build failed on macOS due to ancient nasm present in toolchain prefix otherwise.

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed