### PR TITLE
[tools/depends][target] build freetype with harfbuzz support

### DIFF
--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -6,13 +6,13 @@ endif
 
 DEPENDS = \
 	pcre expat gettext sqlite3 libgpg-error \
-	libgcrypt bzip2 libfstrcmp liblzo2 freetype2 fontconfig \
+	libgcrypt bzip2 libfstrcmp liblzo2 freetype2-noharfbuzz fontconfig \
 	openssl gmp nettle gnutls googletest curl nghttp2 \
 	libjpeg-turbo libpng fribidi harfbuzz libass \
 	libxml2 rapidjson libmicrohttpd mariadb libffi \
 	python3 libshairplay libfmt libspdlog \
 	libplist libcec libbluray tinyxml \
-	taglib libusb libnfs \
+	taglib libusb libnfs freetype2 \
 	pythonmodule-pil pythonmodule-pycryptodome pythonmodule-setuptools \
 	libxslt ffmpeg crossguid libudfread \
 	libdvdread libdvdnav libdvdcss p8-platform flatbuffers dav1d xz
@@ -96,7 +96,8 @@ xz: gettext
 libgcrypt: libgpg-error
 fontconfig: freetype2 expat $(ICONV) $(LIBUUID)
 curl: openssl nghttp2
-harfbuzz: meson-cross-file $(ICONV)
+harfbuzz: meson-cross-file freetype2-noharfbuzz $(ICONV)
+freetype2: harfbuzz $(ZLIB)
 libass: fontconfig fribidi harfbuzz libpng freetype2 expat $(ICONV)
 libmicrohttpd: gnutls libgcrypt libgpg-error
 python3: expat gettext libxml2 sqlite3 openssl libffi bzip2 xz

--- a/tools/depends/target/fontconfig/Makefile
+++ b/tools/depends/target/fontconfig/Makefile
@@ -11,6 +11,12 @@ ARCHIVE=$(SOURCE).tar.bz2
 CONFIGURE=./configure --prefix=$(PREFIX) \
   --disable-libxml2 --disable-docs --with-arch=$(PLATFORM) --disable-shared
 
+ifeq ($(OS),android)
+  # Freetype with Harfbuzz support requires stdc++ lib linking
+  # Fontconfig uses clang and not clang++, therefore we need the explicit stdc++ link
+  export LDFLAGS+= -lstdc++
+endif
+
 LIBDYLIB=$(PLATFORM)/src/.libs/lib$(LIBNAME).a
 
 all: .installed-$(PLATFORM)

--- a/tools/depends/target/freetype2-noharfbuzz/Makefile
+++ b/tools/depends/target/freetype2-noharfbuzz/Makefile
@@ -7,11 +7,15 @@ VERSION=2.10.2
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
 
+# Freetype has a circular dependency with harfbuzz.
+# To enable harfbuzz support in freetype, we build this first to bootstrap harfbuzz
+# and then build freetype2 again with harfbuzz support
+
 # configuration settings
 # force using internal libtool
 export LIBTOOL=builds/unix/libtool
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) builds/unix; \
-          ./configure --prefix=$(PREFIX) --disable-shared --with-png=no --with-harfbuzz=yes
+          ./configure --prefix=$(PREFIX) --disable-shared --with-png=no --with-harfbuzz=no
 
 LIBDYLIB=$(PLATFORM)/objs/.libs/lib$(LIBNAME).a
 

--- a/tools/depends/target/harfbuzz/Makefile
+++ b/tools/depends/target/harfbuzz/Makefile
@@ -20,6 +20,7 @@ CONFIGURE = $(NATIVEPREFIX)/bin/python3 $(NATIVEPREFIX)/bin/meson \
 	-Ddocs=disabled \
 	-Dtests=disabled \
 	-Dicu_builtin=false \
+	-Dfreetype=enabled \
 	-Dintrospection=disabled \
 	-Ddefault_library=static
 


### PR DESCRIPTION
## Description
Freetype/harbuff have circular dependencies to get harfbuzz support in freetype.
Build freetype2-nohb to bootstrap harfbuzz, and then build freetype with harfbuzz support

Fontconfig for android requires an additional ldflag due to the freetype harfbuzz usage. Fontconfig uses c compiler (clang) but harfbuzz brings in some functions from stdc++ (clang++ automatically adds this link usually), so we need to explicitly add -lstdc++ to fontconfig or we get errors like

```
/home/jenkins/workspace/Android-ARM64/tools/depends/xbmc-depends/aarch64-linux-android-21-debug/lib/libharfbuzz.a(hb-ot-font.cc.o): In function `__clang_call_terminate':
hb-ot-font.cc:(.text.__clang_call_terminate[__clang_call_terminate]+0x4): undefined reference to `__cxa_begin_catch'
hb-ot-font.cc:(.text.__clang_call_terminate[__clang_call_terminate]+0x8): undefined reference to `std::terminate()'
/home/jenkins/workspace/Android-ARM64/tools/depends/xbmc-depends/aarch64-linux-android-21-debug/lib/libharfbuzz.a(hb-ot-font.cc.o):(.data.DW.ref.__gxx_personality_v0[DW.ref.__gxx_personality_v0]+0x0): undefined reference to `__gxx_personality_v0'
```

## Motivation and context
Discussion on slack

## How has this been tested?
Build time against ios target

freetype2-nohb build configuration
```
Library configuration:
  external zlib: yes (autoconf test)
  bzip2:         yes (autoconf test)
  libpng:        no
  harfbuzz:      no
  brotli:        no
```

freetype2 build configuration
```
Library configuration:
  external zlib: yes (autoconf test)
  bzip2:         yes (autoconf test)
  libpng:        no
  harfbuzz:      yes (pkg-config)
  brotli:        no

```

## What is the effect on users?


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
