### PR TITLE
[PVR] Refactor CPVRChannelGroup settings handling.

### DIFF
--- a/xbmc/pvr/channels/CMakeLists.txt
+++ b/xbmc/pvr/channels/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES PVRChannel.cpp
             PVRChannelGroup.cpp
             PVRChannelGroupInternal.cpp
             PVRChannelGroupMember.cpp
+            PVRChannelGroupSettings.cpp
             PVRChannelGroups.cpp
             PVRChannelGroupsContainer.cpp
             PVRChannelNumber.cpp
@@ -12,6 +13,7 @@ set(HEADERS PVRChannel.h
             PVRChannelGroup.h
             PVRChannelGroupInternal.h
             PVRChannelGroupMember.h
+            PVRChannelGroupSettings.h
             PVRChannelGroups.h
             PVRChannelGroupsContainer.h
             PVRChannelNumber.h

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -22,9 +22,6 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgInfoTag.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
-#include "settings/lib/Setting.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -41,7 +38,7 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelsPath& path,
                                    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
   : m_allChannelsGroup(allChannelsGroup), m_path(path)
 {
-  InitSettings();
+  GetSettings()->RegisterCallback(this);
 }
 
 CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP& group,
@@ -50,12 +47,12 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP& group,
   , m_allChannelsGroup(allChannelsGroup)
   , m_path(group.bIsRadio, group.strGroupName)
 {
-  InitSettings();
+  GetSettings()->RegisterCallback(this);
 }
 
 CPVRChannelGroup::~CPVRChannelGroup()
 {
-  CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);
+  GetSettings()->UnregisterCallback(this);
   Unload();
 }
 
@@ -72,35 +69,27 @@ bool CPVRChannelGroup::operator!=(const CPVRChannelGroup& right) const
   return !(*this == right);
 }
 
-namespace
+CCriticalSection CPVRChannelGroup::m_settingsSingletonCritSection;
+std::weak_ptr<CPVRChannelGroupSettings> CPVRChannelGroup::m_settingsSingleton;
+
+std::shared_ptr<CPVRChannelGroupSettings> CPVRChannelGroup::GetSettings() const
 {
-
-bool UsingBackendChannelNumbers(const std::shared_ptr<CSettings>& settings)
-{
-  int enabledClientAmount = CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
-  return settings->GetBool(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS) &&
-         (enabledClientAmount == 1 ||
-          (settings->GetBool(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS) &&
-           enabledClientAmount > 1));
-}
-
-} // unnamed namespace
-
-void CPVRChannelGroup::InitSettings()
-{
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  m_bSyncChannelGroups = settings->GetBool(CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS);
-  m_bUsingBackendChannelOrder =
-      settings->GetBool(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER);
-  m_bUsingBackendChannelNumbers = UsingBackendChannelNumbers(settings);
-  m_bStartGroupChannelNumbersFromOne =
-      settings->GetBool(CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE) &&
-      !m_bUsingBackendChannelNumbers;
-
-  settings->RegisterCallback(this, {CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER,
-                                    CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS,
-                                    CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS,
-                                    CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE});
+  CSingleLock lock(m_critSection);
+  if (!m_settings)
+  {
+    CSingleLock singletonLock(m_settingsSingletonCritSection);
+    const std::shared_ptr<CPVRChannelGroupSettings> settings = m_settingsSingleton.lock();
+    if (settings)
+    {
+      m_settings = settings;
+    }
+    else
+    {
+      m_settings = std::make_shared<CPVRChannelGroupSettings>();
+      m_settingsSingleton = m_settings;
+    }
+  }
+  return m_settings;
 }
 
 bool CPVRChannelGroup::Load(
@@ -133,9 +122,7 @@ void CPVRChannelGroup::Unload()
 
 bool CPVRChannelGroup::Update()
 {
-  if (GroupType() == PVR_GROUP_TYPE_USER_DEFINED ||
-      !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-          CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS))
+  if (GroupType() == PVR_GROUP_TYPE_USER_DEFINED || !GetSettings()->SyncChannelGroups())
     return true;
 
   // get the channel group members from the backends.
@@ -216,7 +203,7 @@ struct sortByChannelNumber
 
 void CPVRChannelGroup::Sort()
 {
-  if (m_bUsingBackendChannelOrder)
+  if (GetSettings()->UseBackendChannelOrder())
     SortByClientChannelNumber();
   else
     SortByChannelNumber();
@@ -248,11 +235,12 @@ bool CPVRChannelGroup::UpdateClientPriorities()
 
   CSingleLock lock(m_critSection);
 
+  const bool bUseBackendChannelOrder = GetSettings()->UseBackendChannelOrder();
   for (auto& member : m_sortedMembers)
   {
     int iNewPriority = 0;
 
-    if (m_bUsingBackendChannelOrder)
+    if (bUseBackendChannelOrder)
     {
       std::shared_ptr<CPVRClient> client;
       if (!clients->GetCreatedClient(member->Channel()->ClientID(), client))
@@ -340,11 +328,11 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByChannelNumber(
     const CPVRChannelNumber& channelNumber) const
 {
   CSingleLock lock(m_critSection);
-
+  const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   for (const auto& member : m_sortedMembers)
   {
     CPVRChannelNumber activeChannelNumber =
-        m_bUsingBackendChannelNumbers ? member->ClientChannelNumber() : member->ChannelNumber();
+        bUseBackendChannelNumbers ? member->ClientChannelNumber() : member->ChannelNumber();
     if (activeChannelNumber == channelNumber)
       return member;
   }
@@ -441,10 +429,11 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::GetMember
 void CPVRChannelGroup::GetChannelNumbers(std::vector<std::string>& channelNumbers) const
 {
   CSingleLock lock(m_critSection);
+  const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   for (const auto& member : m_sortedMembers)
   {
     CPVRChannelNumber activeChannelNumber =
-        m_bUsingBackendChannelNumbers ? member->ClientChannelNumber() : member->ChannelNumber();
+        bUseBackendChannelNumbers ? member->ClientChannelNumber() : member->ChannelNumber();
     channelNumbers.emplace_back(activeChannelNumber.FormattedChannelNumber());
   }
 }
@@ -773,13 +762,10 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
 {
   bool bReturn(false);
   unsigned int iChannelNumber(0);
-  const auto& settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  bool bUsingBackendChannelNumbers = UsingBackendChannelNumbers(settings);
-  bool bStartGroupChannelNumbersFromOne =
-      settings->GetBool(CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE) &&
-      !bUsingBackendChannelNumbers;
 
   CSingleLock lock(m_critSection);
+  const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
+  const bool bStartGroupChannelNumbersFromOne = GetSettings()->StartGroupChannelNumbersFromOne();
 
   CPVRChannelNumber currentChannelNumber;
   CPVRChannelNumber currentClientChannelNumber;
@@ -790,7 +776,7 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
       currentClientChannelNumber =
           m_allChannelsGroup->GetClientChannelNumber(sortedMember->Channel());
 
-    if (bUsingBackendChannelNumbers)
+    if (bUseBackendChannelNumbers)
     {
       currentChannelNumber = currentClientChannelNumber;
     }
@@ -853,61 +839,47 @@ bool CPVRChannelGroup::IsNew() const
   return m_iGroupId <= 0;
 }
 
-void CPVRChannelGroup::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
+void CPVRChannelGroup::UseBackendChannelOrderChanged()
 {
-  if (setting == NULL)
-    return;
+  CSingleLock lock(m_critSection);
+  UpdateClientPriorities();
+  OnSettingChanged();
+}
 
+void CPVRChannelGroup::UseBackendChannelNumbersChanged()
+{
+  OnSettingChanged();
+}
+
+void CPVRChannelGroup::StartGroupChannelNumbersFromOneChanged()
+{
+  OnSettingChanged();
+}
+
+void CPVRChannelGroup::OnSettingChanged()
+{
   //! @todo while pvr manager is starting up do accept setting changes.
-  if(!CServiceBroker::GetPVRManager().IsStarted())
+  if (!CServiceBroker::GetPVRManager().IsStarted())
   {
     CLog::Log(LOGWARNING, "Channel group setting change ignored while PVR Manager is starting");
     return;
   }
 
-  const std::string& settingId = setting->GetId();
-  if (settingId == CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS ||
-      settingId == CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER ||
-      settingId == CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS ||
-      settingId == CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE)
-  {
-    const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-    m_bSyncChannelGroups = settings->GetBool(CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS);
-    bool bUsingBackendChannelOrder = settings->GetBool(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER);
-    bool bUsingBackendChannelNumbers = UsingBackendChannelNumbers(settings);
-    bool bStartGroupChannelNumbersFromOne = settings->GetBool(CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE) && !bUsingBackendChannelNumbers;
+  CSingleLock lock(m_critSection);
 
-    CSingleLock lock(m_critSection);
+  CLog::LogFC(LOGDEBUG, LOGPVR,
+              "Renumbering channel group '{}' to use the backend channel order and/or numbers",
+              GroupName());
 
-    bool bChannelNumbersChanged = m_bUsingBackendChannelNumbers != bUsingBackendChannelNumbers;
-    bool bChannelOrderChanged = m_bUsingBackendChannelOrder != bUsingBackendChannelOrder;
-    bool bGroupChannelNumbersFromOneChanged = m_bStartGroupChannelNumbersFromOne != bStartGroupChannelNumbersFromOne;
+  // If we don't sync channel groups make sure the channel numbers are set from
+  // the all channels group using the non default renumber call before sorting
+  if (!GetSettings()->SyncChannelGroups())
+    Renumber(IGNORE_NUMBERING_FROM_ONE);
 
-    m_bUsingBackendChannelOrder = bUsingBackendChannelOrder;
-    m_bUsingBackendChannelNumbers = bUsingBackendChannelNumbers;
-    m_bStartGroupChannelNumbersFromOne = bStartGroupChannelNumbersFromOne;
+  const bool bRenumbered = SortAndRenumber();
+  Persist();
 
-    /* check whether this channel group has to be renumbered */
-    if (bChannelOrderChanged || bChannelNumbersChanged || bGroupChannelNumbersFromOneChanged)
-    {
-      CLog::LogFC(LOGDEBUG, LOGPVR,
-                  "Renumbering channel group '{}' to use the backend channel order and/or numbers",
-                  GroupName());
-
-      if (bChannelOrderChanged)
-        UpdateClientPriorities();
-
-      // If we don't sync channel groups make sure the channel numbers are set from
-      // the all channels group using the non default renumber call before sorting
-      if (!m_bSyncChannelGroups)
-        Renumber(IGNORE_NUMBERING_FROM_ONE);
-
-      bool bRenumbered = SortAndRenumber();
-      Persist();
-
-      m_events.Publish(bRenumbered ? PVREvent::ChannelGroupInvalidated : PVREvent::ChannelGroup);
-    }
-  }
+  m_events.Publish(bRenumbered ? PVREvent::ChannelGroupInvalidated : PVREvent::ChannelGroup);
 }
 
 CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #include "XBDateTime.h"
+#include "pvr/channels/PVRChannelGroupSettings.h"
 #include "pvr/channels/PVRChannelNumber.h"
 #include "pvr/channels/PVRChannelsPath.h"
-#include "settings/lib/ISettingCallback.h"
 #include "utils/EventStream.h"
 
 #include <map>
@@ -46,7 +46,7 @@ namespace PVR
     IGNORE_NUMBERING_FROM_ONE = 1
   };
 
-  class CPVRChannelGroup : public ISettingCallback
+  class CPVRChannelGroup : public IChannelGroupSettingsCallback
   {
     friend class CPVRDatabase;
 
@@ -240,7 +240,10 @@ namespace PVR
 
     //@}
 
-    void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
+    // IChannelGroupSettingsCallback implementation
+    void UseBackendChannelOrderChanged() override;
+    void UseBackendChannelNumbersChanged() override;
+    void StartGroupChannelNumbersFromOneChanged() override;
 
     /*!
      * @brief Get the channel group member that was played last.
@@ -440,11 +443,6 @@ namespace PVR
 
   protected:
     /*!
-     * @brief Init settings
-     */
-    void InitSettings();
-
-    /*!
      * @brief Remove deleted group members from this group.
      * @param groupMembers The group members to use to update this list.
      * @return The removed members .
@@ -475,12 +473,12 @@ namespace PVR
      */
     bool UpdateClientPriorities();
 
+    std::shared_ptr<CPVRChannelGroupSettings> GetSettings() const;
+
     int m_iGroupType = PVR_GROUP_TYPE_DEFAULT; /*!< The type of this group */
     int m_iGroupId = INVALID_GROUP_ID; /*!< The ID of this group in the database */
     bool m_bLoaded = false; /*!< True if this container is loaded, false otherwise */
     bool m_bChanged = false; /*!< true if anything changed in this group that hasn't been persisted, false otherwise */
-    bool m_bUsingBackendChannelOrder = false; /*!< true to use the channel order from backends, false otherwise */
-    bool m_bUsingBackendChannelNumbers = false; /*!< true to use the channel numbers from 1 backend, false otherwise */
     time_t m_iLastWatched = 0; /*!< last time group has been watched */
     uint64_t m_iLastOpened = 0; /*!< time in milliseconds from epoch this group was last opened */
     bool m_bHidden = false; /*!< true if this group is hidden, false otherwise */
@@ -492,8 +490,11 @@ namespace PVR
     mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClients;
     CEventSource<PVREvent> m_events;
-    bool m_bStartGroupChannelNumbersFromOne = false; /*!< true if we start group channel numbers from one when not using backend channel numbers, false otherwise */
-    bool m_bSyncChannelGroups = false; /*!< true if channel groups should be synced with the backend, false otherwise */
+    mutable std::shared_ptr<CPVRChannelGroupSettings> m_settings;
+
+    // the settings singleton shared between all group instances
+    static CCriticalSection m_settingsSingletonCritSection;
+    static std::weak_ptr<CPVRChannelGroupSettings> m_settingsSingleton;
 
   private:
     /*!
@@ -516,6 +517,8 @@ namespace PVR
      */
     bool AddAndUpdateGroupMembers(
         const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
+
+    void OnSettingChanged();
 
     CDateTime GetEPGDate(EpgDateType epgDateType) const;
 

--- a/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (C) 2012-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRChannelGroupSettings.h"
+
+#include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClients.h"
+#include "settings/Settings.h"
+#include "settings/lib/Setting.h"
+
+using namespace PVR;
+
+CPVRChannelGroupSettings::CPVRChannelGroupSettings()
+  : m_settings({CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS,
+                CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER,
+                CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS,
+                CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS,
+                CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE})
+{
+  UpdateSyncChannelGroups();
+  UpdateUseBackendChannelOrder();
+  UpdateUseBackendChannelNumbers();
+  UpdateStartGroupChannelNumbersFromOne();
+
+  m_settings.RegisterCallback(this);
+}
+
+CPVRChannelGroupSettings::~CPVRChannelGroupSettings()
+{
+  m_settings.UnregisterCallback(this);
+}
+
+void CPVRChannelGroupSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
+{
+  if (!setting)
+    return;
+
+  const std::string& settingId = setting->GetId();
+  if (settingId == CSettings::CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS)
+  {
+    if (SyncChannelGroups() != UpdateSyncChannelGroups())
+    {
+      for (const auto& callback : m_callbacks)
+        callback->SyncChannelGroupsChanged();
+    }
+  }
+  else if (settingId == CSettings::CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER)
+  {
+    if (UseBackendChannelOrder() != UpdateUseBackendChannelOrder())
+    {
+      for (const auto& callback : m_callbacks)
+        callback->UseBackendChannelOrderChanged();
+    }
+  }
+  else if (settingId == CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS ||
+           settingId == CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS)
+  {
+    if (UseBackendChannelNumbers() != UpdateUseBackendChannelNumbers())
+    {
+      for (const auto& callback : m_callbacks)
+        callback->UseBackendChannelNumbersChanged();
+    }
+  }
+  else if (settingId == CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE)
+  {
+    if (StartGroupChannelNumbersFromOne() != UpdateStartGroupChannelNumbersFromOne())
+    {
+      for (const auto& callback : m_callbacks)
+        callback->StartGroupChannelNumbersFromOneChanged();
+    }
+  }
+}
+
+void CPVRChannelGroupSettings::RegisterCallback(IChannelGroupSettingsCallback* callback)
+{
+  m_callbacks.insert(callback);
+}
+
+void CPVRChannelGroupSettings::UnregisterCallback(IChannelGroupSettingsCallback* callback)
+{
+  m_callbacks.erase(callback);
+}
+
+bool CPVRChannelGroupSettings::UpdateSyncChannelGroups()
+{
+  m_bSyncChannelGroups = m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS);
+  return m_bSyncChannelGroups;
+}
+
+bool CPVRChannelGroupSettings::UpdateUseBackendChannelOrder()
+{
+  m_bUseBackendChannelOrder =
+      m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER);
+  return m_bUseBackendChannelOrder;
+}
+
+bool CPVRChannelGroupSettings::UpdateUseBackendChannelNumbers()
+{
+  const int enabledClientAmount = CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
+  m_bUseBackendChannelNumbers =
+      m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS) &&
+      (enabledClientAmount == 1 ||
+       (m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS) &&
+        enabledClientAmount > 1));
+  return m_bUseBackendChannelNumbers;
+}
+
+bool CPVRChannelGroupSettings::UpdateStartGroupChannelNumbersFromOne()
+{
+  m_bStartGroupChannelNumbersFromOne =
+      m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE) &&
+      !UseBackendChannelNumbers();
+  return m_bStartGroupChannelNumbersFromOne;
+}

--- a/xbmc/pvr/channels/PVRChannelGroupSettings.h
+++ b/xbmc/pvr/channels/PVRChannelGroupSettings.h
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2012-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/settings/PVRSettings.h"
+#include "settings/lib/ISettingCallback.h"
+
+#include <memory>
+#include <set>
+
+namespace PVR
+{
+
+class IChannelGroupSettingsCallback
+{
+public:
+  virtual ~IChannelGroupSettingsCallback() = default;
+
+  virtual void SyncChannelGroupsChanged() {}
+  virtual void UseBackendChannelOrderChanged() {}
+  virtual void UseBackendChannelNumbersChanged() {}
+  virtual void StartGroupChannelNumbersFromOneChanged() {}
+};
+
+class CPVRChannelGroupSettings : public ISettingCallback
+{
+public:
+  CPVRChannelGroupSettings();
+  virtual ~CPVRChannelGroupSettings();
+
+  void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
+
+  void RegisterCallback(IChannelGroupSettingsCallback* callback);
+  void UnregisterCallback(IChannelGroupSettingsCallback* callback);
+
+  bool SyncChannelGroups() const { return m_bSyncChannelGroups; }
+  bool UseBackendChannelOrder() const { return m_bUseBackendChannelOrder; }
+  bool UseBackendChannelNumbers() const { return m_bUseBackendChannelNumbers; }
+  bool StartGroupChannelNumbersFromOne() const { return m_bStartGroupChannelNumbersFromOne; }
+
+private:
+  bool UpdateSyncChannelGroups();
+  bool UpdateUseBackendChannelOrder();
+  bool UpdateUseBackendChannelNumbers();
+  bool UpdateStartGroupChannelNumbersFromOne();
+
+  bool m_bSyncChannelGroups = false;
+  bool m_bUseBackendChannelOrder = false;
+  bool m_bUseBackendChannelNumbers = false;
+  bool m_bStartGroupChannelNumbersFromOne = false;
+
+  CPVRSettings m_settings;
+  std::set<IChannelGroupSettingsCallback*> m_callbacks;
+};
+
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -62,6 +62,18 @@ CPVRSettings::~CPVRSettings()
   settings->GetSettingsManager()->UnregisterSettingsHandler(this);
 }
 
+void CPVRSettings::RegisterCallback(ISettingCallback* callback)
+{
+  CSingleLock lock(m_critSection);
+  m_callbacks.insert(callback);
+}
+
+void CPVRSettings::UnregisterCallback(ISettingCallback* callback)
+{
+  CSingleLock lock(m_critSection);
+  m_callbacks.erase(callback);
+}
+
 void CPVRSettings::Init(const std::set<std::string>& settingNames)
 {
   for (auto settingName : settingNames)
@@ -100,6 +112,11 @@ void CPVRSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setti
 
   CSingleLock lock(m_critSection);
   m_settings[setting->GetId()] = setting->Clone(setting->GetId());
+  const auto callbacks(m_callbacks);
+  lock.Leave();
+
+  for (const auto& callback : callbacks)
+    callback->OnSettingChanged(setting);
 }
 
 bool CPVRSettings::GetBoolValue(const std::string& settingName) const

--- a/xbmc/pvr/settings/PVRSettings.h
+++ b/xbmc/pvr/settings/PVRSettings.h
@@ -30,6 +30,9 @@ namespace PVR
     explicit CPVRSettings(const std::set<std::string>& settingNames);
     ~CPVRSettings() override;
 
+    void RegisterCallback(ISettingCallback* callback);
+    void UnregisterCallback(ISettingCallback* callback);
+
     // ISettingsHandler implementation
     void OnSettingsLoaded() override;
 
@@ -66,6 +69,7 @@ namespace PVR
 
     mutable CCriticalSection m_critSection;
     std::map<std::string, std::shared_ptr<CSetting>> m_settings;
+    std::set<ISettingCallback*> m_callbacks;
 
     static unsigned int m_iInstances;
   };


### PR DESCRIPTION
Next refactoring round to increase pvr channel* implementation code maintainability.

Idea is to factor settings handling out of class CPVRChannelGroup and to put it into a singleton shared by all channel group instances.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish if/when you find some time...