### PR TITLE
[nfs] Fix URL containing special chars being truncated

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -170,7 +170,8 @@ void CURL::Parse(const std::string& strURL1)
      IsProtocol("videodb") ||
      IsProtocol("musicdb") ||
      IsProtocol("androidapp") ||
-     IsProtocol("pvr"))
+     IsProtocol("pvr") ||
+     IsProtocol("file"))
     sep = "?";
   else
   if(  IsProtocolEqual(strProtocol2, "http")

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -208,6 +208,16 @@ void URIUtils::Split(const std::string& strFileNameAndPath,
   //Splits a full filename in path and file.
   //ex. smb://computer/share/directory/filename.ext -> strPath:smb://computer/share/directory/ and strFileName:filename.ext
   //Trailing slash will be preserved
+  if (IsURL(strFileNameAndPath))
+  {
+    CURL url(strFileNameAndPath);
+
+    strFileName  = url.GetFileNameWithoutPath();
+    strPath = GetDirectory(strFileNameAndPath);
+
+    return;
+  }
+
   strFileName = "";
   strPath = "";
   int i = strFileNameAndPath.size() - 1;
@@ -225,20 +235,6 @@ void URIUtils::Split(const std::string& strFileNameAndPath,
   strPath = strFileNameAndPath.substr(0, i+1);
   // everything to the right of the directory separator
   strFileName = strFileNameAndPath.substr(i+1);
-
-  // if actual uri, ignore options
-  if (IsURL(strFileNameAndPath))
-  {
-    i = strFileName.size() - 1;
-    while (i > 0)
-    {
-      char ch = strFileName[i];
-      if (ch == '?' || ch == '|') break;
-      else i--;
-    }
-    if (i > 0)
-      strFileName = strFileName.substr(0, i);
-  }
 }
 
 std::vector<std::string> URIUtils::SplitPath(const std::string& strPath)

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -125,6 +125,12 @@ TEST_F(TestURIUtils, Split)
   URIUtils::Split("file:///path/to/movie.avi?showinfo=true", varpathOptional, varfileOptional);
   EXPECT_STREQ(refpath.c_str(), varpathOptional.c_str());
   EXPECT_STREQ(reffile.c_str(), varfileOptional.c_str());
+
+  refpath = "nfs:///path/to?/";
+  reffile = "movie?.avi";
+  URIUtils::Split("nfs:///path/to?/movie?.avi", varpathOptional, varfileOptional);
+  EXPECT_STREQ(refpath.c_str(), varpathOptional.c_str());
+  EXPECT_STREQ(reffile.c_str(), varfileOptional.c_str());
 }
 
 TEST_F(TestURIUtils, SplitPath)


### PR DESCRIPTION
## Description
NFS as a filesystem supports certain special characters (like '?') that are valid within a URL. These characters cause filenames to end up truncated in the db, resulting in invalid video entries in the collection that can't be played (because the path doesn't exist) and get removed again when you clean the library.

## Motivation and context
This is a fix for #16383, and an alternative solution compared to the previous attempt in #18311. This solution would disregard any support for query parameters in `nfs://` URLs, while retaining the behavior for `file://` URLs that are currently being used in tests. No longer supporting query parameters would be different from the current behavior, which is why I consider it a breaking change, but not sure how much would actually break because of that.

The other breaking change is that with the previous protocol, query params for *any* URL scheme were removed. The new behavior would require any URL scheme that wants to retain that behavior to be listed in `URL.cpp` like I did for the `file` scheme.

## How has this been tested?
I ran kodi locally on my laptop and connected it to my NFS share on a Synology NAS. In that share I had a movie with special characters in both the folder name as well as the file name:

Stermann & Grissemann - Wollt Ihr das totale Sieb?!/Stermann & Grissemann - Wollt Ihr das totale Sieb?!.mkv

Verified that master puts a truncated path in the sqlite db, and a correct path after the fix.
Verified playing from library works after the fix.
Verified direct play from NFS works both before and after the fix.
Verified clean library behavior.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
