### PR TITLE
[Estuary][platform][addons] Add support for platform dependent default…

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -433,7 +433,7 @@
 					<include content="ImageWidget" condition="!System.HasPVRAddon">
 						<param name="text_label" value="$LOCALIZE[31143]" />
 						<param name="button_label" value="$LOCALIZE[31144]" />
-						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://all/kodi.pvrclient,return)"/>
+						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://default_binary_addons_source/kodi.pvrclient,return)"/>
 						<param name="button_id" value="12400"/>
 						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoTVButton)"/>
 					</include>
@@ -510,7 +510,7 @@
 					<include content="ImageWidget" condition="!System.HasPVRAddon">
 						<param name="text_label" value="$LOCALIZE[31143]" />
 						<param name="button_label" value="$LOCALIZE[31144]" />
-						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://all/kodi.pvrclient,return)"/>
+						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://default_binary_addons_source/kodi.pvrclient,return)"/>
 						<param name="button_id" value="13400"/>
 						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoRadioButton)"/>
 					</include>
@@ -810,7 +810,7 @@
 					<include content="ImageWidget">
 						<param name="text_label" value="$LOCALIZE[31162]" />
 						<param name="button_label" value="$LOCALIZE[31144]" />
-						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://all/category.gameaddons,return)"/>
+						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://default_binary_addons_source/category.gameaddons,return)"/>
 						<param name="button_id" value="17100"/>
 						<param name="visible" value="!Integer.IsGreater(Container(17001).NumItems,0)"/>
 						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoGamesButton)"/>

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -106,6 +106,11 @@ CDataCacheCore &CServiceBroker::GetDataCacheCore()
   return g_application.m_ServiceManager->GetDataCacheCore();
 }
 
+CPlatform& CServiceBroker::GetPlatform()
+{
+  return g_application.m_ServiceManager->GetPlatform();
+}
+
 PLAYLIST::CPlayListPlayer &CServiceBroker::GetPlaylistPlayer()
 {
   return g_application.m_ServiceManager->GetPlaylistPlayer();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -63,6 +63,7 @@ class CDecoderFilterManager;
 class CMediaManager;
 class CCPUInfo;
 class CLog;
+class CPlatform;
 
 namespace KODI
 {
@@ -105,6 +106,7 @@ public:
   static PVR::CPVRManager &GetPVRManager();
   static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();
+  static CPlatform& GetPlatform();
   static PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
   static KODI::GAME::CControllerManager& GetGameControllerManager();
   static KODI::GAME::CGameServices& GetGameServices();

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -28,6 +28,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "platform/Platform.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -627,6 +628,17 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE>& types,
 std::string CGUIWindowAddonBrowser::GetStartFolder(const std::string& dir)
 {
   if (StringUtils::StartsWith(dir, "addons://"))
-    return dir;
+  {
+    if (StringUtils::StartsWith(dir, "addons://default_binary_addons_source/"))
+    {
+      const bool all = CServiceBroker::GetPlatform().SupportsUserInstalledBinaryAddons();
+      std::string startDir = dir;
+      StringUtils::Replace(startDir, "/default_binary_addons_source/", all ? "/all/" : "/user/");
+      return startDir;
+    }
+    else
+      return dir;
+  }
+
   return CGUIMediaWindow::GetStartFolder(dir);
 }

--- a/xbmc/platform/Platform.h
+++ b/xbmc/platform/Platform.h
@@ -10,7 +10,7 @@
 
 /**\brief Class for the Platform object
  *
- * Contains method which retrieve platform specific information
+ * Contains methods to retrieve platform specific information
  * and methods for doing platform specific environment preparation/initialisation
  */
 class CPlatform
@@ -33,7 +33,7 @@ public:
    * This method can be used to do platform specific environment preparation
    * or initialisation (like setting environment variables for example)
    */
-  virtual bool InitStageOne() { return true; };
+  virtual bool InitStageOne() { return true; }
 
   /**\brief Called at a middle stage of application startup
    *
@@ -41,7 +41,7 @@ public:
    * do not depend on windowing/gui. (eg macos XBMCHelper)
    *
    */
-  virtual bool InitStageTwo() { return true; };
+  virtual bool InitStageTwo() { return true; }
 
   /**\brief Called at a late stage of application startup
    *
@@ -49,16 +49,20 @@ public:
    * services/components. (eg , WS-Discovery Daemons)
    *
    */
-  virtual bool InitStageThree() { return true; };
+  virtual bool InitStageThree() { return true; }
 
   /**\brief Flag whether disabled add-ons - installed via packagemanager or manually - should be
    * offered for configuration and activation on kodi startup for this platform
    */
-  virtual bool IsConfigureAddonsAtStartupEnabled() { return false; };
+  virtual bool IsConfigureAddonsAtStartupEnabled() { return false; }
+
+  /**\brief Flag whether this platform supports user installation of binary add-ons.
+   */
+  virtual bool SupportsUserInstalledBinaryAddons() { return true; }
 
   /**\brief Print platform specific info to log
    *
    * Logs platform specific system info during application creation startup
    */
-  virtual void PlatformSyslog(){};
+  virtual void PlatformSyslog() {}
 };

--- a/xbmc/platform/darwin/ios-common/PlatformDarwinEmbedded.cpp
+++ b/xbmc/platform/darwin/ios-common/PlatformDarwinEmbedded.cpp
@@ -53,3 +53,8 @@ bool CPlatformDarwinEmbedded::InitStageTwo()
 
   return true;
 }
+
+bool CPlatformDarwinEmbedded::SupportsUserInstalledBinaryAddons()
+{
+  return false;
+}

--- a/xbmc/platform/darwin/ios-common/PlatformDarwinEmbedded.h
+++ b/xbmc/platform/darwin/ios-common/PlatformDarwinEmbedded.h
@@ -19,4 +19,6 @@ public:
 
   bool InitStageOne() override;
   bool InitStageTwo() override;
+
+  bool SupportsUserInstalledBinaryAddons() override;
 };

--- a/xbmc/platform/win10/PlatformWin10.cpp
+++ b/xbmc/platform/win10/PlatformWin10.cpp
@@ -45,3 +45,8 @@ void CPlatformWin10::PlatformSyslog()
 {
   CWIN32Util::PlatformSyslog();
 }
+
+bool CPlatformWin10::SupportsUserInstalledBinaryAddons()
+{
+  return false;
+}

--- a/xbmc/platform/win10/PlatformWin10.h
+++ b/xbmc/platform/win10/PlatformWin10.h
@@ -21,4 +21,5 @@ class CPlatformWin10 : public CPlatform
 
     bool InitStageOne() override;
     void PlatformSyslog() override;
+    bool SupportsUserInstalledBinaryAddons() override;
 };


### PR DESCRIPTION
… installation source for binary addons.

Superseeds #19910 

Runtime-tested on macOS, simulating behavior on UWP, iOS and TVOS.

@howie-f mind looking at addons code changes?
@sy6sy2 @thexai do the platform dependent changes look okay to you?
@ronie your take on the skin change?