### PR TITLE
Convert HTTP character entities in links to percentage encoding

### DIFF
--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -43,7 +43,7 @@ using namespace XFILE;
 #define SAMPLE_ITEM_1_LABEL "folder1"
 #define SAMPLE_ITEM_2_LABEL "folder2"
 #define SAMPLE_ITEM_3_LABEL "sample3: the sampling.mpg"
-#define SAMPLE_ITEM_4_LABEL "sample4.mpg"
+#define SAMPLE_ITEM_4_LABEL "sample & samplability 4.mpg"
 #define SAMPLE_ITEM_5_LABEL "sample5.mpg"
 #define SAMPLE_ITEM_6_LABEL "sample6.mpg"
 

--- a/xbmc/filesystem/test/data/httpdirectory/apache-default.html
+++ b/xbmc/filesystem/test/data/httpdirectory/apache-default.html
@@ -8,7 +8,7 @@
 <ul><li><a href="folder1/"> folder1/</a></li>
 <li><a href="folder2/"> folder2/</a></li>
 <li><a href="./sample3:%20the%20sampling.mpg"> sample3: the sampling.mpg</a></li>
-<li><a href="sample4.mpg"> sample4.mpg</a></li>
+<li><a href="sample%20&amp;%20samplability%204.mpg"> sample & samplability 4.mpg</a></li>
 <li><a href="sample5.mpg"> sample5.mpg</a></li>
 <li><a href="sample6.mpg"> sample6.mpg</a></li>
 </ul>

--- a/xbmc/filesystem/test/data/httpdirectory/apache-fancy.html
+++ b/xbmc/filesystem/test/data/httpdirectory/apache-fancy.html
@@ -8,7 +8,7 @@
 <pre>      <a href="?C=N;O=D;F=1">Name</a>                    <a href="?C=M;O=A;F=1">Last modified</a>      <a href="?C=S;O=A;F=1">Size</a>  <a href="?C=D;O=A;F=1">Description</a><hr>      <a href="folder1/">folder1/</a>                2019-01-01 01:01    -   
       <a href="folder2/">folder2/</a>                2019-02-02 02:02    -   
       <a href="./sample3:%20the%20sampling.mpg">sample3: the sampling.mpg</a>             2019-03-03 03:03  123
-      <a href="sample4.mpg">sample4.mpg</a>             2019-04-04 04:04  123K  
+      <a href="sample%20&amp;%20samplability%204.mpg">sample & samplability 4.mpg</a>             2019-04-04 04:04  123K
       <a href="sample5.mpg">sample5.mpg</a>             2019-05-05 05:05  123M  
       <a href="sample6.mpg">sample6.mpg</a>             2019-06-06 06:06  123G  
 <hr></pre>

--- a/xbmc/filesystem/test/data/httpdirectory/apache-html.html
+++ b/xbmc/filesystem/test/data/httpdirectory/apache-html.html
@@ -11,7 +11,7 @@
 <tr><td valign="top">&nbsp;</td><td><a href="folder1/">folder1/</a>               </td><td align="right">2019-01-01 01:01  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="folder2/">folder2/</a>               </td><td align="right">2019-02-02 02:02  </td><td align="right">  - </td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="./sample3:%20the%20sampling.mpg">sample3: the sampling.mpg</a>            </td><td align="right">2019-03-03 03:03  </td><td align="right">123 </td><td>&nbsp;</td></tr>
-<tr><td valign="top">&nbsp;</td><td><a href="sample4.mpg">sample4.mpg</a>            </td><td align="right">2019-04-04 04:04  </td><td align="right">123K</td><td>&nbsp;</td></tr>
+<tr><td valign="top">&nbsp;</td><td><a href="sample%20&amp;%20samplability%204.mpg">sample & samplability 4.mpg</a>            </td><td align="right">2019-04-04 04:04  </td><td align="right">123K</td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="sample5.mpg">sample5.mpg</a>            </td><td align="right">2019-05-05 05:05  </td><td align="right">123M</td><td>&nbsp;</td></tr>
 <tr><td valign="top">&nbsp;</td><td><a href="sample6.mpg">sample6.mpg</a>            </td><td align="right">2019-06-06 06:06  </td><td align="right">123G</td><td>&nbsp;</td></tr>
    <tr><th colspan="5"><hr></th></tr>

--- a/xbmc/filesystem/test/data/httpdirectory/basic-multiline.html
+++ b/xbmc/filesystem/test/data/httpdirectory/basic-multiline.html
@@ -8,7 +8,7 @@
       folder2/
     </a>
     <a href="./sample3:%20the%20sampling.mpg">sample3: the sampling.mpg</a>
-    <a href="sample4.mpg">sample4.mpg</a> <a href="sample5.mpg">sample5.mpg</a>
+    <a href="sample%20&%20samplability%204.mpg">sample & samplability 4.mpg</a> <a href="sample5.mpg">sample5.mpg</a>
     <a href="sample6.mpg">
       sample6.mpg
     </a>

--- a/xbmc/filesystem/test/data/httpdirectory/basic.html
+++ b/xbmc/filesystem/test/data/httpdirectory/basic.html
@@ -6,7 +6,7 @@
     <a href="folder1/">folder1/</a>
     <a href="folder2/">folder2/</a>
     <a href="./sample3:%20the%20sampling.mpg">sample3: the sampling.mpg</a>
-    <a href="sample4.mpg">sample4.mpg</a>
+    <a href="sample%20&%20samplability%204.mpg">sample & samplability 4.mpg</a>
     <a href="sample5.mpg">sample5.mpg</a>
     <a href="sample6.mpg">sample6.mpg</a>
   </body>

--- a/xbmc/filesystem/test/data/httpdirectory/lighttp-default.html
+++ b/xbmc/filesystem/test/data/httpdirectory/lighttp-default.html
@@ -26,7 +26,7 @@ div.foot { font: 90% monospace; color: #787878; padding-top: 4px;}
 <tr class="d"><td class="n"><a href="folder1/">folder1</a>/</td><td class="m">2019-Jan-01 01:01:01</td><td class="s">- &nbsp;</td><td class="t">Directory</td></tr>
 <tr class="d"><td class="n"><a href="folder2/">folder2</a>/</td><td class="m">2019-Feb-02 02:02:02</td><td class="s">- &nbsp;</td><td class="t">Directory</td></tr>
 <tr><td class="n"><a href="sample3%3a%20the%20sampling.mpg">sample3: the sampling.mpg</a></td><td class="m">2019-Mar-03 03:03:03</td><td class="s">0.1K</td><td class="t">video/mpeg</td></tr>
-<tr><td class="n"><a href="sample4.mpg">sample4.mpg</a></td><td class="m">2019-Apr-04 04:04:04</td><td class="s">123.0K</td><td class="t">video/mpeg</td></tr>
+<tr><td class="n"><a href="sample%20%26%20samplability%204.mpg">sample &#x26; samplability 4.mpg</a></td><td class="m">2019-Apr-04 04:04:04</td><td class="s">123.0K</td><td class="t">video/mpeg</td></tr>
 <tr><td class="n"><a href="sample5.mpg">sample5.mpg</a></td><td class="m">2019-May-05 05:05:05</td><td class="s">123.0M</td><td class="t">video/mpeg</td></tr>
 <tr><td class="n"><a href="sample6.mpg">sample6.mpg</a></td><td class="m">2019-Jun-06 06:06:06</td><td class="s">123.0G</td><td class="t">video/mpeg</td></tr>
 </tbody>

--- a/xbmc/filesystem/test/data/httpdirectory/nginx-default.html
+++ b/xbmc/filesystem/test/data/httpdirectory/nginx-default.html
@@ -4,7 +4,7 @@
 <h1>Index of /</h1><hr><pre><a href="folder1/">folder1/</a>                                           01-Jan-2019 01:01                   -
 <a href="folder2/">folder2/</a>                                           02-Feb-2019 02:02                   -
 <a href="sample3%3A%20the%20sampling.mpg">sample3: the sampling.mpg</a>      03-Mar-2019 03:03                 123
-<a href="sample4.mpg">sample4.mpg</a>                                        04-Apr-2019 04:04              125952
+<a href="sample%20%26%20samplability%204.mpg">sample &#x26; samplability 4.mpg</a>                                        04-Apr-2019 04:04              125952
 <a href="sample5.mpg">sample5.mpg</a>                                        05-May-2019 05:05           128974848
 <a href="sample6.mpg">sample6.mpg</a>                                        06-Jun-2019 06:06        132070244352
 </pre><hr></body>

--- a/xbmc/filesystem/test/data/httpdirectory/nginx-fancyindex.html
+++ b/xbmc/filesystem/test/data/httpdirectory/nginx-fancyindex.html
@@ -24,7 +24,7 @@
 <tr><td class="link"><a href="folder1/" title="folder1">folder1/</a></td><td class="size">-</td><td class="date">2019-Jan-01 01:01</td></tr>
 <tr><td class="link"><a href="folder2/" title="folder2">folder2/</a></td><td class="size">-</td><td class="date">2019-Feb-02 02:02</td></tr>
 <tr><td class="link"><a href="sample3%3A%20the%20sampling.mpg" title="sample3: the sampling.mpg">sample3: the sampling.mpg</a></td><td class="size">123 B</td><td class="date">2019-Mar-03 03:03</td></tr>
-<tr><td class="link"><a href="sample4.mpg" title="sample4.mpg">sample4.mpg</a></td><td class="size">123.0 KiB</td><td class="date">2019-Apr-04 04:04</td></tr>
+<tr><td class="link"><a href="sample%20%26%20samplability%204.mpg" title="sample &#x26; samplability 4.mpg">sample &#x26; samplability 4.mpg</a></td><td class="size">123.0 KiB</td><td class="date">2019-Apr-04 04:04</td></tr>
 <tr><td class="link"><a href="sample5.mpg" title="sample5.mpg">sample5.mpg</a></td><td class="size">123.0 MiB</td><td class="date">2019-May-05 05:05</td></tr>
 <tr><td class="link"><a href="sample6.mpg" title="sample6.mpg">sample6.mpg</a></td><td class="size">123.0 GiB</td><td class="date">2019-Jun-06 06:06</td></tr>
 </tbody></table>


### PR DESCRIPTION
## Description
Some web servers (Apache) create directory indexes where the file URLs may contain character entities (`&amp;` is common). This causes problems when listing HTTP(S) Directories as some of the processing causes these character entities to become invalid. A safer approach is to convert these characters to percentage encoding (e.g.: `%26`) as early as possible.

## Motivation and context
When adding an HTTP Directory source to Kodi I noticed that although all the files had been scanned to the library correctly I was unable to play any files with an ampersand (&) in the filename. The reason was that the web server (Apache) had encoded the `&` character in the URL as an HTTP character entity (`&amp;`). When manually clicking the link in a browser the character entity was converted into a valid URL encoding.
The bug was caused by `CHTTPDirectory::GetDirectory` converting all `;` characters to percentage encoding but not before converting any character entities to their correct encoding.
```
      // encoding + and ; to URL encode if it is not already encoded by http server used on the remote server (example: Apache)
      // more characters may be added here when required when required by certain http servers
      pos = strLinkBase.find_first_of("+;");
      while (pos != std::string::npos) 
      {
        std::stringstream convert;
        convert << '%' << std::hex << int(strLinkBase.at(pos));
        strLinkBase.replace(pos, 1, convert.str());
        pos = strLinkBase.find_first_of("+;");
      }
```
This meant that a URL which might have started as `Sense%20&amp;%20Sensibility` would become `Sense%20&amp%26%20Sensibility` making it invalid.

## How has this been tested?
Updated the HTML data for the HTTPDirectory unit tests to include a file with an ampersand in the filename. Tested the behaviour of lighttpd and nginx as well as Apache (only Apache generates URLs containing character entities). Also tested by rescanning the HTTP directory and can confirm that files containing an ampersand are both scanned and play correctly.

## What is the effect on users?
Users can access files hosted on an Apache HTTP directory which contain ampersand characters.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
