### PR TITLE
Add RTLD_LOCAL to dlopen() explicitly to force it on macOS

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/DllHelper.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/DllHelper.h
@@ -162,7 +162,7 @@ public:
     }
 #endif
 
-    m_dll = dlopen(path.c_str(), RTLD_LAZY);
+    m_dll = dlopen(path.c_str(), RTLD_LOCAL | RTLD_LAZY);
     if (m_dll == nullptr)
     {
       kodi::Log(ADDON_LOG_ERROR, "Unable to load %s", dlerror());


### PR DESCRIPTION
## Description

On Linux, RTLD_LOCAL is the default. But on macOS, RTLD_GLOBAL is the default.

See https://developer.apple.com/forums/thread/670849?answerId=669217022#669217022

## Motivation and context

When using binary addons, it is preferable that the symbols in each addon stay separate and not pollute the global process namespace.

## How has this been tested?

I have not tested this change.

## What is the effect on users?

No effect on users.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
