### PR TITLE
[PVR] Trigger play channel on startup also on wake from suspend, …

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -614,6 +614,9 @@ void CPVRManager::OnWake()
   /* start job to search for missing channel icons */
   TriggerSearchMissingChannelIcons();
 
+  /* try to play channel on startup */
+  TriggerPlayChannelOnStartup();
+
   /* trigger PVR data updates */
   TriggerChannelGroupsUpdate();
   TriggerChannelsUpdate();


### PR DESCRIPTION
… not only on Kodi application startup.

We have a setting to automatically start watching TV / listening to radio on Kodi startup. This brings Kodi's behavior close to what settop boxes / classical TV sets do.

 But we should also trigger this when Kodi is awoken from suspend, not only on real application startup. I stumbled about this bug when I was trying to demonstrate a friend the above mentioned setting/feature and was wondering why this did not work. :-/

 Runtime-tested on macOS and Android, latest Kodi master.

 @phunkyfish when you find some time for a review...