### PR TITLE
changed: Automatically fetch streamdetails for internet-streams

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2994,7 +2994,8 @@ void CApplication::OnPlayBackStarted(const CFileItem &file)
       || ((!file.HasVideoInfoTag() || !file.GetVideoInfoTag()->HasStreamDetails())
       && (URIUtils::IsBluray(file.GetPath())
       || file.IsDVDFile()
-      || file.IsDiscImage())))
+      || file.IsDiscImage()
+      || file.IsInternetStream())))
     m_appPlayer.SetUpdateStreamDetails();
 
   if (m_stackHelper.IsPlayingISOStack() || m_stackHelper.IsPlayingRegularStack())


### PR DESCRIPTION
This will make Kodi automatically fetch streamdetails for internetstreams which don't have any set yet (like we previously started doing for BR/DVD). Previously it was only possible to fetch streamdetails for internetstreams when explicitly done from an addon (using the "get_stream_details_from_player"-property. In this way addons no longer have to explicitly do this :-)