### PR TITLE
GBM: 10 bit plane support

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -66,6 +66,13 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 
     buf->ReleaseDescriptor();
 
+    auto gui = drm->GetGuiPlane();
+    if (!gui)
+      return nullptr;
+
+    if (!gui->SupportsFormat(CDRMUtils::FourCCWithAlpha(gui->GetFormat())))
+      return nullptr;
+
     auto plane = drm->GetVideoPlane();
     if (!plane)
       return nullptr;

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -203,7 +203,8 @@ bool CDRMUtils::FindPlanes()
           {
             return (plane->GetPlaneId() != videoPlaneId &&
                     (videoPlaneId == 0 || plane->SupportsFormat(DRM_FORMAT_ARGB8888)) &&
-                    plane->SupportsFormat(DRM_FORMAT_XRGB8888));
+                    (plane->SupportsFormat(DRM_FORMAT_XRGB2101010) ||
+                     plane->SupportsFormat(DRM_FORMAT_XRGB8888)));
           }
           return false;
         });
@@ -234,8 +235,18 @@ bool CDRMUtils::FindPlanes()
     CLog::Log(LOGDEBUG, "CDRMUtils::{} - using video plane {}", __FUNCTION__,
               m_video_plane->GetPlaneId());
 
-  CLog::Log(LOGDEBUG, "CDRMUtils::{} - using gui plane {}", __FUNCTION__,
-            m_gui_plane->GetPlaneId());
+  if (m_gui_plane->SupportsFormat(DRM_FORMAT_XRGB2101010))
+  {
+    m_gui_plane->SetFormat(DRM_FORMAT_XRGB2101010);
+    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using 10bit gui plane {}", __FUNCTION__,
+              m_gui_plane->GetPlaneId());
+  }
+  else
+  {
+    m_gui_plane->SetFormat(DRM_FORMAT_XRGB8888);
+    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using gui plane {}", __FUNCTION__,
+              m_gui_plane->GetPlaneId());
+  }
 
   return true;
 }


### PR DESCRIPTION
This adds back 10bit plane and 10bit EGL context support that was removed in #17644

I've also added a check for the drm prime renderer to check if the GUI plane format has an alpha equivalent. I found some intel devices have 10bit planes but no alpha format for them so it would crash.

This doesn't really do anything on it's own but will be needed for rendering 10bit texture in GLES.

Probably worth a test on some arm hardware.