### PR TITLE
[PVR] Cleanup texture db and stale cached images

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -174,8 +174,8 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag,
   if (!groupMember)
     groupMember = CServiceBroker::GetPVRManager().GUIActions()->GetChannelGroupMember(*this);
 
-  if (!tag->Icon().empty())
-    SetArt("icon", tag->Icon());
+  if (!tag->IconPath().empty())
+    SetArt("icon", tag->IconPath());
   else
   {
     std::shared_ptr<CPVRChannel> channel;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -235,8 +235,8 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
   m_dwSize = record->GetSizeInBytes();
 
   // Set art
-  if (!record->m_strIconPath.empty())
-    SetArt("icon", record->m_strIconPath);
+  if (!record->IconPath().empty())
+    SetArt("icon", record->IconPath());
   else
   {
     const std::shared_ptr<CPVRChannel> channel = record->Channel();
@@ -248,11 +248,11 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
       SetArt("icon", "DefaultTVShows.png");
   }
 
-  if (!record->m_strThumbnailPath.empty())
-    SetArt("thumb", record->m_strThumbnailPath);
+  if (!record->ThumbnailPath().empty())
+    SetArt("thumb", record->ThumbnailPath());
 
-  if (!record->m_strFanartPath.empty())
-    SetArt("fanart", record->m_strFanartPath);
+  if (!record->FanartPath().empty())
+    SetArt("fanart", record->FanartPath());
 
   FillInMimeType(false);
 }

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -96,7 +96,9 @@ std::string CTextureCache::GetCachedImage(const std::string &image, CTextureDeta
 bool CTextureCache::CanCacheImageURL(const CURL &url)
 {
   return url.GetUserName().empty() || url.GetUserName() == "music" ||
-          StringUtils::StartsWith(url.GetUserName(), "video_");
+         StringUtils::StartsWith(url.GetUserName(), "video_") ||
+         StringUtils::StartsWith(url.GetUserName(), "pvr") ||
+         StringUtils::StartsWith(url.GetUserName(), "epg");
 }
 
 std::string CTextureCache::CheckCachedImage(const std::string &url, bool &needsRecaching)

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -145,7 +145,9 @@ std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned in
       return "";
     if (thumbURL.GetUserName() == "music")
       additional_info = "music";
-    if (StringUtils::StartsWith(thumbURL.GetUserName(), "video_"))
+    if (StringUtils::StartsWith(thumbURL.GetUserName(), "video_") ||
+        StringUtils::StartsWith(thumbURL.GetUserName(), "pvr") ||
+        StringUtils::StartsWith(thumbURL.GetUserName(), "epg"))
       additional_info = thumbURL.GetUserName();
 
     image = thumbURL.GetHostName();

--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(SOURCES PVRChannelNumberInputHandler.cpp
+set(SOURCES PVRCachedImage.cpp
+	    PVRCachedImages.cpp
+            PVRChannelNumberInputHandler.cpp
             PVRContextMenus.cpp
             PVRDatabase.cpp
             PVREdl.cpp
@@ -9,7 +11,9 @@ set(SOURCES PVRChannelNumberInputHandler.cpp
             PVRStreamProperties.cpp
             PVRThumbLoader.cpp)
 
-set(HEADERS PVRChannelNumberInputHandler.h
+set(HEADERS PVRCachedImage.h
+            PVRCachedImages.h
+            PVRChannelNumberInputHandler.h
             PVRContextMenus.h
             PVRDatabase.h
             PVREdl.h

--- a/xbmc/pvr/PVRCachedImage.cpp
+++ b/xbmc/pvr/PVRCachedImage.cpp
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRCachedImage.h"
+
+#include "TextureDatabase.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+using namespace PVR;
+
+CPVRCachedImage::CPVRCachedImage(const std::string& owner) : m_owner(owner)
+{
+}
+
+CPVRCachedImage::CPVRCachedImage(const std::string& clientImage, const std::string& owner)
+  : m_clientImage(clientImage), m_owner(owner)
+{
+  UpdateLocalImage();
+}
+
+bool CPVRCachedImage::operator==(const CPVRCachedImage& right) const
+{
+  return (this == &right) || (m_clientImage == right.m_clientImage &&
+                              m_localImage == right.m_localImage && m_owner == right.m_owner);
+}
+
+bool CPVRCachedImage::operator!=(const CPVRCachedImage& right) const
+{
+  return !(*this == right);
+}
+
+void CPVRCachedImage::SetClientImage(const std::string& image)
+{
+  if (StringUtils::StartsWith(image, "image://"))
+  {
+    CLog::LogF(LOGERROR, "Not allowed to call this method with an image URL");
+    return;
+  }
+
+  if (m_owner.empty())
+  {
+    CLog::LogF(LOGERROR, "Empty owner");
+    return;
+  }
+
+  m_clientImage = image;
+  UpdateLocalImage();
+}
+
+void CPVRCachedImage::SetOwner(const std::string& owner)
+{
+  if (m_owner != owner)
+  {
+    m_owner = owner;
+    UpdateLocalImage();
+  }
+}
+
+void CPVRCachedImage::UpdateLocalImage()
+{
+  if (m_clientImage.empty())
+    m_localImage.clear();
+  else
+    m_localImage = CTextureUtils::GetWrappedImageURL(m_clientImage, m_owner);
+}

--- a/xbmc/pvr/PVRCachedImage.h
+++ b/xbmc/pvr/PVRCachedImage.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace PVR
+{
+
+class CPVRCachedImage
+{
+public:
+  CPVRCachedImage() = delete;
+  virtual ~CPVRCachedImage() = default;
+
+  explicit CPVRCachedImage(const std::string& owner);
+  CPVRCachedImage(const std::string& clientImage, const std::string& owner);
+
+  bool operator==(const CPVRCachedImage& right) const;
+  bool operator!=(const CPVRCachedImage& right) const;
+
+  const std::string& GetClientImage() const { return m_clientImage; }
+  const std::string& GetLocalImage() const { return m_localImage; }
+
+  void SetClientImage(const std::string& image);
+
+  void SetOwner(const std::string& owner);
+
+private:
+  void UpdateLocalImage();
+
+  std::string m_clientImage;
+  std::string m_localImage;
+  std::string m_owner;
+};
+
+} // namespace PVR

--- a/xbmc/pvr/PVRCachedImages.cpp
+++ b/xbmc/pvr/PVRCachedImages.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRCachedImages.h"
+
+#include "TextureCache.h"
+#include "TextureDatabase.h"
+#include "URL.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+
+using namespace PVR;
+
+int CPVRCachedImages::Cleanup(const std::vector<PVRImagePattern>& urlPatterns,
+                              const std::vector<std::string>& urlsToCheck,
+                              bool clearTextureForPath /* = false */)
+{
+  int iCleanedImages = 0;
+
+  if (urlPatterns.empty())
+  {
+    CLog::LogFC(LOGERROR, LOGPVR, "No URL patterns given");
+    return iCleanedImages;
+  }
+
+  CTextureDatabase db;
+  if (!db.Open())
+  {
+    CLog::LogFC(LOGERROR, LOGPVR, "Failed to open texture database");
+    return iCleanedImages;
+  }
+
+  CDatabase::Filter filter;
+
+  for (const auto& pattern : urlPatterns)
+  {
+    const std::string encodedPattern =
+        StringUtils::Format("{}@{}", pattern.owner, CURL::Encode(pattern.path));
+
+    std::string escapedPattern;
+    for (int i = 0; i < encodedPattern.size(); ++i)
+    {
+      if (encodedPattern[i] == '%' || encodedPattern[i] == '^')
+        escapedPattern += '^';
+
+      escapedPattern += encodedPattern[i];
+    }
+
+    const std::string where =
+        StringUtils::Format("url LIKE 'image://{}%' ESCAPE '^'", escapedPattern);
+    filter.AppendWhere(where, false); // logical OR
+  }
+
+  CVariant items;
+  if (!db.GetTextures(items, filter))
+  {
+    CLog::LogFC(LOGERROR, LOGPVR, "Failed to get items from texture database");
+    return iCleanedImages;
+  }
+
+  for (unsigned int i = 0; i < items.size(); ++i)
+  {
+    // Unwrap the image:// URL returned from texture db.
+    const std::string textureURL = UnwrapImageURL(items[i]["url"].asString());
+
+    bool bFound = false;
+    for (const auto& url : urlsToCheck)
+    {
+      if (url == textureURL)
+      {
+        bFound = true;
+        break; // next item
+      }
+    }
+
+    if (!bFound)
+    {
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Removing stale cached image: '{}'", textureURL);
+      CTextureCache::GetInstance().ClearCachedImage(items[i]["textureid"].asInteger());
+
+      if (clearTextureForPath)
+        db.ClearTextureForPath(textureURL, "thumb");
+
+      iCleanedImages++;
+    }
+  }
+
+  return iCleanedImages;
+}
+
+std::string CPVRCachedImages::UnwrapImageURL(const std::string& url)
+{
+  return StringUtils::StartsWith(url, "image://") ? CURL(url).GetHostName() : url;
+}

--- a/xbmc/pvr/PVRCachedImages.h
+++ b/xbmc/pvr/PVRCachedImages.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace PVR
+{
+
+struct PVRImagePattern
+{
+  PVRImagePattern(const std::string& _owner, const std::string& _path) : owner(_owner), path(_path)
+  {
+  }
+
+  std::string owner;
+  std::string path;
+};
+
+class CPVRCachedImages
+{
+public:
+  /*!
+   * @brief Erase stale texture db entries and image files.
+   * @param urlPatterns The URL patterns to fetch from texture database.
+   * @param urlsToCheck The URLs to check for still being present in the texture db.
+   * @param clearTextureForPath Whether to clear the path in texture database.
+   * @return number of cleaned up images.
+   */
+  static int Cleanup(const std::vector<PVRImagePattern>& urlPatterns,
+                     const std::vector<std::string>& urlsToCheck,
+                     bool clearTextureForPath = false);
+
+  /*!
+   * @brief Extract the wrapped URL from an image URL.
+   * @param url The URL to unwrap.
+   * @return The unwrapped URL if url is an image URL, url otherwise.
+   */
+  static std::string UnwrapImageURL(const std::string& url);
+};
+
+} // namespace PVR

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -327,16 +327,15 @@ int CPVRDatabase::Get(bool bRadio,
     {
       while (!m_pDS->eof())
       {
-        const std::shared_ptr<CPVRChannel> channel(new CPVRChannel());
+        const std::shared_ptr<CPVRChannel> channel(new CPVRChannel(
+            m_pDS->fv("bIsRadio").get_asBool(), m_pDS->fv("sIconPath").get_asString()));
 
         channel->m_iChannelId = m_pDS->fv("idChannel").get_asInt();
         channel->m_iUniqueId = m_pDS->fv("iUniqueId").get_asInt();
-        channel->m_bIsRadio = m_pDS->fv("bIsRadio").get_asBool();
         channel->m_bIsHidden = m_pDS->fv("bIsHidden").get_asBool();
         channel->m_bIsUserSetIcon = m_pDS->fv("bIsUserSetIcon").get_asBool();
         channel->m_bIsUserSetName = m_pDS->fv("bIsUserSetName").get_asBool();
         channel->m_bIsLocked = m_pDS->fv("bIsLocked").get_asBool();
-        channel->m_strIconPath = m_pDS->fv("sIconPath").get_asString();
         channel->m_strChannelName = m_pDS->fv("sChannelName").get_asString();
         channel->m_bEPGEnabled = m_pDS->fv("bEPGEnabled").get_asBool();
         channel->m_strEPGScraper = m_pDS->fv("sEPGScraper").get_asString();
@@ -730,27 +729,34 @@ bool CPVRDatabase::Persist(CPVRChannel& channel, bool bCommit)
   if (strValue.empty())
   {
     /* new channel */
-    strQuery = PrepareSQL("INSERT INTO channels ("
+    strQuery = PrepareSQL(
+        "INSERT INTO channels ("
         "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsUserSetName, bIsLocked, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "idEpg, bHasArchive) "
         "VALUES (%i, %i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i)",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
-        channel.IconPath().c_str(), channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), static_cast<unsigned int>(channel.LastWatched()), channel.ClientID(),
-        channel.EpgID(), channel.HasArchive());
+        channel.UniqueID(), (channel.IsRadio() ? 1 : 0), (channel.IsHidden() ? 1 : 0),
+        (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0),
+        (channel.IsLocked() ? 1 : 0), channel.ClientIconPath().c_str(),
+        channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0),
+        channel.EPGScraper().c_str(), static_cast<unsigned int>(channel.LastWatched()),
+        channel.ClientID(), channel.EpgID(), channel.HasArchive());
   }
   else
   {
     /* update channel */
-    strQuery = PrepareSQL("REPLACE INTO channels ("
+    strQuery = PrepareSQL(
+        "REPLACE INTO channels ("
         "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsUserSetName, bIsLocked, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "idChannel, idEpg, bHasArchive) "
         "VALUES (%i, %i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %s, %i, %i)",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
-        channel.IconPath().c_str(), channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), static_cast<unsigned int>(channel.LastWatched()), channel.ClientID(),
-        strValue.c_str(),
-        channel.EpgID(), channel.HasArchive());
+        channel.UniqueID(), (channel.IsRadio() ? 1 : 0), (channel.IsHidden() ? 1 : 0),
+        (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0),
+        (channel.IsLocked() ? 1 : 0), channel.ClientIconPath().c_str(),
+        channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0),
+        channel.EPGScraper().c_str(), static_cast<unsigned int>(channel.LastWatched()),
+        channel.ClientID(), strValue.c_str(), channel.EpgID(), channel.HasArchive());
   }
 
   if (QueueInsertQuery(strQuery))

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -860,6 +860,7 @@ void CPVRManager::TriggerCleanupCachedImages()
     CLog::Log(LOGINFO, "PVR Manager: Starting cleanup of cached images.");
     iCleanedImages += Recordings()->CleanupCachedImages();
     iCleanedImages += ChannelGroups()->CleanupCachedImages();
+    iCleanedImages += EpgContainer().CleanupCachedImages();
     CLog::Log(LOGINFO, "PVR Manager: Cleaned up {} cached images.", iCleanedImages);
     return true;
   });

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -859,6 +859,7 @@ void CPVRManager::TriggerCleanupCachedImages()
     int iCleanedImages = 0;
     CLog::Log(LOGINFO, "PVR Manager: Starting cleanup of cached images.");
     iCleanedImages += Recordings()->CleanupCachedImages();
+    iCleanedImages += ChannelGroups()->CleanupCachedImages();
     CLog::Log(LOGINFO, "PVR Manager: Cleaned up {} cached images.", iCleanedImages);
     return true;
   });

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -295,6 +295,11 @@ namespace PVR
     void TriggerSearchMissingChannelIcons();
 
     /*!
+     * @brief Let the background thread erase stale texture db entries and image files.
+     */
+    void TriggerCleanupCachedImages();
+
+    /*!
      * @brief Let the background thread search for missing channel icons for channels contained in the given group.
      * @param group The channel group.
      */

--- a/xbmc/pvr/PVRThumbLoader.cpp
+++ b/xbmc/pvr/PVRThumbLoader.cpp
@@ -13,6 +13,7 @@
 #include "TextureCache.h"
 #include "TextureCacheJob.h"
 #include "pictures/Picture.h"
+#include "pvr/PVRCachedImages.h"
 #include "pvr/PVRManager.h"
 #include "pvr/filesystem/PVRGUIDirectory.h"
 #include "settings/AdvancedSettings.h"
@@ -110,7 +111,7 @@ std::string CPVRThumbLoader::CreateChannelGroupThumb(const CFileItem& channelGro
     {
       const std::string& icon = channel->GetArt("icon");
       if (!icon.empty())
-        channelIcons.emplace_back(icon);
+        channelIcons.emplace_back(CPVRCachedImages::UnwrapImageURL(icon));
 
       if (channelIcons.size() == 9) // limit number of tiles
         break;

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -307,11 +307,11 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording& xbmcRecording,
           sizeof(addonRecording.strGenreDescription) - 1);
   strncpy(addonRecording.strChannelName, xbmcRecording.m_strChannelName.c_str(),
           sizeof(addonRecording.strChannelName) - 1);
-  strncpy(addonRecording.strIconPath, xbmcRecording.m_strIconPath.c_str(),
+  strncpy(addonRecording.strIconPath, xbmcRecording.ClientIconPath().c_str(),
           sizeof(addonRecording.strIconPath) - 1);
-  strncpy(addonRecording.strThumbnailPath, xbmcRecording.m_strThumbnailPath.c_str(),
+  strncpy(addonRecording.strThumbnailPath, xbmcRecording.ClientThumbnailPath().c_str(),
           sizeof(addonRecording.strThumbnailPath) - 1);
-  strncpy(addonRecording.strFanartPath, xbmcRecording.m_strFanartPath.c_str(),
+  strncpy(addonRecording.strFanartPath, xbmcRecording.ClientFanartPath().c_str(),
           sizeof(addonRecording.strFanartPath) - 1);
   addonRecording.recordingTime =
       recTime - CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection;

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -394,7 +394,7 @@ void CPVRClient::WriteClientChannelInfo(const std::shared_ptr<CPVRChannel>& xbmc
   addonChannel.iSubChannelNumber = xbmcChannel->ClientChannelNumber().GetSubChannelNumber();
   strncpy(addonChannel.strChannelName, xbmcChannel->ClientChannelName().c_str(),
           sizeof(addonChannel.strChannelName) - 1);
-  strncpy(addonChannel.strIconPath, xbmcChannel->IconPath().c_str(),
+  strncpy(addonChannel.strIconPath, xbmcChannel->ClientIconPath().c_str(),
           sizeof(addonChannel.strIconPath) - 1);
   addonChannel.iEncryptionSystem = xbmcChannel->EncryptionSystem();
   addonChannel.bIsRadio = xbmcChannel->IsRadio();

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -738,7 +738,7 @@ public:
       m_strWriter(kodiTag->DeTokenize(kodiTag->Writers())),
       m_strIMDBNumber(kodiTag->IMDBNumber()),
       m_strEpisodeName(kodiTag->EpisodeName()),
-      m_strIconPath(kodiTag->Icon()),
+      m_strIconPath(kodiTag->ClientIconPath()),
       m_strSeriesLink(kodiTag->SeriesLink()),
       m_strGenreDescription(kodiTag->GetGenresLabel())
   {

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -28,6 +28,8 @@
 
 using namespace PVR;
 
+const std::string CPVRChannel::IMAGE_OWNER_PATTERN = "pvrchannel_{}";
+
 bool CPVRChannel::operator==(const CPVRChannel& right) const
 {
   return (m_bIsRadio == right.m_bIsRadio &&
@@ -40,13 +42,16 @@ bool CPVRChannel::operator!=(const CPVRChannel& right) const
   return !(*this == right);
 }
 
-CPVRChannel::CPVRChannel()
+CPVRChannel::CPVRChannel(bool bRadio)
+  : m_bIsRadio(bRadio),
+    m_iconPath("", StringUtils::Format(IMAGE_OWNER_PATTERN, bRadio ? "radio" : "tv"))
 {
   UpdateEncryptionName();
 }
 
-CPVRChannel::CPVRChannel(bool bRadio)
-  : m_bIsRadio(bRadio)
+CPVRChannel::CPVRChannel(bool bRadio, const std::string& iconPath)
+  : m_bIsRadio(bRadio),
+    m_iconPath(iconPath, StringUtils::Format(IMAGE_OWNER_PATTERN, bRadio ? "radio" : "tv"))
 {
   UpdateEncryptionName();
 }
@@ -54,7 +59,8 @@ CPVRChannel::CPVRChannel(bool bRadio)
 CPVRChannel::CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId)
   : m_bIsRadio(channel.bIsRadio),
     m_bIsHidden(channel.bIsHidden),
-    m_strIconPath(channel.strIconPath),
+    m_iconPath(channel.strIconPath,
+               StringUtils::Format(IMAGE_OWNER_PATTERN, channel.bIsRadio ? "radio" : "tv")),
     m_strChannelName(channel.strChannelName),
     m_bHasArchive(channel.bHasArchive),
     m_bEPGEnabled(!channel.bIsHidden),
@@ -82,7 +88,7 @@ void CPVRChannel::Serialize(CVariant& value) const
   value["channeltype"] = m_bIsRadio ? "radio" : "tv";
   value["hidden"] = m_bIsHidden;
   value["locked"] = m_bIsLocked;
-  value["icon"] = m_strIconPath;
+  value["icon"] = ClientIconPath();
   value["channel"]  = m_strChannelName;
   value["uniqueid"]  = m_iUniqueId;
   CDateTime lastPlayed(m_iLastWatched);
@@ -196,8 +202,8 @@ bool CPVRChannel::UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel)
   // only update the channel name and icon if the user hasn't changed them manually
   if (m_strChannelName.empty() || !IsUserSetName())
     SetChannelName(channel->ClientChannelName());
-  if (m_strIconPath.empty() || !IsUserSetIcon())
-    SetIconPath(channel->IconPath());
+  if (IconPath().empty() || !IsUserSetIcon())
+    SetIconPath(channel->ClientIconPath());
 
   return m_bChanged;
 }
@@ -318,17 +324,20 @@ bool CPVRChannel::SetArchive(bool bHasArchive)
 
 bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIcon /* = false */)
 {
-  CSingleLock lock(m_critSection);
-  if (m_strIconPath != strIconPath)
+  if (StringUtils::StartsWith(strIconPath, "image://"))
   {
-    m_strIconPath = strIconPath;
-
-    m_bChanged = true;
-    m_bIsUserSetIcon = bIsUserSetIcon && !m_strIconPath.empty();
-    return true;
+    CLog::LogF(LOGERROR, "Not allowed to call this method with an image URL");
+    return false;
   }
 
-  return false;
+  CSingleLock lock(m_critSection);
+  if (ClientIconPath() == strIconPath)
+    return false;
+
+  m_iconPath.SetClientImage(strIconPath);
+  m_bChanged = true;
+  m_bIsUserSetIcon = bIsUserSetIcon && !IconPath().empty();
+  return true;
 }
 
 bool CPVRChannel::SetChannelName(const std::string& strChannelName, bool bIsUserSetName /*= false*/)
@@ -668,10 +677,16 @@ bool CPVRChannel::IsLocked() const
   return m_bIsLocked;
 }
 
+std::string CPVRChannel::ClientIconPath() const
+{
+  CSingleLock lock(m_critSection);
+  return m_iconPath.GetClientImage();
+}
+
 std::string CPVRChannel::IconPath() const
 {
   CSingleLock lock(m_critSection);
-  return m_strIconPath;
+  return m_iconPath.GetLocalImage();
 }
 
 bool CPVRChannel::IsUserSetIcon() const

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h"
+#include "pvr/PVRCachedImage.h"
 #include "pvr/channels/PVRChannelNumber.h"
 #include "threads/CriticalSection.h"
 #include "utils/ISerializable.h"
@@ -34,7 +35,10 @@ namespace PVR
     friend class CPVRDatabase;
 
   public:
+    static const std::string IMAGE_OWNER_PATTERN;
+
     explicit CPVRChannel(bool bRadio);
+    CPVRChannel(bool bRadio, const std::string& iconPath);
     CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId);
 
     virtual ~CPVRChannel();
@@ -142,6 +146,11 @@ namespace PVR
      * @return True if the flag was changed, false otherwise.
      */
     bool SetArchive(bool bHasArchive);
+
+    /*!
+     * @return The path to the icon for this channel as given by the client.
+     */
+    std::string ClientIconPath() const;
 
     /*!
      * @return The path to the icon for this channel.
@@ -433,7 +442,7 @@ namespace PVR
 
     //@}
   private:
-    CPVRChannel();
+    CPVRChannel() = delete;
     CPVRChannel(const CPVRChannel& tag) = delete;
     CPVRChannel& operator=(const CPVRChannel& channel) = delete;
 
@@ -456,7 +465,7 @@ namespace PVR
     bool m_bIsUserSetName = false; /*!< true if user set the channel name via GUI, false if not */
     bool m_bIsUserSetIcon = false; /*!< true if user set the icon via GUI, false if not */
     bool m_bIsLocked = false; /*!< true if channel is locked, false if not */
-    std::string m_strIconPath; /*!< the path to the icon for this channel */
+    CPVRCachedImage m_iconPath; /*!< the path to the icon for this channel */
     std::string m_strChannelName; /*!< the name for this channel used by XBMC */
     time_t m_iLastWatched = 0; /*!< last time channel has been watched */
     bool m_bChanged = false; /*!< true if anything in this entry was changed that needs to be persisted */

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -12,6 +12,7 @@
 
 #include "ServiceBroker.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channel_groups.h"
+#include "pvr/PVRCachedImages.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
@@ -1148,4 +1149,20 @@ void CPVRChannelGroup::SetPosition(int iPosition)
     if (m_bLoaded)
       m_bChanged = true;
   }
+}
+
+int CPVRChannelGroup::CleanupCachedImages()
+{
+  std::vector<std::string> urlsToCheck;
+  {
+    CSingleLock lock(m_critSection);
+    for (const auto& groupMember : m_members)
+    {
+      urlsToCheck.emplace_back(groupMember.second->Channel()->ClientIconPath());
+    }
+  }
+
+  const std::string owner =
+      StringUtils::Format(CPVRChannel::IMAGE_OWNER_PATTERN, IsRadio() ? "radio" : "tv");
+  return CPVRCachedImages::Cleanup({{owner, ""}}, urlsToCheck);
 }

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -450,6 +450,12 @@ namespace PVR
      */
     bool IsDeleted() const { return m_bDeleted; }
 
+    /*!
+     * @brief Erase stale texture db entries and image files.
+     * @return number of cleaned up images.
+     */
+    int CleanupCachedImages();
+
   protected:
     /*!
      * @brief Remove deleted group members from this group.

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -600,6 +600,9 @@ int CPVRChannelGroups::CleanupCachedImages()
 {
   int iCleanedImages = 0;
 
+  // cleanup channels
+  iCleanedImages += GetGroupAll()->CleanupCachedImages();
+
   // cleanup groups
   std::vector<std::string> urlsToCheck;
   {

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -9,6 +9,7 @@
 #include "PVRChannelGroups.h"
 
 #include "ServiceBroker.h"
+#include "pvr/PVRCachedImages.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
@@ -593,4 +594,25 @@ bool CPVRChannelGroups::CreateChannelEpgs()
       bReturn = (*it)->CreateChannelEpgs();
   }
   return bReturn;
+}
+
+int CPVRChannelGroups::CleanupCachedImages()
+{
+  int iCleanedImages = 0;
+
+  // cleanup groups
+  std::vector<std::string> urlsToCheck;
+  {
+    CSingleLock lock(m_critSection);
+    for (const auto& group : m_groups)
+    {
+      urlsToCheck.emplace_back(group->GetPath());
+    }
+  }
+
+  // kodi-generated thumbnail (see CPVRThumbLoader)
+  const std::string path = StringUtils::Format("pvr://channels/{}/", IsRadio() ? "radio" : "tv");
+  iCleanedImages += CPVRCachedImages::Cleanup({{"pvr", path}}, urlsToCheck, true);
+
+  return iCleanedImages;
 }

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -211,6 +211,12 @@ namespace PVR
      */
     bool UpdateChannelNumbersFromAllChannelsGroup();
 
+    /*!
+     * @brief Erase stale texture db entries and image files.
+     * @return number of cleaned up images.
+     */
+    int CleanupCachedImages();
+
   private:
     bool LoadFromDb();
     void SortGroups();

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -157,3 +157,8 @@ bool CPVRChannelGroupsContainer::CreateChannelEpgs()
 {
   return m_groupsTV->CreateChannelEpgs() && m_groupsRadio->CreateChannelEpgs();
 }
+
+int CPVRChannelGroupsContainer::CleanupCachedImages()
+{
+  return m_groupsTV->CleanupCachedImages() + m_groupsRadio->CleanupCachedImages();
+}

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -151,6 +151,12 @@ namespace PVR
      */
     bool CreateChannelEpgs();
 
+    /*!
+     * @brief Erase stale texture db entries and image files.
+     * @return number of cleaned up images.
+     */
+    int CleanupCachedImages();
+
   private:
     CPVRChannelGroupsContainer& operator=(const CPVRChannelGroupsContainer&) = delete;
     CPVRChannelGroupsContainer(const CPVRChannelGroupsContainer&) = delete;

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
+#include "pvr/PVRCachedImages.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/epg/EpgChannelData.h"
@@ -551,4 +552,12 @@ bool CPVREpg::IsValid() const
 void CPVREpg::RemovedFromContainer()
 {
   m_events.Publish(PVREvent::EpgDeleted);
+}
+
+int CPVREpg::CleanupCachedImages(const std::shared_ptr<CPVREpgDatabase>& database)
+{
+  const std::vector<std::string> urlsToCheck = database->GetAllIconPaths(EpgID());
+  const std::string owner = StringUtils::Format(CPVREpgInfoTag::IMAGE_OWNER_PATTERN, EpgID());
+
+  return CPVRCachedImages::Cleanup({{owner, ""}}, urlsToCheck);
 }

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -282,6 +282,13 @@ namespace PVR
      */
     void RemovedFromContainer();
 
+    /*!
+     * @brief Erase stale texture db entries and image files.
+     * @param database The EPG database
+     * @return number of cleaned up images.
+     */
+    int CleanupCachedImages(const std::shared_ptr<CPVREpgDatabase>& database);
+
   private:
     CPVREpg() = delete;
     CPVREpg(const CPVREpg&) = delete;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -937,4 +937,25 @@ void CPVREpgContainer::OnSystemWake()
   m_bSuspended = false;
 }
 
+int CPVREpgContainer::CleanupCachedImages()
+{
+  int iCleanedImages = 0;
+
+  CSingleLock lock(m_critSection);
+
+  const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
+  if (!database)
+  {
+    CLog::LogF(LOGERROR, "No EPG database");
+    return iCleanedImages;
+  }
+
+  for (const auto& epg : m_epgIdToEpgMap)
+  {
+    iCleanedImages += epg.second->CleanupCachedImages(database);
+  }
+
+  return iCleanedImages;
+}
+
 } // namespace PVR

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -219,6 +219,12 @@ namespace PVR
      */
     void OnSystemWake();
 
+    /*!
+     * @brief Erase stale texture db entries and image files.
+     * @return number of cleaned up images.
+     */
+    int CleanupCachedImages();
+
   private:
     /*!
      * @brief Notify EPG table observers when the currently active tag changed.

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -110,6 +110,13 @@ namespace PVR
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllEpgTags(int iEpgID);
 
     /*!
+     * @brief Get all icon paths for a given EPG id.
+     * @param iEpgID The ID of the EPG.
+     * @return The entries.
+     */
+    std::vector<std::string> GetAllIconPaths(int iEpgID);
+
+    /*!
      * @brief Get the start time of the first tag in this EPG.
      * @param iEpgID The ID of the EPG.
      * @return The time.

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "XBDateTime.h"
+#include "pvr/PVRCachedImage.h"
 #include "threads/CriticalSection.h"
 #include "utils/ISerializable.h"
 
@@ -30,6 +31,8 @@ namespace PVR
     friend class CPVREpgDatabase;
 
   public:
+    static const std::string IMAGE_OWNER_PATTERN;
+
     /*!
      * @brief Create a new EPG infotag.
      * @param data The tag's data.
@@ -318,10 +321,16 @@ namespace PVR
     std::string EpisodeName() const;
 
     /*!
-     * @brief Get the path to the icon for this event.
+     * @brief Get the path to the icon for this event used by Kodi.
      * @return The path to the icon
      */
-    std::string Icon() const;
+    std::string IconPath() const;
+
+    /*!
+     * @brief Get the path to the icon for this event as given by the client.
+     * @return The path to the icon
+     */
+    std::string ClientIconPath() const;
 
     /*!
      * @brief The path to this event.
@@ -431,8 +440,9 @@ namespace PVR
     static const std::string DeTokenize(const std::vector<std::string>& tokens);
 
   private:
-    CPVREpgInfoTag();
+    CPVREpgInfoTag(int iEpgID, const std::string& iconPath);
 
+    CPVREpgInfoTag() = delete;
     CPVREpgInfoTag(const CPVREpgInfoTag& tag) = delete;
     CPVREpgInfoTag& operator =(const CPVREpgInfoTag& other) = delete;
 
@@ -474,7 +484,7 @@ namespace PVR
     std::string m_strIMDBNumber; /*!< imdb number */
     std::vector<std::string> m_genre; /*!< genre */
     std::string m_strEpisodeName; /*!< episode name */
-    std::string m_strIconPath; /*!< the path to the icon */
+    CPVRCachedImage m_iconPath; /*!< the path to the icon */
     std::string m_strFileNameAndPath; /*!< the filename and path */
     CDateTime m_startTime; /*!< event start time */
     CDateTime m_endTime; /*!< event end time */

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -635,7 +635,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         strValue = epgTag->GetWritersLabel();
         return true;
       case LISTITEM_EPG_EVENT_ICON:
-        strValue = epgTag->Icon();
+        strValue = epgTag->IconPath();
         return true;
       case VIDEOPLAYER_PARENTAL_RATING:
       case LISTITEM_PARENTAL_RATING:
@@ -728,7 +728,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::
       const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag)
       {
-        strValue = epgTag->Icon();
+        strValue = epgTag->IconPath();
       }
       return true;
     }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -25,6 +25,7 @@
  */
 
 #include "XBDateTime.h"
+#include "pvr/PVRCachedImage.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 #include "video/Bookmark.h"
@@ -65,15 +66,14 @@ namespace PVR
   class CPVRRecording final : public CVideoInfoTag
   {
   public:
+    static const std::string IMAGE_OWNER_PATTERN;
+
     int m_iClientId; /*!< ID of the backend */
     std::string m_strRecordingId; /*!< unique ID of the recording on the client */
     std::string m_strChannelName; /*!< name of the channel this was recorded from */
     int m_iPriority; /*!< priority of this recording */
     int m_iLifetime; /*!< lifetime of this recording */
     std::string m_strDirectory; /*!< directory of this recording on the client */
-    std::string m_strIconPath; /*!< icon path */
-    std::string m_strThumbnailPath; /*!< thumbnail path */
-    std::string m_strFanartPath; /*!< fanart path */
     unsigned m_iRecordingId; /*!< id that won't change while xbmc is running */
 
     CPVRRecording();
@@ -282,6 +282,42 @@ namespace PVR
     int ClientID() const;
 
     /*!
+     * @brief Return the icon path as given by the client.
+     * @return The path.
+     */
+    const std::string& ClientIconPath() const { return m_iconPath.GetClientImage(); }
+
+    /*!
+     * @brief Return the thumbnail path as given by the client.
+     * @return The path.
+     */
+    const std::string& ClientThumbnailPath() const { return m_thumbnailPath.GetClientImage(); }
+
+    /*!
+     * @brief Return the fanart path as given by the client.
+     * @return The path.
+     */
+    const std::string& ClientFanartPath() const { return m_fanartPath.GetClientImage(); }
+
+    /*!
+     * @brief Return the icon path used by Kodi.
+     * @return The path.
+     */
+    const std::string& IconPath() const { return m_iconPath.GetLocalImage(); }
+
+    /*!
+     * @brief Return the thumnail path used by Kodi.
+     * @return The path.
+     */
+    const std::string& ThumbnailPath() const { return m_thumbnailPath.GetLocalImage(); }
+
+    /*!
+     * @brief Return the fanart path used by Kodi.
+     * @return The path.
+     */
+    const std::string& FanartPath() const { return m_fanartPath.GetLocalImage(); }
+
+    /*!
      * @brief Retrieve the recording Episode Name
      * @note Returns an empty string if no Episode Name was provided by the PVR client
      */
@@ -406,6 +442,9 @@ namespace PVR
   private:
     void UpdatePath();
 
+    CPVRCachedImage m_iconPath; /*!< icon path */
+    CPVRCachedImage m_thumbnailPath; /*!< thumbnail path */
+    CPVRCachedImage m_fanartPath; /*!< fanart path */
     CDateTime m_recordingTime; /*!< start time of the recording */
     bool m_bGotMetaData;
     bool m_bIsDeleted; /*!< set if entry is a deleted recording which can be undelete */

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -96,6 +96,12 @@ namespace PVR
      */
     std::shared_ptr<CPVRRecording> GetRecordingForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
 
+    /*!
+     * @brief Erase stale texture db entries and image files.
+     * @return number of cleaned up images.
+     */
+    int CleanupCachedImages();
+
   private:
     mutable CCriticalSection m_critSection;
     bool m_bIsUpdating = false;


### PR DESCRIPTION
Texture db and `Thumbnails` directory over time gets filled by PVR components with lots of stale db entries and cached files for channel logos, EPG tag thumbnails, recording thumbnails, recording icons, ...

This PR introduces a background job to cleanup the mess on a regular base (30 secs after PVR startup, then every 12 hours). 

Although for some user actions we could detect the need to clean the db immediately (e.g. user triggers to delete a recording from inside Kodi), we also need a background job to catch deletion/change of images done by the user in the backend while kodi is not running. The job covers everything, no need to pollute the code with additional logics to do a live cleanup. 

Changes were tested carefully for some weeks on macOS and Android.

@phunkyfish when you find some time for a review, I suggest to do it commit by commit, thaen you should be able to follow the code logics quite well.