### PR TITLE
[GUI][Settings] Update settings when playback start/stop

### DIFF
--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -106,6 +106,17 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
       }
       break;
     }
+
+    case GUI_MSG_PLAYBACK_STARTED:
+    case GUI_MSG_PLAYBACK_ENDED:
+    case GUI_MSG_PLAYBACK_STOPPED:
+    {
+      if (IsActive())
+      {
+        UpdateSettings();
+      }
+      break;
+    }
   }
 
   return CGUIDialogSettingsManagerBase::OnMessage(message);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When there are settings that use the setting condition `isplaying` and the user starts or stops a video while browsing the settings, the status of settings will not be updated, this allows updating

@enen92 on your report i tried to find a possible solution

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With PR#20010 i have introduced setting condition `isplaying` https://github.com/xbmc/xbmc/pull/20010/commits/054ee81f903ba4ce44e8e3d8ac73a04650fc2c62
and has been used with two settings:
`Override ASS/SSA fonts`
`Override ASS/SSA styles`

this works, but not in real time e.g. while a user browse the settings and the video is stopped,
the settings are not updated, and to reflect the new changes to the user should press back and re-enter to the settings page

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Play a video, open subtitle settings page and look if
`Override ASS/SSA fonts`
`Override ASS/SSA styles`
will be enabled in real time while stop the video

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
a better experience

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
