### PR TITLE
CWinSystemBase: add virtual method GetConnectedOutputs

### DIFF
--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -171,6 +171,8 @@ public:
   // Gets debug info from video renderer
   virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; };
 
+  virtual std::vector<std::string> GetConnectedOutputs() { return {}; }
+
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);
   virtual std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() { return nullptr; }

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -462,16 +462,19 @@ bool CWinSystemX11::UseLimitedColor()
   return CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
 }
 
-void CWinSystemX11::GetConnectedOutputs(std::vector<std::string> *outputs)
+std::vector<std::string> CWinSystemX11::GetConnectedOutputs()
 {
+  std::vector<std::string> outputs;
   std::vector<XOutput> outs;
   g_xrandr.Query(true);
   outs = g_xrandr.GetModes();
-  outputs->push_back("Default");
+  outputs.emplace_back("Default");
   for(unsigned int i=0; i<outs.size(); ++i)
   {
-    outputs->push_back(outs[i].name);
+    outputs.emplace_back(outs[i].name);
   }
+
+  return outputs;
 }
 
 bool CWinSystemX11::IsCurrentOutput(const std::string& output)

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -62,11 +62,12 @@ public:
   bool HasCalibration(const RESOLUTION_INFO &resInfo) override;
   bool UseLimitedColor() override;
 
+  std::vector<std::string> GetConnectedOutputs() override;
+
   // Local to WinSystemX11 only
   Display*  GetDisplay() { return m_dpy; }
   int GetScreen() { return m_screen; }
   void NotifyXRREvent();
-  void GetConnectedOutputs(std::vector<std::string> *outputs);
   bool IsCurrentOutput(const std::string& output);
   void RecreateWindow();
   int GetCrtc() { return m_crtc; }

--- a/xbmc/windowing/ios/WinSystemIOS.h
+++ b/xbmc/windowing/ios/WinSystemIOS.h
@@ -62,12 +62,13 @@ public:
 
   std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
 
+  std::vector<std::string> GetConnectedOutputs() override;
+
   bool InitDisplayLink(CVideoSyncIos *syncImpl);
   void DeinitDisplayLink(void);
   void OnAppFocusChange(bool focus);
   bool IsBackgrounded() const { return m_bIsBackgrounded; }
   CVEAGLContext GetEAGLContextObj();
-  void GetConnectedOutputs(std::vector<std::string> *outputs);
   void MoveToTouchscreen();
 
   // winevents override

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -470,14 +470,17 @@ CVEAGLContext CWinSystemIOS::GetEAGLContextObj()
   return [g_xbmcController getEAGLContextObj];
 }
 
-void CWinSystemIOS::GetConnectedOutputs(std::vector<std::string> *outputs)
+std::vector<std::string> CWinSystemIOS::GetConnectedOutputs()
 {
-  outputs->push_back("Default");
-  outputs->push_back(CONST_TOUCHSCREEN);
+  std::vector<std::string> outputs;
+  outputs.emplace_back("Default");
+  outputs.emplace_back(CONST_TOUCHSCREEN);
   if ([[UIScreen screens] count] > 1)
   {
-    outputs->push_back(CONST_EXTERNAL);
+    outputs.emplace_back(CONST_EXTERNAL);
   }
+
+  return outputs;
 }
 
 void CWinSystemIOS::MoveToTouchscreen()

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.h
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.h
@@ -59,6 +59,8 @@ public:
 
   std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
 
+  std::vector<std::string> GetConnectedOutputs() override;
+
   void        WindowChangedScreen();
 
   void        AnnounceOnLostDevice();
@@ -73,7 +75,6 @@ public:
 #else
   void* GetNSOpenGLContext();
 #endif
-  void GetConnectedOutputs(std::vector<std::string> *outputs);
 
   // winevents override
   bool MessagePump() override;

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -1831,15 +1831,18 @@ bool CWinSystemOSX::MessagePump()
   return m_winEvents->MessagePump();
 }
 
-void CWinSystemOSX::GetConnectedOutputs(std::vector<std::string> *outputs)
+std::vector<std::string> CWinSystemOSX::GetConnectedOutputs()
 {
-  outputs->push_back("Default");
+  std::vector<std::string> outputs;
+  outputs.emplace_back("Default");
 
   int numDisplays = [[NSScreen screens] count];
 
   for (int disp = 0; disp < numDisplays; disp++)
   {
     NSString *dispName = screenNameForDisplay(GetDisplayID(disp));
-    outputs->push_back([dispName UTF8String]);
+    outputs.emplace_back([dispName UTF8String]);
   }
+
+  return outputs;
 }

--- a/xbmc/windowing/tvos/WinSystemTVOS.h
+++ b/xbmc/windowing/tvos/WinSystemTVOS.h
@@ -74,12 +74,13 @@ public:
 
   //virtual std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
 
+  std::vector<std::string> GetConnectedOutputs() override;
+
   bool InitDisplayLink(CVideoSyncTVos* syncImpl);
   void DeinitDisplayLink(void);
   void OnAppFocusChange(bool focus);
   bool IsBackgrounded() const { return m_bIsBackgrounded; }
   CVEAGLContext GetEAGLContextObj();
-  void GetConnectedOutputs(std::vector<std::string>* outputs);
 
   // winevents override
   bool MessagePump() override;

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -437,10 +437,13 @@ CVEAGLContext CWinSystemTVOS::GetEAGLContextObj()
   return [g_xbmcController getEAGLContextObj];
 }
 
-void CWinSystemTVOS::GetConnectedOutputs(std::vector<std::string>* outputs)
+std::vector<std::string> CWinSystemTVOS::GetConnectedOutputs()
 {
-  outputs->push_back("Default");
-  outputs->push_back(CONST_HDMI);
+  std::vector<std::string> outputs;
+  outputs.emplace_back("Default");
+  outputs.emplace_back(CONST_HDMI);
+
+  return outputs;
 }
 
 bool CWinSystemTVOS::MessagePump()

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -399,13 +399,15 @@ bool CWinSystemWayland::CanDoWindowed()
   return true;
 }
 
-void CWinSystemWayland::GetConnectedOutputs(std::vector<std::string>* outputs)
+std::vector<std::string> CWinSystemWayland::GetConnectedOutputs()
 {
   CSingleLock lock(m_outputsMutex);
-  std::transform(m_outputs.cbegin(), m_outputs.cend(), std::back_inserter(*outputs),
+  std::vector<std::string> outputs;
+  std::transform(m_outputs.cbegin(), m_outputs.cend(), std::back_inserter(outputs),
                  [this](decltype(m_outputs)::value_type const& pair)
-                 {
-                   return UserFriendlyOutputName(pair.second); });
+                 { return UserFriendlyOutputName(pair.second); });
+
+  return outputs;
 }
 
 bool CWinSystemWayland::UseLimitedColor()

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -88,8 +88,7 @@ public:
   using PresentationFeedbackHandler = std::function<void(timespec /* tv */, std::uint32_t /* refresh */, std::uint32_t /* sync output id */, float /* sync output fps */, std::uint64_t /* msc */)>;
   CSignalRegistration RegisterOnPresentationFeedback(const PresentationFeedbackHandler& handler);
 
-  // Like CWinSystemX11
-  void GetConnectedOutputs(std::vector<std::string>* outputs);
+  std::vector<std::string> GetConnectedOutputs() override;
 
   // winevents override
   bool MessagePump() override;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -644,12 +644,16 @@ void CWinSystemWin32::SetMinimized(bool minimized)
   m_bMinimized = minimized;
 }
 
-void CWinSystemWin32::GetConnectedOutputs(std::vector<std::string>* outputs)
+std::vector<std::string> CWinSystemWin32::GetConnectedOutputs()
 {
+  std::vector<std::string> outputs;
+
   for (auto& display : m_displays)
   {
-    outputs->push_back(KODI::PLATFORM::WINDOWS::FromW(display.MonitorNameW));
+    outputs.emplace_back(KODI::PLATFORM::WINDOWS::FromW(display.MonitorNameW));
   }
+
+  return outputs;
 }
 
 void CWinSystemWin32::RestoreDesktopResolution(MONITOR_DETAILS* details)

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -104,6 +104,8 @@ public:
   bool WindowedMode() const { return m_state != WINDOW_STATE_FULLSCREEN; }
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
+  std::vector<std::string> GetConnectedOutputs() override;
+
   // CWinSystemWin32
   HWND GetHwnd() const { return m_hWnd; }
   bool IsAlteringWindow() const { return m_IsAlteringWindow; }
@@ -111,7 +113,6 @@ public:
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized);
-  void GetConnectedOutputs(std::vector<std::string> *outputs);
 
   // touchscreen support
   typedef BOOL(WINAPI *pGetGestureInfo)(HGESTUREINFO, PGESTUREINFO);


### PR DESCRIPTION
This provides correct inheritance for the `GetConnectedOutputs` method. The way it was done before didn't account for the fact that more than one window system can be present at one time (wayland, x11, gbm).

I was getting a crash because the order of the ifdefs when using the windowing system that didn't match.
```
Thread 1 (Thread 0x7f17c41cb140 (LWP 774004)):
#0  __GI___pthread_mutex_lock (mutex=0x350) at ../nptl/pthread_mutex_lock.c:67
#1  0x0000000002aa22da in XbmcThreads::CRecursiveMutex::lock() (this=0x350) at /home/lukas/Documents/git/xbmc/xbmc/threads/platform/RecursiveMutex.h:33
#2  0x0000000002aa42ce in XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock() (this=0x350) at /home/lukas/Documents/git/xbmc/xbmc/threads/Lockables.h:49
#3  0x0000000002aa3368 in XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock(CCriticalSection&) (this=0x7ffdc25f95a0, lockable=...) at /home/lukas/Documents/git/xbmc/xbmc/threads/Lockables.h:112
#4  0x0000000002aa232d in CSingleLock::CSingleLock(CCriticalSection&) (this=0x7ffdc25f95a0, cs=...) at /home/lukas/Documents/git/xbmc/xbmc/threads/SingleLock.h:27
#5  0x0000000003ebc501 in KODI::WINDOWING::WAYLAND::CWinSystemWayland::GetConnectedOutputs(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >*) (this=0x0, outputs=0x7ffdc25f9630) at /home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/WinSystemWayland.cpp:404
#6  0x00000000037af5b9 in CDisplaySettings::SettingOptionsMonitorsFiller(std::shared_ptr<CSetting const> const&, std::vector<StringSettingOption, std::allocator<StringSettingOption> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, void*) (setting=std::shared_ptr<const class CSetting> (use count 8, weak count 1) = {...}, list=std::vector of length 0, capacity 0, current="Default", data=0x0) at /home/lukas/Documents/git/xbmc/xbmc/settings/DisplaySettings.cpp:890
```

This may result in a regression for X11 and OSX as I removed the path that they used and went with what I thought was the more sane approach.
