### PR TITLE
Cache false values from CPVRRecording::IsInProgress()

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -229,6 +229,7 @@ void CPVRRecording::Reset()
   m_bGotMetaData = false;
   m_iRecordingId = 0;
   m_bIsDeleted = false;
+  m_bInProgress = true;
   m_iEpgEventId = EPG_TAG_INVALID_UID;
   m_iSeason = -1;
   m_iEpisode = -1;
@@ -554,8 +555,10 @@ bool CPVRRecording::IsInProgress() const
   // Note: It is not enough to only check recording time and duration against 'now'.
   //       Only the state of the related timer is a safe indicator that the backend
   //       actually is recording this.
-
-  return GetRecordingTimer() != nullptr;
+  // Once the recording is known to not be in progress that will never change.
+  if (m_bInProgress)
+    m_bInProgress = GetRecordingTimer() != nullptr;
+  return m_bInProgress;
 }
 
 void CPVRRecording::SetGenre(int iGenreType, int iGenreSubType, const std::string& strGenre)

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -409,6 +409,7 @@ namespace PVR
     CDateTime m_recordingTime; /*!< start time of the recording */
     bool m_bGotMetaData;
     bool m_bIsDeleted; /*!< set if entry is a deleted recording which can be undelete */
+    mutable bool m_bInProgress; /*!< set if recording might be in progress */
     unsigned int m_iEpgEventId; /*!< epg broadcast id associated with this recording */
     int m_iChannelUid; /*!< channel uid associated with this recording */
     bool m_bRadio; /*!< radio or tv recording */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Cache false values from `CPVRRecording::IsInProgress()` to avoid calling the expensive `CPVRRecording::GetRecordingTimer()` too much.

Once a recording returns false from here, it will never return true. (Something can't go from being false to being true, it can only be true and then eventually turn false when the recording ends, never will return to true after that.)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While watching a not in-progress recording, a lot of CPU time (as observed in perf top is spent in this stack:
```
#0  0x000055ececa6b000 in PVR::CPVRTimers::GetActiveRecordings() const ()
#1  0x000055ececa7c7de in PVR::CPVRRecording::GetRecordingTimer() const ()
#2  0x000055ececa7ca82 in PVR::CPVRRecording::IsInProgress() const ()
#3  0x000055ececa7f277 in PVR::CPVRRecordings::UpdateInProgressSize() ()
#4  0x000055ececb4dfed in ?? ()
#5  0x000055ececb4cfb7 in PVR::CPVRManagerJobQueue::ExecutePendingJobs() ()
#6  0x000055ececb4fa82 in PVR::CPVRManager::Process() ()
...
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran it, it reduces the CPU usage.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
This change reduces CPU usage during playback of PVR recordings (except those that are in-progress).

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
