### PR TITLE
[Backport][Addons][Filesystem] Resolve int <--> bool compiler warnings on MSVC

### DIFF
--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -999,7 +999,7 @@ bool Interface_Filesystem::io_control_get_seek_possible(void* kodiBase, void* fi
   {
     CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}')", __FUNCTION__,
               kodiBase, file);
-    return -1;
+    return false;
   }
 
   return static_cast<CFile*>(file)->IoControl(EIoControl::IOCTRL_SEEK_POSSIBLE, nullptr) != 0
@@ -1016,7 +1016,7 @@ bool Interface_Filesystem::io_control_get_cache_status(void* kodiBase,
   {
     CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}, status='{}')",
               __FUNCTION__, kodiBase, file, static_cast<const void*>(status));
-    return -1;
+    return false;
   }
 
   SCacheStatus data = {0};
@@ -1039,7 +1039,7 @@ bool Interface_Filesystem::io_control_set_cache_rate(void* kodiBase, void* file,
   {
     CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}')", __FUNCTION__,
               kodiBase, file);
-    return -1;
+    return false;
   }
 
   return static_cast<CFile*>(file)->IoControl(EIoControl::IOCTRL_CACHE_SETRATE, &rate) >= 0 ? true
@@ -1053,7 +1053,7 @@ bool Interface_Filesystem::io_control_set_retry(void* kodiBase, void* file, bool
   {
     CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}')", __FUNCTION__,
               kodiBase, file);
-    return -1;
+    return false;
   }
 
   return static_cast<CFile*>(file)->IoControl(EIoControl::IOCTRL_SET_RETRY, &retry) >= 0 ? true


### PR DESCRIPTION
## Description

Backport of PR https://github.com/xbmc/xbmc/pull/19878, which reads:

There are four warnings present in xbmc/addons/interfaces/Filesystem.cpp due to functions with a return type of **bool** returning **-1** as opposed to **false** for an error condition. When **-1** is cast to **bool**, it may evaluate to **true** instead of **false**.

## Motivation and context
Warning cleanup

## How has this been tested?
Tested on Windows 10 21H1, x64 (Desktop).  Prior to the change a build would flag these lines with warnings; after the change they are no longer flagged.

## What is the effect on users?
Nothing expected; warning cleanup only.  Possible that if these function(s) are failing for any users that the **-1** return value may cause the calling function to assume success, but I think that's unlikely, this concern has been in the code for a while now.  Suggest this be considered as a benign warning cleanup only.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)

Warning cleanup on MSVC x64.

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed