### PR TITLE
Use c++ initializer {} in place of ZeroMemory and memset

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2036,8 +2036,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   }
   case TMSG_VIDEORESIZE:
   {
-    XBMC_Event newEvent;
-    memset(&newEvent, 0, sizeof(newEvent));
+    XBMC_Event newEvent = {};
     newEvent.type = XBMC_VIDEORESIZE;
     newEvent.resize.w = pMsg->param1;
     newEvent.resize.h = pMsg->param2;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -318,7 +318,7 @@ snd_pcm_chmap_t* CAESinkALSA::CopyALSAchmap(snd_pcm_chmap_t* alsaMap)
 
 std::string CAESinkALSA::ALSAchmapToString(snd_pcm_chmap_t* alsaMap)
 {
-  char buf[128] = { 0 };
+  char buf[128] = {};
   //! @bug ALSA bug - buffer overflow by a factor of 2 is possible
   //! http://mailman.alsa-project.org/pipermail/alsa-devel/2014-December/085815.html
   int err = snd_pcm_chmap_print(alsaMap, sizeof(buf) / 2, buf);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -224,8 +224,7 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
   m_dwBufferLen = m_dwChunkSize * 12; //180ms total buffer
 
   // fill in the secondary sound buffer descriptor
-  DSBUFFERDESC dsbdesc;
-  memset(&dsbdesc, 0, sizeof(DSBUFFERDESC));
+  DSBUFFERDESC dsbdesc = {};
   dsbdesc.dwSize = sizeof(DSBUFFERDESC);
   dsbdesc.dwFlags = DSBCAPS_GETCURRENTPOSITION2 /** Better position accuracy */
                   | DSBCAPS_TRUEPLAYPOSITION    /** Vista+ accurate position */

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -184,8 +184,6 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
     return false;
   }
 
-  WAVEFORMATEXTENSIBLE wfxex = {0};
-
   // clamp samplerate between 44100 and 192000
   if (format.m_sampleRate < 44100)
     format.m_sampleRate = 44100;
@@ -193,8 +191,8 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
   if (format.m_sampleRate > 192000)
     format.m_sampleRate = 192000;
 
-  //fill waveformatex
-  ZeroMemory(&wfxex, sizeof(WAVEFORMATEXTENSIBLE));
+  // fill waveformatex
+  WAVEFORMATEXTENSIBLE wfxex = {};
   wfxex.Format.cbSize          = sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX);
   wfxex.Format.nChannels       = format.m_channelLayout.Count();
   wfxex.Format.nSamplesPerSec  = format.m_sampleRate;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -517,8 +517,7 @@ void CAESinkOSS::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       info.m_deviceType = AE_DEVTYPE_PCM;
     }
 
-    oss_audioinfo ainfo;
-    memset(&ainfo, 0, sizeof(ainfo));
+    oss_audioinfo ainfo = {};
     ainfo.dev = i;
     if (ioctl(mixerfd, SNDCTL_AUDIOINFO, &ainfo) != -1) {
 #if 0

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -401,7 +401,7 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
   CAEChannelInfo       deviceChannels;
   bool                 add192 = false;
 
-  WAVEFORMATEXTENSIBLE wfxex = {0};
+  WAVEFORMATEXTENSIBLE wfxex = {};
   HRESULT              hr;
 
   for(RendererDetail& details : CAESinkFactoryWin::GetRendererDetails())

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -84,7 +84,7 @@ CAESinkXAudio::CAESinkXAudio() :
 #ifdef  _DEBUG
   else
   {
-    XAUDIO2_DEBUG_CONFIGURATION config = { 0 };
+    XAUDIO2_DEBUG_CONFIGURATION config = {};
     config.BreakMask = XAUDIO2_LOG_ERRORS | XAUDIO2_LOG_WARNINGS | XAUDIO2_LOG_API_CALLS | XAUDIO2_LOG_STREAMING;
     config.TraceMask = XAUDIO2_LOG_ERRORS | XAUDIO2_LOG_WARNINGS | XAUDIO2_LOG_API_CALLS | XAUDIO2_LOG_STREAMING;
     config.LogTiming = true;
@@ -248,7 +248,7 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
   ctx->sink = this;
   memcpy(ctx->data, data[0] + offset * m_format.m_frameSize, dataLenght);
 
-  XAUDIO2_BUFFER xbuffer = { 0 };
+  XAUDIO2_BUFFER xbuffer = {};
   xbuffer.AudioBytes = dataLenght;
   xbuffer.pAudioData = ctx->data;
   xbuffer.pContext = ctx;
@@ -335,7 +335,7 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
   HRESULT hr = S_OK, hr2 = S_OK;
   CAEDeviceInfo deviceInfo;
   CAEChannelInfo deviceChannels;
-  WAVEFORMATEXTENSIBLE wfxex = { 0 };
+  WAVEFORMATEXTENSIBLE wfxex = {};
   bool add192 = false;
 
   UINT32 eflags = 0;// XAUDIO2_DEBUG_ENGINE;
@@ -605,7 +605,7 @@ failed:
 bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &format)
 {
   std::wstring device = KODI::PLATFORM::WINDOWS::ToW(deviceId);
-  WAVEFORMATEXTENSIBLE wfxex = { 0 };
+  WAVEFORMATEXTENSIBLE wfxex = {};
 
   if ( format.m_dataFormat <= AE_FMT_FLOAT
     || format.m_dataFormat == AE_FMT_RAW)

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -402,8 +402,7 @@ bool CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
 {
   CLog::Log(LOGINFO, "{}: {} {}", __FUNCTION__, strPath, strSwitches);
 
-  STARTUPINFOW si;
-  memset(&si, 0, sizeof(si));
+  STARTUPINFOW si = {};
   si.cb = sizeof(si);
   si.dwFlags = STARTF_USESHOWWINDOW;
   si.wShowWindow = m_hideconsole ? SW_HIDE : SW_SHOW;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -1388,7 +1388,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
     return CDVDVideoCodec::VC_NONE;
 
 #ifdef TARGET_WINDOWS_DESKTOP
-  D3D11_VIDEO_DECODER_EXTENSION data = {0};
+  D3D11_VIDEO_DECODER_EXTENSION data = {};
   union {
     DXVA_Status_H264 h264;
     DXVA_Status_VC1 vc1;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1573,7 +1573,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
         st->iBitsPerSample = pStream->codecpar->bits_per_raw_sample;
         st->iChannelLayout = pStream->codecpar->channel_layout;
-        char buf[32] = { 0 };
+        char buf[32] = {};
         av_get_channel_layout_string(buf, 31, st->iChannels, st->iChannelLayout);
         st->m_channelLayoutName = buf;
         if (st->iBitsPerSample == 0)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1382,8 +1382,7 @@ bool CDVDInputStreamNavigator::SetState(const std::string &xmlstate)
   if( !m_dvdnav )
     return false;
 
-  dvd_state_t save_state;
-  memset( &save_state, 0, sizeof( save_state ) );
+  dvd_state_t save_state = {};
 
   if( !CDVDStateSerializer::XMLToDVDState(&save_state, xmlstate)  )
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.cpp
@@ -15,10 +15,8 @@
 
 bool CDVDStateSerializer::test( const dvd_state_t *state  )
 {
-  dvd_state_t state2;
+  dvd_state_t state2 = {};
   std::string buffer;
-
-  memset( &state2, 0, sizeof(dvd_state_t));
 
   DVDToXMLState(buffer, state);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -378,7 +378,7 @@ bool CVaapi1Texture::TestInteropDeepColor(VADisplay vaDpy, EGLDisplay eglDisplay
   VAImage image;
   VABufferInfo bufferInfo;
 
-  VASurfaceAttrib attribs = { };
+  VASurfaceAttrib attribs = {};
   attribs.flags = VA_SURFACE_ATTRIB_SETTABLE;
   attribs.type = VASurfaceAttribPixelFormat;
   attribs.value.type = VAGenericValueTypeInteger;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
@@ -50,8 +50,7 @@ uint32_t* convert_rgba(CDVDOverlayImage* o, bool mergealpha)
   if(!rgba)
     return NULL;
 
-  uint32_t palette[256];
-  memset(palette, 0, 256 * sizeof(palette[0]));
+  uint32_t palette[256] = {};
   for(int i = 0; i < o->palette_colors; i++)
     palette[i] = build_rgba((o->palette[i] >> PIXEL_ASHIFT) & 0xff
                           , (o->palette[i] >> PIXEL_RSHIFT) & 0xff

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -177,7 +177,7 @@ protected:
   double m_latencyTweak = 0.0;
   /// Display latency updated in PrepareNextRender in DVD clock units, includes m_latencyTweak
   double m_displayLatency = 0.0;
-  std::atomic_int m_videoDelay = {0};
+  std::atomic_int m_videoDelay = {};
 
   int m_QueueSize = 2;
   int m_QueueSkip = 0;

--- a/xbmc/filesystem/test/TestFile.cpp
+++ b/xbmc/filesystem/test/TestFile.cpp
@@ -29,8 +29,7 @@ TEST(TestFile, Read)
   const std::string fifthBuf = "multimedia jukebox." + newLine;
 
   XFILE::CFile file;
-  char buf[23];
-  memset(buf, 0, sizeof(buf));
+  char buf[23] = {};
 
   size_t currentPos;
   ASSERT_TRUE(file.Open(
@@ -89,8 +88,7 @@ TEST(TestFile, Write)
 {
   XFILE::CFile *file;
   const char str[] = "TestFile.Write test string\n";
-  char buf[30];
-  memset(buf, 0, sizeof(buf));
+  char buf[30] = {};
 
   ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -36,8 +36,7 @@ protected:
 TEST_F(TestZipFile, Read)
 {
   XFILE::CFile file;
-  char buf[20];
-  memset(&buf, 0, sizeof(buf));
+  char buf[20] = {};
   std::string reffile, strpathinzip;
   CFileItemList itemlist;
 
@@ -125,8 +124,7 @@ TEST_F(TestZipFile, Stat)
 TEST_F(TestZipFile, CorruptedFile)
 {
   XFILE::CFile *file;
-  char buf[16];
-  memset(&buf, 0, sizeof(buf));
+  char buf[16] = {};
   std::string reffilepath, strpathinzip, str;
   CFileItemList itemlist;
   ssize_t size, i;

--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -259,7 +259,7 @@ bool CD3DTexture::CreateInternal(const void* pixels /* nullptr */, unsigned int 
     m_mipLevels = 1;
 
   CD3D11_TEXTURE2D_DESC textureDesc(m_format, m_width, m_height, 1, m_mipLevels, m_bindFlags, m_usage, m_cpuFlags, 1, 0, miscFlags);
-  D3D11_SUBRESOURCE_DATA initData = { 0 };
+  D3D11_SUBRESOURCE_DATA initData = {};
   initData.pSysMem = pixels;
   initData.SysMemPitch = srcPitch ? srcPitch : CD3DHelper::BitsPerPixel(m_format) * m_width / 8;
   initData.SysMemSlicePitch = 0;

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -299,8 +299,7 @@ bool CGUIFontTTFDX::UpdateDynamicVertexBuffer(const SVertex* pSysMem, unsigned i
   if (width > m_vertexWidth) // create or re-create
   {
     CD3D11_BUFFER_DESC bufferDesc(width, D3D11_BIND_VERTEX_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-    D3D11_SUBRESOURCE_DATA initData;
-    ZeroMemory(&initData, sizeof(D3D11_SUBRESOURCE_DATA));
+    D3D11_SUBRESOURCE_DATA initData = {};
     initData.pSysMem = pSysMem;
 
     if (FAILED(pDevice->CreateBuffer(&bufferDesc, &initData, m_vertexBuffer.ReleaseAndGetAddressOf())))

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -345,7 +345,7 @@ void CGUIFontTTFDX::CreateStaticIndexBuffer(void)
   }
 
   CD3D11_BUFFER_DESC desc(sizeof(index), D3D11_BIND_INDEX_BUFFER, D3D11_USAGE_IMMUTABLE);
-  D3D11_SUBRESOURCE_DATA initData = { 0 };
+  D3D11_SUBRESOURCE_DATA initData = {};
   initData.pSysMem = index;
 
   if (SUCCEEDED(pDevice->CreateBuffer(&desc, &initData, m_staticIndexBuffer.ReleaseAndGetAddressOf())))

--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -58,8 +58,6 @@ CGUIShaderDX::CGUIShaderDX() :
     m_currentShader(0),
     m_clipPossible(false)
 {
-  ZeroMemory(&m_cbViewPort, sizeof(m_cbViewPort));
-  ZeroMemory(&m_cbWorldViewProj, sizeof(m_cbWorldViewProj));
 }
 
 CGUIShaderDX::~CGUIShaderDX()

--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -147,8 +147,7 @@ bool CGUIShaderDX::CreateBuffers()
 bool CGUIShaderDX::CreateSamplers()
 {
   // Describe the Sampler State
-  D3D11_SAMPLER_DESC sampDesc;
-  memset(&sampDesc, 0, sizeof(D3D11_SAMPLER_DESC));
+  D3D11_SAMPLER_DESC sampDesc = {};
   sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
   sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
   sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -116,8 +116,8 @@ private:
   void ClipToScissorParams(void);
 
   // GUI constants
-  cbViewPort m_cbViewPort;
-  cbWorldViewProj m_cbWorldViewProj;
+  cbViewPort m_cbViewPort = {};
+  cbWorldViewProj m_cbWorldViewProj = {};
 
   bool  m_bCreated;
   size_t m_currentShader;

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -106,9 +106,8 @@ bool CXBTFReader::Open(const std::string& path)
     uint32_t u32;
     uint64_t u64;
 
-    // one extra char to null terminate the string with the following memset
-    char path[CXBTFFile::MaximumPathLength + 1];
-    memset(path, 0, sizeof(path));
+    // one extra char to null terminate the string
+    char path[CXBTFFile::MaximumPathLength + 1] = {};
     if (!ReadString(m_file, path, sizeof(path) - 1))
       return false;
     xbtfFile.SetPath(path);

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -273,7 +273,7 @@ bool CInputManager::ProcessEventServer(int windowId, float frameTime)
     CPoint pos;
     if (es->GetMousePos(pos.x, pos.y) && m_Mouse.IsEnabled())
     {
-      XBMC_Event newEvent;
+      XBMC_Event newEvent = {};
       newEvent.type = XBMC_MOUSEMOTION;
       newEvent.motion.x = (uint16_t)pos.x;
       newEvent.motion.y = (uint16_t)pos.y;

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -498,7 +498,7 @@ std::string CNetworkBase::GetIpStr(const struct sockaddr* sa)
   if (!sa)
     return result;
 
-  char buffer[INET6_ADDRSTRLEN] = { 0 };
+  char buffer[INET6_ADDRSTRLEN] = {};
   switch (sa->sa_family)
   {
   case AF_INET:

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -352,7 +352,7 @@ bool CTCPServer::InitializeBlue()
     CLog::Log(LOGINFO, "JSONRPC Server: Unable to get bluetooth socket");
     return false;
   }
-  struct sockaddr_rc sa  = {0};
+  struct sockaddr_rc sa = {};
   sa.rc_family  = AF_BLUETOOTH;
   sa.rc_bdaddr  = bt_bdaddr_any;
   sa.rc_channel = 0;

--- a/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
@@ -92,7 +92,7 @@ void CHTTPFileHandler::SetLastModifiedDate(const struct __stat64 *statBuffer)
 {
   struct tm *time;
 #ifdef HAVE_LOCALTIME_R
-  struct tm result = { };
+  struct tm result = {};
   time = localtime_r((const time_t*)&statBuffer->st_mtime, &result);
 #else
   time = localtime((time_t *)&statBuffer->st_mtime);

--- a/xbmc/platform/android/activity/AndroidKey.cpp
+++ b/xbmc/platform/android/activity/AndroidKey.cpp
@@ -316,8 +316,7 @@ void CAndroidKey::XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, uint1
   if (!winSystem)
     return;
 
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
 
   unsigned char type = up ? XBMC_KEYUP : XBMC_KEYDOWN;
   newEvent.type = type;

--- a/xbmc/platform/android/activity/AndroidMouse.cpp
+++ b/xbmc/platform/android/activity/AndroidMouse.cpp
@@ -55,9 +55,7 @@ void CAndroidMouse::MouseMove(float x, float y)
 #ifdef DEBUG_VERBOSE
   CXBMCApp::android_printf("%s: x:%f, y:%f", __PRETTY_FUNCTION__, x, y);
 #endif
-  XBMC_Event newEvent;
-
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
 
   newEvent.type = XBMC_MOUSEMOTION;
   newEvent.motion.x = x;
@@ -72,9 +70,7 @@ void CAndroidMouse::MouseButton(float x, float y, int32_t action, int32_t button
 #ifdef DEBUG_VERBOSE
   CXBMCApp::android_printf("%s: x:%f, y:%f, action:%i, buttons:%i", __PRETTY_FUNCTION__, x, y, action, buttons);
 #endif
-  XBMC_Event newEvent;
-
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
 
   int32_t checkButtons = buttons;
   if (action ==  AMOTION_EVENT_ACTION_UP)
@@ -102,9 +98,7 @@ void CAndroidMouse::MouseWheel(float x, float y, float value)
 #ifdef DEBUG_VERBOSE
   CXBMCApp::android_printf("%s: val:%f", __PRETTY_FUNCTION__, value);
 #endif
-  XBMC_Event newEvent;
-
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
 
   if (value > 0.0f)
   {

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -176,8 +176,7 @@ public:
     return;
   }
 
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
   unichar currentKey = [text characterAtIndex:0];
 
   // handle upper case letters
@@ -215,8 +214,7 @@ public:
 
 -(void)sendKey:(XBMCKey) key
 {
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
 
   //newEvent.key.keysym.unicode = key;
   newEvent.key.keysym.sym = key;

--- a/xbmc/platform/darwin/osx/smc.c
+++ b/xbmc/platform/darwin/osx/smc.c
@@ -99,11 +99,9 @@ kern_return_t SMCCall(int index, SMCKeyData_t *inputStructure, SMCKeyData_t *out
 kern_return_t SMCReadKey(UInt32ConstChar_t key, SMCVal_t *val)
 {
   kern_return_t result;
-  SMCKeyData_t  inputStructure;
-  SMCKeyData_t  outputStructure;
+  SMCKeyData_t inputStructure = {};
+  SMCKeyData_t outputStructure = {};
 
-  memset(&inputStructure, 0, sizeof(SMCKeyData_t));
-  memset(&outputStructure, 0, sizeof(SMCKeyData_t));
   memset(val, 0, sizeof(SMCVal_t));
 
   inputStructure.key = _strtoul(key, 4, 16);

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -148,7 +148,7 @@ void CLirc::ProcessCode(char *buf)
               &deviceName[0], buttonName);
     m_firstClickTime = std::chrono::steady_clock::now();
 
-    XBMC_Event newEvent;
+    XBMC_Event newEvent = {};
     newEvent.type = XBMC_BUTTON;
     newEvent.keybutton.button = button;
     newEvent.keybutton.holdtime = 0;
@@ -159,7 +159,7 @@ void CLirc::ProcessCode(char *buf)
   }
   else if (repeat > CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_remoteDelay)
   {
-    XBMC_Event newEvent;
+    XBMC_Event newEvent = {};
     newEvent.type = XBMC_BUTTON;
     newEvent.keybutton.button = button;
 

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -222,8 +222,7 @@ void CLibInputKeyboard::ProcessKey(libinput_event_keyboard *e)
   if (!m_ctx || !m_keymap || !m_state)
     return;
 
-  XBMC_Event event;
-  memset(&event, 0, sizeof(event));
+  XBMC_Event event = {};
 
   const uint32_t xkbkey = libinput_event_keyboard_get_key(e) + 8;
   const bool pressed = libinput_event_keyboard_get_key_state(e) == LIBINPUT_KEY_STATE_PRESSED;

--- a/xbmc/platform/linux/input/LibInputPointer.cpp
+++ b/xbmc/platform/linux/input/LibInputPointer.cpp
@@ -52,8 +52,7 @@ void CLibInputPointer::ProcessButton(libinput_event_pointer *e)
       break;
   }
 
-  XBMC_Event event;
-  memset(&event, 0, sizeof(event));
+  XBMC_Event event = {};
 
   event.type = pressed ? XBMC_MOUSEBUTTONDOWN : XBMC_MOUSEBUTTONUP;
   event.button.button = xbmc_button;
@@ -86,8 +85,7 @@ void CLibInputPointer::ProcessMotion(libinput_event_pointer *e)
   m_pos.Y = std::min(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(), m_pos.Y);
   m_pos.Y = std::max(0, m_pos.Y);
 
-  XBMC_Event event;
-  memset(&event, 0, sizeof(event));
+  XBMC_Event event = {};
 
   event.type = XBMC_MOUSEMOTION;
   event.motion.x = static_cast<uint16_t>(m_pos.X);
@@ -107,7 +105,7 @@ void CLibInputPointer::ProcessMotionAbsolute(libinput_event_pointer *e)
   m_pos.X = static_cast<int>(libinput_event_pointer_get_absolute_x_transformed(e, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()));
   m_pos.Y = static_cast<int>(libinput_event_pointer_get_absolute_y_transformed(e, CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight()));
 
-  XBMC_Event event;
+  XBMC_Event event = {};
   event.type = XBMC_MOUSEMOTION;
   event.motion.x = static_cast<uint16_t>(m_pos.X);
   event.motion.y = static_cast<uint16_t>(m_pos.Y);
@@ -133,8 +131,7 @@ void CLibInputPointer::ProcessAxis(libinput_event_pointer *e)
   else
     scroll = XBMC_BUTTON_WHEELDOWN;
 
-  XBMC_Event event;
-  memset(&event, 0, sizeof(event));
+  XBMC_Event event = {};
 
   event.type = XBMC_MOUSEBUTTONDOWN;
   event.button.button = scroll;

--- a/xbmc/platform/posix/XHandle.cpp
+++ b/xbmc/platform/posix/XHandle.cpp
@@ -13,7 +13,7 @@
 
 #include <cassert>
 
-int CXHandle::m_objectTracker[10] = {0};
+int CXHandle::m_objectTracker[10] = {};
 
 HANDLE WINAPI GetCurrentProcess(void) {
   return (HANDLE)-1; // -1 a special value - pseudo handle

--- a/xbmc/platform/win10/input/RemoteControlXbox.cpp
+++ b/xbmc/platform/win10/input/RemoteControlXbox.cpp
@@ -87,7 +87,7 @@ void CRemoteControlXbox::HandleAcceleratorKey(const CoreDispatcher& sender, cons
   if (!button)
     return;
 
-  XBMC_Event newEvent;
+  XBMC_Event newEvent = {};
   newEvent.type = XBMC_BUTTON;
   newEvent.keybutton.button = button;
   newEvent.keybutton.holdtime = 0;
@@ -140,7 +140,7 @@ void CRemoteControlXbox::HandleAcceleratorKey(const CoreDispatcher& sender, cons
 
 void CRemoteControlXbox::HandleMediaButton(const SystemMediaTransportControlsButtonPressedEventArgs& args)
 {
-  XBMC_Event newEvent;
+  XBMC_Event newEvent = {};
   newEvent.type = XBMC_BUTTON;
   newEvent.keybutton.button = TranslateMediaKey(args.Button());
   newEvent.keybutton.holdtime = 0;

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -81,8 +81,8 @@ int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
   int iResult;                  // results flag
   ULONG ulChanges=0;
   DWORD dwBytesReturned;
-  T_SPDT_SBUF sptd_sb;  //SCSI Pass Through Direct variable.
-  byte DataBuf[8];  //Buffer for holding data to/from drive.
+  T_SPDT_SBUF sptd_sb = {}; // SCSI Pass Through Direct variable.
+  byte DataBuf[8] = {}; // Buffer for holding data to/from drive.
 
   CLog::LogF(LOGDEBUG, "Requesting status for drive {}.", strPath);
 
@@ -161,9 +161,6 @@ int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
   sptd_sb.sptd.Cdb[13]=0;
   sptd_sb.sptd.Cdb[14]=0;
   sptd_sb.sptd.Cdb[15]=0;
-
-  ZeroMemory(DataBuf, 8);
-  ZeroMemory(sptd_sb.SenseBuf, MAX_SENSE_LEN);
 
   //Send the command to drive
   CLog::LogF(LOGDEBUG, "Requesting tray status for drive {}.", strPath);
@@ -313,8 +310,7 @@ int CWIN32Util::GetDesktopColorDepth()
   CLog::LogF(LOGDEBUG, "s not implemented");
   return 32;
 #else
-  DEVMODE devmode;
-  ZeroMemory(&devmode, sizeof(devmode));
+  DEVMODE devmode = {};
   devmode.dmSize = sizeof(devmode);
   EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devmode);
   return (int)devmode.dmBitsPerPel;

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1210,8 +1210,7 @@ bool CWIN32Util::IsUsbDevice(const std::wstring &strWdrive)
     return false;
 
   // setup query
-  STORAGE_PROPERTY_QUERY query;
-  memset(&query, 0, sizeof(query));
+  STORAGE_PROPERTY_QUERY query = {};
   query.PropertyId = StorageDeviceProperty;
   query.QueryType = PropertyStandardQuery;
 

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -243,7 +243,7 @@ bool CWIN32Util::XBMCShellExecute(const std::string &strPath, bool bWaitForScrip
   g_charsetConverter.utf8ToW(strWorkingDir, WstrWorkingDir);
 
   bool ret;
-  SHELLEXECUTEINFOW ShExecInfo = {0};
+  SHELLEXECUTEINFOW ShExecInfo = {};
   ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFOW);
   ShExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
   ShExecInfo.hwnd = NULL;

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -383,7 +383,7 @@ bool CIRServerSuite::HandleRemoteEvent(CIrssMessage& message)
     CLog::LogF(LOGDEBUG, "remoteEvent: {} {}", deviceName, keycode);
     unsigned button = m_irTranslator.TranslateButton(deviceName, keycode);
 
-    XBMC_Event newEvent;
+    XBMC_Event newEvent = {};
     newEvent.type = XBMC_BUTTON;
     newEvent.keybutton.button = button;
     newEvent.keybutton.holdtime = 0;

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -241,11 +241,11 @@ bool CNetworkInterfaceWin32::GetHostMacAddress(const struct sockaddr& host, std:
   if (GetBestInterfaceEx(&static_cast<struct sockaddr>(host), &InterfaceIndex) != NO_ERROR)
     return false;
 
-  NET_LUID luid = { 0 };
+  NET_LUID luid = {};
   if (ConvertInterfaceIndexToLuid(InterfaceIndex, &luid) != NO_ERROR)
     return false;
 
-  MIB_IPNET_ROW2 neighborIp = { 0 };
+  MIB_IPNET_ROW2 neighborIp = {};
   neighborIp.InterfaceLuid = luid;
   neighborIp.InterfaceIndex;
   neighborIp.Address.si_family = host.sa_family;

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -295,7 +295,7 @@ DEVINST CWin32StorageProvider::GetDrivesDevInstByDiskNumber(long DiskNumber)
   // Retrieve a context structure for a device interface of a device
   // information set.
   DWORD dwIndex = 0;
-  SP_DEVICE_INTERFACE_DATA devInterfaceData = { 0 };
+  SP_DEVICE_INTERFACE_DATA devInterfaceData = {};
   devInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
   BOOL bRet = FALSE;
 

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -324,7 +324,7 @@ DEVINST CWin32StorageProvider::GetDrivesDevInstByDiskNumber(long DiskNumber)
         continue;
 
       pspdidd->cbSize = sizeof(*pspdidd);
-      ZeroMemory((PVOID)&spdd, sizeof(spdd));
+      memset(&spdd, 0, sizeof(spdd));
       spdd.cbSize = sizeof(spdd);
 
       long res = SetupDiGetDeviceInterfaceDetail(hDevInfo, &spdid,

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -937,7 +937,7 @@ void DX::DeviceResources::Present()
   // The first argument instructs DXGI to block until VSync, putting the application
   // to sleep until the next VSync. This ensures we don't waste any cycles rendering
   // frames that will never be displayed to the screen.
-  DXGI_PRESENT_PARAMETERS parameters = { 0 };
+  DXGI_PRESENT_PARAMETERS parameters = {};
   HRESULT hr = m_swapChain->Present1(1, 0, &parameters);
 
   // If the device was removed either by a disconnection or a driver upgrade, we
@@ -973,8 +973,8 @@ void DX::DeviceResources::ClearRenderTarget(ID3D11RenderTargetView* pRTView, flo
 
 void DX::DeviceResources::HandleOutputChange(const std::function<bool(DXGI_OUTPUT_DESC)>& cmpFunc)
 {
-  DXGI_ADAPTER_DESC currentDesc = { 0 };
-  DXGI_ADAPTER_DESC foundDesc = { 0 };
+  DXGI_ADAPTER_DESC currentDesc = {};
+  DXGI_ADAPTER_DESC foundDesc = {};
 
   ComPtr<IDXGIFactory1> factory;
   if (m_adapter)

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -157,8 +157,7 @@ void DX::DeviceResources::GetDisplayMode(DXGI_MODE_DESC* mode) const
   mode->ScanlineOrdering = scDesc.BufferDesc.ScanlineOrdering;
 
 #ifdef TARGET_WINDOWS_DESKTOP
-  DEVMODEW sDevMode;
-  memset(&sDevMode, 0, sizeof(sDevMode));
+  DEVMODEW sDevMode = {};
   sDevMode.dmSize = sizeof(sDevMode);
 
   // EnumDisplaySettingsW is only one way to detect current refresh rate

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -405,8 +405,7 @@ void DX::DeviceResources::CreateDeviceResources()
                                                                           // Add more message IDs here as needed
       };
 
-      D3D11_INFO_QUEUE_FILTER filter;
-      ZeroMemory(&filter, sizeof(filter));
+      D3D11_INFO_QUEUE_FILTER filter = {};
       filter.DenyList.NumIDs = hide.size();
       filter.DenyList.pIDList = hide.data();
       d3dInfoQueue->AddStorageFilterEntries(&filter);

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -87,7 +87,7 @@ bool CRenderSystemDX::InitRenderSystem()
   CPoint camPoint = { outputSize.Width * 0.5f, outputSize.Height * 0.5f };
   SetCameraPosition(camPoint, outputSize.Width, outputSize.Height);
 
-  DXGI_ADAPTER_DESC AIdentifier = { 0 };
+  DXGI_ADAPTER_DESC AIdentifier = {};
   m_deviceResources->GetAdapterDesc(&AIdentifier);
   m_RenderRenderer = KODI::PLATFORM::WINDOWS::FromW(AIdentifier.Description);
   uint32_t version = 0;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -179,8 +179,7 @@ bool CRenderSystemDX::CreateStates()
   m_BlendDisableState = nullptr;
 
   // Initialize the description of the stencil state.
-  D3D11_DEPTH_STENCIL_DESC depthStencilDesc;
-  ZeroMemory(&depthStencilDesc, sizeof(D3D11_DEPTH_STENCIL_DESC));
+  D3D11_DEPTH_STENCIL_DESC depthStencilDesc = {};
 
   // Set up the description of the stencil state.
   depthStencilDesc.DepthEnable = false;
@@ -231,8 +230,7 @@ bool CRenderSystemDX::CreateStates()
 
   m_pContext->RSSetState(m_RSScissorDisable.Get()); // by default
 
-  D3D11_BLEND_DESC blendState = { 0 };
-  ZeroMemory(&blendState, sizeof(D3D11_BLEND_DESC));
+  D3D11_BLEND_DESC blendState = {};
   blendState.RenderTarget[0].BlendEnable = true;
   blendState.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA; // D3D11_BLEND_SRC_ALPHA;
   blendState.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA; // D3D11_BLEND_INV_SRC_ALPHA;

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -53,7 +53,7 @@ bool CScreenshotSurfaceWindows::Capture()
   if (!backbuffer.Get())
     return false;
 
-  D3D11_TEXTURE2D_DESC desc = { 0 };
+  D3D11_TEXTURE2D_DESC desc = {};
   backbuffer.GetDesc(&desc);
   desc.Usage = D3D11_USAGE_STAGING;
   desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -270,7 +270,7 @@ void CAdvancedSettings::Initialize()
   m_bShoutcastArt = true;
 
   m_musicThumbs = "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG|cover.jpg|Cover.jpg|cover.jpeg|thumb.jpg|Thumb.jpg|thumb.JPG|Thumb.JPG";
-  m_musicArtistExtraArt = { };
+  m_musicArtistExtraArt = {};
   m_musicAlbumExtraArt = {};
 
   m_bMusicLibraryAllItemsOnBottom = false;

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -212,12 +212,10 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
   pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
   pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
 
-  IMAGEHLP_LINE64 Line;
-  memset(&Line, 0, sizeof(Line));
+  IMAGEHLP_LINE64 Line = {};
   Line.SizeOfStruct = sizeof(Line);
 
-  IMAGEHLP_MODULE64 Module;
-  memset(&Module, 0, sizeof(Module));
+  IMAGEHLP_MODULE64 Module = {};
   Module.SizeOfStruct = sizeof(Module);
   int seq=0;
 

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -140,7 +140,7 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
   KODI::TIME::SystemTime stLocalTime;
   KODI::TIME::GetLocalTime(&stLocalTime);
   bool returncode = false;
-  STACKFRAME64 frame = { 0 };
+  STACKFRAME64 frame = {};
   HANDLE hCurProc = GetCurrentProcess();
   IMAGEHLP_SYMBOL64* pSym = NULL;
   HANDLE hDumpFile = INVALID_HANDLE_VALUE;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -88,7 +88,6 @@ using namespace XFILE;
 #ifdef TARGET_WINDOWS_DESKTOP
 static bool sysGetVersionExWByRef(OSVERSIONINFOEXW& osVerInfo)
 {
-  ZeroMemory(&osVerInfo, sizeof(osVerInfo));
   osVerInfo.dwOSVersionInfoSize = sizeof(osVerInfo);
 
   typedef NTSTATUS(__stdcall *RtlGetVersionPtr)(RTL_OSVERSIONINFOEXW* pOsInfo);
@@ -503,7 +502,7 @@ std::string CSysInfo::GetKernelName(bool emptyIfUnknown /*= false*/)
   if (kernelName.empty())
   {
 #if defined(TARGET_WINDOWS_DESKTOP)
-    OSVERSIONINFOEXW osvi;
+    OSVERSIONINFOEXW osvi = {};
     if (sysGetVersionExWByRef(osvi) && osvi.dwPlatformId == VER_PLATFORM_WIN32_NT)
       kernelName = "Windows NT";
 #elif defined(TARGET_WINDOWS_STORE)

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -91,8 +91,7 @@ bool CXBMCTinyXML::LoadFile(const std::string& _filename, const std::string& doc
 bool CXBMCTinyXML::LoadFile(FILE *f, TiXmlEncoding encoding)
 {
   std::string data;
-  char buf[BUFFER_SIZE];
-  memset(buf, 0, BUFFER_SIZE);
+  char buf[BUFFER_SIZE] = {};
   int result;
   while ((result = fread(buf, 1, BUFFER_SIZE, f)) > 0)
     data.append(buf, result);

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -381,8 +381,7 @@ bool CWinEventsX11::MessagePump()
           break;
 
         m_structureChanged = true;
-        XBMC_Event newEvent;
-        memset(&newEvent, 0, sizeof(newEvent));
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = xevent.xconfigure.width;
         newEvent.resize.h = xevent.xconfigure.height;
@@ -401,8 +400,7 @@ bool CWinEventsX11::MessagePump()
 
       case KeyPress:
       {
-        XBMC_Event newEvent;
-        memset(&newEvent, 0, sizeof(newEvent));
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_KEYDOWN;
         KeySym xkeysym;
 
@@ -495,9 +493,8 @@ bool CWinEventsX11::MessagePump()
             continue;
         }
 
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         KeySym xkeysym;
-        memset(&newEvent, 0, sizeof(newEvent));
         newEvent.type = XBMC_KEYUP;
         xkeysym = XLookupKeysym(&xevent.xkey, 0);
         newEvent.key.keysym.scancode = xevent.xkey.keycode;
@@ -522,8 +519,7 @@ bool CWinEventsX11::MessagePump()
       {
         if (xevent.xmotion.window != m_window)
           break;
-        XBMC_Event newEvent;
-        memset(&newEvent, 0, sizeof(newEvent));
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_MOUSEMOTION;
         newEvent.motion.x = (int16_t)xevent.xmotion.x;
         newEvent.motion.y = (int16_t)xevent.xmotion.y;
@@ -534,8 +530,7 @@ bool CWinEventsX11::MessagePump()
 
       case ButtonPress:
       {
-        XBMC_Event newEvent;
-        memset(&newEvent, 0, sizeof(newEvent));
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_MOUSEBUTTONDOWN;
         newEvent.button.button = (unsigned char)xevent.xbutton.button;
         newEvent.button.x = (int16_t)xevent.xbutton.x;
@@ -547,8 +542,7 @@ bool CWinEventsX11::MessagePump()
 
       case ButtonRelease:
       {
-        XBMC_Event newEvent;
-        memset(&newEvent, 0, sizeof(newEvent));
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_MOUSEBUTTONUP;
         newEvent.button.button = (unsigned char)xevent.xbutton.button;
         newEvent.button.x = (int16_t)xevent.xbutton.x;

--- a/xbmc/windowing/osx/WinEventsSDL.cpp
+++ b/xbmc/windowing/osx/WinEventsSDL.cpp
@@ -67,7 +67,7 @@ bool CWinEventsSDL::MessagePump()
           break;
         }
 
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_KEYDOWN;
         newEvent.key.keysym.scancode = event.key.keysym.scancode;
         newEvent.key.keysym.sym = (XBMCKey) event.key.keysym.sym;
@@ -90,7 +90,7 @@ bool CWinEventsSDL::MessagePump()
 
       case SDL_KEYUP:
       {
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_KEYUP;
         newEvent.key.keysym.scancode = event.key.keysym.scancode;
         newEvent.key.keysym.sym = (XBMCKey) event.key.keysym.sym;
@@ -105,7 +105,7 @@ bool CWinEventsSDL::MessagePump()
 
       case SDL_MOUSEBUTTONDOWN:
       {
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_MOUSEBUTTONDOWN;
         newEvent.button.button = event.button.button;
         newEvent.button.x = event.button.x;
@@ -119,7 +119,7 @@ bool CWinEventsSDL::MessagePump()
 
       case SDL_MOUSEBUTTONUP:
       {
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_MOUSEBUTTONUP;
         newEvent.button.button = event.button.button;
         newEvent.button.x = event.button.x;
@@ -141,7 +141,7 @@ bool CWinEventsSDL::MessagePump()
           Cocoa_ShowMouse();
           break;
         }
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_MOUSEMOTION;
         newEvent.motion.x = event.motion.x;
         newEvent.motion.y = event.motion.y;
@@ -161,7 +161,7 @@ bool CWinEventsSDL::MessagePump()
         {
           break;
         }
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = event.resize.w;
         newEvent.resize.h = event.resize.h;
@@ -173,7 +173,7 @@ bool CWinEventsSDL::MessagePump()
       }
       case SDL_USEREVENT:
       {
-        XBMC_Event newEvent;
+        XBMC_Event newEvent = {};
         newEvent.type = XBMC_USEREVENT;
         newEvent.user.code = event.user.code;
         std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -90,8 +90,7 @@ using namespace std::chrono_literals;
     if ([context view])
     {
       NSPoint window_origin = [[[context view] window] frame].origin;
-      XBMC_Event newEvent;
-      memset(&newEvent, 0, sizeof(newEvent));
+      XBMC_Event newEvent = {};
       newEvent.type = XBMC_VIDEOMOVE;
       newEvent.move.x = window_origin.x;
       newEvent.move.y = window_origin.y;

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -183,8 +183,7 @@ void CWinEventsWin10::UpdateWindowSize()
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen && !appView.IsFullScreenMode())
     CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen = false;
 
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
   newEvent.type = XBMC_VIDEORESIZE;
   newEvent.resize.w = size.Width;
   newEvent.resize.h = size.Height;
@@ -287,8 +286,7 @@ void CWinEventsWin10::OnWindowClosed(const CoreWindow& sender, const CoreWindowE
   // send quit command to the application if it's still running
   if (!g_application.m_bStop)
   {
-    XBMC_Event newEvent;
-    memset(&newEvent, 0, sizeof(newEvent));
+    XBMC_Event newEvent = {};
     newEvent.type = XBMC_QUIT;
     MessagePush(&newEvent);
   }
@@ -296,8 +294,7 @@ void CWinEventsWin10::OnWindowClosed(const CoreWindow& sender, const CoreWindowE
 
 void CWinEventsWin10::OnPointerPressed(const CoreWindow&, const PointerEventArgs& args)
 {
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
 
   PointerPoint point = args.CurrentPoint();
   auto position = GetScreenPoint(point.Position());
@@ -345,8 +342,7 @@ void CWinEventsWin10::OnPointerMoved(const CoreWindow&, const PointerEventArgs& 
     return;
   }
 
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
   newEvent.type = XBMC_MOUSEMOTION;
   newEvent.motion.x = position.X;
   newEvent.motion.y = position.Y;
@@ -364,8 +360,7 @@ void CWinEventsWin10::OnPointerReleased(const CoreWindow&, const PointerEventArg
     return;
   }
 
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
   newEvent.type = XBMC_MOUSEBUTTONUP;
   newEvent.button.x = position.X;
   newEvent.button.y = position.Y;
@@ -393,8 +388,7 @@ void CWinEventsWin10::OnPointerExited(const CoreWindow&, const PointerEventArgs&
 
 void CWinEventsWin10::OnPointerWheelChanged(const CoreWindow&, const PointerEventArgs& args)
 {
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
   newEvent.type = XBMC_MOUSEBUTTONDOWN;
   newEvent.button.x = args.CurrentPoint().Position().X;
   newEvent.button.y = args.CurrentPoint().Position().Y;
@@ -408,8 +402,7 @@ void CWinEventsWin10::Kodi_KeyEvent(unsigned int vkey, unsigned scancode, unsign
 {
   using State = CoreVirtualKeyStates;
 
-  XBMC_keysym keysym;
-  memset(&keysym, 0, sizeof(keysym));
+  XBMC_keysym keysym = {};
   keysym.scancode = scancode;
   keysym.sym = KODI::WINDOWING::WINDOWS::VK_keymap[vkey];
   keysym.unicode = keycode;
@@ -448,8 +441,7 @@ void CWinEventsWin10::Kodi_KeyEvent(unsigned int vkey, unsigned scancode, unsign
 
   keysym.mod = static_cast<XBMCMod>(mod);
 
-  XBMC_Event newEvent;
-  memset(&newEvent, 0, sizeof(newEvent));
+  XBMC_Event newEvent = {};
   newEvent.type = isDown ? XBMC_KEYDOWN : XBMC_KEYUP;
   newEvent.key.keysym = keysym;
   MessagePush(&newEvent);

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -906,7 +906,7 @@ void CWinEventsWin32::OnGesture(HWND hWnd, LPARAM lParam)
   if (!DX::Windowing()->PtrGetGestureInfo)
     return;
 
-  GESTUREINFO gi = {0};
+  GESTUREINFO gi = {};
   gi.cbSize = sizeof(gi);
   DX::Windowing()->PtrGetGestureInfo(reinterpret_cast<HGESTUREINFO>(lParam), &gi);
 

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -224,8 +224,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
 {
   using KODI::PLATFORM::WINDOWS::FromW;
 
-  XBMC_Event newEvent;
-  ZeroMemory(&newEvent, sizeof(newEvent));
+  XBMC_Event newEvent = {};
   static HDEVNOTIFY hDeviceNotify;
 
 #if 0
@@ -829,9 +828,8 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
 
 void CWinEventsWin32::RegisterDeviceInterfaceToHwnd(GUID InterfaceClassGuid, HWND hWnd, HDEVNOTIFY *hDeviceNotify)
 {
-  DEV_BROADCAST_DEVICEINTERFACE NotificationFilter;
+  DEV_BROADCAST_DEVICEINTERFACE NotificationFilter = {};
 
-  ZeroMemory( &NotificationFilter, sizeof(NotificationFilter) );
   NotificationFilter.dbcc_size = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
   NotificationFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
   NotificationFilter.dbcc_classguid = InterfaceClassGuid;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -721,8 +721,7 @@ RECT CWinSystemWin32::ScreenRect(HMONITOR handle)
     return RECT();
   }
 
-  DEVMODEW sDevMode;
-  ZeroMemory(&sDevMode, sizeof(sDevMode));
+  DEVMODEW sDevMode = {};
   sDevMode.dmSize = sizeof(sDevMode);
   if(!EnumDisplaySettingsW(details->DeviceNameW.c_str(), ENUM_CURRENT_SETTINGS, &sDevMode))
     CLog::LogF(LOGERROR, " EnumDisplaySettings failed with {}", GetLastError());
@@ -779,8 +778,7 @@ void CWinSystemWin32::GetConnectedDisplays(std::vector<MONITOR_DETAILS>& outputs
     if (foundScreen)
     {
       // get information about the display's current position and display mode
-      DEVMODEW dm;
-      ZeroMemory(&dm, sizeof(dm));
+      DEVMODEW dm = {};
       dm.dmSize = sizeof(dm);
       if (EnumDisplaySettingsExW(ddAdapter.DeviceName, ENUM_CURRENT_SETTINGS, &dm, 0) == FALSE)
         EnumDisplaySettingsExW(ddAdapter.DeviceName, ENUM_REGISTRY_SETTINGS, &dm, 0);

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -142,7 +142,7 @@ bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, 
   m_hIcon = LoadIcon(m_hInstance, MAKEINTRESOURCE(IDI_MAIN_ICON));
 
   // Register the windows class
-  WNDCLASSEX wndClass = { 0 };
+  WNDCLASSEX wndClass = {};
   wndClass.cbSize = sizeof(wndClass);
   wndClass.style = CS_HREDRAW | CS_VREDRAW;
   wndClass.lpfnWndProc = CWinEventsWin32::WndProc;
@@ -423,7 +423,7 @@ void CWinSystemWin32::AdjustWindow(bool forceResize)
 void CWinSystemWin32::CenterCursor() const
 {
   RECT rect;
-  POINT point = { 0 };
+  POINT point = {};
 
   //Gets the client rect, then translates it to screen coordinates
   //so that SetCursorPos isn't called with relative x and y values
@@ -742,7 +742,7 @@ void CWinSystemWin32::GetConnectedDisplays(std::vector<MONITOR_DETAILS>& outputs
   const POINT ptZero = { 0, 0 };
   HMONITOR hmPrimary = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
 
-  DISPLAY_DEVICEW ddAdapter = { 0 };
+  DISPLAY_DEVICEW ddAdapter = {};
   ddAdapter.cb = sizeof(ddAdapter);
 
   for (DWORD adapter = 0; EnumDisplayDevicesW(nullptr, adapter, &ddAdapter, 0); ++adapter)
@@ -753,7 +753,7 @@ void CWinSystemWin32::GetConnectedDisplays(std::vector<MONITOR_DETAILS>& outputs
       || !(ddAdapter.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP))
       continue;
 
-    DISPLAY_DEVICEW ddMon = { 0 };
+    DISPLAY_DEVICEW ddMon = {};
     ddMon.cb = sizeof(ddMon);
     bool foundScreen = false;
 
@@ -804,7 +804,7 @@ void CWinSystemWin32::GetConnectedDisplays(std::vector<MONITOR_DETAILS>& outputs
       md.Bpp = dm.dmBitsPerPel;
       md.Interlaced = (dm.dmDisplayFlags & DM_INTERLACED) ? true : false;
 
-      MONITORINFO mi = { 0 };
+      MONITORINFO mi = {};
       mi.cbSize = sizeof(mi);
       if (GetMonitorInfoW(hm, &mi) && (mi.dwFlags & MONITORINFOF_PRIMARY))
         md.IsPrimary = true;
@@ -819,7 +819,7 @@ bool CWinSystemWin32::ChangeResolution(const RESOLUTION_INFO& res, bool forceCha
   using KODI::PLATFORM::WINDOWS::ToW;
   std::wstring outputW = ToW(res.strOutput);
 
-  DEVMODEW sDevMode = { 0 };
+  DEVMODEW sDevMode = {};
   sDevMode.dmSize = sizeof(sDevMode);
 
   // If we can't read the current resolution or any detail of the resolution is different than res
@@ -850,7 +850,7 @@ bool CWinSystemWin32::ChangeResolution(const RESOLUTION_INFO& res, bool forceCha
                  static_cast<int>(res.fRefreshRate));
 
       // Get current resolution stored in registry
-      DEVMODEW sDevModeRegistry = { 0 };
+      DEVMODEW sDevModeRegistry = {};
       sDevModeRegistry.dmSize = sizeof(sDevModeRegistry);
       if (EnumDisplaySettingsW(outputW.c_str(), ENUM_REGISTRY_SETTINGS, &sDevModeRegistry))
       {
@@ -945,7 +945,7 @@ void CWinSystemWin32::UpdateResolutions()
 
   for(int mode = 0;; mode++)
   {
-    DEVMODEW devmode = { 0 };
+    DEVMODEW devmode = {};
     devmode.dmSize = sizeof(devmode);
     if(EnumDisplaySettingsW(details->DeviceNameW.c_str(), mode, &devmode) == 0)
       break;
@@ -1101,7 +1101,7 @@ void CWinSystemWin32::SetForegroundWindowInternal(HWND hWnd)
   if (!IsWindow(hWnd)) return;
 
   // if the window isn't focused, bring it to front or SetFullScreen will fail
-  BYTE keyState[256] = { 0 };
+  BYTE keyState[256] = {};
   // to unlock SetForegroundWindow we need to imitate Alt pressing
   if (GetKeyboardState(reinterpret_cast<LPBYTE>(&keyState)) && !(keyState[VK_MENU] & 0x80))
     keybd_event(VK_MENU, 0, KEYEVENTF_EXTENDEDKEY | 0, 0);
@@ -1182,7 +1182,7 @@ void CWinSystemWin32::NotifyAppFocusChange(bool bGaining)
     if (bGaining)
       SetWindowPos(m_hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOREDRAW);
 
-    RESOLUTION_INFO res = { 0 };
+    RESOLUTION_INFO res = {};
     const RESOLUTION resolution = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
     if (bGaining && resolution > RES_INVALID)
       res = CDisplaySettings::GetInstance().GetResolutionInfo(resolution);


### PR DESCRIPTION
## Description
 - Use c++ initializer {} in place of ZeroMemory and memset.
 - Unify {} format from `{0}`, `{ 0 }` and `{ }` to `{}` in all places.

## Motivation and context
Get a simpler code and less prone to making mistakes. It is not expected to fix any issue and it should not change the current behavior at all.

Divided on four commits for easy review:

- **Commit 1**: Use {} in place of ZeroMemory.
- **Commit 2**: Replace { 0 }, {0} and { } by {}.
- **Commit 3**: Use {} in place of memset(x, 0, sizeof(x)).
- ~**Commit 4**: [XBMC_event] add default initializer in struct and remove memset(event, 0, sizeof(event)).~


## How has this been tested?
Runtime tested (only Windows x64).


## What is the effect on users?
Nothing


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
