### PR TITLE
Workaround for #19883: Check if applied locale correctly lowers chars and fallback

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -171,6 +171,11 @@ if command_exists gdb; then
   fi
 fi
 
+
+# Check if locale is affected by "Turkish I"
+# See https://github.com/xbmc/xbmc/issues/19883 for details
+unset LC_CTYPE LC_ALL LANG
+
 LOOP=1
 while [ $(( $LOOP )) = "1" ]
 do

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -979,6 +979,18 @@ void CLangInfo::SetCurrentRegion(const std::string& strName)
 
   m_currentRegion->SetGlobalLocale();
 
+  // Check if locale is affected by "Turkish I"
+  // See https://github.com/xbmc/xbmc/issues/19883 for details
+  if (std::tolower('i') != std::tolower('I'))
+  {
+    CLog::Log(
+        LOGWARNING,
+        "region '{}' is affected by 'Turkish I' problem - falling back to default region '{}'",
+        m_currentRegion->m_strName, m_defaultRegion.m_strName);
+    m_currentRegion = &m_defaultRegion;
+    m_currentRegion->SetGlobalLocale();
+  }
+
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   if (settings->GetString(CSettings::SETTING_LOCALE_SHORTDATEFORMAT) == SETTING_REGIONAL_DEFAULT)
     SetShortDateFormat(m_currentRegion->m_strDateFormatShort);


### PR DESCRIPTION
## Description

Matrix-only workaround for #19883 . We agreed that master has to get a proper fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
