### PR TITLE
[Windows] Fix Sync playback to display

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -419,7 +419,10 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
   {
     CLog::Log(LOGDEBUG, "{} - flushing renderer", __FUNCTION__);
 
+// fix deadlock on Windows only when is enabled 'Sync playback to display'
+#ifndef TARGET_WINDOWS
     CSingleExit exitlock(CServiceBroker::GetWinSystem()->GetGfxContext());
+#endif
 
     CSingleLock lock(m_statelock);
     CSingleLock lock2(m_presentlock);

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -125,7 +125,7 @@ void DX::DeviceResources::Release()
 void DX::DeviceResources::GetOutput(IDXGIOutput** ppOutput) const
 {
   ComPtr<IDXGIOutput> pOutput;
-  if (FAILED(m_swapChain->GetContainingOutput(pOutput.GetAddressOf())) || !pOutput)
+  if (!m_swapChain || FAILED(m_swapChain->GetContainingOutput(pOutput.GetAddressOf())) || !pOutput)
     m_output.As(&pOutput);
   *ppOutput = pOutput.Detach();
 }
@@ -140,14 +140,16 @@ void DX::DeviceResources::GetDisplayMode(DXGI_MODE_DESC* mode) const
 {
   DXGI_OUTPUT_DESC outDesc;
   ComPtr<IDXGIOutput> pOutput;
+  DXGI_SWAP_CHAIN_DESC scDesc;
+
+  if (!m_swapChain)
+    return;
+
+  m_swapChain->GetDesc(&scDesc);
 
   GetOutput(pOutput.GetAddressOf());
   pOutput->GetDesc(&outDesc);
 
-  DXGI_SWAP_CHAIN_DESC scDesc;
-  m_swapChain->GetDesc(&scDesc);
-
-  memset(mode, 0, sizeof(DXGI_MODE_DESC));
   // desktop coords depend on DPI
   mode->Width = DX::ConvertDipsToPixels(outDesc.DesktopCoordinates.right - outDesc.DesktopCoordinates.left, m_dpi);
   mode->Height = DX::ConvertDipsToPixels(outDesc.DesktopCoordinates.bottom - outDesc.DesktopCoordinates.top, m_dpi);
@@ -228,7 +230,7 @@ bool DX::DeviceResources::SetFullScreen(bool fullscreen, RESOLUTION_INFO& res)
     const bool isResValid = res.iWidth > 0 && res.iHeight > 0 && res.fRefreshRate > 0.f;
     if (isResValid)
     {
-      DXGI_MODE_DESC currentMode;
+      DXGI_MODE_DESC currentMode = {};
       GetDisplayMode(&currentMode);
       DXGI_SWAP_CHAIN_DESC scDesc;
       m_swapChain->GetDesc(&scDesc);
@@ -1225,9 +1227,7 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
 HDR_STATUS DX::DeviceResources::ToggleHDR()
 {
   DXGI_MODE_DESC md = {};
-
-  if (m_swapChain)
-    GetDisplayMode(&md);
+  GetDisplayMode(&md);
 
   // Toggle display HDR
   DX::Windowing()->SetAlteringWindow(true);

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -116,7 +116,7 @@ void CVideoSyncD3D::Cleanup()
 
 float CVideoSyncD3D::GetFps()
 {
-  DXGI_MODE_DESC DisplayMode;
+  DXGI_MODE_DESC DisplayMode = {};
   DX::DeviceResources::Get()->GetDisplayMode(&DisplayMode);
 
   m_fps = (DisplayMode.RefreshRate.Denominator != 0) ? (float)DisplayMode.RefreshRate.Numerator / (float)DisplayMode.RefreshRate.Denominator : 0.0f;


### PR DESCRIPTION
## Description
Fix Sync playback to display.

Fix possible crash when is enabled "Sync playback to display" option in combination with HDR passthrough.
Fix possible deadlock when is enabled "Sync playback to display" on some systems only.
 
## Motivation and context
See https://forum.kodi.tv/showthread.php?tid=363334

Root cause of crash is clear: When activating "Sync playback to display" then `DeviceResources::GetDisplayMode()`  is called continuously here:

https://github.com/xbmc/xbmc/blob/f9b3ae227077b6780c9bb687d109af249b50994b/xbmc/windowing/windows/VideoSyncD3D.cpp#L117-L122

and has no protection against `m_swapChain = nullptr`. This may happen during HDR toggle instants. This part of fix is trivial and safe: include `nullptr` check inside `GetDisplayMode()`.


I'm not really sure about the deadlock, also I can't reproduce it on the Intel NUC. It seems to be caused at this point:

https://github.com/xbmc/xbmc/blob/f9b3ae227077b6780c9bb687d109af249b50994b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp#L422

However I don't know what is the relation with setting "Sync playback to display". I'm also not sure why that call is needed here. Deleting `CSingleExit exitlock(CServiceBroker::GetWinSystem()->GetGfxContext())` nothing bad seems to happen and the deadlock is fixed.

## How has this been tested?
Runtime tested Windows x64 on Intel NUC8i3BEK and Nvidia RTX 2060.

The user who originally reported the problem also confirms that the fix works fine: https://forum.kodi.tv/showthread.php?tid=363334&pid=3055839#pid3055839

## What is the effect on users?
Fix possible crash when is enabled "Sync playback to display" option in combination with HDR passthrough.
Fix possible deadlock when is enabled "Sync playback to display" on some systems only (not related to HDR).


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
