### PR TITLE
[translations] Create sync-addon-metadata-translations.yml

### DIFF
--- a/.github/workflows/sync-addon-metadata-translations.yml
+++ b/.github/workflows/sync-addon-metadata-translations.yml
@@ -1,0 +1,70 @@
+name: Sync addon metadata translations
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - '**skin.estuary**addon.xml'
+      - '**skin.estuary**resource.language.**strings.po'
+      - '**skin.estouchy**addon.xml'
+      - '**skin.estouchy**resource.language.**strings.po'
+      - '**audioencoder.kodi.builtin.aac**addon.xml'
+      - '**audioencoder.kodi.builtin.aac**resource.language.**strings.po'
+      - '**audioencoder.kodi.builtin.wma**addon.xml'
+      - '**audioencoder.kodi.builtin.wma**resource.language.**strings.po'
+      - '**screensaver.xbmc.builtin.dim**addon.xml'
+      - '**screensaver.xbmc.builtin.dim**resource.language.**strings.po'
+
+jobs:
+  default:
+    if: github.repository == 'xbmc/xbmc'
+    runs-on: ubuntu-latest
+
+    strategy:
+
+      fail-fast: false
+      matrix:
+        python-version: [ 3.9 ]
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: project
+
+      - name: Checkout sync_addon_metadata_translations repository
+        uses: actions/checkout@v2
+        with:
+          repository: xbmc/sync_addon_metadata_translations
+          path: sync_addon_metadata_translations
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install sync_addon_metadata_translations/
+
+      - name: Run sync-addon-metadata-translations
+        run: |
+          sync-addon-metadata-translations --path ./skin.estuary/
+          sync-addon-metadata-translations --path ./skin.estouchy/
+          sync-addon-metadata-translations --path ./audioencoder.kodi.builtin.aac/
+          sync-addon-metadata-translations --path ./audioencoder.kodi.builtin.wma/
+          sync-addon-metadata-translations --path ./screensaver.xbmc.builtin.dim/
+        working-directory: ./project/addons
+
+      - name: Create PR for sync-addon-metadata-translations changes
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Sync of addon metadata translations
+          title: Sync of addon metadata translations
+          body: Sync of addon metadata translations triggered by ${{ github.sha }}
+          branch: amt-sync
+          delete-branch: true
+          path: ./project
+          reviewers: gade01


### PR DESCRIPTION
## Description
This action will automatically sync `summary`, `description` and `disclaimer` between addon.xml and language files for these addons:
- audioencoder.kodi.builtin.aac
- audioencoder.kodi.builtin.wma
- screensaver.xbmc.builtin.dim
- skin.estouchy
- skin.estuary 

When changes are done in either addon.xml or in the language files, the action will open a pull request with the synced changes.

## Motivation and context
Part of Weblate workflow

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
