### PR TITLE
[PVR][GUI] Suppress Select Client dialog on New channel if there is only valid target client

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -461,7 +461,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
   PromptAndSaveList();
 
   int iSelection = 0;
-  if (CServiceBroker::GetPVRManager().Clients()->CreatedClientAmount() > 1)
+  if (m_clientsWithSettingsList.size() > 1)
   {
     CGUIDialogSelect* pDlgSelect = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
     if (!pDlgSelect)


### PR DESCRIPTION
## Description
In the PVR Channel Manager, if there are multiple PVR addons installed that support the type of channels being displayed (TV/Radio), thew New Channel button will always display the Select Client dialog even if there is only one client that support channel settings.

This appears to be a small bug wherein the number of clients for the channel type is being interrogated instead of the number of those clients that support channel settings.  The dialog already populates this list, I propose a simple one-line change to correct the behavior.

## Motivation and context
Noted while working/testing other PRs for this dialog as I happened to have two PVR addons installed and active:

PVR addon 1: Supports TV and Radio channels, does not support channel add/settings for either type
PVR addon 2: Supports Radio channels as well as channel add/settings.

## How has this been tested?
Tested on Windows 10 21H1 (Desktop), x64, against master branch current as of this writing (29.06.2021).

I modified "PVR addon 1" such that it claimed to support channel settings and was able to use in concert with "PVR addon 2" to validate the proposed behavior.  In that configuration there was one TV client that supported channel settings (no select dialog) and two Radio clients that supported channel settings (select dialog).

## What is the effect on users?
If the user has multiple PVR addons installed but only one supports channel settings, there is an unnecessary extra step to select from a list of one item each time New Channel is clicked.

## Screenshots (if appropriate):
Here's the "before", where there are two addons installed that support Radio, but only one supports channel settings.  My expectation was not to be prompted:

![onlyoneclient](https://user-images.githubusercontent.com/706055/123893168-eabbe100-d929-11eb-8e50-e0136c249ebc.png)

Here's an "after", where there are two addons installs that support Radio, and both support channel settings.  Both PVR clients appear in the selection dialog, as expected:

![multipleclients](https://user-images.githubusercontent.com/706055/123893321-2d7db900-d92a-11eb-8cce-f0d3d695c5df.png)

Not shown: an "after" where only one addon supports channel settings; difficult to illustrate since nothing happens :)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
