### PR TITLE
Fix GUIFontTTF cache

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -735,12 +735,9 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyph
     return NULL;
 
   // quick access to ascii chars
-  if (letter < 255)
+  if (letter < 255 && glyphIndex < 255)
   {
-    character_t ch = (style << 8) | (glyphIndex & 0xff);
-
-    if (glyphIndex > 255)
-      ch += 2048;
+    character_t ch = (style << 8) | glyphIndex;
 
     if (ch < LOOKUPTABLE_SIZE && m_charquick[ch])
       return m_charquick[ch];
@@ -807,13 +804,9 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyph
   memset(m_charquick, 0, sizeof(m_charquick));
   for (int i = 0; i < m_numChars; i++)
   {
-    if (m_char[i].letter < 255)
+    if (m_char[i].letter < 255 && m_char[i].glyphIndex < 255)
     {
-      character_t ch =
-          ((m_char[i].glyphAndStyle & 0xffff0000) >> 8) | (m_char[i].glyphIndex & 0xff);
-
-      if (m_char[i].glyphIndex > 255)
-        ch += 2048;
+      character_t ch = ((m_char[i].glyphAndStyle & 0xffff0000) >> 8) | m_char[i].glyphIndex;
 
       if (ch < LOOKUPTABLE_SIZE)
         m_charquick[ch] = m_char + i;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -28,7 +28,7 @@ using namespace DirectX;
 using namespace DirectX::PackedVector;
 #endif
 
-constexpr size_t LOOKUPTABLE_SIZE = 256 * 8 * 2;
+constexpr size_t LOOKUPTABLE_SIZE = 256 * 8;
 
 class CTexture;
 class CRenderSystemBase;


### PR DESCRIPTION
## Description
Fix GUIFontTTF cache

Fixes https://github.com/xbmc/xbmc/issues/20130

## Motivation and context
With some fonts that use advanced OpenType features some characters are wrong rendered (replaced by other chars). 
See https://github.com/xbmc/xbmc/issues/20130

As a summary there are several related commits after Harfbuzz merge:

- https://github.com/xbmc/xbmc/pull/19765 causes crash by array out of bound. 
- https://github.com/xbmc/xbmc/pull/19998 causes some letters combinations (ff, fi, fl. standard ligatures) wrong render.
- https://github.com/xbmc/xbmc/pull/20015 causes some letters replaced, only with determined fonts that uses determined OpenType features.
- This PR...

The fix consists in only use lookup table when it's an ASCII character and `glyphIndex < 255`

The performance impact is practically non-existent with Estuary skin since only some specific letters combinations generates  glyphIndex > 255 (ff, fi, fl).

With other skins / fonts the impact is still low since only certain combinations are not cached: some uppercases followed lowercase  i.e.   'Zoom'  'Windows' words.

What happens here is that some fonts can use OpenType advanced features so that the same letter is repeated several times with different glyph IDs so that a slightly different spacing is used depending on the next letter... to improve readability. And only the glyph with standard o base spacing has ID < 255,  the other repetitions of the same letter with special spacing can have any glyph ID.

In fact, any letter or symbol can have a glyph ID > 255, but only in the first 255 lookup table is used and also it usually coincides that they are the most used. I can't think any reason why a particular font could assign glyph ID > 255 for common letters a-z, A-Z, 0-9 although it would be possible. Then lookup table would not be used but it would still work fine.

## How has this been tested?
Runtime tested on Windows x64
Tested on LibreELEC here: https://github.com/xbmc/xbmc/issues/20130#issuecomment-917618754

## What is the effect on users?
Fixes some characters wrong render when using custom fonts / skins. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
