### PR TITLE
[Estuary] Make views which display poster items consistent

### DIFF
--- a/addons/skin.estuary/xml/View_51_Poster.xml
+++ b/addons/skin.estuary/xml/View_51_Poster.xml
@@ -143,6 +143,47 @@
 				<aspectratio>scale</aspectratio>
 				<texture fallback="DefaultMovies.png" background="true">$VAR[PosterThumbVar]</texture>
 			</control>
+			<control type="group">
+				<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
+				<control type="image">
+					<left>4</left>
+					<top>670</top>
+					<width>476</width>
+					<height>50</height>
+					<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
+					<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
+				</control>
+				<control type="label">
+					<left>0</left>
+					<top>690</top>
+					<width>435</width>
+					<height>24</height>
+					<label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
+					<font>font20_title</font>
+					<shadowcolor>text_shadow</shadowcolor>
+					<align>right</align>
+					<aligny>center</aligny>
+				</control>
+				<control type="image">
+					<left>445</left>
+					<top>690</top>
+					<width>24</width>
+					<height>24</height>
+					<texture>lists/played-total.png</texture>
+					<align>right</align>
+					<aligny>center</aligny>
+				</control>
+			</control>
+			<control type="progress">
+				<left>4</left>
+				<top>702</top>
+				<width>476</width>
+				<height>1</height>
+				<texturebg></texturebg>
+				<midtexture colordiffuse="button_focus" border="3">progress/texturebg_alt_white.png</midtexture>
+				<info>ListItem.PercentPlayed</info>
+				<visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+			</control>
 			<control type="image">
 				<left>1</left>
 				<top>1</top>

--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -63,6 +63,16 @@
 					<viewtype label="31100">icon</viewtype>
 					<itemlayout width="370">
 						<control type="image">
+							<left>0</left>
+							<top>90</top>
+							<width>370</width>
+							<height>480</height>
+							<texture>dialogs/dialog-bg-nobo.png</texture>
+							<bordertexture border="21">overlays/shadow.png</bordertexture>
+							<bordersize>20</bordersize>
+							<visible>String.IsEmpty(ListItem.Art(poster)) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
+						</control>
+						<control type="image">
 							<depth>DepthContentPopout</depth>
 							<left>0</left>
 							<top>90</top>
@@ -82,11 +92,44 @@
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label]</label>
 						</control>
+						<control type="group">
+							<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
+							<control type="image">
+								<left>35</left>
+								<top>500</top>
+								<width>298</width>
+								<height>50</height>
+								<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
+								<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
+							</control>
+							<control type="label">
+								<left>0</left>
+								<top>522</top>
+								<width>292</width>
+								<height>24</height>
+								<label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
+								<font>font20_title</font>
+								<shadowcolor>text_shadow</shadowcolor>
+								<align>right</align>
+								<aligny>center</aligny>
+							</control>
+							<control type="image">
+								<left>302</left>
+								<top>522</top>
+								<width>24</width>
+								<height>24</height>
+								<texture>lists/played-total.png</texture>
+								<align>right</align>
+								<aligny>center</aligny>
+							</control>
+						</control>
 						<control type="image">
-							<left>169</left>
-							<top>560</top>
+							<left>35</left>
+							<top>518</top>
 							<width>32</width>
 							<height>32</height>
+							<align>left</align>
+							<aligny>center</aligny>
 							<texture>$VAR[WallWatchedIconVar]</texture>
 						</control>
 						<control type="group">
@@ -94,8 +137,28 @@
 							<top>92</top>
 							<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
 						</control>
+						<control type="progress">
+							<left>32</left>
+							<top>530</top>
+							<width>298</width>
+							<height>1</height>
+							<texturebg></texturebg>
+							<midtexture colordiffuse="button_focus" border="3">progress/texturebg_alt_white.png</midtexture>
+							<info>ListItem.PercentPlayed</info>
+							<visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+						</control>
 					</itemlayout>
 					<focusedlayout width="370">
+						<control type="image">
+							<left>0</left>
+							<top>90</top>
+							<width>370</width>
+							<height>480</height>
+							<texture>dialogs/dialog-bg-nobo.png</texture>
+							<bordertexture border="21">overlays/shadow.png</bordertexture>
+							<bordersize>20</bordersize>
+							<visible>String.IsEmpty(ListItem.Art(poster)) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
+						</control>
 						<control type="image">
 							<depth>DepthContentPopout</depth>
 							<left>0</left>
@@ -117,17 +180,60 @@
 							<label>$INFO[ListItem.Label]</label>
 							<autoscroll time="3000" delay="3000" repeat="3000">True</autoscroll>
 						</control>
+						<control type="group">
+							<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
+							<control type="image">
+								<left>35</left>
+								<top>500</top>
+								<width>298</width>
+								<height>50</height>
+								<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
+								<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
+							</control>
+							<control type="label">
+								<left>0</left>
+								<top>522</top>
+								<width>292</width>
+								<height>24</height>
+								<label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
+								<font>font20_title</font>
+								<shadowcolor>text_shadow</shadowcolor>
+								<align>right</align>
+								<aligny>center</aligny>
+							</control>
+							<control type="image">
+								<left>302</left>
+								<top>522</top>
+								<width>24</width>
+								<height>24</height>
+								<texture>lists/played-total.png</texture>
+								<align>right</align>
+								<aligny>center</aligny>
+							</control>
+						</control>
 						<control type="image">
-							<left>169</left>
-							<top>560</top>
+							<left>35</left>
+							<top>518</top>
 							<width>32</width>
 							<height>32</height>
+							<align>left</align>
+							<aligny>center</aligny>
 							<texture>$VAR[WallWatchedIconVar]</texture>
 						</control>
 						<control type="group">
 							<left>158</left>
 							<top>92</top>
 							<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
+						</control>
+						<control type="progress">
+							<left>32</left>
+							<top>530</top>
+							<width>298</width>
+							<height>1</height>
+							<texturebg></texturebg>
+							<midtexture colordiffuse="button_focus" border="3">progress/texturebg_alt_white.png</midtexture>
+							<info>ListItem.PercentPlayed</info>
+							<visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
 						</control>
 					</focusedlayout>
 				</control>

--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -309,10 +309,9 @@
 			</control>
 			<control type="group">
 				<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
-				<top>320</top>
 				<control type="image">
 					<left>35</left>
-					<top>0</top>
+					<top>320</top>
 					<width>250</width>
 					<height>50</height>
 					<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
@@ -320,7 +319,7 @@
 				</control>
 				<control type="label">
 					<left>0</left>
-					<top>20</top>
+					<top>340</top>
 					<width>244</width>
 					<label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
 					<font>font20_title</font>
@@ -329,7 +328,7 @@
 				</control>
 				<control type="image">
 					<left>254</left>
-					<top>23</top>
+					<top>343</top>
 					<width>24</width>
 					<height>24</height>
 					<texture>lists/played-total.png</texture>


### PR DESCRIPTION
## Description

This post on forum https://forum.kodi.tv/showthread.php?tid=362562&pid=3036265#pid3036265 prompted me to do a comparison of the views which make use of Posters to display items.

This resulted in me finding a number of consistency issues, thus this PR seeks to make all views which make use of Poster to be consistent in the info shown.

### Before Images

**Image 1 - Infowall Movies**
![image](https://user-images.githubusercontent.com/5781142/126484970-22f23002-01f9-4b5c-9a4c-f9e7f367974e.png)

**Image 2 - Poster Movies**
![image](https://user-images.githubusercontent.com/5781142/126485532-2731cae2-b536-41b5-acd1-8fb623705b90.png)

**Image 3 - Shift Movies**
![image](https://user-images.githubusercontent.com/5781142/126485591-4db5c2d6-368e-4b45-81be-d45d4f7b2ea0.png)

**Image 4 - Shift Movies**
![image](https://user-images.githubusercontent.com/5781142/126485678-18575a29-937d-4074-86b9-b323c2c9b980.png)

**Image 5 - Infowall TV Shows**
![image](https://user-images.githubusercontent.com/5781142/126485477-dbf8a360-f95c-4875-8643-3deeb696c5ff.png)

**Image 6 - Poster TV Shows**
![image](https://user-images.githubusercontent.com/5781142/126485769-342bd920-1514-458e-90ff-de041325406f.png)

**Image 7 - Shift TV Shows**
![image](https://user-images.githubusercontent.com/5781142/126485810-bcf904c1-757e-4e0d-977d-a3ef4a62a3b3.png)

### Consistency issues found

**Movies**
Looking at Image 1 for Movie Infowall the following is displayed

- Watched status icon (icon displayed ontop of bottom left of poster)
- Progress bar (blue bar underneath poster)

Compared to Movie Infowall

**a.** Movie Poster view is missing progress bar status for in focus item (it is already shown for all items not in focus)  (see Image 2)
**b.** Movie Shift view is missing progress bar status for all items (either Image 3 or 4)
**c.** Movie Shift view when no poster is available displays thumb/icon  with no background (see Image 4)

**TV Shows**
Looking at Image 5 for TV Shows Infowall the following is displayed

- Watched status icon (icon displayed ontop of bottom left of poster)
- Watched/Total episode count (displayed ontop of bottom right of poster)

Compared to TV Shows Infowall

**d.** TV Show Poster view is missing watched/total episode count for in focus item (see Image 6)
**e.** TV Show Shift view is missing watched/total episode count for all items (see Image 7)

### After Images

**Image 8 - Poster Movies**
Progress bar added for in focus item
![image](https://user-images.githubusercontent.com/5781142/126866417-158d91d7-5a74-40f3-bb92-42df87d8276f.png)

**Image 9 - Shift Movies**
Progress bar added for all items
Watched status icon moved onto poster to be consistent with wall views and to be consistent with changes for TV Shows
Background added for where no poster is available
![image](https://user-images.githubusercontent.com/5781142/126489021-7e1b8340-9750-46af-89f0-73e705ca9b15.png)

**Image 10 - Poster TV Shows**
Watched/total episode count added for in focus item
![image](https://user-images.githubusercontent.com/5781142/126866503-47773a2f-a422-46a2-a5dc-5a9dc8df15a6.png)

**Image 11 - Shift TV Shows**
Watched staus icon moved onto poster and watched/total episode count added for all items
![image](https://user-images.githubusercontent.com/5781142/126488925-1cf0bcb6-e1ce-436c-a5e1-e0bc9b6cd337.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
