### PR TITLE
[UWP] [Xbox] Removed non working HDR toggle code

### DIFF
--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1262,48 +1262,7 @@ HDR_STATUS CWIN32Util::ToggleWindowsHDR(DXGI_MODE_DESC& modeDesc)
   HDR_STATUS status = HDR_STATUS::HDR_TOGGLE_FAILED;
 
 #ifdef TARGET_WINDOWS_STORE
-  auto hdmiDisplayInfo = HdmiDisplayInformation::GetForCurrentView();
-
-  if (hdmiDisplayInfo == nullptr)
-    return status;
-
-  auto current = hdmiDisplayInfo.GetCurrentDisplayMode();
-
-  auto newColorSp = (current.ColorSpace() == HdmiDisplayColorSpace::BT2020)
-                        ? HdmiDisplayColorSpace::BT709
-                        : HdmiDisplayColorSpace::BT2020;
-
-  auto modes = hdmiDisplayInfo.GetSupportedDisplayModes();
-
-  // Browse over all modes available like the current (resolution and refresh)
-  // but reciprocals HDR (color space and transfer).
-  // NOTE: transfer for HDR is here "fake HDR" (EotfSdr) to be
-  // able render SRD content with HDR ON, same as Windows HDR switch does.
-  // GUI-skin is SDR. The real HDR mode is activated later when playback begins.
-  for (const auto& mode : modes)
-  {
-    if (mode.ColorSpace() == newColorSp &&
-        mode.ResolutionHeightInRawPixels() == current.ResolutionHeightInRawPixels() &&
-        mode.ResolutionWidthInRawPixels() == current.ResolutionWidthInRawPixels() &&
-        mode.StereoEnabled() == false && fabs(mode.RefreshRate() - current.RefreshRate()) < 0.0001)
-    {
-      if (current.ColorSpace() == HdmiDisplayColorSpace::BT2020) // HDR is ON
-      {
-        CLog::LogF(LOGINFO, "Toggle Windows HDR Off (ON => OFF).");
-        if (Wait(hdmiDisplayInfo.RequestSetCurrentDisplayModeAsync(mode,
-                                                                   HdmiDisplayHdrOption::None)))
-          status = HDR_STATUS::HDR_OFF;
-      }
-      else // HDR is OFF
-      {
-        CLog::LogF(LOGINFO, "Toggle Windows HDR On (OFF => ON).");
-        if (Wait(hdmiDisplayInfo.RequestSetCurrentDisplayModeAsync(mode,
-                                                                   HdmiDisplayHdrOption::EotfSdr)))
-          status = HDR_STATUS::HDR_ON;
-      }
-      break;
-    }
-  }
+  // Not supported - not implemented yet
 #else
   uint32_t pathCount = 0;
   uint32_t modeCount = 0;
@@ -1524,7 +1483,7 @@ HDR_STATUS CWIN32Util::GetWindowsHDRStatus()
   {
     status = advancedColorEnabled ? HDR_STATUS::HDR_ON : HDR_STATUS::HDR_OFF;
     if (CServiceBroker::IsServiceManagerUp())
-      CLog::LogF(LOGDEBUG, "Display HDR capable and current HDR status is {}",
+      CLog::LogF(LOGDEBUG, "Display is HDR capable and current HDR status is {}",
                  advancedColorEnabled ? "ON" : "OFF");
   }
 

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -164,7 +164,7 @@ void CWinSystemWin10DX::InitHooks(IDXGIOutput* pOutput)
 
 bool CWinSystemWin10DX::IsHDRDisplay()
 {
-  return (CWIN32Util::GetWindowsHDRStatus() != HDR_STATUS::HDR_UNSUPPORTED);
+  return false; // use tone mapping by default on Xbox
 }
 
 HDR_STATUS CWinSystemWin10DX::GetOSHDRStatus()


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/19879

Fixes wrong picture due tone mapping stays disabled and HDR passthrough is not working on Xbox.


## What is the effect on users?
Tone mapping is enabled by default on Xbox and right picture is obtained for 4K HDR sources.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
