### PR TITLE
AESinkAudioTrack: Use min_buffer periods

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -711,7 +711,9 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   delay += m_hw_delay;
 
   // stop smoothing if we have the new API available
-  if (m_hw_delay != 0)
+  // though normal RAW still is really bad delay wise
+  bool rawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
+  if ((m_hw_delay != 0) && !rawPt)
     m_linearmovingaverage.clear();
 
   if (usesAdvancedLogging)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -509,17 +509,20 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       }
       else
       {
-        // aim at 200 ms buffer and 50 ms periods
+        // aim at 200 ms buffer and 50 ms periods but at least two periods of min_buffer
+        m_min_buffer_size *= 2;
         m_audiotrackbuffer_sec =
             static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
+
+        int c = 2;
         while (m_audiotrackbuffer_sec < 0.15)
         {
           m_min_buffer_size += min_buffer;
+          c++;
           m_audiotrackbuffer_sec =
               static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
         }
-        // division by 4 -> 4 periods into one buffer
-        m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / 4;
+        m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / c;
       }
     }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -709,6 +709,11 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   }
 
   delay += m_hw_delay;
+
+  // stop smoothing if we have the new API available
+  if (m_hw_delay != 0)
+    m_linearmovingaverage.clear();
+
   if (usesAdvancedLogging)
   {
     CLog::Log(LOGINFO, "Combined Delay: {} ms", delay * 1000);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -34,7 +34,7 @@ using namespace jni;
 // is the max TrueHD package
 const unsigned int MAX_RAW_AUDIO_BUFFER_HD = 61440;
 const unsigned int MAX_RAW_AUDIO_BUFFER = 16384;
-const unsigned int MOVING_AVERAGE_MAX_MEMBERS = 5;
+const unsigned int MOVING_AVERAGE_MAX_MEMBERS = 3;
 const uint64_t UINT64_LOWER_BYTES = 0x00000000FFFFFFFF;
 const uint64_t UINT64_UPPER_BYTES = 0xFFFFFFFF00000000;
 


### PR DESCRIPTION
While looking at some user's logfiles on the forum I have seen that the logic with having 1/4th of the buffer as periods is not optimal. The reason is not the ratio but the way it is divided.

Imagine the following:
min_buffer = 64 ms
2 * min_buffer = 128 ms
3 * min_buffer = 192 ms

Now we use:
buffersize = 192 ms
periodSize = 192 / 4 ms = 48 ms

This 48 is not a "valid" period, means it might work okayish or not. New code does the following:

Divider = 2;
min_buffer = 64 ms
2 * min_buffer = 128 ms
3 * min_buffer = 192 ms - increment c by 1

Resulting in:
buffersize = 192 ms
periodSize = 192 / 3 ms = 64 ms == min_buffer - so it's a valid value by itself to be filled into the sink.

How was this tested:
- Not at all.

Would be happy if someone could test it. It has an additional debug print commit in there that shows me if it works better than before.
