### PR TITLE
[addons] move sort out of for-loop that fills the vector to be sorted

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -793,21 +793,21 @@ void CGUIDialogAddonInfo::BuildDependencyList()
     }
 
     m_depsInstalledWithAvailable.emplace_back(dep, addonInstalled, addonAvailable);
-
-    // sort criteria in dialog:
-    // 1. optional add-ons to top
-    // 2. scripts/modules to bottom
-    std::sort(m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
-              [](const auto& a, const auto& b) {
-                if (a.m_depInfo.optional != b.m_depInfo.optional)
-                {
-                  return a.m_depInfo.optional;
-                }
-
-                const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
-                return (depA && depA->MainType() != ADDON_SCRIPT_MODULE);
-              });
   }
+
+  // sort criteria in dialog:
+  // 1. optional add-ons to top
+  // 2. scripts/modules to bottom
+  std::sort(m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
+            [](const auto& a, const auto& b) {
+              if (a.m_depInfo.optional != b.m_depInfo.optional)
+              {
+                return a.m_depInfo.optional;
+              }
+
+              const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
+              return (depA && depA->MainType() != ADDON_SCRIPT_MODULE);
+            });
 }
 
 bool CInstalledWithAvailable::IsInstalledUpToDate() const


### PR DESCRIPTION
## Description
it is nonsense to sort a vector inside the for loop that fills the vector. just sort once after it is set up.

## What is the effect on users?
none

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
