### PR TITLE
[cmake][osx] Handle macro for xcode project differences for build systems

### DIFF
--- a/cmake/scripts/osx/Macros.cmake
+++ b/cmake/scripts/osx/Macros.cmake
@@ -26,12 +26,6 @@ function(core_link_library lib wraplib)
     set(check_arg ${ARGV2})
     set(data_arg  ${ARGV3})
 
-    # iOS: EFFECTIVE_PLATFORM_NAME is not resolved
-    # http://public.kitware.com/pipermail/cmake/2016-March/063049.html
-    if(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
-      get_target_property(dir ${lib} BINARY_DIR)
-      set(link_lib ${dir}/${CORE_BUILD_CONFIG}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    endif()
   else()
     set(target ${ARGV2})
     set(link_lib ${lib})

--- a/cmake/scripts/osx/Macros.cmake
+++ b/cmake/scripts/osx/Macros.cmake
@@ -4,7 +4,13 @@ function(core_link_library lib wraplib)
   elseif(CMAKE_GENERATOR MATCHES "Xcode")
     # CURRENT_VARIANT is an Xcode env var
     # CPU is a project cmake var
-    set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$(CURRENT_VARIANT)/${CPU}/wrapper.o)
+    # Xcode new build system (CMAKE_XCODE_BUILD_SYSTEM=12) requires the env var CURRENT_VARIANT to be passed WITHOUT brackets
+    # Xcode Legacy build system (CMAKE_XCODE_BUILD_SYSTEM=1) requires the env var CURRENT_VARIANT to be passed WITH brackets
+    if(CMAKE_XCODE_BUILD_SYSTEM STREQUAL 12)
+      set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$CURRENT_VARIANT/${CPU}/wrapper.o)
+    else()
+			set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$(CURRENT_VARIANT)/${CPU}/wrapper.o)
+    endif()
   else()
     message(FATAL_ERROR "Unsupported generator in core_link_library")
   endif()


### PR DESCRIPTION
## Description
Apple are pushing their new build system more and more, to the point that xcode 13 throws errors for the legacy build system by default.
Cmake xcode project generation for the new build system handles the parsing of an env var to a shell script build step different to the legacy system, so now we detect the build system type and alter the macro as required.

## Motivation and context
Working default xcode generation regardless of Xcode buildsystem type (new/legacy)

## How has this been tested?
Locally generating for new and legacy build systems and executing the wrap_libdvdnav target

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
