### PR TITLE
[cmake][binary addons] make major version compare between addon and Kodi

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -41,6 +41,19 @@ endmacro()
 macro (build_addon target prefix libs)
   addon_version(${target} ${prefix})
 
+  # Compare addon version to Kodi's Version
+  # 1. If addon version is larger then Kodi version, it's not the correct API and
+  #    need to abort to prevent new addon release and upload to wrong
+  #    Kodi addon mirror.
+  # 2. If addon version is lower than Kodi version, it may or may not work
+  #    due to API changes. Show a warning message in this case.
+  string(REGEX REPLACE "^([0-9]*)\.[0-9]*\.[0-9]*" "\\1" ${prefix}_VERSION_MAJOR ${${prefix}_VERSION})
+  if(${${prefix}_VERSION_MAJOR} GREATER ${APP_VERSION_MAJOR})
+    message(FATAL_ERROR "Addon major version ${${prefix}_VERSION_MAJOR} larger than Kodi's major version ${APP_VERSION_MAJOR}. Correct API cannot be guaranteed and build will be aborted!")
+  elseif(${${prefix}_VERSION_MAJOR} LESS ${APP_VERSION_MAJOR})
+    message(WARNING "Addon major version ${${prefix}_VERSION_MAJOR} smaller than Kodi's major version ${APP_VERSION_MAJOR}. WARNING: Possible API changes may not be included. Since Kodi 20, addon and Kodi should use the same major version.")
+  endif()
+
   # Below comes the generation of a list with used sources where the includes to
   # kodi's headers becomes checked.
   # This goes the following steps to identify them:


### PR DESCRIPTION
## Description

As now the binary addons should use as major the same as Kodi itself, becomes here a check added to prevent builds of newer addon by older Kodi. So also Jenkins can never upload wrongly a bad version to our binary addons mirror.

If version is less as Kodi's one can addon maybe still work and brings only a warning.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
Want to rework the addon build system to makes it easier by new Kodi releases, further was few days ago where wrongly one released an addon for Nexus and version 20.0.0, with Jenkinsfile set to `buildPlugin(version: "Matrix")` and was uploaded to http://mirrors.kodi.tv/addons/matrix/

This then the first step.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
With edited version on addon.

Here Kodi 20 and addon version 19.0.0:
```
Scanning dependencies of target vfs.rar
[ 52%] Creating directories for 'vfs.rar'
[ 58%] No download step for 'vfs.rar'
[ 64%] No patch step for 'vfs.rar'
[ 70%] No update step for 'vfs.rar'
[ 76%] Performing configure step for 'vfs.rar'
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Checking to see if CXX compiler accepts flag -flto
-- Checking to see if CXX compiler accepts flag -flto - yes
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Found TinyXML: /home/alwin/Development/Kodi/_Addons/_alwin/vfs/vfs.rar/build/build/depends/include  
-- RAR_VERSION=19.0.0
CMake Warning at build/build/depends/lib/kodi/AddonHelpers.cmake:56 (message):
  Addon major version 19 smaller as Kodi's version 20.  Attention: Possible
  API changes may not be included.  Since Kodi 20, addon and Kodi should use
  the same major version.
```

And here Kodi 20 and addon version 21.0.0:
```
Scanning dependencies of target vfs.rar
[ 52%] Creating directories for 'vfs.rar'
[ 58%] No download step for 'vfs.rar'
[ 64%] No patch step for 'vfs.rar'
[ 70%] No update step for 'vfs.rar'
[ 76%] Performing configure step for 'vfs.rar'
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Checking to see if CXX compiler accepts flag -flto
-- Checking to see if CXX compiler accepts flag -flto - yes
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Found TinyXML: /home/alwin/Development/Kodi/_Addons/_alwin/vfs/vfs.rar/build/build/depends/include  
-- RAR_VERSION=21.0.0
CMake Error at build/build/depends/lib/kodi/AddonHelpers.cmake:53 (message):
  Addon major version 21 higher as Kodi's version 20.  In this case,
  correctly used API cannot be guaranteed and construction will be aborted!
Call Stack (most recent call first):
  CMakeLists.txt:42 (build_addon)


-- Configuring incomplete, errors occurred!
See also "/home/alwin/Development/Kodi/_Addons/_alwin/vfs/vfs.rar/build/vfs.rar-prefix/src/vfs.rar-build/CMakeFiles/CMakeOutput.log".
make[2]: *** [CMakeFiles/vfs.rar.dir/build.make:108: vfs.rar-prefix/src/vfs.rar-stamp/vfs.rar-configure] Fehler 1
make[1]: *** [CMakeFiles/Makefile2:210: CMakeFiles/vfs.rar.dir/all] Fehler 2
make: *** [Makefile:84: all] Fehler 2
```

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
