### PR TITLE
GBM: use windowing method for HDR activation

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -8,8 +8,10 @@
 
 #include "VideoLayerBridgeDRMPRIME.h"
 
+#include "ServiceBroker.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
 #include "utils/log.h"
+#include "windowing/WinSystem.h"
 #include "windowing/gbm/drm/DRMAtomic.h"
 
 #include <utility>
@@ -35,17 +37,12 @@ void CVideoLayerBridgeDRMPRIME::Disable()
   m_DRM->AddProperty(plane, "FB_ID", 0);
   m_DRM->AddProperty(plane, "CRTC_ID", 0);
 
-  // disable HDR metadata
-  auto connector = m_DRM->GetConnector();
-  if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
-  {
-    m_DRM->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
-    m_DRM->SetActive(true);
+  auto winSystem = CServiceBroker::GetWinSystem();
+  if (!winSystem)
+    return;
 
-    if (m_hdr_blob_id)
-      drmModeDestroyPropertyBlob(m_DRM->GetFileDescriptor(), m_hdr_blob_id);
-    m_hdr_blob_id = 0;
-  }
+  // disable HDR metadata
+  winSystem->SetHDR(nullptr);
 }
 
 void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
@@ -159,7 +156,13 @@ void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
 
 void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 {
+  auto winSystem = CServiceBroker::GetWinSystem();
+  if (!winSystem)
+    return;
+
   const VideoPicture& picture = buffer->GetPicture();
+
+  winSystem->SetHDR(&picture);
 
   auto plane = m_DRM->GetVideoPlane();
 
@@ -172,64 +175,6 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
   std::tie(result, value) = plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture));
   if (result)
     m_DRM->AddProperty(plane, "COLOR_RANGE", value);
-
-  auto connector = m_DRM->GetConnector();
-  if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
-  {
-    m_hdr_metadata.metadata_type = HDMI_STATIC_METADATA_TYPE1;
-    m_hdr_metadata.hdmi_metadata_type1.eotf = GetEOTF(picture);
-    m_hdr_metadata.hdmi_metadata_type1.metadata_type = HDMI_STATIC_METADATA_TYPE1;
-
-    if (m_hdr_blob_id)
-      drmModeDestroyPropertyBlob(m_DRM->GetFileDescriptor(), m_hdr_blob_id);
-    m_hdr_blob_id = 0;
-
-    if (m_hdr_metadata.hdmi_metadata_type1.eotf)
-    {
-      const AVMasteringDisplayMetadata* mdmd = GetMasteringDisplayMetadata(picture);
-      if (mdmd && mdmd->has_primaries)
-      {
-        // Convert to unsigned 16-bit values in units of 0.00002,
-        // where 0x0000 represents zero and 0xC350 represents 1.0000
-        for (int i = 0; i < 3; i++)
-        {
-          m_hdr_metadata.hdmi_metadata_type1.display_primaries[i].x =
-              std::round(av_q2d(mdmd->display_primaries[i][0]) * 50000.0);
-          m_hdr_metadata.hdmi_metadata_type1.display_primaries[i].y =
-              std::round(av_q2d(mdmd->display_primaries[i][1]) * 50000.0);
-        }
-        m_hdr_metadata.hdmi_metadata_type1.white_point.x =
-            std::round(av_q2d(mdmd->white_point[0]) * 50000.0);
-        m_hdr_metadata.hdmi_metadata_type1.white_point.y =
-            std::round(av_q2d(mdmd->white_point[1]) * 50000.0);
-      }
-      if (mdmd && mdmd->has_luminance)
-      {
-        // Convert to unsigned 16-bit value in units of 1 cd/m2,
-        // where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2
-        m_hdr_metadata.hdmi_metadata_type1.max_display_mastering_luminance =
-            std::round(av_q2d(mdmd->max_luminance));
-
-        // Convert to unsigned 16-bit value in units of 0.0001 cd/m2,
-        // where 0x0001 represents 0.0001 cd/m2 and 0xFFFF represents 6.5535 cd/m2
-        m_hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance =
-            std::round(av_q2d(mdmd->min_luminance) * 10000.0);
-      }
-
-      const AVContentLightMetadata* clmd = GetContentLightMetadata(picture);
-      if (clmd)
-      {
-        m_hdr_metadata.hdmi_metadata_type1.max_cll = clmd->MaxCLL;
-        m_hdr_metadata.hdmi_metadata_type1.max_fall = clmd->MaxFALL;
-      }
-
-      drmModeCreatePropertyBlob(m_DRM->GetFileDescriptor(), &m_hdr_metadata, sizeof(m_hdr_metadata),
-                                &m_hdr_blob_id);
-    }
-
-    m_DRM->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdr_blob_id);
-    m_DRM->SetActive(true);
-  }
 }
 
 void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -15,34 +15,6 @@
 
 #include <drm_mode.h>
 
-#ifndef HAVE_HDR_OUTPUT_METADATA
-// HDR structs is copied from linux include/linux/hdmi.h
-struct hdr_metadata_infoframe
-{
-  uint8_t eotf;
-  uint8_t metadata_type;
-  struct
-  {
-    uint16_t x, y;
-  } display_primaries[3];
-  struct
-  {
-    uint16_t x, y;
-  } white_point;
-  uint16_t max_display_mastering_luminance;
-  uint16_t min_display_mastering_luminance;
-  uint16_t max_cll;
-  uint16_t max_fall;
-};
-struct hdr_output_metadata
-{
-  uint32_t metadata_type;
-  union {
-    struct hdr_metadata_infoframe hdmi_metadata_type1;
-  };
-};
-#endif
-
 namespace KODI
 {
 namespace WINDOWING
@@ -78,7 +50,4 @@ private:
 
   CVideoBufferDRMPRIME* m_buffer = nullptr;
   CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
-
-  uint32_t m_hdr_blob_id = 0;
-  struct hdr_output_metadata m_hdr_metadata = {};
 };

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -162,6 +162,12 @@ public:
   virtual void* GetHWContext() { return nullptr; }
 
   std::shared_ptr<CDPMSSupport> GetDPMSManager();
+
+  /**
+   * @brief Set the HDR metadata. Passing nullptr as the parameter should
+   * disable HDR.
+   *
+   */
   virtual bool SetHDR(const VideoPicture* videoPicture) { return false; }
   virtual bool IsHDRDisplay() { return false; }
   virtual HDR_STATUS ToggleHDR() { return HDR_STATUS::HDR_UNSUPPORTED; }

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -372,11 +372,21 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
               std::round(av_q2d(mdmd->display_primaries[i][0]) * 50000.0);
           hdr_metadata.hdmi_metadata_type1.display_primaries[i].y =
               std::round(av_q2d(mdmd->display_primaries[i][1]) * 50000.0);
+
+          CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - display_primaries[{}].x: {}",
+                    __FUNCTION__, i, hdr_metadata.hdmi_metadata_type1.display_primaries[i].x);
+          CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - display_primaries[{}].y: {}",
+                    __FUNCTION__, i, hdr_metadata.hdmi_metadata_type1.display_primaries[i].y);
         }
         hdr_metadata.hdmi_metadata_type1.white_point.x =
             std::round(av_q2d(mdmd->white_point[0]) * 50000.0);
         hdr_metadata.hdmi_metadata_type1.white_point.y =
             std::round(av_q2d(mdmd->white_point[1]) * 50000.0);
+
+        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - white_point.x: {}", __FUNCTION__,
+                  hdr_metadata.hdmi_metadata_type1.white_point.x);
+        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - white_point.y: {}", __FUNCTION__,
+                  hdr_metadata.hdmi_metadata_type1.white_point.y);
       }
       if (mdmd && mdmd->has_luminance)
       {
@@ -389,6 +399,11 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
         // where 0x0001 represents 0.0001 cd/m2 and 0xFFFF represents 6.5535 cd/m2
         hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance =
             std::round(av_q2d(mdmd->min_luminance) * 10000.0);
+
+        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_display_mastering_luminance: {}",
+                  __FUNCTION__, hdr_metadata.hdmi_metadata_type1.max_display_mastering_luminance);
+        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - min_display_mastering_luminance: {}",
+                  __FUNCTION__, hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance);
       }
 
       const AVContentLightMetadata* clmd = DRMPRIME::GetContentLightMetadata(*videoPicture);
@@ -396,6 +411,11 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       {
         hdr_metadata.hdmi_metadata_type1.max_cll = clmd->MaxCLL;
         hdr_metadata.hdmi_metadata_type1.max_fall = clmd->MaxFALL;
+
+        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_cll: {}", __FUNCTION__,
+                  hdr_metadata.hdmi_metadata_type1.max_cll);
+        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_fall: {}", __FUNCTION__,
+                  hdr_metadata.hdmi_metadata_type1.max_fall);
       }
 
       drmModeCreatePropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata),

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -12,6 +12,7 @@
 #include "OptionalsReg.h"
 #include "ServiceBroker.h"
 #include "VideoSyncGbm.h"
+#include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
 #include "drm/DRMAtomic.h"
 #include "drm/DRMLegacy.h"
 #include "drm/OffScreenModeSetting.h"
@@ -26,6 +27,35 @@
 
 #include <mutex>
 #include <string.h>
+
+#ifndef HAVE_HDR_OUTPUT_METADATA
+// HDR structs is copied from linux include/linux/hdmi.h
+struct hdr_metadata_infoframe
+{
+  uint8_t eotf;
+  uint8_t metadata_type;
+  struct
+  {
+    uint16_t x, y;
+  } display_primaries[3];
+  struct
+  {
+    uint16_t x, y;
+  } white_point;
+  uint16_t max_display_mastering_luminance;
+  uint16_t min_display_mastering_luminance;
+  uint16_t max_cll;
+  uint16_t max_fall;
+};
+struct hdr_output_metadata
+{
+  uint32_t metadata_type;
+  union
+  {
+    struct hdr_metadata_infoframe hdmi_metadata_type1;
+  };
+};
+#endif
 
 using namespace KODI::WINDOWING::GBM;
 
@@ -281,4 +311,115 @@ std::unique_ptr<CVideoSync> CWinSystemGbm::GetVideoSync(void* clock)
 std::vector<std::string> CWinSystemGbm::GetConnectedOutputs()
 {
   return m_DRM->GetConnectedConnectorNames();
+}
+
+bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+{
+  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return false;
+
+  auto settings = settingsComponent->GetSettings();
+  if (!settings)
+    return false;
+
+  if (!settings->GetBool(SETTING_WINSYSTEM_IS_HDR_DISPLAY))
+    return false;
+
+  auto drm = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
+  if (!drm)
+    return false;
+
+  if (!videoPicture)
+  {
+    auto connector = drm->GetConnector();
+    if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
+    {
+      drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
+      drm->SetActive(true);
+
+      if (m_hdr_blob_id)
+        drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
+      m_hdr_blob_id = 0;
+    }
+
+    return true;
+  }
+
+  auto connector = drm->GetConnector();
+  if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
+  {
+    hdr_output_metadata hdr_metadata = {};
+
+    hdr_metadata.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
+    hdr_metadata.hdmi_metadata_type1.eotf = DRMPRIME::GetEOTF(*videoPicture);
+    hdr_metadata.hdmi_metadata_type1.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
+
+    if (m_hdr_blob_id)
+      drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
+    m_hdr_blob_id = 0;
+
+    if (hdr_metadata.hdmi_metadata_type1.eotf)
+    {
+      const AVMasteringDisplayMetadata* mdmd = DRMPRIME::GetMasteringDisplayMetadata(*videoPicture);
+      if (mdmd && mdmd->has_primaries)
+      {
+        // Convert to unsigned 16-bit values in units of 0.00002,
+        // where 0x0000 represents zero and 0xC350 represents 1.0000
+        for (int i = 0; i < 3; i++)
+        {
+          hdr_metadata.hdmi_metadata_type1.display_primaries[i].x =
+              std::round(av_q2d(mdmd->display_primaries[i][0]) * 50000.0);
+          hdr_metadata.hdmi_metadata_type1.display_primaries[i].y =
+              std::round(av_q2d(mdmd->display_primaries[i][1]) * 50000.0);
+        }
+        hdr_metadata.hdmi_metadata_type1.white_point.x =
+            std::round(av_q2d(mdmd->white_point[0]) * 50000.0);
+        hdr_metadata.hdmi_metadata_type1.white_point.y =
+            std::round(av_q2d(mdmd->white_point[1]) * 50000.0);
+      }
+      if (mdmd && mdmd->has_luminance)
+      {
+        // Convert to unsigned 16-bit value in units of 1 cd/m2,
+        // where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2
+        hdr_metadata.hdmi_metadata_type1.max_display_mastering_luminance =
+            std::round(av_q2d(mdmd->max_luminance));
+
+        // Convert to unsigned 16-bit value in units of 0.0001 cd/m2,
+        // where 0x0001 represents 0.0001 cd/m2 and 0xFFFF represents 6.5535 cd/m2
+        hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance =
+            std::round(av_q2d(mdmd->min_luminance) * 10000.0);
+      }
+
+      const AVContentLightMetadata* clmd = DRMPRIME::GetContentLightMetadata(*videoPicture);
+      if (clmd)
+      {
+        hdr_metadata.hdmi_metadata_type1.max_cll = clmd->MaxCLL;
+        hdr_metadata.hdmi_metadata_type1.max_fall = clmd->MaxFALL;
+      }
+
+      drmModeCreatePropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata),
+                                &m_hdr_blob_id);
+    }
+
+    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdr_blob_id);
+    drm->SetActive(true);
+  }
+
+  return true;
+}
+
+bool CWinSystemGbm::IsHDRDisplay()
+{
+  auto drm = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
+  if (!drm)
+    return false;
+
+  auto connector = drm->GetConnector();
+  if (!connector)
+    return false;
+
+  //! @todo: improve detection (edid?)
+  // we have no way to know if the display is actually HDR capable and we blindly set the HDR metadata
+  return connector->SupportsProperty("HDR_OUTPUT_METADATA");
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -57,6 +57,9 @@ public:
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
 
+  bool SetHDR(const VideoPicture* videoPicture) override;
+  bool IsHDRDisplay() override;
+
   std::shared_ptr<CVideoLayerBridge> GetVideoLayerBridge() const { return m_videoLayerBridge; }
   void RegisterVideoLayerBridge(std::shared_ptr<CVideoLayerBridge> bridge)
   {
@@ -83,6 +86,9 @@ protected:
   bool m_dispReset = false;
   XbmcThreads::EndTime<> m_dispResetTimer;
   std::unique_ptr<CLibInputHandler> m_libinput;
+
+private:
+  uint32_t m_hdr_blob_id = 0;
 };
 
 }


### PR DESCRIPTION
This changes the way the HDR activation is done when using GBM to use the interface we have in `CWinSystemBase`.

This is needed to allow HDR activation when not using direct-to-plane rendering.

This also enables the use of the new HDR setting in `settings -> player -> video -> processing -> Use display HDR capabilities`.

The problem here is that we can't yet actually detect if the monitor is HDR capable or not. We need the detection that is in #19141. Currently we just detect if we can output HDR metadata (if the GPU/connector supports it).

I've also added an extra commit to add some debug logging for the HDR metadata to the `VIDEO` component logging.

For platforms that were able to use direct-to-plane and HDR nothing should change. For regular video rendering this will work through the normal renderer `CLinuxRendererGLES` (but not `CRendererDRMPRIMEGLES` yet or `CLinuxRendererGL`) but you may have to disable the new setting to use tone mapping if you don't actually have an HDR capable display.


cc @jernejsk and @popcornmix for testing on their devices :chart_with_upwards_trend: 