### PR TITLE
[PVR] Fix and simplify addon connection state change handling.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -840,6 +840,10 @@ void CPVRManager::ConnectionStateChange(CPVRClient* client,
 {
   CJobManager::GetInstance().Submit([this, client, connectString, state, message] {
     Clients()->ConnectionStateChange(client, connectString, state, message);
+
+    if (state == PVR_CONNECTION_STATE_CONNECTED)
+      Start(); // start over
+
     return true;
   });
 }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -226,6 +226,13 @@ PVR_CONNECTION_STATE CPVRClient::GetConnectionState() const
 
 void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
 {
+  if (state == PVR_CONNECTION_STATE_CONNECTED)
+  {
+    // update properties - some will only be available after add-on is connected to backend
+    if (!GetAddonProperties())
+      CLog::LogF(LOGERROR, "Error reading PVR client properties");
+  }
+
   CSingleLock lock(m_critSection);
 
   m_prevConnectionState = m_connectionState;
@@ -235,7 +242,7 @@ void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
     m_ignoreClient = false;
   else if (m_connectionState == PVR_CONNECTION_STATE_CONNECTING &&
            m_prevConnectionState == PVR_CONNECTION_STATE_UNKNOWN)
-    m_ignoreClient = true;
+    m_ignoreClient = true; // ignore until connected
 }
 
 PVR_CONNECTION_STATE CPVRClient::GetPreviousConnectionState() const
@@ -1385,7 +1392,7 @@ PVR_ERROR CPVRClient::DoAddonCall(const char* strFunctionName,
   if (m_bBlockAddonCalls)
     return PVR_ERROR_SERVER_ERROR;
 
-  if (!m_bReadyToUse && bCheckReadyToUse)
+  if (bCheckReadyToUse && (!ReadyToUse() || IgnoreClient()))
     return PVR_ERROR_SERVER_ERROR;
 
   // Call.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -918,12 +918,6 @@ public:
   PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES* times);
 
   /*!
-   * @brief reads the client's properties.
-   * @return True on success, false otherwise.
-   */
-  bool GetAddonProperties();
-
-  /*!
    * @brief Get the client's menu hooks.
    * @return The hooks. Guaranteed never to be nullptr.
    */
@@ -1013,6 +1007,12 @@ private:
    * @brief Resets all class members to their defaults. Called by the constructors.
    */
   void ResetProperties(int iClientId = PVR_INVALID_CLIENT_ID);
+
+  /*!
+   * @brief reads the client's properties.
+   * @return True on success, false otherwise.
+   */
+  bool GetAddonProperties();
 
   /*!
    * @brief Copy over group info from xbmcGroup to addonGroup.

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -728,15 +728,6 @@ void CPVRClients::ConnectionStateChange(CPVRClient* client,
 
   // Notify user.
   CJobManager::GetInstance().AddJob(new CPVREventLogJob(bNotify, bError, client->Name(), strMsg, client->Icon()), nullptr);
-
-  if (newState == PVR_CONNECTION_STATE_CONNECTED)
-  {
-    // update properties on connect
-    if (!client->GetAddonProperties())
-      CLog::LogF(LOGERROR, "Error reading PVR client properties");
-
-    CServiceBroker::GetPVRManager().Start();
-  }
 }
 
 PVR_ERROR CPVRClients::ForCreatedClients(const char* strFunctionName,


### PR DESCRIPTION
Should fix #20090 - I was not able to reproduce, but the supplied logs contain everything I need to be confident I understood the root cause of the issue. 

Runtime-tested on macOS and Android, latest kodi master, with different single and multi add.on scenarios. No regressions found.

@phunkyfish when you find some time for the review.