### PR TITLE
windowing/gbm: allow specifying the output connector

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2364,6 +2364,7 @@
               <condition>HAVE_OSX</condition>
               <condition>HAS_DX</condition>
               <condition>HAVE_IOS</condition>
+              <condition>HAVE_GBM</condition>
             </or>
           </requirement>
           <level>0</level>

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -271,3 +271,8 @@ std::unique_ptr<CVideoSync> CWinSystemGbm::GetVideoSync(void* clock)
 {
   return std::make_unique<CVideoSyncGbm>(clock);
 }
+
+std::vector<std::string> CWinSystemGbm::GetConnectedOutputs()
+{
+  return m_DRM->GetConnectedConnectorNames();
+}

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -66,6 +66,8 @@ public:
   CGBMUtils::CGBMDevice* GetGBMDevice() const { return m_GBM->GetDevice(); }
   std::shared_ptr<CDRMUtils> GetDrm() const { return m_DRM; }
 
+  std::vector<std::string> GetConnectedOutputs() override;
+
 protected:
   void OnLostDevice();
 

--- a/xbmc/windowing/gbm/drm/DRMConnector.cpp
+++ b/xbmc/windowing/gbm/drm/DRMConnector.cpp
@@ -10,7 +10,41 @@
 
 #include "utils/log.h"
 
+#include <map>
+
 using namespace KODI::WINDOWING::GBM;
+
+namespace
+{
+
+std::map<int, std::string> connectorTypeNames = {
+    {DRM_MODE_CONNECTOR_Unknown, "unknown"},
+    {DRM_MODE_CONNECTOR_VGA, "VGA"},
+    {DRM_MODE_CONNECTOR_DVII, "DVI-I"},
+    {DRM_MODE_CONNECTOR_DVID, "DVI-D"},
+    {DRM_MODE_CONNECTOR_DVIA, "DVI-A"},
+    {DRM_MODE_CONNECTOR_Composite, "composite"},
+    {DRM_MODE_CONNECTOR_SVIDEO, "s-video"},
+    {DRM_MODE_CONNECTOR_LVDS, "LVDS"},
+    {DRM_MODE_CONNECTOR_Component, "component"},
+    {DRM_MODE_CONNECTOR_9PinDIN, "9-pin DIN"},
+    {DRM_MODE_CONNECTOR_DisplayPort, "DP"},
+    {DRM_MODE_CONNECTOR_HDMIA, "HDMI-A"},
+    {DRM_MODE_CONNECTOR_HDMIB, "HDMI-B"},
+    {DRM_MODE_CONNECTOR_TV, "TV"},
+    {DRM_MODE_CONNECTOR_eDP, "eDP"},
+    {DRM_MODE_CONNECTOR_VIRTUAL, "Virtual"},
+    {DRM_MODE_CONNECTOR_DSI, "DSI"},
+    {DRM_MODE_CONNECTOR_DPI, "DPI"},
+};
+
+std::map<drmModeConnection, std::string> connectorStatusNames = {
+    {DRM_MODE_CONNECTED, "connected"},
+    {DRM_MODE_DISCONNECTED, "disconnected"},
+    {DRM_MODE_UNKNOWNCONNECTION, "unknown"},
+};
+
+} // namespace
 
 CDRMConnector::CDRMConnector(int fd, uint32_t connector)
   : CDRMObject(fd), m_connector(drmModeGetConnector(m_fd, connector))
@@ -36,4 +70,27 @@ bool CDRMConnector::CheckConnector()
   }
 
   return m_connector->connection == DRM_MODE_CONNECTED;
+}
+
+std::string CDRMConnector::GetType()
+{
+  auto typeName = connectorTypeNames.find(m_connector->connector_type);
+  if (typeName == connectorTypeNames.end())
+    return connectorTypeNames[DRM_MODE_CONNECTOR_Unknown];
+
+  return typeName->second;
+}
+
+std::string CDRMConnector::GetStatus()
+{
+  auto statusName = connectorStatusNames.find(m_connector->connection);
+  if (statusName == connectorStatusNames.end())
+    return connectorStatusNames[DRM_MODE_UNKNOWNCONNECTION];
+
+  return statusName->second;
+}
+
+std::string CDRMConnector::GetName()
+{
+  return GetType() + "-" + std::to_string(m_connector->connector_type_id);
 }

--- a/xbmc/windowing/gbm/drm/DRMConnector.h
+++ b/xbmc/windowing/gbm/drm/DRMConnector.h
@@ -10,6 +10,8 @@
 
 #include "DRMObject.h"
 
+#include <string>
+
 namespace KODI
 {
 namespace WINDOWING
@@ -24,6 +26,10 @@ public:
   CDRMConnector(const CDRMConnector&) = delete;
   CDRMConnector& operator=(const CDRMConnector&) = delete;
   ~CDRMConnector() = default;
+
+  std::string GetType();
+  std::string GetStatus();
+  std::string GetName();
 
   uint32_t GetEncoderId() const { return m_connector->encoder_id; }
   uint32_t* GetConnectorId() const { return &m_connector->connector_id; }

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -504,9 +504,40 @@ bool CDRMUtils::InitDrm()
 
 bool CDRMUtils::FindConnector()
 {
-  auto connector = std::find_if(m_connectors.begin(), m_connectors.end(), [](auto& connector) {
-    return connector->GetEncoderId() > 0 && connector->IsConnected();
-  });
+  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return false;
+
+  auto settings = settingsComponent->GetSettings();
+  if (!settings)
+    return false;
+
+  std::vector<std::unique_ptr<CDRMConnector>>::iterator connector;
+
+  std::string connectorName = settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
+  if (connectorName != "Default")
+  {
+    connector = std::find_if(m_connectors.begin(), m_connectors.end(),
+                             [&connectorName](auto& connector)
+                             {
+                               return connector->GetEncoderId() > 0 && connector->IsConnected() &&
+                                      connector->GetName() == connectorName;
+                             });
+  }
+
+  if (connector == m_connectors.end())
+  {
+    CLog::Log(LOGDEBUG, "CDRMUtils::{} - failed to find specified connector: {}, trying default",
+              __FUNCTION__, connectorName);
+    connectorName = "Default";
+  }
+
+  if (connectorName == "Default")
+  {
+    connector = std::find_if(m_connectors.begin(), m_connectors.end(),
+                             [](auto& connector)
+                             { return connector->GetEncoderId() > 0 && connector->IsConnected(); });
+  }
 
   if (connector == m_connectors.end())
   {
@@ -515,7 +546,7 @@ bool CDRMUtils::FindConnector()
   }
 
   CLog::Log(LOGINFO, "CDRMUtils::{} - using connector: {}", __FUNCTION__,
-            *connector->get()->GetConnectorId());
+            connector->get()->GetName());
 
   m_connector = connector->get();
   return true;
@@ -682,6 +713,18 @@ std::vector<RESOLUTION_INFO> CDRMUtils::GetModes()
   }
 
   return resolutions;
+}
+
+std::vector<std::string> CDRMUtils::GetConnectedConnectorNames()
+{
+  std::vector<std::string> connectorNames;
+  for (const auto& connector : m_connectors)
+  {
+    if (connector->IsConnected())
+      connectorNames.emplace_back(connector->GetName());
+  }
+
+  return connectorNames;
 }
 
 uint32_t CDRMUtils::FourCCWithAlpha(uint32_t fourcc)

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -53,6 +53,8 @@ public:
   CDRMCrtc* GetCrtc() const { return m_crtc; }
   CDRMConnector* GetConnector() const { return m_connector; }
 
+  std::vector<std::string> GetConnectedConnectorNames();
+
   virtual RESOLUTION_INFO GetCurrentMode();
   virtual std::vector<RESOLUTION_INFO> GetModes();
   virtual bool SetMode(const RESOLUTION_INFO& res);


### PR DESCRIPTION
This allows specifying the output monitor/connector when using GBM. The implementation is basic and currently requires a kodi restart for the changes to take affect. This can likely be changed in the future but it's good enough for now.

The selection is simply the connector names (DP-1, DP-2, HDMI-A-1, etc). We don't parse edid's so we don't know the monitor names.

The connector selection will look for the specified connector but will fallback to looking for the first connected connector (the old behaviour). This is so that we can get an output in case your selected connector is unplugged.