### PR TITLE
[addons] sync service.xbmc.versioncheck with repo

### DIFF
--- a/addons/service.xbmc.versioncheck/addon.xml
+++ b/addons/service.xbmc.versioncheck/addon.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.xbmc.versioncheck" name="Version Check" version="0.5.9+matrix.1" provider-name="Team Kodi">
+<addon id="service.xbmc.versioncheck" name="Version Check" version="0.5.19+matrix.1" provider-name="Team Kodi">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
     <extension point="xbmc.service" library="resources/lib/runner.py"/>
     <extension point="xbmc.addon.metadata">
         <news>
-- add Kodi 18.9 release
-- fixup Kodi 19 pre alpha2 translatePath
+- add Kodi 19.1 release
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.af_za/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.af_za/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Afrikaans (http://www.transifex.com/projects/p/xbmc-addons/language/af/)\n"
+"Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: af\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Algemeen"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.am_et/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.am_et/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Amharic (http://www.transifex.com/projects/p/xbmc-addons/language/am/)\n"
+"Language: am\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: am\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "ባጠቃላይ"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ar_sa/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ar_sa/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Arabic (http://www.transifex.com/projects/p/xbmc-addons/language/ar/)\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ar\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "عام"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ar_ye/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ar_ye/strings.po
@@ -1,0 +1,124 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ar_ye\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ast_es/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ast_es/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ast_es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.az_az/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.az_az/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: az_az\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.be_by/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.be_by/strings.po
@@ -7,59 +7,116 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Belarusian (http://www.transifex.com/projects/p/xbmc-addons/language/be/)\n"
+"PO-Revision-Date: 2021-04-30 09:25+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Belarusian <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/be_by/>\n"
+"Language: be_by\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: be\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 4.6\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
-msgstr "We would like to recommend you to upgrade."
+msgstr ""
 
 msgctxt "#32002"
 msgid "Visit Kodi.tv for more information."
-msgstr "Visit Kodi.tv for more information."
+msgstr ""
 
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
-msgstr "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
 
 msgctxt "#32011"
 msgid "Use your package manager(apt) to upgrade."
-msgstr "Use your package manager(apt) to upgrade."
+msgstr ""
 
 msgctxt "#32012"
 msgid "A new version is available, do you want to upgrade now?"
-msgstr "A new version is available, do you want to upgrade now?"
+msgstr ""
 
 msgctxt "#32013"
 msgid "Upgrade successful"
-msgstr "Upgrade successful"
+msgstr ""
 
 msgctxt "#32014"
 msgid "Do you want to restart Kodi to finish the upgrade?"
-msgstr "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
 
 msgctxt "#32015"
 msgid "Do you want to check the repository for a new version?"
-msgstr "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
-msgstr "General"
+msgstr "Асноўныя"
 
 msgctxt "#32021"
 msgid "Enable Kodi version check?"
-msgstr "Enable Kodi version check?"
+msgstr ""
 
 msgctxt "#32022"
 msgid "Please enter your password"
-msgstr "Please enter your password"
+msgstr ""
 
 msgctxt "#32023"
 msgid "Linux: Upgrade complete system"
-msgstr "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.bg_bg/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.bg_bg/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Bulgarian (http://www.transifex.com/projects/p/xbmc-addons/language/bg/)\n"
+"PO-Revision-Date: 2021-04-30 09:25+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Bulgarian <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/bg_bg/>\n"
+"Language: bg_bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -34,7 +35,7 @@ msgstr "Можете да включите/изключите напомняне
 
 msgctxt "#32011"
 msgid "Use your package manager(apt) to upgrade."
-msgstr "Актуализирайте чрез вашия диспечер на пакети  (apt)."
+msgstr "Актуализирайте чрез вашия диспечер на пакети (apt)."
 
 msgctxt "#32012"
 msgid "A new version is available, do you want to upgrade now?"
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Линукс: Актуализиране чрез apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Налична е нова стабилна версия на Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "За повече информация посетете www.kodi.tv"
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Налична е нова стабилна версия на Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "За повече информация посетете www.kodi.tv"
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "В момента ползвате версия %s, при налична %s."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Препоръчително е да актуализирате до по-нова версия."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.bs_ba/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.bs_ba/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Bosnian (http://www.transifex.com/projects/p/xbmc-addons/language/bs/)\n"
+"Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bs\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Opšte"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ca_es/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ca_es/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Catalan (http://www.transifex.com/projects/p/xbmc-addons/language/ca/)\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -27,6 +27,10 @@ msgstr "Visita Kodi.tv per més informació."
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
 msgstr "Vols eliminar aquest recordatori?"
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
 
 msgctxt "#32011"
 msgid "Use your package manager(apt) to upgrade."
@@ -48,6 +52,10 @@ msgctxt "#32015"
 msgid "Do you want to check the repository for a new version?"
 msgstr "Vols comprovar el repositori per buscar una versió nova?"
 
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
 msgctxt "#32020"
 msgid "General"
 msgstr "General"
@@ -63,3 +71,51 @@ msgstr "Si us plau indtroduïu la contrasenya"
 msgctxt "#32023"
 msgid "Linux: Upgrade complete system"
 msgstr "Linux: Actualitzar tot el sistema"
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.cs_cz/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.cs_cz/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Czech (http://www.transifex.com/projects/p/xbmc-addons/language/cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aktualizace za použití apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Je k dispozici nová stabilní verze Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Navštivte http://kodi.tv pro více informací."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Je k dispozici nová stabilní verze Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Navštivte http://kodi.tv pro více informací."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Používáte %s zatímco je %s k dispozici."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Je doporučeno upgradovat na novější verzi."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.cy_gb/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.cy_gb/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Welsh (http://www.transifex.com/projects/p/xbmc-addons/language/cy/)\n"
+"Language: cy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cy\n"
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Cyffredinol"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.da_dk/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.da_dk/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Danish (http://www.transifex.com/projects/p/xbmc-addons/language/da/)\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Opgrader ved brug af apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Der er en ny stabil version af Kodi tilgængelig."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Besøg http://kodi.tv for mere information."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Der er en ny stabil version af Kodi tilgængelig."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Besøg http://kodi.tv for mere information."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Du benytter %s, mens %s er tilgængelig."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Det anbefales at du opdaterer til en nyere version."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.de_de/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.de_de/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: German (http://www.transifex.com/projects/p/xbmc-addons/language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aktualisierung durch apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Eine neue stabile Kodi-Version ist verfügbar."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Besuchen Sie http://kodi.tv für mehr Informationen."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Eine neue stabile Kodi-Version ist verfügbar."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Besuchen Sie http://kodi.tv für mehr Informationen."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "%s wird verwendet, obwohl %s verfügbar ist."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Es wird empfohlen, dass Sie auf eine neuere Version aktualisieren."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.el_gr/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.el_gr/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Greek (http://www.transifex.com/projects/p/xbmc-addons/language/el/)\n"
+"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Αναβάθμιση με χρήση apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Είναι διαθέσιμη νεώτερη σταθερή έκδοση του Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Επισκεφθείτε το http://kodi.tv για περισσότερες πληροφορίες."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Είναι διαθέσιμη νεώτερη σταθερή έκδοση του Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Επισκεφθείτε το http://kodi.tv για περισσότερες πληροφορίες."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Χρησιμοποιείτε την έκδοση %s ενώ είναι διαθέσιμη η %s."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Προτείνεται η αναβάθμιση σε νεώτερη έκδοση."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.en_au/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.en_au/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: English (Australia) (http://www.transifex.com/projects/p/xbmc-addons/language/en_AU/)\n"
+"Language: en_AU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_AU\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "General"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.en_nz/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.en_nz/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: English (New Zealand) (http://www.transifex.com/projects/p/xbmc-addons/language/en_NZ/)\n"
+"Language: en_NZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_NZ\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Upgrade using apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "A new stable version of Kodi is available."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visit http://kodi.tv for more information."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "A new stable version of Kodi is available."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visit http://kodi.tv for more information."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Using %s while %s is available."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "It is recommended that you to upgrade to a newer version."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.en_us/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.en_us/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: English (US) (http://www.transifex.com/projects/p/xbmc-addons/language/en_US/)\n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_US\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Upgrade using apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "A new stable version of Kodi is available."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visit http://kodi.tv for more information."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "A new stable version of Kodi is available."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visit http://kodi.tv for more information."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Using %s while %s is available."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "It is recommended that you to upgrade to a newer version."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.eo/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.eo/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Esperanto (http://www.transifex.com/projects/p/xbmc-addons/language/eo/)\n"
+"Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Generalo"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.es_ar/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.es_ar/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/projects/p/xbmc-addons/language/es_AR/)\n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_AR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "General"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.es_es/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.es_es/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/xbmc-addons/language/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizar usado apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Una nueva versión estable de Kodi está disponible."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visite http://kodi.tv para más información."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Una nueva versión estable de Kodi está disponible."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visite http://kodi.tv para más información."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Usando %s mientras que %s está disponible."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Se recomienda que actualice a una nueva versión."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.es_mx/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.es_mx/strings.po
@@ -7,27 +7,116 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Spanish (Mexico) (http://www.transifex.com/projects/p/xbmc-addons/language/es_MX/)\n"
+"PO-Revision-Date: 2021-02-20 02:28+0000\n"
+"Last-Translator: Edson Armando <edsonarmando78@outlook.com>\n"
+"Language-Team: Spanish (Mexico) <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/es_mx/>\n"
+"Language: es_mx\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_MX\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.4.2\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
-msgstr "Nos gustaria recomendarle actualizar."
+msgstr "Nos gustaría recomendarte que actualices."
 
 msgctxt "#32002"
 msgid "Visit Kodi.tv for more information."
-msgstr "Visita Kodi.tv para mas informacion."
+msgstr "Visita Kodi.tv para mas información."
 
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
-msgstr "Usted quiere remover este recordatorio?"
+msgstr "¿Quieres eliminar este recordatorio?"
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr "Puedes activarlo/desactivarlo en la configuración del complemento."
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr "Utiliza tu gestor de paquetes (apt) para actualizar."
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr "Una nueva versión está disponible, ¿quieres actualizar ahora?"
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr "Actualización exitosa"
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr "¿Quieres reiniciar Kodi para finalizar la actualización?"
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr "¿Quieres buscar nuevas versiones en el repositorio?"
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr "Hay una nueva versión estable de Kodi disponible."
 
 msgctxt "#32020"
 msgid "General"
 msgstr "General"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr "¿Activar la comprobación de versión de Kodi?"
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr "Por favor ingresa tu contraseña"
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr "Linux: Actualizar el sistema completo"
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr "Linux: Actualizar utilizando apt"
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr "Una nueva versión estable de Kodi está disponible."
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr "Visita http://kodi.tv para más información."
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr "Una nueva versión estable de Kodi está disponible."
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr "Visita http://kodi.tv para más información."
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr "Utilizando versión %s mientras la %s está disponible."
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr "Es recomendable que actualices a una nueva versión."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr "Tu versión %s del módulo de criptografía de Python es muy antigua. Necesitas al menos la versión 1.7."
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr "Por favor actualiza tu sistema operativo."
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr "Para más información, visita https://kodi.wiki/view/Linux"

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.et_ee/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.et_ee/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Estonian (http://www.transifex.com/projects/p/xbmc-addons/language/et/)\n"
+"Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Üldine"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.eu_es/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.eu_es/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Basque (http://www.transifex.com/projects/p/xbmc-addons/language/eu/)\n"
+"Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Orokorra"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.fa_af/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.fa_af/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Persian (http://www.transifex.com/projects/p/xbmc-addons/language/fa/)\n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fa\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "عمومی"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.fa_ir/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.fa_ir/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/projects/p/xbmc-addons/language/fa_IR/)\n"
+"Language: fa_IR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fa_IR\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "عمومی"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.fi_fi/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.fi_fi/strings.po
@@ -10,11 +10,36 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Finnish (http://www.transifex.com/projects/p/xbmc-addons/language/fi/)\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
 
 msgctxt "#32013"
 msgid "Upgrade successful"
@@ -23,6 +48,10 @@ msgstr "Päivitys onnistui"
 msgctxt "#32014"
 msgid "Do you want to restart Kodi to finish the upgrade?"
 msgstr "Haluatko käynnistää Kodin viimeistellääksesi päivityksen?"
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
 
 msgctxt "#32016"
 msgid "There is a newer stable Kodi version available."
@@ -40,26 +69,53 @@ msgctxt "#32022"
 msgid "Please enter your password"
 msgstr "Ole hyvä ja syötä salasanasi"
 
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Uusi stable-versio on saatavilla Kodista."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Käy http://kodi.tv saadaksesi lisätietoa"
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Uusi stable-versio on saatavilla Kodista."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Käy http://kodi.tv saadaksesi lisätietoa"
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Käytät %s , mutta %s on saatavilla."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "On suositeltavaa, että päivität uudempaan versioon."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.fo_fo/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.fo_fo/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Faroese (http://www.transifex.com/projects/p/xbmc-addons/language/fo/)\n"
+"Language: fo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Vanligt"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.fr_ca/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.fr_ca/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: French (Canada) (http://www.transifex.com/projects/p/xbmc-addons/language/fr_CA/)\n"
+"Language: fr_CA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr_CA\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux : mettre à niveau en utilisant apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Une nouvelle version stable de Kodi est proposée."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visitez http://kodi.tv pour plus d'informations."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Une nouvelle version de Kodi est proposée."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visitez http://kodi.tv pour plus d'informations."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "%s est utilisée alors que %s est proposée."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Il vous est recommandé de mettre à niveau vers une nouvelle version."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.fr_fr/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.fr_fr/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: French (http://www.transifex.com/projects/p/xbmc-addons/language/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux : mettre à niveau en utilisant apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Une nouvelle version stable de Kodi est disponible."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Consulter http://kodi.tv pour plus d'informations."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Une nouvelle version stable de Kodi est disponible."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Consulter http://kodi.tv pour plus d'informations."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "%s est utilisée alors que %s est disponible."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Il est recommandé de mettre à niveau vers une nouvelle version."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.gl_es/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.gl_es/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Galician (http://www.transifex.com/projects/p/xbmc-addons/language/gl/)\n"
+"PO-Revision-Date: 2021-04-30 09:25+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Galician (Spain) <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/gl_es/>\n"
+"Language: gl_es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: gl\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizar empregando apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
-msgstr "Está dispoñible unha versión estable nova de Kodi. "
+msgstr "Está dispoñible unha versión estable nova de Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Ir a http://kodi.tv para máis información."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
-msgstr "Está dispoñíbel unha nova versión estábel de Kodi. "
+msgstr "Está dispoñíbel unha nova versión estábel de Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Ir a http://kodi.tv para máis información."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Está a empregar a versión %s mentres que a %s está dispoñíbel."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "É recomendábel actualizar á nova versión."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.he_il/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.he_il/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Hebrew (http://www.transifex.com/projects/p/xbmc-addons/language/he/)\n"
+"PO-Revision-Date: 2021-04-30 09:25+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Hebrew (Israel) <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/he_il/>\n"
+"Language: he_il\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: he\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Weblate 4.6\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -54,7 +55,7 @@ msgstr "התרצה לבדוק האם זמינה גרסה חדשה במאגר?"
 
 msgctxt "#32016"
 msgid "There is a newer stable Kodi version available."
-msgstr "קיימת גרסה יציבה חדשה של קודי זמינה להורדה "
+msgstr "קיימת גרסה יציבה חדשה של קודי זמינה להורדה"
 
 msgctxt "#32020"
 msgid "General"
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "לינוקס: שדרוג באמצעות apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "גרסה יציבה חדשה של קודי זמינה."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "בקר ב-http://kodi.tv למידע נוסף."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "גרסה יציבה חדשה של קודי זמינה."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "בקר ב-http://kodi.tv למידע נוסף."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "שימוש ב%s בעוד %s זמין."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "מומלץ לך לשדרג לגרסה חדשה יותר."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.hi_in/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.hi_in/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Hindi (Devanagiri) (http://www.transifex.com/projects/p/xbmc-addons/language/hi/)\n"
+"Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "सामान्य"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.hr_hr/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.hr_hr/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Croatian (http://www.transifex.com/projects/p/xbmc-addons/language/hr/)\n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hr\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: ažurirajte koristeći 'apt'"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Dostupna je novija stabilna inačica Kodija."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Posjetite http://kodi.tv za više informacija."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Dostupna je novija stabilna inačica Kodija."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Posjetite http://kodi.tv za više informacija."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Koristite %s dok je %s dostupna."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Preporučljivo je da nadogradite na noviju inačicu."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.hu_hu/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.hu_hu/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Hungarian (http://www.transifex.com/projects/p/xbmc-addons/language/hu/)\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Frissítés apt segítségével"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Újabb stabil Kodi kiadás elérhető."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "További információkért keresse fel az http://kodi.tv oldalt!"
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Újabb stabil Kodi kiadás elérhető."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "További információkért keresse fel az http://kodi.tv."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "%s használata mialatt %s elérhető."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Javasolt a hogy frissítsen az újabb változatra."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.hy_am/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.hy_am/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Armenian (http://www.transifex.com/projects/p/xbmc-addons/language/hy/)\n"
+"Language: hy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hy\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Գլխավոր"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.id_id/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.id_id/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Indonesian (http://www.transifex.com/projects/p/xbmc-addons/language/id/)\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32001"
@@ -27,6 +27,10 @@ msgstr "Kunjungi Kodi.tv untuk informasi lebih lanjut."
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
 msgstr "Apakah anda ingin menghapus pengingat ini?"
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
 
 msgctxt "#32011"
 msgid "Use your package manager(apt) to upgrade."
@@ -71,3 +75,47 @@ msgstr "Linux: Upgrade sistem seluruhnya"
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Perbarui menggunakan apt"
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.is_is/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.is_is/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Icelandic (http://www.transifex.com/projects/p/xbmc-addons/language/is/)\n"
+"PO-Revision-Date: 2021-04-30 09:25+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Icelandic <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/is_is/>\n"
+"Language: is_is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: is\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Weblate 4.6\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -27,6 +28,10 @@ msgstr "Farðu inn á Kodi.tv til að fá fleiri upplýsingar."
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
 msgstr "Viltu fjarlægja þessa áminningu ?"
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
 
 msgctxt "#32011"
 msgid "Use your package manager(apt) to upgrade."
@@ -42,7 +47,7 @@ msgstr "Uppfærsla heppnaðist"
 
 msgctxt "#32014"
 msgid "Do you want to restart Kodi to finish the upgrade?"
-msgstr "Viltu endurræsa  Kodi til að ljúka uppfærslu ?"
+msgstr "Viltu endurræsa Kodi til að ljúka uppfærslu ?"
 
 msgctxt "#32015"
 msgid "Do you want to check the repository for a new version?"
@@ -71,3 +76,47 @@ msgstr "Linux: Uppfærðu allt kerfið"
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Uppfærðu með apt"
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.it_it/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.it_it/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Italian (http://www.transifex.com/projects/p/xbmc-addons/language/it/)\n"
+"PO-Revision-Date: 2021-04-30 09:25+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Italian <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/it_it/>\n"
+"Language: it_it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.6\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aggiorna utilizzando apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
-msgstr "Una nuova versione stabile di di Kodi è disponibile "
+msgstr "Una nuova versione stabile di Kodi è disponibile."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visita http://kodi.tv per più informazioni."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
-msgstr "Una nuova versione stabile di di Kodi è disponibile."
+msgstr "Una nuova versione stabile di Kodi è disponibile."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visita http://kodi.tv per più informazioni."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Usa %s mentre %s è disponibile."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "E' raccomandato che tu aggiorni ad una nuova versione."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ja_jp/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ja_jp/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Japanese (http://www.transifex.com/projects/p/xbmc-addons/language/ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "一般"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.kn_in/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.kn_in/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: kn_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ko_kr/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ko_kr/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Korean (http://www.transifex.com/projects/p/xbmc-addons/language/ko/)\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "리눅스: apt를 사용하여 업그레이드"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "안정적인 Kodi 새 버전을 사용할 수 있습니다."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "자세한 정보는 http://kodi.tv를 방문하세요."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "안정적인 Kodi 새 버전을 사용할 수 있습니다."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "자세한 정보는 http://kodi.tv를 방문하세요."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "현재 사용 중인 버전은 %s 이며 최신 버전 %s 을(를) 사용할 수 있습니다"
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "새 버전으로 업그레이드 하기를 권장합니다."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.lt_lt/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.lt_lt/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Lithuanian (http://www.transifex.com/projects/p/xbmc-addons/language/lt/)\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lt\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: atnaujinti naudojant apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Galima nauja Kodi versija."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Apsilankykite http://kodi.tv, norėdami gauti daugiau informacijos."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Galima nauja stabili Kodi versija."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Apsilankykite http://kodi.tv, norėdami gauti daugiau informacijos."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Naudojama %s, kai yra prieinama %s."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Rekomenduojama atnaujinti į naujesnę versiją."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.lv_lv/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.lv_lv/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Latvian (http://www.transifex.com/projects/p/xbmc-addons/language/lv/)\n"
+"Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lv\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Vispārīgi"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.mi/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.mi/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.mk_mk/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.mk_mk/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Macedonian (http://www.transifex.com/projects/p/xbmc-addons/language/mk/)\n"
+"Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mk\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Општо"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ml_in/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ml_in/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Malayalam (http://www.transifex.com/projects/p/xbmc-addons/language/ml/)\n"
+"Language: ml\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ml\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "പോതുവായത്"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.mn_mn/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.mn_mn/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Mongolian (Mongolia) (http://www.transifex.com/projects/p/xbmc-addons/language/mn_MN/)\n"
+"Language: mn_MN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mn_MN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Ерөнхий"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ms_my/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ms_my/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Malay (http://www.transifex.com/projects/p/xbmc-addons/language/ms/)\n"
+"Language: ms\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ms\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Am"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.mt_mt/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.mt_mt/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Maltese (http://www.transifex.com/projects/p/xbmc-addons/language/mt/)\n"
+"Language: mt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mt\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Ġenerali"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.my_mm/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.my_mm/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Burmese (http://www.transifex.com/projects/p/xbmc-addons/language/my/)\n"
+"Language: my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: my\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "ယေဘုယျ"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.nb_no/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.nb_no/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Norwegian (http://www.transifex.com/projects/p/xbmc-addons/language/no/)\n"
+"Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: no\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Oppgrader med apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "En ny stabil versjon av Kodi er tilgjengelig."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Se http://kodi.tv for mer informasjon."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "En ny stabil versjon av Kodi er tilgjengelig."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Se http://kodi.tv for mer informasjon."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Bruker %s mens %s er tilgjengelig."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Det er anbefalt å oppgradere til en nyere versjon."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.nl_nl/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.nl_nl/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/xbmc-addons/language/nl/)\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Upgrade gebruikt apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Een nieuwe stabiele versie van Kodi is beschikbaar."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Bezoek http://kodi.tv voor meer informatie."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Een nieuwe stabiele versie van Kodi is beschikbaar."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Bezoek Http://kodi.tv voor meer informatie."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "In gebruik %s terwijl %s beschikbaar is."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Het is aanbevolen dat je upgrade naar een nieuwere versie."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.oc_fr/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.oc_fr/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: oc_fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.os_os/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.os_os/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: os_os\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.pl_pl/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.pl_pl/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Polish (http://www.transifex.com/projects/p/xbmc-addons/language/pl/)\n"
+"PO-Revision-Date: 2021-02-07 10:28+0000\n"
+"Last-Translator: bkiziuk <kiziuk@gmail.com>\n"
+"Language-Team: Polish <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/pl_pl/>\n"
+"Language: pl_pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.4.2\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -54,7 +55,7 @@ msgstr "Czy chcesz sprawdzić repozytorium czy jest nowa wersja?"
 
 msgctxt "#32016"
 msgid "There is a newer stable Kodi version available."
-msgstr "Dostępna jest nowa stabilna wersja Kodi"
+msgstr "Dostępna jest nowa stabilna wersja Kodi."
 
 msgctxt "#32020"
 msgid "General"
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aktualizuj za pomocą menadżera pakietów (apt)"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Dostępna jest nowa, stabilna wersja Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Odwiedź stronę http://kodi.tv po więcej informacji."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Dostępna jest nowa, stabilna wersja Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Odwiedź stronę http://kodi.tv po więcej informacji."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Korzystasz z %s a dostępna jest już wersja %s."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Zaleca się uaktualnienie do nowszej wersji."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr "Wersja %s modułu kryptograficznego Python'a jest zbyt stara. Wymagana jest co najmniej wersja 1.7."
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr "Dokonaj uaktualnienia systemu operacyjnego."
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr "Aby znaleźć więcej informacji, odwiedź https://kodi.wiki/view/Linux"

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.pt_br/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.pt_br/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/xbmc-addons/language/pt_BR/)\n"
+"PO-Revision-Date: 2021-02-12 14:28+0000\n"
+"Last-Translator: Wanilton Campos <admin@mediabrasil.tv>\n"
+"Language-Team: Portuguese (Brazil) <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/pt_br/>\n"
+"Language: pt_br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.4.2\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Atualizar usando apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Uma nova versão estável do Kodi se encontra disponível."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "visite http://kodi.tv para maiores informações."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Uma nova versão estável do Kodi se encontra disponível."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visite http://kodi.tv para maiores informações."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Usando %s enquanto %s está disponível."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Recomendável que você atualize para versão mais recente."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr "Sua versão %s do módulo de criptografia Python é muito antiga. Você precisa ao menos a versão 1.7."
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr "Atualize seu sistema operacional."
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr "Para mais informações, veja https://kodi.wiki/view/Linux"

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.pt_pt/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.pt_pt/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Portuguese (http://www.transifex.com/projects/p/xbmc-addons/language/pt/)\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizar com apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Está disponível uma nova versão do Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visite http://kodi.tv para mais informação."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Está disponível uma nova versão do Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Visite http://kodi.tv para mais informação."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Possuis a %s embora esteja disponível a %s."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Recomenda-se que actualize para uma versão mais recente."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ro_md/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ro_md/strings.po
@@ -1,0 +1,124 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro_md\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && "
+"n % 100 <= 19) ? 1 : 2);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ro_ro/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ro_ro/strings.po
@@ -10,15 +10,40 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Romanian (http://www.transifex.com/projects/p/xbmc-addons/language/ro/)\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ro\n"
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
 
 msgctxt "#32002"
 msgid "Visit Kodi.tv for more information."
 msgstr "Vizitați Kodi.tv pentru mai multe informații"
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
 
 msgctxt "#32014"
 msgid "Do you want to restart Kodi to finish the upgrade?"
@@ -44,30 +69,53 @@ msgctxt "#32022"
 msgid "Please enter your password"
 msgstr "Introduceți parola dumneavoastră"
 
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizare folosind apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Este disponibilă o versiune stabilă mai nouă pentru Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Vizitați http://kodi.tv pentru mai multe informații."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Este disponibilă o versiune stabilă mai nouă pentru Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Vizitați http://kodi.tv pentru mai multe informații."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Folosiți versiunea %s în timp ce versiunea %s este disponibilă."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Este recomandat să treceți la o versiune mai nouă."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ru_ru/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ru_ru/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Russian (http://www.transifex.com/projects/p/xbmc-addons/language/ru/)\n"
+"PO-Revision-Date: 2021-04-06 20:29+0000\n"
+"Last-Translator: Dmitry Petrov <dimakrm361@gmail.com>\n"
+"Language-Team: Russian <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/ru_ru/>\n"
+"Language: ru_ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.5.3\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Обновление с помощью apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Доступна новая стабильная версия Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Для более полной информации посетите http://kodi.tv"
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Доступна новая стабильная версия Kodi."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Для более полной информации посетите http://kodi.tv"
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Вы используете %s, но обновленная версия %s уже доступна."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Рекомендуется обновление до новой версии."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr "Версия %s криптографического модуля устарела. Требуется как минимум версия 1.7."
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr "Пожалуйста, обновите операционную систему."
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr "Для подробной информации, смотрите https://kodi.wiki/view/Linux"

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.scn/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.scn/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: scn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.si_lk/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.si_lk/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: si_lk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.sk_sk/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.sk_sk/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Slovak (http://www.transifex.com/projects/p/xbmc-addons/language/sk/)\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sk\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 msgctxt "#32001"
@@ -27,6 +27,10 @@ msgstr "Pre viac informácií navštívte Kodi.tv"
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
 msgstr "Chcete túto pripomienku odstrániť?"
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
 
 msgctxt "#32011"
 msgid "Use your package manager(apt) to upgrade."
@@ -72,18 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aktualizovať pomocou apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Nová stabilná verzia Kodi je k dipozícii."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Pre viac informácií navštívte http://kodi.tv."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Nová stabilná verzia Kodi je k dipozícii."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Pre viac informácií navštívte http://kodi.tv."
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.sl_si/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.sl_si/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Slovenian (http://www.transifex.com/projects/p/xbmc-addons/language/sl/)\n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sl\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "GNU/Linux: nadgradite z apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Na voljo je nova stabilna različica Kodija."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Za dodatne informacije obiščite http://kodi.tv"
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Na voljo je nova stabilna različica Kodija."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Za dodatne informacije obiščite Kodi.tv."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Uporabljate %s, ko je na voljo že %s."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Priporočamo, da nadgradite sistem na novejšo različico."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.sq_al/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.sq_al/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Albanian (http://www.transifex.com/projects/p/xbmc-addons/language/sq/)\n"
+"Language: sq\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sq\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Të përgjithshëm"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.sr_rs/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.sr_rs/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Serbian (Cyrillic) (http://www.transifex.com/projects/p/xbmc-addons/language/sr_RS/)\n"
+"Language: sr_RS\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr_RS\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Опште"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.sr_rs@latin/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Serbian (http://www.transifex.com/projects/p/xbmc-addons/language/sr/)\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Opšte"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.sv_se/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.sv_se/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Swedish (http://www.transifex.com/projects/p/xbmc-addons/language/sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Uppgradera med apt"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "En ny stabil Kodi-version finns tillgänglig."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Besök Kodi.tv för mer information."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "En ny stabil Kodi-version finns tillgänglig."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Besök Kodi.tv för mer information."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "Använder %s medan %s är tillgänglig."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Vi rekommenderar att du uppgraderar till en nyare version."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.szl/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.szl/strings.po
@@ -1,0 +1,124 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: szl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.ta_in/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.ta_in/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Tamil (India) (http://www.transifex.com/projects/p/xbmc-addons/language/ta_IN/)\n"
+"Language: ta_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ta_IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "பொதுவானது"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.te_in/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.te_in/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: te_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.tg_tj/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.tg_tj/strings.po
@@ -1,0 +1,123 @@
+# Kodi Media Center language file
+# Addon Name: Version Check
+# Addon id: service.xbmc.versioncheck
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tg_tj\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
+
+# empty strings from id 32017 to 32019
+msgctxt "#32020"
+msgid "General"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.th_th/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.th_th/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Thai (http://www.transifex.com/projects/p/xbmc-addons/language/th/)\n"
+"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: th\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "ทั่วไป"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.tr_tr/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.tr_tr/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Turkish (http://www.transifex.com/projects/p/xbmc-addons/language/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32001"
@@ -76,26 +76,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: apt kullanarak güncelle"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "Yeni kararlı bir Kodi sürümü mevcut."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Daha fazla bilgi için http://kodi.tv adresini ziyaret edin."
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Yeni kararlı bir Kodi sürümü mevcut."
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "Daha fazla bilgi için http://kodi.tv adresini ziyaret edin."
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "%s kullanırken %s mevcut."
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Daha yeni bir sürüme güncellemeniz önerilir."
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.uk_ua/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.uk_ua/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Ukrainian (http://www.transifex.com/projects/p/xbmc-addons/language/uk/)\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uk\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Загальні"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.uz_uz/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.uz_uz/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Uzbek (http://www.transifex.com/projects/p/xbmc-addons/language/uz/)\n"
+"Language: uz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uz\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Umumiy"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.vi_vn/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.vi_vn/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Vietnamese (http://www.transifex.com/projects/p/xbmc-addons/language/vi/)\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "Chung"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.zh_cn/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.zh_cn/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Chinese (Simple) (http://www.transifex.com/projects/p/xbmc-addons/language/zh/)\n"
+"PO-Revision-Date: 2021-03-22 02:28+0000\n"
+"Last-Translator: Meano  Lee <meanocat@gmail.com>\n"
+"Language-Team: Chinese (China) <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/zh_cn/>\n"
+"Language: zh_cn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32001"
 msgid "We would like to recommend you to upgrade."
@@ -76,26 +77,45 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux：使用 apt 来升级"
 
+#. Used in OK dialog
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
 msgstr "有新的稳定版 Kodi 可用。"
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32031"
 msgid "Visit http://kodi.tv for more information."
 msgstr "更多信息访问 http://kodi.tv。"
 
+#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "有新的稳定版 Kodi 可用。"
 
+#. Direct people to the website. Used in OK dialog
 msgctxt "#32033"
 msgid "Visit http://kodi.tv for more information."
 msgstr "更多信息访问 http://kodi.tv。"
 
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
 msgstr "使用 %s 当 %s 可用。"
 
+#. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "建议升级到新版本。"
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr "Python cryptography 模块版本过时。最低要求版本为 1.7。"
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr "请更新您的操作系统。"
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr "更多详情，请访问 https://kodi.wiki/view/Linux"

--- a/addons/service.xbmc.versioncheck/resources/language/resource.language.zh_tw/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/resource.language.zh_tw/strings.po
@@ -10,12 +10,113 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Chinese (Traditional) (http://www.transifex.com/projects/p/xbmc-addons/language/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "#32001"
+msgid "We would like to recommend you to upgrade."
+msgstr ""
+
+msgctxt "#32002"
+msgid "Visit Kodi.tv for more information."
+msgstr ""
+
+# empty strings from id 32003 to 32008
+msgctxt "#32009"
+msgid "Would you like to remove this reminder?"
+msgstr ""
+
+msgctxt "#32010"
+msgid "You can enable/disable it through add-on settings."
+msgstr ""
+
+msgctxt "#32011"
+msgid "Use your package manager(apt) to upgrade."
+msgstr ""
+
+msgctxt "#32012"
+msgid "A new version is available, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Upgrade successful"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Do you want to restart Kodi to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Do you want to check the repository for a new version?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "There is a newer stable Kodi version available."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
 msgstr "一般設定"
+
+msgctxt "#32021"
+msgid "Enable Kodi version check?"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Please enter your password"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Linux: Upgrade complete system"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Linux: Upgrade using apt"
+msgstr ""
+
+# empty strings from id 32025 to 32029
+#. Used in OK dialog
+msgctxt "#32030"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32031"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32032"
+msgid "A new stable version of Kodi is available."
+msgstr ""
+
+#. Direct people to the website. Used in OK dialog
+msgctxt "#32033"
+msgid "Visit http://kodi.tv for more information."
+msgstr ""
+
+#. For example: "You are using 13.1 prealpha while 13.2 stable is available"
+msgctxt "#32034"
+msgid "Using %s while %s is available."
+msgstr ""
+
+#. Used in OK dialog
+msgctxt "#32035"
+msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+# empty strings from id 32036 to 32039
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/lib/version_check/service.py
+++ b/addons/service.xbmc.versioncheck/resources/lib/version_check/service.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -34,17 +33,21 @@ from .json_interface import get_version_file_list
 from .json_interface import get_installed_version
 from .versions import compare_version
 
-if sys.version_info[0] == 3 and sys.version_info[1] >= 8:
-    try:
-        from .distro import distro
 
-        DISTRIBUTION = distro.linux_distribution(full_distribution_name=False)[0].lower()
+DISTRIBUTION = ''
 
-    except (AttributeError, ImportError):
-        DISTRIBUTION = ''
+if sys.platform.startswith('linux'):
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 8:
+        try:
+            from .distro import distro
 
-else:
-    DISTRIBUTION = platform.linux_distribution(full_distribution_name=0)[0].lower()  # pylint: disable=deprecated-method
+            DISTRIBUTION = distro.linux_distribution(full_distribution_name=False)[0].lower()
+
+        except (AttributeError, ImportError):
+            DISTRIBUTION = ''
+
+    else:
+        DISTRIBUTION = platform.linux_distribution(full_distribution_name=0)[0].lower()  # pylint: disable=deprecated-method
 
 if not DISTRIBUTION:
     DISTRIBUTION = platform.uname()[0].lower()

--- a/addons/service.xbmc.versioncheck/resources/versions.txt
+++ b/addons/service.xbmc.versioncheck/resources/versions.txt
@@ -3,6 +3,24 @@
     "releases": {
         "stable": [
             {
+                "major": "19",
+                "minor": "1",
+                "tag": "stable",
+                "tagversion":"",
+                "revision": "20210508-85e05228b4",
+                "extrainfo": "final",
+                "addon_support": "yes"
+            },
+            {
+                "major": "19",
+                "minor": "0",
+                "tag": "stable",
+                "tagversion":"",
+                "revision": "20210218-f44fdfbf67",
+                "extrainfo": "final",
+                "addon_support": "yes"
+            },
+            {
                 "major": "18",
                 "minor": "9",
                 "tag": "stable",
@@ -302,6 +320,15 @@
         ],
         "releasecandidate": [
             {
+                "major": "19",
+                "minor": "0",
+                "tag": "releasecandidate",
+                "tagversion":"1",
+                "revision": "20210115-90a1e12804",
+                "extrainfo": "RC1",
+                "addon_support": "yes"
+            },
+            {
                 "major": "18",
                 "minor": "0",
                 "tag": "releasecandidate",
@@ -528,6 +555,24 @@
             }
         ],
         "beta": [
+            {
+                "major": "19",
+                "minor": "0",
+                "tag": "beta",
+                "tagversion":"2",
+                "revision": "20201207-8cc9e80e41",
+                "extrainfo": "beta2",
+                "addon_support": "yes"
+            },
+            {
+                "major": "19",
+                "minor": "0",
+                "tag": "beta",
+                "tagversion":"1",
+                "revision": "20201117-88e186e4b4",
+                "extrainfo": "beta1",
+                "addon_support": "yes"
+            },
             {
                 "major": "18",
                 "minor": "0",
@@ -836,6 +881,15 @@
             }
         ],
         "alpha": [
+            {
+                "major": "19",
+                "minor": "0",
+                "tag": "alpha",
+                "tagversion":"3",
+                "revision": "20201031-bb0699db41",
+                "extrainfo": "alpha3",
+                "addon_support": "yes"
+            },
             {
                 "major": "19",
                 "minor": "0",


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20059

## Motivation and context
On Xbox versioncheck previous versions causes Python exception (See #19666) is already fixed in upstream although issue is still present in the first run until addon gets auto-updated. Updated version should be included inside the installer too.

## How has this been tested?


## What is the effect on users?
Fixes versioncheck Python error at the first run after install v19.2

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
