### PR TITLE
[clang-tidy] fix performance-* warnings

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace std::chrono;
@@ -74,7 +75,7 @@ bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
     // delim2 used to strip anything past the port
     const std::string delim1 = "://";
     const std::string delim2 = ":";
-    for (auto item : m_vecWSDInfo)
+    for (const auto& item : m_vecWSDInfo)
     {
       int found = item.xaddrs.find(delim1);
       if (found == std::string::npos)
@@ -102,7 +103,7 @@ void CWSDiscoveryPosix::SetItems(std::vector<wsd_req_info> entries)
 {
   {
     CSingleLock lock(m_critWSD);
-    m_vecWSDInfo = entries;
+    m_vecWSDInfo = std::move(entries);
   }
 }
 } // namespace WSDiscovery

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -85,7 +85,7 @@ bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
       // fallback incase xaddrs doesnt return back "GetMetadata" expected address format (delim2)
       if (found == std::string::npos)
       {
-        found = tmpxaddrs.find("/");
+        found = tmpxaddrs.find('/');
       }
       std::string host = tmpxaddrs.substr(0, found);
 

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -317,8 +317,8 @@ bool CWSDiscoveryListenerUDP::DispatchCommand()
   return true;
 }
 
-void CWSDiscoveryListenerUDP::AddCommand(const std::string message,
-                                         const std::string extraparameter /* = "" */)
+void CWSDiscoveryListenerUDP::AddCommand(const std::string& message,
+                                         const std::string& extraparameter /* = "" */)
 {
 
   CSingleLock lock(crit_commandqueue);
@@ -446,7 +446,7 @@ void CWSDiscoveryListenerUDP::ParseBuffer(const std::string& buffer)
 
 bool CWSDiscoveryListenerUDP::buildSoapMessage(const std::string& action,
                                                std::string& msg,
-                                               const std::string extraparameter)
+                                               const std::string& extraparameter)
 {
   auto msg_uuid = StringUtils::CreateUUID();
   std::string body;

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -492,7 +492,7 @@ template<std::size_t SIZE>
 const std::string CWSDiscoveryListenerUDP::wsd_tag_find(
     const std::string& xml, const std::array<std::pair<std::string, std::string>, SIZE>& tag)
 {
-  for (auto tagpair : tag)
+  for (const auto& tagpair : tag)
   {
     std::size_t found1 = xml.find(tagpair.first);
     if (found1 != std::string::npos)

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
@@ -55,7 +55,7 @@ private:
    * in        (string) extra data field (currently used solely for resolve addresses)
    * return    (void)
    */
-  void AddCommand(const std::string message, const std::string extraparameter = "");
+  void AddCommand(const std::string& message, const std::string& extraparameter = "");
 
   /*
    * Process received broadcast messages and add accepted items to 
@@ -73,7 +73,7 @@ private:
    */
   bool buildSoapMessage(const std::string& action,
                         std::string& msg,
-                        const std::string extraparameter);
+                        const std::string& extraparameter);
 
   // Closes socket and handles setting state for WS-Discovery
   void Cleanup(bool aborted);

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -353,7 +353,7 @@ CSettingList::CSettingList(const std::string& id,
                            std::shared_ptr<CSetting> settingDefinition,
                            int label,
                            CSettingsManager* settingsManager /* = nullptr */)
-  : CSettingList(id, settingDefinition, settingsManager)
+  : CSettingList(id, std::move(settingDefinition), settingsManager)
 {
   SetLabel(label);
 }


### PR DESCRIPTION
## Description
fix performance-* clang-tidy warnings

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
