### PR TITLE
[PVR] CPVRChannelGroupsContainer::CreateChannelEpgs: Try to create Ra…

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -155,5 +155,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroupsContainer::
 
 bool CPVRChannelGroupsContainer::CreateChannelEpgs()
 {
-  return m_groupsTV->CreateChannelEpgs() && m_groupsRadio->CreateChannelEpgs();
+  bool bReturn = m_groupsTV->CreateChannelEpgs();
+  bReturn &= m_groupsRadio->CreateChannelEpgs();
+  return bReturn;
 }


### PR DESCRIPTION
... dio channel EPGs even if creation of TV channel EPGs failed.

Fixes a small logical error that was there since "ever".

@phunkyfish mind taking a look at the code change?
