### PR TITLE
[Jenkins] bump Android NDK to ndk21e

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -65,7 +65,8 @@ sudo apt install autoconf build-essential curl default-jdk gawk git gperf lib32s
 **[back to top](#table-of-contents)**
 
 ## 3. Prerequisites
-Building Kodi for Android requires Android NDK revision 20. For the SDK just use the latest available.
+Building Kodi for Android requires Android NDK revision 20b. For the SDK just use the latest available.
+Kodi CI/CD platforms currently use r21e for build testing and releases, so we recommend using r21e for the most tested build experience
 
 * **[Android SDK](https://developer.android.com/studio/index.html)** (Look for `Get just the command line tools`)
 * **[Android NDK](https://developer.android.com/ndk/downloads/index.html)**
@@ -85,7 +86,7 @@ unzip $HOME/Downloads/commandlinetools-linux-6200805_latest.zip -d $HOME/android
 
 Extract Android NDK:
 ```
-unzip $HOME/Downloads/android-ndk-r20-linux-x86_64.zip -d $HOME/android-tools
+unzip $HOME/Downloads/android-ndk-r21e-linux-x86_64.zip -d $HOME/android-tools
 ```
 
 ### 3.2. Configure Android SDK
@@ -112,7 +113,7 @@ keytool -genkey -keystore ~/.android/debug.keystore -v -alias androiddebugkey -d
 * Whenever you want to compile/develop you need to mount the image
   * `open ~/android-dev.dmg`
 * Once you have your hdd image with case sensitive hfs+ file system execute all the steps inside of this filesystem. You need to adapt all paths in this guide so that they match your local environment. As an example here is a configure line that demonstrates possible paths:
-  * `./configure --with-tarballs=/Users/Shared/xbmc-depends/tarballs --host=arm-linux-androideabi --with-sdk-path=/Volumes/android-dev/android/android-sdk-macosx --with-ndk-path=/Volumes/android-dev/android/android-ndk-r20 --prefix=/Volumes/android-dev/android/xbmc-depends`
+  * `./configure --with-tarballs=/Users/Shared/xbmc-depends/tarballs --host=arm-linux-androideabi --with-sdk-path=/Volumes/android-dev/android/android-sdk-macosx --with-ndk-path=/Volumes/android-dev/android/android-ndk-r21e --prefix=/Volumes/android-dev/android/xbmc-depends`
   
 **[back to top](#table-of-contents)** | **[back to section top](#3-prerequisites)**
 
@@ -138,22 +139,22 @@ cd $HOME/kodi/tools/depends
 
 Configure build for aarch64:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=aarch64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r20 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=aarch64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r21e --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for arm:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r20 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r21e --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for x86:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=i686-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r20 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=i686-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r21e --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for x86_64:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r20 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r21e --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 > **Note:** Android x86 and x86_64 are not maintained and are not 100% sure that everything works correctly!

--- a/tools/buildsteps/android-arm64-v8a/configure-depends
+++ b/tools/buildsteps/android-arm64-v8a/configure-depends
@@ -14,5 +14,5 @@ then
     --with-ndk-path=$NDK_PATH \
     $(if [ "$NDK_API" != "Default" ]; then echo --with-ndk-api=$NDK_API;fi) \
     --prefix=$XBMC_DEPENDS_ROOT \
-    --enable-neon $DEBUG_SWITCH
+    $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -14,5 +14,5 @@ then
     --with-ndk-path=$NDK_PATH \
     $(if [ "$NDK_API" != "Default" ]; then echo --with-ndk-api=$NDK_API;fi) \
     --prefix=$XBMC_DEPENDS_ROOT \
-    --enable-neon $DEBUG_SWITCH
+    $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -41,7 +41,7 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   android)
-    DEFAULT_NDK_VERSION="20" # NDK package version (newer API can be inside)
+    DEFAULT_NDK_VERSION="21e" # NDK package version (newer API can be inside)
     DEFAULT_NDK_API="21" # Lollipop API level (21) defined in package ./sysroot/usr/include/android/api-level.h
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"


### PR DESCRIPTION
## Description
Bump Android NDK version used by Jenkins to r21e.
Update docs to note the minimum NDK is r20b, but our CI/CD pipeline now builds with r21e, and therefore recommended to use that for any users wishing to build Kodi.

## Motivation and context
Taglib 1.12 causes Jenkins android builds to fail due to the following failure

```
17:48:33 In file included from /home/jenkins/workspace/Android-ARM64/tools/depends/target/taglib/aarch64-linux-android-21-debug/taglib/toolkit/tbytevector.cpp:29:
17:48:33 /home/jenkins/android-tools//android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/cmath:622:68: error: too many arguments provided to function-like macro invocation
17:48:33   static_assert(is_same<_FloatT, float>::value || is_same<_FloatT, double>::value
17:48:33                                                                    ^
17:48:33 /home/jenkins/android-tools//android-ndk-r20/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/__config:861:13: note: macro 'static_assert' defined here
17:48:33 #    define static_assert(__b, __m) _Static_assert(__b, __m)
17:48:33             ^
```

This is actually caused by a preprocessor failure in the NDK header include. Using r20b locally, the failure does not occur, but the current 20 on jenkins fails.

## How has this been tested?
Jenkins builds run. Aarch64 android runtime tested ok
Built jenkins android aarch64 platform with updated taglib 1.12 and succeeds.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
