### PR TITLE
linux: improve DRM format and modifier logging

### DIFF
--- a/cmake/modules/FindLibDRM.cmake
+++ b/cmake/modules/FindLibDRM.cmake
@@ -42,11 +42,18 @@ check_c_source_compiles("#include <drm_mode.h>
                          }
                          " LIBDRM_HAS_HDR_OUTPUT_METADATA)
 
+include(CheckSymbolExists)
+set(CMAKE_REQUIRED_LIBRARIES ${LIBDRM_LIBRARY})
+check_symbol_exists(drmGetFormatModifierName xf86drm.h LIBDRM_HAS_MODIFIER_NAME)
+
 if(LIBDRM_FOUND)
   set(LIBDRM_LIBRARIES ${LIBDRM_LIBRARY})
   set(LIBDRM_INCLUDE_DIRS ${LIBDRM_INCLUDE_DIR})
   if(LIBDRM_HAS_HDR_OUTPUT_METADATA)
     set(LIBDRM_DEFINITIONS -DHAVE_HDR_OUTPUT_METADATA=1)
+  endif()
+  if(LIBDRM_HAS_MODIFIER_NAME)
+    list(APPEND LIBDRM_DEFINITIONS -DHAVE_DRM_MODIFIER_NAME=1)
   endif()
 
   if(NOT TARGET LIBDRM::LIBDRM)

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "utils/BufferObject.h"
+#include "utils/DRMHelpers.h"
 #include "utils/log.h"
 
 extern "C"
@@ -96,7 +97,7 @@ void CVideoBufferDMA::SetDimensions(int width,
                                   planeOffsets[plane]));
 
     CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
-              __FUNCTION__, m_id, m_fourcc, planeStr);
+              __FUNCTION__, m_id, DRMHELPERS::FourCCToString(m_fourcc), planeStr);
   }
 }
 
@@ -110,7 +111,8 @@ bool CVideoBufferDMA::Alloc()
   m_planes = 3; // CAddonVideoCodec only requests AV_PIX_FMT_YUV420P for now
 
   CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - id={} fourcc={} fd={} size={} addr={}",
-            __FUNCTION__, m_id, m_fourcc, m_fd, m_size, fmt::ptr(m_addr));
+            __FUNCTION__, m_id, DRMHELPERS::FourCCToString(m_fourcc), m_fd, m_size,
+            fmt::ptr(m_addr));
 
   return true;
 }
@@ -140,7 +142,7 @@ void CVideoBufferDMA::Export(AVFrame* frame, uint32_t width, uint32_t height)
                                   m_offsets[plane]));
 
     CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
-              __FUNCTION__, m_id, m_fourcc, planeStr);
+              __FUNCTION__, m_id, DRMHELPERS::FourCCToString(m_fourcc), planeStr);
   }
 
   for (uint32_t i = 0; i < AV_NUM_DATA_POINTERS; i++)

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -216,6 +216,11 @@ if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_L
     list(APPEND SOURCES EGLImage.cpp)
     list(APPEND HEADERS EGLImage.h)
   endif()
+
+  if(LIBDRM_FOUND)
+    list(APPEND SOURCES DRMHelpers.cpp)
+    list(APPEND HEADERS DRMHelpers.h)
+  endif()
 endif()
 
 core_add_library(utils)

--- a/xbmc/utils/DRMHelpers.cpp
+++ b/xbmc/utils/DRMHelpers.cpp
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DRMHelpers.h"
+
+#include <sstream>
+
+namespace DRMHELPERS
+{
+
+std::string FourCCToString(uint32_t fourcc)
+{
+  std::stringstream ss;
+  ss << static_cast<char>((fourcc & 0x000000FF));
+  ss << static_cast<char>((fourcc & 0x0000FF00) >> 8);
+  ss << static_cast<char>((fourcc & 0x00FF0000) >> 16);
+  ss << static_cast<char>((fourcc & 0xFF000000) >> 24);
+
+  return ss.str();
+}
+
+} // namespace DRMHELPERS

--- a/xbmc/utils/DRMHelpers.cpp
+++ b/xbmc/utils/DRMHelpers.cpp
@@ -8,7 +8,12 @@
 
 #include "DRMHelpers.h"
 
+#include "utils/StringUtils.h"
+
 #include <sstream>
+
+#include <drm_fourcc.h>
+#include <xf86drm.h>
 
 namespace DRMHELPERS
 {
@@ -22,6 +27,34 @@ std::string FourCCToString(uint32_t fourcc)
   ss << static_cast<char>((fourcc & 0xFF000000) >> 24);
 
   return ss.str();
+}
+
+std::string ModifierToString(uint64_t modifier)
+{
+#if defined(HAVE_DRM_MODIFIER_NAME)
+  std::string modifierVendorStr{"UNKNOWN_VENDOR"};
+
+  const char* vendorName = drmGetFormatModifierVendor(modifier);
+  if (vendorName)
+    modifierVendorStr = std::string(vendorName);
+
+  free(const_cast<char*>(vendorName));
+
+  std::string modifierNameStr{"UNKNOWN_MODIFIER"};
+
+  const char* modifierName = drmGetFormatModifierName(modifier);
+  if (modifierName)
+    modifierNameStr = std::string(modifierName);
+
+  free(const_cast<char*>(modifierName));
+
+  if (modifier == DRM_FORMAT_MOD_LINEAR)
+    return modifierNameStr;
+
+  return modifierVendorStr + "_" + modifierNameStr;
+#else
+  return StringUtils::Format("{:#x}", modifier);
+#endif
 }
 
 } // namespace DRMHELPERS

--- a/xbmc/utils/DRMHelpers.h
+++ b/xbmc/utils/DRMHelpers.h
@@ -15,4 +15,6 @@ namespace DRMHELPERS
 
 std::string FourCCToString(uint32_t fourcc);
 
+std::string ModifierToString(uint64_t modifier);
+
 } // namespace DRMHELPERS

--- a/xbmc/utils/DRMHelpers.h
+++ b/xbmc/utils/DRMHelpers.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace DRMHELPERS
+{
+
+std::string FourCCToString(uint32_t fourcc);
+
+} // namespace DRMHELPERS

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -240,15 +240,24 @@ bool CEGLImage::SupportsFormat(uint32_t format)
   }
 
   auto foundFormat = std::find(formats.begin(), formats.end(), format);
+  if (foundFormat == formats.end() || CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
+  {
+    std::string formatStr;
+    for (const auto& supportedFormat : formats)
+      formatStr.append("\n" + FourCCToString(supportedFormat));
+
+    CLog::Log(LOGDEBUG, "CEGLImage::{} - supported formats:{}", __FUNCTION__, formatStr);
+  }
+
   if (foundFormat != formats.end())
+  {
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CEGLImage::{} - supported format: {}", __FUNCTION__,
+              FourCCToString(format));
     return true;
+  }
 
-  CLog::Log(LOGDEBUG, "CEGLImage::{} - format not supported: {}", __FUNCTION__,
+  CLog::Log(LOGERROR, "CEGLImage::{} - format not supported: {}", __FUNCTION__,
             FourCCToString(format));
-
-  CLog::Log(LOGERROR, "CEGLImage::{} - supported formats:", __FUNCTION__);
-  for (const auto& supportedFormat : formats)
-    CLog::Log(LOGERROR, "CEGLImage::{} -   {}", __FUNCTION__, FourCCToString(supportedFormat));
 
   return false;
 }
@@ -295,15 +304,23 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
   }
 
   auto foundModifier = std::find(modifiers.begin(), modifiers.end(), modifier);
+  if (foundModifier == modifiers.end() || CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
+  {
+    std::string modifierStr;
+    for (const auto& supportedModifier : modifiers)
+      modifierStr.append("\n" + std::to_string(supportedModifier));
+
+    CLog::Log(LOGDEBUG, "CEGLImage::{} - supported modifiers:{}", __FUNCTION__, modifierStr);
+  }
+
   if (foundModifier != modifiers.end())
+  {
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CEGLImage::{} - supported modifier: {}", __FUNCTION__, modifier);
     return true;
+  }
 
-  CLog::Log(LOGDEBUG, "CEGLImage::{} - modifier ({:#x}) not supported for format ({})",
+  CLog::Log(LOGERROR, "CEGLImage::{} - modifier ({:#x}) not supported for format ({})",
             __FUNCTION__, modifier, FourCCToString(format));
-
-  CLog::Log(LOGERROR, "CEGLImage::{} - supported modifiers:", __FUNCTION__);
-  for (const auto& supportedModifier : modifiers)
-    CLog::Log(LOGERROR, "CEGLImage::{} -   {}", __FUNCTION__, supportedModifier);
 
   return false;
 }

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -9,11 +9,11 @@
 #include "EGLImage.h"
 
 #include "ServiceBroker.h"
+#include "utils/DRMHelpers.h"
 #include "utils/EGLUtils.h"
 #include "utils/log.h"
 
 #include <map>
-#include <sstream>
 
 namespace
 {
@@ -101,17 +101,6 @@ std::map<EGLint, const char*> eglAttributes =
 #endif
 };
 
-std::string FourCCToString(uint32_t fourcc)
-{
-  std::stringstream ss;
-  ss << static_cast<char>((fourcc & 0x000000FF));
-  ss << static_cast<char>((fourcc & 0x0000FF00) >> 8);
-  ss << static_cast<char>((fourcc & 0x00FF0000) >> 16);
-  ss << static_cast<char>((fourcc & 0xFF000000) >> 24);
-
-  return ss.str();
-}
-
 } // namespace
 
 CEGLImage::CEGLImage(EGLDisplay display) :
@@ -184,7 +173,7 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
       else
       {
         if (eglAttrKey != eglAttributes.end() && eglAttrKey->first == EGL_LINUX_DRM_FOURCC_EXT)
-          valueStr = FourCCToString(attrs[i + 1]);
+          valueStr = DRMHELPERS::FourCCToString(attrs[i + 1]);
         else
           valueStr = std::to_string(attrs[i + 1]);
       }
@@ -244,7 +233,7 @@ bool CEGLImage::SupportsFormat(uint32_t format)
   {
     std::string formatStr;
     for (const auto& supportedFormat : formats)
-      formatStr.append("\n" + FourCCToString(supportedFormat));
+      formatStr.append("\n" + DRMHELPERS::FourCCToString(supportedFormat));
 
     CLog::Log(LOGDEBUG, "CEGLImage::{} - supported formats:{}", __FUNCTION__, formatStr);
   }
@@ -252,12 +241,12 @@ bool CEGLImage::SupportsFormat(uint32_t format)
   if (foundFormat != formats.end())
   {
     CLog::Log(LOGDEBUG, LOGVIDEO, "CEGLImage::{} - supported format: {}", __FUNCTION__,
-              FourCCToString(format));
+              DRMHELPERS::FourCCToString(format));
     return true;
   }
 
   CLog::Log(LOGERROR, "CEGLImage::{} - format not supported: {}", __FUNCTION__,
-            FourCCToString(format));
+            DRMHELPERS::FourCCToString(format));
 
   return false;
 }
@@ -287,7 +276,7 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     CLog::Log(LOGERROR,
               "CEGLImage::{} - failed to query the max number of EGL dma-buf format modifiers for "
               "format: {} - {:#4x}",
-              __FUNCTION__, FourCCToString(format), eglGetError());
+              __FUNCTION__, DRMHELPERS::FourCCToString(format), eglGetError());
     return false;
   }
 
@@ -299,7 +288,7 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     CLog::Log(
         LOGERROR,
         "CEGLImage::{} - failed to query EGL dma-buf format modifiers for format: {} - {:#4x}",
-        __FUNCTION__, FourCCToString(format), eglGetError());
+        __FUNCTION__, DRMHELPERS::FourCCToString(format), eglGetError());
     return false;
   }
 
@@ -320,7 +309,7 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
   }
 
   CLog::Log(LOGERROR, "CEGLImage::{} - modifier ({:#x}) not supported for format ({})",
-            __FUNCTION__, modifier, FourCCToString(format));
+            __FUNCTION__, modifier, DRMHELPERS::FourCCToString(format));
 
   return false;
 }

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -297,19 +297,21 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
   {
     std::string modifierStr;
     for (const auto& supportedModifier : modifiers)
-      modifierStr.append("\n" + std::to_string(supportedModifier));
+      modifierStr.append("\n" + DRMHELPERS::ModifierToString(supportedModifier));
 
     CLog::Log(LOGDEBUG, "CEGLImage::{} - supported modifiers:{}", __FUNCTION__, modifierStr);
   }
 
   if (foundModifier != modifiers.end())
   {
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CEGLImage::{} - supported modifier: {}", __FUNCTION__, modifier);
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CEGLImage::{} - supported modifier: {}", __FUNCTION__,
+              DRMHELPERS::ModifierToString(modifier));
     return true;
   }
 
   CLog::Log(LOGERROR, "CEGLImage::{} - modifier ({:#x}) not supported for format ({})",
-            __FUNCTION__, modifier, DRMHELPERS::FourCCToString(format));
+            __FUNCTION__, DRMHELPERS::ModifierToString(modifier),
+            DRMHELPERS::FourCCToString(format));
 
   return false;
 }

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -9,6 +9,7 @@
 #include "DRMPlane.h"
 
 #include "DRMUtils.h"
+#include "utils/DRMHelpers.h"
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::GBM;
@@ -46,7 +47,7 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     if (!SupportsFormat(format))
     {
       CLog::Log(LOGDEBUG, "CDRMPlane::{} - format not supported: {}", __FUNCTION__,
-                CDRMUtils::FourCCToString(format));
+                DRMHELPERS::FourCCToString(format));
       return false;
     }
   }
@@ -56,7 +57,7 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     if (formatModifiers->empty())
     {
       CLog::Log(LOGDEBUG, "CDRMPlane::{} - format not supported: {}", __FUNCTION__,
-                CDRMUtils::FourCCToString(format));
+                DRMHELPERS::FourCCToString(format));
       return false;
     }
 
@@ -64,13 +65,13 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     if (formatModifier == formatModifiers->end())
     {
       CLog::Log(LOGDEBUG, "CDRMPlane::{} - modifier ({:#x}) not supported for format ({})",
-                __FUNCTION__, modifier, CDRMUtils::FourCCToString(format));
+                __FUNCTION__, modifier, DRMHELPERS::FourCCToString(format));
       return false;
     }
   }
 
   CLog::Log(LOGDEBUG, "CDRMPlane::{} - found plane format ({}) and modifier ({:#x})", __FUNCTION__,
-            CDRMUtils::FourCCToString(format), modifier);
+            DRMHELPERS::FourCCToString(format), modifier);
 
   return true;
 }

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -64,14 +64,15 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     auto formatModifier = std::find(formatModifiers->begin(), formatModifiers->end(), modifier);
     if (formatModifier == formatModifiers->end())
     {
-      CLog::Log(LOGDEBUG, "CDRMPlane::{} - modifier ({:#x}) not supported for format ({})",
-                __FUNCTION__, modifier, DRMHELPERS::FourCCToString(format));
+      CLog::Log(LOGDEBUG, "CDRMPlane::{} - modifier ({}) not supported for format ({})",
+                __FUNCTION__, DRMHELPERS::ModifierToString(modifier),
+                DRMHELPERS::FourCCToString(format));
       return false;
     }
   }
 
-  CLog::Log(LOGDEBUG, "CDRMPlane::{} - found plane format ({}) and modifier ({:#x})", __FUNCTION__,
-            DRMHELPERS::FourCCToString(format), modifier);
+  CLog::Log(LOGDEBUG, "CDRMPlane::{} - found plane format ({}) and modifier ({})", __FUNCTION__,
+            DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier));
 
   return true;
 }

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/DRMHelpers.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -103,7 +104,8 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
   if (modifiers[0] && modifiers[0] != DRM_FORMAT_MOD_INVALID)
   {
     flags |= DRM_MODE_FB_MODIFIERS;
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using modifier: {:#x}", __FUNCTION__, modifiers[0]);
+    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using modifier: {}", __FUNCTION__,
+              DRMHELPERS::ModifierToString(modifiers[0]));
   }
 
   int ret = drmModeAddFB2WithModifiers(m_fd,

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -680,14 +680,3 @@ uint32_t CDRMUtils::FourCCWithoutAlpha(uint32_t fourcc)
 {
   return (fourcc & 0xFFFFFF00) | static_cast<uint32_t>('X');
 }
-
-std::string CDRMUtils::FourCCToString(uint32_t fourcc)
-{
-  std::stringstream ss;
-  ss << static_cast<char>((fourcc & 0x000000FF));
-  ss << static_cast<char>((fourcc & 0x0000FF00) >> 8);
-  ss << static_cast<char>((fourcc & 0x00FF0000) >> 16);
-  ss << static_cast<char>((fourcc & 0xFF000000) >> 24);
-
-  return ss.str();
-}

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -59,7 +59,6 @@ public:
 
   static uint32_t FourCCWithAlpha(uint32_t fourcc);
   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
-  static std::string FourCCToString(uint32_t fourcc);
 
 protected:
   bool OpenDrm(bool needConnector);


### PR DESCRIPTION
This PR does a few things to improve logging:
1) allows logging the supported drm formats and modifiers when importing via EGL. This is gated by the VIDEO component logging (or if the EGL import doesn't support the requested format/modifier).
2) adds a `DRMHELPERS` namespace to be used across multiple classes as a unified way to get the drm format.
3) adds a new way to pretty print the modifier name via libdrm. This requires libdrm `2.4.107` so I have added it with a compile time check for `drmGetFormatModifierName`. This is simply for logging and doesn't provide any functional difference.

You will now see something like:
```
2021-09-18 21:41:01.899 T:1219578   DEBUG <general>: CDRMUtils::DrmFbGetFromBo - using modifier: INTEL_X_TILED
```