### PR TITLE
gbm: Set colourspace and bits per pixel

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -20,6 +20,18 @@ extern "C"
 namespace DRMPRIME
 {
 
+std::string GetColorimetry(const VideoPicture& picture)
+{
+  switch (picture.color_space)
+  {
+    case AVCOL_SPC_BT2020_CL:
+    case AVCOL_SPC_BT2020_NCL:
+      return "BT2020_RGB";
+  }
+
+  return "Default";
+}
+
 std::string GetColorEncoding(const VideoPicture& picture)
 {
   switch (picture.color_space)

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -34,6 +34,7 @@ enum hdmi_eotf
   HDMI_EOTF_BT_2100_HLG,
 };
 
+std::string GetColorimetry(const VideoPicture& picture);
 std::string GetColorEncoding(const VideoPicture& picture);
 std::string GetColorRange(const VideoPicture& picture);
 uint8_t GetEOTF(const VideoPicture& picture);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -165,11 +165,12 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 
   bool result;
   uint64_t value;
-  std::tie(result, value) = plane->GetPropertyValue("COLOR_ENCODING", GetColorEncoding(picture));
+  std::tie(result, value) =
+      plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));
   if (result)
     m_DRM->AddProperty(plane, "COLOR_ENCODING", value);
 
-  std::tie(result, value) = plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture));
+  std::tie(result, value) = plane->GetPropertyEnumValue("COLOR_RANGE", GetColorRange(picture));
   if (result)
     m_DRM->AddProperty(plane, "COLOR_RANGE", value);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -35,8 +35,20 @@ void CVideoLayerBridgeDRMPRIME::Disable()
   m_DRM->AddProperty(plane, "FB_ID", 0);
   m_DRM->AddProperty(plane, "CRTC_ID", 0);
 
-  // disable HDR metadata
   auto connector = m_DRM->GetConnector();
+
+  bool result;
+  uint64_t value;
+  std::tie(result, value) = connector->GetPropertyEnumValue("Colorspace", "Default");
+  if (result)
+  {
+    CLog::Log(LOGDEBUG,
+              "CVideoLayerBridgeDRMPRIME::{} - setting connector colorspace to Default ({})",
+              __FUNCTION__, result);
+    m_DRM->AddProperty(connector, "Colorspace", value);
+  }
+
+  // disable HDR metadata
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
   {
     m_DRM->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
@@ -175,6 +187,15 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
     m_DRM->AddProperty(plane, "COLOR_RANGE", value);
 
   auto connector = m_DRM->GetConnector();
+
+  std::tie(result, value) = connector->GetPropertyEnumValue("Colorspace", GetColorimetry(picture));
+  if (result)
+  {
+    result = m_DRM->AddProperty(connector, "Colorspace", value);
+    CLog::Log(LOGDEBUG, "CVideoLayerBridgeDRMPRIME::{} - setting connector colorspace to {} ({})",
+              __FUNCTION__, GetColorimetry(picture), result);
+  }
+
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
   {
     m_hdr_metadata.metadata_type = HDMI_STATIC_METADATA_TYPE1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -81,4 +81,5 @@ private:
 
   uint32_t m_hdr_blob_id = 0;
   struct hdr_output_metadata m_hdr_metadata = {};
+  uint64_t m_previous_bpc = 0;
 };

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -48,7 +48,7 @@ bool CDRMAtomic::SetScalingFilter(CDRMObject* object, const char* name, const ch
 {
   bool result;
   uint64_t value;
-  std::tie(result, value) = m_gui_plane->GetPropertyValue(name, type);
+  std::tie(result, value) = m_gui_plane->GetPropertyEnumValue(name, type);
   if (!result)
     return false;
 

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -122,6 +122,25 @@ bool CDRMObject::GetPropertyValue(const std::string& name, uint64_t& val) const
   return true;
 }
 
+bool CDRMObject::GetPropertyRange(const std::string& name, uint64_t& min, uint64_t& max) const
+{
+  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
+                               [&name](auto& prop) { return prop->name == name; });
+
+  if (property == m_propsInfo.end())
+    return false;
+
+  auto prop = property->get();
+
+  if (!static_cast<bool>(drm_property_type_is(prop, DRM_MODE_PROP_RANGE)))
+    return false;
+
+  min = prop->values[0];
+  max = prop->values[1];
+
+  return true;
+}
+
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -81,8 +81,8 @@ bool CDRMObject::GetProperties(uint32_t id, uint32_t type)
 }
 
 //! @todo: improve with c++17
-std::tuple<bool, uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
-                                                        const std::string& valueName) const
+std::tuple<bool, uint64_t> CDRMObject::GetPropertyEnumValue(const std::string& name,
+                                                            const std::string& valueName) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](const auto& prop) { return prop->name == name; });

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -74,8 +74,11 @@ bool CDRMObject::GetProperties(uint32_t id, uint32_t type)
   m_type = type;
 
   for (uint32_t i = 0; i < m_props->count_props; i++)
+  {
     m_propsInfo.emplace_back(std::unique_ptr<drmModePropertyRes, DrmModePropertyResDeleter>(
         drmModeGetProperty(m_fd, m_props->props[i])));
+    m_propsValues.emplace_back(m_props->prop_values[i]);
+  }
 
   return true;
 }
@@ -104,6 +107,19 @@ std::tuple<bool, uint64_t> CDRMObject::GetPropertyEnumValue(const std::string& n
   }
 
   return std::make_tuple(false, 0);
+}
+
+bool CDRMObject::GetPropertyValue(const std::string& name, uint64_t& val) const
+{
+  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
+                               [&name](auto& prop) { return prop->name == name; });
+
+  if (property == m_propsInfo.end())
+    return false;
+
+  val = m_propsValues[property - m_propsInfo.begin()];
+
+  return true;
 }
 
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -36,6 +36,7 @@ public:
   uint32_t GetPropertyId(const std::string& name) const;
   std::tuple<bool, uint64_t> GetPropertyEnumValue(const std::string& name,
                                                   const std::string& valueName) const;
+  bool GetPropertyValue(const std::string& name, uint64_t& val) const;
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);
@@ -58,6 +59,7 @@ protected:
   };
 
   std::vector<std::unique_ptr<drmModePropertyRes, DrmModePropertyResDeleter>> m_propsInfo;
+  std::vector<uint64_t> m_propsValues;
 
   int m_fd{-1};
 

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -34,8 +34,8 @@ public:
 
   uint32_t GetId() const { return m_id; }
   uint32_t GetPropertyId(const std::string& name) const;
-  std::tuple<bool, uint64_t> GetPropertyValue(const std::string& name,
-                                              const std::string& valueName) const;
+  std::tuple<bool, uint64_t> GetPropertyEnumValue(const std::string& name,
+                                                  const std::string& valueName) const;
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -37,6 +37,7 @@ public:
   std::tuple<bool, uint64_t> GetPropertyEnumValue(const std::string& name,
                                                   const std::string& valueName) const;
   bool GetPropertyValue(const std::string& name, uint64_t& val) const;
+  bool GetPropertyRange(const std::string& name, uint64_t& min, uint64_t& max) const;
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);


### PR DESCRIPTION
## Description
Set colourspace and bits per pixel when playing high bit depth video

## Motivation and context
Allows gbm platforms (like Pi 4) to drive 12-bit YCC422 over hdmi when playing 

## How has this been tested?
Tested on Pi 4 with 4K HDR display and with a HDMI analyser.

## What is the effect on users?
Improved picture quality (less banding).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
