### PR TITLE
[Subtitles] Avoid using hardcoded style ids

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -85,6 +85,12 @@ protected:
   bool CreateTrack();
 
   /*!
+  * \brief Create a new empty ASS style
+  * \return True if success, false if error
+  */
+  bool CreateStyle();
+
+  /*!
   * \brief Specify whether the subtitles are
   * native (loaded from ASS/SSA file or stream)
   * or adapted (converted from other types e.g. SubRip)
@@ -133,6 +139,11 @@ private:
   ASS_Renderer* m_renderer = nullptr;
   mutable CCriticalSection m_section;
   ASSSubType m_subtitleType;
-  int m_currentStyleId;
+
+  // current default style ID of the ASS track
+  int m_currentDefaultStyleId{ASS_NO_ID};
+
+  // default allocated style ID for the kodi user configured subtitle style
+  int m_defaultKodiStyleId{ASS_NO_ID};
   bool m_drawWithinBlackBars;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
@@ -27,7 +27,7 @@ CSubtitlesAdapter::~CSubtitlesAdapter()
 bool CSubtitlesAdapter::Initialize()
 {
   m_libass->SetSubtitleType(ADAPTED);
-  return m_libass->CreateTrack();
+  return m_libass->CreateTrack() && m_libass->CreateStyle();
 }
 
 int CSubtitlesAdapter::AddSubtitle(const char* text, double startTime, double stopTime)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR tries to improve a bit the way we handle libass styles for converted overlay types - by avoiding the usage of hardcoded style ids. Making assumptions about the presence (or absence) of a given default style id provided beforehand by libass is wrong as it might change between library versions (and strongly depends on the library internals). So this PR allocates a default kodi style id before ass_events are created so that the id is set on all events. When applying the style properties from the overlayrender, this style is then "enabled" and used when populating the struct.

@CastagnaIT looks like I can't add you as a reviewer. Can you please also take a look?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix the issues with subtitles not being displayed in Ubuntu (at least it does for me).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime tested with native and converted subs

## What is the effect on users?
Should fix converted subtitles not displaying with different library versions

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
