### PR TITLE
[osx] change explicit HAS_SDL define to TARGET_DARWIN_OSX

### DIFF
--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -208,7 +208,7 @@ void CPowerManager::OnWake()
   if (dialog)
     dialog->Close(true); // force close. no closing animation, sound etc at this early stage
 
-#if defined(HAS_SDL) || defined(TARGET_WINDOWS)
+#if defined(TARGET_DARWIN_OSX) || defined(TARGET_WINDOWS)
   if (CServiceBroker::GetWinSystem()->IsFullScreen())
   {
 #if defined(TARGET_WINDOWS_DESKTOP)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -904,7 +904,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 #if defined(TARGET_WINDOWS_DESKTOP)
   XMLUtils::GetBoolean(pRootElement, "minimizetotray", m_minimizeToTray);
 #endif
-#if defined(HAS_SDL) || defined(TARGET_WINDOWS)
+#if defined(TARGET_DARWIN_OSX) || defined(TARGET_WINDOWS)
   XMLUtils::GetBoolean(pRootElement, "fullscreen", m_startFullScreen);
 #endif
   XMLUtils::GetBoolean(pRootElement, "splash", m_splashImage);


### PR DESCRIPTION
## Description
OSX is the last platform utilising SDL, change define to target platform

## Motivation and context
further osx sdl cleanups

## How has this been tested?

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
