### PR TITLE
Fix bug for not applying VolumeAmplification setting correctly at playback: issue# 17564

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -488,7 +488,8 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
         m_audioSink.Resume();
     }
 
-    m_audioSink.SetDynamicRangeCompression((long)(m_processInfo.GetVideoSettings().m_VolumeAmplification * 100));
+    m_audioSink.SetDynamicRangeCompression(
+      static_cast<long>(m_processInfo.GetVideoSettings().m_VolumeAmplification * 100));
     
     SetSyncType(audioframe.passthrough);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -484,12 +484,12 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
       if (!m_audioSink.Create(audioframe, m_streaminfo.codec, m_synctype == SYNC_RESAMPLE))
         CLog::Log(LOGERROR, "%s - failed to create audio renderer", __FUNCTION__);
 
-      m_audioSink.SetDynamicRangeCompression((long)(m_processInfo.GetVideoSettings().m_VolumeAmplification * 100));
-
       if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
         m_audioSink.Resume();
     }
 
+    m_audioSink.SetDynamicRangeCompression((long)(m_processInfo.GetVideoSettings().m_VolumeAmplification * 100));
+    
     SetSyncType(audioframe.passthrough);
 
     // downmix


### PR DESCRIPTION

## Description
Fixed bug when applying VolumeAmplification setting.

Bug was introduced in Leia fork, when videoSettings were moved to player: https://github.com/xbmc/xbmc/pull/12944/commits/dd254c8f8f0d24786cbb4e9758d14eee8b2ef6df

Currently if AudioSink check for valid format is true, then call inside statement to set VolumeAmplification would not be reached. End result is if check was valid, VolumeAmplification from settings would not be applied at playback, and sound output would be low.

Moved call to set VolumeAmplification outside of IF statement. VolumeAmplification setting now gets applied correctly on playback, as intended.

## Motivation and context
Bugfix. Fixes Issue#17564 

## How has this been tested?
Compiled Kodi from Matrix 19.1 snapshot to a Windows x64 executable. Tested on Windows 10 x64 machine.
Used Visual Studio 2017 Community and all supporting build requirements as documented in official Kodi readme.
This change should not affect other code, just fix a bug.

## What is the effect on users?
End users will notice that after starting Kodi, VolumeAmplification settings are respected when playing media and sound level is as expected.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
