### PR TITLE
[linux] Use posix_memalign to implement AlignedMalloc

### DIFF
--- a/xbmc/platform/linux/MemUtils.cpp
+++ b/xbmc/platform/linux/MemUtils.cpp
@@ -18,7 +18,9 @@ namespace MEMORY
 
 void* AlignedMalloc(size_t s, size_t alignTo)
 {
-  return aligned_alloc(alignTo, s);
+  void* p = nullptr;
+  posix_memalign(&p, alignTo, s);
+  return p;
 }
 
 void AlignedFree(void* p)


### PR DESCRIPTION
## Description
`aligned_alloc` requires the size to be a multiple of alignement which isn't always the case as it used in Kodi. Use `posix_memalign` instead as it doesn't have this limitation.

## Motivation and context
Address sanitizer complained:
```
=================================================================
==52711==ERROR: AddressSanitizer: invalid alignment requested in aligned_alloc: 32, alignment must be a power of two and the requested size 0x44e8 must be a multiple of alignment (thread T5 (AESink))
    #0 0x5607673f6e01 in aligned_alloc (/home/mark/Coding/Repos/kodi-git/build/kodi-wayland+0x25592e01)
    #1 0x56076841bb54 in KODI::MEMORY::AlignedMalloc(unsigned long, unsigned long) /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/platform/linux/MemUtils.cpp:21:10
    #2 0x56076ee956e1 in ActiveAE::CActiveAESink::GenerateNoise() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp:1093:38
    #3 0x56076ee9410d in ActiveAE::CActiveAESink::OpenSink() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp:893:5
    #4 0x56076ee84f33 in ActiveAE::CActiveAESink::StateMachine(int, Actor::Protocol*, Actor::Message*) /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp:273:11
    #5 0x56076ee9ebea in ActiveAE::CActiveAESink::Process() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp:653:7
    #6 0x56076a38d7d1 in CThread::Action() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/threads/Thread.cpp:273:5
    #7 0x56076a3901b7 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/threads/Thread.cpp:139:18
    #8 0x56076a38f2c1 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:61:14
    #9 0x56076a38eda5 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:96:14
    #10 0x56076a38ec43 in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:253:13
    #11 0x56076a38ea08 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:260:11
    #12 0x56076a38e638 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > > >::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:211:13
    #13 0x7fad4c11d3c3 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:82:18

==52711==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: AddressSanitizer: invalid-aligned-alloc-alignment (/home/mark/Coding/Repos/kodi-git/build/kodi-wayland+0x25592e01) in aligned_alloc
Thread T5 (AESink) created by T4 (ActiveAE) here:
    #0 0x560767365bd4 in pthread_create (/home/mark/Coding/Repos/kodi-git/build/kodi-wayland+0x25501bd4)
    #1 0x7fad4c11d6aa in __gthread_create /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x7fad4c11d6aa in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x56076a38af19 in CThread::Create(bool) /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/threads/Thread.cpp:97:20
    #4 0x56076ee7e14d in ActiveAE::CActiveAESink::Start() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp:45:5
    #5 0x56076ede1b3b in ActiveAE::CActiveAE::Process() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp:1038:10
    #6 0x56076ede3f58 in non-virtual thunk to ActiveAE::CActiveAE::Process() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
    #7 0x56076a38d7d1 in CThread::Action() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/threads/Thread.cpp:273:5
    #8 0x56076a3901b7 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/threads/Thread.cpp:139:18
    #9 0x56076a38f2c1 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:61:14
    #10 0x56076a38eda5 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:96:14
    #11 0x56076a38ec43 in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:253:13
    #12 0x56076a38ea08 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:260:11
    #13 0x56076a38e638 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > > >::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:211:13
    #14 0x7fad4c11d3c3 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:82:18

Thread T4 (ActiveAE) created by T0 here:
    #0 0x560767365bd4 in pthread_create (/home/mark/Coding/Repos/kodi-git/build/kodi-wayland+0x25501bd4)
    #1 0x7fad4c11d6aa in __gthread_create /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x7fad4c11d6aa in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x56076a38af19 in CThread::Create(bool) /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/threads/Thread.cpp:97:20
    #4 0x56076edfba2e in ActiveAE::CActiveAE::Start() /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp:2658:3
    #5 0x56076c09c5aa in CApplication::Create(CAppParamParser const&) /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/Application.cpp:413:16
    #6 0x56076a4fc1f6 in XBMC_Run /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/platform/xbmc.cpp:29:22
    #7 0x560767430c6e in main /home/mark/Coding/Repos/kodi-git/xbmc/xbmc/platform/posix/main.cpp:61:10
    #8 0x7fad4cba4b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

==52711==ABORTING
```

## How has this been tested?
Running with address sanitizer and it doesn't complain anymore.

## What is the effect on users?
Probably none.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
