### PR TITLE
[Music] Fix grouping discs by subtitle if first disc has one

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5558,7 +5558,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
     items.Reserve(total);
     int albumOffset = 2;
     CAlbum album;
-    bool useTitle = false;
+    bool useTitle = true; // Assume we want to match by disc title later unless we have no titles
     std::string oldDiscTitle;
     const dbiplus::query_data& data = m_pDS->get_result_set().records;
     for (const auto& i : results)
@@ -5569,23 +5569,22 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
       {
         if (album.idAlbum != record->at(albumOffset + album_idAlbum).get_asInt())
         { // New album
-          useTitle = false;
+          useTitle = true;
           album = GetAlbumFromDataset(record, albumOffset);
         }
 
         int discnum = record->at(0).get_asInt();
         std::string strDiscSubtitle = record->at(1).get_asString();
         if (strDiscSubtitle.empty())
-          // Make (fake) disc title from disc number
-          strDiscSubtitle = StringUtils::Format("%s %i", g_localizeStrings.Get(427), discnum);
+        { // Make (fake) disc title from disc number, group by disc number as no real title to match
+          strDiscSubtitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), discnum);
+          useTitle = false;
+        }
         else if (oldDiscTitle == strDiscSubtitle)
-        { // When real disc titles are provided (as they ALWAYS are for boxed sets)
-          // group discs together by title not number.
-          useTitle = true;
+        { // disc title already added to list, fetch the next disc
           continue;
         }
-        else
-          oldDiscTitle = strDiscSubtitle;
+        oldDiscTitle = strDiscSubtitle;
 
         CMusicDbUrl itemUrl = musicUrl;
         std::string path = StringUtils::Format("%i/", discnum);


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20052

## What is the effect on users?
Fixes an issue with boxed sets where the first two discs could not be combined into one by using the same disc title for both discs.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
