### PR TITLE
[PVR] Fix Channel Manager dialog synchronization issues with backend data (New Channel / Channel Settings)

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -46,6 +46,7 @@ namespace PVR
   private:
     void Clear();
     void Update();
+    void PromptAndSaveList();
     void SaveList();
     void Renumber();
     void SetData(int iItem);


### PR DESCRIPTION
## Description
This PR attempts to address a set of state concerns with the PVR Channel Manager dialog, this time in relation to synchronization with the backend PVR addon (client) during the "New Channel" and "Channel Settings" operations, although a few other operations were affected.

I've had this PR around for a while now sitting unsubmitted, I've flip-flopped between proposing API changes for the New Channel/Channel Settings dialogs and this method of "just reload the data and don't change the API" method; I'm hopeful this is the proper direction to take as I feel it provides the backend/client the most implementation flexibility and _may_ be able to be backported if flagged as such.  Proposed changes to how "Delete Channel" works are not included here as they ended up clearly unrelated in nature.

**Proposed Changes:**

- Prompt to save state changes before switching from TV channels to Radio channels or vice-versa
- Prompt to save state changes before opening the Group Manager dialog (that dialog will show some channel metadata like the channel name and icon)
- Prompt to save state changes before opening the backend/client "New Channel" dialog
- Prompt to save changes before opening the "Settings" dialog for any given channel
- Reload/update the channel data from the backend/client if a state change save/persist operation was declined
- Reload channel data from the backend/client after a "New Channel" operation and automatically select the first new channel detected in the channel group; the current PVR API does not allow for an addon to provide any type of true/false status determining if a channel was added or not, this also allows for the addon dialog to "add" more than one channel
- Reload channel data from the backend/client after a "Channel Settings" operation to ensure it's matched up with whatever the backend/client changed

PVR addon backend/client modules may or may not be expected to call the proper "TriggerUpdate" method(s) for these operations, and whether the addon does or does not seems to not matter; the "TriggerUpdate" methods are asynchronous in nature and won't have any bearing on the state of this dialog unless the user closes and reopens it after the backend/client has executed these trigger(s).

PR has a a couple notes:

- This PR does not attempt to address any "Delete Channel" issues/deficiencies as I felt they are unrelated, and I intend to follow-up with at least 2 or 3 more PRs sorry @ksooo :)
- As-is this PR cannot be backported to Matrix baseline; Matrix and master have diverged too much.  It might be possible but it will definitely not be the same changeset.  Please consider this before tagging as "backport" (I'm really not sure it can be backported at all, but if asked I will try).

## Motivation and context

I feel that this PR solves a number of valid Kodi <--> PVR addon state issues and makes the Channel Manager behave more naturally.  Being prompted to save changes before an operation that would otherwise ignore them seems common sense.  Handling new channels or changes to channels that occurred outside of this code, but yet still at the code's request via an addon-supplied dialog seems like a good way to go?

## How has this been tested?
Tested on Windows 10 21H1, x64 (Desktop) and "Windows 11 Build 22000 x64" (Desktop).  Prior to the proposed changeset I had a great deal more difficulty dealing with a PVR addon that supports both "New Channel" and "Channel Settings"; the UI was always out of sync with the backend, even if that backend invoked the proper data update "Trigger" methods.  After the changeset I felt like the Channel Manager was much more functional.

## What is the effect on users?
I'd like to think this only makes end user's lives easier if they are using a PVR addon that supports "New Channel" and/or "Channel Settings"?

## Screenshots (if appropriate):
I'm copping out on screenshots right now; it's difficult to provide meaningful before/after screenshots for operations that do nothing in the "before" state but end up doing something in the "after" state.  Please comment on screenshot(s) that would be useful and I will add them.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
