### PR TITLE
[PVR] Resolve "EPG Grid can get locked into a short timeframe during/after Clear Data operation"

### DIFF
--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -600,7 +600,7 @@ CDateTime CPVREpgTagsContainer::GetLastEndTime() const
   if (m_database)
   {
     const CDateTime dbResult = m_database->GetLastEndTime(m_iEpgID);
-    if (result.IsValid() || (dbResult.IsValid() && dbResult > result))
+    if (!result.IsValid() || (dbResult.IsValid() && dbResult > result))
       result = dbResult;
   }
 


### PR DESCRIPTION
## Description
Resolves Issue https://github.com/xbmc/xbmc/issues/19423

Backport to Matrix is requested as the Issue affects that baseline as well; the original Issue was reported against Matrix.

## Motivation and context
Going through my open Issues and thought I may as well try and fix some :)

In this case, if the user executes a "Clear Data" operation against the PVR guide data and navigates into the EPG before that data is fully refreshed from the backend, the EPG timeframe will be locked into a range based on a valid start time and an invalid end time.  Root cause appears to be a typo in **CPVREpgTagsContainer::GetLastEndTime()** that will erroneously ignore a valid end time derived from **m_changedTags**.

NOTE: I originally added code to both **CPVREpgTagsContainer::GetFirstStartTime()** and **CPVREpgTagsContainer::GetLastEndTime()** to actually iterate over the **m_changedTags** vector to determine the actual "FirstStart" and "LastEnd" values instead of assuming the first changed tag has the earliest start time and the last changed tag has the latest end time, but found it to be unnecessary to resolve the Issue, so I took all of that out due to the potential for race conditions while the EPG tags are updated by the backend.

## How has this been tested?
Tested on Windows 10 (Desktop) 21H1, x64 against current master branch as of 2021.06.25.

## What is the effect on users?
Resolves Issue https://github.com/xbmc/xbmc/issues/19423

## Screenshots (if appropriate):
N/A

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
