### PR TITLE
fixed: For http directories we should consider strict-check flag in IsInternetStream()

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1036,7 +1036,7 @@ bool CFileItem::IsCUESheet() const
 bool CFileItem::IsInternetStream(const bool bStrictCheck /* = false */) const
 {
   if (HasProperty("IsHTTPDirectory"))
-    return false;
+    return bStrictCheck;
 
   if (!m_strDynPath.empty())
     return URIUtils::IsInternetStream(m_strDynPath, bStrictCheck);


### PR DESCRIPTION
We already do the same thing for dav(s)/ftp so we should consistently do this for http directories as well.