### PR TITLE
[PVR][GUI] Show formatted channel number in PVR channel manager dialog

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -735,7 +735,7 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty("Icon", channel->IconPath());
     channelFile->SetProperty("EPGSource", 0);
     channelFile->SetProperty("ParentalLocked", channel->IsLocked());
-    channelFile->SetProperty("Number", std::to_string(member->ChannelNumber().GetChannelNumber()));
+    channelFile->SetProperty("Number", member->ChannelNumber().FormattedChannelNumber());
 
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*channelFile);
     if (client)


### PR DESCRIPTION
## Description
When 'Use channel numbers from backend' is enabled the PVR Channel Manager dialog will only show the base channel number as opposed to the formatted channel number.  "26" versus "26.1", for example.

## Motivation and context
PVR addons may use a channel.subchannel format for their channel numbers, and there are often multiple channels that share the same base channel number.  ATSC and FM Radio come to mind, not sure about DVB or other broadcast systems outside of North America.

## How has this been tested?
Tested on Windows 10 21H1 (Desktop), x64, against master branch current as of 29.06.2021.  Noted no concerns for either TV or an FM Radio addon.

## What is the effect on users?
For addons that allow channel management (add/settings/delete) showing the full channel number helps differentiate between channel items that have subchannel numbers.

## Screenshots (if appropriate):
This screenshot shows a handful of FM radio channels before the change, the subchannel number is missing.  (400 and 500 do not have a subchannel number)
![radio-before](https://user-images.githubusercontent.com/706055/123821332-4dc95b80-d8c9-11eb-8a69-0a59553db236.png)

After the change, the subchannel number appears for these channels.  There was no effect on channels that were not expected to have a subchannel:
![radio-after](https://user-images.githubusercontent.com/706055/123821440-62a5ef00-d8c9-11eb-85c0-1866190b9e26.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
