### PR TITLE
AESinkPipewire: fix compile error by adding include

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -17,6 +17,7 @@
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/log.h"
 
+#include <pipewire/keys.h>
 #include <spa/param/audio/raw.h>
 
 namespace


### PR DESCRIPTION
This fixes #19846

