### PR TITLE
[profiles] fix: mediasource return -1 (not found) for "plugin://" protocol

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1164,8 +1164,11 @@ int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES
 
   if (checkURL.IsProtocol("shout"))
     strPath = checkURL.GetHostName();
+
+  // a plugin path should not be configured in any mediasource
   if (checkURL.IsProtocol("plugin"))
-    return 1;
+    return -1;
+
   if (checkURL.IsProtocol("multipath"))
     strPath = CMultiPathDirectory::GetFirstPath(strPath);
 


### PR DESCRIPTION
## Description
fixes https://github.com/xbmc/xbmc/issues/20143

function `int CUtil::GetMatchingSource()` literally returns the value **1** when checking the plugin path of a just started video or audio add-on. this is wrong because the returned value should be the index of the matching mediasource in `sources.xml`.

if, _by coincidence_, the 2nd video (or audio) source is restricted by a mediasource lock, the code will be verified though completely unrelated to the started add-on/plugin.

so do not return early with an incorrect return value of 1 in this case. ~~let the function determine the correct value.~~ return `-1` which indicates 'not found'.

OMG! this is >12 year old code. who will review this?

## How has this been tested?
Debian Buster

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

thanks @CursedDevelopment for discovering the main issue