### PR TITLE
[bp][profiles] fix: mediasource return -1 (not found) for "plugin://" protocol

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1163,8 +1163,11 @@ int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES
 
   if (checkURL.IsProtocol("shout"))
     strPath = checkURL.GetHostName();
+
+  // a plugin path should not be configured in any mediasource
   if (checkURL.IsProtocol("plugin"))
-    return 1;
+    return -1;
+
   if (checkURL.IsProtocol("multipath"))
     strPath = CMultiPathDirectory::GetFirstPath(strPath);
 


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20195

function int CUtil::GetMatchingSource() literally returns the value 1 when checking the plugin path of a just started video or audio add-on. this is wrong because the returned value should be the index of the matching mediasource in sources.xml.

if, by coincidence, the 2nd video (or audio) source is restricted by a mediasource lock, the code will be verified though completely unrelated to the started add-on/plugin.

so do not return early with an incorrect return value of 1 in this case. return -1 which indicates 'not found'.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
