### PR TITLE
WS-Discovery interface implementation

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21429,7 +21429,30 @@ msgctxt "#37046"
 msgid "1080"
 msgstr ""
 
-#empty strings from id 37047 to 38010
+#: system/settings/settings.xml
+msgctxt "#37047"
+msgid "WS-Discovery"
+msgstr ""
+
+#. Setting #37048 Enable WS-Discovery Service"
+#: system/settings/settings.xml
+msgctxt "#37048"
+msgid "Enable WS-Discovery Service"
+msgstr ""
+
+#. Description of setting #37048 Enable WS-Discovery Service"
+#: system/settings/settings.xml
+msgctxt "#37049"
+msgid "Enable service to search for SMB services using the WS-Discovery protocol"
+msgstr ""
+
+#. Label for component level debug logging setting
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#37050"
+msgid "Verbose logging for the [B]WS-Discovery[/B] component"
+msgstr ""
+
+#empty strings from id 37051 to 38010
 
 #. Setting #38011 "Show All Items entry"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2254,6 +2254,13 @@
           </dependencies>
         </setting>
       </group>
+      <group id="3" label="37047">
+        <setting id="services.wsdiscovery" type="boolean" label="37048" help="37049">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
     <category id="weather" label="8" help="36316">
       <group id="1" label="16000">

--- a/system/settings/windows.xml
+++ b/system/settings/windows.xml
@@ -9,7 +9,12 @@
       </group>
     </category>
     <category id="smb">
-      <visible>false</visible>
+      <group id="1">
+        <visible>false</visible>
+      </group>
+      <group id="2">
+        <visible>false</visible>
+      </group>
     </category>
   </section>
   <section id="system">

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -84,6 +84,13 @@ XBPython& CServiceBroker::GetXBPython()
 }
 #endif
 
+#if defined(HAS_FILESYSTEM_SMB)
+WSDiscovery::IWSDiscovery& CServiceBroker::GetWSDiscovery()
+{
+  return g_application.m_ServiceManager->GetWSDiscovery();
+}
+#endif
+
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
 MEDIA_DETECT::CDetectDVDMedia& CServiceBroker::GetDetectDVDMedia()
 {

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -65,6 +65,11 @@ class CCPUInfo;
 class CLog;
 class CPlatform;
 
+namespace WSDiscovery
+{
+class IWSDiscovery;
+}
+
 namespace KODI
 {
 namespace GAME
@@ -102,6 +107,7 @@ public:
   static ADDON::CBinaryAddonCache &GetBinaryAddonCache();
   static ADDON::CVFSAddonCache &GetVFSAddonCache();
   static XBPython &GetXBPython();
+  static WSDiscovery::IWSDiscovery& GetWSDiscovery();
   static MEDIA_DETECT::CDetectDVDMedia& GetDetectDVDMedia();
   static PVR::CPVRManager &GetPVRManager();
   static CContextMenuManager& GetContextMenuManager();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -29,7 +29,7 @@
 #if defined(HAS_FILESYSTEM_SMB)
 #include "network/IWSDiscovery.h"
 #if defined(TARGET_WINDOWS)
-// ToDo
+#include "platform/win32/network/WSDiscoveryWin32.h"
 #else // !defined(TARGET_WINDOWS)
 #include "platform/posix/filesystem/SMBWSDiscovery.h"
 #endif // defined(TARGET_WINDOWS)

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -26,6 +26,14 @@
 #include "interfaces/python/XBPython.h"
 #include "network/Network.h"
 #include "peripherals/Peripherals.h"
+#if defined(HAS_FILESYSTEM_SMB)
+#include "network/IWSDiscovery.h"
+#if defined(TARGET_WINDOWS)
+// ToDo
+#else // !defined(TARGET_WINDOWS)
+#include "platform/posix/filesystem/SMBWSDiscovery.h"
+#endif // defined(TARGET_WINDOWS)
+#endif // HAS_FILESYSTEM_SMB
 #include "powermanagement/PowerManager.h"
 #include "profiles/ProfileManager.h"
 #include "pvr/PVRManager.h"
@@ -184,6 +192,10 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
 
   m_playerCoreFactory.reset(new CPlayerCoreFactory(*profileManager));
 
+#if defined(HAS_FILESYSTEM_SMB)
+  m_WSDiscovery = WSDiscovery::IWSDiscovery::GetInstance();
+#endif
+
   if (!m_Platform->InitStageThree())
     return false;
 
@@ -195,6 +207,9 @@ void CServiceManager::DeinitStageThree()
 {
   init_level = 2;
 
+#if defined(HAS_FILESYSTEM_SMB)
+  m_WSDiscovery.reset();
+#endif
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
   m_DetectDVDType->StopThread();
   m_DetectDVDType.reset();
@@ -245,6 +260,13 @@ void CServiceManager::DeinitStageOne()
   m_XBPython.reset();
 #endif
 }
+
+#if defined(HAS_FILESYSTEM_SMB)
+WSDiscovery::IWSDiscovery& CServiceManager::GetWSDiscovery()
+{
+  return *m_WSDiscovery;
+}
+#endif
 
 ADDON::CAddonMgr &CServiceManager::GetAddonMgr()
 {

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -38,6 +38,12 @@ class CContextMenuManager;
 #ifdef HAS_PYTHON
 class XBPython;
 #endif
+#if defined(HAS_FILESYSTEM_SMB)
+namespace WSDiscovery
+{
+class IWSDiscovery;
+}
+#endif
 class CDataCacheCore;
 class CFavouritesService;
 class CNetworkBase;
@@ -102,6 +108,9 @@ public:
 #ifdef HAS_PYTHON
   XBPython& GetXBPython();
 #endif
+#if defined(HAS_FILESYSTEM_SMB)
+  WSDiscovery::IWSDiscovery& GetWSDiscovery();
+#endif
   PVR::CPVRManager& GetPVRManager();
   CContextMenuManager& GetContextMenuManager();
   CDataCacheCore& GetDataCacheCore();
@@ -156,6 +165,9 @@ protected:
   std::unique_ptr<ADDON::CVFSAddonCache> m_vfsAddonCache;
   std::unique_ptr<ADDON::CServiceAddonManager> m_serviceAddons;
   std::unique_ptr<ADDON::CRepositoryUpdater> m_repositoryUpdater;
+#if defined(HAS_FILESYSTEM_SMB)
+  std::unique_ptr<WSDiscovery::IWSDiscovery> m_WSDiscovery;
+#endif
 #ifdef HAS_PYTHON
   std::unique_ptr<XBPython> m_XBPython;
 #endif

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -43,3 +43,4 @@
 #define LOGPVR        (1 << (LOGMASKBIT + 15))
 #define LOGEPG        (1 << (LOGMASKBIT + 16))
 #define LOGANNOUNCE   (1 << (LOGMASKBIT + 17))
+#define LOGWSDISCOVERY (1 << (LOGMASKBIT + 18))

--- a/xbmc/network/CMakeLists.txt
+++ b/xbmc/network/CMakeLists.txt
@@ -41,6 +41,10 @@ if(SHAIRPLAY_FOUND)
   list(APPEND HEADERS AirTunesServer.h)
 endif()
 
+if(SMBCLIENT_FOUND)
+  list(APPEND HEADERS IWSDiscovery.h)
+endif()
+
 if(MICROHTTPD_FOUND)
   list(APPEND SOURCES WebServer.cpp)
   list(APPEND HEADERS WebServer.h)

--- a/xbmc/network/IWSDiscovery.h
+++ b/xbmc/network/IWSDiscovery.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2021- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace WSDiscovery
+{
+class IWSDiscovery
+{
+public:
+  virtual ~IWSDiscovery() = default;
+  virtual bool StartServices() = 0;
+  virtual bool StopServices() = 0;
+  virtual bool IsRunning() = 0;
+
+  static std::unique_ptr<IWSDiscovery> GetInstance();
+};
+} // namespace WSDiscovery

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -66,6 +66,7 @@
 
 #if defined(HAS_FILESYSTEM_SMB)
 #if defined(TARGET_WINDOWS)
+#include "platform/win32/network/WSDiscoveryWin32.h"
 #else // defined(TARGET_POSIX)
 #include "platform/posix/filesystem/SMBWSDiscovery.h"
 #endif

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -49,7 +49,8 @@ public:
     ES_UPNPRENDERER,
     ES_UPNPSERVER,
     ES_EVENTSERVER,
-    ES_ZEROCONF
+    ES_ZEROCONF,
+    ES_WSDISCOVERY,
   };
 
   bool StartServer(enum ESERVERS server, bool start);
@@ -96,6 +97,10 @@ public:
   bool StartZeroconf();
   bool IsZeroconfRunning();
   bool StopZeroconf();
+
+  bool StartWSDiscovery();
+  bool IsWSDiscoveryRunning();
+  bool StopWSDiscovery();
 
 private:
   CNetworkServices(const CNetworkServices&);

--- a/xbmc/platform/posix/filesystem/CMakeLists.txt
+++ b/xbmc/platform/posix/filesystem/CMakeLists.txt
@@ -6,9 +6,13 @@ set(HEADERS PosixDirectory.h
 
 if(SMBCLIENT_FOUND)
   list(APPEND SOURCES SMBDirectory.cpp
-                      SMBFile.cpp)
+                      SMBFile.cpp
+                      SMBWSDiscovery.cpp
+                      SMBWSDiscoveryListener.cpp)
   list(APPEND HEADERS SMBDirectory.h
-                      SMBFile.h)
+                      SMBFile.h
+                      SMBWSDiscovery.h
+                      SMBWSDiscoveryListener.h)
 endif()
 
 core_add_library(platform_posix_filesystem)

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (C) 2021- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SMBWSDiscovery.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "network/IWSDiscovery.h"
+#include "threads/SingleLock.h"
+#include "utils/log.h"
+
+#include "platform/posix/filesystem/SMBWSDiscoveryListener.h"
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace std::chrono;
+using namespace WSDiscovery;
+
+namespace WSDiscovery
+{
+std::unique_ptr<IWSDiscovery> IWSDiscovery::GetInstance()
+{
+  return std::make_unique<WSDiscovery::CWSDiscoveryPosix>();
+}
+
+CWSDiscoveryPosix::CWSDiscoveryPosix()
+{
+  // Set our wsd_instance ID to seconds since epoch
+  auto epochduration = system_clock::now().time_since_epoch();
+  wsd_instance_id = epochduration.count() * system_clock::period::num / system_clock::period::den;
+
+  m_WSDListenerUDP = std::make_unique<CWSDiscoveryListenerUDP>();
+}
+
+CWSDiscoveryPosix::~CWSDiscoveryPosix()
+{
+  StopServices();
+}
+
+bool CWSDiscoveryPosix::StopServices()
+{
+  m_WSDListenerUDP->Stop();
+
+  return true;
+}
+
+bool CWSDiscoveryPosix::StartServices()
+{
+  m_WSDListenerUDP->Start();
+
+  return true;
+}
+
+bool CWSDiscoveryPosix::IsRunning()
+{
+  return m_WSDListenerUDP->IsRunning();
+}
+
+bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
+{
+  {
+    CSingleLock lock(m_critWSD);
+
+    // delim1 used to strip protocol from xaddrs
+    // delim2 used to strip anything past the port
+    const std::string delim1 = "://";
+    const std::string delim2 = ":";
+    for (auto item : m_vecWSDInfo)
+    {
+      int found = item.xaddrs.find(delim1);
+      if (found == std::string::npos)
+        continue;
+
+      std::string tmpxaddrs = item.xaddrs.substr(found + delim1.size());
+      found = tmpxaddrs.find(delim2);
+      // fallback incase xaddrs doesnt return back "GetMetadata" expected address format (delim2)
+      if (found == std::string::npos)
+      {
+        found = tmpxaddrs.find("/");
+      }
+      std::string host = tmpxaddrs.substr(0, found);
+
+      CFileItemPtr pItem = std::make_shared<CFileItem>(host);
+      pItem->SetPath("smb://" + host + '/');
+      pItem->m_bIsFolder = true;
+      items.Add(pItem);
+    }
+  }
+  return true;
+}
+
+void CWSDiscoveryPosix::SetItems(std::vector<wsd_req_info> entries)
+{
+  {
+    CSingleLock lock(m_critWSD);
+    m_vecWSDInfo = entries;
+  }
+}
+} // namespace WSDiscovery

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (C) 2021- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "network/IWSDiscovery.h"
+#include "threads/CriticalSection.h"
+#include "threads/SingleLock.h"
+
+#include "platform/posix/filesystem/SMBWSDiscoveryListener.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class CFileItemList;
+
+namespace WSDiscovery
+{
+class CWSDiscoveryListenerUDP;
+}
+
+namespace WSDiscovery
+{
+struct wsd_req_info
+{
+  std::string action; // ToDo: Action probably isnt required to be stored
+  std::string msgid;
+  std::string types; // ToDo: Types may not be needed.
+  std::string address;
+  std::string xaddrs;
+
+  bool operator==(const wsd_req_info& item) const
+  {
+    return ((item.xaddrs == xaddrs) && (item.address == address));
+  }
+};
+
+class CWSDiscoveryPosix : public WSDiscovery::IWSDiscovery
+{
+public:
+  CWSDiscoveryPosix();
+
+  // IWSDiscovery interface methods
+  ~CWSDiscoveryPosix() override;
+  bool StartServices() override;
+  bool StopServices() override;
+  bool IsRunning() override;
+
+  /*
+   * Get List of smb servers found by WSD
+   * out    (CFileItemList&) List of fileitems populated with smb addresses
+   * return (bool) true if >0 WSD addresses found
+  */
+  bool GetServerList(CFileItemList& items);
+
+  const long long GetInstanceID() { return wsd_instance_id; };
+
+  /*
+   * Set List of WSD info request
+   * out    (vector<wsd_req_info>) vector of WSD responses received
+   * return void
+  */
+  void SetItems(std::vector<WSDiscovery::wsd_req_info> entries);
+
+private:
+  CCriticalSection m_critWSD;
+
+  /*
+   * As per docs - Pg32 - http://specs.xmlsoap.org/ws/2005/04/discovery/ws-discovery.pdf
+   * MUST be incremented by >= 1 each time the service has gone down, lost state,
+   * and came back up again. SHOULD NOT be incremented otherwise. Means to set
+   * this value include, but are not limited to:
+   * • A counter that is incremented on each 'cold' boot
+   * • The boot time of the service, expressed as seconds elapsed since midnight
+   * January 1, 1970 
+   *
+   * Our implementation will only set this on creation of the class
+   * We arent providing services to clients, so this should be ok.
+   */
+  long long wsd_instance_id;
+
+  // WSD UDP daemon
+  std::unique_ptr<WSDiscovery::CWSDiscoveryListenerUDP> m_WSDListenerUDP;
+
+  std::vector<WSDiscovery::wsd_req_info> m_vecWSDInfo;
+};
+} // namespace WSDiscovery

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -1,0 +1,528 @@
+/*
+ *  Copyright (C) 2021- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SMBWSDiscoveryListener.h"
+
+#include "ServiceBroker.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include "platform/posix/filesystem/SMBWSDiscovery.h"
+
+#include <array>
+#include <chrono>
+#include <stdio.h>
+#include <string>
+#include <utility>
+
+#include <arpa/inet.h>
+#include <fmt/format.h>
+#include <sys/select.h>
+#include <unistd.h>
+
+using namespace WSDiscovery;
+
+namespace WSDiscovery
+{
+
+// Templates for SOAPXML messages for WS-Discovery messages
+static const std::string soap_msg_templ =
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+    "<soap:Envelope "
+    "xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" "
+    "xmlns:wsa=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" "
+    "xmlns:wsd=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\" "
+    "xmlns:wsx=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" "
+    "xmlns:wsdp=\"http://schemas.xmlsoap.org/ws/2006/02/devprof\" "
+    "xmlns:un0=\"http://schemas.microsoft.com/windows/pnpx/2005/10\" "
+    "xmlns:pub=\"http://schemas.microsoft.com/windows/pub/2005/07\">\n"
+    "<soap:Header>\n"
+    "<wsa:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</wsa:To>\n"
+    "<wsa:Action>{}</wsa:Action>\n"
+    "<wsa:MessageID>urn:uuid:{}</wsa:MessageID>\n"
+    "<wsd:AppSequence InstanceId=\"{}\" MessageNumber=\"{}\" />\n"
+    "{}"
+    "</soap:Header>\n"
+    "{}"
+    "</soap:Envelope>\n";
+
+static const std::string hello_body = "<soap:Body>\n"
+                                      "<wsd:Hello>\n"
+                                      "<wsa:EndpointReference>\n"
+                                      "<wsa:Address>urn:uuid:{}</wsa:Address>\n"
+                                      "</wsa:EndpointReference>\n"
+                                      "<wsd:Types>wsdp:Device pub:Computer</wsd:Types>\n"
+                                      "<wsd:MetadataVersion>1</wsd:MetadataVersion>\n"
+                                      "</wsd:Hello>\n"
+                                      "</soap:Body>\n";
+
+static const std::string bye_body = "<soap:Body>\n"
+                                    "<wsd:Bye>\n"
+                                    "<wsa:EndpointReference>\n"
+                                    "<wsa:Address>urn:uuid:{}</wsa:Address>\n"
+                                    "</wsa:EndpointReference>\n"
+                                    "<wsd:Types>wsdp:Device pub:Computer</wsd:Types>\n"
+                                    "<wsd:MetadataVersion>2</wsd:MetadataVersion>\n"
+                                    "</wsd:Bye>\n"
+                                    "</soap:Body>\n";
+
+static const std::string probe_body = "<soap:Body>\n"
+                                      "<wsd:Probe>\n"
+                                      "<wsd:Types>wsdp:Device</wsd:Types>\n"
+                                      "</wsd:Probe>\n"
+                                      "</soap:Body>\n";
+
+static const std::string resolve_body = "<soap:Body>\n"
+                                        "<wsd:Resolve>\n"
+                                        "<wsa:EndpointReference>\n"
+                                        "<wsa:Address>"
+                                        "{}"
+                                        "</wsa:Address>\n"
+                                        "</wsa:EndpointReference>\n"
+                                        "</wsd:Resolve>\n"
+                                        "</soap:Body>\n";
+
+// These are the only actions we concern ourselves with for our WS-D implementation
+static const std::string WSD_ACT_HELLO = "http://schemas.xmlsoap.org/ws/2005/04/discovery/Hello";
+static const std::string WSD_ACT_BYE = "http://schemas.xmlsoap.org/ws/2005/04/discovery/Bye";
+static const std::string WSD_ACT_PROBEMATCH =
+    "http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches";
+static const std::string WSD_ACT_PROBE = "http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe";
+static const std::string WSD_ACT_RESOLVE =
+    "http://schemas.xmlsoap.org/ws/2005/04/discovery/Resolve";
+static const std::string WSD_ACT_RESOLVEMATCHES =
+    "http://schemas.xmlsoap.org/ws/2005/04/discovery/ResolveMatches";
+
+
+// These are xml start/finish tags we need info from
+static const std::array<std::pair<std::string, std::string>, 2> action_tag{
+    {{"<wsa:Action>", "</wsa:Action>"},
+     {"<wsa:Action SOAP-ENV:mustUnderstand=\"true\">", "</wsa:Action>"}}};
+
+static const std::array<std::pair<std::string, std::string>, 2> msgid_tag{
+    {{"<wsa:MessageID>", "</wsa:MessageID>"},
+     {"<wsa:MessageID SOAP-ENV:mustUnderstand=\"true\">", "</wsa:MessageID>"}}};
+
+static const std::array<std::pair<std::string, std::string>, 1> xaddrs_tag{
+    {{"<wsd:XAddrs>", "</wsd:XAddrs>"}}};
+
+static const std::array<std::pair<std::string, std::string>, 1> address_tag{
+    {{"<wsa:Address>", "</wsa:Address>"}}};
+
+static const std::array<std::pair<std::string, std::string>, 1> types_tag{
+    {{"<wsd:Types>", "</wsd:Types>"}}};
+
+CWSDiscoveryListenerUDP::CWSDiscoveryListenerUDP()
+  : CThread("WSDiscoveryListenerUDP"), wsd_instance_address(StringUtils::CreateUUID())
+{
+}
+
+CWSDiscoveryListenerUDP::~CWSDiscoveryListenerUDP()
+{
+}
+
+void CWSDiscoveryListenerUDP::Stop()
+{
+  StopThread(true);
+  CLog::Log(LOGINFO, "CWSDiscoveryListenerUDP::Stop - Stopped");
+}
+
+void CWSDiscoveryListenerUDP::Start()
+{
+  if (IsRunning())
+    return;
+
+  // Clear existing data. We dont know how long service has been down, so we may not
+  // have correct services that may have sent BYE actions
+  m_vecWSDInfo.clear();
+  CWSDiscoveryPosix& WSInstance =
+      dynamic_cast<CWSDiscoveryPosix&>(CServiceBroker::GetWSDiscovery());
+  WSInstance.SetItems(m_vecWSDInfo);
+
+  // Create thread and set low priority
+  Create();
+  SetPriority(GetMinPriority());
+  CLog::Log(LOGINFO, "CWSDiscoveryListenerUDP::Start - Started");
+}
+
+void CWSDiscoveryListenerUDP::Process()
+{
+  fd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (fd < 0)
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::Process - Socket Creation failed");
+    return;
+  }
+
+  // set socket reuse
+  int enable = 1;
+  if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&enable, sizeof(enable)) < 0)
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY, "CWSDiscoveryListenerUDP::Process - Reuse Option failed");
+    Cleanup(true);
+    return;
+  }
+
+  // set up destination address
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(wsdUDP);
+
+  // bind to receive address
+  if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY, "CWSDiscoveryListenerUDP::Process - Bind failed");
+    Cleanup(true);
+    return;
+  }
+
+  // use setsockopt() to request join a multicast group on all interfaces
+  // maybe use firstconnected?
+  struct ip_mreq mreq;
+  mreq.imr_multiaddr.s_addr = inet_addr(WDSIPv4MultiGroup);
+  mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+  if (setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*)&mreq, sizeof(mreq)) < 0)
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::Process - Multicast Option failed");
+    Cleanup(true);
+    return;
+  }
+
+  // Disable receiving broadcast messages on loopback
+  // So we dont receive messages we send.
+  int disable = 0;
+  if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, (char*)&disable, sizeof(disable)) < 0)
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::Process - Loopback Disable Option failed");
+    Cleanup(true);
+    return;
+  }
+
+  std::string bufferoutput;
+  fd_set rset;
+  int nready;
+  struct timeval timeout;
+
+  FD_ZERO(&rset);
+
+  // Send HELLO to the world
+  AddCommand(WSD_ACT_HELLO);
+  DispatchCommand();
+
+  AddCommand(WSD_ACT_PROBE);
+  DispatchCommand();
+
+  while (!m_bStop)
+  {
+    FD_SET(fd, &rset);
+    timeout.tv_sec = 3;
+    timeout.tv_usec = 0;
+    nready = select((fd + 1), &rset, NULL, NULL, &timeout);
+
+    if (m_bStop)
+      break;
+
+    // if udp socket is readable receive the message.
+    if (FD_ISSET(fd, &rset))
+    {
+      bufferoutput = "";
+      char msgbuf[UDPBUFFSIZE];
+      socklen_t addrlen = sizeof(addr);
+      int nbytes = recvfrom(fd, msgbuf, UDPBUFFSIZE, 0, (struct sockaddr*)&addr, &addrlen);
+      msgbuf[nbytes] = '\0';
+      // turn msgbuf into std::string
+      bufferoutput.append(msgbuf, nbytes);
+
+      ParseBuffer(bufferoutput);
+    }
+    // Action any commands queued
+    while (DispatchCommand())
+    {
+    }
+  }
+
+  // Be a nice citizen and send BYE to the world
+  AddCommand(WSD_ACT_BYE);
+  DispatchCommand();
+  Cleanup(false);
+  return;
+}
+
+void CWSDiscoveryListenerUDP::Cleanup(bool aborted)
+{
+  close(fd);
+
+  if (aborted)
+  {
+    // Thread is stopping due to a failure state
+    // Update service setting to be disabled
+    auto settingsComponent = CServiceBroker::GetSettingsComponent();
+    if (!settingsComponent)
+      return;
+
+    auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    if (!settings)
+      return;
+
+    if (settings->GetBool(CSettings::SETTING_SERVICES_WSDISCOVERY))
+    {
+      settings->SetBool(CSettings::SETTING_SERVICES_WSDISCOVERY, false);
+      settings->Save();
+    }
+  }
+}
+
+bool CWSDiscoveryListenerUDP::DispatchCommand()
+{
+  Command sendCommand;
+  {
+    CSingleLock lock(crit_commandqueue);
+    if (m_commandbuffer.size() <= 0)
+      return false;
+
+    auto it = m_commandbuffer.begin();
+    sendCommand = *it;
+    m_commandbuffer.erase(it);
+  }
+
+  int ret;
+
+  // As its udp, send multiple messages due to unreliability
+  // Windows seems to send 4-6 times for reference
+  for (int i = 0; i < retries; i++)
+  {
+    do
+    {
+      ret = sendto(fd, sendCommand.commandMsg.c_str(), sendCommand.commandMsg.size(), 0,
+                   (struct sockaddr*)&sendCommand.address, sizeof(sendCommand.address));
+    } while (ret == -1 && !m_bStop);
+    std::chrono::seconds sec(1);
+    CThread::Sleep(sec);
+  }
+
+  CLog::Log(LOGDEBUG, LOGWSDISCOVERY, "CWSDiscoveryListenerUDP::DispatchCommand - Command sent");
+
+  return true;
+}
+
+void CWSDiscoveryListenerUDP::AddCommand(const std::string message,
+                                         const std::string extraparameter /* = "" */)
+{
+
+  CSingleLock lock(crit_commandqueue);
+
+  std::string msg{};
+
+  if (!buildSoapMessage(message, msg, extraparameter))
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::AddCommand - Invalid Soap Message");
+    return;
+  }
+
+  // ToDo: IPv6
+  struct sockaddr_in addr;
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(wsdUDP);
+
+  addr.sin_addr.s_addr = inet_addr(WDSIPv4MultiGroup);
+  memset(&addr.sin_zero, 0, sizeof(addr.sin_zero));
+
+  Command newCommand{{addr}, {msg}};
+
+  m_commandbuffer.push_back(newCommand);
+}
+
+void CWSDiscoveryListenerUDP::ParseBuffer(const std::string& buffer)
+{
+  wsd_req_info info;
+
+  // MUST have an action tag
+  std::string action = wsd_tag_find(buffer, action_tag);
+  if (action.empty())
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::ParseBuffer - No Action tag found");
+    return;
+  }
+
+  info.action = action;
+
+  // Only handle actions we need when received
+  if (!((action == WSD_ACT_HELLO) || (action == WSD_ACT_BYE) ||
+        (action == WSD_ACT_RESOLVEMATCHES) || (action == WSD_ACT_PROBEMATCH)))
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::ParseBuffer - Action not supported");
+    PrintWSDInfo(info);
+    return;
+  }
+
+  // MUST have a msgid tag
+  std::string msgid = wsd_tag_find(buffer, msgid_tag);
+  if (msgid.empty())
+  {
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::ParseBuffer - No msgid tag found");
+    return;
+  }
+
+  info.msgid = msgid;
+
+  std::string types = wsd_tag_find(buffer, types_tag);
+  info.types = types;
+  std::string address = wsd_tag_find(buffer, address_tag);
+  info.address = address;
+  std::string xaddrs = wsd_tag_find(buffer, xaddrs_tag);
+  info.xaddrs = xaddrs;
+
+  if (xaddrs.empty() && (action != WSD_ACT_BYE))
+  {
+    // Do a resolve against address to hopefully receive an xaddrs field=
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::ParseBuffer - Resolve Action dispatched");
+    AddCommand(WSD_ACT_RESOLVE, address);
+    // Discard this message
+    PrintWSDInfo(info);
+    return;
+  }
+
+  {
+    CSingleLock lock(crit_wsdqueue);
+    auto searchitem = std::find_if(m_vecWSDInfo.begin(), m_vecWSDInfo.end(),
+                                   [info](const wsd_req_info& item) { return item == info; });
+
+    if (searchitem == m_vecWSDInfo.end())
+    {
+      CWSDiscoveryPosix& WSInstance =
+          dynamic_cast<CWSDiscoveryPosix&>(CServiceBroker::GetWSDiscovery());
+      if (info.action != WSD_ACT_BYE)
+      {
+        // Acceptable request received, add to our server list
+        CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+                  "CWSDiscoveryListenerUDP::ParseBuffer - Actionable message");
+        m_vecWSDInfo.emplace_back(info);
+        WSInstance.SetItems(m_vecWSDInfo);
+        PrintWSDInfo(info);
+        return;
+      }
+      else
+      {
+        // WSD_ACT_BYE does not include an xaddrs tag
+        // We only want to match the address when receiving a WSD_ACT_BYE message to
+        // remove from our maintained list
+        auto searchbye = std::find_if(
+            m_vecWSDInfo.begin(), m_vecWSDInfo.end(),
+            [info, this](const wsd_req_info& item) { return equalsAddress(item, info); });
+        if (searchbye != m_vecWSDInfo.end())
+        {
+          CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+                    "CWSDiscoveryListenerUDP::ParseBuffer - BYE action -"
+                    " removing entry");
+          m_vecWSDInfo.erase(searchbye);
+          PrintWSDInfo(info);
+          WSInstance.SetItems(m_vecWSDInfo);
+          return;
+        }
+      }
+    }
+  }
+
+  // Only duplicate items get this far, silently drop
+  return;
+}
+
+bool CWSDiscoveryListenerUDP::buildSoapMessage(const std::string& action,
+                                               std::string& msg,
+                                               const std::string extraparameter)
+{
+  auto msg_uuid = StringUtils::CreateUUID();
+  std::string body;
+  std::string relatesTo; // Not implemented, may not be needed for our limited usage
+  int messagenumber = 1;
+
+  CWSDiscoveryPosix& WSInstance =
+      dynamic_cast<CWSDiscoveryPosix&>(CServiceBroker::GetWSDiscovery());
+  long long wsd_instance_id = WSInstance.GetInstanceID();
+
+  if (action == WSD_ACT_HELLO)
+  {
+    body = fmt::format(hello_body, wsd_instance_address);
+  }
+  else if (action == WSD_ACT_BYE)
+  {
+    body = fmt::format(bye_body, wsd_instance_address);
+  }
+  else if (action == WSD_ACT_PROBE)
+  {
+    body = probe_body;
+  }
+  else if (action == WSD_ACT_RESOLVE)
+  {
+    body = fmt::format(resolve_body, extraparameter);
+  }
+  if (body.empty())
+  {
+    // May lead to excessive logspam
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "CWSDiscoveryListenerUDP::buildSoapMessage unimplemented WSD_ACTION");
+    return false;
+  }
+
+  // Todo: how are fmt exception/failures handled with libfmt?
+  msg = fmt::format(soap_msg_templ, action, msg_uuid, wsd_instance_id, messagenumber, relatesTo,
+                    body);
+
+  return true;
+}
+
+template<std::size_t SIZE>
+const std::string CWSDiscoveryListenerUDP::wsd_tag_find(
+    const std::string& xml, const std::array<std::pair<std::string, std::string>, SIZE>& tag)
+{
+  for (auto tagpair : tag)
+  {
+    std::size_t found1 = xml.find(tagpair.first);
+    if (found1 != std::string::npos)
+    {
+      std::size_t found2 = xml.find(tagpair.second);
+      if (found2 != std::string::npos)
+      {
+        return xml.substr((found1 + tagpair.first.size()),
+                          (found2 - (found1 + tagpair.first.size())));
+      }
+    }
+  }
+  return "";
+}
+
+const bool CWSDiscoveryListenerUDP::equalsAddress(const wsd_req_info& lhs, const wsd_req_info& rhs)
+{
+  return lhs.address == rhs.address;
+}
+
+void CWSDiscoveryListenerUDP::PrintWSDInfo(const wsd_req_info& info)
+{
+  CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+            "CWSDiscoveryUtils::printstruct - message contents\n"
+            "\tAction: {}\n"
+            "\tMsgID: {}\n"
+            "\tAddress: {}\n"
+            "\tTypes: {}\n"
+            "\tXAddrs: {}\n",
+            info.action, info.msgid, info.address, info.types, info.xaddrs);
+}
+
+} // namespace WSDiscovery

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (C) 2021- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+#include "threads/Thread.h"
+
+#include <string>
+#include <vector>
+
+#include <netinet/in.h>
+
+namespace WSDiscovery
+{
+struct wsd_req_info;
+}
+
+namespace WSDiscovery
+{
+class CWSDiscoveryListenerUDP : public CThread
+{
+public:
+  CWSDiscoveryListenerUDP();
+  ~CWSDiscoveryListenerUDP();
+
+  void Start();
+  void Stop();
+
+protected:
+  // CThread
+  void Process() override;
+
+private:
+  struct Command
+  {
+    struct sockaddr_in address;
+    std::string commandMsg;
+  };
+
+  /*
+   * Dispatch UDP command from command Queue
+   * return    (bool) true if message dispatched
+   */
+  bool DispatchCommand();
+
+  /*
+   * Build SOAPXML command and add to command Queue
+   * in        (string) action type
+   * in        (string) extra data field (currently used solely for resolve addresses)
+   * return    (void)
+   */
+  void AddCommand(const std::string message, const std::string extraparameter = "");
+
+  /*
+   * Process received broadcast messages and add accepted items to 
+   * in        (string) SOAPXML Message
+   * return    (void)
+   */
+  void ParseBuffer(const std::string& buffer);
+
+  /*
+   * Generates an XML SOAP message given a particular action type
+   * in        (string) action type
+   * in/out    (string) created message
+   * in        (string) extra data field (currently used for resolve addresses)
+   * return    (bool) true if full message crafted
+   */
+  bool buildSoapMessage(const std::string& action,
+                        std::string& msg,
+                        const std::string extraparameter);
+
+  // Closes socket and handles setting state for WS-Discovery
+  void Cleanup(bool aborted);
+
+private:
+  template<std::size_t SIZE>
+  const std::string wsd_tag_find(const std::string& xml,
+                                 const std::array<std::pair<std::string, std::string>, SIZE>& tag);
+
+  // Debug print WSD packet data
+  void PrintWSDInfo(const WSDiscovery::wsd_req_info& info);
+
+  // compare WSD entry address
+  const bool equalsAddress(const WSDiscovery::wsd_req_info& lhs,
+                           const WSDiscovery::wsd_req_info& rhs);
+
+  // Socket FD for send/recv
+  int fd;
+
+  std::vector<Command> m_commandbuffer;
+
+  CCriticalSection crit_commandqueue;
+  CCriticalSection crit_wsdqueue;
+
+  std::vector<WSDiscovery::wsd_req_info> m_vecWSDInfo;
+
+  // GUID that should remain constant for an instance
+  const std::string wsd_instance_address;
+
+  // Number of sends for UDP messages
+  const int retries = 4;
+
+  // Max udp packet size (+ UDP header + IP header overhead = 65535)
+  const int UDPBUFFSIZE = 65507;
+
+  // Port for unicast/multicast WSD traffic
+  const int wsdUDP = 3702;
+
+  // ipv4 multicast group WSD - https://specs.xmlsoap.org/ws/2005/04/discovery/ws-discovery.pdf
+  const char* WDSIPv4MultiGroup = "239.255.255.250";
+
+  // ToDo: ipv6 broadcast address
+  // const char* WDSIPv6MultiGroup = "FF02::C"
+};
+} // namespace WSDiscovery

--- a/xbmc/platform/win32/PlatformWin32.cpp
+++ b/xbmc/platform/win32/PlatformWin32.cpp
@@ -12,17 +12,11 @@
 #include "win32util.h"
 #include "windowing/windows/WinSystemWin32DX.h"
 
-#include "platform/win32/network/WSDiscoveryWin32.h"
 #include "platform/win32/powermanagement/Win32PowerSyscall.h"
 
 CPlatform* CPlatform::CreateInstance()
 {
   return new CPlatformWin32();
-}
-
-CPlatformWin32::~CPlatformWin32()
-{
-  CWSDiscoverySupport::Get()->Terminate();
 }
 
 bool CPlatformWin32::InitStageOne()
@@ -38,16 +32,6 @@ bool CPlatformWin32::InitStageOne()
   CWinSystemWin32DX::Register();
 
   CWin32PowerSyscall::Register();
-
-  return true;
-}
-
-bool CPlatformWin32::InitStageThree()
-{
-  if (!CPlatform::InitStageThree())
-    return false;
-
-  CWSDiscoverySupport::Get()->Initialize();
 
   return true;
 }

--- a/xbmc/platform/win32/PlatformWin32.h
+++ b/xbmc/platform/win32/PlatformWin32.h
@@ -15,9 +15,8 @@ class CPlatformWin32 : public CPlatform
 public:
   CPlatformWin32() = default;
 
-  ~CPlatformWin32() override;
+  ~CPlatformWin32() = default;
 
   bool InitStageOne() override;
-  bool InitStageThree() override;
   void PlatformSyslog() override;
 };

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "PasswordManager.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "utils/CharsetConverter.h"
 #include "utils/XTimeUtils.h"
@@ -637,14 +638,15 @@ static bool localGetShares(const std::wstring& serverNameToScan, const std::stri
 // Get servers using WS-Discovery protocol
 static bool localGetServers(const std::string& urlPrefixForItems, CFileItemList& items)
 {
-  auto wsd = CWSDiscoverySupport::Get();
+  WSDiscovery::CWSDiscoveryWindows& wsd =
+      dynamic_cast<WSDiscovery::CWSDiscoveryWindows&>(CServiceBroker::GetWSDiscovery());
 
   // Get servers immediately from WSD daemon process
-  if (wsd && wsd->IsInitialized() && wsd->ThereAreServers())
+  if (wsd.IsRunning() && wsd.ThereAreServers())
   {
-    for (const auto& ip : wsd->GetServersIPs())
+    for (const auto& ip : wsd.GetServersIPs())
     {
-      std::wstring hostname = wsd->ResolveHostName(ip);
+      std::wstring hostname = wsd.ResolveHostName(ip);
       std::string shareNameUtf8;
       if (g_charsetConverter.wToUTF8(hostname, shareNameUtf8, true) && !shareNameUtf8.empty())
       {

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -79,7 +79,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
         pList = nullptr; // end of list
     } while (type != L"Computer" && pList != nullptr);
 
-    CLog::Log(LOGDEBUG,
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
               "[WS-Discovery]: HELLO packet received: device type = '{}', device address = '{}'",
               FromW(type), FromW(addr));
 
@@ -93,8 +93,8 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
       if (it == m_serversIPs.end())
       {
         m_serversIPs.push_back(ip);
-        CLog::Log(LOGDEBUG, "[WS-Discovery]: IP '{}' has been inserted into the server list.",
-                  FromW(ip));
+        CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+                  "[WS-Discovery]: IP '{}' has been inserted into the server list.", FromW(ip));
       }
     }
   }
@@ -116,7 +116,8 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* 
   {
     const std::wstring addr(address);
 
-    CLog::Log(LOGDEBUG, "[WS-Discovery]: BYE packet received: device address = '{}'", FromW(addr));
+    CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+              "[WS-Discovery]: BYE packet received: device address = '{}'", FromW(addr));
 
     const std::wstring ip = addr.substr(0, addr.find(L":", 0));
     auto it = std::find(m_serversIPs.begin(), m_serversIPs.end(), ip);
@@ -125,8 +126,8 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* 
     if (it != m_serversIPs.end())
     {
       m_serversIPs.erase(it);
-      CLog::Log(LOGDEBUG, "[WS-Discovery]: IP '{}' has been removed from the server list.",
-                FromW(ip));
+      CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
+                "[WS-Discovery]: IP '{}' has been removed from the server list.", FromW(ip));
     }
   }
 
@@ -148,7 +149,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchComplete(LPCWSTR tag)
 {
   CSingleLock lock(m_criticalSection);
 
-  CLog::Log(LOGDEBUG,
+  CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
             "[WS-Discovery]: The initial servers search has completed successfully with {} "
             "server(s) found:",
             m_serversIPs.size());

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.h
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "network/IWSDiscovery.h"
 #include "threads/CriticalSection.h"
 
 #include <wsdapi.h>
@@ -15,7 +16,8 @@
 
 #include <vector>
 
-
+namespace WSDiscovery
+{
 class CClientNotificationSink : public IWSDiscoveryProviderNotify
 {
 public:
@@ -41,18 +43,16 @@ private:
   CCriticalSection m_criticalSection;
 };
 
-class CWSDiscoverySupport
+class CWSDiscoveryWindows : public WSDiscovery::IWSDiscovery
 {
 public:
-  CWSDiscoverySupport();
-  ~CWSDiscoverySupport();
+  CWSDiscoveryWindows() = default;
+  ~CWSDiscoveryWindows() override;
 
-  static std::shared_ptr<CWSDiscoverySupport> Get();
+  bool StartServices() override;
+  bool StopServices() override;
+  bool IsRunning() override;
 
-  bool Initialize();
-  void Terminate();
-
-  bool IsInitialized() { return m_initialized; }
   bool ThereAreServers();
   std::vector<std::wstring> GetServersIPs();
 
@@ -63,3 +63,4 @@ private:
   IWSDiscoveryProvider* m_provider = nullptr;
   CClientNotificationSink* m_sink = nullptr;
 };
+} // namespace WSDiscovery

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -336,6 +336,7 @@ constexpr const char* CSettings::SETTING_SMB_WORKGROUP;
 constexpr const char* CSettings::SETTING_SMB_MINPROTOCOL;
 constexpr const char* CSettings::SETTING_SMB_MAXPROTOCOL;
 constexpr const char* CSettings::SETTING_SMB_LEGACYSECURITY;
+constexpr const char* CSettings::SETTING_SERVICES_WSDISCOVERY;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_MONITOR;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_SCREEN;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_WHITELIST;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -334,6 +334,7 @@ public:
   static constexpr auto SETTING_SMB_MINPROTOCOL = "smb.minprotocol";
   static constexpr auto SETTING_SMB_MAXPROTOCOL = "smb.maxprotocol";
   static constexpr auto SETTING_SMB_LEGACYSECURITY = "smb.legacysecurity";
+  static constexpr auto SETTING_SERVICES_WSDISCOVERY = "services.wsdiscovery";
   static constexpr auto SETTING_VIDEOSCREEN_MONITOR = "videoscreen.monitor";
   static constexpr auto SETTING_VIDEOSCREEN_SCREEN = "videoscreen.screen";
   static constexpr auto SETTING_VIDEOSCREEN_WHITELIST = "videoscreen.whitelist";

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -221,6 +221,9 @@ void CLog::SettingOptionsLoggingComponentsFiller(const SettingConstPtr& setting,
   list.emplace_back(g_localizeStrings.Get(679), LOGCEC);
 #endif
   list.emplace_back(g_localizeStrings.Get(682), LOGDATABASE);
+#if defined(HAS_FILESYSTEM_SMB)
+  list.emplace_back(g_localizeStrings.Get(37050), LOGWSDISCOVERY);
+#endif
 }
 
 Logger CLog::GetLogger(const std::string& loggerName)


### PR DESCRIPTION
## Description
This implements the WS-Discovery protocol for SMB discovery for posix platforms

This PR is predominantly to get early feedback, and to have others test and let me know of any obscure cases we might need to handle for a more robust implementation. We essentially stick to the bare minimum that i believe is required to adhere to the WSD specs and act as a client.

Be gentle on the review ;) I have no doubts you guys will have some ideas about better implementations. Let me know, open to anything suggested.

ToDo:

- [X] Interface for WSD to unify Windows/posix creation/init for their respective WSD implementations
- [X] Settings to allow user to enable/disable the WSD daemons if they wish
- [ ] Further testing
- [x] More code comments
- [ ] ~~ipv6 support - Most likely a followup PR~~ - Do in another PR some day

## Motivation and context
Provide detection of SMB servers as per WS-Discovery specification

## How has this been tested?
OSX client, Synology Nas + windows smb shares
Android aarch64 client tested working on same network

## What is the effect on users?
Allows users the ability to have their system detect smb servers that adhere to WS-Discovery spec

Fixes #18840 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
