### PR TITLE
[addons][audiodecoder] fix media info list show and content scan about packed audiodecoder files

### DIFF
--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -139,6 +139,7 @@ bool CAudioDecoder::Load(const std::string& fileName,
     tag.SetNoOfChannels(cTag->channels);
     tag.SetBitRate(cTag->bitrate);
     tag.SetComment(cTag->comment);
+    tag.SetLoaded(true);
   }
 
   delete cTag;

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -52,7 +52,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
 
   std::string strExtension = URIUtils::GetExtension(url);
   StringUtils::ToLower(strExtension);
-  if (!strExtension.empty() && CServiceBroker::IsBinaryAddonCacheUp())
+  if (!strExtension.empty() && CServiceBroker::IsBinaryAddonCacheUp() &&
+      !StringUtils::EndsWith(strExtension, "stream"))
   {
     std::vector<AddonInfoPtr> addonInfos;
     CServiceBroker::GetAddonMgr().GetAddonInfos(addonInfos, true, ADDON_AUDIODECODER);


### PR DESCRIPTION
## Description

Commit 1:
-----------------
_**[vfs][addons]** Don't check for subdirectories in an open audio decoderlist_

Previously "CFileDirectoryFactory::Create" tried to find and open additional paths with an open audio decoder file, which contains sub-songs.
The sub-files always contain a `.***stream` as an extension, with this the file extension is checked for "stream".

However, since other folders can never be contained there, this check is avoided.

Commit 2:
-----------------
_**[addons]** Mark MusicInfoTag from audiodecoder content as loaded_

Previously this was not done with "tag.SetLoaded(true);" carried out, whereby Kodi could never use the files given here in its file lists.

Adding this call fixes a major error and e.g. content checks and database storage work after this change.

Commit 3:
-----------------
_**[vfs][addons]** Combine test fields of the VFS and audio decoder add-ons_

Before that, they both did exactly the same thing. Since both are binary addons anyway, the field is combined with this and the necessary check only needs to be done once.

In addition, a little documentation has been added to make the said code more understandable.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
Relates to issues reported here:
- https://github.com/xbmc/audiodecoder.sacd/issues/17
- https://github.com/xbmc/audiodecoder.sacd/issues/4

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
With some audiodecoder addons where support tracks and vfs.rar to confirm still works.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
