### PR TITLE
change explanation string for cddb

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19481,7 +19481,7 @@ msgstr ""
 #. Description of setting with label #227 "Load audio CD information from online service"
 #: system/settings/settings.xml
 msgctxt "#36284"
-msgid "Read the information belonging to an audio CD, like song title and artist, from the Internet database freedb.org."
+msgid "Read the information belonging to an audio CD, like song title and artist, from the Internet database gnudb.org."
 msgstr ""
 
 #. Description of setting label #20000 "Saved music folder"


### PR DESCRIPTION
According to 

https://github.com/xbmc/xbmc/blob/master/xbmc/settings/AdvancedSettings.cpp#L177

freedb.org doesn't seem to be the default anymore. Hence the string should be replaced as well ;)

