### PR TITLE
[Windows] Add new setting "Use 10 bit for SDR" in Display Settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7050,6 +7050,8 @@ msgctxt "#13415"
 msgid "Render method"
 msgstr ""
 
+#. Value for setting with label #13415 "Player / Videos / Render method"
+#. Value for setting with label #36098 "System / Display / Use 10 bit for SDR"
 #: system/settings/settings.xml
 #: xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
 msgctxt "#13416"
@@ -13403,7 +13405,8 @@ msgctxt "#20419"
 msgid "Replace file names with library titles"
 msgstr ""
 
-#. Settings -> PVR -> Playback -> Switch to fullscreen value
+#. Value for setting with label #19171 "PVR & Live TV / Playback / Switch to full screen"
+#. Value for setting with label #36098 "System / Display / Use 10 bit for SDR"
 #: system/settings/settings.xml
 msgctxt "#20420"
 msgid "Never"
@@ -13414,6 +13417,8 @@ msgctxt "#20421"
 msgid "If only one season"
 msgstr ""
 
+#. Value for setting with label #170 "Player / Videos / Adjust display refresh rate"
+#. Value for setting with label #36098 "System / Display / Use 10 bit for SDR"
 #: system/settings/settings.xml
 msgctxt "#20422"
 msgid "Always"
@@ -18404,7 +18409,13 @@ msgctxt "#36050"
 msgid "On start"
 msgstr ""
 
-#empty strings from id 36051 to 36098
+#empty strings from id 36051 to 36097
+
+#. Label of setting "System / Display / Use 10 bit for SDR"
+#: system/settings/settings.xml
+msgctxt "#36098"
+msgid "Use 10 bit for SDR"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36099"
@@ -20786,7 +20797,11 @@ msgctxt "#36577"
 msgid "Specify the resolution for the 3D lookup table. Use a lower resolution for quick preview and higher resolution for more accurate picture. Using a high resolution may take seconds to prepare when parameters are changed or a new video is started."
 msgstr ""
 
-#empty string with id 36578
+#. Description of setting "System / Display / Use 10 bit for SDR" with label #36098
+#: system/settings/settings.xml
+msgctxt "#36578"
+msgid "Improves video quality by using 10-bit video surfaces for Standard Dynamic Range (SDR) video.[CR][Auto detect] Enables 10 bit for SDR only if the connected display supports HDR.[CR][Always] Enables 10 bit for SDR even if the connected display doesn't support HDR.[CR][Never] Do not use 10 bit for SDR.[CR]HDR passthrough mode always uses 10-bit regardless of this setting."
+msgstr ""
 
 #. primaries labels
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2413,6 +2413,19 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+        <setting id="videoscreen.10bitsurfaces" type="integer" label="36098" help="36578">
+        <requirement>HAS_DX</requirement>
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13416">0</option> <!-- AUTO -->
+              <option label="20420">1</option> <!-- NEVER -->
+              <option label="20422">2</option> <!-- ALWAYS -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
         <setting id="videoscreen.dither" type="boolean" label="36099" help="36598">
           <requirement>
             <or>

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -79,6 +79,9 @@ namespace DX
 
     bool SetFullScreen(bool fullscreen, RESOLUTION_INFO& res);
 
+    // Apply display settings changes
+    void ApplyDisplaySettings();
+
     // HDR display support
     HDR_STATUS ToggleHDR();
     void SetHdrMetaData(DXGI_HDR_METADATA_HDR10& hdr10) const;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -358,7 +358,6 @@ void CAdvancedSettings::Initialize()
   m_GLRectangleHack = false;
   m_iSkipLoopFilter = 0;
   m_bVirtualShares = true;
-  m_bTry10bitOutput = false;
 
   m_cpuTempCmd = "";
   m_gpuTempCmd = "";
@@ -921,7 +920,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   XMLUtils::GetBoolean(pRootElement,"virtualshares", m_bVirtualShares);
   XMLUtils::GetUInt(pRootElement, "packagefoldersize", m_addonPackageFolderSize);
-  XMLUtils::GetBoolean(pRootElement, "try10bitoutput", m_bTry10bitOutput);
 
   // EPG
   pElement = pRootElement->FirstChildElement("epg");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -304,7 +304,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_iSkipLoopFilter;
 
     bool m_bVirtualShares;
-    bool m_bTry10bitOutput;
 
     std::string m_cpuTempCmd;
     std::string m_gpuTempCmd;

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -58,6 +58,10 @@
 #include "windowing/windows/WinSystemWin32DX.h"
 #endif
 
+#ifdef TARGET_WINDOWS
+#include "rendering/dx/DeviceResources.h"
+#endif
+
 using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
@@ -339,6 +343,13 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
       m_resolutionChangeAborted = false;
 
     return true;
+  }
+  else if (settingId == CSettings::SETTING_VIDEOSCREEN_10BITSURFACES)
+  {
+#ifdef TARGET_WINDOWS
+    DX::DeviceResources::Get()->ApplyDisplaySettings();
+    return true;
+#endif
   }
 #if defined(HAVE_X11) || defined(TARGET_WINDOWS_DESKTOP) || defined(TARGET_DARWIN_OSX)
   else if (settingId == CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -352,6 +352,7 @@ constexpr const char* CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_TESTPATTERN;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_FRAMEPACKING;
+constexpr const char* CSettings::SETTING_VIDEOSCREEN_10BITSURFACES;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_CHANNELS;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_CONFIG;
@@ -957,6 +958,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_DISPLAYPROFILE);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_10BITSURFACES);
   GetSettingsManager()->RegisterCallback(&CDisplaySettings::GetInstance(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -351,6 +351,7 @@ public:
   static constexpr auto SETTING_VIDEOSCREEN_TESTPATTERN = "videoscreen.testpattern";
   static constexpr auto SETTING_VIDEOSCREEN_LIMITEDRANGE = "videoscreen.limitedrange";
   static constexpr auto SETTING_VIDEOSCREEN_FRAMEPACKING = "videoscreen.framepacking";
+  static constexpr auto SETTING_VIDEOSCREEN_10BITSURFACES = "videoscreen.10bitsurfaces";
   static constexpr auto SETTING_AUDIOOUTPUT_AUDIODEVICE = "audiooutput.audiodevice";
   static constexpr auto SETTING_AUDIOOUTPUT_CHANNELS = "audiooutput.channels";
   static constexpr auto SETTING_AUDIOOUTPUT_CONFIG = "audiooutput.config";


### PR DESCRIPTION
## Description
- Add new setting "Use 10 bit for SDR" in Display Settings.
- Removes advanced setting `try10bitoutput` as the new setting already provides this functionality (and more).

## Motivation and context
This functionality has been around for a long time but it was only accessible through advanced settings so it is surely little used. Also now in the master branch and even v19.2 is also used by default when the system supports HDR pass-through (since all systems that support HDR must also support 10-bit).

However that leaves out users who do not have an HDR display but have modern systems that are perfectly capable of 10-bit.

Now this setting simply makes this possibility more visible and provides more fine control:

**[Auto detect] (default)**: It does not changes the current behavior, 10-bit swapchain is used (also for SDR content) if an HDR display is detected. That indirectly also ensures that Windows 10 is being used and with more or less current video drivers.

**[Always]**: Enable the use of 10-bit swapchain regardless of whether or not there is an HDR display. It is the equivalent setting value that replaces advanced setting `try10bitoutput`. It can also be used with Windows 8, etc. with DirectX feature level >= 11.0. It will not be activated effectively if the system does not support it in any way.

**[Never]**: Never enable 10-bit swapchain for SDR content. Users with an HDR display can use this option for testing purposes or if for some reason they do not want to use 10-bit for SDR content. Even with this setting, 10 bits will still be used when playing content in HDR pass-through mode.

## How has this been tested?
Runtime tested on two systems HDR capable / not capable.

## What is the effect on users?
For users without HDR screen it allows to use 10-bit video surfaces without the need to use advanced settings and for users with HDR screen it allows to disable 10-bit for SDR content.

## Screenshots (if appropriate):

![screenshot00006](https://user-images.githubusercontent.com/58434170/128244225-f15c6a07-795a-462e-b40b-355aaea48f5e.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
