### PR TITLE
[tools/depends/target][python3] enable _multiprocessing module

### DIFF
--- a/cmake/modules/FindPython.cmake
+++ b/cmake/modules/FindPython.cmake
@@ -21,6 +21,10 @@ if(KODI_DEPENDSBUILD)
 
   if(NOT CORE_SYSTEM_NAME STREQUAL android)
     set(PYTHON_DEP_LIBRARIES pthread dl util)
+    if(CORE_SYSTEM_NAME STREQUAL linux)
+      # python archive built via depends requires librt for _posixshmem library
+      list(APPEND PYTHON_DEP_LIBRARIES rt)
+    endif()
   endif()
 
   set(PYTHON_LIBRARIES ${PYTHON_LIBRARY} ${FFI_LIBRARY} ${EXPAT_LIBRARY} ${INTL_LIBRARY} ${GMP_LIBRARY} ${PYTHON_DEP_LIBRARIES})

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -87,6 +87,7 @@ endif
 all: .installed-$(PLATFORM)
 
 gettext: $(ICONV)
+xz: gettext
 libgcrypt: libgpg-error
 fontconfig: freetype2 expat $(ICONV) $(LIBUUID)
 curl: openssl nghttp2

--- a/tools/depends/target/python3/Makefile
+++ b/tools/depends/target/python3/Makefile
@@ -60,6 +60,10 @@ ifeq ($(OS),android)
 else
 	cd $(PLATFORM); sed -ie 's|_locale -DPy_BUILD_CORE_BUILTIN _localemodule.c  # -lintl|_locale -DPy_BUILD_CORE_BUILTIN _localemodule.c   -lintl $(LINK_ICONV)|' Modules/Setup
 endif
+ifeq ($(OS),linux)
+	# _posixshmem module requires librt for linux for SHM_OPEN/SHM_UNLINK
+	cd $(PLATFORM); sed -ie 's|# -lrt # _posixshmem|-lrt # _posixshmem|' Modules/Setup
+endif
 ifeq ($(OS),osx)
 	echo "_scproxy \$$(srcdir)/Modules/_scproxy.c -framework SystemConfiguration -framework CoreFoundation" >> $(PLATFORM)/Modules/Setup
 endif

--- a/tools/depends/target/python3/modules.setup
+++ b/tools/depends/target/python3/modules.setup
@@ -254,6 +254,12 @@ _sha3 _sha3/sha3module.c
 # _blake module
 _blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c
 
+# _multiprocessing module
+_multiprocessing _multiprocessing/multiprocessing.c _multiprocessing/semaphore.c
+
+# _posixshmem module does not run on android platform due to missing primitives shm_open/shm_unlink
+_posixshmem _multiprocessing/posixshmem.c -I$(srcdir)/Modules/_multiprocessing # -lrt # _posixshmem
+
 # The _tkinter module.
 #
 # The command for _tkinter is long and site specific.  Please


### PR DESCRIPTION
## Description
Builds _multiprocessing and _posixshmem modules for tools/depends platforms.
Have flagged as a bugfix due to it being considered a "standard library" for python. Therefore ive flagged as backport needed. I'll raise that PR, and the powers that be can decide if they want to accept it as a backport.

https://github.com/xbmc/xbmc/pull/20034/commits/7b2d6fa8075f40432d69bf8e31add326492737b1 fixes a race condition for depends builds where xz may be built before gettext, although gettext is a dependecy of xz. Was brought to light in this PR by the 2 linux x86_64 jenkins builds repeatedly failing to link xz to libintl_gettext

## Motivation and context
fixes #20031
fixes #19458 

## How has this been tested?
OSX using test plugin provided by @zach-morris
Android aarch64 same test plugin


## What is the effect on users?
allows use of _multiprocessing module backed python modules (eg. concurrent.futures)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
