### PR TITLE
[linux] storage: check if devnode is valid pointer

### DIFF
--- a/xbmc/platform/linux/storage/UDevProvider.cpp
+++ b/xbmc/platform/linux/storage/UDevProvider.cpp
@@ -117,8 +117,16 @@ void CUDevProvider::GetDisks(VECSOURCES& disks, bool removable)
     if (!device)
       continue;
 
+    // filter out devices without devnode
+    const char* devnode = udev_device_get_devnode(device);
+    if (!devnode)
+    {
+      udev_device_unref(device);
+      continue;
+    }
+
     // filter out devices that are not mounted
-    const char *mountpoint = get_mountpoint(udev_device_get_devnode(device));
+    const char* mountpoint = get_mountpoint(devnode);
     if (!mountpoint)
     {
       udev_device_unref(device);
@@ -225,16 +233,17 @@ bool CUDevProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
 
   if (FD_ISSET(udev_monitor_get_fd(m_udevMon), &readfds))
   {
-		struct udev_device *dev = udev_monitor_receive_device(m_udevMon);
+    struct udev_device* dev = udev_monitor_receive_device(m_udevMon);
     if (!dev)
       return false;
 
-    const char *action  = udev_device_get_action(dev);
-    if (action)
+    const char* action = udev_device_get_action(dev);
+    const char* devnode = udev_device_get_devnode(dev);
+    if (action && devnode)
     {
       std::string label;
       const char *udev_label = udev_device_get_property_value(dev, "ID_FS_LABEL");
-      const char *mountpoint = get_mountpoint(udev_device_get_devnode(dev));
+      const char* mountpoint = get_mountpoint(devnode);
       if (udev_label)
         label = udev_label;
       else if (mountpoint)


### PR DESCRIPTION
## Description
Prevent segfault if udev_device_get_devnode() returned NULL.

## Motivation and context
This change fixes segfault when `udev_device` doesn't have devnode.

## How has this been tested?
Tested on Alpine linux with libudev-zero(master branch)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
