### PR TITLE
GSoC fixes

### DIFF
--- a/tools/windows/prepare-binary-addons-dev.bat
+++ b/tools/windows/prepare-binary-addons-dev.bat
@@ -18,7 +18,7 @@ FOR %%b IN (%*) DO (
 SETLOCAL DisableDelayedExpansion
 
 rem set Visual C++ build environment
-call "%VS140COMNTOOLS%..\..\VC\bin\amd64_x86\vcvarsamd64_x86.bat" || call "%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
+call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat" || call "%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
 
 SET WORKDIR=%WORKSPACE%
 
@@ -76,7 +76,7 @@ IF "%addon%" NEQ "" (
 )
 
 rem execute cmake to generate Visual Studio 12 project files
-cmake "%ADDONS_PATH%" -G "Visual Studio 14" ^
+cmake "%ADDONS_PATH%" -G "Visual Studio 16 2019" ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%SCRIPTS_PATH%/CFlagOverrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%SCRIPTS_PATH%/CXXFlagOverrides.cmake" ^

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -241,7 +241,7 @@ extern "C"
   ///
   typedef struct game_stream_video_properties
   {
-    /// @brief The to used pixel format
+    /// @brief The stream's pixel format
     GAME_PIXEL_FORMAT format;
 
     /// @brief The nominal used width

--- a/xbmc/games/addons/streams/IGameClientStream.h
+++ b/xbmc/games/addons/streams/IGameClientStream.h
@@ -61,7 +61,7 @@ public:
   /*!
    * \brief Free an allocated buffer
    *
-   * \param buffer The buffer returned from GetStreamBuffer()
+   * \param buffer The buffer returned from GetBuffer()
    */
   virtual void ReleaseBuffer(game_stream_buffer& buffer) {}
 

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
@@ -45,7 +45,7 @@ bool CGUIDialogAxisDetection::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonM
                                                    const JOYSTICK::CDriverPrimitive& primitive)
 {
   if (primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS)
-    AddAxis(buttonMap->DeviceName(), primitive.Index());
+    AddAxis(buttonMap->Location(), primitive.Index());
 
   return true;
 }
@@ -66,19 +66,19 @@ bool CGUIDialogAxisDetection::AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) co
 void CGUIDialogAxisDetection::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap,
                                          unsigned int axisIndex)
 {
-  AddAxis(buttonMap->DeviceName(), axisIndex);
+  AddAxis(buttonMap->Location(), axisIndex);
 }
 
-void CGUIDialogAxisDetection::AddAxis(const std::string& deviceName, unsigned int axisIndex)
+void CGUIDialogAxisDetection::AddAxis(const std::string& deviceLocation, unsigned int axisIndex)
 {
   auto it = std::find_if(m_detectedAxes.begin(), m_detectedAxes.end(),
-                         [&deviceName, axisIndex](const AxisEntry& axis) {
-                           return axis.first == deviceName && axis.second == axisIndex;
+                         [&deviceLocation, axisIndex](const AxisEntry& axis) {
+                           return axis.first == deviceLocation && axis.second == axisIndex;
                          });
 
   if (it == m_detectedAxes.end())
   {
-    m_detectedAxes.emplace_back(std::make_pair(deviceName, axisIndex));
+    m_detectedAxes.emplace_back(std::make_pair(deviceLocation, axisIndex));
     m_captureEvent.Set();
   }
 }

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
@@ -39,7 +39,7 @@ protected:
   void OnClose(bool bAccepted) override {}
 
 private:
-  void AddAxis(const std::string& deviceName, unsigned int axisIndex);
+  void AddAxis(const std::string& deviceLocation, unsigned int axisIndex);
 
   // Axis types
   using DeviceName = std::string;

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -62,21 +62,21 @@ bool CGUIDialogIgnoreInput::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonMap
                                                  const JOYSTICK::CDriverPrimitive& primitive)
 {
   // Check if we have already started capturing primitives for a device
-  const bool bHasDevice = !m_deviceName.empty();
+  const bool bHasDevice = !m_location.empty();
 
   // If a primitive comes from a different device, ignore it
-  if (bHasDevice && m_deviceName != buttonMap->DeviceName())
+  if (bHasDevice && m_location != buttonMap->Location())
   {
     CLog::Log(LOGDEBUG, "{}: ignoring input from device {}", buttonMap->ControllerID(),
-              buttonMap->DeviceName());
+              buttonMap->Location());
     return false;
   }
 
   if (!bHasDevice)
   {
     CLog::Log(LOGDEBUG, "{}: capturing input for device {}", buttonMap->ControllerID(),
-              buttonMap->DeviceName());
-    m_deviceName = buttonMap->DeviceName();
+              buttonMap->Location());
+    m_location = buttonMap->Location();
   }
 
   if (AddPrimitive(primitive))
@@ -96,10 +96,10 @@ void CGUIDialogIgnoreInput::OnClose(bool bAccepted)
     {
       // See documentation of IButtonMapCallback::ResetIgnoredPrimitives()
       // for why this call is needed
-      if (m_deviceName.empty())
+      if (m_location.empty())
         callback.second->ResetIgnoredPrimitives();
 
-      if (m_deviceName.empty() || m_deviceName == callback.first)
+      if (m_location.empty() || m_location == callback.first)
         callback.second->SaveButtonMap();
     }
     else

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
@@ -40,7 +40,7 @@ protected:
 private:
   bool AddPrimitive(const JOYSTICK::CDriverPrimitive& primitive);
 
-  std::string m_deviceName;
+  std::string m_location;
   std::vector<JOYSTICK::CDriverPrimitive> m_capturedPrimitives;
 };
 } // namespace GAME

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -54,7 +54,7 @@ void CGUIConfigurationWizard::InitializeState(void)
   m_throttleDirection = JOYSTICK::THROTTLE_DIRECTION::NONE;
   m_history.clear();
   m_lateAxisDetected = false;
-  m_deviceName.clear();
+  m_location.clear();
 }
 
 void CGUIConfigurationWizard::Run(const std::string& strControllerId,
@@ -211,7 +211,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
   bool bHandled = false;
 
   // Abort if another controller cancels the prompt
-  if (IsMapping() && !IsMapping(buttonMap->DeviceName()))
+  if (IsMapping() && !IsMapping(buttonMap->Location()))
   {
     //! @todo This only succeeds for game.controller.default; no actions are
     //        currently defined for other controllers
@@ -289,7 +289,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
         else
         {
           CLog::Log(LOGDEBUG, "{}: mapping feature \"{}\" for device {}", m_strControllerId,
-                    feature.Name(), buttonMap->DeviceName());
+                    feature.Name(), buttonMap->Location());
 
           switch (feature.Type())
           {
@@ -344,9 +344,9 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
 
           m_inputEvent.Set();
 
-          if (m_deviceName.empty())
+          if (m_location.empty())
           {
-            m_deviceName = buttonMap->DeviceName();
+            m_location = buttonMap->Location();
             m_bIsKeyboard = (primitive.Type() == PRIMITIVE_TYPE::KEY);
           }
         }
@@ -449,12 +449,12 @@ bool CGUIConfigurationWizard::OnAction(unsigned int actionId)
 
 bool CGUIConfigurationWizard::IsMapping() const
 {
-  return !m_deviceName.empty();
+  return !m_location.empty();
 }
 
-bool CGUIConfigurationWizard::IsMapping(const std::string& deviceName) const
+bool CGUIConfigurationWizard::IsMapping(const std::string& location) const
 {
-  return m_deviceName == deviceName;
+  return m_location == location;
 }
 
 void CGUIConfigurationWizard::InstallHooks(void)

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -78,7 +78,7 @@ private:
   void InitializeState(void);
 
   bool IsMapping() const;
-  bool IsMapping(const std::string& deviceName) const;
+  bool IsMapping(const std::string& location) const;
 
   void InstallHooks(void);
   void RemoveHooks(void);
@@ -99,7 +99,7 @@ private:
   JOYSTICK::THROTTLE_DIRECTION m_throttleDirection;
   std::set<JOYSTICK::CDriverPrimitive> m_history; // History to avoid repeated features
   bool m_lateAxisDetected; // Set to true if an axis is detected during button mapping
-  std::string m_deviceName; // Name of device that we're mapping
+  std::string m_location; // Peripheral location of device that we're mapping
   bool m_bIsKeyboard = false; // True if we're mapping keyboard keys
   CCriticalSection m_stateMutex;
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -259,6 +259,7 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
     {
       width = std::max(0.0f, right - left); // if left=0, this fills to size of parent
       hasLeft = true;
+      hasWidth = true;
     }
     else if (hasCenter)
     {
@@ -271,12 +272,14 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
       { // centre given, so fill to edge of parent
         width = std::max(0.0f, std::min(parentSize - center, center) * 2);
         left = center - width/2;
-        hasLeft = hasWidth = true;
+        hasLeft = true;
+        hasWidth = true;
       }
     }
     else if (hasLeft) // neither right nor center specified
     {
       width = std::max(0.0f, parentSize - left); // if left=0, this fills to parent
+      hasWidth = true;
     }
   }
   return hasLeft && hasWidth;

--- a/xbmc/input/joysticks/interfaces/IButtonMap.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMap.h
@@ -41,11 +41,11 @@ public:
   virtual std::string ControllerID(void) const = 0;
 
   /*!
-   * \brief The name of the peripheral associated with this button map
+   * \brief The Location of the peripheral associated with this button map
    *
-   * \return The peripheral's name
+   * \return The peripheral's location
    */
-  virtual std::string DeviceName(void) const = 0;
+  virtual std::string Location(void) const = 0;
 
   /*!
    * \brief Load the button map into memory

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -38,9 +38,9 @@ CAddonButtonMap::~CAddonButtonMap(void)
     addon->UnregisterButtonMap(this);
 }
 
-std::string CAddonButtonMap::DeviceName(void) const
+std::string CAddonButtonMap::Location(void) const
 {
-  return m_device->DeviceName();
+  return m_device->Location();
 }
 
 bool CAddonButtonMap::Load(void)
@@ -65,7 +65,7 @@ bool CAddonButtonMap::Load(void)
   if (bSuccess)
     driverMap = CreateLookupTable(features);
   else
-    CLog::Log(LOGDEBUG, "Failed to load button map for \"{}\"", m_device->DeviceName());
+    CLog::Log(LOGDEBUG, "Failed to load button map for \"{}\"", m_device->Location());
 
   {
     CSingleLock lock(m_mutex);

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -31,7 +31,7 @@ public:
   // Implementation of IButtonMap
   std::string ControllerID(void) const override { return m_strControllerId; }
 
-  std::string DeviceName(void) const override;
+  std::string Location(void) const override;
 
   bool Load(void) override;
 

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -333,7 +333,7 @@ bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
   {
     for (std::vector<DriverHandler>::iterator it = m_driverHandlers.begin();
          it != m_driverHandlers.end(); ++it)
-      it->handler->OnAxisMotion(axisIndex, center, center, range);
+      it->handler->OnAxisMotion(axisIndex, static_cast<float>(center), center, range);
     return true;
   }
 


### PR DESCRIPTION
## Description

This PR contains fixes from the last four years of GSoC projects. Includes:

* One fix from GSoC 2017 - https://github.com/garbear/xbmc/pull/86
* Code path optimization from GSoC 2020 - https://github.com/garbear/xbmc/pull/116
* Controller fix from GSoC 2020 - https://github.com/garbear/xbmc/pull/119
* Three random fixes I made over the years

## Motivation and context

Hoping to land one or two GSoC PRs to master this summer. I've been building these fixes in my `retroplayer` branches and figured now was a good time to upstream them.

## How has this been tested?

Compile-tested on Win64. Runtime tested the fix on Linux.

## What is the effect on users?

The only visible effect is the fix:

* Fixed similar controllers interfering with each other while button mapping

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
