### PR TITLE
[AudioEngine] AESinkAudioTrack remove setLegacyStreamType

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -158,7 +158,6 @@ jni::CJNIAudioTrack *CAESinkAUDIOTRACK::CreateAudioTrack(int stream, int sampleR
     CJNIAudioAttributesBuilder attrBuilder;
     attrBuilder.setUsage(CJNIAudioAttributes::USAGE_MEDIA);
     attrBuilder.setContentType(CJNIAudioAttributes::CONTENT_TYPE_MUSIC);
-    attrBuilder.setLegacyStreamType(CJNIAudioManager::STREAM_MUSIC);
 
     CJNIAudioFormatBuilder fmtBuilder;
     fmtBuilder.setChannelMask(channelMask);


### PR DESCRIPTION
## Description
setLegacyStreamType is recommended to not be used when setting setContentType and setUsage
when building an AudioAttribute as it overrides the more accurate setusage/setcontenttype usage

https://developer.android.com/reference/android/media/AudioAttributes.Builder#setLegacyStreamType(int)

## Motivation and context
Stumbled across it when looking at some other android stuff.
No real effect other than being more accurate to the android docs for usage.

## How has this been tested?
pixel3a

## What is the effect on users?
No real effect on users

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
