### PR TITLE
Fix c++ warnings (Visual Studio 2019)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -448,7 +448,8 @@ bool CContext::GetFormatAndConfig(AVCodecContext* avctx, D3D11_VIDEO_DECODER_DES
       }
 
       // check decoder config
-      D3D11_VIDEO_DECODER_DESC checkFormat = {*mode.guid, avctx->coded_width, avctx->coded_height,
+      D3D11_VIDEO_DECODER_DESC checkFormat = {*mode.guid, static_cast<UINT>(avctx->coded_width),
+                                              static_cast<UINT>(avctx->coded_height),
                                               render_targets_dxgi[j]};
       if (!GetConfig(checkFormat, config))
         continue;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -460,8 +460,10 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
   if (!views[2])
     return false;
 
-  RECT sourceRECT = { src.x1, src.y1, src.x2, src.y2 };
-  RECT dstRECT    = { dst.x1, dst.y1, dst.x2, dst.y2 };
+  RECT sourceRECT = {static_cast<LONG>(src.x1), static_cast<LONG>(src.y1),
+                     static_cast<LONG>(src.x2), static_cast<LONG>(src.y2)};
+  RECT dstRECT = {static_cast<LONG>(dst.x1), static_cast<LONG>(dst.y1), static_cast<LONG>(dst.x2),
+                  static_cast<LONG>(dst.y2)};
 
   D3D11_VIDEO_FRAME_FORMAT dxvaFrameFormat = D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE;
 
@@ -573,14 +575,16 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
   {
     // input colorspace
     bool isBT601 = views[2]->color_space == AVCOL_SPC_BT470BG || views[2]->color_space == AVCOL_SPC_SMPTE170M;
+    // clang-format off
     D3D11_VIDEO_PROCESSOR_COLOR_SPACE colorSpace
     {
-      0,                            // 0 - Playback, 1 - Processing
-      views[2]->full_range ? 0 : 1, // 0 - Full (0-255), 1 - Limited (16-235) (RGB)
-      isBT601 ? 1 : 0,              // 0 - BT.601, 1 - BT.709
-      0,                            // 0 - Conventional YCbCr, 1 - xvYCC
-      views[2]->full_range ? 2 : 1  // 0 - driver defaults, 2 - Full range [0-255], 1 - Studio range [16-235] (YUV)
+      0u,                             // 0 - Playback, 1 - Processing
+      views[2]->full_range ? 0u : 1u, // 0 - Full (0-255), 1 - Limited (16-235) (RGB)
+      isBT601 ? 1u : 0u,              // 0 - BT.601, 1 - BT.709
+      0u,                             // 0 - Conventional YCbCr, 1 - xvYCC
+      views[2]->full_range ? 2u : 1u  // 0 - driver defaults, 2 - Full range [0-255], 1 - Studio range [16-235] (YUV)
     };
+    // clang-format on
     m_pVideoContext->VideoProcessorSetStreamColorSpace(m_pVideoProcessor.Get(), DEFAULT_STREAM_INDEX, &colorSpace);
     // Output color space
     // don't apply any color range conversion, this will be fixed at later stage.

--- a/xbmc/dialogs/GUIDialogMediaFilter.h
+++ b/xbmc/dialogs/GUIDialogMediaFilter.h
@@ -36,7 +36,8 @@ public:
 
   static void ShowAndEditMediaFilter(const std::string &path, CSmartPlaylist &filter);
 
-  typedef struct {
+  struct Filter
+  {
     std::string mediaType;
     Field field;
     uint32_t label;
@@ -47,7 +48,7 @@ public:
     std::shared_ptr<CSetting> setting = nullptr;
     CSmartPlaylistRule* rule = nullptr;
     void* data = nullptr;
-  } Filter;
+  };
 
 protected:
   // specializations of CGUIWindow

--- a/xbmc/pictures/ExifParse.cpp
+++ b/xbmc/pictures/ExifParse.cpp
@@ -101,22 +101,23 @@ static void ErrNonfatal(const char* const msg, int a1, int a2);
 
 //--------------------------------------------------------------------------
 // Exif format descriptor stuff
-#define FMT_BYTE       1
-#define FMT_STRING     2
-#define FMT_USHORT     3
-#define FMT_ULONG      4
-#define FMT_URATIONAL  5
-#define FMT_SBYTE      6
-#define FMT_UNDEFINED  7
-#define FMT_SSHORT     8
-#define FMT_SLONG      9
-#define FMT_SRATIONAL 10
-#define FMT_SINGLE    11
-#define FMT_DOUBLE    12
+namespace
+{
+constexpr auto FMT_BYTE = 1;
+constexpr auto FMT_USHORT = 2;
+constexpr auto FMT_ULONG = 3;
+constexpr auto FMT_URATIONAL = 4;
+constexpr auto FMT_SBYTE = 5;
+constexpr auto FMT_SSHORT = 6;
+constexpr auto FMT_SLONG = 7;
+constexpr auto FMT_SRATIONAL = 8;
+constexpr auto FMT_SINGLE = 9;
+constexpr auto FMT_DOUBLE = 10;
 // NOTE: Remember to change NUM_FORMATS if you define a new format
-#define NUM_FORMATS   12
+constexpr auto NUM_FORMATS = 10;
 
-const unsigned int BytesPerFormat[NUM_FORMATS] = { 1,1,2,4,8,1,1,2,4,8,4,8 };
+const unsigned int BytesPerFormat[NUM_FORMATS] = {1, 2, 4, 8, 1, 2, 4, 8, 4, 8};
+} // namespace
 
 //--------------------------------------------------------------------------
 // Internationalisation string IDs. The enum order must match that in the


### PR DESCRIPTION
## Description
Fix c++ warnings (Visual Studio 2019)

1.
```
18>T:\KODI\kodi\xbmc\dialogs\GUIDialogMediaFilter.h(39,18): warning C5208: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes (compiling source file T:\KODI\kodi\xbmc\dialogs\GUIDialogMediaFilter.cpp)
```

2.
```
18>T:\KODI\kodi\xbmc\pictures\ExifParse.cpp(105,1): warning C4005: 'FMT_STRING': macro redefinition
18>T:\KODI\kodi\project\BuildDependencies\x64\include\fmt/format.h(3528): message : see previous definition of 'FMT_STRING' (compiling source file T:\KODI\kodi\xbmc\pictures\ExifParse.cpp)
```

3.
```
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\DVDCodecs\Video\DXVA.cpp(451,64): warning C4838: conversion from 'int' to 'UINT' requires a narrowing conversion
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\DVDCodecs\Video\DXVA.cpp(451,84): warning C4838: conversion from 'int' to 'UINT' requires a narrowing conversion
```

4.
```
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(463,26): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(463,34): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(463,42): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(463,50): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(464,26): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(464,34): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(464,42): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(464,50): warning C4838: conversion from 'T' to 'LONG' requires a narrowing conversion
18>        with
18>        [
18>            T=float
18>        ]
```

5.
```
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(579,15): warning C4838: conversion from 'int' to 'UINT' requires a narrowing conversion
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(580,7): warning C4838: conversion from 'int' to 'UINT' requires a narrowing conversion
18>T:\KODI\kodi\xbmc\cores\VideoPlayer\VideoRenderers\HwDecRender\DXVAHD.cpp(582,15): warning C4838: conversion from 'int' to 'UINT' requires a narrowing conversion
```
## Motivation and context
Eliminate some of the few remaining warnings with VS 2019

## How has this been tested?
Build with Visual Studio 2019

## What is the effect on users?
None


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
