### PR TITLE
Fix episode thumbs still showing Spoiler Overlay after being watched

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -42,8 +42,10 @@
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "threads/SingleLock.h"
 #include "utils/Archive.h"
 #include "utils/Crc32.h"
@@ -3289,6 +3291,27 @@ bool CFileItem::SkipLocalArt() const
        || IsLiveTV()
        || IsPVRRecording()
        || IsDVD());
+}
+
+std::string CFileItem::GetThumbHideIfUnwatched(const CFileItem* item) const
+{
+  const std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
+          CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
+  if (setting && item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_type == MediaTypeEpisode &&
+      item->GetVideoInfoTag()->GetPlayCount() == 0 &&
+      !CSettingUtils::FindIntInList(setting,
+                                    CSettings::VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE) &&
+      item->HasArt("thumb"))
+  {
+    const std::string fanArt = item->GetArt("fanart");
+    if (fanArt.empty())
+      return "OverlaySpoiler.png";
+    else
+      return fanArt;
+  }
+
+  return item->GetArt("thumb");
 }
 
 std::string CFileItem::FindLocalArt(const std::string &artFile, bool useFolder) const

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -427,6 +427,13 @@ public:
    */
   bool SkipLocalArt() const;
 
+  /*! \brief Get the thumb for the item, but hide it to prevent spoilers if
+             the user has set 'Show information for unwatched items' appropriately.
+   \param item the item to get the thumb image for.
+   \return fanart or spoiler overlay if item is an unwatched episode, thumb art otherwise.
+   */
+  std::string GetThumbHideIfUnwatched(const CFileItem* item) const;
+
   // Gets the .tbn file associated with this item
   std::string GetTBNFile() const;
   // Gets the folder image associated with this item (defaults to folder.jpg)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10833,7 +10833,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
         return item->GetArt("icon");
       case LISTITEM_ICON:
       {
-        std::string strThumb = item->GetArt("thumb");
+        std::string strThumb = item->GetThumbHideIfUnwatched(item);
         if (strThumb.empty())
           strThumb = item->GetArt("icon");
         if (fallback)
@@ -10845,7 +10845,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
       case LISTITEM_OVERLAY:
         return item->GetOverlayImage();
       case LISTITEM_THUMB:
-        return item->GetArt("thumb");
+        return item->GetThumbHideIfUnwatched(item);
       case LISTITEM_FOLDERPATH:
         return CURL(item->GetPath()).GetWithoutUserDetails();
       case LISTITEM_FOLDERNAME:

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -27,7 +27,6 @@
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "settings/lib/Setting.h"
 #include "utils/EmbeddedArt.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -381,25 +380,6 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
         artwork.insert(std::make_pair(type, art));
     }
     pItem->AppendArt(artwork);
-  }
-
-  // hide thumb if episode is unwatched 
-  std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(
-    CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
-  if (pItem->HasArt("thumb") && pItem->HasVideoInfoTag() &&
-      pItem->GetVideoInfoTag()->m_type == MediaTypeEpisode &&
-      pItem->GetVideoInfoTag()->GetPlayCount() == 0 && setting &&
-      !CSettingUtils::FindIntInList(setting, CSettings::VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE))
-  {
-    // use fanart if available
-    if (pItem->HasArt("fanart"))
-    {
-      pItem->SetArt("thumb", pItem->GetArt("fanart"));
-    }
-    else
-    {
-      pItem->SetArt("thumb", "OverlaySpoiler.png");
-    }
   }
 
   m_videoDatabase->Close();


### PR DESCRIPTION
## Description
Fix for the issue raised a long time ago in #15296 
The setting we are speaking of here is **Settings -> Media -> Videos -> Show information for unwatched items** 
And the **Episode thumb** option which can be:
- Selected = TV show episode thumbs will always be shown regardless of watched status. 
- Unselected = TV show episode thumbs will be hidden for unwatched episodes.

When the option was unselected, there was a bug which meant on an initial media add/scan to library the thumbs would be hidden (by the spoiler overlay) but they would remain hidden when watched or when the watched status was changed.

## Motivation and context
Fix/change to make the GUI interface responsible for hiding the thumbs where appropriate, and leave the database library art alone - media scrapers can do their job and users can still choose custom artwork.
See #15296 for more details.

## How has this been tested?
Built on Ubuntu 20.10
Tested by changing the selection status of the **Episode thumb** setting and:
Looking at existing TV Shows with a mixture of watched/unwatched items and changing the watched status.
Tested the different list views and the information dialog view of the default Estuary skin.
Tested by adding a new TV Show to the library with the "Episode thumb" both selected and unselected and seeing that the thumbs are shown/hidden appropriately.

## What is the effect on users?
Users will have TV show thumbs for unwatched episodes hidden (if they set the appropriate setting) and thumbs will show/hide as episodes are watched or marked as watched/unwatched.
HOWEVER: Users who have set the setting and added/scraped TV shows to their library with the old version of the code will need to do a refresh of the show for this fix to take effect. That is because the thumb artwork in their database will already be set wrong for unwatched items.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

Bug fix, but also improvement on previous implementation as this now does not change artwork in the database, now only changes what is shown in the GUI interface.

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed