### PR TITLE
[warnings] Fix two new warnings after #20027

### DIFF
--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -145,6 +145,8 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
   IMAGEHLP_SYMBOL64* pSym = NULL;
   HANDLE hDumpFile = INVALID_HANDLE_VALUE;
   tSC pSC = NULL;
+  IMAGEHLP_LINE64 Line = {};
+  Line.SizeOfStruct = sizeof(Line);
 
   HMODULE hDbgHelpDll = ::LoadLibrary(L"DBGHELP.DLL");
   if (!hDbgHelpDll)
@@ -212,11 +214,6 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
   pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
   pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
 
-  IMAGEHLP_LINE64 Line = {};
-  Line.SizeOfStruct = sizeof(Line);
-
-  IMAGEHLP_MODULE64 Module = {};
-  Module.SizeOfStruct = sizeof(Module);
   int seq=0;
 
   strOutput = StringUtils::Format("Thread {} (process {})\r\n", GetCurrentThreadId(),


### PR DESCRIPTION
## Description
Fix two new warnings after #20027

## Motivation and context
```
14:22:02 F:\builds\workspace\WIN-64\xbmc\threads\platform\win\Win32Exception.cpp(248): warning C4533: initialization of 'Module' is skipped by 'goto cleanup' [F:\builds\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
14:22:03   F:\builds\workspace\WIN-64\xbmc\threads\platform\win\Win32Exception.cpp(218): note: see declaration of 'Module'
14:22:03   F:\builds\workspace\WIN-64\xbmc\threads\platform\win\Win32Exception.cpp(248): note: see declaration of 'cleanup'
14:22:03 F:\builds\workspace\WIN-64\xbmc\threads\platform\win\Win32Exception.cpp(248): warning C4533: initialization of 'Line' is skipped by 'goto cleanup' [F:\builds\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
14:22:03   F:\builds\workspace\WIN-64\xbmc\threads\platform\win\Win32Exception.cpp(215): note: see declaration of 'Line'
14:22:03   F:\builds\workspace\WIN-64\xbmc\threads\platform\win\Win32Exception.cpp(248): note: see declaration of 'cleanup'
```

`IMAGEHLP_MODULE64 Module` is not used and can be removed.
`IMAGEHLP_LINE64 Line = {};` moved before `goto cleanup` to not be skipped.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
