### PR TITLE
DRMPRIME: keep plane coords of video render area private

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -104,13 +104,19 @@ void CBaseRenderer::restoreRotatedCoords()
     m_rotatedDestCoords[i] = m_savedRotatedDestCoords[i];
 }
 
-void CBaseRenderer::CalcNormalRenderRect(float offsetX, float offsetY, float width, float height,
-                                         float inputFrameRatio, float zoomAmount, float verticalShift)
+void CBaseRenderer::CalcDestRect(float offsetX,
+                                 float offsetY,
+                                 float width,
+                                 float height,
+                                 float inputFrameRatio,
+                                 float zoomAmount,
+                                 float verticalShift,
+                                 CRect& destRect)
 {
   // if view window is empty, set empty destination
   if (height == 0 || width == 0)
   {
-    m_destRect.SetRect(0.0f, 0.0f, 0.0f, 0.0f);
+    destRect.SetRect(0.0f, 0.0f, 0.0f, 0.0f);
     return;
   }
 
@@ -190,10 +196,26 @@ void CBaseRenderer::CalcNormalRenderRect(float offsetX, float offsetY, float wid
   else if (verticalShift < -1.0f)
     posY += shiftRange * (verticalShift + 1.0f);
 
-  m_destRect.x1 = (float)MathUtils::round_int(static_cast<double>(posX + offsetX));
-  m_destRect.x2 = m_destRect.x1 + MathUtils::round_int(static_cast<double>(newWidth));
-  m_destRect.y1 = (float)MathUtils::round_int(static_cast<double>(posY + offsetY));
-  m_destRect.y2 = m_destRect.y1 + MathUtils::round_int(static_cast<double>(newHeight));
+  destRect.x1 = static_cast<float>(MathUtils::round_int(static_cast<double>(posX + offsetX)));
+  destRect.x2 = destRect.x1 + MathUtils::round_int(static_cast<double>(newWidth));
+  destRect.y1 = static_cast<float>(MathUtils::round_int(static_cast<double>(posY + offsetY)));
+  destRect.y2 = destRect.y1 + MathUtils::round_int(static_cast<double>(newHeight));
+}
+
+void CBaseRenderer::CalcNormalRenderRect(float offsetX,
+                                         float offsetY,
+                                         float width,
+                                         float height,
+                                         float inputFrameRatio,
+                                         float zoomAmount,
+                                         float verticalShift)
+{
+  CalcDestRect(offsetX, offsetY, width, height, inputFrameRatio, zoomAmount, verticalShift,
+               m_destRect);
+
+  // bail out if view window is empty
+  if (height == 0 || width == 0)
+    return;
 
   // clip as needed
   if (!(CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo() || CServiceBroker::GetWinSystem()->GetGfxContext().IsCalibrating()))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -99,6 +99,14 @@ public:
   virtual CRenderCapture* GetRenderCapture() { return nullptr; }
 
 protected:
+  void CalcDestRect(float offsetX,
+                    float offsetY,
+                    float width,
+                    float height,
+                    float inputFrameRatio,
+                    float zoomAmount,
+                    float verticalShift,
+                    CRect& destRect);
   void CalcNormalRenderRect(float offsetX, float offsetY, float width, float height,
                             float inputFrameRatio, float zoomAmount, float verticalShift);
   void CalculateFrameAspectRatio(unsigned int desired_width, unsigned int desired_height);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -131,10 +131,14 @@ void CRendererDRMPRIME::ManageRenderArea()
   RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
   if (info.iScreenWidth != info.iWidth)
   {
-    CalcNormalRenderRect(0, 0, info.iScreenWidth, info.iScreenHeight,
-                         GetAspectRatio() * CDisplaySettings::GetInstance().GetPixelRatio(),
-                         CDisplaySettings::GetInstance().GetZoomAmount(),
-                         CDisplaySettings::GetInstance().GetVerticalShift());
+    CalcDestRect(0, 0, info.iScreenWidth, info.iScreenHeight,
+                 GetAspectRatio() * CDisplaySettings::GetInstance().GetPixelRatio(),
+                 CDisplaySettings::GetInstance().GetZoomAmount(),
+                 CDisplaySettings::GetInstance().GetVerticalShift(), m_planeDestRect);
+  }
+  else
+  {
+    m_planeDestRect = m_destRect;
   }
 }
 
@@ -224,7 +228,7 @@ void CRendererDRMPRIME::RenderUpdate(
   if (m_iLastRenderBuffer == -1)
     m_videoLayerBridge->Configure(buffer);
 
-  m_videoLayerBridge->SetVideoPlane(buffer, m_destRect);
+  m_videoLayerBridge->SetVideoPlane(buffer, m_planeDestRect);
 
   m_iLastRenderBuffer = index;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -50,6 +50,7 @@ protected:
 private:
   bool m_bConfigured = false;
   int m_iLastRenderBuffer = -1;
+  CRect m_planeDestRect;
 
   std::shared_ptr<CVideoLayerBridgeDRMPRIME> m_videoLayerBridge;
 


### PR DESCRIPTION
## Description
Store plane coordinates of render area in a separate, private member
instead of re-using m_destRect so that m_destRect is again guaranteed
to be within m_viewRect.

## Motivation and context
Fixing #20085, see also #20173 for some background discussion

## How has this been tested?
Tested on LibreELEC / RPi4. Verified that subtitles where shown when GUI limit was active.

## What is the effect on users?
Subtitles will be visible, even if the GUI limit setting is used (and active).

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
