### PR TITLE
Fix some memory leaks in unit tests

### DIFF
--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -314,8 +314,8 @@ int SqliteDatabase::connect(bool create) {
     {
       sqlite3_extended_result_codes(conn, 1);
       sqlite3_busy_handler(conn, busy_callback, NULL);
-      char* err=NULL;
-      if (setErr(sqlite3_exec(getHandle(),"PRAGMA empty_result_callbacks=ON",NULL,NULL,&err),"PRAGMA empty_result_callbacks=ON") != SQLITE_OK)
+      if (setErr(sqlite3_exec(getHandle(), "PRAGMA empty_result_callbacks=ON", NULL, NULL, NULL),
+                 "PRAGMA empty_result_callbacks=ON") != SQLITE_OK)
       {
         throw DbErrors("%s", getErrorMsg());
       }
@@ -791,9 +791,15 @@ int SqliteDataset::exec(const std::string &sql) {
   else
     {
       if (errmsg)
-        throw DbErrors("%s (%s)", db->getErrorMsg(), errmsg);
+      {
+        DbErrors err("%s (%s)", db->getErrorMsg(), errmsg);
+        sqlite3_free(errmsg);
+        throw err;
+      }
       else
+      {
         throw DbErrors("%s", db->getErrorMsg());
+      }
     }
 }
 

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -59,7 +59,7 @@ bool CDirectoryCache::GetDirectory(const std::string& strPath, CFileItemList &it
   std::string storedPath = CURL(strPath).GetWithoutOptions();
   URIUtils::RemoveSlashAtEnd(storedPath);
 
-  iCache i = m_cache.find(storedPath);
+  auto i = m_cache.find(storedPath);
   if (i != m_cache.end())
   {
     CDir& dir = i->second;
@@ -136,7 +136,7 @@ void CDirectoryCache::ClearSubPaths(const std::string& strPath)
   // Get rid of any URL options, else the compare may be wrong
   std::string storedPath = CURL(strPath).GetWithoutOptions();
 
-  iCache i = m_cache.begin();
+  auto i = m_cache.begin();
   while (i != m_cache.end())
   {
     if (URIUtils::PathHasParent(i->first, storedPath))
@@ -154,7 +154,7 @@ void CDirectoryCache::AddFile(const std::string& strFile)
   std::string strPath = URIUtils::GetDirectory(CURL(strFile).GetWithoutOptions());
   URIUtils::RemoveSlashAtEnd(strPath);
 
-  iCache i = m_cache.find(strPath);
+  auto i = m_cache.find(strPath);
   if (i != m_cache.end())
   {
     CDir& dir = i->second;
@@ -175,7 +175,7 @@ bool CDirectoryCache::FileExists(const std::string& strFile, bool& bInCache)
   std::string storedPath = URIUtils::GetDirectory(strPath);
   URIUtils::RemoveSlashAtEnd(storedPath);
 
-  iCache i = m_cache.find(storedPath);
+  auto i = m_cache.find(storedPath);
   if (i != m_cache.end())
   {
     bInCache = true;
@@ -211,7 +211,7 @@ void CDirectoryCache::InitCache(std::set<std::string>& dirs)
 
 void CDirectoryCache::ClearCache(std::set<std::string>& dirs)
 {
-  iCache i = m_cache.begin();
+  auto i = m_cache.begin();
   while (i != m_cache.end())
   {
     if (dirs.find(i->first) != dirs.end())
@@ -226,9 +226,9 @@ void CDirectoryCache::CheckIfFull()
   CSingleLock lock (m_cs);
 
   // find the last accessed folder, and remove if the number of cached folders is too many
-  iCache lastAccessed = m_cache.end();
+  auto lastAccessed = m_cache.end();
   unsigned int numCached = 0;
-  for (iCache i = m_cache.begin(); i != m_cache.end(); i++)
+  for (auto i = m_cache.begin(); i != m_cache.end(); i++)
   {
     // ensure dirs that are always cached aren't cleared
     if (i->second.m_cacheType != DIR_CACHE_ALWAYS)
@@ -253,7 +253,7 @@ void CDirectoryCache::PrintStats() const
   unsigned int oldest = UINT_MAX;
   unsigned int numItems = 0;
   unsigned int numDirs = 0;
-  for (ciCache i = m_cache.begin(); i != m_cache.end(); i++)
+  for (auto i = m_cache.begin(); i != m_cache.end(); i++)
   {
     const CDir& dir = i->second;
     oldest = std::min(oldest, dir.GetLastAccess());

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -28,15 +28,12 @@ CDirectoryCache::CDir::CDir(DIR_CACHE_TYPE cacheType)
 {
   m_cacheType = cacheType;
   m_lastAccess = 0;
-  m_Items = new CFileItemList;
+  m_Items = std::make_unique<CFileItemList>();
   m_Items->SetIgnoreURLOptions(true);
   m_Items->SetFastLookup(true);
 }
 
-CDirectoryCache::CDir::~CDir()
-{
-  delete m_Items;
-}
+CDirectoryCache::CDir::~CDir() = default;
 
 void CDirectoryCache::CDir::SetLastAccess(unsigned int &accessCounter)
 {
@@ -62,15 +59,15 @@ bool CDirectoryCache::GetDirectory(const std::string& strPath, CFileItemList &it
   std::string storedPath = CURL(strPath).GetWithoutOptions();
   URIUtils::RemoveSlashAtEnd(storedPath);
 
-  ciCache i = m_cache.find(storedPath);
+  iCache i = m_cache.find(storedPath);
   if (i != m_cache.end())
   {
-    CDir* dir = i->second;
-    if (dir->m_cacheType == XFILE::DIR_CACHE_ALWAYS ||
-       (dir->m_cacheType == XFILE::DIR_CACHE_ONCE && retrieveAll))
+    CDir& dir = i->second;
+    if (dir.m_cacheType == XFILE::DIR_CACHE_ALWAYS ||
+        (dir.m_cacheType == XFILE::DIR_CACHE_ONCE && retrieveAll))
     {
-      items.Copy(*dir->m_Items);
-      dir->SetLastAccess(m_accessCounter);
+      items.Copy(*dir.m_Items);
+      dir.SetLastAccess(m_accessCounter);
 #ifdef _DEBUG
       m_cacheHits+=items.Size();
 #endif
@@ -106,10 +103,10 @@ void CDirectoryCache::SetDirectory(const std::string& strPath, const CFileItemLi
 
   CheckIfFull();
 
-  CDir* dir = new CDir(cacheType);
-  dir->m_Items->Copy(items);
-  dir->SetLastAccess(m_accessCounter);
-  m_cache.insert(std::pair<std::string, CDir*>(storedPath, dir));
+  CDir dir(cacheType);
+  dir.m_Items->Copy(items);
+  dir.SetLastAccess(m_accessCounter);
+  m_cache.emplace(std::make_pair(storedPath, std::move(dir)));
 }
 
 void CDirectoryCache::ClearFile(const std::string& strFile)
@@ -129,9 +126,7 @@ void CDirectoryCache::ClearDirectory(const std::string& strPath)
   std::string storedPath = CURL(strPath).GetWithoutOptions();
   URIUtils::RemoveSlashAtEnd(storedPath);
 
-  iCache i = m_cache.find(storedPath);
-  if (i != m_cache.end())
-    Delete(i);
+  m_cache.erase(storedPath);
 }
 
 void CDirectoryCache::ClearSubPaths(const std::string& strPath)
@@ -145,7 +140,7 @@ void CDirectoryCache::ClearSubPaths(const std::string& strPath)
   while (i != m_cache.end())
   {
     if (URIUtils::PathHasParent(i->first, storedPath))
-      Delete(i++);
+      m_cache.erase(i++);
     else
       i++;
   }
@@ -159,13 +154,13 @@ void CDirectoryCache::AddFile(const std::string& strFile)
   std::string strPath = URIUtils::GetDirectory(CURL(strFile).GetWithoutOptions());
   URIUtils::RemoveSlashAtEnd(strPath);
 
-  ciCache i = m_cache.find(strPath);
+  iCache i = m_cache.find(strPath);
   if (i != m_cache.end())
   {
-    CDir *dir = i->second;
+    CDir& dir = i->second;
     CFileItemPtr item(new CFileItem(strFile, false));
-    dir->m_Items->Add(item);
-    dir->SetLastAccess(m_accessCounter);
+    dir.m_Items->Add(item);
+    dir.SetLastAccess(m_accessCounter);
   }
 }
 
@@ -180,16 +175,16 @@ bool CDirectoryCache::FileExists(const std::string& strFile, bool& bInCache)
   std::string storedPath = URIUtils::GetDirectory(strPath);
   URIUtils::RemoveSlashAtEnd(storedPath);
 
-  ciCache i = m_cache.find(storedPath);
+  iCache i = m_cache.find(storedPath);
   if (i != m_cache.end())
   {
     bInCache = true;
-    CDir *dir = i->second;
-    dir->SetLastAccess(m_accessCounter);
+    CDir& dir = i->second;
+    dir.SetLastAccess(m_accessCounter);
 #ifdef _DEBUG
     m_cacheHits++;
 #endif
-    return (URIUtils::PathEquals(strPath, storedPath) || dir->m_Items->Contains(strFile));
+    return (URIUtils::PathEquals(strPath, storedPath) || dir.m_Items->Contains(strFile));
   }
 #ifdef _DEBUG
   m_cacheMisses++;
@@ -201,10 +196,7 @@ void CDirectoryCache::Clear()
 {
   // this routine clears everything
   CSingleLock lock (m_cs);
-
-  iCache i = m_cache.begin();
-  while (i != m_cache.end() )
-    Delete(i++);
+  m_cache.clear();
 }
 
 void CDirectoryCache::InitCache(std::set<std::string>& dirs)
@@ -223,7 +215,7 @@ void CDirectoryCache::ClearCache(std::set<std::string>& dirs)
   while (i != m_cache.end())
   {
     if (dirs.find(i->first) != dirs.end())
-      Delete(i++);
+      m_cache.erase(i++);
     else
       i++;
   }
@@ -239,22 +231,16 @@ void CDirectoryCache::CheckIfFull()
   for (iCache i = m_cache.begin(); i != m_cache.end(); i++)
   {
     // ensure dirs that are always cached aren't cleared
-    if (i->second->m_cacheType != DIR_CACHE_ALWAYS)
+    if (i->second.m_cacheType != DIR_CACHE_ALWAYS)
     {
-      if (lastAccessed == m_cache.end() || i->second->GetLastAccess() < lastAccessed->second->GetLastAccess())
+      if (lastAccessed == m_cache.end() ||
+          i->second.GetLastAccess() < lastAccessed->second.GetLastAccess())
         lastAccessed = i;
       numCached++;
     }
   }
   if (lastAccessed != m_cache.end() && numCached >= MAX_CACHED_DIRS)
-    Delete(lastAccessed);
-}
-
-void CDirectoryCache::Delete(iCache it)
-{
-  CDir* dir = it->second;
-  delete dir;
-  m_cache.erase(it);
+    m_cache.erase(lastAccessed);
 }
 
 #ifdef _DEBUG
@@ -269,9 +255,9 @@ void CDirectoryCache::PrintStats() const
   unsigned int numDirs = 0;
   for (ciCache i = m_cache.begin(); i != m_cache.end(); i++)
   {
-    CDir *dir = i->second;
-    oldest = std::min(oldest, dir->GetLastAccess());
-    numItems += dir->m_Items->Size();
+    const CDir& dir = i->second;
+    oldest = std::min(oldest, dir.GetLastAccess());
+    numItems += dir.m_Items->Size();
     numDirs++;
   }
   CLog::Log(LOGDEBUG, "{} - {} folders cached, with {} items total.  Oldest is {}, current is {}",

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -59,8 +59,6 @@ namespace XFILE
     void CheckIfFull();
 
     std::map<std::string, CDir> m_cache;
-    typedef std::map<std::string, CDir*>::iterator iCache;
-    typedef std::map<std::string, CDir*>::const_iterator ciCache;
 
     mutable CCriticalSection m_cs;
 

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -12,6 +12,7 @@
 #include "threads/CriticalSection.h"
 
 #include <map>
+#include <memory>
 #include <set>
 
 class CFileItem;
@@ -24,12 +25,14 @@ namespace XFILE
     {
     public:
       explicit CDir(DIR_CACHE_TYPE cacheType);
+      CDir(CDir&& dir) = default;
+      CDir& operator=(CDir&& dir) = default;
       virtual ~CDir();
 
       void SetLastAccess(unsigned int &accessCounter);
       unsigned int GetLastAccess() const { return m_lastAccess; }
 
-      CFileItemList* m_Items;
+      std::unique_ptr<CFileItemList> m_Items;
       DIR_CACHE_TYPE m_cacheType;
     private:
       CDir(const CDir&) = delete;
@@ -55,10 +58,9 @@ namespace XFILE
     void ClearCache(std::set<std::string>& dirs);
     void CheckIfFull();
 
-    std::map<std::string, CDir*> m_cache;
+    std::map<std::string, CDir> m_cache;
     typedef std::map<std::string, CDir*>::iterator iCache;
     typedef std::map<std::string, CDir*>::const_iterator ciCache;
-    void Delete(iCache i);
 
     mutable CCriticalSection m_cs;
 

--- a/xbmc/filesystem/test/TestFile.cpp
+++ b/xbmc/filesystem/test/TestFile.cpp
@@ -146,19 +146,20 @@ TEST(TestFile, Delete)
   EXPECT_TRUE(XFILE::CFile::Exists(path));
   EXPECT_TRUE(XFILE::CFile::Delete(path));
   EXPECT_FALSE(XFILE::CFile::Exists(path));
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(file));
 }
 
 TEST(TestFile, Rename)
 {
-  XFILE::CFile *file;
+  XFILE::CFile *file1, *file2;
   std::string path1, path2;
 
-  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
-  file->Close();
-  path1 = XBMC_TEMPFILEPATH(file);
-  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
-  file->Close();
-  path2 = XBMC_TEMPFILEPATH(file);
+  ASSERT_NE(nullptr, file1 = XBMC_CREATETEMPFILE(""));
+  file1->Close();
+  path1 = XBMC_TEMPFILEPATH(file1);
+  ASSERT_NE(nullptr, file2 = XBMC_CREATETEMPFILE(""));
+  file2->Close();
+  path2 = XBMC_TEMPFILEPATH(file2);
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
   EXPECT_FALSE(XFILE::CFile::Exists(path1));
   EXPECT_TRUE(XFILE::CFile::Exists(path2));
@@ -166,19 +167,21 @@ TEST(TestFile, Rename)
   EXPECT_TRUE(XFILE::CFile::Exists(path1));
   EXPECT_FALSE(XFILE::CFile::Exists(path2));
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(file1));
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(file2));
 }
 
 TEST(TestFile, Copy)
 {
-  XFILE::CFile *file;
+  XFILE::CFile *file1, *file2;
   std::string path1, path2;
 
-  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
-  file->Close();
-  path1 = XBMC_TEMPFILEPATH(file);
-  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
-  file->Close();
-  path2 = XBMC_TEMPFILEPATH(file);
+  ASSERT_NE(nullptr, file1 = XBMC_CREATETEMPFILE(""));
+  file1->Close();
+  path1 = XBMC_TEMPFILEPATH(file1);
+  ASSERT_NE(nullptr, file2 = XBMC_CREATETEMPFILE(""));
+  file2->Close();
+  path2 = XBMC_TEMPFILEPATH(file2);
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
   EXPECT_FALSE(XFILE::CFile::Exists(path1));
   EXPECT_TRUE(XFILE::CFile::Exists(path2));
@@ -187,6 +190,8 @@ TEST(TestFile, Copy)
   EXPECT_TRUE(XFILE::CFile::Exists(path2));
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
   EXPECT_TRUE(XFILE::CFile::Delete(path2));
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(file1));
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(file2));
 }
 
 TEST(TestFile, SetHidden)

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -10,6 +10,8 @@
 
 #include "threads/Thread.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 template<class E>
@@ -56,25 +58,14 @@ public:
 
 class thread
 {
-  IRunnable* f;
-  CThread* cthread;
+  std::unique_ptr<CThread> cthread;
 
-//  inline thread(const thread& other) { }
 public:
-  inline explicit thread(IRunnable& runnable) :
-    f(&runnable), cthread(new CThread(f, "DumbThread"))
+  inline explicit thread(IRunnable& runnable)
+    : cthread(std::make_unique<CThread>(&runnable, "DumbThread"))
   {
     cthread->Create();
   }
-
-  inline thread() : f(NULL), cthread(NULL) {}
-  ~thread()
-  {
-    delete cthread;
-  }
-
-  inline thread(thread& other) : f(other.f), cthread(other.cthread) { other.f = NULL; other.cthread = NULL; }
-  inline thread& operator=(thread& other) { f = other.f; other.f = NULL; cthread = other.cthread; other.cthread = NULL; return *this; }
 
   void join() { cthread->Join(std::chrono::milliseconds::max()); }
 

--- a/xbmc/utils/JSONVariantParser.cpp
+++ b/xbmc/utils/JSONVariantParser.cpp
@@ -46,6 +46,7 @@ private:
   CVariant& m_parsedObject;
   std::vector<CVariant *> m_parse;
   std::string m_key;
+  CVariant m_root;
 
   enum class PARSE_STATUS
   {
@@ -160,7 +161,10 @@ void CJSONVariantParserHandler::PushObject(const CVariant& variant)
     m_parse.push_back(&(*temp)[temp->size() - 1]);
   }
   else if (m_parse.empty())
-    m_parse.push_back(new CVariant(variant));
+  {
+    m_root = variant;
+    m_parse.push_back(&m_root);
+  }
 
   if (variant.isObject())
     m_status = PARSE_STATUS::Object;
@@ -188,8 +192,6 @@ void CJSONVariantParserHandler::PopObject()
   else
   {
     m_parsedObject = *variant;
-    delete variant;
-
     m_status = PARSE_STATUS::Variable;
   }
 }

--- a/xbmc/utils/test/TestFileOperationJob.cpp
+++ b/xbmc/utils/test/TestFileOperationJob.cpp
@@ -80,6 +80,8 @@ TEST(TestFileOperationJob, ActionMove)
 
   EXPECT_TRUE(XFILE::CFile::Delete(destfile));
   EXPECT_TRUE(XFILE::CDirectory::Remove(destpath));
+
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(tmpfile));
 }
 
 TEST(TestFileOperationJob, ActionDelete)
@@ -130,6 +132,8 @@ TEST(TestFileOperationJob, ActionDelete)
   EXPECT_TRUE(job.DoWork());
   EXPECT_FALSE(XFILE::CFile::Exists(destfile));
   EXPECT_TRUE(XFILE::CDirectory::Remove(destpath));
+
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(tmpfile));
 }
 
 TEST(TestFileOperationJob, ActionReplace)

--- a/xbmc/utils/test/TestFileUtils.cpp
+++ b/xbmc/utils/test/TestFileUtils.cpp
@@ -26,6 +26,7 @@ TEST(TestFileUtils, DeleteItem_CFileItemPtr)
   item->Select(true);
   tmpfile->Close();  //Close tmpfile before we try to delete it
   EXPECT_TRUE(CFileUtils::DeleteItem(item));
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(tmpfile));
 }
 
 TEST(TestFileUtils, DeleteItemString)
@@ -35,6 +36,7 @@ TEST(TestFileUtils, DeleteItemString)
   ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfile->Close();  //Close tmpfile before we try to delete it
   EXPECT_TRUE(CFileUtils::DeleteItem(XBMC_TEMPFILEPATH(tmpfile)));
+  EXPECT_FALSE(XBMC_DELETETEMPFILE(tmpfile));
 }
 
 /* Executing RenameFile() requires input from the user */


### PR DESCRIPTION
## Description
These memory leaks were detected with leak sanitizer when running the unit tests. With these commits applied the unit tests are leak free (at least on Linux) with the exception of some internal leaks in SQLite.

But running Kodi itself still results in >3000 memory leaks :(

## Motivation and context
I think nobody likes memory leaks :)

## How has this been tested?
Unit test are still ok, running Kodi doesn't show issues.

## What is the effect on users?
Probably none.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
