### PR TITLE
[FIX] avoid calls to remote servers when saving streamdetails for dvd…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2991,12 +2991,9 @@ void CApplication::OnPlayBackStarted(const CFileItem &file)
   // check if VideoPlayer should set file item stream details from its current streams
   if (file.GetProperty("get_stream_details_from_player").asBoolean()
       || ((!file.HasVideoInfoTag() || !file.GetVideoInfoTag()->HasStreamDetails())
-      && (file.IsDiscImage()
+      && (URIUtils::IsBluray(file.GetPath())
       || file.IsDVDFile()
-      || file.IsBDFile()
-      || file.IsBluray()
-      || file.IsDVD()
-      || file.IsOnDVD())))
+      || file.IsDiscImage())))
     m_appPlayer.SetUpdateStreamDetails();
 
   if (m_stackHelper.IsPlayingISOStack() || m_stackHelper.IsPlayingRegularStack())


### PR DESCRIPTION
…/bluray

## Description
Current implementation uses a call to `file.IsBluray()` which in turn calls `GetOpticalMediaPath()` if the file is not bluray related. This checks for the existence of various files.  If the file is a stream, this causes 6 calls to the remote server. This can be avoided by calling `URIUtils::IsBluray()` directly as at this point any bluray media already has the correct protocol added and the file existence checks are not needed.
The issue can be easily replicated by playing a `.strm` file containing a url to a remotely streamed video. Curl logging will show 6 calls to the remote server.

## Motivation and context
Kodi should not probe remote servers for the existence of files when playing a stream where there are no stream details in the db. Issue was brought to light by @matthuisman in https://github.com/xbmc/xbmc/pull/19776  We do still want to save the details for bluray/dvd/iso material if there are no existing details.

## How has this been tested?
Tested against a local and remote http server, with bluray images and directories on the local server and a stream from the remote server.  Curl logging enabled.  Details were correctly saved for all bluray items, no details were saved for the stream and no attempts were made to test for the existence of files.  Also checked that dvd material and iso's still work correctly.

## What is the effect on users?
No impact on end users.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
