### PR TITLE
[PVR] CPVRTimerInfoTag must have a timer type, otherwise related add-…

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -435,8 +435,7 @@ namespace PVR
       if (!timer || URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER) || timer->IsBroken())
         return false;
 
-      const std::shared_ptr<CPVRTimerType> timerType(timer->GetTimerType());
-      return timerType && timerType->SupportsEnableDisable();
+      return timer->GetTimerType()->SupportsEnableDisable();
     }
 
     bool ToggleTimerState::Execute(const CFileItemPtr& item) const
@@ -470,8 +469,7 @@ namespace PVR
         const std::shared_ptr<CPVRTimerInfoTag> parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
         if (parentTimer)
         {
-          const std::shared_ptr<CPVRTimerType> parentTimerType(parentTimer->GetTimerType());
-          if (parentTimerType && !parentTimerType->IsReadOnly())
+          if (!parentTimer->GetTimerType()->IsReadOnly())
             return g_localizeStrings.Get(19243); /* Edit timer rule */
         }
       }
@@ -503,10 +501,7 @@ namespace PVR
       {
         const std::shared_ptr<CPVRTimerInfoTag> parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
         if (parentTimer)
-        {
-          const std::shared_ptr<CPVRTimerType> parentTimerType(parentTimer->GetTimerType());
-          return parentTimerType && parentTimerType->AllowsDelete();
-        }
+          return parentTimer->GetTimerType()->AllowsDelete();
       }
 
       return false;
@@ -529,19 +524,18 @@ namespace PVR
       const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
       if (timer)
       {
-        const std::shared_ptr<CPVRTimerType> timerType(timer->GetTimerType());
-        if (timerType)
+        const std::shared_ptr<CPVRTimerType> timerType = timer->GetTimerType();
+        if (item.GetEPGInfoTag())
         {
-          if (item.GetEPGInfoTag())
-          {
-            if (timerType->IsReminder())
-              return g_localizeStrings.Get(timerType->IsReadOnly() ? 829 : 830); /* View/Edit reminder */
-            else
-              return g_localizeStrings.Get(timerType->IsReadOnly() ? 19241 : 19242); /* View/Edit timer */
-          }
+          if (timerType->IsReminder())
+            return g_localizeStrings.Get(timerType->IsReadOnly() ? 829 /* View reminder */
+                                                                 : 830); /* Edit reminder */
           else
-            return g_localizeStrings.Get(timerType->IsReadOnly() ? 21483 : 21450); /* View/Edit */
+            return g_localizeStrings.Get(timerType->IsReadOnly() ? 19241 /* View timer */
+                                                                 : 19242); /* Edit timer */
         }
+        else
+          return g_localizeStrings.Get(timerType->IsReadOnly() ? 21483 : 21450); /* View/Edit */
       }
       return g_localizeStrings.Get(19241); /* View timer */
     }
@@ -579,10 +573,7 @@ namespace PVR
     {
       const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
       if (timer && (!item.GetEPGInfoTag() || !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER)) && !timer->IsRecording())
-      {
-        const std::shared_ptr<CPVRTimerType> timerType(timer->GetTimerType());
-        return timerType && timerType->AllowsDelete();
-      }
+        return timer->GetTimerType()->AllowsDelete();
 
       return false;
     }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -351,8 +351,7 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag& xbmcTimer, PVR_TIM
   addonTimer.iClientIndex = xbmcTimer.m_iClientIndex;
   addonTimer.iParentClientIndex = xbmcTimer.m_iParentClientIndex;
   addonTimer.state = xbmcTimer.m_state;
-  addonTimer.iTimerType =
-      xbmcTimer.GetTimerType() ? xbmcTimer.GetTimerType()->GetTypeId() : PVR_TIMER_TYPE_NONE;
+  addonTimer.iTimerType = xbmcTimer.GetTimerType()->GetTypeId();
   addonTimer.iClientChannelUid = xbmcTimer.m_iClientChannelUid;
   strncpy(addonTimer.strTitle, xbmcTimer.m_strTitle.c_str(), sizeof(addonTimer.strTitle) - 1);
   strncpy(addonTimer.strEpgSearchString, xbmcTimer.m_strEpgSearchString.c_str(),

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -218,7 +218,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
       SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 19059); /* Stop recording */
       bHideRecord = false;
     }
-    else if (timer->HasTimerType() && !timer->GetTimerType()->IsReadOnly())
+    else if (!timer->GetTimerType()->IsReadOnly())
     {
       SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 19060); /* Delete timer */
       bHideRecord = false;

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -465,7 +465,7 @@ namespace PVR
 
   bool CPVRGUIActions::AddTimer(const std::shared_ptr<CPVRTimerInfoTag>& item) const
   {
-    if (!item->Channel() && item->GetTimerType() && !item->GetTimerType()->IsEpgBasedTimerRule())
+    if (!item->Channel() && !item->GetTimerType()->IsEpgBasedTimerRule())
     {
       CLog::LogF(LOGERROR, "No channel given");
       HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19109}); // "Error", "Could not save the timer. Check the log for more information about this message."
@@ -919,7 +919,7 @@ namespace PVR
         return false;
       }
     }
-    else if (timer->HasTimerType() && !timer->GetTimerType()->AllowsDelete())
+    else if (!timer->GetTimerType()->AllowsDelete())
     {
       return false;
     }
@@ -970,7 +970,7 @@ namespace PVR
     bool bConfirmed(false);
     const std::shared_ptr<CPVRTimerInfoTag> parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
 
-    if (parentTimer && parentTimer->HasTimerType() && parentTimer->GetTimerType()->AllowsDelete())
+    if (parentTimer && parentTimer->GetTimerType()->AllowsDelete())
     {
       // timer was scheduled by a deletable timer rule. prompt user for confirmation for deleting the timer rule, including scheduled timers.
       bool bCancel(false);

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -181,12 +181,6 @@ namespace PVR
     bool IsRecording() const { return m_state == PVR_TIMER_STATE_RECORDING; }
 
     /*!
-      * @brief Checks whether this timer has a timer type.
-      * @return True if this timer has a timer type, false otherwise
-      */
-    bool HasTimerType() const { return m_timerType.get() != NULL; }
-
-    /*!
       * @brief Gets the type of this timer.
       * @return the timer type or NULL if this tag has no timer type.
       */


### PR DESCRIPTION
…on needs to be fixed.

A `CTimerInfoTag` instance must (!) have a timer type. Otherwise very bad things might happen, which cannot be recovered from and lead to very strange and hard to debug followup bugs. So, this PR removes any null checks for the timer type and throws in case no timer type can be found or an attempt is made to set an empty timer type. 

Tested on macOS with different pvr add-ons, latest kodi master

@phunkyfish when you find some time... 