### PR TITLE
[Subtitles] Keep aspect ratio with PGS subtitles

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -32,6 +32,8 @@
 #include "OverlayRendererDX.h"
 #endif
 
+#include <algorithm>
+
 using namespace OVERLAY;
 
 COverlay::COverlay()
@@ -170,36 +172,51 @@ void CRenderer::Render(COverlay* o)
   COverlay::EPosition pos   = o->m_pos;
   COverlay::EAlign    align = o->m_align;
 
-  if(pos == COverlay::POSITION_RELATIVE)
+  if (pos == COverlay::POSITION_RELATIVE)
   {
     float scale_x = 1.0;
     float scale_y = 1.0;
+    float scale_w = 1.0;
+    float scale_h = 1.0;
 
-    if(align == COverlay::ALIGN_SCREEN
-    || align == COverlay::ALIGN_SUBTITLE)
+    if (align == COverlay::ALIGN_SCREEN || align == COverlay::ALIGN_SUBTITLE)
     {
       scale_x = m_rv.Width();
       scale_y = m_rv.Height();
+      scale_w = scale_x;
+      scale_h = scale_y;
     }
-
-    if(align == COverlay::ALIGN_VIDEO)
+    else if (align == COverlay::ALIGN_VIDEO)
     {
       scale_x = m_rs.Width();
       scale_y = m_rs.Height();
+      scale_w = scale_x;
+      scale_h = scale_y;
+    }
+    else if (align == COverlay::ALIGN_SCREEN_AR)
+    {
+      // Align to screen by keeping aspect ratio to fit into the screen area
+      float source_width = o->m_source_width > 0 ? o->m_source_width : m_rs.Width();
+      float source_height = o->m_source_height > 0 ? o->m_source_height : m_rs.Height();
+      float ratio = std::min<float>(m_rv.Width() / source_width, m_rv.Height() / source_height);
+      scale_x = m_rv.Width();
+      scale_y = m_rv.Height();
+      scale_w = ratio;
+      scale_h = ratio;
     }
 
-    state.x      *= scale_x;
-    state.y      *= scale_y;
-    state.width  *= scale_x;
-    state.height *= scale_y;
+    state.x *= scale_x;
+    state.y *= scale_y;
+    state.width *= scale_w;
+    state.height *= scale_h;
 
     pos = COverlay::POSITION_ABSOLUTE;
   }
 
-  if(pos == COverlay::POSITION_ABSOLUTE)
+  if (pos == COverlay::POSITION_ABSOLUTE)
   {
-    if(align == COverlay::ALIGN_SCREEN
-    || align == COverlay::ALIGN_SUBTITLE)
+    if (align == COverlay::ALIGN_SCREEN || align == COverlay::ALIGN_SCREEN_AR ||
+        align == COverlay::ALIGN_SUBTITLE)
     {
       if(align == COverlay::ALIGN_SUBTITLE)
       {
@@ -213,8 +230,7 @@ void CRenderer::Render(COverlay* o)
         state.y += m_rv.y1;
       }
     }
-
-    if(align == COverlay::ALIGN_VIDEO)
+    else if (align == COverlay::ALIGN_VIDEO)
     {
       float scale_x = m_rd.Width() / m_rs.Width();
       float scale_y = m_rd.Height() / m_rs.Height();
@@ -227,7 +243,6 @@ void CRenderer::Render(COverlay* o)
       state.x      += m_rd.x1;
       state.y      += m_rd.y1;
     }
-
   }
 
   state.x += GetStereoscopicDepth();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -61,6 +61,7 @@ namespace OVERLAY {
     enum EAlign
     {
       ALIGN_SCREEN,
+      ALIGN_SCREEN_AR,
       ALIGN_VIDEO,
       ALIGN_SUBTITLE
     } m_align;
@@ -76,6 +77,8 @@ namespace OVERLAY {
     float m_y;
     float m_width;
     float m_height;
+    float m_source_width; // Video source width resolution used to calculate aspect ratio
+    float m_source_height; // Video source height resolution used to calculate aspect ratio
   };
 
   class CRenderer : public Observer

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -229,31 +229,17 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
 
   if(o->source_width && o->source_height)
   {
-    float center_x = (float)(0.5f * o->width  + o->x) / o->source_width;
+    float center_x = (float)(0.5f * o->width + o->x) / o->source_width;
     float center_y = (float)(0.5f * o->height + o->y) / o->source_height;
 
+    m_align = ALIGN_SCREEN_AR;
+    m_pos = POSITION_RELATIVE;
+    m_x = center_x;
+    m_y = center_y;
     m_width = static_cast<float>(o->width);
     m_height = static_cast<float>(o->height);
-    m_pos    = POSITION_RELATIVE;
-
-#if 0
-    if(center_x > 0.4 && center_x < 0.6
-    && center_y > 0.8 && center_y < 1.0)
-    {
-     /* render bottom aligned to subtitle line */
-      m_align  = ALIGN_SUBTITLE;
-      m_x      = 0.0f;
-      m_y      = - 0.5 * m_height;
-    }
-    else
-#endif
-    {
-      m_align = ALIGN_SCREEN_AR;
-      m_x      = center_x;
-      m_y      = center_y;
-      m_source_width = static_cast<float>(o->source_width);
-      m_source_height = static_cast<float>(o->source_height);
-    }
+    m_source_width = static_cast<float>(o->source_width);
+    m_source_height = static_cast<float>(o->source_height);
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -232,8 +232,8 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
     float center_x = (float)(0.5f * o->width  + o->x) / o->source_width;
     float center_y = (float)(0.5f * o->height + o->y) / o->source_height;
 
-    m_width  = (float)o->width  / o->source_width;
-    m_height = (float)o->height / o->source_height;
+    m_width = static_cast<float>(o->width);
+    m_height = static_cast<float>(o->height);
     m_pos    = POSITION_RELATIVE;
 
 #if 0
@@ -248,10 +248,11 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
     else
 #endif
     {
-      /* render aligned to screen to avoid cropping problems */
-      m_align  = ALIGN_SCREEN;
+      m_align = ALIGN_SCREEN_AR;
       m_x      = center_x;
       m_y      = center_y;
+      m_source_width = static_cast<float>(o->source_width);
+      m_source_height = static_cast<float>(o->source_height);
     }
   }
   else

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -207,15 +207,16 @@ COverlayTextureGL::COverlayTextureGL(CDVDOverlayImage* o)
     float center_x = (0.5f * o->width  + o->x) / o->source_width;
     float center_y = (0.5f * o->height + o->y) / o->source_height;
 
-    m_width  = (float)o->width  / o->source_width;
-    m_height = (float)o->height / o->source_height;
+    m_width = static_cast<float>(o->width);
+    m_height = static_cast<float>(o->height);
     m_pos    = POSITION_RELATIVE;
 
     {
-      /* render aligned to screen to avoid cropping problems */
-      m_align  = ALIGN_SCREEN;
+      m_align = ALIGN_SCREEN_AR;
       m_x      = center_x;
       m_y      = center_y;
+      m_source_width = static_cast<float>(o->source_width);
+      m_source_height = static_cast<float>(o->source_height);
     }
   }
   else

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -207,17 +207,14 @@ COverlayTextureGL::COverlayTextureGL(CDVDOverlayImage* o)
     float center_x = (0.5f * o->width  + o->x) / o->source_width;
     float center_y = (0.5f * o->height + o->y) / o->source_height;
 
+    m_align = ALIGN_SCREEN_AR;
+    m_pos = POSITION_RELATIVE;
+    m_x = center_x;
+    m_y = center_y;
     m_width = static_cast<float>(o->width);
     m_height = static_cast<float>(o->height);
-    m_pos    = POSITION_RELATIVE;
-
-    {
-      m_align = ALIGN_SCREEN_AR;
-      m_x      = center_x;
-      m_y      = center_y;
-      m_source_width = static_cast<float>(o->source_width);
-      m_source_height = static_cast<float>(o->source_height);
-    }
+    m_source_width = static_cast<float>(o->source_width);
+    m_source_height = static_cast<float>(o->source_height);
   }
   else
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Currently PGS subtitles images are stretched in the screen
instead should keep the right aspect ratio but still fill the available screen area

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When i playback a film i noticed the subtitles stretched out
then i found also the Issue opened #14866
this is an attempt to fix this problem, as the calculation for correct resizing of images is missing

in any case this PR not solve all requests of #14866
e.g. i have also noticed that the subtitle positions set to the PGS subtitles are fully ignored and overrided by default by Kodi
I think this situation could also be handled better, it is possible that i will do another PR in the future separately if this one will be approved

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried to play two samples files and 1 my mkv movie by reducing the height of the window
then compared also with VLC

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
here i have changed the size of the window excessively so that the difference is clearly visible

Before:
![02_broken](https://user-images.githubusercontent.com/3257156/135295094-d2e2f3dd-291a-42d0-bc51-c3c4ae058b90.jpg)
After:
![01_Fixed](https://user-images.githubusercontent.com/3257156/135295124-319ed430-848f-4a59-b22b-c91fc7ecb85e.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
