### PR TITLE
[GLES] add ACES and Hable tone mapping

### DIFF
--- a/system/shaders/GLES/2.0/gles_tonemap.frag
+++ b/system/shaders/GLES/2.0/gles_tonemap.frag
@@ -1,4 +1,50 @@
-float tonemap(float val)
+#if (defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE))
+const float ST2084_m1 = 2610.0 / (4096.0 * 4.0);
+const float ST2084_m2 = (2523.0 / 4096.0) * 128.0;
+const float ST2084_c1 = 3424.0 / 4096.0;
+const float ST2084_c2 = (2413.0 / 4096.0) * 32.0;
+const float ST2084_c3 = (2392.0 / 4096.0) * 32.0;
+#endif
+
+#if defined(KODI_TONE_MAPPING_REINHARD)
+float reinhard(float x)
 {
-  return val * (1.0 + val / (m_toneP1 * m_toneP1)) / (1.0 + val);
+  return x * (1.0 + x / (m_toneP1 * m_toneP1)) / (1.0 + x);
 }
+#endif
+
+#if defined(KODI_TONE_MAPPING_ACES)
+vec3 aces(vec3 x)
+{
+  float A = 2.51;
+  float B = 0.03;
+  float C = 2.43;
+  float D = 0.59;
+  float E = 0.14;
+  return (x * (A * x + B)) / (x * (C * x + D) + E);
+}
+#endif
+
+#if defined(KODI_TONE_MAPPING_HABLE)
+vec3 hable(vec3 x)
+{
+  float A = 0.15;
+  float B = 0.5;
+  float C = 0.1;
+  float D = 0.2;
+  float E = 0.02;
+  float F = 0.3;
+  return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F;
+}
+#endif
+
+#if (defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE))
+vec3 inversePQ(vec3 x)
+{
+  x = pow(max(x, 0.0), vec3(1.0 / ST2084_m2));
+  x = max(x - ST2084_c1, 0.0) / (ST2084_c2 - ST2084_c3 * x);
+  x = pow(x, vec3(1.0 / ST2084_m1));
+  return x;
+}
+#endif
+

--- a/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
+++ b/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
@@ -34,6 +34,7 @@ uniform mat3 m_primMat;
 uniform float m_gammaDstInv;
 uniform float m_gammaSrc;
 uniform float m_toneP1;
+uniform float m_luminance;
 uniform vec3 m_coefsDst;
 uniform float m_alpha;
 
@@ -66,9 +67,23 @@ void main()
   rgb.rgb = max(vec3(0), m_primMat * rgb.rgb);
   rgb.rgb = pow(rgb.rgb, vec3(m_gammaDstInv));
 
-#if defined(XBMC_TONE_MAPPING)
+#if defined(KODI_TONE_MAPPING_REINHARD)
   float luma = dot(rgb.rgb, m_coefsDst);
-  rgb.rgb *= tonemap(luma) / luma;
+  rgb.rgb *= reinhard(luma) / luma;
+
+#elif defined(KODI_TONE_MAPPING_ACES)
+  rgb.rgb = inversePQ(rgb.rgb);
+  rgb.rgb *= (10000.0 / m_luminance) * (2.0 / m_toneP1);
+  rgb.rgb = aces(rgb.rgb);
+  rgb.rgb *= (1.24 / m_toneP1);
+  rgb.rgb = pow(rgb.rgb, vec3(0.27));
+
+#elif defined(KODI_TONE_MAPPING_HABLE)
+  rgb.rgb = inversePQ(rgb.rgb);
+  rgb.rgb *= m_toneP1;
+  float wp = m_luminance / 100.0;
+  rgb.rgb = hable(rgb.rgb * wp) / hable(vec3(wp));
+  rgb.rgb = pow(rgb.rgb, vec3(1.0 / 2.2));
 #endif
 
 #endif

--- a/system/shaders/GLES/2.0/gles_yuv2rgb_bob.frag
+++ b/system/shaders/GLES/2.0/gles_yuv2rgb_bob.frag
@@ -36,6 +36,7 @@ uniform mat3 m_primMat;
 uniform float m_gammaDstInv;
 uniform float m_gammaSrc;
 uniform float m_toneP1;
+uniform float m_luminance;
 uniform vec3 m_coefsDst;
 
 void main()
@@ -87,9 +88,23 @@ void main()
   rgb.rgb = max(vec3(0), m_primMat * rgb.rgb);
   rgb.rgb = pow(rgb.rgb, vec3(m_gammaDstInv));
 
-#if defined(XBMC_TONE_MAPPING)
+#if defined(KODI_TONE_MAPPING_REINHARD)
   float luma = dot(rgb.rgb, m_coefsDst);
-  rgb.rgb *= tonemap(luma) / luma;
+  rgb.rgb *= reinhard(luma) / luma;
+
+#elif defined(KODI_TONE_MAPPING_ACES)
+  rgb.rgb = inversePQ(rgb.rgb);
+  rgb.rgb *= (10000.0 / m_luminance) * (2.0 / m_toneP1);
+  rgb.rgb = aces(rgb.rgb);
+  rgb.rgb *= (1.24 / m_toneP1);
+  rgb.rgb = pow(rgb.rgb, vec3(0.27));
+
+#elif defined(KODI_TONE_MAPPING_HABLE)
+  rgb.rgb = inversePQ(rgb.rgb);
+  rgb.rgb *= m_toneP1;
+  float wp = m_luminance / 100.0;
+  rgb.rgb = hable(rgb.rgb * wp) / hable(vec3(wp));
+  rgb.rgb = pow(rgb.rgb, vec3(1.0 / 2.2));
 #endif
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -202,6 +202,7 @@ protected:
   bool m_fullRange;
   AVColorPrimaries m_srcPrimaries;
   bool m_toneMap = false;
+  int m_toneMapMethod = 0;
   bool m_passthroughHDR = false;
   unsigned char* m_planeBuffer = nullptr;
   size_t m_planeBufferSize = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -23,7 +23,11 @@ using namespace Shaders;
 // BaseYUV2RGBGLSLShader - base class for GLSL YUV2RGB shaders
 //////////////////////////////////////////////////////////////////////
 
-BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format, AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries, bool toneMap)
+BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
+                                             AVColorPrimaries dstPrimaries,
+                                             AVColorPrimaries srcPrimaries,
+                                             bool toneMap,
+                                             int toneMapMethod)
 {
   m_width = 1;
   m_height = 1;
@@ -53,7 +57,13 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format, AVColorPrimar
   if (toneMap)
   {
     m_toneMapping = true;
-    m_defines += "#define XBMC_TONE_MAPPING\n";
+    m_toneMappingMethod = toneMapMethod;
+    if (toneMapMethod == VS_TONEMAPMETHOD_REINHARD)
+      m_defines += "#define KODI_TONE_MAPPING_REINHARD\n";
+    else if (toneMapMethod == VS_TONEMAPMETHOD_ACES)
+      m_defines += "#define KODI_TONE_MAPPING_ACES\n";
+    else if (toneMapMethod == VS_TONEMAPMETHOD_HABLE)
+      m_defines += "#define KODI_TONE_MAPPING_HABLE\n";
   }
 
   VertexShader()->LoadSource("gles_yuv2rgb.vert", m_defines);
@@ -87,6 +97,7 @@ void BaseYUV2RGBGLSLShader::OnCompiledAndLinked()
   m_hGammaDstInv = glGetUniformLocation(ProgramHandle(), "m_gammaDstInv");
   m_hCoefsDst = glGetUniformLocation(ProgramHandle(), "m_coefsDst");
   m_hToneP1 = glGetUniformLocation(ProgramHandle(), "m_toneP1");
+  m_hLuminance = glGetUniformLocation(ProgramHandle(), "m_luminance");
   VerifyGLState();
 }
 
@@ -118,28 +129,44 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
 
   if (m_toneMapping)
   {
-    float param = 0.7;
-
-    if (m_hasLightMetadata)
+    if (m_toneMappingMethod == VS_TONEMAPMETHOD_REINHARD)
     {
-      param = log10(100) / log10(m_lightMetadata.MaxCLL);
+      float param = 0.7;
+
+      if (m_hasLightMetadata)
+      {
+        param = log10(100) / log10(m_lightMetadata.MaxCLL);
+      }
+      else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance)
+      {
+        param = log10(100) /
+                log10(m_displayMetadata.max_luminance.num / m_displayMetadata.max_luminance.den);
+      }
+
+      // Sanity check
+      if (param < 0.1f || param > 5.0f)
+      {
+        param = 0.7f;
+      }
+
+      param *= m_toneMappingParam;
+
+      Matrix3x1 coefs = m_convMatrix.GetRGBYuvCoefs(AVColorSpace::AVCOL_SPC_BT709);
+      glUniform3f(m_hCoefsDst, coefs[0], coefs[1], coefs[2]);
+      glUniform1f(m_hToneP1, param);
     }
-    else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance)
+    else if (m_toneMappingMethod == VS_TONEMAPMETHOD_ACES)
     {
-      param = log10(100) / log10(m_displayMetadata.max_luminance.num/m_displayMetadata.max_luminance.den);
+      glUniform1f(m_hLuminance, GetLuminanceValue());
+      glUniform1f(m_hToneP1, m_toneMappingParam);
     }
-
-    // Sanity check
-    if (param < 0.1f || param > 5.0f)
+    else if (m_toneMappingMethod == VS_TONEMAPMETHOD_HABLE)
     {
-      param = 0.7f;
+      float lumin = GetLuminanceValue();
+      float param = (10000.0f / lumin) * (2.0f / m_toneMappingParam);
+      glUniform1f(m_hLuminance, lumin);
+      glUniform1f(m_hToneP1, param);
     }
-
-    param *= m_toneMappingParam;
-
-    Matrix3x1 coefs = m_convMatrix.GetRGBYuvCoefs(AVColorSpace::AVCOL_SPC_BT709);
-    glUniform3f(m_hCoefsDst, coefs[0], coefs[1], coefs[2]);
-    glUniform1f(m_hToneP1, param);
   }
 
   VerifyGLState();
@@ -181,13 +208,49 @@ void BaseYUV2RGBGLSLShader::SetDisplayMetadata(bool hasDisplayMetadata, AVMaster
   m_lightMetadata = lightMetadata;
 }
 
+float BaseYUV2RGBGLSLShader::GetLuminanceValue() const
+{
+  float lum1 = 400.0f; // default for bad quality HDR-PQ sources (with no metadata)
+  float lum2 = lum1;
+  float lum3 = lum1;
+
+  if (m_hasLightMetadata)
+  {
+    uint16_t lum = m_displayMetadata.max_luminance.num / m_displayMetadata.max_luminance.den;
+    if (m_lightMetadata.MaxCLL >= lum)
+    {
+      lum1 = static_cast<float>(lum);
+      lum2 = static_cast<float>(m_lightMetadata.MaxCLL);
+    }
+    else
+    {
+      lum1 = static_cast<float>(m_lightMetadata.MaxCLL);
+      lum2 = static_cast<float>(lum);
+    }
+    lum3 = static_cast<float>(m_lightMetadata.MaxFALL);
+    lum1 = (lum1 * 0.5f) + (lum2 * 0.2f) + (lum3 * 0.3f);
+  }
+  else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance &&
+           m_displayMetadata.max_luminance.num > 0)
+  {
+    uint16_t lum = m_displayMetadata.max_luminance.num / m_displayMetadata.max_luminance.den;
+    lum1 = static_cast<float>(lum);
+  }
+
+  return lum1;
+}
+
 //////////////////////////////////////////////////////////////////////
 // YUV2RGBProgressiveShader - YUV2RGB with no deinterlacing
 // Use for weave deinterlacing / progressive
 //////////////////////////////////////////////////////////////////////
 
-YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(EShaderFormat format, AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries, bool toneMap)
-  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap)
+YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(EShaderFormat format,
+                                                   AVColorPrimaries dstPrimaries,
+                                                   AVColorPrimaries srcPrimaries,
+                                                   bool toneMap,
+                                                   int toneMapMethod)
+  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod)
 {
   PixelShader()->LoadSource("gles_yuv2rgb_basic.frag", m_defines);
   PixelShader()->InsertSource("gles_tonemap.frag", "void main()");
@@ -198,8 +261,12 @@ YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(EShaderFormat format, AVColor
 // YUV2RGBBobShader - YUV2RGB with Bob deinterlacing
 //////////////////////////////////////////////////////////////////////
 
-YUV2RGBBobShader::YUV2RGBBobShader(EShaderFormat format, AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries, bool toneMap)
-  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap)
+YUV2RGBBobShader::YUV2RGBBobShader(EShaderFormat format,
+                                   AVColorPrimaries dstPrimaries,
+                                   AVColorPrimaries srcPrimaries,
+                                   bool toneMap,
+                                   int toneMapMethod)
+  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod)
 {
   m_hStepX = -1;
   m_hStepY = -1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -10,6 +10,7 @@
 
 #include "ConversionMatrix.h"
 #include "ShaderFormats.h"
+#include "cores/VideoSettings.h"
 #include "guilib/Shader.h"
 #include "utils/TransformMatrix.h"
 
@@ -23,7 +24,11 @@ namespace Shaders {
   class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
   {
   public:
-    BaseYUV2RGBGLSLShader(EShaderFormat format, AVColorPrimaries dst, AVColorPrimaries src, bool toneMap);
+    BaseYUV2RGBGLSLShader(EShaderFormat format,
+                          AVColorPrimaries dst,
+                          AVColorPrimaries src,
+                          bool toneMap,
+                          int toneMapMethod);
     ~BaseYUV2RGBGLSLShader() override;
     void SetField(int field) { m_field = field; }
     void SetWidth(int w) { m_width = w; }
@@ -36,6 +41,7 @@ namespace Shaders {
     void SetDisplayMetadata(bool hasDisplayMetadata, AVMasteringDisplayMetadata displayMetadata,
                             bool hasLightMetadata, AVContentLightMetadata lightMetadata);
     void SetToneMapParam(float param) { m_toneMappingParam = param; }
+    float GetLuminanceValue() const;
 
     GLint GetVertexLoc() { return m_hVertex; }
     GLint GetYcoordLoc() { return m_hYcoord; }
@@ -60,6 +66,7 @@ namespace Shaders {
     bool m_hasLightMetadata{false};
     AVContentLightMetadata m_lightMetadata;
     bool m_toneMapping{false};
+    int m_toneMappingMethod{VS_TONEMAPMETHOD_REINHARD};
     float m_toneMappingParam{1.0};
 
     bool m_colorConversion{false};
@@ -82,6 +89,7 @@ namespace Shaders {
     GLint m_hPrimMat{-1};
     GLint m_hToneP1{-1};
     GLint m_hCoefsDst{-1};
+    GLint m_hLuminance = -1;
 
     GLint m_hVertex{-1};
     GLint m_hYcoord{-1};
@@ -101,13 +109,21 @@ namespace Shaders {
   class YUV2RGBProgressiveShader : public BaseYUV2RGBGLSLShader
   {
   public:
-    YUV2RGBProgressiveShader(EShaderFormat format, AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries, bool toneMap);
+    YUV2RGBProgressiveShader(EShaderFormat format,
+                             AVColorPrimaries dstPrimaries,
+                             AVColorPrimaries srcPrimaries,
+                             bool toneMap,
+                             int toneMapMethod);
   };
 
   class YUV2RGBBobShader : public BaseYUV2RGBGLSLShader
   {
   public:
-    YUV2RGBBobShader(EShaderFormat format, AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries, bool toneMap);
+    YUV2RGBBobShader(EShaderFormat format,
+                     AVColorPrimaries dstPrimaries,
+                     AVColorPrimaries srcPrimaries,
+                     bool toneMap,
+                     int toneMapMethod);
     void OnCompiledAndLinked() override;
     bool OnEnabled() override;
 


### PR DESCRIPTION
This is the GLES equivalent for #18751 and also includes the fix added in #18805

```
2021-09-19 23:55:02.732 T:1406921    INFO <general>: GLES: Selecting YUV 2 RGB shader
2021-09-19 23:55:02.732 T:1406921   DEBUG <general>: GLES: BaseYUV2RGBGLSLShader: defines:
                                                   #define XBMC_NV12_RRG
                                                   #define XBMC_COL_CONVERSION
                                                   #define KODI_TONE_MAPPING_ACES
```