### PR TITLE
[PVR][GUI] Channel manager dialog control state enhancements

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -51,6 +51,9 @@ namespace PVR
     void SetData(int iItem);
     void RenameChannel(const CFileItemPtr& pItem);
 
+    void ClearChannelOptions();
+    void EnableChannelOptions(bool bEnable);
+
     bool OnPopupMenu(int iItem);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     bool OnActionMove(const CAction& action);
@@ -70,11 +73,12 @@ namespace PVR
     bool OnClickButtonNewChannel();
 
     bool PersistChannel(const CFileItemPtr& pItem, const std::shared_ptr<CPVRChannelGroup>& group, unsigned int* iChannelNumber);
-    void SetItemsUnchanged();
+
+    bool HasChangedItems() const;
+    void SetItemChanged(const CFileItemPtr& pItem);
 
     bool m_bIsRadio = false;
     bool m_bMovingMode = false;
-    bool m_bContainsChanges = false;
     bool m_bAllowNewChannel = false;
     bool m_bAllowRenumber = false;
 


### PR DESCRIPTION
## Description
This PR intends to enhance the PVR Channel Manager dialog implementation to address a handful of GUI state concerns:

- Enable/disable the "Channel Options" group of controls only when there are channels to select from
- Enable/disable the "Apply changes now" button based on if any channel(s) have been changed
- Fix "Channel Options" state after a channel has been deleted
- Only save changes to channels specifically flagged as "Changed" by the dialog

**NOTE:** This PR was scaled back to not try and address some state/data concerns between the dialog and the PVR backend(s) that can arise when the PVR backend(s) supports Channel Add / Channel Settings.  Open PR [19831](https://github.com/xbmc/xbmc/pull/19831) will alter how I was planning to deal with that and I didn't want to cause any merge conflicts.

## Motivation and context
I've had a lot of problems with this dialog during development of a Radio PVR addon that requires it's use since there is no actual "backend" to pull data from, the user needs a way to input/manage everything via Kodi.  This is another incremental set of changes I felt was useful and would make sense.

## How has this been tested?
Tested on Windows 10 (Desktop) x64, with a development branch of the aforementioned radio PVR addon in conjunction with a release branch of a TV PVR addon.  Tests included having one of the two addons enabled (for switching between Radio and TV via the dialog) and with both enabled.  The radio addon supports Channel Add and Channel Settings, the TV addon does not support either.

## What is the effect on users?
I propose the effect on users is that it would provide better GUI consistency and feedback?  Disabling controls that wouldn't do anything if they were accessed seems more intuitive to me?  The change(s) that deal with making sure the values in the "Channel  Options" group of controls reflects the actual selected channel in the list box is probably the most user-friendly benefit?

## Screenshots (if appropriate):

This illustrates the existing behavior of the "Channel Options" group of controls as well as the "Apply changes now" button; these controls will always be enabled regardless of if the GUI state supports that:

![12-before](https://user-images.githubusercontent.com/706055/120957849-6b6d3000-c724-11eb-9d5e-15f8c18e4524.png)

After the proposed changes, both the "Channel Options" group of controls and the "Apply changes now" button will be disabled if there is no channel selected ...

![12-after1](https://user-images.githubusercontent.com/706055/120958314-6eb4eb80-c725-11eb-872c-a7428a43f9ee.png)

... the "Apply changes now" button remains disabled unless the user makes a change ...

![12-after2](https://user-images.githubusercontent.com/706055/120958339-87250600-c725-11eb-9070-d30d8736614c.png)

... and the "Apply changes now" button will be enabled once the user indeed makes a change to a channel:

![12-after3](https://user-images.githubusercontent.com/706055/120958414-b3d91d80-c725-11eb-8392-7ba5e6348612.png)

This illustrates the existing behavior of what can happen when the last channel in the list/group has been deleted; note that there is no longer a channel named "WLVW-FM" in the group (it was deleted), and automatic selection of the first channel in the list rather than the last one in the list is not intuitive:

![delete-before](https://user-images.githubusercontent.com/706055/120957924-8f307600-c724-11eb-9a57-693d6c503b39.png)

After the proposed changes; the new last channel in the list will be selected and it's details/settings will appear in the "Channel Options" group of controls:

![delete-after](https://user-images.githubusercontent.com/706055/120958637-26e29400-c726-11eb-9996-c21d52a81f5e.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
