### PR TITLE
Websocket: handle partial messages

### DIFF
--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -50,7 +50,12 @@ static const bdaddr_t bt_bdaddr_local = {{0, 0, 0, 0xff, 0xff, 0xff}};
 
 using namespace JSONRPC;
 
-#define RECEIVEBUFFER 1024
+#define RECEIVEBUFFER 4096
+
+namespace
+{
+constexpr size_t maxBufferLength = 64 * 1024;
+}
 
 CTCPServer *CTCPServer::ServerInstance = NULL;
 
@@ -643,11 +648,13 @@ void CTCPServer::CTCPClient::Copy(const CTCPClient& client)
 CTCPServer::CWebSocketClient::CWebSocketClient(CWebSocket *websocket)
 {
   m_websocket = websocket;
+  m_buffer.reserve(maxBufferLength);
 }
 
 CTCPServer::CWebSocketClient::CWebSocketClient(const CWebSocketClient& client)
 {
   *this = client;
+  m_buffer.reserve(maxBufferLength);
 }
 
 CTCPServer::CWebSocketClient::CWebSocketClient(CWebSocket *websocket, const CTCPClient& client)
@@ -655,6 +662,7 @@ CTCPServer::CWebSocketClient::CWebSocketClient(CWebSocket *websocket, const CTCP
   Copy(client);
 
   m_websocket = websocket;
+  m_buffer.reserve(maxBufferLength);
 }
 
 CTCPServer::CWebSocketClient::~CWebSocketClient()
@@ -667,6 +675,7 @@ CTCPServer::CWebSocketClient& CTCPServer::CWebSocketClient::operator=(const CWeb
   Copy(client);
 
   m_websocket = client.m_websocket;
+  m_buffer = client.m_buffer;
 
   return *this;
 }
@@ -686,10 +695,21 @@ void CTCPServer::CWebSocketClient::PushBuffer(CTCPServer *host, const char *buff
 {
   bool send;
   const CWebSocketMessage *msg = NULL;
-  size_t len = length;
+
+  if (m_buffer.size() + length > maxBufferLength)
+  {
+    CLog::Log(LOGINFO, "WebSocket: client buffer size {} exceeded", maxBufferLength);
+    return Disconnect();
+  }
+
+  m_buffer.append(buffer, length);
+
+  const char* buf = m_buffer.data();
+  size_t len = m_buffer.size();
+
   do
   {
-    if ((msg = m_websocket->Handle(buffer, len, send)) != NULL && msg->IsComplete())
+    if ((msg = m_websocket->Handle(buf, len, send)) != NULL && msg->IsComplete())
     {
       std::vector<const CWebSocketFrame *> frames = msg->GetFrames();
       if (send)
@@ -707,6 +727,9 @@ void CTCPServer::CWebSocketClient::PushBuffer(CTCPServer *host, const char *buff
     }
   }
   while (len > 0 && msg != NULL);
+
+  if (len < m_buffer.size())
+    m_buffer = m_buffer.substr(m_buffer.size() - len);
 
   if (m_websocket->GetState() == WebSocketStateClosed)
     Disconnect();
@@ -727,4 +750,3 @@ void CTCPServer::CWebSocketClient::Disconnect()
       CTCPClient::Disconnect();
   }
 }
-

--- a/xbmc/network/TCPServer.h
+++ b/xbmc/network/TCPServer.h
@@ -104,6 +104,7 @@ namespace JSONRPC
 
     private:
       CWebSocket *m_websocket;
+      std::string m_buffer;
     };
 
     std::vector<CTCPClient*> m_connections;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
An internal buffer was added to CTCPServer::CWebSocketClient to help with the processing of incomplete messages. 
RECEIVEBUFFER size was also increased from 1024 to 4096.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently any mesage larger than RECEIVEBUFFER will be discarded as being invalid. This causes complete corruption of the stream as the next read will contain the remnants of the previous message. This can also happen when several smaller packets are sent rapidly because of the way operating systems buffer network connections.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I was in the processing of writing a desktop remote control application for Kodi when I discovered this issue. The application was used to successfully test the three main test cases that occur when dealing with TCP sockets.

1. Partial packet read
2. Full packet read
3. Multiple packet reads

All changes were done to the master branch and compile without warnings on Ubuntu 20.04.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
There should be no effect to end users. This change only effects developers using the websocket API.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
