### PR TITLE
[VideoPlayer][Estuary] 'Radiotext Plus' should be 'RadioText Plus'

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16086,7 +16086,7 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#29900"
-msgid "Radiotext Plus info"
+msgid "RadioText Plus info"
 msgstr ""
 
 #. Music band name which make the song (if present)


### PR DESCRIPTION
## Description
This is likely the most minor/cosmetic issue that has ever been submitted, but per **IEC 62106-2** and **IEC 62106-6** RadioText Plus should be referred to as either "RadioText Plus" or "RT+" -- the "T" should be capitalized.

I see no need to backport this to Matrix as it's entirely cosmetic in nature and does not negatively affect anything at all.

## Motivation and context
Align English string translations for "RadioText Plus" to the RT+ specification.

## How has this been tested?
Tested on Windows 21H1 (x64) desktop; this is a trivial skin change.  After the change the GUI dialog capitalized the "T" in "RadioText Plus", as expected.

## What is the effect on users?
None at all.  This is about as trivial as a PR can be.

## Screenshots (if appropriate):

Before the change:

![image](https://user-images.githubusercontent.com/706055/125023047-0cb11400-e04c-11eb-9e1b-43b9af95ac09.png)

After the change:

![image](https://user-images.githubusercontent.com/706055/125023189-54d03680-e04c-11eb-9dd9-f7e7b5e00bbf.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
