### PR TITLE
add riscv compile defines

### DIFF
--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -11,19 +11,22 @@
 #include "coffldr.h"
 #include "LibraryLoader.h"
 
+// clang-format off
 #if defined(__linux__) && \
-    !defined(__powerpc__) && \
-    !defined(__arm__) && \
     !defined(__aarch64__) && \
+    !defined(__arc__) && \
+    !defined(__arm__) && \
     !defined(__mips__) && \
+    !defined(__powerpc__) && \
+    !defined(__or1k__) && \
+    !defined(__riscv) && \
     !defined(__SH4__) && \
     !defined(__sparc__) && \
-    !defined(__arc__) && \
-    !defined(__or1k__) && \
     !defined(__xtensa__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif
+// clang-format on
 
 #ifndef NULL
 #define NULL 0

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -18,17 +18,19 @@
  * $Id: ldt_keeper.c 22733 2007-03-18 22:18:11Z nicodvb $
  */
 
-//#ifndef __powerpc__
-#if !defined(__powerpc__) && \
-    !defined(__ppc__) && \
+// clang-format off
+#if !defined(__aarch64__) && \
+    !defined(__arc__) &&\
     !defined(__arm__) && \
-    !defined(__aarch64__) && \
     !defined(__mips__) && \
+    !defined(__or1k__) && \
+    !defined(__powerpc__) && \
+    !defined(__ppc__) && \
+    !defined(__riscv) && \
     !defined(__SH4__) && \
     !defined(__sparc__) && \
-    !defined(__arc__) && \
-    !defined(__or1k__) && \
     !defined(__xtensa__)
+// clang-format on
 
 #include "ldt_keeper.h"
 

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -21,19 +21,22 @@
 // avoid including system.h or other magic includes.
 // use 'gcc -dM -E - < /dev/null' or similar to find them.
 
-#if defined(__ppc__) || \
-    defined(__powerpc__) || \
-    defined(__mips__) || \
+// clang-format off
+#if defined(__aarch64__) || \
+    defined(__arc__) || \
     defined(__arm__) || \
-    defined(__aarch64__) || \
+    defined(_M_ARM) || \
+    defined(__mips__) || \
+    defined(__or1k__) || \
+    defined(__powerpc__) || \
+    defined(__ppc__) || \
+    defined(__riscv) || \
     defined(__SH4__) || \
     defined(__sparc__) || \
-    defined(__arc__) || \
-    defined(_M_ARM) || \
-    defined(__or1k__) || \
     defined(__xtensa__)
-  #define DISABLE_MATHUTILS_ASM_ROUND_INT
+#define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
+// clang-format on
 
 /*! \brief Math utility class.
  Note that the test() routine should return true for all implementations


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Update Kodi to allow compile to complete on RISC-V

Add `defined(__riscv)` so as to:
- Disable `USE_LDT_KEEPER`
- Enable `DISABLE_MATHUTILS_ASM_ROUND_INT`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The defined(__riscv) is used by a number of the architectures to disable/enable functionality not available on the architecture.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Full test compile has been done using LibreELEC/LibreELEC.tv:master. Further work continuing to further bring up LE with __riscv.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No impact on users. This change is only to allow the Kodi source to be compiled for RISC-V

## Screenshots (if appropriate):
As per the guidelines below - vaclidate that `__riscv` is the correct **define**.
https://github.com/xbmc/xbmc/blob/8d098aee94781c9fad5c383f69242a69984bb69a/xbmc/utils/MathUtils.h#L20-L22
```
$ ./gcc-riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc -dM -E - < /dev/null | grep -i risc
#define __riscv 1
#define __riscv_atomic 1
#define __riscv_cmodel_medlow 1
#define __riscv_fdiv 1
#define __riscv_float_abi_double 1
#define __riscv_mul 1
#define __riscv_muldiv 1
#define __riscv_xlen 64
#define __riscv_fsqrt 1
#define __riscv_m 2000000
#define __riscv_a 2000000
#define __riscv_c 2000000
#define __riscv_d 2000000
#define __riscv_f 2000000
#define __riscv_i 2000000
#define __riscv_zicsr 2000000
#define __riscv_compressed 1
#define __riscv_flen 64
#define __riscv_arch_test 1
#define __riscv_div 1
#define __riscv_zifencei 2000000
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
