### PR TITLE
changed: Disable Curl HTTP2 by default

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -340,7 +340,7 @@ void CAdvancedSettings::Initialize()
   m_curlKeepAliveInterval = 30;
   m_curlDisableIPV6 = false;      //Certain hardware/OS combinations have trouble
                                   //with ipv6.
-  m_curlDisableHTTP2 = false;
+  m_curlDisableHTTP2 = true;
 
 #if defined(TARGET_WINDOWS_DESKTOP)
   m_minimizeToTray = false;


### PR DESCRIPTION
Consider this a proposal to disable Curl HTTP2 by default (for now). The reason is that we're seeing a lot of issues when Curl is used with http2. 

Note that we could also consider only doing this for Matrix.