### PR TITLE
[FIX]Video smatplaylists SQL limit incorrectly set to 0

### DIFF
--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -55,7 +55,8 @@ namespace XFILE
     std::vector<std::string> virtualFolders;
 
     SortDescription sorting;
-    sorting.limitEnd = playlist.GetLimit();
+    if (playlist.GetLimit() > 0)
+      sorting.limitEnd = playlist.GetLimit();
     sorting.sortBy = playlist.GetOrder();
     sorting.sortOrder = playlist.GetOrderAscending() ? SortOrderAscending : SortOrderDescending;
     sorting.sortAttributes = playlist.GetOrderAttributes();


### PR DESCRIPTION
## Description
In some circumstances when using video smartplaylists, a `LIMIT 0` is appended to SQL queries against the video database.  This automatically returns an empty set rather than any actual results.

## Motivation and context
Video smartplaylists are broken in v20 if both `order by` and `limit` are left at the defaults of `none` & `no limit`.  This is because  the initial end limit value of `-1` is immediately overwritten with `0` in `CSmartPlaylistDirectory::GetDirectory()`. A later check in `CVideoDatabase::GetMoviesByWhere()` calls `CDatabaseUtils::BuildLimitClause()` if both the start limit and end limit values are set to zero and no results are returned.

Fixed by only overwriting the initial value of `-1` in the end limit if the value in the playlist is greater than zero.  Thanks to @Montellese for the clear explanation and code suggestion.

## How has this been tested?
Tested against a local SQLite db with several smart playlists. Before this change, video smartplaylists with no limit and a sort order of none returned no results.  After the change the expected results were returned for the same settings.

## What is the effect on users?
Video smart playlists will work correctly in v20 if no limits and no sort orders are specified.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
