### PR TITLE
[Subtitles] Fixed wrong ASS/SSA format detection

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
@@ -15,6 +15,7 @@
 #include "DVDSubtitleParserSubrip.h"
 #include "DVDSubtitleParserVplayer.h"
 #include "DVDSubtitleStream.h"
+#include "utils/StringUtils.h"
 
 #include <cstring>
 #include <memory>
@@ -51,8 +52,11 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
       {
         return new CDVDSubtitleParserVplayer(std::move(pStream), strFile.c_str());
       }
-      else if ((!memcmp(line, "Dialogue: Marked", 16)) || (!memcmp(line, "Dialogue: ", 10)) ||
-               (!memcmp(line, "[Events]", 8)))
+      else if (!StringUtils::CompareNoCase(line, "!: This is a Sub Station Alpha v", 32) ||
+               !StringUtils::CompareNoCase(line, "ScriptType: v4.00", 17) ||
+               !StringUtils::CompareNoCase(line, "Dialogue: Marked", 16) ||
+               !StringUtils::CompareNoCase(line, "Dialogue: ", 10) ||
+               !StringUtils::CompareNoCase(line, "[Events]", 8))
       {
         return new CDVDSubtitleParserSSA(std::move(pStream), strFile.c_str());
       }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The ASS/SSA subtitle format types are not correctly detected

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ASS/SSA subtitles with embedded fonts are misidentified as SubRips or discarded,
this because miss some string comparing.

Forum report: https://forum.kodi.tv/showthread.php?tid=363783&highlight=subtitles

The changes are done by take ispiration from VLC sources, that are well working

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using differents ASS files with embedded fonts

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Can play ASS/SSA subtitles files with embedded fonts

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
