### PR TITLE
[PVR] Refactor and cleanup CPVRChannelGroup(Internal)::(AddTo|AppendTo|RemoveFrom)Group.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -128,17 +128,6 @@ namespace PVR
     virtual bool RemoveFromGroup(const std::shared_ptr<CPVRChannel>& channel);
 
     /*!
-     * @brief Add a channel to this container.
-     * @param channel The channel to add.
-     * @param channelNumber The channel number of the channel to add. Use empty channel number if it's to be generated.
-     * @param iOrder The value denoting the order of this member in the group, 0 if unknown and needs to be generated
-     * @return True if the channel was added, false otherwise.
-     */
-    virtual bool AddToGroup(const std::shared_ptr<CPVRChannel>& channel,
-                            const CPVRChannelNumber& channelNumber,
-                            int iOrder);
-
-    /*!
      * @brief Append a channel to this container.
      * @param channel The channel to append.
      * @return True if the channel was appended, false otherwise.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -51,13 +51,6 @@ namespace PVR
     bool IsGroupMember(const std::shared_ptr<CPVRChannel>& channel) const override;
 
     /*!
-     * @see CPVRChannelGroup::AddToGroup
-     */
-    bool AddToGroup(const std::shared_ptr<CPVRChannel>& channel,
-                    const CPVRChannelNumber& channelNumber,
-                    int iOrder) override;
-
-    /*!
      * @see CPVRChannelGroup::AppendToGroup
      */
     bool AppendToGroup(const std::shared_ptr<CPVRChannel>& channel) override;


### PR DESCRIPTION
Just what the subject says. No functional changes.

Runtime-tested on macOS and Android.

@phunkyfish good to go in?