### PR TITLE
[tools/depends] bump cmake 3.20.3 + xcode new build system support

### DIFF
--- a/cmake/scripts/darwin_embedded/Macros.cmake
+++ b/cmake/scripts/darwin_embedded/Macros.cmake
@@ -2,7 +2,9 @@ function(core_link_library lib wraplib)
   if(CMAKE_GENERATOR MATCHES "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL Ninja)
     set(wrapper_obj cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o)
   elseif(CMAKE_GENERATOR MATCHES "Xcode")
-    set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$(CURRENT_VARIANT)/$(CURRENT_ARCH)/wrapper.o)
+    # CURRENT_VARIANT is an Xcode env var
+    # CPU is a project cmake var
+    set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$(CURRENT_VARIANT)/${CPU}/wrapper.o)
   else()
     message(FATAL_ERROR "Unsupported generator in core_link_library")
   endif()
@@ -52,8 +54,7 @@ function(core_link_library lib wraplib)
                      COMMAND ${CMAKE_C_COMPILER}
                      ARGS    ${CUSTOM_COMMAND_ARGS_LDFLAGS} ${export} -Wl,-force_load ${link_lib} ${extra_libs}
                              -o ${CMAKE_BINARY_DIR}/${wraplib}-${ARCH}${extension}
-                     DEPENDS ${target} wrapper.def wrapper
-                     VERBATIM)
+                     DEPENDS ${target} wrapper.def wrapper)
 
   get_filename_component(libname ${wraplib} NAME_WE)
   add_custom_target(wrap_${libname} ALL DEPENDS ${wraplib}-${ARCH}${extension})

--- a/cmake/scripts/osx/Macros.cmake
+++ b/cmake/scripts/osx/Macros.cmake
@@ -2,7 +2,9 @@ function(core_link_library lib wraplib)
   if(CMAKE_GENERATOR MATCHES "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL Ninja)
     set(wrapper_obj cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o)
   elseif(CMAKE_GENERATOR MATCHES "Xcode")
-    set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$(CURRENT_VARIANT)/$(CURRENT_ARCH)/wrapper.o)
+    # CURRENT_VARIANT is an Xcode env var
+    # CPU is a project cmake var
+    set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$CURRENT_VARIANT/${CPU}/wrapper.o)
   else()
     message(FATAL_ERROR "Unsupported generator in core_link_library")
   endif()
@@ -52,8 +54,7 @@ function(core_link_library lib wraplib)
                      COMMAND ${CMAKE_C_COMPILER}
                      ARGS    ${CUSTOM_COMMAND_ARGS_LDFLAGS} ${export} -Wl,-force_load ${link_lib} ${extra_libs}
                              -o ${CMAKE_BINARY_DIR}/${wraplib}-${ARCH}${extension}
-                     DEPENDS ${target} wrapper.def wrapper
-                     VERBATIM)
+                     DEPENDS ${target} wrapper.def wrapper)
 
   get_filename_component(libname ${wraplib} NAME_WE)
   add_custom_target(wrap_${libname} ALL DEPENDS ${wraplib}-${ARCH}${extension})

--- a/tools/depends/native/cmake/Makefile
+++ b/tools/depends/native/cmake/Makefile
@@ -3,7 +3,7 @@ PLATFORM=$(NATIVEPLATFORM)
 DEPS= ../../Makefile.include Makefile
 
 APPNAME=cmake
-VERSION=3.18.4
+VERSION=3.20.3
 SOURCE=$(APPNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/tools/depends/target/cmakebuildsys/Makefile
+++ b/tools/depends/target/cmakebuildsys/Makefile
@@ -11,9 +11,12 @@ ifeq ($(Configuration),)
 endif
 
 ifeq ($(OS),darwin_embedded)
-  CMAKE_BUILD_ARGUMENTS = -G Xcode
+  # cmake toolset option buildsystem selects the legacy xcode build system
+  # cmake 3.19+ with xcode 12 defaults to the new build system. Stick with the legacy
+  # system for now for our building
+  CMAKE_BUILD_ARGUMENTS = -G Xcode -T buildsystem=1
 else ifeq ($(GEN),Xcode)
-  CMAKE_BUILD_ARGUMENTS = -G Xcode
+  CMAKE_BUILD_ARGUMENTS = -G Xcode -T buildsystem=1
 else
   CMAKE_BUILD_ARGUMENTS = -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$(Configuration)
 endif

--- a/tools/depends/target/mariadb/03-cmake3.20_syntax_fix.patch
+++ b/tools/depends/target/mariadb/03-cmake3.20_syntax_fix.patch
@@ -1,0 +1,11 @@
+--- a/cmake/ConnectorName.cmake
++++ b/cmake/ConnectorName.cmake
+@@ -22,7 +22,7 @@
+     SET(MACHINE_NAME "x64")
+   ELSE()
+     SET(MACHINE_NAME "32")
+-  END()
++  ENDIF()
+ ENDIF()
+ 
+ SET(product_name "mysql-connector-c-${CPACK_PACKAGE_VERSION}-${PLATFORM_NAME}${CONCAT_SIGN}${MACHINE_NAME}")

--- a/tools/depends/target/mariadb/Makefile
+++ b/tools/depends/target/mariadb/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile 01-android.patch 02-symbol_rename-gnutls_clash.patch
+DEPS= ../../Makefile.include Makefile 01-android.patch 02-symbol_rename-gnutls_clash.patch 03-cmake3.20_syntax_fix.patch
 
 LIBNAME=mariadb
 VERSION=3.1.9
@@ -23,6 +23,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../01-android.patch
 	cd $(PLATFORM); patch -p1 -i ../02-symbol_rename-gnutls_clash.patch
+	cd $(PLATFORM); patch -p1 -i ../03-cmake3.20_syntax_fix.patch
 	cd $(PLATFORM)/build; $(CMAKE) $(PLUGIN_BUILD_FLAGS) -DWITH_UNIT_TESTS:BOOL=OFF -DWITH_EXTERNAL_ZLIB:BOOL=ON -DWITH_CURL:BOOL=OFF ..
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
## Description
Bump cmake to 3.20.3
Fix support for Xcode "new" build system for the osx target, but also explicitly set xcode project to continue to use the "legacy" system for all apple targets

## Motivation and context
Cmake 3.19+ in combination with xcode 12+ by default will use Xcode's "new" build system. There are supposed benefits, however in my testing the speed-ups suggested arent really apparent for our codebase. Apple have indicated they will remove the "legacy" build system at some point in the future.

The "new" xcode build system was introduced in Xcode 10, and cmake now believe that Xcode 12 now works to a sufficient level with a cmake generated project and the "new" system.

For our purposes i think we should continue to use the legacy build system for now (CI uses xcode 11 where cmake will default to the legacy system anyway), as this allows consistency for users who build themselves and need to compare to the official releases. 

The final commit actually makes changes to support a "new" build system project. Without this, the new system fails (change in env vars available and weird cmake quoting issues). In local testing the "legacy" system continued to work with these changes.

IOS new build system
The ios/tvos targets with the new build system are still not fully functional. Cmake appears to have some issues generating a project that uses add_custom_command(OUTPUT) as an input to a target. For some reason the scripts created for the new build system arent being built in order (parallelisation) as a dependency, and are therefore sometimes not being run prior to the target, and then build failures occur. executing the target a second time always succeeds. There are 2 targets this happens with (python_bindings, compileinfo). 
I was dealing with this issue with cmake 3.18 + new build system for osx, but bumping to 3.20 "solved" the issue. May be able to wait on cmake to fix it upstream, or the better solution may be to alter our cmake to specifically imply the dependency. A problem for another time though. 

## How has this been tested?
Locally using Xcode 12.4 on Catalina 10.15.7 against OSX target. ios legacy target still works, but the new build system ios target is not fully functional as yet.

## What is the effect on users?
Should be no effect for users, as we are choosing to actively use the same build system prior to this PR

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
