### PR TITLE
[Estuary] PVR Guide window: Truncated channel names should scroll whe…

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -586,6 +586,7 @@
 						<textcolor>button_focus</textcolor>
 						<aligny>center</aligny>
 						<textoffsetx>10</textoffsetx>
+						<scroll>true</scroll>
 					</control>
 				</focusedchannellayout>
 				<itemlayout height="62" width="60">


### PR DESCRIPTION
…n focused.

In PVR guide window long channel names might get truncated. The label should scroll to reveal the full name when it gets focused.

![screenshot00002](https://user-images.githubusercontent.com/3226626/132047124-9559357c-26c8-4e25-92d1-739fd061ffc2.png)
  