### PR TITLE
[cmake][osx] Partial revert - xcode variable usage

### DIFF
--- a/cmake/scripts/osx/Macros.cmake
+++ b/cmake/scripts/osx/Macros.cmake
@@ -4,7 +4,7 @@ function(core_link_library lib wraplib)
   elseif(CMAKE_GENERATOR MATCHES "Xcode")
     # CURRENT_VARIANT is an Xcode env var
     # CPU is a project cmake var
-    set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$CURRENT_VARIANT/${CPU}/wrapper.o)
+    set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$(CURRENT_VARIANT)/${CPU}/wrapper.o)
   else()
     message(FATAL_ERROR "Unsupported generator in core_link_library")
   endif()


### PR DESCRIPTION
## Description
I changed this as the "new" build system didnt play nice, but i later added a commit to default to the legacy system with xcode 12 still.
Because of that, roll this back to the "default" working code for the Legacy build system.

## Motivation and context
Just an annoying change. Get back to sane defaults for now. Deal with cmake generation of the "new" build system at a nother time.

## How has this been tested?
Xcode 11.3.1, xcode 12.5.1 legacy build system cmake generation

## What is the effect on users?
N/A for users
Devs get working defaults back

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
