### PR TITLE
[bp][addons] fix display logic for official/3rd party modules

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -752,9 +752,6 @@ void CGUIDialogAddonInfo::BuildDependencyList()
   m_deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(m_item->GetAddonInfo()->ID(),
                                                           OnlyEnabledRootAddon::NO);
 
-  const bool showAllDependencies =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_showAllDependencies;
-
   for (const auto& dep : m_deps)
   {
     std::shared_ptr<IAddon> addonInstalled;
@@ -781,8 +778,7 @@ void CGUIDialogAddonInfo::BuildDependencyList()
       // - dependencies are unavailable (for informational purposes) OR
       // - the dependency is not a script/module                     OR
       // - the script/module is not available at an official repo
-      if (showAllDependencies || !addonAvailable ||
-          addonAvailable->MainType() != ADDON_SCRIPT_MODULE ||
+      if (!addonAvailable || addonAvailable->MainType() != ADDON_SCRIPT_MODULE ||
           !CAddonRepos::IsFromOfficialRepo(addonAvailable, CheckAddonPath::NO))
       {
         m_showDepDialogOnInstall = true;

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -796,19 +796,19 @@ void CGUIDialogAddonInfo::BuildDependencyList()
 
     m_depsInstalledWithAvailable.emplace_back(
         CInstalledWithAvailable{dep, addonInstalled, addonAvailable});
-
-    // sort criteria in dialog:
-    // 1. optional add-ons to top
-    // 2. scripts/modules to bottom
-    std::sort(m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
-              [](const auto& a, const auto& b) {
-                if (a.m_depInfo.optional != b.m_depInfo.optional)
-                {
-                  return a.m_depInfo.optional;
-                }
-
-                const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
-                return (depA && depA->MainType() != ADDON_SCRIPT_MODULE);
-              });
   }
+
+  // sort criteria in dialog:
+  // 1. optional add-ons to top
+  // 2. scripts/modules to bottom
+  std::sort(m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
+            [](const auto& a, const auto& b) {
+              if (a.m_depInfo.optional != b.m_depInfo.optional)
+              {
+                return a.m_depInfo.optional;
+              }
+
+              const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
+              return (depA && depA->MainType() != ADDON_SCRIPT_MODULE);
+            });
 }

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -15,6 +15,7 @@
 #include "addons/AddonDatabase.h"
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
+#include "addons/AddonRepos.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/IAddon.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
@@ -646,15 +647,20 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
             }
           }
 
-          item->SetLabel2(StringUtils::Format(
-              g_localizeStrings.Get(messageId).c_str(), it.m_depInfo.versionMin.asString().c_str(),
-              it.m_installed ? it.m_installed->Version().asString().c_str() : "",
-              it.m_available ? it.m_available->Version().asString().c_str() : "",
-              it.m_depInfo.optional ? g_localizeStrings.Get(24184).c_str() : ""));
+          if (entryPoint == EntryPoint::SHOW_DEPENDENCIES ||
+              infoAddon->MainType() != ADDON_SCRIPT_MODULE ||
+              !CAddonRepos::IsFromOfficialRepo(infoAddon, CheckAddonPath::NO))
+          {
+            item->SetLabel2(StringUtils::Format(
+                g_localizeStrings.Get(messageId), it.m_depInfo.versionMin.asString(),
+                it.m_installed ? it.m_installed->Version().asString() : "",
+                it.m_available ? it.m_available->Version().asString() : "",
+                it.m_depInfo.optional ? g_localizeStrings.Get(24184) : ""));
 
-          item->SetArt("icon", infoAddon->Icon());
-          item->SetProperty("addon_id", it.m_depInfo.id);
-          items.Add(item);
+            item->SetArt("icon", infoAddon->Icon());
+            item->SetProperty("addon_id", it.m_depInfo.id);
+            items.Add(item);
+          }
         }
       }
       else
@@ -769,33 +775,44 @@ void CGUIDialogAddonInfo::BuildDependencyList()
 
     if (!addonInstalled)
     {
-      // after pushing the install button the dependency install dialog will
-      // pop up only if non-module dependencies are going to be installed or
-      // dependencies are unavailable. the latter is for informational purposes
 
+      // after pushing the install button the dependency install dialog
+      // will be opened only if...
+      // - dependencies are unavailable (for informational purposes) OR
+      // - the dependency is not a script/module                     OR
+      // - the script/module is not available at an official repo
       if (showAllDependencies || !addonAvailable ||
-          addonAvailable->MainType() != ADDON_SCRIPT_MODULE)
+          addonAvailable->MainType() != ADDON_SCRIPT_MODULE ||
+          !CAddonRepos::IsFromOfficialRepo(addonAvailable, CheckAddonPath::NO))
+      {
+        m_showDepDialogOnInstall = true;
+      }
+    }
+    else
+    {
+
+      // only display dialog if updates for already installed dependencies will install
+      if (addonAvailable && addonAvailable->Version() > addonInstalled->Version())
       {
         m_showDepDialogOnInstall = true;
       }
     }
 
-    // AddonType ADDON_SCRIPT_MODULE needs to be filtered as these low-level add-ons
-    // should be hidden to the user in the dependency select dialog
+    m_depsInstalledWithAvailable.emplace_back(
+        CInstalledWithAvailable{dep, addonInstalled, addonAvailable});
 
-    if (showAllDependencies ||
-        (addonInstalled && addonInstalled->MainType() != ADDON_SCRIPT_MODULE) ||
-        (addonAvailable && addonAvailable->MainType() != ADDON_SCRIPT_MODULE) ||
-        (!addonAvailable && !addonInstalled))
-    {
-      m_depsInstalledWithAvailable.emplace_back(
-          CInstalledWithAvailable{dep, addonInstalled, addonAvailable});
-    }
+    // sort criteria in dialog:
+    // 1. optional add-ons to top
+    // 2. scripts/modules to bottom
+    std::sort(m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
+              [](const auto& a, const auto& b) {
+                if (a.m_depInfo.optional != b.m_depInfo.optional)
+                {
+                  return a.m_depInfo.optional;
+                }
 
-    // sort optional add-ons to top of the list
-
-    std::sort(
-        m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
-        [](const auto& a, const auto& b) { return a.m_depInfo.optional > b.m_depInfo.optional; });
+                const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
+                return (depA && depA->MainType() != ADDON_SCRIPT_MODULE);
+              });
   }
 }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -349,7 +349,6 @@ void CAdvancedSettings::Initialize()
 #endif
   m_showExitButton = true;
   m_splashImage = true;
-  m_showAllDependencies = false;
 
   m_playlistRetries = 100;
   m_playlistTimeout = 20; // 20 seconds timeout
@@ -897,7 +896,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   XMLUtils::GetBoolean(pRootElement, "fullscreen", m_startFullScreen);
 #endif
   XMLUtils::GetBoolean(pRootElement, "splash", m_splashImage);
-  XMLUtils::GetBoolean(pRootElement, "showalldependencies", m_showAllDependencies);
   XMLUtils::GetBoolean(pRootElement, "showexitbutton", m_showExitButton);
   XMLUtils::GetBoolean(pRootElement, "canwindowed", m_canWindowed);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -302,12 +302,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_GLRectangleHack;
     int m_iSkipLoopFilter;
 
-    /*!< @brief Decision flag to show or hide specific dependencies in the list of the AddonInfo dialog
-    as this information usually adds no value for a consumer.
-    True to recursively show any dependency of the selected add-on
-    False to hide 'low-level' dependencies like e.g. scripts/modules (default) */
-    bool m_showAllDependencies;
-
     bool m_bVirtualShares;
     bool m_bTry10bitOutput;
 


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/19805

fixes display logic of the dependency info dialog and deprecates the advanced setting `<showalldependencies>` like it was done on master. documenting the setting in the wiki would be obsolete then so i'd suggest including this into Matrix.

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
