### PR TITLE
InputManager: Allow volume up / volume down and mute actions to be performed without interrupting screensaver

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -682,7 +682,9 @@ bool CInputManager::AlwaysProcess(const CAction& action)
     if (builtInFunction == "powerdown" || builtInFunction == "reboot" ||
         builtInFunction == "restart" || builtInFunction == "restartapp" ||
         builtInFunction == "suspend" || builtInFunction == "hibernate" ||
-        builtInFunction == "quit" || builtInFunction == "shutdown")
+        builtInFunction == "quit" || builtInFunction == "shutdown" ||
+        builtInFunction == "volumeup" || builtInFunction == "volumedown" ||
+        builtInFunction == "mute")
     {
       return true;
     }


### PR DESCRIPTION
## Description

This allows a user to change the volume when playing music without interrupting a screensaver if it is active. 

## Motivation and context

A user may wish to change the volume without activating the interface. 

## How has this been tested?

This has been a downstream patch in OSMC for a number of years without reports of regressions.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
