### PR TITLE
[PVR][Estuary] Suppress PVR Recording 'Size' label when set to '0.00 B'

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -538,10 +538,10 @@
 		<value condition="ListItem.IsNew">[B][COLOR button_focus]$LOCALIZE[842][/COLOR][/B] - </value>
 	</variable>
 	<variable name="RecordingSizeLabel">
-		<value condition="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0 B)">$INFO[ListItem.Size,[COLOR grey]$LOCALIZE[22031]:[/COLOR] ,[CR]]</value>
+		<value condition="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0.00 B)">$INFO[ListItem.Size,[COLOR grey]$LOCALIZE[22031]:[/COLOR] ,[CR]]</value>
 	</variable>
 	<variable name="RecordingDateSizeLabel">
-		<value condition="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0 B)">$INFO[ListItem.Date,[COLOR grey],[/COLOR]]$INFO[ListItem.Size, (,)[CR]]</value>
+		<value condition="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0.00 B)">$INFO[ListItem.Date,[COLOR grey],[/COLOR]]$INFO[ListItem.Size, (,)[CR]]</value>
 		<value>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]</value>
 	</variable>
 	<variable name="ExpirationDateTimeLabel">


### PR DESCRIPTION
## Description
A post-Matrix change introduced what I feel is a (minor) missed impact to the PVR "Estuary" skin implementation. For PVR backends that do not/cannot support reporting recording file size, the value that was previously checked against to determine visibility was "0 B", now it seems to be "0.00 B", which will cause the optional Recording size field(s) to display in the GUI due to this logical delta.

I quite honestly did not dig far enough into why this value is now "0.00 B" instead of "0 B", but I think it's relatively safe to assume this is a missed impact as opposed to a defect.  If anyone thinks that the value of "0.00 B" as opposed to "0 B" is the root cause, please point me to where/when that changed so I can attempt to provide a PR that targets that specifically instead of trying to deal with leaf ramification(s).

## Motivation and context
Just a thing I noticed while working on something completely unrelated since I am the maintainer of a third-party PVR addon that does not support reporting recording size.

## How has this been tested?
Tested on Windows 10 21H1, Desktop, x64.  Before the change the GUI would show a value of "0.00 B" for size, after it will be suppressed.

## What is the effect on users?
The Estuary skin will not show a value to the user that is not known and should have been suppressed (because it's optional).

## Screenshots (if appropriate):

Before the change; note the presence of a "Size: 0.00 B" data point (new to Nexus; Matrix is not affected):
![before](https://user-images.githubusercontent.com/706055/121763778-997bb700-cb0c-11eb-80b5-2d065cf1ab19.png)

After the change this data point has been suppressed, as it would have been in Matrix:
![after](https://user-images.githubusercontent.com/706055/121763784-a3051f00-cb0c-11eb-8752-82edbf470471.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
