### PR TITLE
Fix: GUIFontTTF lookup table after Harfbuzz merge

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -737,7 +737,11 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyph
   // quick access to ascii chars
   if (letter < 255)
   {
-    character_t ch = (style << 8) | letter;
+    character_t ch = (style << 8) | (glyphIndex & 0xff);
+
+    if (glyphIndex > 255)
+      ch += 2048;
+
     if (ch < LOOKUPTABLE_SIZE && m_charquick[ch])
       return m_charquick[ch];
   }
@@ -801,12 +805,18 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyph
 
   // fixup quick access
   memset(m_charquick, 0, sizeof(m_charquick));
-  for(int i=0;i<m_numChars;i++)
+  for (int i = 0; i < m_numChars; i++)
   {
     if (m_char[i].letter < 255)
     {
-      character_t ch = ((m_char[i].glyphAndStyle & 0xffff0000) >> 8) | m_char[i].letter;
-      m_charquick[ch] = m_char+i;
+      character_t ch =
+          ((m_char[i].glyphAndStyle & 0xffff0000) >> 8) | (m_char[i].glyphIndex & 0xff);
+
+      if (m_char[i].glyphIndex > 255)
+        ch += 2048;
+
+      if (ch < LOOKUPTABLE_SIZE)
+        m_charquick[ch] = m_char + i;
     }
   }
 

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -28,7 +28,7 @@ using namespace DirectX;
 using namespace DirectX::PackedVector;
 #endif
 
-constexpr size_t LOOKUPTABLE_SIZE = 256 * 8;
+constexpr size_t LOOKUPTABLE_SIZE = 256 * 8 * 2;
 
 class CTexture;
 class CRenderSystemBase;


### PR DESCRIPTION
## Description
Fix GUIFontTTF lookup table after Harfbuzz merge.

Increments lookup table size from 2048 to 4096 elements to allow store ASCII chars with `glyphIndex` > 255 and updates caching logic according.

## Motivation and context
After Harfbuzz merge some issues have come up:

See https://github.com/xbmc/xbmc/pull/19944#issuecomment-886221405 and https://github.com/xbmc/xbmc/pull/19998#issuecomment-890371713 to understand the problem. There are different solutions to correct the problem but there are also concerns not only to obtain a correct functionality but also the performance is not affected (see https://github.com/xbmc/xbmc/pull/19998#issuecomment-890966587).

Ultimately the root cause is that Harfbuzz can return non-ASCII characters even though the input characters are only ASCII. This is so depending on special font features as ligatures (see https://typofonderie.com/font-support/opentype-features/ and https://stackoverflow.com/questions/62552451/why-harfbuzz-shape-2-single-char-into-one-glyph).

Thus arises the need to modify the caching system used since it was not designed to support characters with ID > 255.

Roughly, the proposed solution consists of doubling the size of the lookup table and using the additional 2048 elements to store characters with glyph ID > 255 that can arise from normal ASCII characters (ID < 255). TT fonts can contain many thousands of symbols so only the least significant 8 bits (0xff) are used to store a sub-set of symbols usually with adjacent IDs as ligatures.

First 2048 elements --> 255 ASCII characters (glyph ID < 255) and their styles variations as before
Seconds 2048 elements --> up to 255 characters with glyph ID > 255 and their style variations

I think it is a good solution since it meets all the premises:

- Array out of bound errors are prevented.
- All ASCII characters are cached even though if their glyph ID > 255.
- The same performance is maintained as before.
- Text is rendered correctly using ligatures.

## How has this been tested?
Runtime tested


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
