### PR TITLE
[Xbox] Fix SSL certs verification errors on Python add-ons

### DIFF
--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -46,6 +46,12 @@
   "sys.modules['pkg_resources'] = pkg_resources\n" \
   ""
 
+#define RUNSCRIPT_SETUP_ENVIROMENT_VARIABLES \
+  "" \
+  "from os import environ\n" \
+  "environ['SSL_CERT_FILE'] = 'system/certs/cacert.pem'\n" \
+  ""
+
 #define RUNSCRIPT_POSTSCRIPT \
         "print('-->Python Interpreter Initialized<--')\n" \
         ""
@@ -54,6 +60,11 @@
 
 #define RUNSCRIPT_COMPLIANT \
   RUNSCRIPT_PREAMBLE RUNSCRIPT_SETUPTOOLS_HACK RUNSCRIPT_POSTSCRIPT
+
+#elif defined(TARGET_WINDOWS_STORE)
+
+#define RUNSCRIPT_COMPLIANT \
+  RUNSCRIPT_PREAMBLE RUNSCRIPT_SETUP_ENVIROMENT_VARIABLES RUNSCRIPT_POSTSCRIPT
 
 #else
 

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -502,8 +502,12 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
     CEnvironment::putenv(buf);
     buf = "PYTHONOPTIMIZE=1";
     CEnvironment::putenv(buf);
-    buf = "OS=win32";
-    CEnvironment::putenv(buf);
+
+#ifdef TARGET_WINDOWS_STORE
+    CEnvironment::putenv("OS=win10");
+#else
+    CEnvironment::putenv("OS=win32");
+#endif
 
     std::wstring pythonHomeW;
     CCharsetConverter::utf8ToW(CSpecialProtocol::TranslatePath("special://xbmc/system/python"),

--- a/xbmc/platform/win10/PlatformWin10.cpp
+++ b/xbmc/platform/win10/PlatformWin10.cpp
@@ -27,9 +27,7 @@ bool CPlatformWin10::InitStageOne()
   if (!CPlatform::InitStageOne())
     return false;
 
-  CEnvironment::setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
-
-  CEnvironment::setenv("OS", "win32"); // for python scripts that check the OS
+  CEnvironment::setenv("OS", "win10"); // for python scripts that check the OS
 
   // enable independent locale for each thread, see https://connect.microsoft.com/VisualStudio/feedback/details/794122
   CWIN32Util::SetThreadLocalLocale(true);


### PR DESCRIPTION
## Description
Fix SSL certs verification errors on Python add-ons

- Fixes https://github.com/xbmc/metadata.themoviedb.org.python/issues/84
- Changes environment variable `OS` to `win10` in all places for better consistence

## Motivation and context
See https://github.com/xbmc/metadata.themoviedb.org.python/issues/84

The root cause seems to be that in UWP environment variables are only valid for the current process. Then Python environment variables needs to be set from self Python process. 

NOTE: UWP build running on Windows 10 desktop are unaffected because can use CA trust store from system (don't need `system/certs/cacert.pem`)

**EDIT:** As it is now the addons already do see the environment variable `SSL_CERT_FILE`. The problem is that it does not need to be seen by the addons but the internal libraries of Python: urllib, OpenSSL, etc.

## How has this been tested?
Runtime tested on Xbox Series S

## What is the effect on users?
Fix SSL certs verification errors on all Python addons they use 'urllib' with HTTPS connections.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
