### PR TITLE
[cleanup] Remove unnecessary semicolons from headers

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -243,10 +243,10 @@ public:
   std::unique_ptr<MEDIA_DETECT::CAutorun> m_Autorun;
 #endif
 
-  inline bool IsInScreenSaver() { return m_screensaverActive; };
+  inline bool IsInScreenSaver() { return m_screensaverActive; }
   inline std::string ScreensaverIdInUse() { return m_screensaverIdInUse; }
 
-  inline bool IsDPMSActive() { return m_dpmsIsActive; };
+  inline bool IsDPMSActive() { return m_dpmsIsActive; }
   int m_iScreenSaveLock = 0; // spiff: are we checking for a lock? if so, ignore the screensaver state, if -1 we have failed to input locks
 
   std::string m_strPlayListFile;
@@ -265,7 +265,7 @@ public:
 
   bool SwitchToFullScreen(bool force = false);
 
-  bool GetRenderGUI() const override { return m_renderGUI; };
+  bool GetRenderGUI() const override { return m_renderGUI; }
 
   bool SetLanguage(const std::string &strLanguage);
   bool LoadLanguage(bool reload);

--- a/xbmc/BackgroundInfoLoader.h
+++ b/xbmc/BackgroundInfoLoader.h
@@ -37,16 +37,16 @@ public:
   void Run() override;
   void SetObserver(IBackgroundLoaderObserver* pObserver);
   void SetProgressCallback(IProgressCallback* pCallback);
-  virtual bool LoadItem(CFileItem* pItem) { return false; };
-  virtual bool LoadItemCached(CFileItem* pItem) { return false; };
-  virtual bool LoadItemLookup(CFileItem* pItem) { return false; };
+  virtual bool LoadItem(CFileItem* pItem) { return false; }
+  virtual bool LoadItemCached(CFileItem* pItem) { return false; }
+  virtual bool LoadItemLookup(CFileItem* pItem) { return false; }
 
   void StopThread(); // will actually stop the loader thread.
   void StopAsync();  // will ask loader to stop as soon as possible, but not block
 
 protected:
-  virtual void OnLoaderStart() {};
-  virtual void OnLoaderFinish() {};
+  virtual void OnLoaderStart() {}
+  virtual void OnLoaderFinish() {}
 
   CFileItemList *m_pVecItems;
   std::vector<CFileItemPtr> m_vecItems; // FileItemList would delete the items and we only want to keep a reference.

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -122,13 +122,13 @@ public:
   explicit CFileItem(const EventPtr& eventLogEntry);
 
   ~CFileItem(void) override;
-  CGUIListItem *Clone() const override { return new CFileItem(*this); };
+  CGUIListItem* Clone() const override { return new CFileItem(*this); }
 
   const CURL GetURL() const;
   void SetURL(const CURL& url);
   bool IsURL(const CURL& url) const;
-  const std::string &GetPath() const { return m_strPath; };
-  void SetPath(const std::string &path) { m_strPath = path; };
+  const std::string& GetPath() const { return m_strPath; }
+  void SetPath(const std::string& path) { m_strPath = path; }
   bool IsPath(const std::string& path, bool ignoreURLOptions = false) const;
 
   const CURL GetDynURL() const;
@@ -146,7 +146,7 @@ public:
   void Serialize(CVariant& value) const override;
   void ToSortable(SortItem &sortable, Field field) const override;
   void ToSortable(SortItem &sortable, const Fields &fields) const;
-  bool IsFileItem() const override { return true; };
+  bool IsFileItem() const override { return true; }
 
   bool Exists(bool bUseCache = true) const;
 
@@ -483,7 +483,7 @@ public:
   \brief Some sources do not support HTTP HEAD request to determine i.e. mime type
   \return false if HEAD requests have to be avoided
   */
-  bool ContentLookup() { return m_doContentLookup; };
+  bool ContentLookup() { return m_doContentLookup; }
 
   /*!
    \brief (Re)set the mime-type for internet files if allowed (m_doContentLookup)
@@ -495,11 +495,11 @@ public:
    *\brief Lookup via HTTP HEAD request might not be needed, use this setter to
    * disable ContentLookup.
    */
-  void SetContentLookup(bool enable) { m_doContentLookup = enable; };
+  void SetContentLookup(bool enable) { m_doContentLookup = enable; }
 
   /* general extra info about the contents of the item, not for display */
-  void SetExtraInfo(const std::string& info) { m_extrainfo = info; };
-  const std::string& GetExtraInfo() const { return m_extrainfo; };
+  void SetExtraInfo(const std::string& info) { m_extrainfo = info; }
+  const std::string& GetExtraInfo() const { return m_extrainfo; }
 
   /*! \brief Update an item with information from another item
    We take metadata information from the given item and supplement the current item
@@ -706,7 +706,7 @@ public:
   void SetIgnoreURLOptions(bool ignoreURLOptions);
   void SetFastLookup(bool fastLookup);
   bool Contains(const std::string& fileName) const;
-  bool GetFastLookup() const { return m_fastLookup; };
+  bool GetFastLookup() const { return m_fastLookup; }
 
   /*! \brief stack a CFileItemList
    By default we stack all items (files and folders) in a CFileItemList
@@ -780,11 +780,11 @@ public:
    With this set the folder state will be ignored, allowing folders and files to sort interleaved.
    \param sort whether to ignore the folder state.
    */
-  void SetSortIgnoreFolders(bool sort) { m_sortIgnoreFolders = sort; };
-  bool GetReplaceListing() const { return m_replaceListing; };
+  void SetSortIgnoreFolders(bool sort) { m_sortIgnoreFolders = sort; }
+  bool GetReplaceListing() const { return m_replaceListing; }
   void SetReplaceListing(bool replace);
-  void SetContent(const std::string &content) { m_content = content; };
-  const std::string &GetContent() const { return m_content; };
+  void SetContent(const std::string& content) { m_content = content; }
+  const std::string& GetContent() const { return m_content; }
 
   void ClearSortState();
 

--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -115,8 +115,8 @@ private:
     bool DeleteIfRequired(bool deleteImmediately = false);
     void SetTexture(CTexture* texture);
 
-    const std::string &GetPath() const { return m_path; };
-    const CTextureArray &GetTexture() const { return m_texture; };
+    const std::string& GetPath() const { return m_path; }
+    const CTextureArray& GetTexture() const { return m_texture; }
 
   private:
     static const unsigned int TIME_TO_DELETE = 2000;

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -56,7 +56,7 @@ public:
   CTextureCacheJob(const std::string &url, const std::string &oldHash = "");
   ~CTextureCacheJob() override;
 
-  const char* GetType() const override { return kJobTypeCacheImage; };
+  const char* GetType() const override { return kJobTypeCacheImage; }
   bool operator==(const CJob *job) const override;
   bool DoWork() override;
 
@@ -126,7 +126,7 @@ class CTextureUseCountJob : public CJob
 public:
   explicit CTextureUseCountJob(const std::vector<CTextureDetails> &textures);
 
-  const char* GetType() const override { return "usecount"; };
+  const char* GetType() const override { return "usecount"; }
   bool operator==(const CJob *job) const override;
   bool DoWork() override;
 

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -120,6 +120,6 @@ protected:
   void CreateTables() override;
   void CreateAnalytics() override;
   void UpdateTables(int version) override;
-  int GetSchemaVersion() const override { return 13; };
-  const char *GetBaseDBName() const override { return "Textures"; };
+  int GetSchemaVersion() const override { return 13; }
+  const char* GetBaseDBName() const override { return "Textures"; }
 };

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -93,8 +93,8 @@ public:
 
   std::string ID() const override{ return m_addonInfo->ID(); }
   std::string Name() const override { return m_addonInfo->Name(); }
-  bool IsInUse() const override{ return false; };
-  bool IsBinary() const override { return m_addonInfo->IsBinary(); };
+  bool IsInUse() const override { return false; }
+  bool IsBinary() const override { return m_addonInfo->IsBinary(); }
   AddonVersion Version() const override { return m_addonInfo->Version(); }
   AddonVersion MinVersion() const override { return m_addonInfo->MinVersion(); }
   std::string Summary() const override { return m_addonInfo->Summary(); }
@@ -104,9 +104,9 @@ public:
   std::string LibPath() const override;
   std::string Author() const override { return m_addonInfo->Author(); }
   std::string ChangeLog() const override { return m_addonInfo->ChangeLog(); }
-  std::string Icon() const override { return m_addonInfo->Icon(); };
+  std::string Icon() const override { return m_addonInfo->Icon(); }
   ArtMap Art() const override { return m_addonInfo->Art(); }
-  std::vector<std::string> Screenshots() const override { return m_addonInfo->Screenshots(); };
+  std::vector<std::string> Screenshots() const override { return m_addonInfo->Screenshots(); }
   std::string Disclaimer() const override { return m_addonInfo->Disclaimer(); }
   AddonLifecycleState LifecycleState() const override { return m_addonInfo->LifecycleState(); }
   std::string LifecycleStateDescription() const override

--- a/xbmc/addons/AddonEvents.h
+++ b/xbmc/addons/AddonEvents.h
@@ -15,7 +15,7 @@ namespace ADDON
   struct AddonEvent
   {
     std::string id;
-    explicit AddonEvent(std::string id) : id(std::move(id)) {};
+    explicit AddonEvent(std::string id) : id(std::move(id)) {}
 
     // Note: Do not remove the virtual dtor. There are types derived from AddonEvent (see below)
     //       and there are several places where 'typeid' is used to determine the runtime type of

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -237,7 +237,7 @@ public:
    */
   static bool GetAddon(const std::string& addonID, ADDON::RepositoryPtr& repo, ADDON::AddonPtr& addon);
 
-  void SetDependsInstall(DependencyJob dependsInstall) { m_dependsInstall = dependsInstall; };
+  void SetDependsInstall(DependencyJob dependsInstall) { m_dependsInstall = dependsInstall; }
   void SetAllowCheckForUpdates(AllowCheckForUpdates allowCheckForUpdates)
   {
     m_allowCheckForUpdates = allowCheckForUpdates;

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -48,7 +48,7 @@ class CAddonRepos
 {
 public:
   CAddonRepos() = delete;
-  explicit CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr){};
+  explicit CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr) {}
 
   /*!
    * \brief Load the map of all available addon versions in any installed repository

--- a/xbmc/addons/ContextMenuAddon.h
+++ b/xbmc/addons/ContextMenuAddon.h
@@ -23,7 +23,7 @@ namespace ADDON
   public:
     explicit CContextMenuAddon(const AddonInfoPtr& addonInfo);
 
-    const std::vector<CContextMenuItem>& GetItems() const { return m_items; };
+    const std::vector<CContextMenuItem>& GetItems() const { return m_items; }
 
   private:
     void ParseMenu(const CAddonExtensions* elem, const std::string& parent, int& anonGroupCount);

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -78,7 +78,7 @@ namespace ADDON
     explicit CRepositoryUpdateJob(const RepositoryPtr& repo);
     ~CRepositoryUpdateJob() override = default;
     bool DoWork() override;
-    const RepositoryPtr& GetAddon() const { return m_repo; };
+    const RepositoryPtr& GetAddon() const { return m_repo; }
 
   private:
     const RepositoryPtr m_repo;

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -128,7 +128,7 @@ public:
   /*! \brief Return whether skin debugging is enabled
    \return true if skin debugging (set via <debugging>true</debugging> in addon.xml) is enabled.
    */
-  bool IsDebugging() const { return m_debugging; };
+  bool IsDebugging() const { return m_debugging; }
 
   /*! \brief Get the id of the first window to load
    The first window is generally Startup.xml unless it doesn't exist or if the skinner
@@ -152,9 +152,9 @@ public:
 
   void ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions = NULL);
 
-  float GetEffectsSlowdown() const { return m_effectsSlowDown; };
+  float GetEffectsSlowdown() const { return m_effectsSlowDown; }
 
-  const std::vector<CStartupWindow> &GetStartupWindows() const { return m_startupWindows; };
+  const std::vector<CStartupWindow>& GetStartupWindows() const { return m_startupWindows; }
 
   /*! \brief Retrieve the skin paths to search for skin XML files
    \param paths [out] vector of paths to search, in order.

--- a/xbmc/addons/addoninfo/AddonType.h
+++ b/xbmc/addons/addoninfo/AddonType.h
@@ -77,7 +77,7 @@ class CAddonDatabaseSerializer;
 class CAddonType : public CAddonExtensions
 {
 public:
-  CAddonType(TYPE type = ADDON_UNKNOWN) : m_type(type) {};
+  CAddonType(TYPE type = ADDON_UNKNOWN) : m_type(type) {}
 
   TYPE Type() const { return m_type; }
   std::string LibPath() const;

--- a/xbmc/addons/binary-addons/AddonInstanceHandler.h
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.h
@@ -40,7 +40,7 @@ namespace ADDON
     ADDON_STATUS CreateInstance(KODI_HANDLE instance);
     void DestroyInstance();
     const AddonDllPtr& Addon() const { return m_addon; }
-    AddonInfoPtr GetAddonInfo() const { return m_addonInfo; };
+    AddonInfoPtr GetAddonInfo() const { return m_addonInfo; }
 
     virtual void OnPreInstall() {}
     virtual void OnPostInstall(bool update, bool modal) {}

--- a/xbmc/addons/interfaces/gui/Window.h
+++ b/xbmc/addons/interfaces/gui/Window.h
@@ -264,8 +264,8 @@ extern "C"
     CGUIAddonWindowDialog(int id, const std::string& strXML, ADDON::CAddonDll* addon);
 
     bool IsDialogRunning() const override { return m_bRunning; }
-    bool IsDialog() const override { return true; };
-    bool IsModalDialog() const override { return true; };
+    bool IsDialog() const override { return true; }
+    bool IsModalDialog() const override { return true; }
 
     void Show(bool show = true, bool modal = true);
     void Show_Internal(bool show = true);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -1708,7 +1708,7 @@ public:
   ///
   /// @remarks
   ///
-  virtual int GetChapter() { return -1; };
+  virtual int GetChapter() { return -1; }
   //--------------------------------------------------------------------------
 
   //==========================================================================
@@ -1719,7 +1719,7 @@ public:
   ///
   /// @remarks
   ///
-  virtual int GetChapterCount() { return 0; };
+  virtual int GetChapterCount() { return 0; }
   //--------------------------------------------------------------------------
 
   //==========================================================================
@@ -1731,7 +1731,7 @@ public:
   ///
   /// @remarks
   ///
-  virtual const char* GetChapterName(int ch) { return nullptr; };
+  virtual const char* GetChapterName(int ch) { return nullptr; }
   //--------------------------------------------------------------------------
 
   //==========================================================================
@@ -1743,7 +1743,7 @@ public:
   ///
   /// @remarks
   ///
-  virtual int64_t GetChapterPos(int ch) { return 0; };
+  virtual int64_t GetChapterPos(int ch) { return 0; }
   //--------------------------------------------------------------------------
 
   //==========================================================================
@@ -1755,7 +1755,7 @@ public:
   ///
   /// @remarks
   ///
-  virtual bool SeekChapter(int ch) { return false; };
+  virtual bool SeekChapter(int ch) { return false; }
   //--------------------------------------------------------------------------
 
   ///@}

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/gl/Shader.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/gl/Shader.h
@@ -526,7 +526,7 @@ public:
   /// @ingroup cpp_kodi_gui_helpers_gl_CShaderProgram_child
   /// @brief Mandatory child function to set the necessary CPU to GPU data
   ///
-  virtual void OnCompiledAndLinked(){};
+  virtual void OnCompiledAndLinked() {}
   //--------------------------------------------------------------------------
 
   //==========================================================================
@@ -536,14 +536,14 @@ public:
   ///
   /// @return true if enable was successfull done
   ///
-  virtual bool OnEnabled() { return true; };
+  virtual bool OnEnabled() { return true; }
   //--------------------------------------------------------------------------
 
   //==========================================================================
   /// @ingroup cpp_kodi_gui_helpers_gl_CShaderProgram_child
   /// @brief Optional child function that may have to be performed when
   /// switching off the shader
-  virtual void OnDisabled(){};
+  virtual void OnDisabled() {}
   //--------------------------------------------------------------------------
   /// @}
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/platform/android/System.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/platform/android/System.h
@@ -45,7 +45,9 @@ class ATTRIBUTE_HIDDEN CInterfaceAndroidSystem
 public:
   CInterfaceAndroidSystem()
     : m_interface(static_cast<AddonToKodiFuncTable_android_system*>(
-          GetInterface(INTERFACE_ANDROID_SYSTEM_NAME, INTERFACE_ANDROID_SYSTEM_VERSION))){};
+          GetInterface(INTERFACE_ANDROID_SYSTEM_NAME, INTERFACE_ANDROID_SYSTEM_VERSION)))
+  {
+  }
 
   //============================================================================
   /// @ingroup cpp_kodi_platform_CInterfaceAndroidSystem

--- a/xbmc/cdrip/CDDARipJob.h
+++ b/xbmc/cdrip/CDDARipJob.h
@@ -37,7 +37,7 @@ public:
 
   ~CCDDARipJob() override;
 
-  const char* GetType() const override { return "cdrip"; };
+  const char* GetType() const override { return "cdrip"; }
   bool operator==(const CJob *job) const override;
   bool DoWork() override;
   std::string GetOutput() const { return m_output; }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -68,7 +68,9 @@ class CActiveAEControlProtocol : public Protocol
 {
 public:
   CActiveAEControlProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     INIT = 0,
@@ -108,7 +110,9 @@ class CActiveAEDataProtocol : public Protocol
 {
 public:
   CActiveAEDataProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     NEWSOUND = 0,

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -46,7 +46,9 @@ class CSinkControlProtocol : public Protocol
 {
 public:
   CSinkControlProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     CONFIGURE,
@@ -71,7 +73,9 @@ class CSinkDataProtocol : public Protocol
 {
 public:
   CSinkDataProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     SAMPLE = 0,

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -44,7 +44,7 @@ public:
   /*
     This method returns latency of hardware.
   */
-  virtual double GetLatency() { return 0.0; };
+  virtual double GetLatency() { return 0.0; }
 
   /*!
    * @brief Adds packets to be sent out, this routine MUST block or sleep.
@@ -59,7 +59,7 @@ public:
    * @brief instruct the sink to add a pause
    * @param millis ms to pause
    */
-  virtual void AddPause(unsigned int millis) {};
+  virtual void AddPause(unsigned int millis) {}
 
   /*!
    * @brief Return a timestamped status structure with delay and sink info
@@ -70,16 +70,16 @@ public:
   /*
     Drain the sink
    */
-  virtual void Drain() {};
+  virtual void Drain() {}
 
   /*
     Indicates if sink can handle volume control.
   */
-  virtual bool  HasVolume() {return false;};
+  virtual bool HasVolume() { return false; }
 
   /*
     This method sets the volume control, volume ranges from 0.0 to 1.0.
   */
-  virtual void  SetVolume(float volume) {};
+  virtual void SetVolume(float volume) {}
 };
 

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -25,7 +25,7 @@ class IAEClockCallback
 public:
   virtual ~IAEClockCallback() = default;
   virtual double GetClock() = 0;
-  virtual double GetClockSpeed() { return 1.0; };
+  virtual double GetClockSpeed() { return 1.0; }
 };
 
 class CAESyncInfo

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -45,7 +45,7 @@ public:
   unsigned int AddPackets(uint8_t **data, unsigned int frames, unsigned int offset) override;
   void Drain() override;
 
-  bool HasVolume() override { return true; };
+  bool HasVolume() override { return true; }
   void SetVolume(float volume) override;
 
   bool IsInitialized();

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
@@ -30,7 +30,7 @@ public:
 
   void AddListener(void* userdata);
   void Sync();
-  int GetSync() const { return m_sync; };
+  int GetSync() const { return m_sync; }
 
 private:
   static void OnCoreDone(void* userdata, uint32_t id, int seq);

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -86,15 +86,15 @@ enum ERENDERFEATURE
 class IPlayer
 {
 public:
-  explicit IPlayer(IPlayerCallback& callback): m_callback(callback){};
+  explicit IPlayer(IPlayerCallback& callback) : m_callback(callback) {}
   virtual ~IPlayer() = default;
-  virtual bool Initialize(TiXmlElement* pConfig) { return true; };
+  virtual bool Initialize(TiXmlElement* pConfig) { return true; }
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options){ return false;}
   virtual bool QueueNextFile(const CFileItem &file) { return false; }
   virtual void OnNothingToQueueNotify() {}
   virtual bool CloseFile(bool reopen = false) = 0;
   virtual bool IsPlaying() const { return false;}
-  virtual bool CanPause() { return true; };
+  virtual bool CanPause() { return true; }
   virtual void Pause() = 0;
   virtual bool HasVideo() const = 0;
   virtual bool HasAudio() const = 0;
@@ -111,27 +111,27 @@ public:
   virtual void SetDynamicRangeCompression(long drc){}
 
   virtual void SetAVDelay(float fValue = 0.0f) {}
-  virtual float GetAVDelay()                    { return 0.0f;};
+  virtual float GetAVDelay() { return 0.0f; }
 
-  virtual void SetSubTitleDelay(float fValue = 0.0f){};
+  virtual void SetSubTitleDelay(float fValue = 0.0f) {}
   virtual float GetSubTitleDelay()    { return 0.0f; }
   virtual int  GetSubtitleCount()     { return 0; }
   virtual int  GetSubtitle()          { return -1; }
-  virtual void GetSubtitleStreamInfo(int index, SubtitleStreamInfo &info){};
-  virtual void SetSubtitle(int iStream){};
-  virtual bool GetSubtitleVisible(){ return false;};
-  virtual void SetSubtitleVisible(bool bVisible){};
+  virtual void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) {}
+  virtual void SetSubtitle(int iStream) {}
+  virtual bool GetSubtitleVisible() { return false; }
+  virtual void SetSubtitleVisible(bool bVisible) {}
 
   /** \brief Adds the subtitle(s) provided by the given file to the available player streams
   *          and actives the first of the added stream(s). E.g., vob subs can contain multiple streams.
   *   \param[in] strSubPath The full path of the subtitle file.
   */
-  virtual void  AddSubtitle(const std::string& strSubPath) {};
+  virtual void AddSubtitle(const std::string& strSubPath) {}
 
   virtual int  GetAudioStreamCount()  { return 0; }
   virtual int  GetAudioStream()       { return -1; }
-  virtual void SetAudioStream(int iStream){};
-  virtual void GetAudioStreamInfo(int index, AudioStreamInfo &info){};
+  virtual void SetAudioStream(int iStream) {}
+  virtual void GetAudioStreamInfo(int index, AudioStreamInfo& info) {}
 
   virtual int GetVideoStream() const { return -1; }
   virtual int GetVideoStreamCount() const { return 0; }
@@ -142,10 +142,10 @@ public:
   virtual void SetProgram(int progId) {}
   virtual int GetProgramsCount() { return 0; }
 
-  virtual std::shared_ptr<TextCacheStruct_t> GetTeletextCache() { return NULL; };
-  virtual void LoadPage(int p, int sp, unsigned char* buffer) {};
+  virtual std::shared_ptr<TextCacheStruct_t> GetTeletextCache() { return NULL; }
+  virtual void LoadPage(int p, int sp, unsigned char* buffer) {}
 
-  virtual std::string GetRadioText(unsigned int line) { return ""; };
+  virtual std::string GetRadioText(unsigned int line) { return ""; }
 
   virtual int  GetChapterCount()                               { return 0; }
   virtual int  GetChapter()                                    { return -1; }
@@ -154,7 +154,7 @@ public:
   virtual int  SeekChapter(int iChapter)                       { return -1; }
 //  virtual bool GetChapterInfo(int chapter, SChapterInfo &info) { return false; }
 
-  virtual void SeekTime(int64_t iTime = 0){};
+  virtual void SeekTime(int64_t iTime = 0) {}
   /*
    \brief seek relative to current time, returns false if not implemented by player
    \param iTime The time in milliseconds to seek. A positive value will seek forward, a negative backward.
@@ -178,54 +178,71 @@ public:
    */
   virtual void SetTotalTime(int64_t time) { }
   virtual void SetSpeed(float speed) = 0;
-  virtual void SetTempo(float tempo) { };
+  virtual void SetTempo(float tempo) {}
   virtual bool SupportsTempo() { return false; }
-  virtual void FrameAdvance(int frames) { };
+  virtual void FrameAdvance(int frames) {}
 
   //Returns true if not playback (paused or stopped being filled)
-  virtual bool IsCaching() const {return false;};
+  virtual bool IsCaching() const { return false; }
   //Cache filled in Percent
-  virtual int GetCacheLevel() const {return -1;};
+  virtual int GetCacheLevel() const { return -1; }
 
-  virtual bool IsInMenu() const {return false;};
-  virtual bool HasMenu() const { return false; };
+  virtual bool IsInMenu() const { return false; }
+  virtual bool HasMenu() const { return false; }
 
-  virtual void DoAudioWork(){};
-  virtual bool OnAction(const CAction &action) { return false; };
+  virtual void DoAudioWork() {}
+  virtual bool OnAction(const CAction& action) { return false; }
 
   //returns a state that is needed for resuming from a specific time
-  virtual std::string GetPlayerState() { return ""; };
-  virtual bool SetPlayerState(const std::string& state) { return false;};
+  virtual std::string GetPlayerState() { return ""; }
+  virtual bool SetPlayerState(const std::string& state) { return false; }
 
-  virtual void GetAudioCapabilities(std::vector<int> &audioCaps) { audioCaps.assign(1,IPC_AUD_ALL); };
+  virtual void GetAudioCapabilities(std::vector<int>& audioCaps)
+  {
+    audioCaps.assign(1, IPC_AUD_ALL);
+  }
   /*!
    \brief define the subtitle capabilities of the player
    */
-  virtual void GetSubtitleCapabilities(std::vector<int> &subCaps) { subCaps.assign(1,IPC_SUBS_ALL); };
+  virtual void GetSubtitleCapabilities(std::vector<int>& subCaps)
+  {
+    subCaps.assign(1, IPC_SUBS_ALL);
+  }
 
   /*!
    \brief hook into render loop of render thread
    */
-  virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) {};
-  virtual void FlushRenderer() {};
-  virtual void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch) {};
-  virtual float GetRenderAspectRatio() { return 1.0; };
-  virtual void TriggerUpdateResolution() {};
-  virtual bool IsRenderingVideo() { return false; };
+  virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) {}
+  virtual void FlushRenderer() {}
+  virtual void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch) {}
+  virtual float GetRenderAspectRatio() { return 1.0; }
+  virtual void TriggerUpdateResolution() {}
+  virtual bool IsRenderingVideo() { return false; }
 
-  virtual bool Supports(EINTERLACEMETHOD method) { return false; };
+  virtual bool Supports(EINTERLACEMETHOD method) { return false; }
   virtual EINTERLACEMETHOD GetDeinterlacingMethodDefault() { return EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE; }
-  virtual bool Supports(ESCALINGMETHOD method) { return false; };
-  virtual bool Supports(ERENDERFEATURE feature) { return false; };
+  virtual bool Supports(ESCALINGMETHOD method) { return false; }
+  virtual bool Supports(ERENDERFEATURE feature) { return false; }
 
-  virtual unsigned int RenderCaptureAlloc() { return 0; };
-  virtual void RenderCaptureRelease(unsigned int captureId) {};
-  virtual void RenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags) {};
-  virtual bool RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size) { return false; };
+  virtual unsigned int RenderCaptureAlloc() { return 0; }
+  virtual void RenderCaptureRelease(unsigned int captureId) {}
+  virtual void RenderCapture(unsigned int captureId,
+                             unsigned int width,
+                             unsigned int height,
+                             int flags)
+  {
+  }
+  virtual bool RenderCaptureGetPixels(unsigned int captureId,
+                                      unsigned int millis,
+                                      uint8_t* buffer,
+                                      unsigned int size)
+  {
+    return false;
+  }
 
   // video and audio settings
-  virtual CVideoSettings GetVideoSettings() { return CVideoSettings(); };
-  virtual void SetVideoSettings(CVideoSettings& settings) {};
+  virtual CVideoSettings GetVideoSettings() { return CVideoSettings(); }
+  virtual void SetVideoSettings(CVideoSettings& settings) {}
 
   /*!
    * \brief Check if any players are playing a game

--- a/xbmc/cores/IPlayerCallback.h
+++ b/xbmc/cores/IPlayerCallback.h
@@ -21,17 +21,17 @@ public:
   virtual ~IPlayerCallback() = default;
   virtual void OnPlayBackEnded() = 0;
   virtual void OnPlayBackStarted(const CFileItem &file) = 0;
-  virtual void OnPlayerCloseFile(const CFileItem &file, const CBookmark &bookmark) {};
-  virtual void OnPlayBackPaused() {};
-  virtual void OnPlayBackResumed() {};
+  virtual void OnPlayerCloseFile(const CFileItem& file, const CBookmark& bookmark) {}
+  virtual void OnPlayBackPaused() {}
+  virtual void OnPlayBackResumed() {}
   virtual void OnPlayBackStopped() = 0;
   virtual void OnPlayBackError() = 0;
   virtual void OnQueueNextItem() = 0;
-  virtual void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) {};
-  virtual void OnPlayBackSeekChapter(int iChapter) {};
-  virtual void OnPlayBackSpeedChanged(int iSpeed) {};
-  virtual void OnAVChange() {};
-  virtual void OnAVStarted(const CFileItem &file) {};
-  virtual void RequestVideoSettings(const CFileItem &fileItem) {};
-  virtual void StoreVideoSettings(const CFileItem &fileItem, CVideoSettings vs) {};
+  virtual void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) {}
+  virtual void OnPlayBackSeekChapter(int iChapter) {}
+  virtual void OnPlayBackSpeedChanged(int iSpeed) {}
+  virtual void OnAVChange() {}
+  virtual void OnAVStarted(const CFileItem& file) {}
+  virtual void RequestVideoSettings(const CFileItem& fileItem) {}
+  virtual void StoreVideoSettings(const CFileItem& fileItem, CVideoSettings vs) {}
 };

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
@@ -40,7 +40,7 @@ public:
   IGUIRenderSettings* GetRenderSettings() const;
 
   // implementation of CGUIControl
-  CGUIGameControl* Clone() const override { return new CGUIGameControl(*this); };
+  CGUIGameControl* Clone() const override { return new CGUIGameControl(*this); }
   void Process(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
   void Render() override;
   void RenderEx() override;

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.h
@@ -61,25 +61,25 @@ public:
 
   // required if pool is registered with BufferManager BM call configure
   // as soon as it knows parameters: pixFmx, size
-  virtual void Configure(AVPixelFormat format, int size) {};
+  virtual void Configure(AVPixelFormat format, int size) {}
 
   // required if pool is registered with BufferManager
-  virtual bool IsConfigured() { return false;};
+  virtual bool IsConfigured() { return false; }
 
   // required if pool is registered with BufferManager
   // called before Get() to check if buffer pool is suitable
-  virtual bool IsCompatible(AVPixelFormat format, int size) { return false;};
+  virtual bool IsCompatible(AVPixelFormat format, int size) { return false; }
 
   // callback when BM releases buffer pool. i.e. before a new codec is created
   // clients can register a new pool on this callback
-  virtual void Released(CVideoBufferManager &videoBufferManager) {};
+  virtual void Released(CVideoBufferManager& videoBufferManager) {}
 
   // called by BM when buffer is discarded
   // pool calls back when all buffers are back home
-  virtual void Discard(CVideoBufferManager *bm, ReadyToDispose cb) { (bm->*cb)(this); };
+  virtual void Discard(CVideoBufferManager* bm, ReadyToDispose cb) { (bm->*cb)(this); }
 
   // call on Get() before returning buffer to caller
-  std::shared_ptr<IVideoBufferPool> GetPtr() { return shared_from_this(); };
+  std::shared_ptr<IVideoBufferPool> GetPtr() { return shared_from_this(); }
 };
 
 class CVideoBuffer
@@ -90,14 +90,19 @@ public:
   void Acquire();
   void Acquire(std::shared_ptr<IVideoBufferPool> pool);
   void Release();
-  int GetId() const { return m_id; };
+  int GetId() const { return m_id; }
 
   virtual AVPixelFormat GetFormat();
-  virtual uint8_t* GetMemPtr() { return nullptr; };
-  virtual void GetPlanes(uint8_t*(&planes)[YuvImage::MAX_PLANES]) {};
-  virtual void GetStrides(int(&strides)[YuvImage::MAX_PLANES]) {};
-  virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) {};
-  virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]) {};
+  virtual uint8_t* GetMemPtr() { return nullptr; }
+  virtual void GetPlanes(uint8_t* (&planes)[YuvImage::MAX_PLANES]) {}
+  virtual void GetStrides(int (&strides)[YuvImage::MAX_PLANES]) {}
+  virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) {}
+  virtual void SetDimensions(int width,
+                             int height,
+                             const int (&strides)[YuvImage::MAX_PLANES],
+                             const int (&planeOffsets)[YuvImage::MAX_PLANES])
+  {
+  }
 
   static bool CopyPicture(YuvImage* pDst, YuvImage *pSrc);
   static bool CopyNV12Picture(YuvImage* pDst, YuvImage *pSrc);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -33,7 +33,7 @@ public:
   void GetData(DVDAudioFrame &frame) override;
   void Reset() override;
   AEAudioFormat GetFormat() override { return m_format; }
-  std::string GetName() override { return m_codecName; };
+  std::string GetName() override { return m_codecName; }
   enum AVMatrixEncoding GetMatrixEncoding() override;
   enum AVAudioServiceType GetAudioServiceType() override;
   int GetProfile() override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -165,7 +165,7 @@ public:
    * will be called by video player indicating the playback speed. see DVD_PLAYSPEED_NORMAL,
    * DVD_PLAYSPEED_PAUSE and friends.
    */
-  virtual void SetSpeed(int iSpeed) {};
+  virtual void SetSpeed(int iSpeed) {}
 
   /**
    * should return codecs name
@@ -235,7 +235,7 @@ public:
    * Re-open the decoder.
    * Decoder request to re-open
    */
-  virtual void Reopen() {};
+  virtual void Reopen() {}
 
 protected:
   CProcessInfo &m_processInfo;
@@ -255,7 +255,7 @@ public:
   virtual unsigned GetAllowedReferences() { return 0; }
   virtual bool CanSkipDeint() {return false; }
   virtual const std::string Name() = 0;
-  virtual void SetCodecControl(int flags) {};
+  virtual void SetCodecControl(int flags) {}
 };
 
 class ICallbackHWAccel

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -54,8 +54,7 @@ class CMediaCodecVideoBufferPool;
 class CMediaCodecVideoBuffer : public CVideoBuffer
 {
 public:
-  CMediaCodecVideoBuffer(int id)
-    : CVideoBuffer(id){};
+  CMediaCodecVideoBuffer(int id) : CVideoBuffer(id) {}
   ~CMediaCodecVideoBuffer() override = default;
 
   void Set(int internalId,
@@ -76,7 +75,7 @@ public:
   void GetTransformMatrix(float* textureMatrix);
   void UpdateTexImage();
   void RenderUpdate(const CRect& DestRect, int64_t displayTime);
-  bool HasSurfaceTexture() const { return m_surfacetexture.operator bool(); };
+  bool HasSurfaceTexture() const { return m_surfacetexture.operator bool(); }
 
 private:
   int m_bufferId = -1;
@@ -92,7 +91,9 @@ class CMediaCodecVideoBufferPool : public IVideoBufferPool
 {
 public:
   CMediaCodecVideoBufferPool(std::shared_ptr<CJNIMediaCodec> mediaCodec)
-    : m_codec(std::move(mediaCodec)){};
+    : m_codec(std::move(mediaCodec))
+  {
+  }
 
   ~CMediaCodecVideoBufferPool() override;
 
@@ -127,7 +128,7 @@ public:
   void Reset() override;
   bool Reconfigure(CDVDStreamInfo& hints) override;
   VCReturn GetPicture(VideoPicture* pVideoPicture) override;
-  const char* GetName() override { return m_formatname.c_str(); };
+  const char* GetName() override { return m_formatname.c_str(); }
   void SetCodecControl(int flags) override;
   unsigned GetAllowedReferences() override;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -56,7 +56,7 @@ protected:
   void UpdateName();
   bool SetPictureParams(VideoPicture* pVideoPicture);
 
-  bool HasHardware() { return m_pHardware != nullptr; };
+  bool HasHardware() { return m_pHardware != nullptr; }
   void SetHardware(IHardwareDecoder *hardware);
 
   AVFrame* m_pFrame = nullptr;;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -192,7 +192,9 @@ class COutputControlProtocol : public Protocol
 {
 public:
   COutputControlProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     INIT,
@@ -212,7 +214,9 @@ class COutputDataProtocol : public Protocol
 {
 public:
   COutputDataProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     NEWFRAME = 0,
@@ -357,7 +361,7 @@ class IVaapiWinSystem
 {
 public:
   virtual VADisplay GetVADisplay() = 0;
-  virtual void *GetEGLDisplay() { return nullptr; };
+  virtual void* GetEGLDisplay() { return nullptr; }
 };
 
 //-----------------------------------------------------------------------------
@@ -454,7 +458,8 @@ public:
   virtual bool DoesSync() = 0;
   virtual bool WantsPic() {return true;}
   virtual bool UseVideoSurface() = 0;
-  virtual void Discard(COutput *output, ReadyToDispose cb) { (output->*cb)(this); };
+  virtual void Discard(COutput* output, ReadyToDispose cb) { (output->*cb)(this); }
+
 protected:
   CVaapiConfig m_config;
   int m_step;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -243,7 +243,9 @@ class CMixerControlProtocol : public Actor::Protocol
 {
 public:
   CMixerControlProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     INIT = 0,
@@ -261,7 +263,9 @@ class CMixerDataProtocol : public Actor::Protocol
 {
 public:
   CMixerDataProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Protocol(std::move(name), inEvent, outEvent){};
+    : Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     FRAME,
@@ -352,7 +356,9 @@ class COutputControlProtocol : public Actor::Protocol
 {
 public:
   COutputControlProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Actor::Protocol(std::move(name), inEvent, outEvent){};
+    : Actor::Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     INIT,
@@ -372,7 +378,9 @@ class COutputDataProtocol : public Actor::Protocol
 {
 public:
   COutputDataProtocol(std::string name, CEvent* inEvent, CEvent* outEvent)
-    : Actor::Protocol(std::move(name), inEvent, outEvent){};
+    : Actor::Protocol(std::move(name), inEvent, outEvent)
+  {
+  }
   enum OutSignal
   {
     NEWFRAME = 0,

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -124,7 +124,7 @@ public:
 class CDemuxStreamVideo : public CDemuxStream
 {
 public:
-  CDemuxStreamVideo() { type = STREAM_VIDEO; };
+  CDemuxStreamVideo() { type = STREAM_VIDEO; }
 
   ~CDemuxStreamVideo() override = default;
   int iFpsScale = 0; // scale of 1000 and a rate of 29970 will result in 29.97 fps
@@ -336,29 +336,29 @@ public:
   /*
    * enable / disable demux stream
    */
-  virtual void EnableStream(int64_t demuxerId, int id, bool enable) { EnableStream(id, enable); };
+  virtual void EnableStream(int64_t demuxerId, int id, bool enable) { EnableStream(id, enable); }
 
   /*
   * implicitly enable and open a demux stream for playback
   */
-  virtual void OpenStream(int64_t demuxerId, int id) { OpenStream(id); };
+  virtual void OpenStream(int64_t demuxerId, int id) { OpenStream(id); }
 
   /*
    * sets desired width / height for video stream
    * adaptive demuxers like DASH can use this to choose best fitting video stream
    */
-  virtual void SetVideoResolution(int width, int height){};
+  virtual void SetVideoResolution(int width, int height) {}
 
   /*
   * return the id of the demuxer
   */
-  int64_t GetDemuxerId() { return m_demuxerId; };
+  int64_t GetDemuxerId() { return m_demuxerId; }
 
 protected:
-  virtual void EnableStream(int id, bool enable){};
-  virtual void OpenStream(int id){};
+  virtual void EnableStream(int id, bool enable) {}
+  virtual void OpenStream(int id) {}
   virtual CDemuxStream* GetStream(int iStreamId) const = 0;
-  virtual std::string GetStreamCodecName(int iStreamId) { return ""; };
+  virtual std::string GetStreamCodecName(int iStreamId) { return ""; }
 
   int GetNrOfStreams(StreamType streamType);
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -21,10 +21,13 @@ public:
   explicit CDVDDemuxCC(AVCodecID codec);
   ~CDVDDemuxCC() override;
 
-  bool Reset() override { return true; };
+  bool Reset() override { return true; }
   void Flush() override {};
-  DemuxPacket* Read() override { return NULL; };
-  bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override {return true;};
+  DemuxPacket* Read() override { return NULL; }
+  bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override
+  {
+    return true;
+  }
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -111,10 +111,10 @@ public:
     virtual bool HasMenu() = 0;
     virtual bool IsInMenu() = 0;
     virtual void SkipStill() = 0;
-    virtual double GetTimeStampCorrection() { return 0.0; };
+    virtual double GetTimeStampCorrection() { return 0.0; }
     virtual bool GetState(std::string &xmlstate) = 0;
     virtual bool SetState(const std::string &xmlstate) = 0;
-    virtual bool CanSeek() { return !IsInMenu(); };
+    virtual bool CanSeek() { return !IsInMenu(); }
   };
 
   class IDemux
@@ -125,15 +125,15 @@ public:
     virtual DemuxPacket* ReadDemux() = 0;
     virtual CDemuxStream* GetStream(int iStreamId) const = 0;
     virtual std::vector<CDemuxStream*> GetStreams() const = 0;
-    virtual void EnableStream(int iStreamId, bool enable) {};
-    virtual bool OpenStream(int iStreamId) { return false; };
+    virtual void EnableStream(int iStreamId, bool enable) {}
+    virtual bool OpenStream(int iStreamId) { return false; }
     virtual int GetNrOfStreams() const = 0;
     virtual void SetSpeed(int iSpeed) = 0;
-    virtual void FillBuffer(bool mode) {};
+    virtual void FillBuffer(bool mode) {}
     virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) = 0;
     virtual void AbortDemux() = 0;
     virtual void FlushDemux() = 0;
-    virtual void SetVideoResolution(int width, int height) {};
+    virtual void SetVideoResolution(int width, int height) {}
   };
 
   enum ENextStream
@@ -150,7 +150,7 @@ public:
   virtual int Read(uint8_t* buf, int buf_size) = 0;
   virtual int64_t Seek(int64_t offset, int whence) = 0;
   virtual int64_t GetLength() = 0;
-  virtual std::string& GetContent() { return m_content; };
+  virtual std::string& GetContent() { return m_content; }
   virtual std::string GetFileName();
   virtual CURL GetURL();
   virtual ENextStream NextStream() { return NEXTSTREAM_NONE; }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -51,7 +51,7 @@ public:
   void Pause(bool bPaused);
 
   // Demux interface
-  CDVDInputStream::IDemux* GetIDemux() override { return nullptr; };
+  CDVDInputStream::IDemux* GetIDemux() override { return nullptr; }
   bool OpenDemux() override;
   DemuxPacket* ReadDemux() override;
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.h
@@ -35,7 +35,7 @@ public:
   long Seek(long offset, int whence);
 
   char* ReadLine(char* pBuffer, int iLen);
-  //wchar* ReadLineW(wchar* pBuffer, int iLen) { return NULL; };
+  //wchar* ReadLineW(wchar* pBuffer, int iLen) { return NULL; }
 
   std::stringstream m_stringstream;
 };

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -35,7 +35,7 @@ public:
 class IDVDStreamPlayer
 {
 public:
-  explicit IDVDStreamPlayer(CProcessInfo &processInfo) : m_processInfo(processInfo) {};
+  explicit IDVDStreamPlayer(CProcessInfo& processInfo) : m_processInfo(processInfo) {}
   virtual ~IDVDStreamPlayer() = default;
   virtual bool OpenStream(CDVDStreamInfo hint) = 0;
   virtual void CloseStream(bool bWaitForBuffers) = 0;
@@ -74,7 +74,7 @@ class CDVDVideoCodec;
 class IDVDStreamPlayerVideo : public IDVDStreamPlayer
 {
 public:
-  explicit IDVDStreamPlayerVideo(CProcessInfo &processInfo) : IDVDStreamPlayer(processInfo) {};
+  explicit IDVDStreamPlayerVideo(CProcessInfo& processInfo) : IDVDStreamPlayer(processInfo) {}
   ~IDVDStreamPlayerVideo() override = default;
   bool OpenStream(CDVDStreamInfo hint) override = 0;
   void CloseStream(bool bWaitForBuffers) override = 0;
@@ -94,14 +94,14 @@ public:
   virtual std::string GetPlayerInfo() = 0;
   virtual int GetVideoBitrate() = 0;
   virtual void SetSpeed(int iSpeed) = 0;
-  virtual bool IsEOS() { return false; };
+  virtual bool IsEOS() { return false; }
 };
 
 class CDVDAudioCodec;
 class IDVDStreamPlayerAudio : public IDVDStreamPlayer
 {
 public:
-  explicit IDVDStreamPlayerAudio(CProcessInfo &processInfo) : IDVDStreamPlayer(processInfo) {};
+  explicit IDVDStreamPlayerAudio(CProcessInfo& processInfo) : IDVDStreamPlayer(processInfo) {}
   ~IDVDStreamPlayerAudio() override = default;
   bool OpenStream(CDVDStreamInfo hints) override = 0;
   void CloseStream(bool bWaitForBuffers) override = 0;
@@ -112,8 +112,8 @@ public:
   virtual int  GetLevel() const = 0;
   bool IsInited() const override = 0;
   void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override = 0;
-  virtual void SetVolume(float fVolume) {};
-  virtual void SetMute(bool bOnOff) {};
+  virtual void SetVolume(float fVolume) {}
+  virtual void SetMute(bool bOnOff) {}
   virtual void SetDynamicRangeCompression(long drc) = 0;
   virtual std::string GetPlayerInfo() = 0;
   virtual int GetAudioChannels() = 0;
@@ -121,5 +121,5 @@ public:
   bool IsStalled() const override = 0;
   virtual bool IsPassthrough() const = 0;
   virtual float GetDynamicRangeAmplification() const = 0;
-  virtual bool IsEOS() { return false; };
+  virtual bool IsEOS() { return false; }
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -55,9 +55,9 @@ public:
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) = 0;
   virtual bool IsConfigured() = 0;
   virtual void AddVideoPicture(const VideoPicture &picture, int index) = 0;
-  virtual bool IsPictureHW(const VideoPicture &picture) { return false; };
+  virtual bool IsPictureHW(const VideoPicture& picture) { return false; }
   virtual void UnInit() = 0;
-  virtual bool Flush(bool saveBuffers) { return false; };
+  virtual bool Flush(bool saveBuffers) { return false; }
   virtual void SetBufferSize(int numBuffers) { }
   virtual void ReleaseBuffer(int idx) { }
   virtual bool NeedBuffer(int idx) { return false; }
@@ -71,10 +71,10 @@ public:
 
   // Feature support
   virtual bool SupportsMultiPassRendering() = 0;
-  virtual bool Supports(ERENDERFEATURE feature) { return false; };
+  virtual bool Supports(ERENDERFEATURE feature) { return false; }
   virtual bool Supports(ESCALINGMETHOD method) = 0;
 
-  virtual bool WantsDoublePass() { return false; };
+  virtual bool WantsDoublePass() { return false; }
 
   void SetViewMode(int viewMode);
 
@@ -94,7 +94,7 @@ public:
   void SetVideoSettings(const CVideoSettings &settings);
 
   // Gets debug info from render buffer
-  virtual DEBUG_INFO_VIDEO GetDebugInfo(int idx) { return {}; };
+  virtual DEBUG_INFO_VIDEO GetDebugInfo(int idx) { return {}; }
 
   virtual CRenderCapture* GetRenderCapture() { return nullptr; }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -25,19 +25,19 @@ public:
   void AddVideoPicture(const VideoPicture& picture, int index) override;
   void ReleaseBuffer(int idx) override;
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
-  bool IsConfigured() override { return m_bConfigured; };
-  bool ConfigChanged(const VideoPicture& picture) override { return false; };
+  bool IsConfigured() override { return m_bConfigured; }
+  bool ConfigChanged(const VideoPicture& picture) override { return false; }
   CRenderInfo GetRenderInfo() override;
   void UnInit() override{};
   void Update() override{};
   void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
-  bool SupportsMultiPassRendering() override { return false; };
+  bool SupportsMultiPassRendering() override { return false; }
 
   // Player functions
-  bool IsGuiLayer() override { return false; };
+  bool IsGuiLayer() override { return false; }
 
   // Feature support
-  bool Supports(ESCALINGMETHOD method) override { return false; };
+  bool Supports(ESCALINGMETHOD method) override { return false; }
   bool Supports(ERENDERFEATURE feature) override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.h
@@ -52,7 +52,7 @@ protected:
 
   EShaderFormat GetShaderFormat() override;
 
-  bool CanSaveBuffers() override { return false; };
+  bool CanSaveBuffers() override { return false; }
 
   bool m_isYuv = false;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -146,10 +146,10 @@ protected:
   GLint GetInternalFormat(GLint format, int bpp);
 
   // hooks for HwDec Renderer
-  virtual bool LoadShadersHook() { return false; };
-  virtual bool RenderHook(int idx) { return false; };
-  virtual void AfterRenderHook(int idx) {};
-  virtual bool CanSaveBuffers() { return true; };
+  virtual bool LoadShadersHook() { return false; }
+  virtual bool RenderHook(int idx) { return false; }
+  virtual void AfterRenderHook(int idx) {}
+  virtual bool CanSaveBuffers() { return true; }
 
   struct
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -126,9 +126,9 @@ protected:
   void RenderSinglePass(int index, int field); // single pass glsl renderer
 
   // hooks for HwDec Renderered
-  virtual bool LoadShadersHook() { return false; };
-  virtual bool RenderHook(int idx) { return false; };
-  virtual void AfterRenderHook(int idx) {};
+  virtual bool LoadShadersHook() { return false; }
+  virtual bool RenderHook(int idx) { return false; }
+  virtual void AfterRenderHook(int idx) {}
 
   struct
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -110,8 +110,8 @@ public:
    */
   void DiscardBuffer();
 
-  void SetDelay(int delay) { m_videoDelay = delay; };
-  int GetDelay() { return m_videoDelay; };
+  void SetDelay(int delay) { m_videoDelay = delay; }
+  int GetDelay() { return m_videoDelay; }
 
   void SetVideoSettings(CVideoSettings settings);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -114,7 +114,7 @@ public:
   virtual CRenderInfo GetRenderInfo();
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned int orientation);
   virtual bool Supports(ESCALINGMETHOD method) = 0;
-  virtual bool WantsDoublePass() { return false; };
+  virtual bool WantsDoublePass() { return false; }
   virtual bool NeedBuffer(int idx) { return false; }
 
   void AddVideoPicture(const VideoPicture &picture, int index);

--- a/xbmc/cores/paplayer/AudioDecoder.h
+++ b/xbmc/cores/paplayer/AudioDecoder.h
@@ -48,12 +48,18 @@ public:
 
   int ReadSamples(int numsamples);
 
-  bool CanSeek() { if (m_codec) return m_codec->CanSeek(); else return false; };
+  bool CanSeek()
+  {
+    if (m_codec)
+      return m_codec->CanSeek();
+    else
+      return false;
+  }
   int64_t Seek(int64_t time);
   int64_t TotalTime();
   void SetTotalTime(int64_t time);
   void Start() { m_canPlay = true;}; // cause a pre-buffered stream to start.
-  int GetStatus() { return m_status; };
+  int GetStatus() { return m_status; }
   void SetStatus(int status) { m_status = status; }
 
   AEAudioFormat GetFormat();

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -28,9 +28,9 @@ public:
   class Filter
   {
   public:
-    Filter() : fields("*") {};
-    explicit Filter(const char *w) : fields("*"), where(w) {};
-    explicit Filter(const std::string &w) : fields("*"), where(w) {};
+    Filter() : fields("*") {}
+    explicit Filter(const char* w) : fields("*"), where(w) {}
+    explicit Filter(const std::string& w) : fields("*"), where(w) {}
 
     void AppendField(const std::string &strField);
     void AppendJoin(const std::string &strJoin);
@@ -80,8 +80,11 @@ public:
   class ExistsSubQuery
   {
   public:
-    explicit ExistsSubQuery(const std::string &table) : tablename(table) {};
-    ExistsSubQuery(const std::string &table, const std::string &parameter) : tablename(table), param(parameter) {};
+    explicit ExistsSubQuery(const std::string& table) : tablename(table) {}
+    ExistsSubQuery(const std::string& table, const std::string& parameter)
+      : tablename(table), param(parameter)
+    {
+    }
     void AppendJoin(const std::string &strJoin);
     void AppendWhere(const std::string &strWhere, bool combineWithAnd = true);
     bool BuildSQL(std::string &strSQL);
@@ -267,11 +270,11 @@ protected:
    Note that analytics (views, indices, triggers) are not present during this
    function, so don't rely on them.
    */
-  virtual void UpdateTables(int version) {};
+  virtual void UpdateTables(int version) {}
 
   /* \brief The minimum schema version that we support updating from.
    */
-  virtual int GetMinSchemaVersion() const { return 0; };
+  virtual int GetMinSchemaVersion() const { return 0; }
 
   /* \brief The current schema version.
    */

--- a/xbmc/dbwrappers/DatabaseQuery.h
+++ b/xbmc/dbwrappers/DatabaseQuery.h
@@ -81,7 +81,7 @@ protected:
   virtual std::string         FormatParameter(const std::string &negate, const std::string &oper, const CDatabase &db, const std::string &type) const;
   virtual std::string         FormatWhereClause(const std::string &negate, const std::string &oper, const std::string &param,
                                                 const CDatabase &db, const std::string &type) const;
-  virtual SEARCH_OPERATOR     GetOperator(const std::string &type) const { return m_operator; };
+  virtual SEARCH_OPERATOR GetOperator(const std::string& type) const { return m_operator; }
   virtual std::string         GetOperatorString(SEARCH_OPERATOR op) const;
   virtual std::string         GetBooleanQuery(const std::string &negate, const std::string &strType) const { return ""; }
 

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -85,8 +85,8 @@ public:
 /* active status is OK state */
   virtual bool isActive(void) const { return active; }
 /* Set new name of sequence table */
-  void setSequenceTable(const char *new_seq_table) { sequence_table = new_seq_table; };
-/* Get name of sequence table */
+  void setSequenceTable(const char* new_seq_table) { sequence_table = new_seq_table; }
+  /* Get name of sequence table */
   const char *getSequenceTable(void) { return sequence_table.c_str(); }
 /* Get the default character set */
   const char *getDefaultCharset(void) { return default_charset.c_str(); }
@@ -128,11 +128,11 @@ public:
 
 /* virtual methods for transaction */
 
-  virtual void start_transaction() {};
-  virtual void commit_transaction() {};
-  virtual void rollback_transaction() {};
+  virtual void start_transaction() {}
+  virtual void commit_transaction() {}
+  virtual void rollback_transaction() {}
 
-/* virtual methods for formatting */
+  /* virtual methods for formatting */
 
   /*! \brief Prepare a SQL statement for execution or querying using C printf nomenclature.
    \param format - C printf compliant format string
@@ -148,8 +148,7 @@ public:
    */
   virtual std::string vprepare(const char *format, va_list args) = 0;
 
-  virtual bool in_transaction() {return false;};
-
+  virtual bool in_transaction() { return false; }
 };
 
 
@@ -341,9 +340,9 @@ public:
 /* Delete statements from database */
   virtual void deletion();
 /* Cancel changes, made in insert or edit states of dataset */
-  virtual void cancel() {};
-/* interrupt any pending database operation  */
-	virtual void interrupt() {};
+  virtual void cancel() {}
+  /* interrupt any pending database operation  */
+  virtual void interrupt() {}
 
   virtual void setParamList(const ParamList &params);
   virtual bool locate();
@@ -370,9 +369,9 @@ public:
 
 
 /* Return field name by it index */
-//  virtual char *field_name(int f_index) { return field_by_index(f_index)->get_field_name(); };
+  //  virtual char *field_name(int f_index) { return field_by_index(f_index)->get_field_name(); }
 
-/* Getting value of field for current record */
+  /* Getting value of field for current record */
   virtual const field_value get_field_value(const char *f_name);
   virtual const field_value get_field_value(int index);
 /* Alias to get_field_value */
@@ -384,10 +383,10 @@ public:
   bool get_autocommit() { return autocommit; }
 
 /* ----------------- for debug -------------------- */
-  Fields *get_fields_object() {return fields_object;};
-  Fields *get_edit_object() {return edit_object;};
+  Fields* get_fields_object() { return fields_object; }
+  Fields* get_edit_object() { return edit_object; }
 
-/* --------------- for fast access ---------------- */
+  /* --------------- for fast access ---------------- */
   const result_set& get_result_set() { return result; }
   const sql_record* get_sql_record();
 
@@ -400,23 +399,20 @@ public:
 /* Struct to store an indexMapped field access entry */
   struct FieldIndexMapEntry
   {
-   explicit FieldIndexMapEntry(const char *name):fieldIndex(~0), strName(name){};
-   bool operator < (const FieldIndexMapEntry &other) const {return strName < other.strName;};
-   unsigned int fieldIndex;
-   std::string strName;
+    explicit FieldIndexMapEntry(const char* name) : fieldIndex(~0), strName(name) {}
+    bool operator<(const FieldIndexMapEntry& other) const { return strName < other.strName; }
+    unsigned int fieldIndex;
+    std::string strName;
   };
 
 /* Comparator to quickly find an indexMapped field access entry in the unsorted fieldIndexMap_Entries vector */
   struct FieldIndexMapComparator
   {
-   explicit FieldIndexMapComparator(const std::vector<FieldIndexMapEntry> &c): c_(c) {};
-   bool operator()(const unsigned int &v, const FieldIndexMapEntry &o) const
-   {
-     return c_[v] < o;
-   };
-   bool operator()(const unsigned int &v1, const unsigned int &v2) const
-   {
-     return c_[v1] < c_[v2];
+    explicit FieldIndexMapComparator(const std::vector<FieldIndexMapEntry>& c) : c_(c) {}
+    bool operator()(const unsigned int& v, const FieldIndexMapEntry& o) const { return c_[v] < o; };
+    bool operator()(const unsigned int& v1, const unsigned int& v2) const
+    {
+      return c_[v1] < c_[v2];
    };
    bool operator()(const FieldIndexMapEntry &o, const unsigned int &v) const
    {
@@ -446,12 +442,13 @@ public:
 /* Get the column index from a string field_value request */
   bool get_index_map_entry(const char *f_name);
 
-  void set_ds_state(dsStates new_state) {ds_state = new_state;};
- public:
-/* return ds_state value */
-  dsStates get_state() {return ds_state;};
+  void set_ds_state(dsStates new_state) { ds_state = new_state; }
 
-/*add a new value to select_sql*/
+public:
+  /* return ds_state value */
+  dsStates get_state() { return ds_state; }
+
+  /*add a new value to select_sql*/
   void set_select_sql(const char *sel_sql);
   void set_select_sql(const std::string &select_sql);
 /*add a new value to update_sql*/

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -74,7 +74,7 @@ public:
 /* virtual methods for formatting */
   std::string vprepare(const char *format, va_list args) override;
 
-  bool in_transaction() override {return _in_transaction;};
+  bool in_transaction() override { return _in_transaction; }
   int query_with_reconnect(const char* query);
   void configure_connection();
 

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -80,8 +80,7 @@ public:
 /* virtual methods for formatting */
   std::string vprepare(const char *format, va_list args) override;
 
-  bool in_transaction() override {return _in_transaction;};
-
+  bool in_transaction() override { return _in_transaction; }
 };
 
 

--- a/xbmc/dialogs/GUIDialogFileBrowser.h
+++ b/xbmc/dialogs/GUIDialogFileBrowser.h
@@ -31,7 +31,7 @@ public:
   void FrameMove() override;
   void OnWindowLoaded() override;
   void OnWindowUnload() override;
-  bool IsConfirmed() { return m_bConfirmed; };
+  bool IsConfirmed() { return m_bConfirmed; }
   void SetHeading(const std::string &heading);
 
   static bool ShowAndGetDirectory(const VECSOURCES &shares, const std::string &heading, std::string &path, bool bWriteOnly=false);
@@ -47,9 +47,9 @@ public:
 
   void OnItemLoaded(CFileItem *item) override {};
 
-  bool HasListItems() const override { return true; };
+  bool HasListItems() const override { return true; }
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
-  int GetViewContainerID() const override { return m_viewControl.GetCurrentControl(); };
+  int GetViewContainerID() const override { return m_viewControl.GetCurrentControl(); }
 
 protected:
   void GoParentFolder();

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.h
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.h
@@ -32,9 +32,9 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void SetHeading(const std::string& heading);
     void SetText(const std::string& text);
     const std::string &GetText() const;
-    bool IsConfirmed() { return m_bIsConfirmed; };
-    void SetHiddenInput(bool hiddenInput) { m_hiddenInput = hiddenInput; };
-    bool IsInputHidden() const { return m_hiddenInput; };
+    bool IsConfirmed() { return m_bIsConfirmed; }
+    void SetHiddenInput(bool hiddenInput) { m_hiddenInput = hiddenInput; }
+    bool IsInputHidden() const { return m_hiddenInput; }
 
   protected:
     void OnWindowLoaded() override;

--- a/xbmc/dialogs/GUIDialogMediaSource.h
+++ b/xbmc/dialogs/GUIDialogMediaSource.h
@@ -29,7 +29,7 @@ public:
   static bool ShowAndEditMediaSource(const std::string &type, const CMediaSource &share);
   static bool ShowAndEditMediaSource(const std::string &type, const std::string &share);
 
-  bool IsConfirmed() const { return m_confirmed; };
+  bool IsConfirmed() const { return m_confirmed; }
 
   void SetShare(const CMediaSource &share);
   void SetTypeOfMedia(const std::string &type, bool editNotAdd = false);

--- a/xbmc/dialogs/GUIDialogNumeric.h
+++ b/xbmc/dialogs/GUIDialogNumeric.h
@@ -34,7 +34,7 @@ public:
 
   bool IsConfirmed() const;
   bool IsCanceled() const;
-  bool IsInputHidden() const { return m_mode == INPUT_PASSWORD; };
+  bool IsInputHidden() const { return m_mode == INPUT_PASSWORD; }
 
   static bool ShowAndVerifyNewPassword(std::string& strNewPassword);
   static int ShowAndVerifyPassword(std::string& strPassword, const std::string& strHeading, int iRetries);

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -28,7 +28,7 @@ public:
   void Progress();
   bool IsCanceled() const { return m_iChoice == CHOICE_CANCELED; }
   void SetPercentage(int iPercentage);
-  int GetPercentage() const { return m_percentage; };
+  int GetPercentage() const { return m_percentage; }
   void ShowProgressBar(bool bOnOff);
 
   void ShowChoice(int iChoice, const CVariant& label);

--- a/xbmc/filesystem/AudioBookFileDirectory.h
+++ b/xbmc/filesystem/AudioBookFileDirectory.h
@@ -21,7 +21,8 @@ namespace XFILE
       bool GetDirectory(const CURL& url, CFileItemList &items) override;
       bool Exists(const CURL& url) override;
       bool ContainsFiles(const CURL& url) override;
-      bool IsAllowed(const CURL& url) const override { return true; };
+      bool IsAllowed(const CURL& url) const override { return true; }
+
     protected:
       AVIOContext* m_ioctx = nullptr;
       AVFormatContext* m_fctx = nullptr;

--- a/xbmc/filesystem/DAVDirectory.h
+++ b/xbmc/filesystem/DAVDirectory.h
@@ -23,7 +23,8 @@ namespace XFILE
       bool Create(const CURL& url) override;
       bool Exists(const CURL& url) override;
       bool Remove(const CURL& url) override;
-      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
+      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; }
+
     private:
       void ParseResponse(const TiXmlElement *pElement, CFileItem &item);
   };

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -27,7 +27,7 @@ namespace XFILE
       virtual ~CDir();
 
       void SetLastAccess(unsigned int &accessCounter);
-      unsigned int GetLastAccess() const { return m_lastAccess; };
+      unsigned int GetLastAccess() const { return m_lastAccess; }
 
       CFileItemList* m_Items;
       DIR_CACHE_TYPE m_cacheType;

--- a/xbmc/filesystem/HTTPDirectory.h
+++ b/xbmc/filesystem/HTTPDirectory.h
@@ -19,7 +19,8 @@ namespace XFILE
       ~CHTTPDirectory(void) override;
       bool GetDirectory(const CURL& url, CFileItemList &items) override;
       bool Exists(const CURL& url) override;
-      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
+      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; }
+
     private:
   };
 }

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -68,12 +68,12 @@ public:
    \return the progress as a float in the range 0..100.
    \sa GetDirectory, CancelDirectory
    */
-  virtual float GetProgress() const { return 0.0f; };
+  virtual float GetProgress() const { return 0.0f; }
   /*!
    \brief Cancel the current directory fetch (if possible).
    \sa GetDirectory
    */
-  virtual void CancelDirectory() { };
+  virtual void CancelDirectory() {}
   /*!
   \brief Create the directory
   \param url Directory to create.
@@ -119,7 +119,7 @@ public:
   \param url Directory at hand.
   \return Returns the cache type.
   */
-  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
+  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; }
 
   void SetMask(const std::string& strMask);
   void SetFlags(int flags);

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -46,8 +46,8 @@ public:
   virtual ~IFile();
 
   virtual bool Open(const CURL& url) = 0;
-  virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false) { return false; };
-  virtual bool ReOpen(const CURL& url) { return false; };
+  virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false) { return false; }
+  virtual bool ReOpen(const CURL& url) { return false; }
   virtual bool Exists(const CURL& url) = 0;
   /**
    * Fills struct __stat64 with information about file specified by url.
@@ -98,7 +98,7 @@ public:
   virtual int64_t GetPosition() = 0;
   virtual int64_t GetLength() = 0;
   virtual void Flush() { }
-  virtual int Truncate(int64_t size) { return -1;};
+  virtual int Truncate(int64_t size) { return -1; }
 
   /* Returns the minium size that can be read from input stream.   *
    * For example cdrom access where access could be sector based.  *
@@ -107,7 +107,7 @@ public:
    * It can also be used to indicate a file system is non buffered *
    * but accepts any read size, have it return the value 1         */
   virtual int  GetChunkSize() {return 0;}
-  virtual double GetDownloadSpeed() { return 0.0; };
+  virtual double GetDownloadSpeed() { return 0.0; }
 
   virtual bool Delete(const CURL& url) { return false; }
   virtual bool Rename(const CURL& url, const CURL& urlnew) { return false; }

--- a/xbmc/filesystem/NFSDirectory.h
+++ b/xbmc/filesystem/NFSDirectory.h
@@ -21,7 +21,7 @@ namespace XFILE
       CNFSDirectory(void);
       ~CNFSDirectory(void) override;
       bool GetDirectory(const CURL& url, CFileItemList &items) override;
-      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
+      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; }
       bool Create(const CURL& url) override;
       bool Exists(const CURL& url) override;
       bool Remove(const CURL& url) override;

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -123,7 +123,10 @@ namespace XFILE
 
     //implement iocontrol for seek_possible for preventing the stat in File class for
     //getting this info ...
-    int IoControl(EIoControl request, void* param) override{ return request == IOCTRL_SEEK_POSSIBLE ? 1 : -1; };
+    int IoControl(EIoControl request, void* param) override
+    {
+      return request == IOCTRL_SEEK_POSSIBLE ? 1 : -1;
+    }
     int GetChunkSize() override {return static_cast<int>(gNfsConnection.GetMaxReadChunkSize());}
 
     bool OpenForWrite(const CURL& url, bool bOverWrite = false) override;

--- a/xbmc/filesystem/PVRDirectory.h
+++ b/xbmc/filesystem/PVRDirectory.h
@@ -21,7 +21,7 @@ public:
 
   bool GetDirectory(const CURL& url, CFileItemList &items) override;
   bool AllowAll() const override { return true; }
-  DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_NEVER; };
+  DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_NEVER; }
   bool Exists(const CURL& url) override;
 
   static bool SupportsWriteFileOperations(const std::string& strPath);

--- a/xbmc/filesystem/RSSDirectory.h
+++ b/xbmc/filesystem/RSSDirectory.h
@@ -22,7 +22,8 @@ namespace XFILE
     bool Exists(const CURL& url) override;
     bool AllowAll() const override { return true; }
     bool ContainsFiles(const CURL& url) override;
-    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
+    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; }
+
   protected:
     // key is path, value is cache invalidation date
     static std::map<std::string,CDateTime> m_cache;

--- a/xbmc/filesystem/ShoutcastFile.h
+++ b/xbmc/filesystem/ShoutcastFile.h
@@ -38,8 +38,12 @@ public:
   int64_t GetPosition() override;
   int64_t GetLength() override;
   bool Open(const CURL& url) override;
-  bool Exists(const CURL& url) override { return true;};
-  int Stat(const CURL& url, struct __stat64* buffer) override { errno = ENOENT; return -1; };
+  bool Exists(const CURL& url) override { return true; }
+  int Stat(const CURL& url, struct __stat64* buffer) override
+  {
+    errno = ENOENT;
+    return -1;
+  }
   ssize_t Read(void* lpBuf, size_t uiBufSize) override;
   int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) override;
   void Close() override;

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -50,7 +50,7 @@ namespace XFILE
 
     void GetSources(VECSOURCES &sources) const;
 
-    void AllowNonLocalSources(bool allow) { m_allowNonLocalSources = allow; };
+    void AllowNonLocalSources(bool allow) { m_allowNonLocalSources = allow; }
 
     std::shared_ptr<IDirectory> GetDirImpl() { return m_pDir; }
     void ReleaseDirImpl() { m_pDir.reset(); }

--- a/xbmc/filesystem/XbtDirectory.h
+++ b/xbmc/filesystem/XbtDirectory.h
@@ -24,7 +24,7 @@ public:
   ~CXbtDirectory() override;
 
   // specialization of IDirectory
-  DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ALWAYS; };
+  DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ALWAYS; }
   bool GetDirectory(const CURL& url, CFileItemList& items) override;
 
   // specialization of IFileDirectory

--- a/xbmc/filesystem/ZeroconfDirectory.h
+++ b/xbmc/filesystem/ZeroconfDirectory.h
@@ -22,7 +22,7 @@ namespace XFILE
       CZeroconfDirectory(void);
       ~CZeroconfDirectory(void) override;
       bool GetDirectory(const CURL& url, CFileItemList &items) override;
-      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_NEVER; };
+      DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_NEVER; }
   };
 }
 

--- a/xbmc/filesystem/ZipDirectory.h
+++ b/xbmc/filesystem/ZipDirectory.h
@@ -19,6 +19,6 @@ namespace XFILE
     ~CZipDirectory() override;
     bool GetDirectory(const CURL& url, CFileItemList& items) override;
     bool ContainsFiles(const CURL& url) override;
-    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ALWAYS; };
+    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ALWAYS; }
   };
 }

--- a/xbmc/guilib/D3DResource.h
+++ b/xbmc/guilib/D3DResource.h
@@ -36,7 +36,7 @@ typedef enum SHADER_METHOD {
 class ID3DResource
 {
 public:
-  virtual ~ID3DResource() {};
+  virtual ~ID3DResource() {}
 
   virtual void OnDestroyDevice(bool fatal)=0;
   virtual void OnCreateDevice()=0;
@@ -101,7 +101,7 @@ public:
   bool UnlockRect(UINT subresource) const;
 
   // Accessors
-  ID3D11Texture2D* Get() const { return m_texture.Get(); };
+  ID3D11Texture2D* Get() const { return m_texture.Get(); }
   ID3D11ShaderResourceView* GetShaderResource(DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN);
   ID3D11ShaderResourceView** GetAddressOfSRV(DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN);
   ID3D11RenderTargetView* GetRenderTarget();
@@ -176,7 +176,7 @@ public:
   bool EndPass();
   bool End();
 
-  ID3DX11Effect *Get() const { return m_effect.Get(); };
+  ID3DX11Effect* Get() const { return m_effect.Get(); }
 
   void OnDestroyDevice(bool fatal) override;
   void OnCreateDevice() override;
@@ -206,7 +206,7 @@ public:
   void Release();
   unsigned int GetStride() { return m_stride; }
   DXGI_FORMAT GetFormat() { return m_format; }
-  ID3D11Buffer* Get() const { return m_buffer.Get(); };
+  ID3D11Buffer* Get() const { return m_buffer.Get(); }
 
   void OnDestroyDevice(bool fatal) override;
   void OnCreateDevice() override;

--- a/xbmc/guilib/DispResource.h
+++ b/xbmc/guilib/DispResource.h
@@ -14,9 +14,9 @@
 class IDispResource
 {
 public:
-  virtual void OnLostDisplay() {};
-  virtual void OnResetDisplay() {};
-  virtual void OnAppFocusChange(bool focus) {};
+  virtual void OnLostDisplay() {}
+  virtual void OnResetDisplay() {}
+  virtual void OnAppFocusChange(bool focus) {}
 };
 
 // interface used by clients to register into render loop

--- a/xbmc/guilib/GUIAction.h
+++ b/xbmc/guilib/GUIAction.h
@@ -35,7 +35,7 @@ public:
   /**
    * Check if there is any action
    */
-  bool HasAnyActions() const { return m_actions.size() > 0; };
+  bool HasAnyActions() const { return m_actions.size() > 0; }
   /**
    * Get navigation route that meet its conditions first
    */

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -84,9 +84,9 @@ public:
    */
   void SetRenderOffset(const CPoint &offset);
 
-  void SetClickActions(const CGUIAction& clickActions) { m_clickActions = clickActions; };
-  void SetFocusActions(const CGUIAction& focusActions) { m_focusActions = focusActions; };
-  void SetUnFocusActions(const CGUIAction& unfocusActions) { m_unfocusActions = unfocusActions; };
+  void SetClickActions(const CGUIAction& clickActions) { m_clickActions = clickActions; }
+  void SetFocusActions(const CGUIAction& focusActions) { m_focusActions = focusActions; }
+  void SetUnFocusActions(const CGUIAction& unfocusActions) { m_unfocusActions = unfocusActions; }
 
   void SetAutoScrolling(const TiXmlNode *node);
   void ResetAutoScrolling();
@@ -113,11 +113,11 @@ protected:
   virtual void SetPageControlRange();
   virtual void UpdatePageControl(int offset);
   virtual void CalculateLayout();
-  virtual void SelectItem(int item) {};
-  virtual bool SelectItemFromPoint(const CPoint &point) { return false; };
-  virtual int GetCursorFromPoint(const CPoint &point, CPoint *itemPoint = NULL) const { return -1; };
+  virtual void SelectItem(int item) {}
+  virtual bool SelectItemFromPoint(const CPoint& point) { return false; }
+  virtual int GetCursorFromPoint(const CPoint& point, CPoint* itemPoint = NULL) const { return -1; }
   virtual void Reset();
-  virtual size_t GetNumItems() const { return m_items.size(); };
+  virtual size_t GetNumItems() const { return m_items.size(); }
   virtual int GetCurrentPage() const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
   void OnFocus() override;
@@ -167,9 +167,9 @@ protected:
 
   void UpdateScrollByLetter();
   void GetCacheOffsets(int &cacheBefore, int &cacheAfter) const;
-  int GetCacheCount() const { return m_cacheItems; };
-  bool ScrollingDown() const { return m_scroller.IsScrollingDown(); };
-  bool ScrollingUp() const { return m_scroller.IsScrollingUp(); };
+  int GetCacheCount() const { return m_cacheItems; }
+  bool ScrollingDown() const { return m_scroller.IsScrollingDown(); }
+  bool ScrollingUp() const { return m_scroller.IsScrollingUp(); }
   void OnNextLetter();
   void OnPrevLetter();
   void OnJumpLetter(const std::string& letter, bool skip = false);
@@ -181,7 +181,7 @@ protected:
    this also marks the control as dirty (if needed)
    */
   virtual void SetCursor(int cursor);
-  inline int GetCursor() const { return m_cursor; };
+  inline int GetCursor() const { return m_cursor; }
 
   /*! \brief Set the container offset
    Should be used by all base classes rather than directly setting it, as
@@ -192,7 +192,7 @@ protected:
    returns the first row. This may be outside of the range of available items. Use GetItemOffset() to retrieve the first visible item in the list.
    \sa GetItemOffset
   */
-  inline int GetOffset() const { return m_offset; };
+  inline int GetOffset() const { return m_offset; }
   /*! \brief Returns the index of the first visible item
    returns the first visible item. This will always be in the range of available items. Use GetOffset() to retrieve the first visible row in the list.
    \sa GetOffset

--- a/xbmc/guilib/GUIBorderedImage.h
+++ b/xbmc/guilib/GUIBorderedImage.h
@@ -17,7 +17,7 @@ class CGUIBorderedImage : public CGUIImage
 public:
   CGUIBorderedImage(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& texture, const CTextureInfo& borderTexture, const CRect &borderSize);
   ~CGUIBorderedImage(void) override = default;
-  CGUIBorderedImage *Clone() const override { return new CGUIBorderedImage(*this); };
+  CGUIBorderedImage* Clone() const override { return new CGUIBorderedImage(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -35,7 +35,7 @@ public:
   CGUIButtonControl(const CGUIButtonControl& control);
 
   ~CGUIButtonControl() override = default;
-  CGUIButtonControl *Clone() const override { return new CGUIButtonControl(*this); };
+  CGUIButtonControl* Clone() const override { return new CGUIButtonControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -48,12 +48,12 @@ public:
   void SetPosition(float posX, float posY) override;
   virtual void SetLabel(const std::string & aLabel);
   virtual void SetLabel2(const std::string & aLabel2);
-  void SetClickActions(const CGUIAction& clickActions) { m_clickActions = clickActions; };
-  const CGUIAction &GetClickActions() const { return m_clickActions; };
-  void SetFocusActions(const CGUIAction& focusActions) { m_focusActions = focusActions; };
-  void SetUnFocusActions(const CGUIAction& unfocusActions) { m_unfocusActions = unfocusActions; };
-  const CLabelInfo& GetLabelInfo() const { return m_label.GetLabelInfo(); };
-  virtual std::string GetLabel() const { return GetDescription(); };
+  void SetClickActions(const CGUIAction& clickActions) { m_clickActions = clickActions; }
+  const CGUIAction& GetClickActions() const { return m_clickActions; }
+  void SetFocusActions(const CGUIAction& focusActions) { m_focusActions = focusActions; }
+  void SetUnFocusActions(const CGUIAction& unfocusActions) { m_unfocusActions = unfocusActions; }
+  const CLabelInfo& GetLabelInfo() const { return m_label.GetLabelInfo(); }
+  virtual std::string GetLabel() const { return GetDescription(); }
   virtual std::string GetLabel2() const;
   void SetSelected(bool bSelected);
   std::string GetDescription() const override;
@@ -65,7 +65,7 @@ public:
   void PythonSetDisabledColor(UTILS::Color disabledColor);
 
   virtual void OnClick();
-  bool HasClickActions() const { return m_clickActions.HasActionsMeetingCondition(); };
+  bool HasClickActions() const { return m_clickActions.HasActionsMeetingCondition(); }
 
   bool UpdateColors() override;
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -84,13 +84,13 @@ public:
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void DoRender();
-  virtual void Render() {};
+  virtual void Render() {}
   // Called after the actual rendering is completed to trigger additional
   // non GUI rendering operations
-  virtual void RenderEx() {};
+  virtual void RenderEx() {}
 
   /*! \brief Returns whether or not we have processed */
-  bool HasProcessed() const { return m_hasProcessed; };
+  bool HasProcessed() const { return m_hasProcessed; }
 
   // OnAction() is called by our window when we are the focused control.
   // We should process any control-specific actions in the derived classes,
@@ -110,8 +110,8 @@ public:
   virtual bool OnInfo();
   virtual void OnNextControl();
   virtual void OnPrevControl();
-  virtual void OnFocus() {};
-  virtual void OnUnFocus() {};
+  virtual void OnFocus() {}
+  virtual void OnUnFocus() {}
 
   /*! \brief React to a mouse event
 
@@ -135,7 +135,10 @@ public:
    \return EVENT_RESULT corresponding to whether the control handles this event
    \sa SendMouseEvent, HitTest, CanFocusFromPoint, CMouseEvent
    */
-  virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event) { return EVENT_RESULT_UNHANDLED; };
+  virtual EVENT_RESULT OnMouseEvent(const CPoint& point, const CMouseEvent& event)
+  {
+    return EVENT_RESULT_UNHANDLED;
+  }
 
   /*! \brief Unfocus the control if the given point on screen is not within it's boundary
    \param point the location in transformed skin coordinates from the upper left corner of the parent control.
@@ -152,16 +155,16 @@ public:
 
   virtual bool OnMessage(CGUIMessage& message);
   virtual int GetID(void) const;
-  virtual void SetID(int id) { m_controlID = id; };
+  virtual void SetID(int id) { m_controlID = id; }
   int GetParentID() const;
   virtual bool HasFocus() const;
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void DynamicResourceAlloc(bool bOnOff);
-  virtual bool IsDynamicallyAllocated() { return false; };
+  virtual bool IsDynamicallyAllocated() { return false; }
   virtual bool CanFocus() const;
   virtual bool IsVisible() const;
-  bool IsVisibleFromSkin() const { return m_visibleFromSkinCondition; };
+  bool IsVisibleFromSkin() const { return m_visibleFromSkinCondition; }
   virtual bool IsDisabled() const;
   virtual void SetPosition(float posX, float posY);
   virtual void SetHitRect(const CRect &rect, const UTILS::Color &color);
@@ -175,11 +178,11 @@ public:
   virtual float GetHeight() const;
 
   void MarkDirtyRegion(const unsigned int dirtyState = DIRTY_STATE_CONTROL);
-  bool IsControlDirty() const { return m_controlDirtyState != 0; };
+  bool IsControlDirty() const { return m_controlDirtyState != 0; }
 
   /*! \brief return the render region in screen coordinates of this control
    */
-  const CRect &GetRenderRegion() const { return m_renderRegion; };
+  const CRect& GetRenderRegion() const { return m_renderRegion; }
   /*! \brief calculate the render region in parentcontrol coordinates of this control
    Called during process to update m_renderRegion
    */
@@ -214,18 +217,18 @@ public:
   virtual void SetHeight(float height);
   virtual void SetVisible(bool bVisible, bool setVisState = false);
   void SetVisibleCondition(const std::string &expression, const std::string &allowHiddenFocus = "");
-  bool HasVisibleCondition() const { return m_visibleCondition != NULL; };
+  bool HasVisibleCondition() const { return m_visibleCondition != NULL; }
   void SetEnableCondition(const std::string &expression);
   virtual void UpdateVisibility(const CGUIListItem *item);
   virtual void SetInitialVisibility();
   virtual void SetEnabled(bool bEnable);
-  virtual void SetInvalid() { m_bInvalidated = true; };
-  virtual void SetPulseOnSelect(bool pulse) { m_pulseOnSelect = pulse; };
-  virtual std::string GetDescription() const { return ""; };
-  virtual std::string GetDescriptionByIndex(int index) const { return ""; };
+  virtual void SetInvalid() { m_bInvalidated = true; }
+  virtual void SetPulseOnSelect(bool pulse) { m_pulseOnSelect = pulse; }
+  virtual std::string GetDescription() const { return ""; }
+  virtual std::string GetDescriptionByIndex(int index) const { return ""; }
 
   void SetAnimations(const std::vector<CAnimation> &animations);
-  const std::vector<CAnimation> &GetAnimations() const { return m_animations; };
+  const std::vector<CAnimation>& GetAnimations() const { return m_animations; }
 
   virtual void QueueAnimation(ANIMATION_TYPE anim);
   virtual bool IsAnimating(ANIMATION_TYPE anim);
@@ -235,20 +238,20 @@ public:
   virtual void ResetAnimations();
 
   // push information updates
-  virtual void UpdateInfo(const CGUIListItem *item = NULL) {};
-  virtual void SetPushUpdates(bool pushUpdates) { m_pushedUpdates = pushUpdates; };
+  virtual void UpdateInfo(const CGUIListItem* item = NULL) {}
+  virtual void SetPushUpdates(bool pushUpdates) { m_pushedUpdates = pushUpdates; }
 
-  virtual bool IsGroup() const { return false; };
-  virtual bool IsContainer() const { return false; };
-  virtual bool GetCondition(int condition, int data) const { return false; };
+  virtual bool IsGroup() const { return false; }
+  virtual bool IsContainer() const { return false; }
+  virtual bool GetCondition(int condition, int data) const { return false; }
 
-  void SetParentControl(CGUIControl *control) { m_parentControl = control; };
-  CGUIControl *GetParentControl(void) const { return m_parentControl; };
+  void SetParentControl(CGUIControl* control) { m_parentControl = control; }
+  CGUIControl* GetParentControl(void) const { return m_parentControl; }
   virtual void SaveStates(std::vector<CControlState> &states);
   virtual CGUIControl *GetControl(int id, std::vector<CGUIControl*> *idCollector = nullptr);
 
 
-  void SetControlStats(GUICONTROLSTATS *controlStats) { m_controlStats = controlStats; };
+  void SetControlStats(GUICONTROLSTATS* controlStats) { m_controlStats = controlStats; }
   virtual void UpdateControlStats();
 
   enum GUICONTROLTYPES {
@@ -295,14 +298,14 @@ public:
   enum GUISCROLLVALUE { FOCUS = 0, NEVER, ALWAYS };
 
 #ifdef _DEBUG
-  virtual void DumpTextureUse() {};
+  virtual void DumpTextureUse() {}
 #endif
 protected:
   /*!
    \brief Return the coordinates of the top left of the control, in the control's parent coordinates
    \return The top left coordinates of the control
    */
-  virtual CPoint GetPosition() const { return CPoint(GetXPosition(), GetYPosition()); };
+  virtual CPoint GetPosition() const { return CPoint(GetXPosition(), GetYPosition()); }
 
   /*! \brief Called when the mouse is over the control.
    Default implementation selects the control.

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -28,7 +28,7 @@ public:
   CGUIControlGroup(int parentID, int controlID, float posX, float posY, float width, float height);
   CGUIControlGroup(const CGUIControlGroup &from);
   ~CGUIControlGroup(void) override;
-  CGUIControlGroup *Clone() const override { return new CGUIControlGroup(*this); };
+  CGUIControlGroup* Clone() const override { return new CGUIControlGroup(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -61,12 +61,16 @@ public:
   bool InsertControl(CGUIControl *control, const CGUIControl *insertPoint);
   virtual bool RemoveControl(const CGUIControl *control);
   virtual void ClearAll();
-  void SetDefaultControl(int id, bool always) { m_defaultControl = id; m_defaultAlways = always; };
-  void SetRenderFocusedLast(bool renderLast) { m_renderFocusedLast = renderLast; };
+  void SetDefaultControl(int id, bool always)
+  {
+    m_defaultControl = id;
+    m_defaultAlways = always;
+  }
+  void SetRenderFocusedLast(bool renderLast) { m_renderFocusedLast = renderLast; }
 
   void SaveStates(std::vector<CControlState> &states) override;
 
-  bool IsGroup() const override { return true; };
+  bool IsGroup() const override { return true; }
 
 #ifdef _DEBUG
   void DumpTextureUse() override;
@@ -89,7 +93,11 @@ private:
 
   struct IDCollectorList
   {
-    ~IDCollectorList() { for (auto item : m_items) delete item; };
+    ~IDCollectorList()
+    {
+      for (auto item : m_items)
+        delete item;
+    }
 
     std::vector<CGUIControl *> *Get() {
       if (++m_stackDepth > m_items.size())
@@ -97,7 +105,7 @@ private:
       return m_items[m_stackDepth - 1];
     }
 
-    void Release() { --m_stackDepth; };
+    void Release() { --m_stackDepth; }
 
     COLLECTORTYPE m_items;
     size_t m_stackDepth = 0;
@@ -105,11 +113,9 @@ private:
 
   struct IDCollector
   {
-    explicit IDCollector(IDCollectorList &list)
-      : m_list(list)
-      , m_collector(list.Get()) {};
+    explicit IDCollector(IDCollectorList& list) : m_list(list), m_collector(list.Get()) {}
 
-    ~IDCollector() { m_list.Release(); };
+    ~IDCollector() { m_list.Release(); }
 
     IDCollectorList &m_list;
     std::vector<CGUIControl *> *m_collector;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -24,7 +24,7 @@ class CGUIControlGroupList : public CGUIControlGroup
 public:
   CGUIControlGroupList(int parentID, int controlID, float posX, float posY, float width, float height, float itemGap, int pageControl, ORIENTATION orientation, bool useControlPositions, uint32_t alignment, const CScroller& scroller);
   ~CGUIControlGroupList(void) override;
-  CGUIControlGroupList *Clone() const override { return new CGUIControlGroupList(*this); };
+  CGUIControlGroupList* Clone() const override { return new CGUIControlGroupList(*this); }
 
   float GetWidth() const override;
   float GetHeight() const override;

--- a/xbmc/guilib/GUIControlProfiler.h
+++ b/xbmc/guilib/GUIControlProfiler.h
@@ -39,7 +39,7 @@ public:
   void BeginRender(void);
   void EndRender(void);
   void SaveToXML(TiXmlElement *parent);
-  unsigned int GetTotalTime(void) const { return m_visTime + m_renderTime; };
+  unsigned int GetTotalTime(void) const { return m_visTime + m_renderTime; }
 
   CGUIControlProfilerItem *AddControl(CGUIControl *pControl);
   CGUIControlProfilerItem *FindOrAddControl(CGUIControl *pControl, bool recurse);
@@ -57,12 +57,12 @@ public:
   void EndVisibility(CGUIControl *pControl);
   void BeginRender(CGUIControl *pControl);
   void EndRender(CGUIControl *pControl);
-  int GetMaxFrameCount(void) const { return m_iMaxFrameCount; };
-  void SetMaxFrameCount(int iMaxFrameCount) { m_iMaxFrameCount = iMaxFrameCount; };
-  void SetOutputFile(const std::string &strOutputFile) { m_strOutputFile = strOutputFile; };
-  const std::string &GetOutputFile(void) const { return m_strOutputFile; };
+  int GetMaxFrameCount(void) const { return m_iMaxFrameCount; }
+  void SetMaxFrameCount(int iMaxFrameCount) { m_iMaxFrameCount = iMaxFrameCount; }
+  void SetOutputFile(const std::string& strOutputFile) { m_strOutputFile = strOutputFile; }
+  const std::string& GetOutputFile(void) const { return m_strOutputFile; }
   bool SaveResults(void);
-  unsigned int GetTotalTime(void) const { return m_ItemHead.GetTotalTime(); };
+  unsigned int GetTotalTime(void) const { return m_ItemHead.GetTotalTime(); }
 
   float m_fPerfScale;
 private:

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -49,17 +49,17 @@ public:
 
   bool OnBack(int actionID) override;
 
-  bool IsDialogRunning() const override { return m_active; };
-  bool IsDialog() const override { return true;};
-  bool IsModalDialog() const override { return m_modalityType == DialogModalityType::MODAL; };
-  virtual DialogModalityType GetModalityType() const { return m_modalityType; };
+  bool IsDialogRunning() const override { return m_active; }
+  bool IsDialog() const override { return true; }
+  bool IsModalDialog() const override { return m_modalityType == DialogModalityType::MODAL; }
+  virtual DialogModalityType GetModalityType() const { return m_modalityType; }
 
   void SetAutoClose(unsigned int timeoutMs);
   void ResetAutoClose(void);
   void CancelAutoClose(void);
-  bool IsAutoClosed(void) const { return m_bAutoClosed; };
-  void SetSound(bool OnOff) { m_enableSound = OnOff; };
-  bool IsSoundEnabled() const override { return m_enableSound; };
+  bool IsAutoClosed(void) const { return m_bAutoClosed; }
+  void SetSound(bool OnOff) { m_enableSound = OnOff; }
+  bool IsSoundEnabled() const override { return m_enableSound; }
 
 protected:
   bool Load(TiXmlElement *pRootElement) override;

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -46,7 +46,7 @@ public:
                   const CLabelInfo& labelInfo, const std::string &text);
   explicit CGUIEditControl(const CGUIButtonControl &button);
   ~CGUIEditControl(void) override;
-  CGUIEditControl *Clone() const override { return new CGUIEditControl(*this); };
+  CGUIEditControl* Clone() const override { return new CGUIEditControl(*this); }
 
   bool OnMessage(CGUIMessage &message) override;
   bool OnAction(const CAction &action) override;
@@ -63,9 +63,12 @@ public:
 
   void SetInputType(INPUT_TYPE type, const CVariant& heading);
 
-  void SetTextChangeActions(const CGUIAction& textChangeActions) { m_textChangeActions = textChangeActions; };
+  void SetTextChangeActions(const CGUIAction& textChangeActions)
+  {
+    m_textChangeActions = textChangeActions;
+  }
 
-  bool HasTextChangeActions() const { return m_textChangeActions.HasActionsMeetingCondition(); };
+  bool HasTextChangeActions() const { return m_textChangeActions.HasActionsMeetingCondition(); }
 
   virtual bool HasInvalidInput() const { return m_invalidInput; }
   virtual void SetInputValidation(StringValidation::Validator inputValidator, void *data = NULL);

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -29,7 +29,7 @@ public:
   CGUIFadeLabelControl(int parentID, int controlID, float posX, float posY, float width, float height, const CLabelInfo& labelInfo, bool scrollOut, unsigned int timeToDelayAtEnd, bool resetOnLabelChange, bool randomized);
   CGUIFadeLabelControl(const CGUIFadeLabelControl &from);
   ~CGUIFadeLabelControl(void) override;
-  CGUIFadeLabelControl *Clone() const override { return new CGUIFadeLabelControl(*this); };
+  CGUIFadeLabelControl* Clone() const override { return new CGUIFadeLabelControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;

--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -24,7 +24,7 @@ class CGUIFixedListContainer : public CGUIBaseContainer
 public:
   CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition, int cursorRange);
   ~CGUIFixedListContainer(void) override;
-  CGUIFixedListContainer *Clone() const override { return new CGUIFixedListContainer(*this); };
+  CGUIFixedListContainer* Clone() const override { return new CGUIFixedListContainer(*this); }
 
   bool OnAction(const CAction &action) override;
 

--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -143,7 +143,7 @@ public:
   void Begin();
   void End();
 
-  uint32_t GetStyle() const { return m_style; };
+  uint32_t GetStyle() const { return m_style; }
 
   static wchar_t RemapGlyph(wchar_t letter);
 

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -87,7 +87,7 @@ public:
   virtual CVertexBuffer CreateVertexBuffer(const std::vector<SVertex> &vertices) const { assert(false); return CVertexBuffer(); }
   virtual void DestroyVertexBuffer(CVertexBuffer &bufferHandle) const {}
 
-  const std::string& GetFileName() const { return m_strFileName; };
+  const std::string& GetFileName() const { return m_strFileName; }
 
 protected:
   explicit CGUIFontTTF(const std::string& strFileName);

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -55,7 +55,7 @@ public:
   CGUIImage(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& texture);
   CGUIImage(const CGUIImage &left);
   ~CGUIImage(void) override;
-  CGUIImage *Clone() const override { return new CGUIImage(*this); };
+  CGUIImage* Clone() const override { return new CGUIImage(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -65,7 +65,7 @@ public:
   void AllocResources() override;
   void FreeResources(bool immediately = false) override;
   void DynamicResourceAlloc(bool bOnOff) override;
-  bool IsDynamicallyAllocated() override { return m_bDynamicResourceAlloc; };
+  bool IsDynamicallyAllocated() override { return m_bDynamicResourceAlloc; }
   void SetInvalid() override;
   bool CanFocus() const override;
   void UpdateInfo(const CGUIListItem *item = NULL) override;

--- a/xbmc/guilib/GUIKeyboard.h
+++ b/xbmc/guilib/GUIKeyboard.h
@@ -24,7 +24,7 @@ typedef void (*char_callback_t) (CGUIKeyboard *ref, const std::string &typedStri
 class CGUIKeyboard : public ITimerCallback
 {
   public:
-    CGUIKeyboard():m_idleTimer(this){};
+    CGUIKeyboard() : m_idleTimer(this) {}
     ~CGUIKeyboard() override = default;
 
     // entrypoint

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -139,7 +139,7 @@ public:
    \param rect CRect containing the extents of the current text
    \sa GetRenderRect, UpdateRenderRect
    */
-  void SetRenderRect(const CRect &rect) { m_renderRect = rect; };
+  void SetRenderRect(const CRect& rect) { m_renderRect = rect; }
 
   /*! \brief Set whether or not this label control should scroll
    \param scrolling true if this label should scroll.
@@ -148,7 +148,7 @@ public:
 
   /*! \brief Set max. text scroll count
   */
-  void SetScrollLoopCount(unsigned int loopCount) { m_maxScrollLoops = loopCount; };
+  void SetScrollLoopCount(unsigned int loopCount) { m_maxScrollLoops = loopCount; }
 
   /*! \brief Set how this label should handle overflowing text.
    \param overflow the overflow type
@@ -168,13 +168,13 @@ public:
    \return CRect containing the extents of the current text
    \sa SetRenderRect, UpdateRenderRect
    */
-  const CRect &GetRenderRect() const { return m_renderRect; };
+  const CRect& GetRenderRect() const { return m_renderRect; }
 
   /*! \brief Returns the precalculated full width of the current text, regardless of layout
    \return full width of the current text
    \sa CalcTextWidth
    */
-  float GetTextWidth() const { return m_textLayout.GetTextWidth(); };
+  float GetTextWidth() const { return m_textLayout.GetTextWidth(); }
 
   /*! \brief Returns the maximal width that this label can render into
    \return Maximal width that this label can render into. Note that this may differ from the
@@ -188,10 +188,10 @@ public:
    \return width of the given text
    \sa GetTextWidth
    */
-  float CalcTextWidth(const std::wstring &text) const { return m_textLayout.GetTextWidth(text); };
+  float CalcTextWidth(const std::wstring& text) const { return m_textLayout.GetTextWidth(text); }
 
-  const CLabelInfo& GetLabelInfo() const { return m_label; };
-  CLabelInfo &GetLabelInfo() { return m_label; };
+  const CLabelInfo& GetLabelInfo() const { return m_label; }
+  CLabelInfo& GetLabelInfo() { return m_label; }
 
   /*! \brief Check a left aligned and right aligned label for overlap and cut the labels off so that no overlap occurs
 

--- a/xbmc/guilib/GUILabelControl.h
+++ b/xbmc/guilib/GUILabelControl.h
@@ -27,7 +27,7 @@ class CGUILabelControl :
 public:
   CGUILabelControl(int parentID, int controlID, float posX, float posY, float width, float height, const CLabelInfo& labelInfo, bool wrapMultiLine, bool bHasPath);
   ~CGUILabelControl(void) override;
-  CGUILabelControl *Clone() const override { return new CGUILabelControl(*this); };
+  CGUILabelControl* Clone() const override { return new CGUILabelControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -39,11 +39,11 @@ public:
   void SetWidth(float width) override;
   CRect CalcRenderRegion() const override;
 
-  const CLabelInfo& GetLabelInfo() const { return m_label.GetLabelInfo(); };
+  const CLabelInfo& GetLabelInfo() const { return m_label.GetLabelInfo(); }
   void SetLabel(const std::string &strLabel);
   void ShowCursor(bool bShow = true);
   void SetCursorPos(int iPos);
-  int GetCursorPos() const { return m_iCursorPos;};
+  int GetCursorPos() const { return m_iCursorPos; }
   void SetInfo(const KODI::GUILIB::GUIINFO::CGUIInfoLabel&labelInfo);
   void SetWidthControl(float minWidth, bool bScroll);
   void SetAlignment(uint32_t align);

--- a/xbmc/guilib/GUIListContainer.h
+++ b/xbmc/guilib/GUIListContainer.h
@@ -33,7 +33,7 @@ public:
                          float textureHeight, float itemWidth, float itemHeight, float spaceBetweenItems);
 //#endif
   ~CGUIListContainer(void) override;
-  CGUIListContainer *Clone() const override { return new CGUIListContainer(*this); };
+  CGUIListContainer* Clone() const override { return new CGUIListContainer(*this); }
 
   bool OnAction(const CAction &action) override;
   bool OnMessage(CGUIMessage& message) override;

--- a/xbmc/guilib/GUIListGroup.h
+++ b/xbmc/guilib/GUIListGroup.h
@@ -25,7 +25,7 @@ public:
   CGUIListGroup(int parentID, int controlID, float posX, float posY, float width, float height);
   CGUIListGroup(const CGUIListGroup &right);
   ~CGUIListGroup(void) override;
-  CGUIListGroup *Clone() const override { return new CGUIListGroup(*this); };
+  CGUIListGroup* Clone() const override { return new CGUIListGroup(*this); }
 
   void AddControl(CGUIControl *control, int position = -1) override;
 

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -51,7 +51,7 @@ public:
   CGUIListItem(const CGUIListItem& item);
   explicit CGUIListItem(const std::string& strLabel);
   virtual ~CGUIListItem(void);
-  virtual CGUIListItem *Clone() const { return new CGUIListItem(*this); };
+  virtual CGUIListItem* Clone() const { return new CGUIListItem(*this); }
 
   CGUIListItem& operator =(const CGUIListItem& item);
 
@@ -123,7 +123,7 @@ public:
   bool IsSelected() const;
 
   bool HasOverlay() const;
-  virtual bool IsFileItem() const { return false; };
+  virtual bool IsFileItem() const { return false; }
 
   void SetLayout(CGUIListItemLayoutPtr layout);
   CGUIListItemLayout *GetLayout();
@@ -156,7 +156,7 @@ public:
   void Serialize(CVariant& value);
 
   bool       HasProperty(const std::string &strKey) const;
-  bool       HasProperties() const { return !m_mapProperties.empty(); };
+  bool HasProperties() const { return !m_mapProperties.empty(); }
   void       ClearProperty(const std::string &strKey);
 
   const CVariant &GetProperty(const std::string &strKey) const;

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -29,11 +29,11 @@ public:
   void SetFocusedItem(unsigned int focus);
   bool IsAnimating(ANIMATION_TYPE animType);
   void ResetAnimation(ANIMATION_TYPE animType);
-  void SetInvalid() { m_invalidated = true; };
+  void SetInvalid() { m_invalidated = true; }
   void FreeResources(bool immediately = false);
-  void SetParentControl(CGUIControl *control) { m_group.SetParentControl(control); };
+  void SetParentControl(CGUIControl* control) { m_group.SetParentControl(control); }
 
-//#ifdef GUILIB_PYTHON_COMPATIBILITY
+  //#ifdef GUILIB_PYTHON_COMPATIBILITY
   void CreateListControlLayouts(float width, float height, bool focused, const CLabelInfo &labelInfo, const CLabelInfo &labelInfo2, const CTextureInfo &texture, const CTextureInfo &textureFocus, float texHeight, float iconWidth, float iconHeight, const std::string &nofocusCondition, const std::string &focusCondition);
 //#endif
 

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -28,11 +28,11 @@ public:
   CGUIListLabel(int parentID, int controlID, float posX, float posY, float width, float height,
                 const CLabelInfo& labelInfo, const KODI::GUILIB::GUIINFO::CGUIInfoLabel &label, CGUIControl::GUISCROLLVALUE scroll);
   ~CGUIListLabel(void) override;
-  CGUIListLabel *Clone() const override { return new CGUIListLabel(*this); };
+  CGUIListLabel* Clone() const override { return new CGUIListLabel(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
-  bool CanFocus() const override { return false; };
+  bool CanFocus() const override { return false; }
   void UpdateInfo(const CGUIListItem *item = NULL) override;
   void SetFocus(bool focus) override;
   void SetInvalid() override;

--- a/xbmc/guilib/GUIMoverControl.h
+++ b/xbmc/guilib/GUIMoverControl.h
@@ -38,7 +38,7 @@ public:
                    const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus);
 
   ~CGUIMoverControl(void) override = default;
-  CGUIMoverControl *Clone() const override { return new CGUIMoverControl(*this); };
+  CGUIMoverControl* Clone() const override { return new CGUIMoverControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -54,9 +54,9 @@ public:
   void SetPosition(float posX, float posY) override;
   void SetLimits(int iX1, int iY1, int iX2, int iY2);
   void SetLocation(int iLocX, int iLocY, bool bSetPosition = true);
-  int GetXLocation() const { return m_iLocationX;};
-  int GetYLocation() const { return m_iLocationY;};
-  bool CanFocus() const override { return true; };
+  int GetXLocation() const { return m_iLocationX; }
+  int GetYLocation() const { return m_iLocationY; }
+  bool CanFocus() const override { return true; }
 
 protected:
   EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event) override;

--- a/xbmc/guilib/GUIMultiImage.h
+++ b/xbmc/guilib/GUIMultiImage.h
@@ -30,7 +30,7 @@ public:
   CGUIMultiImage(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& texture, unsigned int timePerImage, unsigned int fadeTime, bool randomized, bool loop, unsigned int timeToPauseAtEnd);
   CGUIMultiImage(const CGUIMultiImage &from);
   ~CGUIMultiImage(void) override;
-  CGUIMultiImage *Clone() const override { return new CGUIMultiImage(*this); };
+  CGUIMultiImage* Clone() const override { return new CGUIMultiImage(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -41,7 +41,7 @@ public:
   void AllocResources() override;
   void FreeResources(bool immediately = false) override;
   void DynamicResourceAlloc(bool bOnOff) override;
-  bool IsDynamicallyAllocated() override { return m_bDynamicResourceAlloc; };
+  bool IsDynamicallyAllocated() override { return m_bDynamicResourceAlloc; }
   void SetInvalid() override;
   bool CanFocus() const override;
   std::string GetDescription() const override;
@@ -62,7 +62,7 @@ protected:
   public:
     explicit CMultiImageJob(const std::string &path);
     bool DoWork() override;
-    const char *GetType() const override { return "multiimage"; };
+    const char* GetType() const override { return "multiimage"; }
 
     std::vector<std::string> m_files;
     std::string              m_path;

--- a/xbmc/guilib/GUIPanelContainer.h
+++ b/xbmc/guilib/GUIPanelContainer.h
@@ -24,7 +24,7 @@ class CGUIPanelContainer : public CGUIBaseContainer
 public:
   CGUIPanelContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
   ~CGUIPanelContainer(void) override;
-  CGUIPanelContainer *Clone() const override { return new CGUIPanelContainer(*this); };
+  CGUIPanelContainer* Clone() const override { return new CGUIPanelContainer(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;

--- a/xbmc/guilib/GUIProgressControl.h
+++ b/xbmc/guilib/GUIProgressControl.h
@@ -30,7 +30,7 @@ public:
                       const CTextureInfo& rightTexture, const CTextureInfo& overlayTexture,
                       bool reveal=false);
   ~CGUIProgressControl() override = default;
-  CGUIProgressControl *Clone() const override { return new CGUIProgressControl(*this); };
+  CGUIProgressControl* Clone() const override { return new CGUIProgressControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -43,7 +43,7 @@ public:
   void SetPosition(float posX, float posY) override;
   void SetPercentage(float fPercent);
   void SetInfo(int iInfo, int iInfo2 = 0);
-  int GetInfo() const {return m_iInfoCode;};
+  int GetInfo() const { return m_iInfoCode; }
 
   float GetPercentage() const;
   std::string GetDescription() const override;

--- a/xbmc/guilib/GUIRSSControl.h
+++ b/xbmc/guilib/GUIRSSControl.h
@@ -33,13 +33,13 @@ public:
                  const KODI::GUILIB::GUIINFO::CGUIInfoColor &headlineColor, std::string& strRSSTags);
   CGUIRSSControl(const CGUIRSSControl &from);
   ~CGUIRSSControl(void) override;
-  CGUIRSSControl *Clone() const override { return new CGUIRSSControl(*this); };
+  CGUIRSSControl* Clone() const override { return new CGUIRSSControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
   void OnFeedUpdate(const vecText &feed) override;
   void OnFeedRelease() override;
-  bool CanFocus() const override { return true; };
+  bool CanFocus() const override { return true; }
   CRect CalcRenderRegion() const override;
 
   void OnFocus() override;

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -32,7 +32,7 @@ public:
                          const CTextureInfo& radioOnDisabled, const CTextureInfo& radioOffDisabled);
 
   ~CGUIRadioButtonControl() override = default;
-  CGUIRadioButtonControl *Clone() const override { return new CGUIRadioButtonControl(*this); };
+  CGUIRadioButtonControl* Clone() const override { return new CGUIRadioButtonControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -48,7 +48,8 @@ public:
   std::string GetDescription() const override;
   void SetRadioDimensions(float posX, float posY, float width, float height);
   void SetToggleSelect(const std::string &toggleSelect);
-  bool IsSelected() const { return m_bSelected; };
+  bool IsSelected() const { return m_bSelected; }
+
 protected:
   bool UpdateColors() override;
   std::unique_ptr<CGUITexture> m_imgRadioOnFocus;

--- a/xbmc/guilib/GUIRangesControl.h
+++ b/xbmc/guilib/GUIRangesControl.h
@@ -58,7 +58,7 @@ public:
                     const CTextureInfo& rightTexture, const CTextureInfo& overlayTexture,
                     int iInfo);
   ~CGUIRangesControl() override = default;
-  CGUIRangesControl* Clone() const override { return new CGUIRangesControl(*this); };
+  CGUIRangesControl* Clone() const override { return new CGUIRangesControl(*this); }
 
   void Process(unsigned int iCurrentTime, CDirtyRegionList& dirtyregions) override;
   void Render() override;

--- a/xbmc/guilib/GUIResizeControl.h
+++ b/xbmc/guilib/GUIResizeControl.h
@@ -34,7 +34,7 @@ public:
                     const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus);
 
   ~CGUIResizeControl() override = default;
-  CGUIResizeControl *Clone() const override { return new CGUIResizeControl(*this); };
+  CGUIResizeControl* Clone() const override { return new CGUIResizeControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -49,7 +49,7 @@ public:
   void SetInvalid() override;
   void SetPosition(float posX, float posY) override;
   void SetLimits(float x1, float y1, float x2, float y2);
-  bool CanFocus() const override { return true; };
+  bool CanFocus() const override { return true; }
 
 protected:
   EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event) override;

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -31,7 +31,7 @@ public:
                        const CTextureInfo& nibTexture, const CTextureInfo& nibTextureFocus,
                        ORIENTATION orientation, bool showOnePage);
   ~GUIScrollBarControl() override = default;
-  GUIScrollBarControl *Clone() const override { return new GUIScrollBarControl(*this); };
+  GUIScrollBarControl* Clone() const override { return new GUIScrollBarControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -34,7 +34,7 @@ public:
   void OnUnFocus() override;
   EVENT_RESULT OnMouseEvent(const CPoint& point, const CMouseEvent& event) override;
   void SetActive();
-  bool IsActive() const override { return m_active; };
+  bool IsActive() const override { return m_active; }
   void AllocResources() override;
   void FreeResources(bool immediately = false) override;
   void DynamicResourceAlloc(bool bOnOff) override;
@@ -46,11 +46,11 @@ public:
   void SetHeight(float height) override;
   void SetEnabled(bool bEnable) override;
 
-  void SetText(const std::string &label) {m_buttonControl.SetLabel(label);};
-  float GetXPosition() const override { return m_buttonControl.GetXPosition();};
-  float GetYPosition() const override { return m_buttonControl.GetYPosition();};
+  void SetText(const std::string& label) { m_buttonControl.SetLabel(label); }
+  float GetXPosition() const override { return m_buttonControl.GetXPosition(); }
+  float GetYPosition() const override { return m_buttonControl.GetYPosition(); }
   std::string GetDescription() const override;
-  bool HitTest(const CPoint &point) const override { return m_buttonControl.HitTest(point); };
+  bool HitTest(const CPoint& point) const override { return m_buttonControl.HitTest(point); }
 
 protected:
   bool UpdateColors() override;

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -45,12 +45,12 @@ public:
 
   CGUISliderControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& backGroundTexture, const CTextureInfo& mibTexture, const CTextureInfo& nibTextureFocus, int iType, ORIENTATION orientation);
   ~CGUISliderControl() override = default;
-  CGUISliderControl *Clone() const override { return new CGUISliderControl(*this); };
+  CGUISliderControl* Clone() const override { return new CGUISliderControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
   bool OnAction(const CAction &action) override;
-  virtual bool IsActive() const { return true; };
+  virtual bool IsActive() const { return true; }
   void AllocResources() override;
   void FreeResources(bool immediately = false) override;
   void DynamicResourceAlloc(bool bOnOff) override;
@@ -75,10 +75,10 @@ public:
   float GetFloatValue(RangeSelector selector = RangeSelectorLower) const;
   void SetIntInterval(int iInterval);
   void SetFloatInterval(float fInterval);
-  void SetType(int iType) { m_iType = iType; };
+  void SetType(int iType) { m_iType = iType; }
   int GetType() const { return m_iType; }
   std::string GetDescription() const override;
-  void SetTextValue(const std::string &textValue) { m_textValue = textValue; };
+  void SetTextValue(const std::string& textValue) { m_textValue = textValue; }
   void SetAction(const std::string &action);
 
 protected:

--- a/xbmc/guilib/GUISpinControl.h
+++ b/xbmc/guilib/GUISpinControl.h
@@ -33,7 +33,7 @@ class CGUISpinControl : public CGUIControl
 public:
   CGUISpinControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CTextureInfo& textureUpDisabled, const CTextureInfo& textureDownDisabled, const CLabelInfo& labelInfo, int iType);
   ~CGUISpinControl() override = default;
-  CGUISpinControl *Clone() const override { return new CGUISpinControl(*this); };
+  CGUISpinControl* Clone() const override { return new CGUISpinControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
@@ -64,13 +64,17 @@ public:
   void SetReverse(bool bOnOff);
   int GetMaximum() const;
   int GetMinimum() const;
-  void SetSpinAlign(uint32_t align, float offsetX) { m_label.GetLabelInfo().align = align; m_label.GetLabelInfo().offsetX = offsetX; };
-  void SetType(int iType) { m_iType = iType; };
-  float GetSpinWidth() const { return m_imgspinUp->GetWidth(); };
-  float GetSpinHeight() const { return m_imgspinUp->GetHeight(); };
+  void SetSpinAlign(uint32_t align, float offsetX)
+  {
+    m_label.GetLabelInfo().align = align;
+    m_label.GetLabelInfo().offsetX = offsetX;
+  }
+  void SetType(int iType) { m_iType = iType; }
+  float GetSpinWidth() const { return m_imgspinUp->GetWidth(); }
+  float GetSpinHeight() const { return m_imgspinUp->GetHeight(); }
   void SetFloatInterval(float fInterval);
   void SetShowRange(bool bOnoff) ;
-  void SetShowOnePage(bool showOnePage) { m_showOnePage = showOnePage; };
+  void SetShowOnePage(bool showOnePage) { m_showOnePage = showOnePage; }
   void Clear();
   std::string GetDescription() const override;
   bool IsFocusedOnUp() const;

--- a/xbmc/guilib/GUISpinControlEx.h
+++ b/xbmc/guilib/GUISpinControlEx.h
@@ -25,26 +25,26 @@ class CGUISpinControlEx : public CGUISpinControl
 public:
   CGUISpinControlEx(int parentID, int controlID, float posX, float posY, float width, float height, float spinWidth, float spinHeight, const CLabelInfo& spinInfo, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CTextureInfo& textureUpDisabled, const CTextureInfo& textureDownDisabled, const CLabelInfo& labelInfo, int iType);
   ~CGUISpinControlEx(void) override;
-  CGUISpinControlEx *Clone() const override { return new CGUISpinControlEx(*this); };
+  CGUISpinControlEx* Clone() const override { return new CGUISpinControlEx(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
   void SetPosition(float posX, float posY) override;
-  float GetWidth() const override { return m_buttonControl.GetWidth();};
+  float GetWidth() const override { return m_buttonControl.GetWidth(); }
   void SetWidth(float width) override;
-  float GetHeight() const override { return m_buttonControl.GetHeight();};
+  float GetHeight() const override { return m_buttonControl.GetHeight(); }
   void SetHeight(float height) override;
   void AllocResources() override;
   void FreeResources(bool immediately = false) override;
   void DynamicResourceAlloc(bool bOnOff) override;
   void SetInvalid() override;
   const std::string GetCurrentLabel() const;
-  void SetText(const std::string & aLabel) {m_buttonControl.SetLabel(aLabel);};
+  void SetText(const std::string& aLabel) { m_buttonControl.SetLabel(aLabel); }
   void SetEnabled(bool bEnable) override;
-  float GetXPosition() const override { return m_buttonControl.GetXPosition();};
-  float GetYPosition() const override { return m_buttonControl.GetYPosition();};
+  float GetXPosition() const override { return m_buttonControl.GetXPosition(); }
+  float GetYPosition() const override { return m_buttonControl.GetYPosition(); }
   std::string GetDescription() const override;
-  bool HitTest(const CPoint &point) const override { return m_buttonControl.HitTest(point); };
+  bool HitTest(const CPoint& point) const override { return m_buttonControl.HitTest(point); }
   void SetSpinPosition(float spinPosX);
 
   void SetItemInvalid(bool invalid);

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -52,7 +52,7 @@ public:
   CGUIStaticItem(const TiXmlElement *element, int contextWindow);
   explicit CGUIStaticItem(const CFileItem &item); // for python
   ~CGUIStaticItem() override = default;
-  CGUIListItem *Clone() const override { return new CGUIStaticItem(*this); };
+  CGUIListItem* Clone() const override { return new CGUIStaticItem(*this); }
 
   /*! \brief update any infolabels in the items properties
    Runs through all the items properties, updating any that should be
@@ -77,7 +77,8 @@ public:
    */
   void SetVisibleCondition(const std::string &condition, int context);
 
-  const CGUIAction &GetClickActions() const { return m_clickActions; };
+  const CGUIAction& GetClickActions() const { return m_clickActions; }
+
 private:
   typedef std::vector< std::pair<KODI::GUILIB::GUIINFO::CGUIInfoLabel, std::string> > InfoVector;
   InfoVector m_info;

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -33,7 +33,7 @@ public:
               const CLabelInfo* labelInfoMono = nullptr);
   CGUITextBox(const CGUITextBox &from);
   ~CGUITextBox(void) override;
-  CGUITextBox *Clone() const override { return new CGUITextBox(*this); };
+  CGUITextBox* Clone() const override { return new CGUITextBox(*this); }
 
   void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -72,15 +72,15 @@ public:
    \return width of text
    \sa GetTextExtent, CalcTextExtent
    */
-  float GetTextWidth() const { return m_textWidth; };
+  float GetTextWidth() const { return m_textWidth; }
 
   float GetTextWidth(const std::wstring &text) const;
   
   /*! \brief Returns the precalculated height of the text to be rendered (in constant time).
    \return height of text
   */
-  float GetTextHeight() const { return m_textHeight; };
-  
+  float GetTextHeight() const { return m_textHeight; }
+
   bool Update(const std::string &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
   bool UpdateW(const std::wstring &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
 

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -91,20 +91,26 @@ public:
   void SetUseCache(const bool useCache = true);
   bool SetAspectRatio(const CAspectRatio &aspect);
 
-  const std::string& GetFileName() const { return m_info.filename; };
-  float GetTextureWidth() const { return m_frameWidth; };
-  float GetTextureHeight() const { return m_frameHeight; };
-  float GetWidth() const { return m_width; };
-  float GetHeight() const { return m_height; };
-  float GetXPosition() const { return m_posX; };
-  float GetYPosition() const { return m_posY; };
+  const std::string& GetFileName() const { return m_info.filename; }
+  float GetTextureWidth() const { return m_frameWidth; }
+  float GetTextureHeight() const { return m_frameHeight; }
+  float GetWidth() const { return m_width; }
+  float GetHeight() const { return m_height; }
+  float GetXPosition() const { return m_posX; }
+  float GetYPosition() const { return m_posY; }
   int GetOrientation() const;
-  const CRect &GetRenderRect() const { return m_vertex; };
-  bool IsLazyLoaded() const { return m_info.useLarge; };
+  const CRect& GetRenderRect() const { return m_vertex; }
+  bool IsLazyLoaded() const { return m_info.useLarge; }
 
-  bool HitTest(const CPoint &point) const { return CRect(m_posX, m_posY, m_posX + m_width, m_posY + m_height).PtInRect(point); };
-  bool IsAllocated() const { return m_isAllocated != NO; };
-  bool FailedToAlloc() const { return m_isAllocated == NORMAL_FAILED || m_isAllocated == LARGE_FAILED; };
+  bool HitTest(const CPoint& point) const
+  {
+    return CRect(m_posX, m_posY, m_posX + m_width, m_posY + m_height).PtInRect(point);
+  }
+  bool IsAllocated() const { return m_isAllocated != NO; }
+  bool FailedToAlloc() const
+  {
+    return m_isAllocated == NORMAL_FAILED || m_isAllocated == LARGE_FAILED;
+  }
   bool ReadyToRender() const;
 
 protected:

--- a/xbmc/guilib/GUIToggleButtonControl.h
+++ b/xbmc/guilib/GUIToggleButtonControl.h
@@ -24,7 +24,7 @@ class CGUIToggleButtonControl : public CGUIButtonControl
 public:
   CGUIToggleButtonControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus, const CTextureInfo& altTextureFocus, const CTextureInfo& altTextureNoFocus, const CLabelInfo &labelInfo, bool wrapMultiline = false);
   ~CGUIToggleButtonControl(void) override;
-  CGUIToggleButtonControl *Clone() const override { return new CGUIToggleButtonControl(*this); };
+  CGUIToggleButtonControl* Clone() const override { return new CGUIToggleButtonControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;

--- a/xbmc/guilib/GUIVideoControl.h
+++ b/xbmc/guilib/GUIVideoControl.h
@@ -25,7 +25,7 @@ class CGUIVideoControl :
 public:
   CGUIVideoControl(int parentID, int controlID, float posX, float posY, float width, float height);
   ~CGUIVideoControl(void) override;
-  CGUIVideoControl *Clone() const override { return new CGUIVideoControl(*this); };
+  CGUIVideoControl* Clone() const override { return new CGUIVideoControl(*this); }
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -87,7 +87,7 @@ public:
    Any window that requires updating on a frame by frame basis (such as to maintain
    timers and the like) should override this function.
    */
-  virtual void FrameMove() {};
+  virtual void FrameMove() {}
 
   void Close(bool forceClose = false, int nextWindowID = 0, bool enableSound = true, bool bWait = true);
 
@@ -101,7 +101,7 @@ public:
   using CGUIControlGroup::OnBack;
   virtual bool OnBack(int actionID);
   using CGUIControlGroup::OnInfo;
-  virtual bool OnInfo(int actionID) { return false; };
+  virtual bool OnInfo(int actionID) { return false; }
 
   /*! \brief Clear the background (if necessary) prior to rendering the window
    */
@@ -113,30 +113,30 @@ public:
   bool ControlGroupHasFocus(int groupID, int controlID);
   void SetID(int id) override;
   virtual bool HasID(int controlID) const;
-  const std::vector<int>& GetIDRange() const { return m_idRange; };
-  int GetPreviousWindow() { return m_previousWindow; };
+  const std::vector<int>& GetIDRange() const { return m_idRange; }
+  int GetPreviousWindow() { return m_previousWindow; }
   CRect GetScaledBounds() const;
   void ClearAll() override;
   using CGUIControlGroup::AllocResources;
   virtual void AllocResources(bool forceLoad = false);
   void FreeResources(bool forceUnLoad = false) override;
   void DynamicResourceAlloc(bool bOnOff) override;
-  virtual bool IsDialog() const { return false; };
-  virtual bool IsDialogRunning() const { return false; };
-  virtual bool IsModalDialog() const { return false; };
-  virtual bool IsMediaWindow() const { return false; };
-  virtual bool HasListItems() const { return false; };
-  virtual bool IsSoundEnabled() const { return true; };
-  virtual CFileItemPtr GetCurrentListItem(int offset = 0) { return CFileItemPtr(); };
-  virtual int GetViewContainerID() const { return 0; };
-  virtual int GetViewCount() const { return 0; };
-  virtual bool CanBeActivated() const { return true; };
+  virtual bool IsDialog() const { return false; }
+  virtual bool IsDialogRunning() const { return false; }
+  virtual bool IsModalDialog() const { return false; }
+  virtual bool IsMediaWindow() const { return false; }
+  virtual bool HasListItems() const { return false; }
+  virtual bool IsSoundEnabled() const { return true; }
+  virtual CFileItemPtr GetCurrentListItem(int offset = 0) { return CFileItemPtr(); }
+  virtual int GetViewContainerID() const { return 0; }
+  virtual int GetViewCount() const { return 0; }
+  virtual bool CanBeActivated() const { return true; }
   virtual bool IsActive() const;
-  void SetCoordsRes(const RESOLUTION_INFO &res) { m_coordsRes = res; };
-  const RESOLUTION_INFO &GetCoordsRes() const { return m_coordsRes; };
-  void SetLoadType(LOAD_TYPE loadType) { m_loadType = loadType; };
+  void SetCoordsRes(const RESOLUTION_INFO& res) { m_coordsRes = res; }
+  const RESOLUTION_INFO& GetCoordsRes() const { return m_coordsRes; }
+  void SetLoadType(LOAD_TYPE loadType) { m_loadType = loadType; }
   LOAD_TYPE GetLoadType() { return m_loadType; }
-  int GetRenderOrder() { return m_renderOrder; };
+  int GetRenderOrder() { return m_renderOrder; }
   void SetInitialVisibility() override;
   bool IsVisible() const override { return true; }; // windows are always considered visible as they implement their own
                                                    // versions of UpdateVisibility, and are deemed visible if they're in
@@ -149,13 +149,13 @@ public:
    \brief Return if the window is a custom window
    \return true if the window is an custom window otherwise false
    */
-  bool IsCustom() const { return m_custom; };
+  bool IsCustom() const { return m_custom; }
 
   /*!
    \brief Mark this window as custom window
    \param custom true if this window is a custom window, false if not
    */
-  void SetCustom(bool custom) { m_custom = custom; };
+  void SetCustom(bool custom) { m_custom = custom; }
 
   void DisableAnimations();
 
@@ -188,7 +188,7 @@ public:
 #ifdef _DEBUG
   void DumpTextureUse() override;
 #endif
-  bool HasSaveLastControl() const { return !m_defaultAlways; };
+  bool HasSaveLastControl() const { return !m_defaultAlways; }
 
   virtual void OnDeinitWindow(int nextWindowID);
 protected:

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -122,7 +122,7 @@ public:
    no windows should be able to be initialized.
    \return true if the window manager is initialized, false otherwise.
    */
-  bool Initialized() const { return m_initialized; };
+  bool Initialized() const { return m_initialized; }
 
   /*! \brief Create and initialize all windows and dialogs
    */
@@ -147,8 +147,12 @@ public:
    * \param id the window id
    * \return the window with for the given type \code{T} or null
    */
-  template<typename T, typename std::enable_if<std::is_base_of<CGUIWindow,T>::value>::type* = nullptr>
-  T* GetWindow(int id) const { return dynamic_cast<T *>(GetWindow(id)); };
+  template<typename T,
+           typename std::enable_if<std::is_base_of<CGUIWindow, T>::value>::type* = nullptr>
+  T* GetWindow(int id) const
+  {
+    return dynamic_cast<T*>(GetWindow(id));
+  }
 
   /*! \brief Return the window with the given id or null.
    *
@@ -210,12 +214,15 @@ public:
    *
    * \return true if the given window is an addon window, otherwise false.
    */
-  bool IsAddonWindow(int id) const { return (id >= WINDOW_ADDON_START && id <= WINDOW_ADDON_END); };
+  bool IsAddonWindow(int id) const { return (id >= WINDOW_ADDON_START && id <= WINDOW_ADDON_END); }
   /*! \brief Checks if the given window is a python window.
    *
    * \return true if the given window is a python window, otherwise false.
    */
-  bool IsPythonWindow(int id) const { return (id >= WINDOW_PYTHON_START && id <= WINDOW_PYTHON_END); };
+  bool IsPythonWindow(int id) const
+  {
+    return (id >= WINDOW_PYTHON_START && id <= WINDOW_PYTHON_END);
+  }
 
   bool HasVisibleControls();
 

--- a/xbmc/guilib/GUIWrappingListContainer.h
+++ b/xbmc/guilib/GUIWrappingListContainer.h
@@ -23,7 +23,7 @@ class CGUIWrappingListContainer : public CGUIBaseContainer
 public:
   CGUIWrappingListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition);
   ~CGUIWrappingListContainer(void) override;
-  CGUIWrappingListContainer *Clone() const override { return new CGUIWrappingListContainer(*this); };
+  CGUIWrappingListContainer* Clone() const override { return new CGUIWrappingListContainer(*this); }
 
   bool OnAction(const CAction &action) override;
   bool OnMessage(CGUIMessage& message) override;
@@ -39,7 +39,7 @@ protected:
   bool SelectItemFromPoint(const CPoint &point) override;
   void SelectItem(int item) override;
   void Reset() override;
-  size_t GetNumItems() const override { return m_items.size() - m_extraItems; };
+  size_t GetNumItems() const override { return m_items.size() - m_extraItems; }
   int GetCurrentPage() const override;
   void SetPageControlRange() override;
   void UpdatePageControl(int offset) override;

--- a/xbmc/guilib/IGUIContainer.h
+++ b/xbmc/guilib/IGUIContainer.h
@@ -28,10 +28,10 @@ public:
   IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height)
    : CGUIControl(parentID, controlID, posX, posY, width, height), m_type(VIEW_TYPE_NONE) {}
 
-  bool IsContainer() const override { return true; };
+  bool IsContainer() const override { return true; }
 
-  VIEW_TYPE GetType() const { return m_type; };
-  const std::string &GetLabel() const { return m_label; };
+  VIEW_TYPE GetType() const { return m_type; }
+  const std::string& GetLabel() const { return m_label; }
   void SetType(VIEW_TYPE type, const std::string &label)
   {
     m_type = type;

--- a/xbmc/guilib/IWindowManagerCallback.h
+++ b/xbmc/guilib/IWindowManagerCallback.h
@@ -26,5 +26,5 @@ public:
   virtual void FrameMove(bool processEvents, bool processGUI = true) = 0;
   virtual void Render() = 0;
   virtual void Process() = 0;
-  virtual bool GetRenderGUI() const { return false; };
+  virtual bool GetRenderGUI() const { return false; }
 };

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -52,10 +52,10 @@ public:
   void Calculate(unsigned int time, const CPoint &center);
   void ApplyState(ANIMATION_STATE state, const CPoint &center);
 
-  unsigned int GetDelay() const { return m_delay; };
-  unsigned int GetLength() const { return m_delay + m_length; };
-  const TransformMatrix &GetTransform() const { return m_matrix; };
-  EFFECT_TYPE GetType() const { return m_effect; };
+  unsigned int GetDelay() const { return m_delay; }
+  unsigned int GetLength() const { return m_delay + m_length; }
+  const TransformMatrix& GetTransform() const { return m_matrix; }
+  EFFECT_TYPE GetType() const { return m_effect; }
 
   static std::shared_ptr<Tweener> GetTweener(const TiXmlElement *pAnimationNode);
 protected:
@@ -155,11 +155,11 @@ public:
   void RenderAnimation(TransformMatrix &matrix, const CPoint &center);
   void QueueAnimation(ANIMATION_PROCESS process);
 
-  inline bool IsReversible() const { return m_reversible; };
-  inline ANIMATION_TYPE GetType() const { return m_type; };
-  inline ANIMATION_STATE GetState() const { return m_currentState; };
-  inline ANIMATION_PROCESS GetProcess() const { return m_currentProcess; };
-  inline ANIMATION_PROCESS GetQueuedProcess() const { return m_queuedProcess; };
+  inline bool IsReversible() const { return m_reversible; }
+  inline ANIMATION_TYPE GetType() const { return m_type; }
+  inline ANIMATION_STATE GetState() const { return m_currentState; }
+  inline ANIMATION_PROCESS GetProcess() const { return m_currentProcess; }
+  inline ANIMATION_PROCESS GetQueuedProcess() const { return m_queuedProcess; }
 
   bool CheckCondition();
   void UpdateCondition(const CGUIListItem *item = NULL);
@@ -218,7 +218,7 @@ public:
   /**
    * Immediately stop scrolling
    */
-  void Stop() { m_delta = 0; };
+  void Stop() { m_delta = 0; }
   /**
    * Update the scroller to where it would be at the given time point, calculating a new Value.
    * @param time time point
@@ -229,14 +229,15 @@ public:
   /**
    * Value of scroll
    */
-  float GetValue() const { return m_scrollValue; };
-  void SetValue(float scrollValue) { m_scrollValue = scrollValue; };
+  float GetValue() const { return m_scrollValue; }
+  void SetValue(float scrollValue) { m_scrollValue = scrollValue; }
 
-  bool IsScrolling() const { return m_delta != 0; };
-  bool IsScrollingUp() const { return m_delta < 0; };
-  bool IsScrollingDown() const { return m_delta > 0; };
+  bool IsScrolling() const { return m_delta != 0; }
+  bool IsScrollingUp() const { return m_delta < 0; }
+  bool IsScrollingDown() const { return m_delta > 0; }
 
-  unsigned int GetDuration() const { return m_duration; };
+  unsigned int GetDuration() const { return m_duration; }
+
 private:
   float Tween(float progress);
 

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.h
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.h
@@ -33,8 +33,8 @@ public:
   bool GetInt(int& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 
-  void SetNextWindow(int windowID) { m_nextWindowID = windowID; };
-  void SetPreviousWindow(int windowID) { m_prevWindowID = windowID; };
+  void SetNextWindow(int windowID) { m_nextWindowID = windowID; }
+  void SetPreviousWindow(int windowID) { m_prevWindowID = windowID; }
 
   /*! \brief containers call this to specify that the focus is changing
    \param id control id

--- a/xbmc/guilib/guiinfo/GUIInfoBool.h
+++ b/xbmc/guilib/guiinfo/GUIInfoBool.h
@@ -32,7 +32,7 @@ public:
   explicit CGUIInfoBool(bool value = false);
   ~CGUIInfoBool();
 
-  operator bool() const { return m_value; };
+  operator bool() const { return m_value; }
 
   void Update(const CGUIListItem *item = NULL);
   void Parse(const std::string &expression, int context);

--- a/xbmc/guilib/guiinfo/GUIInfoColor.h
+++ b/xbmc/guilib/guiinfo/GUIInfoColor.h
@@ -31,7 +31,7 @@ class CGUIInfoColor
 public:
   constexpr CGUIInfoColor(::UTILS::Color color = 0):m_color(color) {}
 
-  constexpr operator ::UTILS::Color() const { return m_color; };
+  constexpr operator ::UTILS::Color() const { return m_color; }
 
   bool Update();
   void Parse(const std::string &label, int context);

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.h
@@ -63,7 +63,7 @@ public:
   bool IsConstant() const;
   bool IsEmpty() const;
 
-  const std::string &GetFallback() const { return m_fallback; };
+  const std::string& GetFallback() const { return m_fallback; }
 
   static std::string GetLabel(const std::string &label, int contextWindow = 0, bool preferImage = false);
   static std::string GetItemLabel(const std::string &label, const CGUIListItem *item, bool preferImage = false);

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -41,7 +41,7 @@ public:
 
   bool GetDisplayAfterSeek() const;
   void SetDisplayAfterSeek(unsigned int timeOut = 2500, int seekOffset = 0);
-  void SetShowTime(bool showtime) { m_playerShowTime = showtime; };
+  void SetShowTime(bool showtime) { m_playerShowTime = showtime; }
   void SetShowInfo(bool showinfo);
   bool GetShowInfo() const { return m_playerShowInfo; }
   bool ToggleShowInfo();

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.h
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.h
@@ -32,7 +32,7 @@ public:
   bool GetInt(int& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 
-  float GetFPS() const { return m_fps; };
+  float GetFPS() const { return m_fps; }
   void UpdateFPS();
 
 private:

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -175,8 +175,8 @@ public:
   inline uint8_t GetVKey() const { return m_vkey; }
   inline wchar_t GetUnicode() const { return m_unicode; }
   inline char GetAscii() const { return m_ascii; }
-  inline uint32_t GetModifiers() const { return m_modifiers; };
-  inline uint32_t GetLockingModifiers() const { return m_lockingModifiers; };
+  inline uint32_t GetModifiers() const { return m_modifiers; }
+  inline uint32_t GetLockingModifiers() const { return m_lockingModifiers; }
   inline unsigned int GetHeld() const { return m_held; }
 
   enum Modifier

--- a/xbmc/input/actions/Action.h
+++ b/xbmc/input/actions/Action.h
@@ -47,7 +47,7 @@ public:
   /*! \brief Identifier of the action
    \return id of the action
    */
-  int GetID() const { return m_id; };
+  int GetID() const { return m_id; }
 
   /*! \brief Is this an action from the mouse
    \return true if this is a mouse action, false otherwise
@@ -59,17 +59,17 @@ public:
   /*! \brief Human-readable name of the action
    \return name of the action
    */
-  const std::string& GetName() const { return m_name; };
+  const std::string& GetName() const { return m_name; }
 
   /*! \brief Text of the action if any
    \return text payload of this action.
    */
-  const std::string& GetText() const { return m_text; };
+  const std::string& GetText() const { return m_text; }
 
   /*! \brief Set the text payload of the action
    \param text to be set
    */
-  void SetText(const std::string& text) { m_text = text; };
+  void SetText(const std::string& text) { m_text = text; }
 
   /*! \brief Get an amount associated with this action
    \param zero-based index of amount to retrieve, defaults to 0
@@ -87,22 +87,22 @@ public:
   /*! \brief Unicode value associated with this action
    \return unicode value associated with this action, for keyboard input.
    */
-  wchar_t GetUnicode() const { return m_unicode; };
+  wchar_t GetUnicode() const { return m_unicode; }
 
   /*! \brief Time in ms that the key has been held
    \return time that the key has been held down in ms.
    */
-  unsigned int GetHoldTime() const { return m_holdTime; };
+  unsigned int GetHoldTime() const { return m_holdTime; }
 
   /*! \brief Time since last repeat in ms
    \return time since last repeat in ms. Returns 0 if unknown.
    */
-  float GetRepeat() const { return m_repeat; };
+  float GetRepeat() const { return m_repeat; }
 
   /*! \brief Button code that triggered this action
    \return button code
    */
-  unsigned int GetButtonCode() const { return m_buttonCode; };
+  unsigned int GetButtonCode() const { return m_buttonCode; }
 
   bool IsAnalog() const;
 

--- a/xbmc/input/mouse/MouseStat.h
+++ b/xbmc/input/mouse/MouseStat.h
@@ -86,9 +86,9 @@ public:
   bool IsEnabled() const;
 
   void SetActive(bool active = true);
-  void SetState(MOUSE_STATE state) { m_pointerState = state; };
+  void SetState(MOUSE_STATE state) { m_pointerState = state; }
   void SetEnabled(bool enabled = true);
-  MOUSE_STATE GetState() const { return m_pointerState; };
+  MOUSE_STATE GetState() const { return m_pointerState; }
   uint32_t GetKey() const;
 
   int GetHold(int ButtonID) const;

--- a/xbmc/input/touch/ITouchActionHandler.h
+++ b/xbmc/input/touch/ITouchActionHandler.h
@@ -37,7 +37,7 @@ public:
   /*!
    * \brief A touch action has been aborted
    */
-  virtual void OnTouchAbort(){};
+  virtual void OnTouchAbort() {}
 
   /*!
    * \brief A single touch has started

--- a/xbmc/interfaces/generic/ILanguageInvoker.h
+++ b/xbmc/interfaces/generic/ILanguageInvoker.h
@@ -45,7 +45,7 @@ public:
   InvokerState GetState() const { return m_state; }
   bool IsActive() const;
   bool IsRunning() const;
-  void Reset() { m_state = InvokerStateUninitialized; };
+  void Reset() { m_state = InvokerStateUninitialized; }
 
 protected:
   friend class CLanguageInvokerThread;

--- a/xbmc/interfaces/generic/LanguageInvokerThread.h
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.h
@@ -26,8 +26,8 @@ public:
 
   virtual InvokerState GetState() const;
 
-  const std::string& GetScript() const { return m_script; };
-  LanguageInvokerPtr GetInvoker() const { return m_invoker; };
+  const std::string& GetScript() const { return m_script; }
+  LanguageInvokerPtr GetInvoker() const { return m_invoker; }
   bool Reuseable(const std::string& script) const
   {
     return !m_bStop && m_reusable && GetState() == InvokerStateScriptDone && m_script == script;

--- a/xbmc/interfaces/info/InfoBool.h
+++ b/xbmc/interfaces/info/InfoBool.h
@@ -25,7 +25,7 @@ public:
   InfoBool(const std::string &expression, int context, unsigned int &refreshCounter);
   virtual ~InfoBool() = default;
 
-  virtual void Initialize() {};
+  virtual void Initialize() {}
 
   /*! \brief Get the value of this info bool
    This is called to update (if dirty) and fetch the value of the info bool
@@ -62,7 +62,7 @@ public:
   /*! \brief Update the value of this info bool
    This is called if and only if the info bool is dirty, allowing it to update it's current value
    */
-  virtual void Update(const CGUIListItem *item) {};
+  virtual void Update(const CGUIListItem* item) {}
 
   const std::string &GetExpression() const { return m_expression; }
   bool ListItemDependent() const { return m_listItemDependent; }

--- a/xbmc/interfaces/info/InfoExpression.h
+++ b/xbmc/interfaces/info/InfoExpression.h
@@ -24,8 +24,10 @@ namespace INFO
 class InfoSingle : public InfoBool
 {
 public:
-  InfoSingle(const std::string &expression, int context, unsigned int &refreshCounter)
-    : InfoBool(expression, context, refreshCounter) {};
+  InfoSingle(const std::string& expression, int context, unsigned int& refreshCounter)
+    : InfoBool(expression, context, refreshCounter)
+  {
+  }
   void Initialize() override;
 
   void Update(const CGUIListItem *item) override;
@@ -38,8 +40,10 @@ private:
 class InfoExpression : public InfoBool
 {
 public:
-  InfoExpression(const std::string &expression, int context, unsigned int &refreshCounter)
-    : InfoBool(expression, context, refreshCounter) {};
+  InfoExpression(const std::string& expression, int context, unsigned int& refreshCounter)
+    : InfoBool(expression, context, refreshCounter)
+  {
+  }
   ~InfoExpression() override = default;
 
   void Initialize() override;
@@ -78,9 +82,10 @@ private:
   class InfoLeaf : public InfoSubexpression
   {
   public:
-    InfoLeaf(InfoPtr info, bool invert) : m_info(std::move(info)), m_invert(invert){};
+    InfoLeaf(InfoPtr info, bool invert) : m_info(std::move(info)), m_invert(invert) {}
     bool Evaluate(const CGUIListItem *item) override;
-    node_type_t Type() const override { return NODE_LEAF; };
+    node_type_t Type() const override { return NODE_LEAF; }
+
   private:
     InfoPtr m_info;
     bool m_invert;
@@ -94,7 +99,8 @@ private:
     void AddChild(const InfoSubexpressionPtr &child);
     void Merge(const std::shared_ptr<InfoAssociativeGroup>& other);
     bool Evaluate(const CGUIListItem *item) override;
-    node_type_t Type() const override { return m_type; };
+    node_type_t Type() const override { return m_type; }
+
   private:
     node_type_t m_type;
     std::list<InfoSubexpressionPtr> m_children;

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -71,8 +71,8 @@ namespace XBMCAddon
       inline ~File() override { delete file; }
 
 #if !defined(DOXYGEN_SHOULD_USE_THIS)
-      inline File* __enter__() { return this; };
-      inline void __exit__() { close(); };
+      inline File* __enter__() { return this; }
+      inline void __exit__() { close(); }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/Stat.h
+++ b/xbmc/interfaces/legacy/Stat.h
@@ -62,7 +62,7 @@ namespace XBMCAddon
       ///
       st_mode();
 #else
-      inline long long st_mode() { return st.st_mode; };
+      inline long long st_mode() { return st.st_mode; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -75,7 +75,7 @@ namespace XBMCAddon
       ///
       st_ino();
 #else
-      inline long long st_ino() { return st.st_ino; };
+      inline long long st_ino() { return st.st_ino; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -90,7 +90,7 @@ namespace XBMCAddon
       ///
       st_dev();
 #else
-      inline long long st_dev() { return st.st_dev; };
+      inline long long st_dev() { return st.st_dev; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -103,7 +103,7 @@ namespace XBMCAddon
       ///
       st_nlink();
 #else
-      inline long long st_nlink() { return st.st_nlink; };
+      inline long long st_nlink() { return st.st_nlink; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -116,7 +116,7 @@ namespace XBMCAddon
       ///
       st_uid();
 #else
-      inline long long st_uid() { return st.st_uid; };
+      inline long long st_uid() { return st.st_uid; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -129,7 +129,7 @@ namespace XBMCAddon
       ///
       st_gid();
 #else
-      inline long long st_gid() { return st.st_gid; };
+      inline long long st_gid() { return st.st_gid; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -147,7 +147,7 @@ namespace XBMCAddon
       ///
       st_size();
 #else
-      inline long long st_size() { return st.st_size; };
+      inline long long st_size() { return st.st_size; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -173,7 +173,7 @@ namespace XBMCAddon
       ///
       st_mtime();
 #else
-      inline long long mtime() { return st.st_mtime; };
+      inline long long mtime() { return st.st_mtime; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -186,7 +186,7 @@ namespace XBMCAddon
       ///
       st_ctime();
 #else
-      inline long long ctime() { return st.st_ctime; };
+      inline long long ctime() { return st.st_ctime; }
 #endif
     };
     /// @}

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -257,10 +257,26 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL bool    OnBack(int actionId);
       SWIGHIDDENVIRTUAL void    OnDeinitWindow(int nextWindowID);
 
-      SWIGHIDDENVIRTUAL bool    IsDialogRunning() const { XBMC_TRACE; return false; };
-      SWIGHIDDENVIRTUAL bool    IsDialog() const { XBMC_TRACE; return false; };
-      SWIGHIDDENVIRTUAL bool    IsModalDialog() const { XBMC_TRACE; return false; };
-      SWIGHIDDENVIRTUAL bool    IsMediaWindow() const { XBMC_TRACE; return false; };
+      SWIGHIDDENVIRTUAL bool IsDialogRunning() const
+      {
+        XBMC_TRACE;
+        return false;
+      }
+      SWIGHIDDENVIRTUAL bool IsDialog() const
+      {
+        XBMC_TRACE;
+        return false;
+      }
+      SWIGHIDDENVIRTUAL bool IsModalDialog() const
+      {
+        XBMC_TRACE;
+        return false;
+      }
+      SWIGHIDDENVIRTUAL bool IsMediaWindow() const
+      {
+        XBMC_TRACE;
+        return false;
+      }
       SWIGHIDDENVIRTUAL void    dispose();
 
       /**

--- a/xbmc/interfaces/legacy/WindowInterceptor.h
+++ b/xbmc/interfaces/legacy/WindowInterceptor.h
@@ -158,11 +158,27 @@ namespace XBMCAddon
       void OnDeinitWindow(int nextWindowID) override
       { XBMC_TRACE; if(up()) P::OnDeinitWindow(nextWindowID); else checkedv(OnDeinitWindow(nextWindowID)); }
 
-      bool IsModalDialog() const override { XBMC_TRACE; return checkedb(IsModalDialog()); };
+      bool IsModalDialog() const override
+      {
+        XBMC_TRACE;
+        return checkedb(IsModalDialog());
+      }
 
-      bool IsDialogRunning() const override { XBMC_TRACE; return checkedb(IsDialogRunning()); };
-      bool IsDialog() const override { XBMC_TRACE; return checkedb(IsDialog()); };
-      bool IsMediaWindow() const override { XBMC_TRACE; return checkedb(IsMediaWindow()); };
+      bool IsDialogRunning() const override
+      {
+        XBMC_TRACE;
+        return checkedb(IsDialogRunning());
+      }
+      bool IsDialog() const override
+      {
+        XBMC_TRACE;
+        return checkedb(IsDialog());
+      }
+      bool IsMediaWindow() const override
+      {
+        XBMC_TRACE;
+        return checkedb(IsMediaWindow());
+      }
 
       void SetRenderOrder(int renderOrder) override { XBMC_TRACE; P::m_renderOrder = renderOrder; }
 

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -57,7 +57,7 @@ public:
   /*! \brief Reset the current list of items.
    Derived classes may choose to ignore this.
    */
-  virtual void Reset() {};
+  virtual void Reset() {}
 
   /*! \brief Click event on an item.
    \param item the item that was clicked.
@@ -82,7 +82,7 @@ public:
    \param always whether this item should always be used on first focus.
    \sa GetDefaultItem, AlwaysFocusDefaultItem
    */
-  virtual void SetDefaultItem(int item, bool always) {};
+  virtual void SetDefaultItem(int item, bool always) {}
 
   /*! \brief The default item to focus.
    \return the item to focus by default. -1 for none.

--- a/xbmc/media/decoderfilter/DecoderFilterManager.h
+++ b/xbmc/media/decoderfilter/DecoderFilterManager.h
@@ -47,7 +47,7 @@ public:
   * \param name decodername
   * \return nothing.
   */
-  CDecoderFilter(const std::string& name) : m_name(name) {};
+  CDecoderFilter(const std::string& name) : m_name(name) {}
 
   /**
   * \fn CDecoderFilter::CDecoderFilter(const std::string& name, uint32_t flags, uint32_t maxWidth, uint32_t maxHeight);
@@ -65,7 +65,7 @@ public:
   * \fn CDecoderFilter::operator < (const CDecoderFilter& other);
   * \brief used for sorting / replacing / find
   */
-  bool operator < (const CDecoderFilter& other) const { return m_name < other.m_name; };
+  bool operator<(const CDecoderFilter& other) const { return m_name < other.m_name; }
 
   /**
   * \fn CDecoderFilter::isValid(const CDVDStreamInfo& streamInfo);
@@ -109,8 +109,8 @@ private:
 class CDecoderFilterManager
 {
 public:
-  CDecoderFilterManager() { Load(); };
-  virtual ~CDecoderFilterManager() { Save(); };
+  CDecoderFilterManager() { Load(); }
+  virtual ~CDecoderFilterManager() { Save(); }
 
   /**
   * \fn bool CDecoderFilterManager::add(const CDecoderFilter& filter);

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -885,7 +885,7 @@ protected:
   int GetMinSchemaVersion() const override { return 32; }
   int GetSchemaVersion() const override;
 
-  const char* GetBaseDBName() const override { return "MyMusic"; };
+  const char* GetBaseDBName() const override { return "MyMusic"; }
 
 private:
   /*! \brief (Re)Create the generic database views for songs and albums

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -115,7 +115,7 @@ public:
     or ALBUMARTIST, e.g. COMPOSER or CONDUCTOR etc.
   \return a vector of all contributing artist names and their roles
   */
-  const VECMUSICROLES& GetContributors() const { return m_musicRoles; };
+  const VECMUSICROLES& GetContributors() const { return m_musicRoles; }
   //void AddArtistRole(const int &role, const std::string &artist);
   void AppendArtistRole(const CMusicRole& musicRole);
 

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.h
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.h
@@ -31,7 +31,7 @@ public:
   CGUIDialogInfoProviderSettings();
 
   // specialization of CGUIWindow
-  bool HasListItems() const override { return true; };
+  bool HasListItems() const override { return true; }
 
   const ADDON::ScraperPtr& GetAlbumScraper() const { return m_albumscraper; }
   void SetAlbumScraper(ADDON::ScraperPtr scraper) { m_albumscraper = std::move(scraper); }

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -30,10 +30,10 @@ public:
   bool SetItem(CFileItem* item);
   void SetAlbum(const CAlbum& album, const std::string &path);
   void SetArtist(const CArtist& artist, const std::string &path);
-  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; };
-  bool HasRefreshed() const { return m_hasRefreshed; };
+  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; }
+  bool HasRefreshed() const { return m_hasRefreshed; }
 
-  bool HasListItems() const override { return true; };
+  bool HasListItems() const override { return true; }
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
   std::string GetContent();
   static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
@@ -41,11 +41,11 @@ public:
   void SetSongs(const VECSONGS &songs) const;
   void SetArtTypeList(CFileItemList& artlist);
   void SetScrapedInfo(bool bScraped) { m_scraperAddInfo = bScraped;  }
-  CArtist& GetArtist() { return m_artist; };
-  CAlbum& GetAlbum() { return m_album; };
-  bool IsArtistInfo() const { return m_bArtistInfo; };
-  bool IsCancelled() const { return m_cancelled; };
-  bool HasScrapedInfo() const { return m_scraperAddInfo; };
+  CArtist& GetArtist() { return m_artist; }
+  CAlbum& GetAlbum() { return m_album; }
+  bool IsArtistInfo() const { return m_bArtistInfo; }
+  bool IsCancelled() const { return m_cancelled; }
+  bool HasScrapedInfo() const { return m_scraperAddInfo; }
   void FetchComplete();
   void RefreshInfo();
 

--- a/xbmc/music/dialogs/GUIDialogSongInfo.h
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.h
@@ -23,13 +23,13 @@ public:
   void SetArtTypeList(CFileItemList& artlist);
   bool OnAction(const CAction& action) override;
   bool OnBack(int actionID) override;
-  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; };
+  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; }
 
-  bool HasListItems() const override { return true; };
+  bool HasListItems() const override { return true; }
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
   std::string GetContent();
-  //const CFileItemList& CurrentDirectory() const { return m_artTypeList; };
-  bool IsCancelled() const { return m_cancelled; };
+  //const CFileItemList& CurrentDirectory() const { return m_artTypeList; }
+  bool IsCancelled() const { return m_cancelled; }
   void FetchComplete();
 
   static void ShowFor(CFileItem* pItem);

--- a/xbmc/music/tags/TagLibVFSStream.h
+++ b/xbmc/music/tags/TagLibVFSStream.h
@@ -110,7 +110,7 @@ namespace MUSIC_INFO
     /*!
      * Returns the buffer size that is used for internal buffering.
      */
-    static TagLib::uint bufferSize() { return 1024; };
+    static TagLib::uint bufferSize() { return 1024; }
 
   private:
     std::string   m_strFileName;

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.h
@@ -24,7 +24,7 @@ public:
   void MoveItem(int iStart, int iDest);
 
 protected:
-  bool GoParentFolder() override { return false; };
+  bool GoParentFolder() override { return false; }
   void UpdateButtons() override;
   void OnItemLoaded(CFileItem* pItem) override;
   bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
@@ -29,7 +29,7 @@ protected:
   bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
   void OnPrepareFileItems(CFileItemList &items) override;
   void OnQueueItem(int iItem, bool) override;
-  std::string GetStartFolder(const std::string &dir) override { return ""; };
+  std::string GetStartFolder(const std::string& dir) override { return ""; }
 
   void OnSourcesContext();
   void OnPlaylistContext();

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -38,7 +38,7 @@ public:
 
   std::string ConstructPath() const;
   bool SetPath(const std::string &path);
-  bool IsConfirmed() const override { return m_confirmed; };
+  bool IsConfirmed() const override { return m_confirmed; }
 
 protected:
   // implementations of ISettingCallback

--- a/xbmc/network/Socket.h
+++ b/xbmc/network/Socket.h
@@ -137,7 +137,7 @@ namespace SOCKETS
     // socket functions
     virtual bool Bind(bool localOnly, int port, int range=0) = 0;
     virtual bool Connect() = 0;
-    virtual void Close() {};
+    virtual void Close() {}
 
     // state functions
     bool Ready() { return m_bReady; }

--- a/xbmc/network/UdpClient.h
+++ b/xbmc/network/UdpClient.h
@@ -41,7 +41,12 @@ protected:
   bool Send(struct sockaddr_in aAddress, const std::string& aMessage);
   bool Send(struct sockaddr_in aAddress, unsigned char* pMessage, DWORD dwSize);
 
-  virtual void OnMessage(struct sockaddr_in& aRemoteAddress, const std::string& aMessage, unsigned char* pMessage, DWORD dwMessageLength){};
+  virtual void OnMessage(struct sockaddr_in& aRemoteAddress,
+                         const std::string& aMessage,
+                         unsigned char* pMessage,
+                         DWORD dwMessageLength)
+  {
+  }
 
 protected:
 

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -151,7 +151,7 @@ public:
    *
    * \details This is only used if the response type is one of the HTTPMemoryDownload types.
    */
-  virtual HttpResponseRanges GetResponseData() const { return HttpResponseRanges(); };
+  virtual HttpResponseRanges GetResponseData() const { return HttpResponseRanges(); }
 
   /*!
   * \brief Returns the URL to which the request should be redirected.

--- a/xbmc/network/websocket/WebSocket.h
+++ b/xbmc/network/websocket/WebSocket.h
@@ -108,7 +108,11 @@ class CWebSocket
 {
 public:
   CWebSocket() { m_state = WebSocketStateNotConnected; m_message = NULL; }
-  virtual ~CWebSocket() { if (m_message) delete m_message; };
+  virtual ~CWebSocket()
+  {
+    if (m_message)
+      delete m_message;
+  }
 
   int GetVersion() { return m_version; }
   WebSocketState GetState() { return m_state; }

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -80,7 +80,7 @@ public:
   int ProductId(void) const { return m_iProductId; }
   const char* ProductIdAsString(void) const { return m_strProductId.c_str(); }
   PeripheralType Type(void) const { return m_type; }
-  PeripheralBusType GetBusType(void) const { return m_busType; };
+  PeripheralBusType GetBusType(void) const { return m_busType; }
   const std::string& DeviceName(void) const { return m_strDeviceName; }
   bool IsHidden(void) const { return m_bHidden; }
   void SetHidden(bool bSetTo = true) { m_bHidden = bSetTo; }
@@ -134,7 +134,7 @@ public:
    * @brief Called when a setting changed.
    * @param strChangedSetting The changed setting.
    */
-  virtual void OnSettingChanged(const std::string& strChangedSetting){};
+  virtual void OnSettingChanged(const std::string& strChangedSetting) {}
 
   /*!
    * @brief Called when this device is removed, before calling the destructor.

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -30,7 +30,7 @@ public:
 
   void Create(CGUIWindowSlideShow *pCallback);
   void LoadPic(int iPic, int iSlideNumber, const std::string &strFileName, const int maxWidth, const int maxHeight);
-  bool IsLoading() { return m_isLoading;};
+  bool IsLoading() { return m_isLoading; }
   int SlideNumber() const { return m_iSlideNumber; }
   int Pic() const { return m_iPic; }
 

--- a/xbmc/pictures/JpegParse.h
+++ b/xbmc/pictures/JpegParse.h
@@ -47,8 +47,8 @@ class CJpegParse
     CJpegParse();
    ~CJpegParse(void) = default;
     bool Process(const char *picFileName);
-    const ExifInfo_t * GetExifInfo() const { return &m_ExifInfo; };
-    const IPTCInfo_t * GetIptcInfo() const { return &m_IPTCInfo; };
+    const ExifInfo_t* GetExifInfo() const { return &m_ExifInfo; }
+    const IPTCInfo_t* GetIptcInfo() const { return &m_IPTCInfo; }
 
   private:
     bool ExtractInfo(XFILE::CFile& infile);

--- a/xbmc/pictures/PictureInfoTag.h
+++ b/xbmc/pictures/PictureInfoTag.h
@@ -118,7 +118,7 @@ class CPictureInfoTag : public IArchivable, public ISerializable, public ISortab
   };
 
 public:
-  CPictureInfoTag() { Reset(); };
+  CPictureInfoTag() { Reset(); }
   virtual ~CPictureInfoTag() = default;
   void Reset();
   void Archive(CArchive& ar) override;
@@ -126,7 +126,7 @@ public:
   void ToSortable(SortItem& sortable, Field field) const override;
   const std::string GetInfo(int info) const;
 
-  bool Loaded() const { return m_isLoaded; };
+  bool Loaded() const { return m_isLoaded; }
   bool Load(const std::string &path);
 
   void SetInfo(const std::string& key, const std::string& value);

--- a/xbmc/pictures/PictureThumbLoader.h
+++ b/xbmc/pictures/PictureThumbLoader.h
@@ -20,7 +20,7 @@ public:
   bool LoadItem(CFileItem* pItem) override;
   bool LoadItemCached(CFileItem* pItem) override;
   bool LoadItemLookup(CFileItem* pItem) override;
-  void SetRegenerateThumbs(bool regenerate) { m_regenerateThumbs = regenerate; };
+  void SetRegenerateThumbs(bool regenerate) { m_regenerateThumbs = regenerate; }
   static void ProcessFoldersAndArchives(CFileItem *pItem);
 
   /*!

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -41,8 +41,8 @@ public:
                   TRANSITION_EFFECT transEffect = FADEIN_FADEOUT);
   void UpdateTexture(CTexture* pTexture);
 
-  bool IsLoaded() const { return m_bIsLoaded;};
-  void UnLoad() {m_bIsLoaded = false;};
+  bool IsLoaded() const { return m_bIsLoaded; }
+  void UnLoad() { m_bIsLoaded = false; }
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   void Render();
   void Close();
@@ -50,30 +50,30 @@ public:
   DISPLAY_EFFECT DisplayEffect() const { return m_displayEffect; }
   bool DisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const;
   bool IsStarted() const { return m_iCounter > 0; }
-  bool IsFinished() const { return m_bIsFinished;};
-  bool DrawNextImage() const { return m_bDrawNextImage;};
+  bool IsFinished() const { return m_bIsFinished; }
+  bool DrawNextImage() const { return m_bDrawNextImage; }
 
-  int GetWidth() const { return (int)m_fWidth;};
-  int GetHeight() const { return (int)m_fHeight;};
+  int GetWidth() const { return (int)m_fWidth; }
+  int GetHeight() const { return (int)m_fHeight; }
 
   void Keep();
   bool StartTransition();
   int GetTransitionTime(int iType) const;
   void SetTransitionTime(int iType, int iTime);
 
-  int SlideNumber() const { return m_iSlideNumber;};
+  int SlideNumber() const { return m_iSlideNumber; }
 
   void Zoom(float fZoomAmount, bool immediate = false);
   void Rotate(float fRotateAngle, bool immediate = false);
   void Pause(bool bPause);
   void SetInSlideshow(bool slideshow);
   void SetOriginalSize(int iOriginalWidth, int iOriginalHeight, bool bFullSize);
-  bool FullSize() const { return m_bFullSize;};
+  bool FullSize() const { return m_bFullSize; }
   int GetOriginalWidth();
   int GetOriginalHeight();
 
   void Move(float dX, float dY);
-  float GetZoom() const { return m_fZoomAmount;};
+  float GetZoom() const { return m_fZoomAmount; }
 
   bool m_bIsComic;
   bool m_bCanMoveHorizontally;

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.h
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.h
@@ -20,8 +20,8 @@ public:
   CAndroidAppDirectory() = default;
   ~CAndroidAppDirectory() override = default;
   bool GetDirectory(const CURL& url, CFileItemList& items) override;
-  bool Exists(const CURL& url) override { return true; };
-  bool AllowAll() const override { return true; };
+  bool Exists(const CURL& url) override { return true; }
+  bool AllowAll() const override { return true; }
   DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_NEVER; }
 };
 }

--- a/xbmc/platform/android/media/drm/MediaDrmCryptoSession.h
+++ b/xbmc/platform/android/media/drm/MediaDrmCryptoSession.h
@@ -18,7 +18,7 @@ namespace DRM
   class CharVecBuffer : public XbmcCommons::Buffer
   {
   public:
-    inline CharVecBuffer(const XbmcCommons::Buffer& buf) : XbmcCommons::Buffer(buf) {};
+    inline CharVecBuffer(const XbmcCommons::Buffer& buf) : XbmcCommons::Buffer(buf) {}
 
     inline CharVecBuffer(const std::vector<char>& vec)
       : XbmcCommons::Buffer(vec.size())

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSFile.h
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSFile.h
@@ -29,7 +29,7 @@ namespace XFILE
 class CTVOSFile : public IFile
 {
 public:
-  CTVOSFile(){};
+  CTVOSFile() {}
   ~CTVOSFile();
 
   bool static WantsFile(const CURL& url);

--- a/xbmc/platform/linux/DBusUtil.h
+++ b/xbmc/platform/linux/DBusUtil.h
@@ -50,7 +50,7 @@ private:
 
   struct DBusConnectionDeleter
   {
-    DBusConnectionDeleter() {};
+    DBusConnectionDeleter() {}
     bool closeBeforeUnref = false;
     void operator()(DBusConnection* connection) const;
   };

--- a/xbmc/platform/linux/PlatformLinux.h
+++ b/xbmc/platform/linux/PlatformLinux.h
@@ -21,7 +21,7 @@ public:
   ~CPlatformLinux() override = default;
 
   bool InitStageOne() override;
-  bool IsConfigureAddonsAtStartupEnabled() override { return true; };
+  bool IsConfigureAddonsAtStartupEnabled() override { return true; }
 
 private:
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;

--- a/xbmc/platform/posix/filesystem/SMBDirectory.h
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.h
@@ -20,7 +20,7 @@ public:
   CSMBDirectory(void);
   ~CSMBDirectory(void) override;
   bool GetDirectory(const CURL& url, CFileItemList &items) override;
-  DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
+  DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; }
   bool Create(const CURL& url) override;
   bool Exists(const CURL& url) override;
   bool Remove(const CURL& url) override;

--- a/xbmc/platform/posix/filesystem/SMBFile.h
+++ b/xbmc/platform/posix/filesystem/SMBFile.h
@@ -36,7 +36,7 @@ public:
   void Init();
   void Deinit();
   /* Makes sense to be called after acquiring the lock */
-  bool IsSmbValid() const { return m_context != nullptr; };
+  bool IsSmbValid() const { return m_context != nullptr; }
   void CheckIfIdle();
   void SetActivityTime();
   void AddActiveConnection();

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
@@ -59,7 +59,7 @@ public:
   */
   bool GetServerList(CFileItemList& items);
 
-  const long long GetInstanceID() { return wsd_instance_id; };
+  const long long GetInstanceID() { return wsd_instance_id; }
 
   /*
    * Set List of WSD info request

--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.h
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.h
@@ -20,7 +20,7 @@ namespace XFILE
     CWinLibraryDirectory();
     virtual ~CWinLibraryDirectory(void);
     bool GetDirectory(const CURL& url, CFileItemList &items) override;
-    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
+    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; }
     bool Create(const CURL& url) override;
     bool Exists(const CURL& url) override;
     bool Remove(const CURL& url) override;

--- a/xbmc/platform/win32/powermanagement/Win32PowerSyscall.h
+++ b/xbmc/platform/win32/powermanagement/Win32PowerSyscall.h
@@ -23,7 +23,7 @@ public:
 
 protected:
   virtual void Process(void);
-  virtual void OnStartup() { SetPriority(THREAD_PRIORITY_IDLE); };
+  virtual void OnStartup() { SetPriority(THREAD_PRIORITY_IDLE); }
 
 private:
   static bool PowerManagement(PowerState State);

--- a/xbmc/playlists/PlayList.h
+++ b/xbmc/playlists/PlayList.h
@@ -52,11 +52,11 @@ public:
   void UnShuffle();
   bool IsShuffled() const { return m_bShuffled; }
 
-  void SetPlayed(bool bPlayed) { m_bWasPlayed = true; };
-  bool WasPlayed() const { return m_bWasPlayed; };
+  void SetPlayed(bool bPlayed) { m_bWasPlayed = true; }
+  bool WasPlayed() const { return m_bWasPlayed; }
 
   void SetUnPlayable(int iItem);
-  int GetPlayable() const { return m_iPlayableItems; };
+  int GetPlayable() const { return m_iPlayableItems; }
 
   void UpdateItem(const CFileItem *item);
 

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -109,21 +109,24 @@ public:
 
   void SetName(const std::string &name);
   void SetType(const std::string &type); // music, video, mixed
-  const std::string& GetName() const { return m_playlistName; };
-  const std::string& GetType() const { return m_playlistType; };
+  const std::string& GetName() const { return m_playlistName; }
+  const std::string& GetType() const { return m_playlistType; }
   bool IsVideoType() const;
   bool IsMusicType() const;
 
   void SetMatchAllRules(bool matchAll) { m_ruleCombination.SetType(matchAll ? CSmartPlaylistRuleCombination::CombinationAnd : CSmartPlaylistRuleCombination::CombinationOr); }
   bool GetMatchAllRules() const { return m_ruleCombination.GetType() == CSmartPlaylistRuleCombination::CombinationAnd; }
 
-  void SetLimit(unsigned int limit) { m_limit = limit; };
-  unsigned int GetLimit() const { return m_limit; };
+  void SetLimit(unsigned int limit) { m_limit = limit; }
+  unsigned int GetLimit() const { return m_limit; }
 
-  void SetOrder(SortBy order) { m_orderField = order; };
-  SortBy GetOrder() const { return m_orderField; };
-  void SetOrderAscending(bool orderAscending) { m_orderDirection = orderAscending ? SortOrderAscending : SortOrderDescending; };
-  bool GetOrderAscending() const { return m_orderDirection != SortOrderDescending; };
+  void SetOrder(SortBy order) { m_orderField = order; }
+  SortBy GetOrder() const { return m_orderField; }
+  void SetOrderAscending(bool orderAscending)
+  {
+    m_orderDirection = orderAscending ? SortOrderAscending : SortOrderDescending;
+  }
+  bool GetOrderAscending() const { return m_orderDirection != SortOrderDescending; }
   SortOrder GetOrderDirection() const { return m_orderDirection; }
   void SetOrderAttributes(SortAttribute attributes) { m_orderAttributes = attributes; }
   SortAttribute GetOrderAttributes() const { return m_orderAttributes; }

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -51,7 +51,7 @@ public:
                                                  int& current,
                                                  void* data);
 
-  IPowerSyscall* GetPowerSyscall() const { return m_instance.get(); };
+  IPowerSyscall* GetPowerSyscall() const { return m_instance.get(); }
 
 private:
   void OnSleep() override;

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -42,7 +42,7 @@ public:
 
   virtual void SetViewPort(const CRect& viewPort) = 0;
   virtual void GetViewPort(CRect& viewPort) = 0;
-  virtual void RestoreViewPort() {};
+  virtual void RestoreViewPort() {}
 
   virtual bool ScissorsCanEffectClipping() { return false; }
   virtual CRect ClipRectToScissorRect(const CRect &rect) { return CRect(); }

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -74,8 +74,8 @@ public:
   void SetAlphaBlendEnable(bool enable);
 
   // empty overrides
-  bool IsExtSupported(const char* extension) const override { return false; };
-  bool ResetRenderSystem(int width, int height) override { return true; };
+  bool IsExtSupported(const char* extension) const override { return false; }
+  bool ResetRenderSystem(int width, int height) override { return true; }
 
 protected:
   virtual void PresentRenderImpl(bool rendered) = 0;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -116,7 +116,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     void Initialize(const CAppParamParser &params, CSettingsManager& settingsMgr);
     void Uninitialize(CSettingsManager& settingsMgr);
-    bool Initialized() const { return m_initialized; };
+    bool Initialized() const { return m_initialized; }
     void AddSettingsFile(const std::string &filename);
     bool Load(const CProfileManager &profileManager);
 
@@ -348,7 +348,10 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void SetDebugMode(bool debug);
 
     //! \brief Toggles dirty-region visualization
-    void ToggleDirtyRegionVisualization() { m_guiVisualizeDirtyRegions = !m_guiVisualizeDirtyRegions; };
+    void ToggleDirtyRegionVisualization()
+    {
+      m_guiVisualizeDirtyRegions = !m_guiVisualizeDirtyRegions;
+    }
 
     // runtime settings which cannot be set from advancedsettings.xml
     std::string m_videoExtensions;

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.h
@@ -26,7 +26,7 @@ public:
   CGUIDialogContentSettings();
 
   // specialization of CGUIWindow
-  bool HasListItems() const override { return true; };
+  bool HasListItems() const override { return true; }
 
   CONTENT_TYPE GetContent() const { return m_content; }
   void SetContent(CONTENT_TYPE content);

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
@@ -19,7 +19,7 @@ public:
   CGUIDialogLibExportSettings();
 
   // specialization of CGUIWindow
-  bool HasListItems() const override { return true; };
+  bool HasListItems() const override { return true; }
   static bool Show(CLibExportSettings& settings);
 
 protected:

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.h
@@ -22,7 +22,7 @@ public:
   bool OnMessage(CGUIMessage &message) override;
   bool OnAction(const CAction &action) override;
   bool OnBack(int actionID) override;
-  int GetID() const override { return CGUIDialogSettingsManagerBase::GetID() + m_iSection; };
+  int GetID() const override { return CGUIDialogSettingsManagerBase::GetID() + m_iSection; }
 
   // specialization of CGUIWindow
   bool IsDialog() const override { return false; }

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -34,7 +34,7 @@ class CFileItem;
 class CNetworkLocation
 {
 public:
-  CNetworkLocation() { id = 0; };
+  CNetworkLocation() { id = 0; }
   int id;
   std::string path;
 };

--- a/xbmc/threads/IRunnable.h
+++ b/xbmc/threads/IRunnable.h
@@ -12,6 +12,6 @@ class IRunnable
 {
 public:
   virtual void Run()=0;
-  virtual void Cancel() {};
+  virtual void Cancel() {}
   virtual ~IRunnable() = default;
 };

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -78,8 +78,8 @@ public:
   virtual void OnException(){} // signal termination handler
 
 protected:
-  virtual void OnStartup(){};
-  virtual void OnExit(){};
+  virtual void OnStartup() {}
+  virtual void OnExit() {}
   virtual void Process();
 
   std::atomic<bool> m_bStop;

--- a/xbmc/threads/platform/win/Win32Exception.h
+++ b/xbmc/threads/platform/win/Win32Exception.h
@@ -15,7 +15,7 @@ class win32_exception
 public:
     typedef const void* Address; // OK on Win32 platform
 
-    static void set_version(std::string version) { mVersion = version; };
+    static void set_version(std::string version) { mVersion = version; }
     static bool write_minidump(EXCEPTION_POINTERS* pEp);
     static bool write_stacktrace(EXCEPTION_POINTERS* pEp);
     static bool ShouldHook();

--- a/xbmc/utils/ActorProtocol.h
+++ b/xbmc/utils/ActorProtocol.h
@@ -32,9 +32,10 @@ class CPayloadWrap : public CPayloadWrapBase
 {
 public:
   ~CPayloadWrap() override = default;
-  CPayloadWrap(Payload *data) {m_pPayload.reset(data);};
-  CPayloadWrap(Payload &data) {m_pPayload.reset(new Payload(data));};
-  Payload *GetPlayload() {return m_pPayload.get();};
+  CPayloadWrap(Payload* data) { m_pPayload.reset(data); }
+  CPayloadWrap(Payload& data) { m_pPayload.reset(new Payload(data)); }
+  Payload* GetPlayload() { return m_pPayload.get(); }
+
 protected:
   std::unique_ptr<Payload> m_pPayload;
 };
@@ -98,10 +99,10 @@ public:
   void Purge();
   void PurgeIn(int signal);
   void PurgeOut(int signal);
-  void DeferIn(bool value) {inDefered = value;};
-  void DeferOut(bool value) {outDefered = value;};
-  void Lock() {criticalSection.lock();};
-  void Unlock() {criticalSection.unlock();};
+  void DeferIn(bool value) { inDefered = value; }
+  void DeferOut(bool value) { outDefered = value; }
+  void Lock() { criticalSection.lock(); }
+  void Unlock() { criticalSection.unlock(); }
   std::string portName;
 
 protected:

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -75,7 +75,7 @@ public:
   CBitstreamParser();
   ~CBitstreamParser() = default;
 
-  static bool Open(){ return true; };
+  static bool Open() { return true; }
   static void Close();
   static bool CanStartDecode(const uint8_t *buf, int buf_size);
 };
@@ -88,7 +88,7 @@ public:
 
   bool              Open(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb);
   void              Close(void);
-  bool              NeedConvert(void) const { return m_convert_bitstream; };
+  bool NeedConvert(void) const { return m_convert_bitstream; }
   bool              Convert(uint8_t *pData, int iSize);
   uint8_t*          GetConvertBuffer(void) const;
   int               GetConvertSize() const;

--- a/xbmc/utils/EventStream.h
+++ b/xbmc/utils/EventStream.h
@@ -65,7 +65,7 @@ template<typename Event>
 class CEventSource : public CEventStream<Event>
 {
 public:
-  explicit CEventSource() : m_queue(false, 1, CJob::PRIORITY_HIGH) {};
+  explicit CEventSource() : m_queue(false, 1, CJob::PRIORITY_HIGH) {}
 
   template<typename A>
   void Publish(A event)

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -13,7 +13,7 @@ class IScreenshotSurface
 public:
   virtual ~IScreenshotSurface() = default;
   virtual bool Capture() { return false; }
-  virtual void CaptureVideo(bool blendToBuffer) { };
+  virtual void CaptureVideo(bool blendToBuffer) {}
 
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }

--- a/xbmc/utils/Job.h
+++ b/xbmc/utils/Job.h
@@ -120,7 +120,7 @@ public:
     PRIORITY_HIGH,
     PRIORITY_DEDICATED, // will create a new worker if no worker is available at queue time
   };
-  CJob() { m_callback = NULL; };
+  CJob() { m_callback = NULL; }
 
   /*!
    \brief Destructor for job objects.
@@ -153,7 +153,7 @@ public:
    \return a unique character string describing the job.
    \sa CJobManager
    */
-  virtual const char *GetType() const { return ""; };
+  virtual const char* GetType() const { return ""; }
 
   virtual bool operator==(const CJob* job) const
   {

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -33,7 +33,7 @@ template<typename F>
 class CLambdaJob : public CJob
 {
 public:
-  CLambdaJob(F&& f) : m_f(std::forward<F>(f)) {};
+  CLambdaJob(F&& f) : m_f(std::forward<F>(f)) {}
   bool DoWork() override
   {
     m_f();

--- a/xbmc/utils/ScraperParser.h
+++ b/xbmc/utils/ScraperParser.h
@@ -31,7 +31,7 @@ public:
   ~CScraperParser();
   CScraperParser& operator= (const CScraperParser& parser);
   bool Load(const std::string& strXMLFile);
-  bool IsNoop() const { return m_isNoop; };
+  bool IsNoop() const { return m_isNoop; }
 
   void Clear();
   const std::string& GetFilename() const { return m_strFile; }

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -30,7 +30,7 @@ public:
     SUBTITLE
   };
 
-  explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {};
+  explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {}
   virtual ~CStreamDetail() = default;
   virtual bool IsWorseThan(const CStreamDetail &that) const = 0;
 
@@ -89,7 +89,7 @@ public:
 class CStreamDetails final : public IArchivable, public ISerializable
 {
 public:
-  CStreamDetails() { Reset(); };
+  CStreamDetails() { Reset(); }
   CStreamDetails(const CStreamDetails &that);
   CStreamDetails& operator=(const CStreamDetails &that);
   bool operator ==(const CStreamDetails &that) const;
@@ -98,7 +98,7 @@ public:
   static std::string VideoDimsToResolutionDescription(int iWidth, int iHeight);
   static std::string VideoAspectToAspectDescription(float fAspect);
 
-  bool HasItems(void) const { return m_vecItems.size() > 0; };
+  bool HasItems(void) const { return m_vecItems.size() > 0; }
   int GetStreamCount(CStreamDetail::StreamType type) const;
   int GetVideoStreamCount(void) const;
   int GetAudioStreamCount(void) const;

--- a/xbmc/utils/params_check_macros.h
+++ b/xbmc/utils/params_check_macros.h
@@ -22,12 +22,12 @@
 
 // for use in functions that take printf format string as third parameter and additional printf parameters as fourth parameter
 // note: all non-static class member functions take pointer to class object as hidden first parameter
-// for example: class A { bool log_string(int logLevel, const char* functionName, const char* format, ...) PARAM3_PRINTF_FORMAT; };
+// for example: class A { bool log_string(int logLevel, const char* functionName, const char* format, ...) PARAM3_PRINTF_FORMAT; }
 #define PARAM3_PRINTF_FORMAT __attribute__((format(printf,3,4)))
 
 // for use in functions that take printf format string as fourth parameter and additional printf parameters as fith parameter
 // note: all non-static class member functions take pointer to class object as hidden first parameter
-// for example: class A { bool log_string(int logLevel, const char* functionName, int component, const char* format, ...) PARAM4_PRINTF_FORMAT; };
+// for example: class A { bool log_string(int logLevel, const char* functionName, int component, const char* format, ...) PARAM4_PRINTF_FORMAT; }
 #define PARAM4_PRINTF_FORMAT __attribute__((format(printf,4,5)))
 #else  // ! __GNUC__
 #define PARAM1_PRINTF_FORMAT

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1030,10 +1030,10 @@ private:
    */
   int GetPlayCount(int iFileId);
 
-  int GetMinSchemaVersion() const override { return 75; };
+  int GetMinSchemaVersion() const override { return 75; }
   int GetSchemaVersion() const override;
-  virtual int GetExportVersion() const { return 1; };
-  const char *GetBaseDBName() const override { return "MyVideos"; };
+  virtual int GetExportVersion() const { return 1; }
+  const char* GetBaseDBName() const override { return "MyVideos"; }
 
   void ConstructPath(std::string& strDest, const std::string& strPath, const std::string& strFileName);
   void SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -51,7 +51,7 @@ typedef std::map<std::string, CRating> RatingMap;
 class CVideoInfoTag : public IArchivable, public ISerializable, public ISortable
 {
 public:
-  CVideoInfoTag() { Reset(); };
+  CVideoInfoTag() { Reset(); }
   virtual ~CVideoInfoTag() = default;
   void Reset();
   /* \brief Load information to a videoinfotag from an XML element

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -25,13 +25,13 @@ public:
   void SetMovie(const CFileItem *item);
   bool NeedRefresh() const;
   bool RefreshAll() const;
-  bool HasUpdatedThumb() const { return m_hasUpdatedThumb; };
-  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; };
+  bool HasUpdatedThumb() const { return m_hasUpdatedThumb; }
+  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; }
 
   std::string GetThumbnail() const;
   CFileItemPtr GetCurrentListItem(int offset = 0) override { return m_movieItem; }
-  const CFileItemList& CurrentDirectory() const { return *m_castList; };
-  bool HasListItems() const override { return true; };
+  const CFileItemList& CurrentDirectory() const { return *m_castList; }
+  bool HasListItems() const override { return true; }
 
   static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
 

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -88,7 +88,7 @@ protected:
   virtual void OnQueueItem(int iItem, bool first = false);
   virtual void OnDeleteItem(const CFileItemPtr& pItem);
   void OnDeleteItem(int iItem) override;
-  virtual void DoSearch(const std::string& strSearch, CFileItemList& items) {};
+  virtual void DoSearch(const std::string& strSearch, CFileItemList& items) {}
   std::string GetStartFolder(const std::string &dir) override;
 
   bool OnClick(int iItem, const std::string &player = "") override;

--- a/xbmc/weather/WeatherManager.h
+++ b/xbmc/weather/WeatherManager.h
@@ -86,7 +86,7 @@ public:
   static bool GetSearchResults(const std::string &strSearch, std::string &strResult);
 
   std::string GetLocation(int iLocation);
-  const std::string &GetLastUpdateTime() const { return m_info.lastUpdateTime; };
+  const std::string& GetLastUpdateTime() const { return m_info.lastUpdateTime; }
   const ForecastDay &GetForecast(int day) const;
   bool IsFetched();
   void Reset();

--- a/xbmc/windowing/GraphicContext.h
+++ b/xbmc/windowing/GraphicContext.h
@@ -205,9 +205,16 @@ protected:
   class UITransform
   {
   public:
-    UITransform() : matrix() {};
-    UITransform(const TransformMatrix &m, const float sX = 1.0f, const float sY = 1.0f) : matrix(m), scaleX(sX), scaleY(sY) { };
-    void Reset() { matrix.Reset(); scaleX = scaleY = 1.0f; };
+    UITransform() : matrix() {}
+    UITransform(const TransformMatrix& m, const float sX = 1.0f, const float sY = 1.0f)
+      : matrix(m), scaleX(sX), scaleY(sY)
+    {
+    }
+    void Reset()
+    {
+      matrix.Reset();
+      scaleX = scaleY = 1.0f;
+    }
 
     TransformMatrix matrix;
     float scaleX = 1.0f;

--- a/xbmc/windowing/VideoSync.h
+++ b/xbmc/windowing/VideoSync.h
@@ -16,13 +16,14 @@ typedef void (*PUPDATECLOCK)(int NrVBlanks, uint64_t time, void *clock);
 class CVideoSync
 {
 public:
-  explicit CVideoSync(void *clock) { m_refClock = clock; };
+  explicit CVideoSync(void* clock) { m_refClock = clock; }
   virtual ~CVideoSync() = default;
   virtual bool Setup(PUPDATECLOCK func) = 0;
   virtual void Run(CEvent& stop) = 0;
   virtual void Cleanup() = 0;
   virtual float GetFps() = 0;
-  virtual void RefreshChanged() {};
+  virtual void RefreshChanged() {}
+
 protected:
   PUPDATECLOCK UpdateClock;
   float m_fps;

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -69,7 +69,7 @@ public:
   virtual bool IsCreated(){ return m_bWindowCreated; }
   virtual void NotifyAppFocusChange(bool bGaining) {}
   virtual void NotifyAppActiveChange(bool bActivated) {}
-  virtual void ShowOSMouse(bool show) {};
+  virtual void ShowOSMouse(bool show) {}
   virtual bool HasCursor(){ return true; }
   //some platforms have api for gesture inertial scrolling - default to false and use the InertialScrollingHandler
   virtual bool HasInertialGestures(){ return false; }
@@ -129,7 +129,7 @@ public:
   std::vector<RESOLUTION_WHR> ScreenResolutions(float refreshrate);
   std::vector<REFRESHRATE> RefreshRates(int width, int height, uint32_t dwFlags);
   REFRESHRATE DefaultRefreshRate(std::vector<REFRESHRATE> rates);
-  virtual bool HasCalibration(const RESOLUTION_INFO &resInfo) { return true; };
+  virtual bool HasCalibration(const RESOLUTION_INFO& resInfo) { return true; }
 
   // text input interface
   virtual std::string GetClipboardText(void);
@@ -161,15 +161,15 @@ public:
   virtual void* GetHWContext() { return nullptr; }
 
   std::shared_ptr<CDPMSSupport> GetDPMSManager();
-  virtual bool SetHDR(const VideoPicture* videoPicture) { return false; };
-  virtual bool IsHDRDisplay() { return false; };
-  virtual HDR_STATUS ToggleHDR() { return HDR_STATUS::HDR_UNSUPPORTED; };
-  virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; };
+  virtual bool SetHDR(const VideoPicture* videoPicture) { return false; }
+  virtual bool IsHDRDisplay() { return false; }
+  virtual HDR_STATUS ToggleHDR() { return HDR_STATUS::HDR_UNSUPPORTED; }
+  virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; }
 
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
 
   // Gets debug info from video renderer
-  virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; };
+  virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; }
 
   virtual std::vector<std::string> GetConnectedOutputs() { return {}; }
 

--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -21,16 +21,16 @@ public:
   }
   virtual ~CGLContext() = default;
   virtual bool Refresh(bool force, int screen, Window glWindow, bool &newContext) = 0;
-  virtual bool CreatePB() { return false; };
+  virtual bool CreatePB() { return false; }
   virtual void Destroy() = 0;
   virtual void Detach() = 0;
   virtual void SetVSync(bool enable) = 0;
   virtual void SwapBuffers() = 0;
   virtual void QueryExtensions() = 0;
-  virtual uint64_t GetVblankTiming(uint64_t &msc, uint64_t &interval) { return 0; };
+  virtual uint64_t GetVblankTiming(uint64_t& msc, uint64_t& interval) { return 0; }
   bool IsExtSupported(const char* extension) const;
 
-  std::string ExtPrefix(){ return m_extPrefix; };
+  std::string ExtPrefix() { return m_extPrefix; }
   std::string m_extPrefix;
   std::string m_extensions;
 

--- a/xbmc/windowing/X11/VideoSyncGLX.h
+++ b/xbmc/windowing/X11/VideoSyncGLX.h
@@ -32,8 +32,10 @@ class CWinSystemX11GLContext;
 class CVideoSyncGLX : public CVideoSync, IDispResource
 {
 public:
-  explicit CVideoSyncGLX(void *clock, CWinSystemX11GLContext& winSystem) :
-    CVideoSync(clock), m_winSystem(winSystem) {};
+  explicit CVideoSyncGLX(void* clock, CWinSystemX11GLContext& winSystem)
+    : CVideoSync(clock), m_winSystem(winSystem)
+  {
+  }
   bool Setup(PUPDATECLOCK func) override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;

--- a/xbmc/windowing/X11/VideoSyncOML.h
+++ b/xbmc/windowing/X11/VideoSyncOML.h
@@ -26,8 +26,10 @@ class CWinSystemX11GLContext;
 class CVideoSyncOML : public CVideoSync, IDispResource
 {
 public:
-  explicit CVideoSyncOML(void *clock, CWinSystemX11GLContext& winSystem) :
-    CVideoSync(clock), m_winSystem(winSystem) {};
+  explicit CVideoSyncOML(void* clock, CWinSystemX11GLContext& winSystem)
+    : CVideoSync(clock), m_winSystem(winSystem)
+  {
+  }
   bool Setup(PUPDATECLOCK func) override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -35,12 +35,12 @@ public:
   void UpdateResolutions() override;
 
   void InitiateModeChange();
-  bool IsHdmiModeTriggered() const { return m_HdmiModeTriggered; };
+  bool IsHdmiModeTriggered() const { return m_HdmiModeTriggered; }
   void SetHdmiState(bool connected);
 
   void UpdateDisplayModes();
 
-  bool HasCursor() override { return false; };
+  bool HasCursor() override { return false; }
 
   bool Hide() override;
   bool Show(bool raise = true) override;

--- a/xbmc/windowing/gbm/VideoLayerBridge.h
+++ b/xbmc/windowing/gbm/VideoLayerBridge.h
@@ -19,7 +19,7 @@ class CVideoLayerBridge
 {
 public:
   virtual ~CVideoLayerBridge() = default;
-  virtual void Disable() {};
+  virtual void Disable() {}
 };
 
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -57,7 +57,7 @@ public:
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
 
-  std::shared_ptr<CVideoLayerBridge> GetVideoLayerBridge() const { return m_videoLayerBridge; };
+  std::shared_ptr<CVideoLayerBridge> GetVideoLayerBridge() const { return m_videoLayerBridge; }
   void RegisterVideoLayerBridge(std::shared_ptr<CVideoLayerBridge> bridge)
   {
     m_videoLayerBridge = std::move(bridge);

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -39,9 +39,9 @@ class CDRMUtils
 public:
   CDRMUtils() = default;
   virtual ~CDRMUtils();
-  virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) {};
-  virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) { return false; };
-  virtual bool SetActive(bool active) { return false; };
+  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+  virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
+  virtual bool SetActive(bool active) { return false; }
   virtual bool InitDrm();
   virtual void DestroyDrm();
 

--- a/xbmc/windowing/osx/VideoSyncOsx.h
+++ b/xbmc/windowing/osx/VideoSyncOsx.h
@@ -15,12 +15,10 @@
 class CVideoSyncOsx : public CVideoSync, IDispResource
 {
 public:
-
-  CVideoSyncOsx(void *clock) :
-    CVideoSync(clock),
-    m_LastVBlankTime(0),
-    m_displayLost(false),
-    m_displayReset(false){};
+  CVideoSyncOsx(void* clock)
+    : CVideoSync(clock), m_LastVBlankTime(0), m_displayLost(false), m_displayReset(false)
+  {
+  }
 
   // CVideoSync interface
   bool Setup(PUPDATECLOCK func) override;

--- a/xbmc/windowing/tvos/VideoSyncTVos.h
+++ b/xbmc/windowing/tvos/VideoSyncTVos.h
@@ -16,8 +16,9 @@ class CWinSystemTVOS;
 class CVideoSyncTVos : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncTVos(void* clock, CWinSystemTVOS& winSystem)
-    : CVideoSync(clock), m_winSystem(winSystem){};
+  CVideoSyncTVos(void* clock, CWinSystemTVOS& winSystem) : CVideoSync(clock), m_winSystem(winSystem)
+  {
+  }
 
   // CVideoSync interface
   bool Setup(PUPDATECLOCK func) override;

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -61,8 +61,8 @@ public:
     m_deviceResources->Unregister(resource);
   };
 
-  void Register(IDispResource *resource) override { CWinSystemWin10::Register(resource); };
-  void Unregister(IDispResource *resource) override { CWinSystemWin10::Unregister(resource); };
+  void Register(IDispResource* resource) override { CWinSystemWin10::Register(resource); }
+  void Unregister(IDispResource* resource) override { CWinSystemWin10::Unregister(resource); }
 
   void ShowSplash(const std::string& message) override;
 

--- a/xbmc/windowing/windows/VideoSyncD3D.h
+++ b/xbmc/windowing/windows/VideoSyncD3D.h
@@ -15,7 +15,10 @@
 class CVideoSyncD3D : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncD3D(void *clock) : CVideoSync(clock), m_displayLost(false), m_displayReset(false), m_lastUpdateTime(0) { };
+  CVideoSyncD3D(void* clock)
+    : CVideoSync(clock), m_displayLost(false), m_displayReset(false), m_lastUpdateTime(0)
+  {
+  }
   bool Setup(PUPDATECLOCK func) override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -63,8 +63,8 @@ public:
     m_deviceResources->Unregister(resource);
   };
 
-  void Register(IDispResource *resource) override { CWinSystemWin32::Register(resource); };
-  void Unregister(IDispResource *resource) override { CWinSystemWin32::Unregister(resource); };
+  void Register(IDispResource* resource) override { CWinSystemWin32::Register(resource); }
+  void Unregister(IDispResource* resource) override { CWinSystemWin32::Unregister(resource); }
 
   void FixRefreshRateIfNecessary(const D3D10DDIARG_CREATERESOURCE* pResource) const;
 

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -42,7 +42,7 @@ public:
   void OnInitWindow() override;
   bool IsMediaWindow() const  override { return true; }
   int GetViewContainerID() const  override { return m_viewControl.GetCurrentControl(); }
-  int GetViewCount() const  override { return m_viewControl.GetViewModeCount(); };
+  int GetViewCount() const override { return m_viewControl.GetViewModeCount(); }
   bool HasListItems() const  override { return true; }
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
@@ -77,7 +77,7 @@ protected:
 
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-  virtual bool OnAddMediaSource() { return false; };
+  virtual bool OnAddMediaSource() { return false; }
 
   virtual void FormatItemLabels(CFileItemList &items, const LABEL_MASKS &labelMasks);
   virtual void UpdateButtons();

--- a/xbmc/windows/GUIWindowLoginScreen.h
+++ b/xbmc/windows/GUIWindowLoginScreen.h
@@ -23,9 +23,9 @@ public:
   bool OnAction(const CAction &action) override;
   bool OnBack(int actionID) override;
   void FrameMove() override;
-  bool HasListItems() const override { return true; };
+  bool HasListItems() const override { return true; }
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
-  int GetViewContainerID() const override { return m_viewControl.GetCurrentControl(); };
+  int GetViewContainerID() const override { return m_viewControl.GetCurrentControl(); }
 
 protected:
   void OnInitWindow() override;

--- a/xbmc/windows/GUIWindowSplash.h
+++ b/xbmc/windows/GUIWindowSplash.h
@@ -20,7 +20,7 @@ class CGUIWindowSplash : public CGUIWindow
 public:
   CGUIWindowSplash(void);
   ~CGUIWindowSplash(void) override;
-  bool OnAction(const CAction &action) override { return false; };
+  bool OnAction(const CAction& action) override { return false; }
   void Render() override;
 protected:
   void OnInitWindow() override;


### PR DESCRIPTION
## Description
Remove unnecessary semicolons from headers.

## Motivation and context
Cleanup and unify the format style.

Made using Notepad++ search and replace:

**Commit 1:** `; };\r\n` ---> `; }\r\n`
**Commit 2:** `) {};\r\n` --> `) {}\r\n`
**Commit 3:** `){};\r\n` ---> `) {}\r\n` and `) { };\r\n` ---> `) {}\r\n`
**Commit 4:** `;};\r\n` ---> `; }\r\n`
**Commit 5:** Jenkins says....

## How has this been tested?
Build with VS 2019

## What is the effect on users?
Nothing


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
