### PR TITLE
Define architecture-specific platform tags for Linux

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -611,6 +611,17 @@ bool CAddonInfoBuilder::PlatformSupportsAddon(const AddonInfoPtr& addon)
     "freebsd",
 #elif defined(TARGET_LINUX)
     "linux",
+#if defined(__ARM_ARCH_7A__)
+    "linux-armv7",
+#elif defined(__aarch64__)
+    "linux-aarch64",
+#elif defined(__i686__)
+    "linux-i686",
+#elif defined(__x86_64__)
+    "linux-x86_64",
+#else
+    #warning no architecture dependant platform tag
+#endif
 #elif defined(TARGET_WINDOWS_DESKTOP)
     "windx",
     "windows",


### PR DESCRIPTION
## Description

This will allow binary addon repos to support multiple linux architectures. Currently you must create a separate repo for each linux arch variant.

## Motivation and context

Discussion with @lrusak pointed to this as the reason that an addon repo cannot host binaries for multiple linux architectures together.

This is already possible with every other OS, for example the PVR addon can host an android/aarch64 variant zip as so:

`pvr.plutotv+android-aarch64/pvr.plutotv-0.0.2.zip`

cc @matthuisman who has also experienced this issue

## How has this been tested?

I did not test this change.

## What is the effect on users?

Make it easier for users to install PVR repo addon without having to figure out which architecture they're using first.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
