### PR TITLE
[PVR] Fix crash after PVR Channel Manager dialog Delete operation

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -676,15 +676,13 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
         PVR_ERROR ret = client->DeleteChannel(channel);
         if (ret == PVR_ERROR_NO_ERROR)
         {
-          CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(channel->IsRadio())->RemoveFromGroup(channel);
-          m_channelItems->Remove(m_iSelected);
-
-          Renumber();
-          m_viewControl.SetItems(*m_channelItems);
-          if (m_iSelected >= m_channelItems->Size())
-            m_iSelected = m_channelItems->Size() - 1;
-          m_viewControl.SetSelectedItem(m_iSelected);
-          SetData(m_iSelected);
+          CPVRChannelGroups* groups =
+              CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio);
+          if (groups)
+          {
+            groups->Update();
+            Update();
+          }
         }
         else if (ret == PVR_ERROR_NOT_IMPLEMENTED)
           HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."


### PR DESCRIPTION
## Description
This PR attempts to resolve a problem with the PVR Channel Manager delete channel operation; current builds of v20N may actually crash after using this due to a database inconsistency that occurs.  There were different problems with this operation in Matrix but I think for v20N this is a pretty small change that makes the operation work better, hopefully 'properly':

- Prevents the database inconsistency that can lead to a crash (will describe below)
- Reload the group/channel data from client on a result of ERROR_SUCCESS rather than assuming the channel was actually deleted (there is no PVR_ERROR that the addon can supply to indicate something like "I didn't actually do that, but it wasn't because of an error")
- Do not use the CPVRChannelGroupInternal::RemoveFromGroup() method to remove a channel from the "All channels" group, this seems inappropriate since it just _hides_ the channel, but the backend has actually _deleted_ the channel (this was the primary problem I was looking at in Matrix)

My proposed change is to reload all the TV/Radio channel groups upon ERROR_SUCCESS.  This will cleanly remove the channel from all groups it belonged to and avoid the database problem.  The dialog UI state will be also be updated from the refreshed data, keeping in sync with the client.

## Motivation and context
Something I was working on for Matrix at the time and got back around to for v20N.  I thought the crash was due to porting those changes to v20N and went down the rabbit hole at just preventing/dealing with the data that led to the crash (lots of places need to touched) but ultimately found there was seemingly a simple solution.

Here's what happens in the existing code (v20N):

- A PVR client channel is deleted via the Channel Manager dialog
- The channel is removed from the "All channels group" as expected and won't show up as a valid channel (different behavior than Matrix), but it will not be removed from any groups loaded from the client
- Upon a restart of Kodi the application may crash as there may be an errant row in the **map_channelgroups_channels** table if the PVR client did not trigger a channel groups update before Kodi was closed.  The following database queries illustrate that after deleting radio channel "101.9" and closing Kodi, the channel still appears in **map_channelgroups_channels** as a member of the group "FM Radio" (7), but not "All channels" (4):

> sqlite> select * from channelgroups;
> 1|0|1|All channels|0|0|0|1624936196231
> 4|1|1|All channels|1625025389|0|0|1625025387620
> 6|1|0|Weather Radio|0|0|0|1624935497327
> **7|1|0|FM Radio|0|0|0|0**
> 
> sqlite> select * from map_channelgroups_channels;
> 5|6|400|0|0|400|0
> 5|4|400|0|0|400|0
> 7|4|99|1|0|99|1
> 10|4|500|0|0|500|0
> 10|6|500|0|0|500|0
> 7|7|99|1|0|99|1
> **8|7|101|9|0|101|9**
> 11|4|88|1|0|88|1
> 12|4|102|7|0|102|7
> 11|7|88|1|0|88|1
> 12|7|102|7|0|102|7

During startup, Kodi will crash in CPVRChannelGroup::Load() as there is an invalid/missing channel in the group (in this case the client-supplied "FM Radio" group):

![failurepoint](https://user-images.githubusercontent.com/706055/124060168-72712080-d9fa-11eb-98f0-c428c951c5c6.png)

## How has this been tested?
Tested on Windows 10 21H1 (Desktop) x64, master branch current as of 29.06.2021 and Windows 11 (Desktop) x64 21H2 (Build 22000.51) against master branch current as of 30.06.2021.

I reverified the behavior that the as-is code would lead to the described problems and ran it through a number of tests to ensure that the channel was truly being removed from all groups and the **map_channelgroups_channels** table.  I also changed the PVR addon to not actually delete the channel but still return ERROR_SUCCESS and the non-deleted channel still showed up in the dialog, was in the proper groups, and was still usable by Kodi.

Performing the same delete of channel "101.9", and without closing Kodi, the **map_channelgroups_channels** table does not list the deleted channel in "FM Radio" (2), and the crash no longer occurs:

> sqlite> select * from channelgroups;
> 1|0|1|All channels|0|0|0|0
> 2|1|0|FM Radio|0|0|0|0
> 3|1|0|Weather Radio|0|0|0|0
> 4|1|1|All channels|0|0|0|0
> 
> sqlite> select * from map_channelgroups_channels;
> 1|4|88|1|0|88|1
> 2|4|99|1|0|99|1
> 3|4|102|7|0|102|7
> 4|4|400|0|0|400|0
> 5|4|500|0|0|500|0
> 1|2|88|1|0|88|1
> 2|2|99|1|0|99|1
> 3|2|102|7|0|102|7
> 4|3|400|0|0|400|0
> 5|3|500|0|0|500|0

## What is the effect on users?
Prevents possible Kodi crash on startup after a channel was deleted in the PVR Channel Manager.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
