### PR TITLE
[PVR] Search missing channel icons job must be executed by PVR manage…

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -811,26 +811,22 @@ void CPVRManager::TriggerChannelGroupsUpdate()
 
 void CPVRManager::TriggerSearchMissingChannelIcons()
 {
-  if (IsStarted())
-  {
-    CJobManager::GetInstance().Submit([this] {
-      CPVRGUIChannelIconUpdater updater({ChannelGroups()->GetGroupAllTV(), ChannelGroups()->GetGroupAllRadio()}, true);
-      updater.SearchAndUpdateMissingChannelIcons();
-      return true;
-    });
-  }
+  m_pendingUpdates->Append("pvr-search-missing-channel-icons", [this]() {
+    CPVRGUIChannelIconUpdater updater(
+        {ChannelGroups()->GetGroupAllTV(), ChannelGroups()->GetGroupAllRadio()}, true);
+    updater.SearchAndUpdateMissingChannelIcons();
+    return true;
+  });
 }
 
 void CPVRManager::TriggerSearchMissingChannelIcons(const std::shared_ptr<CPVRChannelGroup>& group)
 {
-  if (IsStarted())
-  {
-    CJobManager::GetInstance().Submit([group] {
-      CPVRGUIChannelIconUpdater updater({group}, false);
-      updater.SearchAndUpdateMissingChannelIcons();
-      return true;
-    });
-  }
+  m_pendingUpdates->Append("pvr-search-missing-channel-icons-" + std::to_string(group->GroupID()),
+                           [group]() {
+                             CPVRGUIChannelIconUpdater updater({group}, false);
+                             updater.SearchAndUpdateMissingChannelIcons();
+                             return true;
+                           });
 }
 
 void CPVRManager::ConnectionStateChange(CPVRClient* client,


### PR DESCRIPTION
…r thread to avoid races in complex restart scenarios.

Fixes #20028 

Channel icon search must be executed under control of PVR manager to ensure the manager is in working state when the job gets executed, which was not the case before because the jobs controlled by `CJobManager` which were used so far can get executed at any time, even while PVR manager is re-initializing. That's what happened for the reporter of #20028 and led to a crash.

Fix was runtime tested by me and the issue reporter.

@phunkyfish when you find some time for a review.