### PR TITLE
[GUI] Improve text rendering by adding support for GPOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ set(required_deps ASS
                   FreeType
                   FriBidi
                   fstrcmp
+                  HarfBuzz
                   Iconv
                   LibDvd
                   Lzo2

--- a/cmake/modules/FindHarfBuzz.cmake
+++ b/cmake/modules/FindHarfBuzz.cmake
@@ -1,0 +1,46 @@
+#.rst:
+# FindHarfbuzz
+# ------------
+# Finds the HarfBuzz library
+#
+# This will define the following variables::
+#
+# HARFBUZZ_FOUND - system has HarfBuzz
+# HARFBUZZ_INCLUDE_DIRS - the HarfBuzz include directory
+# HARFBUZZ_LIBRARIES - the HarfBuzz libraries
+#
+# and the following imported targets::
+#
+#   HarfBuzz::HarfBuzz   - The HarfBuzz library
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_HARFBUZZ harfbuzz QUIET)
+endif()
+
+find_path(HARFBUZZ_INCLUDE_DIR NAMES harfbuzz/hb-ft.h hb-ft.h
+                               PATHS ${PC_HARFBUZZ_INCLUDEDIR}
+                                     ${PC_HARFBUZZ_INCLUDE_DIRS}
+                               PATH_SUFFIXES harfbuzz)
+find_library(HARFBUZZ_LIBRARY NAMES harfbuzz harfbuzz
+                              PATHS ${PC_HARFBUZZ_LIBDIR})
+
+set(HARFBUZZ_VERSION ${PC_HARFBUZZ_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HarfBuzz
+                                  REQUIRED_VARS HARFBUZZ_LIBRARY HARFBUZZ_INCLUDE_DIR
+                                  VERSION_VAR HARFBUZZ_VERSION)
+
+if(HARFBUZZ_FOUND)
+  set(HARFBUZZ_LIBRARIES ${HARFBUZZ_LIBRARY})
+  set(HARFBUZZ_INCLUDE_DIRS ${HARFBUZZ_INCLUDE_DIR})
+
+  if(NOT TARGET HarfBuzz::HarfBuzz)
+    add_library(HarfBuzz::HarfBuzz UNKNOWN IMPORTED)
+    set_target_properties(HarfBuzz::HarfBuzz PROPERTIES
+                                             IMPORTED_LOCATION "${HARFBUZZ_LIBRARY}"
+                                             INTERFACE_INCLUDE_DIRECTORIES "${HARFBUZZ_INCLUDE_DIR}")
+  endif()
+endif()
+
+mark_as_advanced(HARFBUZZ_INCLUDE_DIR HARFBUZZ_LIBRARY)

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -237,7 +237,8 @@ float CGUIFont::GetTextWidth( const vecText &text )
 {
   if (!m_font) return 0;
   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-  return m_font->GetTextWidthInternal(text.begin(), text.end()) * CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX();
+  return m_font->GetTextWidthInternal(text) *
+         CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX();
 }
 
 float CGUIFont::GetCharWidth( character_t ch )

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -586,7 +586,7 @@ float CGUIFontTTF::GetTextWidthInternal(const vecText& text, vecGlyphInfo& glyph
   float width = 0;
   for (auto it = glyphInfos.begin(); it != glyphInfos.end(); it++)
   {
-    Character* c = GetCharacter(text[(*it).cluster],(*it).codepoint);
+    Character* c = GetCharacter(text[(*it).cluster], (*it).codepoint);
     if (c)
     {
       // If last character in line, we want to add render width
@@ -689,7 +689,7 @@ vecGlyphInfo CGUIFontTTF::GetHarfbuzzShapedGlyphs(const vecText& text)
       }
     }
   }
-  
+
   for (auto& run : runs)
   {
     run.buffer = hb_buffer_create();

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -645,6 +645,7 @@ vecGlyphInfo CGUIFontTTF::GetHarfbuzzShapedGlyphs(const vecText& text)
   {
     scripts.emplace_back(hb_unicode_script(ufuncs, static_cast<wchar_t>(0xffff & character)));
   }
+
   // HB_SCRIPT_COMMON or HB_SCRIPT_INHERITED should be replaced with previous script
   for (unsigned int i = 0; i < scripts.size(); i++)
   {
@@ -665,6 +666,7 @@ vecGlyphInfo CGUIFontTTF::GetHarfbuzzShapedGlyphs(const vecText& text)
       lastSetIndex = i;
     }
   }
+
   lastScript = scripts[0];
   int lastRunStart = 0;
   for (unsigned int i = 0; i <= scripts.size(); i++)
@@ -687,6 +689,7 @@ vecGlyphInfo CGUIFontTTF::GetHarfbuzzShapedGlyphs(const vecText& text)
       }
     }
   }
+  
   for (auto& run : runs)
   {
     run.buffer = hb_buffer_create();

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -584,15 +584,15 @@ float CGUIFontTTF::GetTextWidthInternal(const vecText& text)
 float CGUIFontTTF::GetTextWidthInternal(const vecText& text, vecGlyphInfo& glyphInfos)
 {
   float width = 0;
-  for (size_t i = 0; i < glyphInfos.size(); i++)
+  for (auto it = glyphInfos.begin(); it != glyphInfos.end(); it++)
   {
-    Character* c = GetCharacter(text[glyphInfos[i].cluster], glyphInfos[i].codepoint);
+    Character* c = GetCharacter(text[(*it).cluster],(*it).codepoint);
     if (c)
     {
       // If last character in line, we want to add render width
       // and not advance distance - this makes sure that italic text isn't
       // choped on the end (as render width is larger than advance then).
-      if (i == glyphInfos.size() - 1)
+      if (it == glyphInfos.end())
         width += std::max(c->right - c->left + c->offsetX, c->advance);
       else
         width += c->advance;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -373,7 +373,7 @@ void CGUIFontTTF::DrawTextInternal(float x,
   }
 
   Begin();
-  vecGlyphInfo glyphInfos = GetHarfbuzzShapedGlyphs(text);
+  std::vector<hb_glyph_info_t> glyphInfos = GetHarfbuzzShapedGlyphs(text);
   uint32_t rawAlignment = alignment;
   bool dirtyCache(false);
   bool hardwareClipping = m_renderSystem->ScissorsCanEffectClipping();
@@ -576,12 +576,13 @@ void CGUIFontTTF::DrawTextInternal(float x,
 
 float CGUIFontTTF::GetTextWidthInternal(const vecText& text)
 {
-  vecGlyphInfo glyphInfos = GetHarfbuzzShapedGlyphs(text);
+  std::vector<hb_glyph_info_t> glyphInfos = GetHarfbuzzShapedGlyphs(text);
   return GetTextWidthInternal(text, glyphInfos);
 }
 
 // this routine assumes a single line (i.e. it was called from GUITextLayout)
-float CGUIFontTTF::GetTextWidthInternal(const vecText& text, vecGlyphInfo& glyphInfos)
+float CGUIFontTTF::GetTextWidthInternal(const vecText& text,
+                                        std::vector<hb_glyph_info_t>& glyphInfos)
 {
   float width = 0;
   for (auto it = glyphInfos.begin(); it != glyphInfos.end(); it++)
@@ -627,9 +628,9 @@ unsigned int CGUIFontTTF::GetTextureLineHeight() const
   return m_cellHeight + spacing_between_characters_in_texture;
 }
 
-vecGlyphInfo CGUIFontTTF::GetHarfbuzzShapedGlyphs(const vecText& text)
+std::vector<hb_glyph_info_t> CGUIFontTTF::GetHarfbuzzShapedGlyphs(const vecText& text)
 {
-  vecGlyphInfo glyphInfos;
+  std::vector<hb_glyph_info_t> glyphInfos;
   if (text.empty())
   {
     return glyphInfos;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -27,7 +27,8 @@
 
 // stuff for freetype
 #include <ft2build.h>
-
+#include <harfbuzz/hb-ft.h>
+#include <harfbuzz/hb.h>
 #if defined(HAS_GL) || defined(HAS_GLES)
 #include "system_gl.h"
 #endif
@@ -227,6 +228,9 @@ void CGUIFontTTF::Clear()
   m_posY = 0;
   m_nestedBeginCount = 0;
 
+  if (m_hbFont)
+    hb_font_destroy(m_hbFont);
+  m_hbFont = nullptr;
   if (m_face)
     g_freeTypeLibrary.ReleaseFont(m_face);
   m_face = NULL;
@@ -250,7 +254,9 @@ bool CGUIFontTTF::Load(
 
   if (!m_face)
     return false;
-
+  m_hbFont = hb_ft_font_create(m_face, 0);
+  if (!m_hbFont)
+    return false;
   /*
    the values used are described below
 
@@ -325,7 +331,7 @@ bool CGUIFontTTF::Load(
   m_posY = -(int)GetTextureLineHeight();
 
   // cache the ellipses width
-  Character *ellipse = GetCharacter(L'.');
+  Character* ellipse = GetCharacter(L'.', 0);
   if (ellipse) m_ellipsesWidth = ellipse->advance;
 
   return true;
@@ -367,7 +373,7 @@ void CGUIFontTTF::DrawTextInternal(float x,
   }
 
   Begin();
-
+  vecGlyphInfo glyphInfos = GetHarfbuzzShapedGlyphs(text);
   uint32_t rawAlignment = alignment;
   bool dirtyCache(false);
   bool hardwareClipping = m_renderSystem->ScissorsCanEffectClipping();
@@ -406,7 +412,7 @@ void CGUIFontTTF::DrawTextInternal(float x,
     // Check if we will really need to truncate or justify the text
     if ( alignment & XBFONT_TRUNCATED )
     {
-      if ( maxPixelWidth <= 0.0f || GetTextWidthInternal(text.begin(), text.end()) <= maxPixelWidth)
+      if (maxPixelWidth <= 0.0f || GetTextWidthInternal(text, glyphInfos) <= maxPixelWidth)
         alignment &= ~XBFONT_TRUNCATED;
     }
     else if ( alignment & XBFONT_JUSTIFIED )
@@ -422,7 +428,7 @@ void CGUIFontTTF::DrawTextInternal(float x,
     if ( alignment & (XBFONT_RIGHT | XBFONT_CENTER_X) )
     {
       // Get the extent of this line
-      float w = GetTextWidthInternal( text.begin(), text.end() );
+      float w = GetTextWidthInternal(text, glyphInfos);
 
       if ( alignment & XBFONT_TRUNCATED && w > maxPixelWidth + 0.5f ) // + 0.5f due to rounding issues
         w = maxPixelWidth;
@@ -439,12 +445,12 @@ void CGUIFontTTF::DrawTextInternal(float x,
       // first compute the size of the text to render in both characters and pixels
       unsigned int numSpaces = 0;
       float linePixels = 0;
-      for (const auto& pos : text)
+      for (const auto& glyphInfo : glyphInfos)
       {
-        Character* ch = GetCharacter(pos);
+        Character* ch = GetCharacter(text[glyphInfo.cluster], glyphInfo.codepoint);
         if (ch)
         {
-          if ((pos & 0xffff) == L' ')
+          if ((text[glyphInfo.cluster] & 0xffff) == L' ')
             numSpaces +=  1;
           linePixels += ch->advance;
         }
@@ -460,10 +466,10 @@ void CGUIFontTTF::DrawTextInternal(float x,
     // would invalidate the texture coordinates.
     std::queue<Character> characters;
     if (alignment & XBFONT_TRUNCATED)
-      GetCharacter(L'.');
-    for (const auto& pos : text)
+      GetCharacter(L'.', 0);
+    for (const auto& glyphInfo : glyphInfos)
     {
-      Character* ch = GetCharacter(pos);
+      Character* ch = GetCharacter(text[glyphInfo.cluster], glyphInfo.codepoint);
       if (!ch)
       {
         Character null = {};
@@ -478,19 +484,18 @@ void CGUIFontTTF::DrawTextInternal(float x,
       cursorX += ch->advance;
     }
     cursorX = 0;
-
-    for (const auto& pos : text)
+    for (const auto& glyphInfo : glyphInfos)
     {
       // If starting text on a new line, determine justification effects
       // Get the current letter in the CStdString
-      UTILS::Color color = (pos & 0xff0000) >> 16;
+      UTILS::Color color = (text[glyphInfo.cluster] & 0xff0000) >> 16;
       if (color >= colors.size())
         color = 0;
       color = colors[color];
 
       // grab the next character
       Character *ch = &characters.front();
-      if (ch->letterAndStyle == 0)
+      if (ch->letter == 0)
       {
         characters.pop();
         continue;
@@ -503,7 +508,7 @@ void CGUIFontTTF::DrawTextInternal(float x,
         {
           // Yup. Let's draw the ellipses, then bail
           // Perhaps we should really bail to the next line in this case??
-          Character *period = GetCharacter(L'.');
+          Character* period = GetCharacter(L'.', 0);
           if (!period)
             break;
 
@@ -521,7 +526,7 @@ void CGUIFontTTF::DrawTextInternal(float x,
       RenderCharacter(startX + cursorX, startY, ch, color, !scrolling, *tempVertices);
       if ( alignment & XBFONT_JUSTIFIED )
       {
-        if ((pos & 0xffff) == L' ')
+        if ((text[glyphInfo.cluster] & 0xffff) == L' ')
           cursorX += ch->advance + spacePerSpaceCharacter;
         else
           cursorX += ch->advance;
@@ -568,19 +573,26 @@ void CGUIFontTTF::DrawTextInternal(float x,
   End();
 }
 
+
+float CGUIFontTTF::GetTextWidthInternal(const vecText& text)
+{
+  vecGlyphInfo glyphInfos = GetHarfbuzzShapedGlyphs(text);
+  return GetTextWidthInternal(text, glyphInfos);
+}
+
 // this routine assumes a single line (i.e. it was called from GUITextLayout)
-float CGUIFontTTF::GetTextWidthInternal(vecText::const_iterator start, vecText::const_iterator end)
+float CGUIFontTTF::GetTextWidthInternal(const vecText& text, vecGlyphInfo& glyphInfos)
 {
   float width = 0;
-  while (start != end)
+  for (size_t i = 0; i < glyphInfos.size(); i++)
   {
-    Character *c = GetCharacter(*start++);
+    Character* c = GetCharacter(text[glyphInfos[i].cluster], glyphInfos[i].codepoint);
     if (c)
     {
       // If last character in line, we want to add render width
       // and not advance distance - this makes sure that italic text isn't
       // choped on the end (as render width is larger than advance then).
-      if (start == end)
+      if (i == glyphInfos.size() - 1)
         width += std::max(c->right - c->left + c->offsetX, c->advance);
       else
         width += c->advance;
@@ -591,7 +603,7 @@ float CGUIFontTTF::GetTextWidthInternal(vecText::const_iterator start, vecText::
 
 float CGUIFontTTF::GetCharWidthInternal(character_t ch)
 {
-  Character *c = GetCharacter(ch);
+  Character* c = GetCharacter(ch, 0);
   if (c) return c->advance;
   return 0;
 }
@@ -615,7 +627,90 @@ unsigned int CGUIFontTTF::GetTextureLineHeight() const
   return m_cellHeight + spacing_between_characters_in_texture;
 }
 
-CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr)
+vecGlyphInfo CGUIFontTTF::GetHarfbuzzShapedGlyphs(const vecText& text)
+{
+  vecGlyphInfo glyphInfos;
+  if (text.empty())
+  {
+    return glyphInfos;
+  }
+  std::vector<hb_script_t> scripts;
+  std::vector<RunInfo> runs;
+  hb_unicode_funcs_t* ufuncs = hb_unicode_funcs_create(hb_unicode_funcs_get_default());
+  hb_script_t lastScript;
+  int lastScriptIndex = -1;
+  int lastSetIndex = -1;
+
+  for (const auto& character : text)
+  {
+    scripts.emplace_back(hb_unicode_script(ufuncs, static_cast<wchar_t>(0xffff & character)));
+  }
+  // HB_SCRIPT_COMMON or HB_SCRIPT_INHERITED should be replaced with previous script
+  for (unsigned int i = 0; i < scripts.size(); i++)
+  {
+    if (scripts[i] == HB_SCRIPT_COMMON || scripts[i] == HB_SCRIPT_INHERITED)
+    {
+      if (lastScriptIndex != -1)
+      {
+        scripts[i] = lastScript;
+        lastSetIndex = i;
+      }
+    }
+    else
+    {
+      for (unsigned int j = lastSetIndex + 1; j < i; j++)
+        scripts[j] = scripts[i];
+      lastScript = scripts[i];
+      lastScriptIndex = i;
+      lastSetIndex = i;
+    }
+  }
+  lastScript = scripts[0];
+  int lastRunStart = 0;
+  for (unsigned int i = 0; i <= scripts.size(); i++)
+  {
+    if (i == scripts.size() || scripts[i] != lastScript)
+    {
+      RunInfo run{};
+      run.startOffset = lastRunStart;
+      run.endOffset = i;
+      run.script = lastScript;
+      runs.emplace_back(run);
+      if (i < scripts.size())
+      {
+        lastScript = scripts[i];
+        lastRunStart = i;
+      }
+      else
+      {
+        break;
+      }
+    }
+  }
+  for (auto& run : runs)
+  {
+    run.buffer = hb_buffer_create();
+    hb_buffer_set_direction(run.buffer, static_cast<hb_direction_t>(HB_DIRECTION_LTR));
+    hb_buffer_set_script(run.buffer, run.script);
+    for (int j = run.startOffset; j < run.endOffset; j++)
+    {
+      hb_buffer_add(run.buffer, static_cast<wchar_t>(0xffff & text[j]), j);
+    }
+    hb_buffer_set_content_type(run.buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
+    hb_shape(m_hbFont, run.buffer, nullptr, 0);
+    run.glyphInfos = hb_buffer_get_glyph_infos(run.buffer, nullptr);
+    unsigned int glyphCount = hb_buffer_get_length(run.buffer);
+    for (size_t k = 0; k < glyphCount; k++)
+    {
+      glyphInfos.emplace_back(run.glyphInfos[k]);
+    }
+    hb_buffer_destroy(run.buffer);
+  }
+  hb_unicode_funcs_destroy(ufuncs);
+  return glyphInfos;
+}
+
+CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyphIndex)
 {
   wchar_t letter = (wchar_t)(chr & 0xffff);
   character_t style = (chr & 0x7000000) >> 24;
@@ -627,22 +722,22 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr)
   // quick access to ascii chars
   if (letter < 255)
   {
-    character_t ch = (style << 8) | letter;
+    character_t ch = (style << 8) | glyphIndex;
     if (ch < LOOKUPTABLE_SIZE && m_charquick[ch])
       return m_charquick[ch];
   }
 
-  // letters are stored based on style and letter
-  character_t ch = (style << 16) | letter;
+  // letters are stored based on style and glyph
+  character_t ch = (style << 16) | glyphIndex;
 
   int low = 0;
   int high = m_numChars - 1;
   while (low <= high)
   {
     int mid = (low + high) >> 1;
-    if (ch > m_char[mid].letterAndStyle)
+    if (ch > m_char[mid].glyphAndStyle)
       low = mid + 1;
-    else if (ch < m_char[mid].letterAndStyle)
+    else if (ch < m_char[mid].glyphAndStyle)
       high = mid - 1;
     else
       return &m_char[mid];
@@ -672,13 +767,13 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr)
   unsigned int nestedBeginCount = m_nestedBeginCount;
   m_nestedBeginCount = 1;
   if (nestedBeginCount) End();
-  if (!CacheCharacter(letter, style, m_char + low))
+  if (!CacheCharacter(letter, style, m_char + low, glyphIndex))
   { // unable to cache character - try clearing them all out and starting over
     CLog::Log(LOGDEBUG, "{}: Unable to cache character.  Clearing character cache of {} characters",
               __FUNCTION__, m_numChars);
     ClearCharacterCache();
     low = 0;
-    if (!CacheCharacter(letter, style, m_char + low))
+    if (!CacheCharacter(letter, style, m_char + low, glyphIndex))
     {
       CLog::Log(LOGERROR, "{}: Unable to cache character (out of memory?)", __FUNCTION__);
       if (nestedBeginCount) Begin();
@@ -693,9 +788,9 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr)
   memset(m_charquick, 0, sizeof(m_charquick));
   for(int i=0;i<m_numChars;i++)
   {
-    if ((m_char[i].letterAndStyle & 0xffff) < 255)
+    if (m_char[i].letter < 255)
     {
-      character_t ch = ((m_char[i].letterAndStyle & 0xffff0000) >> 8) | (m_char[i].letterAndStyle & 0xff);
+      character_t ch = ((m_char[i].glyphAndStyle & 0xffff0000) >> 8) | (m_char[i].glyphIndex);
       m_charquick[ch] = m_char+i;
     }
   }
@@ -703,12 +798,13 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr)
   return m_char + low;
 }
 
-bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch)
+bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, FT_UInt glyphIndex)
 {
-  int glyph_index = FT_Get_Char_Index( m_face, letter );
+  if (!glyphIndex)
+    glyphIndex = FT_Get_Char_Index(m_face, letter);
 
   FT_Glyph glyph = NULL;
-  if (FT_Load_Glyph( m_face, glyph_index, FT_LOAD_TARGET_LIGHT ))
+  if (FT_Load_Glyph(m_face, glyphIndex, FT_LOAD_TARGET_LIGHT))
   {
     CLog::Log(LOGDEBUG, "{} Failed to load glyph {:x}", __FUNCTION__,
               static_cast<uint32_t>(letter));
@@ -790,7 +886,9 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch)
     }
   }
   // set the character in our table
-  ch->letterAndStyle = (style << 16) | letter;
+  ch->glyphAndStyle = (style << 16) | glyphIndex;
+  ch->glyphIndex = glyphIndex;
+  ch->letter = letter;
   ch->offsetX = (short)bitGlyph->left;
   ch->offsetY = (short)m_cellBaseLine - bitGlyph->top;
   ch->left = isEmptyGlyph ? 0 : ((float)m_posX + ch->offsetX);

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -92,6 +92,21 @@ public:
 protected:
   explicit CGUIFontTTF(const std::string& strFileName);
 
+
+  struct Glyph
+  {
+    hb_glyph_info_t glyphInfo;
+    hb_glyph_position_t glyphPosition;
+
+    // converter for harfbuzz library
+    Glyph(hb_glyph_info_t gInfo, hb_glyph_position_t gPos)
+    {
+      glyphInfo = gInfo;
+      glyphPosition = gPos;
+    }
+    Glyph() {}
+  };
+
   struct Character
   {
     short offsetX, offsetY;
@@ -101,6 +116,7 @@ protected:
     character_t glyphAndStyle;
     wchar_t letter;
   };
+
   struct RunInfo
   {
     int startOffset;
@@ -108,15 +124,16 @@ protected:
     hb_buffer_t* buffer;
     hb_script_t script;
     hb_glyph_info_t* glyphInfos;
+    hb_glyph_position_t* glyphPositions;
   };
 
   void AddReference();
   void RemoveReference();
 
-  std::vector<hb_glyph_info_t> GetHarfbuzzShapedGlyphs(const vecText& text);
+  std::vector<Glyph> GetHarfBuzzShapedGlyphs(const vecText& text);
 
   float GetTextWidthInternal(const vecText& text);
-  float GetTextWidthInternal(const vecText& text, std::vector<hb_glyph_info_t>& glyphInfos);
+  float GetTextWidthInternal(const vecText& text, std::vector<Glyph>& glyph);
   float GetCharWidthInternal(character_t ch);
   float GetTextHeight(float lineSpacing, int numLines) const;
   float GetTextBaseLine() const { return (float)m_cellBaseLine; }

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -8,13 +8,17 @@
 
 #pragma once
 
-#include <string>
-#include <stdint.h>
-#include <vector>
-
-#include "utils/auto_buffer.h"
 #include "utils/Color.h"
 #include "utils/Geometry.h"
+#include "utils/auto_buffer.h"
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include <harfbuzz/hb.h>
 
 #ifdef HAS_DX
 #include <DirectXMath.h>
@@ -43,6 +47,7 @@ typedef struct FT_StrokerRec_ *FT_Stroker;
 
 typedef uint32_t character_t;
 typedef std::vector<character_t> vecText;
+typedef std::vector<hb_glyph_info_t> vecGlyphInfo;
 
 /*!
  \ingroup textures
@@ -93,12 +98,26 @@ protected:
     short offsetX, offsetY;
     float left, top, right, bottom;
     float advance;
-    character_t letterAndStyle;
+    FT_UInt glyphIndex;
+    character_t glyphAndStyle;
+    wchar_t letter;
   };
+  struct RunInfo
+  {
+    int startOffset;
+    int endOffset;
+    hb_buffer_t* buffer;
+    hb_script_t script;
+    hb_glyph_info_t* glyphInfos;
+  };
+
   void AddReference();
   void RemoveReference();
 
-  float GetTextWidthInternal(vecText::const_iterator start, vecText::const_iterator end);
+  vecGlyphInfo GetHarfbuzzShapedGlyphs(const vecText& text);
+
+  float GetTextWidthInternal(const vecText& text);
+  float GetTextWidthInternal(const vecText& text, vecGlyphInfo& glyphInfos);
   float GetCharWidthInternal(character_t ch);
   float GetTextHeight(float lineSpacing, int numLines) const;
   float GetTextBaseLine() const { return (float)m_cellBaseLine; }
@@ -112,8 +131,8 @@ protected:
   std::string m_strFilename;
 
   // Stuff for pre-rendering for speed
-  inline Character *GetCharacter(character_t letter);
-  bool CacheCharacter(wchar_t letter, uint32_t style, Character *ch);
+  inline Character* GetCharacter(character_t letter, FT_UInt glyphIndex);
+  bool CacheCharacter(wchar_t letter, uint32_t style, Character* ch, FT_UInt glyphIndex);
   void RenderCharacter(float posX, float posY, const Character *ch, UTILS::Color color, bool roundX, std::vector<SVertex> &vertices);
   void ClearCharacterCache();
 
@@ -155,6 +174,8 @@ protected:
   // freetype stuff
   FT_Face    m_face;
   FT_Stroker m_stroker;
+
+  hb_font_t* m_hbFont = nullptr;
 
   float m_originX;
   float m_originY;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -47,7 +47,6 @@ typedef struct FT_StrokerRec_ *FT_Stroker;
 
 typedef uint32_t character_t;
 typedef std::vector<character_t> vecText;
-typedef std::vector<hb_glyph_info_t> vecGlyphInfo;
 
 /*!
  \ingroup textures
@@ -114,10 +113,10 @@ protected:
   void AddReference();
   void RemoveReference();
 
-  vecGlyphInfo GetHarfbuzzShapedGlyphs(const vecText& text);
+  std::vector<hb_glyph_info_t> GetHarfbuzzShapedGlyphs(const vecText& text);
 
   float GetTextWidthInternal(const vecText& text);
-  float GetTextWidthInternal(const vecText& text, vecGlyphInfo& glyphInfos);
+  float GetTextWidthInternal(const vecText& text, std::vector<hb_glyph_info_t>& glyphInfos);
   float GetCharWidthInternal(character_t ch);
   float GetTextHeight(float lineSpacing, int numLines) const;
   float GetTextBaseLine() const { return (float)m_cellBaseLine; }
@@ -131,7 +130,7 @@ protected:
   std::string m_strFilename;
 
   // Stuff for pre-rendering for speed
-  inline Character* GetCharacter(character_t letter, FT_UInt glyphIndex);
+  Character* GetCharacter(character_t letter, FT_UInt glyphIndex);
   bool CacheCharacter(wchar_t letter, uint32_t style, Character* ch, FT_UInt glyphIndex);
   void RenderCharacter(float posX, float posY, const Character *ch, UTILS::Color color, bool roundX, std::vector<SVertex> &vertices);
   void ClearCharacterCache();


### PR DESCRIPTION
## Description
This PR is an improvment on #19765 which was a harfbuzz support, but that PR doesn't support glyph positioning, thus it doesn't fully fix #17076 .

## Motivation and context
fixes #17076 and any language that needs glyph positioning to render text correctly.

## How has this been tested?
I build it and tested it on Windows 10 64-bit system using diffrent subtitles and fonts.

## What is the effect on users?
The PR adds support to complex script that uses GPOS tables in fonts like Arabic, Hebrew, Vitnamese, etc.

## Screenshots (if appropriate):
Fixes the diacritical marks in arabic (see red lines).

![image 1](https://user-images.githubusercontent.com/61121825/122259450-e1b72280-ceda-11eb-9d92-c130fcd5147f.png)
![image 2](https://user-images.githubusercontent.com/61121825/122259492-eaa7f400-ceda-11eb-9dad-05c0121d6033.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
