### PR TITLE
[PVR] Reset PVR database: Add selection dialog for components to reset.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9275,6 +9275,7 @@ msgstr ""
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
 #: xbmc/pvr/PVRGUIDirectory.cpp
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#19017"
 msgid "Recordings"
 msgstr ""
@@ -9285,13 +9286,14 @@ msgctxt "#19018"
 msgid "Folder with channel icons"
 msgstr ""
 
-#. label for PVR backend number of channels in system information's PVR section
+#. generic label for pvr channels used in different places
 #: addons/skin.estuary/xml/DialogPVRChannelGuide.xml
 #: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 #: addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: addons/skin.estuary/xml/Home.xml
 #: xbmc/pvr/PVRGUIDirectory.cpp
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#19019"
 msgid "Channels"
@@ -9622,8 +9624,9 @@ msgctxt "#19068"
 msgid "Recording settings"
 msgstr ""
 
-#. Electronic program guide
+#. generic label for the electronic program guide (EPG) used in different places
 #: addons/skin.estuary/xml/Variables.xml
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#19069"
 msgid "Guide"
 msgstr ""
@@ -10081,7 +10084,9 @@ msgctxt "#19145"
 msgid "Grouped"
 msgstr ""
 
+#. generic label for pvr channel groups used in different places
 #: addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#19146"
 msgid "Groups"
 msgstr ""
@@ -10329,21 +10334,21 @@ msgid "Clear data"
 msgstr ""
 
 #. message box text for pvr data reset confirmation
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#19186"
-msgid "All your TV related data (channels, groups, guide, timers, clients) will be cleared. Are you sure?"
+msgid "All selected data will be cleared. Some information cannot be restored from the clients afterwards. Proceed anyway?"
 msgstr ""
 
 #. progress dialog text shown while purging pvr data
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#19187"
-msgid "Clearing all related data."
+msgid "Clearing data."
 msgstr ""
 
 #. message box text for epg data reset confirmation
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#19188"
-msgid "All your guide data will be cleared. Are you sure?"
+msgid "All guide data will be cleared. Are you sure?"
 msgstr ""
 
 #. message box text stating that the PVR backend forbids to record a given epg event.
@@ -10496,8 +10501,9 @@ msgctxt "#19214"
 msgid "Enter a valid URL for the new channel"
 msgstr ""
 
-#. pvr settings "reminders" category label
+#. generic label for PVR reminders used in different places
 #: system/settings/settings.xml
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#19215"
 msgid "Reminders"
 msgstr ""
@@ -15079,7 +15085,9 @@ msgctxt "#24018"
 msgid "Services"
 msgstr ""
 
+#. generic label to denote the addon type pvr clients, used in different places
 #: xbmc/addons/Addon.cpp
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 msgctxt "#24019"
 msgid "PVR clients"
 msgstr ""
@@ -19085,7 +19093,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36209"
-msgid "Delete the databases for channels and guide and reimport the data from the backend afterwards."
+msgid "Clear the databases for PVR data like channels, groups, reminders and guide. Please note that not all data can be restored from the backend afterwards."
 msgstr ""
 
 #: system/settings/settings.xml

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -609,6 +609,12 @@ public:
    */
   void EraseAllVideoSettings(const std::string& path);
 
+  /**
+   * Erases all entries for files starting with path, including the files and path entries
+   * @param path pattern
+   */
+  void EraseAllForPath(const std::string& path);
+
   bool GetStackTimes(const std::string &filePath, std::vector<uint64_t> &times);
   void SetStackTimes(const std::string &filePath, const std::vector<uint64_t> &times);
 


### PR DESCRIPTION
With this PR users can choose which parts of the PVR/EPG database they want to reset. This is helpful, if for examples channel data got inconsistent and needs a reset, but user defined Reminders shall be kept.

Please note that it is not possible to delete channels alone. If channels are reset, groups and EPG must also be reset. Thus, no single "channels" entry in the selection dialog possible.

![screenshot00006](https://user-images.githubusercontent.com/3226626/135706108-90e7bea7-6d8c-47c0-8536-93bceeda9aef.png)

@phunkyfish another request for a code review.