### PR TITLE
[warnings] fixup assorted compiler warnings

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -520,8 +520,6 @@ long MysqlDatabase::nextid(const char* sname) {
     else
     {
       id = -1;
-      unsigned long *lengths;
-      lengths = mysql_fetch_lengths(res);
       snprintf(sqlcmd, sizeof(sqlcmd), "UPDATE %s SET nextid=%d WHERE seq_name = '%s'", seq_table,
                id, sname);
       mysql_free_result(res);

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -77,7 +77,7 @@ bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
     const std::string delim2 = ":";
     for (const auto& item : m_vecWSDInfo)
     {
-      int found = item.xaddrs.find(delim1);
+      auto found = item.xaddrs.find(delim1);
       if (found == std::string::npos)
         continue;
 

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -231,6 +231,9 @@ void CWSDiscoveryListenerUDP::Process()
     timeout.tv_usec = 0;
     nready = select((fd + 1), &rset, NULL, NULL, &timeout);
 
+    if (nready < 0)
+      break;
+
     if (m_bStop)
       break;
 


### PR DESCRIPTION
## Description
Fixes a couple compiler warnings (some introduced by me).

## Motivation and context
Fix the following warnings

```
xbmc/dbwrappers/mysqldataset.cpp:523:22: warning: variable ‘lengths’ set but not used [-Wunused-but-set-variable]
```
```
xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp:81:17: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
```
```
xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp:215:7: warning: variable ‘nready’ set but not used [-Wunused-but-set-variable]
```

## How has this been tested?
compiled

## What is the effect on users?


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
