### PR TITLE
Android: Leanback - Fix potential crash when inserting programs

### DIFF
--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -209,10 +209,14 @@ public class SyncProgramsJobService extends JobService
                         .insert(
                                 TvContractCompat.PreviewPrograms.CONTENT_URI,
                                 previewProgram.toContentValues());
-        long programId = ContentUris.parseId(programUri);
-        Log.d(TAG, "Inserted new program: " + programId);
-        media.setProgramId(programId);
-        mediasAdded.add(media);
+
+        if (programUri != null)
+        {
+          long programId = ContentUris.parseId(programUri);
+          Log.d(TAG, "Inserted new program: " + programId);
+          media.setProgramId(programId);
+          mediasAdded.add(media);
+        }
       }
 
       return mediasAdded;


### PR DESCRIPTION
## Description
According to Android docs ContentResolver.insert returns null
if the underlying contentprovider cannot execute the insert or if it crashes.
Just skip further processing if this happens.

## Motivation and context
Fixes: https://github.com/xbmc/xbmc/issues/19985

## How has this been tested?
Untested.

## What is the effect on users?
Kodi should not crash if inserting programs to the
leanback launcher fails.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)