### PR TITLE
[Music][GUIInfo] Expose ListItem.DateAdded for music library content

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -388,6 +388,13 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
 
         value = CURL(value).GetWithoutUserDetails();
         return true;
+      case LISTITEM_DATE_ADDED:
+        if (tag->GetDateAdded().IsValid())
+        {
+          value = tag->GetDateAdded().GetAsLocalizedDate();
+          return true;
+        }
+        break;
     }
   }
 


### PR DESCRIPTION
## Description
The video library exposes the date an item was added via `ListItem.DateAdded` for all video types.  This PR adds the same functionality for the music library (albums & songs).

## Motivation and context
Video library can show `date added` for all video items, but this seems to have been missing for some reason from the music library. Pointed out in the forum https://forum.kodi.tv/showthread.php?tid=363835
## How has this been tested?
Tested locally with sqlite and a small modification to a skin to show the date an album, track or artist was originally added.  Note that date added can be altered by AS.xml to be one of scan time, last modified time or creation time and so is not necessarily the date added to Kodi's music library.

## What is the effect on users?
Skinners can use `ListItem.DateAdded` in music library views as well as video library views.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
