### PR TITLE
[posix] WS-Discovery: host name detection and lookup

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -71,24 +71,18 @@ bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
   {
     CSingleLock lock(m_critWSD);
 
-    // delim1 used to strip protocol from xaddrs
-    // delim2 used to strip anything past the port
-    const std::string delim1 = "://";
-    const std::string delim2 = ":";
     for (const auto& item : m_vecWSDInfo)
     {
-      auto found = item.xaddrs.find(delim1);
-      if (found == std::string::npos)
-        continue;
-
-      std::string tmpxaddrs = item.xaddrs.substr(found + delim1.size());
-      found = tmpxaddrs.find(delim2);
-      // fallback incase xaddrs doesnt return back "GetMetadata" expected address format (delim2)
-      if (found == std::string::npos)
+      auto found = item.computer.find('/');
+      std::string host;
+      if (found != std::string::npos)
+        host = item.computer.substr(0, found);
+      else
       {
-        found = tmpxaddrs.find('/');
+        if (item.xaddrs_host.empty())
+          continue;
+        host = item.xaddrs_host;
       }
-      std::string host = tmpxaddrs.substr(0, found);
 
       CFileItemPtr pItem = std::make_shared<CFileItem>(host);
       pItem->SetPath("smb://" + host + '/');

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
@@ -34,6 +34,8 @@ struct wsd_req_info
   std::string types; // ToDo: Types may not be needed.
   std::string address;
   std::string xaddrs;
+  std::string xaddrs_host;
+  std::string computer;
 
   bool operator==(const wsd_req_info& item) const
   {

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
@@ -70,6 +70,16 @@ public:
   */
   void SetItems(std::vector<WSDiscovery::wsd_req_info> entries);
 
+  /*
+   * Lookup host name in collected ws-discovery data
+   * in     (const std::string&) Host name
+   * out    (std::string&) IP address if found
+   * return (bool) true if found
+  */
+  bool GetCached(const std::string& strHostName, std::string& strIpAddress);
+
+  static const bool IsInitialized() { return m_isInitialized; }
+
 private:
   CCriticalSection m_critWSD;
 
@@ -91,5 +101,7 @@ private:
   std::unique_ptr<WSDiscovery::CWSDiscoveryListenerUDP> m_WSDListenerUDP;
 
   std::vector<WSDiscovery::wsd_req_info> m_vecWSDInfo;
+
+  static std::atomic<bool> m_isInitialized;
 };
 } // namespace WSDiscovery

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
@@ -78,6 +78,13 @@ private:
   // Closes socket and handles setting state for WS-Discovery
   void Cleanup(bool aborted);
 
+  /*
+   * Use unicast Get to request computer name
+   * in/out    (wsd_req_info&) host info to be updated
+   * return    (void)
+   */
+  void UnicastGet(wsd_req_info& info);
+
 private:
   template<std::size_t SIZE>
   const std::string wsd_tag_find(const std::string& xml,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Implement host name detection via WS-Discovery for posix platforms and
resolve the names in DNSNameCache.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Only IP addresses are shown with #19971.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On Linux X86_64 desktop against Windows, FritzBox and wsdd2 WS-Discovery implementation.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Servers can be selected by name, not only by IP address in local network.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
