### PR TITLE
[SmartRedraw] Fix scrollable fadelabels

### DIFF
--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -151,6 +151,7 @@ void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &d
     if (m_scroll)
     {
       m_textLayout.UpdateScrollinfo(m_scrollInfo);
+      MarkDirtyRegion();
     }
 
     CServiceBroker::GetWinSystem()->GetGfxContext().RemoveTransform();


### PR DESCRIPTION
## Description
Currently if smartredraw is enabled and a dialog contains a scrollable fade label control, the label doesn't scroll. In some specific scenarios, e.g. with notifications/kaytoast dialogs, the dialog might be left on screen because the label doesn't finish the scrolling process. This makes sure that if the label is scrollable the dialog is refreshed anytime the scrollinfo is updated.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/18391
Superseeds https://github.com/xbmc/xbmc/pull/19156

## How has this been tested?
With python xbmcgui.notifications

## What is the effect on users?
None if smartredraw is not enabled. If it is, kaytoasts containing fadelabels should get closed after a while.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
