### PR TITLE
[CGUIDialogVolumeBar] Fix dialog not updating values if smartredraw i…

### DIFF
--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -30,13 +30,13 @@ bool CGUIDialogVolumeBar::OnAction(const CAction &action)
     if (g_application.IsMuted() || g_application.GetVolumeRatio() <= VOLUME_MINIMUM)
     { // cancel the timer, dialog needs to stay visible
       CancelAutoClose();
-      return true;
     }
     else
     { // reset the timer, as we've changed the volume level
       SetAutoClose(VOLUME_BAR_DISPLAY_TIME);
-      return true;
     }
+    MarkDirtyRegion();
+    return true;
   }
   return CGUIDialog::OnAction(action);
 }


### PR DESCRIPTION
…s enabled

## Description
This fixes the volume dialog not being updated if smartredraw is enabled in advancedsettings. `MarkDirtyRegions()` is only called when the volume is actually updated and the dialog should be refreshed.

## Motivation and context
This was mention breafly in https://github.com/xbmc/xbmc/issues/15354 by @HitcherUK. Played a bit with it while investigating https://github.com/xbmc/xbmc/pull/19156.

## How has this been tested?
Tested with and without smartredraw enabled in advancedsettings by using the + and - keyboard shortcuts and seeing the volumebar reacting accordingly

## What is the effect on users?
For those who don't have smartredraw enabled, none. For those who have, it's expected the volumebar to work :)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

