### PR TITLE
[VideoPlayer][RDS] Canada and Mexico also use RBDS instead of RDS

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -1578,7 +1578,8 @@ unsigned int CDVDRadioRDSData::DecodeEPPTransmitterInfo(uint8_t *msgElement)
         return 7;
     }
 
-    m_RDS_IsRBDS = countryName == "US" ? true : false;
+    // The United States, Canada, and Mexico use the RBDS standard
+    m_RDS_IsRBDS = (countryName == "US" || countryName == "CA" || countryName == "MX");
 
     m_currentInfoTag->SetCountry(countryName);
   }


### PR DESCRIPTION
## Description
Noted while implementing Canadian channel PI callsign decoding via RBDS in a PVR FM Radio addon.  Currently Kodi will only switch to RBDS mode if the Country Name decoded from the PI data ends up being set to "US".  Both Canada and Mexico also use RBDS instead of RDS.

## Motivation and context
I'm based in North America (US) and am working with a user in Canada (CA) to deal with the RBDS differences in our countries  (If you see this and are in Mexico, I'd really LOVE to hear from you!). After finally figuring out how Canada encodes the PI data I was running some tests with hard-coded CA PI codes and noted that **VideoPlayerRadioRDS.cpp** requires the addon to assume "US" to trigger the switch to RBDS.

It's not that big of a deal at this point, but I can envision that ultimately Kodi may want to differentiate RDS/RBDS in the UI to handle the differences.  My best explanation is commented in my PVR addon code; the "TODO" is the most important.  Prior to this update I was just setting __`*reinterpret_cast<uint8_t*>(&message->mel_len) = 0x10;`__ to ensure 0xA0 would equate to "US" and trigger RBDS.  I'd prefer to provide Kodi with a proper County Code that equates to Canada or Mexico if possible:

```
		// UECP_MEC_PI
		//
		message->mec = UECP_MEC_PI;
		message->dsn = UECP_MSG_DSN_CURRENT_SET;
		message->psn = UECP_MSG_PSN_MAIN;

		// Kodi expects a single word for PI at the address of mel_len; for RBDS
		// hard-code it to 0xB000 which points to this row in the lookup data which
		// has all three required country codes "US", "CA" and "MX" and can be properly 
		// set via the UECP_EPP_TM_INFO packet by specifying a PSN of 0xA0 for "US",
		// 0xA1 for "CA", and 0xA5 for "MX":
		// 
		//   {"US","CA","BR","DO","LC","MX","__"}, // B
		//
		*reinterpret_cast<uint8_t*>(&message->mel_len) = 0xB0;
		*reinterpret_cast<uint8_t*>(&message->mel_data[0]) = 0x00;

		frame.seq = UECP_DF_SEQ_DISABLED;
		frame.msg_len = 3 + 2;				// mec, dsn, psn + mel_data[2]

		// Convert the UECP data frame into a packet and queue it up
		m_uecp_packets.emplace(uecp_create_data_packet(frame));

		// UECP_EPP_TM_INFO
		//
		// TODO: This must be hard-coded to report "US" for now to ensure
		// Kodi detects RBDS, in the future set this properly to report values
		// that will select "US" (0xA0), "CA" (0xA1), or "MX" (0xA5)
		message->mec = UECP_EPP_TM_INFO;
		message->dsn = UECP_MSG_DSN_CURRENT_SET;
		message->psn = 0xA0;				// "US"

		frame.seq = UECP_DF_SEQ_DISABLED;
		frame.msg_len = 3;					// mec, dsn, psn

```


## How has this been tested?
Tested on Windows 10 21H1 (Desktop), x64.  Prior to the change attempting to send Kodi a (generated) RDS PI code that would trigger RBDS support was limited to hard-coding an ITU Region 2 country to be "US".  After the change, while sadly the addon still needs to hard-code some things in North America, the differentiation between "US", "Canada", and "Mexico" would all trigger RBDS mode.

## What is the effect on users?
I really don't think anyone but me cares about this right now.  There are very few, if any, Kodi PVR FM Radio addons that operate in North America over RBDS.

## Screenshots (if appropriate):
N/A

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
