### PR TITLE
[PVR] MSVC 64-bit warning cleanup in PVRGUIActions.cpp

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -572,7 +572,7 @@ namespace PVR
             return;
         }
 
-        m_actions.insert(std::make_pair(eAction, m_actions.size()));
+        m_actions.insert(std::make_pair(eAction, static_cast<int>(m_actions.size())));
       }
     }
 


### PR DESCRIPTION
## Description
Noted an easily resolved warning in the PVR code when compiled via 64-bit MSVC attributed to this line of code:

https://github.com/xbmc/xbmc/blob/564439ce01be4c920b7d27e130d5319cbf34c959/xbmc/pvr/guilib/PVRGUIActions.cpp#L575

Two ways to fix this on MSVC, either static_cast<> the mapped_value to int or change the std::map<> declaration so that mapped_value is size_t.  Given that CGUIDialogSelect expects int, the static_cast<> seemed like the better option.  Happy to switch to changing the std::map<> declaration instead, it also resolves the warning.

## Motivation and context
When compiling for Windows x64 via MSVC, the following (overly verbose, thank you Microsoft) warning will be issued:

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\utility(241): warning C
4267: 'initializing': conversion from 'size_t' to '_Ty2', possible loss of data [D:\git\xbmc-build\libkodi.vcxproj]
          with
          [
              _Ty2=int
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\xmemory0(881): note:
  see reference to function template instantiation 'std::pair<const _Kty,_Ty>::pair<PVR::`anonymous-namespace'::PVRRECO
  RD_INSTANTRECORDACTION,unsigned __int64,0>(std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsign
  ed __int64> &&) noexcept' being compiled
          with
          [
              _Kty=PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,
              _Ty=int
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\xmemory0(881): note:
  see reference to function template instantiation 'std::pair<const _Kty,_Ty>::pair<PVR::`anonymous-namespace'::PVRRECO
  RD_INSTANTRECORDACTION,unsigned __int64,0>(std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsign
  ed __int64> &&) noexcept' being compiled
          with
          [
              _Kty=PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,
              _Ty=int
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\xtree(984): note: see
   reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,std::pair<P
  VR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64>>(_Alloc &,_Objty *const ,std::pair<PVR::`a
  nonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64> &&)' being compiled
          with
          [
              _Alloc=std::allocator<std::_Tree_node<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORD
  ACTION,int>,std::_Default_allocator_traits<std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTA
  NTRECORDACTION,int>>>::void_pointer>>,
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Objty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\xtree(983): note: see
   reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,std::pair<P
  VR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64>>(_Alloc &,_Objty *const ,std::pair<PVR::`a
  nonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64> &&)' being compiled
          with
          [
              _Alloc=std::allocator<std::_Tree_node<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORD
  ACTION,int>,std::_Default_allocator_traits<std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTA
  NTRECORDACTION,int>>>::void_pointer>>,
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Objty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\xtree(1155): note: se
  e reference to function template instantiation 'std::_Tree_node<_Ty,std::_Default_allocator_traits<_Alloc>::void_poin
  ter> *std::_Tree_comp_alloc<_Traits>::_Buynode<std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,un
  signed __int64>>(std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64> &&)' being com
  piled
          with
          [
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Alloc=std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>>,
              _Traits=std::_Tmap_traits<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int,std::less<PVR::`a
  nonymous-namespace'::PVRRECORD_INSTANTRECORDACTION>,std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRREC
  ORD_INSTANTRECORDACTION,int>>,false>
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\xtree(1155): note: se
  e reference to function template instantiation 'std::_Tree_node<_Ty,std::_Default_allocator_traits<_Alloc>::void_poin
  ter> *std::_Tree_comp_alloc<_Traits>::_Buynode<std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,un
  signed __int64>>(std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64> &&)' being com
  piled
          with
          [
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Alloc=std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>>,
              _Traits=std::_Tmap_traits<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int,std::less<PVR::`a
  nonymous-namespace'::PVRRECORD_INSTANTRECORDACTION>,std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRREC
  ORD_INSTANTRECORDACTION,int>>,false>
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\map(213): note: see r
  eference to function template instantiation 'std::pair<std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<_Ty
  >>>,bool> std::_Tree<std::_Tmap_traits<_Kty,int,_Pr,_Alloc,false>>::emplace<std::pair<PVR::`anonymous-namespace'::PVR
  RECORD_INSTANTRECORDACTION,unsigned __int64>>(std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,uns
  igned __int64> &&)' being compiled
          with
          [
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Kty=PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,
              _Pr=std::less<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION>,
              _Alloc=std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>>
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\include\map(213): note: see r
  eference to function template instantiation 'std::pair<std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<_Ty
  >>>,bool> std::_Tree<std::_Tmap_traits<_Kty,int,_Pr,_Alloc,false>>::emplace<std::pair<PVR::`anonymous-namespace'::PVR
  RECORD_INSTANTRECORDACTION,unsigned __int64>>(std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,uns
  igned __int64> &&)' being compiled
          with
          [
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Kty=PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,
              _Pr=std::less<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION>,
              _Alloc=std::allocator<std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>>
          ] (compiling source file D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp)
  D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp(575): note: see reference to function template instantiation 'std::pair
  <std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<_Ty>>>,bool> std::map<PVR::`anonymous-namespace'::PVRRECO
  RD_INSTANTRECORDACTION,int,std::less<_Kty>,std::allocator<_Ty>>::insert<std::pair<PVR::`anonymous-namespace'::PVRRECO
  RD_INSTANTRECORDACTION,unsigned __int64>,void>(_Valty &&)' being compiled
          with
          [
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Kty=PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,
              _Valty=std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64>
          ]
  D:\git\xbmc\xbmc\pvr\guilib\PVRGUIActions.cpp(575): note: see reference to function template instantiation 'std::pair
  <std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<_Ty>>>,bool> std::map<PVR::`anonymous-namespace'::PVRRECO
  RD_INSTANTRECORDACTION,int,std::less<_Kty>,std::allocator<_Ty>>::insert<std::pair<PVR::`anonymous-namespace'::PVRRECO
  RD_INSTANTRECORDACTION,unsigned __int64>,void>(_Valty &&)' being compiled
          with
          [
              _Ty=std::pair<const PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,int>,
              _Kty=PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,
              _Valty=std::pair<PVR::`anonymous-namespace'::PVRRECORD_INSTANTRECORDACTION,unsigned __int64>
          ]

```

## How has this been tested?
Tested on Windows x64 21H1, x64, with Visual Studio 2019 (build targeted to v141 (2017) compiler).  Change resolved the warning.  Alternative approach of changing the std::map<> to use size_t would also resolve the warning.

## What is the effect on users?
None; the warning is benign and does not have any effect on runtime behavior.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)

Compiler warning clean-up on MSVC.

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
