### PR TITLE
[smartredraw] Fix dialog progress not being updated

### DIFF
--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -160,6 +160,9 @@ void CGUIDialogProgress::SetPercentage(int iPercentage)
   if (iPercentage < 0) iPercentage = 0;
   if (iPercentage > 100) iPercentage = 100;
 
+  if (iPercentage != m_percentage)
+    MarkDirtyRegion();
+
   m_percentage = iPercentage;
 }
 


### PR DESCRIPTION
## Description
This fixes progress dialogs not being updated if smartredraw is enabled. If the new percentage differs from the old/stored one, the dialog must be refreshed (dirtyregions set).

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/15354

## How has this been tested?
With the video download functionality provided by the Aerial screensaver

## What is the effect on users?
DialogProgress should behave decently if smartredraw is enabled

## Screenshots (if appropriate):


![DialogProgress](https://i.imgur.com/9dx0YEH.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
