### PR TITLE
[PVR] Channel Manager: Add 'refresh channel logos'

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9452,7 +9452,13 @@ msgctxt "#19040"
 msgid "Timers"
 msgstr ""
 
-#empty strings from id 19041 to 19042
+#. Label for button to refresh the channel logos
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
+msgctxt "#19041"
+msgid "Refresh channel logos"
+msgstr ""
+
+#empty string with id 19042
 
 #. pvr settings "recording" category label
 #: system/settings/settings.xml

--- a/addons/skin.estuary/xml/DialogPVRChannelManager.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelManager.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">20</defaultcontrol>
+	<defaultcontrol always="true">4</defaultcontrol>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">
 			<centertop>50%</centertop>
-			<height>895</height>
+			<height>995</height>
 			<centerleft>50%</centerleft>
 			<width>1820</width>
 			<include content="DialogBackgroundCommons">
 				<param name="width" value="1820" />
-				<param name="height" value="895" />
+				<param name="height" value="995" />
 				<param name="header_label" value="$VAR[PVRChannelMgrHeader]$INFO[Container(20).NumItems, (,)]" />
 				<param name="header_id" value="2" />
 			</include>
@@ -21,7 +21,7 @@
 					<left>660</left>
 					<top>30</top>
 					<width>12</width>
-					<height>770</height>
+					<height>870</height>
 					<onleft>20</onleft>
 					<onright>9002</onright>
 					<orientation>vertical</orientation>
@@ -30,14 +30,14 @@
 					<left>0</left>
 					<top>10</top>
 					<width>672</width>
-					<height>810</height>
+					<height>910</height>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
 				<control type="list" id="20">
 					<left>20</left>
 					<top>30</top>
 					<width>630</width>
-					<height>770</height>
+					<height>870</height>
 					<onup>20</onup>
 					<ondown>20</ondown>
 					<onleft>9000</onleft>
@@ -142,7 +142,7 @@
 					<onleft>60</onleft>
 					<onright>9000</onright>
 					<onup>34</onup>
-					<ondown>30</ondown>
+					<ondown>35</ondown>
 					<itemgap>-22</itemgap>
 					<control type="label" id="9001">
 						<description>channel options Header</description>
@@ -217,6 +217,14 @@
 						<aligny>center</aligny>
 						<textcolor>button_focus</textcolor>
 						<shadowcolor>black</shadowcolor>
+					</control>
+					<control type="button" id="35">
+						<description>Refresh channel logos Button</description>
+						<width>700</width>
+						<height>100</height>
+						<textoffsetx>40</textoffsetx>
+						<align>center</align>
+						<label>$LOCALIZE[19041]</label>
 					</control>
 					<control type="button" id="31">
 						<description>New channel Button</description>

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -468,6 +468,11 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
       for (unsigned int i = 0; i < m_items.size(); ++i)
         m_items[i]->SetInvalid();
     }
+    else if (message.GetMessage() == GUI_MSG_REFRESH_THUMBS)
+    {
+      if (m_listProvider)
+        m_listProvider->FreeResources(true);
+    }
     else if (message.GetMessage() == GUI_MSG_MOVE_OFFSET)
     {
       int count = message.GetParam1();

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -351,6 +351,13 @@ void CDirectoryProvider::Reset()
   }
 }
 
+void CDirectoryProvider::FreeResources(bool immediately)
+{
+  CSingleLock lock(m_section);
+  for (const auto& item : m_items)
+    item->FreeMemory(immediately);
+}
+
 void CDirectoryProvider::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 {
   CSingleLock lock(m_section);

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -64,6 +64,7 @@ public:
   bool OnInfo(const CGUIListItemPtr &item) override;
   bool OnContextMenu(const CGUIListItemPtr &item) override;
   bool IsUpdating() const override;
+  void FreeResources(bool immediately) override;
 
   // callback from directory job
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -59,6 +59,11 @@ public:
    */
   virtual void Reset() {}
 
+  /*! \brief Free all GUI resources allocated by the items.
+   \param immediately true to free resources imediately, free resources async later otherwise.
+   */
+  virtual void FreeResources(bool immediately) {}
+
   /*! \brief Click event on an item.
    \param item the item that was clicked.
    \return true if the click was handled, false otherwise.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "GUIPassword.h"
 #include "ServiceBroker.h"
+#include "TextureCache.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
@@ -59,6 +60,7 @@
 #define BUTTON_GROUP_MANAGER      30
 #define BUTTON_NEW_CHANNEL        31
 #define BUTTON_RADIO_TV           34
+#define BUTTON_REFRESH_LOGOS 35
 
 using namespace PVR;
 using namespace KODI::MESSAGING;
@@ -518,6 +520,28 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
   return true;
 }
 
+bool CGUIDialogPVRChannelManager::OnClickButtonRefreshChannelLogos()
+{
+  for (const auto& item : *m_channelItems)
+  {
+    const std::string thumb = item->GetArt("thumb");
+    if (!thumb.empty())
+    {
+      // clear current cached image
+      CTextureCache::GetInstance().ClearCachedImage(thumb);
+      item->SetArt("thumb", "");
+    }
+  }
+
+  m_iSelected = 0;
+  Update();
+
+  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
+  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+
+  return true;
+}
+
 bool CGUIDialogPVRChannelManager::OnMessageClick(CGUIMessage& message)
 {
   int iControl = message.GetSenderId();
@@ -549,6 +573,8 @@ bool CGUIDialogPVRChannelManager::OnMessageClick(CGUIMessage& message)
     return OnClickButtonGroupManager(message);
   case BUTTON_NEW_CHANNEL:
     return OnClickButtonNewChannel();
+  case BUTTON_REFRESH_LOGOS:
+    return OnClickButtonRefreshChannelLogos();
   default:
     return false;
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -72,6 +72,7 @@ namespace PVR
     bool OnClickEPGSourceSpin(CGUIMessage& message);
     bool OnClickButtonGroupManager(CGUIMessage& message);
     bool OnClickButtonNewChannel();
+    bool OnClickButtonRefreshChannelLogos();
 
     bool PersistChannel(const CFileItemPtr& pItem, const std::shared_ptr<CPVRChannelGroup>& group, unsigned int* iChannelNumber);
 


### PR DESCRIPTION
Channel logos are cached in texture db. Kodi does not detect if the URL of a channel logo stays the same but the content changes. Calculating hashes, re-fetching each logo periodically from the backends, checking the hashes is not a (good) solution, because only purpose of the cache is to make it possible not to fetch the icons from the server on every startup/periodically.

So I think the most easy and for most users intuitive way to deal with this is to add a button to PVR Channel Manager which refreshes all icons and this is, what this PR implements.

![screenshot00005](https://user-images.githubusercontent.com/3226626/135705843-d87f94c1-5e58-42cb-b707-43dfda889419.png)

@phunkyfish got some time for another code review?
@ronie do the skin changes look okay?
 