### PR TITLE
[GUI][SubtitlesDialog] Add context menu options for subtitle addons

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -60,6 +60,7 @@ msgstr ""
 
 #: xbmc/windows/GUIWindowFileManager.cpp
 #: addons/skin.estuary/xml/Variables.xml
+#: xbmc/video/dialogs/GUIDialogSubtitles.cpp
 msgctxt "#5"
 msgid "Settings"
 msgstr ""
@@ -15094,6 +15095,7 @@ msgctxt "#24020"
 msgid "Configure"
 msgstr ""
 
+#: xbmc/video/dialogs/GUIDialogSubtitles.cpp
 msgctxt "#24021"
 msgid "Disable"
 msgstr ""

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -14,7 +14,9 @@
 #include "URL.h"
 #include "Util.h"
 #include "addons/AddonManager.h"
+#include "addons/gui/GUIDialogAddonSettings.h"
 #include "cores/IPlayer.h"
+#include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/AddonsDirectory.h"
 #include "filesystem/Directory.h"
@@ -48,6 +50,12 @@ constexpr int CONTROL_SUBSEXIST = 130;
 constexpr int CONTROL_SUBSTATUS = 140;
 constexpr int CONTROL_SERVICELIST = 150;
 constexpr int CONTROL_MANUALSEARCH = 160;
+
+enum class SUBTITLE_SERVICE_CONTEXT_BUTTONS
+{
+  ADDON_SETTINGS,
+  ADDON_DISABLE
+};
 } // namespace
 
 /*! \brief simple job to retrieve a directory and store a string (language)
@@ -113,6 +121,9 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
     bool selectAction = (message.GetParam1() == ACTION_SELECT_ITEM ||
                          message.GetParam1() == ACTION_MOUSE_LEFT_CLICK);
 
+    bool contextMenuAction = (message.GetParam1() == ACTION_CONTEXT_MENU ||
+                              message.GetParam1() == ACTION_MOUSE_RIGHT_CLICK);
+
     if (selectAction && iControl == CONTROL_SUBLIST)
     {
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_SUBLIST);
@@ -135,6 +146,17 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
         Search();
       }
       return true;
+    }
+    else if (contextMenuAction && iControl == CONTROL_SERVICELIST)
+    {
+      CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_SERVICELIST);
+      OnMessage(msg);
+
+      const int itemIdx = msg.GetParam1();
+      if (itemIdx >= 0 && itemIdx < m_serviceItems->Size())
+      {
+        OnSubtitleServiceContextMenu(itemIdx);
+      }
     }
     else if (iControl == CONTROL_MANUALSEARCH)
     {
@@ -381,6 +403,53 @@ void CGUIDialogSubtitles::OnSearchComplete(const CFileItemList *items)
   }
 
   SetInvalid();
+}
+
+void CGUIDialogSubtitles::OnSubtitleServiceContextMenu(int itemIdx)
+{
+  const auto service = m_serviceItems->Get(itemIdx);
+
+  CContextButtons buttons;
+  // Subtitle addon settings
+  buttons.Add(static_cast<int>(SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_SETTINGS),
+              g_localizeStrings.Get(21417));
+  // Disable addon
+  buttons.Add(static_cast<int>(SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_DISABLE),
+              g_localizeStrings.Get(24021));
+
+  auto idx = static_cast<SUBTITLE_SERVICE_CONTEXT_BUTTONS>(CGUIDialogContextMenu::Show(buttons));
+  switch (idx)
+  {
+    case SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_SETTINGS:
+    {
+      AddonPtr addon;
+      CServiceBroker::GetAddonMgr().GetAddon(service->GetProperty("Addon.ID").asString(), addon,
+                                             ADDON_SUBTITLE_MODULE, OnlyEnabled::YES);
+      CGUIDialogAddonSettings::ShowForAddon(addon);
+      break;
+    }
+    case SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_DISABLE:
+    {
+      CServiceBroker::GetAddonMgr().DisableAddon(service->GetProperty("Addon.ID").asString(),
+                                                 AddonDisabledReason::USER);
+      const bool currentActiveServiceWasDisabled =
+          m_currentService == service->GetProperty("Addon.ID").asString();
+      FillServices();
+      // restart search if the current active service was disabled
+      if (currentActiveServiceWasDisabled && !m_serviceItems->IsEmpty())
+      {
+        Search();
+      }
+      // if no more services are available make sure the subtitle list is cleaned up
+      else if (m_serviceItems->IsEmpty())
+      {
+        ClearSubtitles();
+      }
+      break;
+    }
+    default:
+      break;
+  }
 }
 
 void CGUIDialogSubtitles::UpdateStatus(STATUS status)

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -39,13 +39,16 @@
 using namespace ADDON;
 using namespace XFILE;
 
-#define CONTROL_NAMELABEL            100
-#define CONTROL_NAMELOGO             110
-#define CONTROL_SUBLIST              120
-#define CONTROL_SUBSEXIST            130
-#define CONTROL_SUBSTATUS            140
-#define CONTROL_SERVICELIST          150
-#define CONTROL_MANUALSEARCH         160
+namespace
+{
+constexpr int CONTROL_NAMELABEL = 100;
+constexpr int CONTROL_NAMELOGO = 110;
+constexpr int CONTROL_SUBLIST = 120;
+constexpr int CONTROL_SUBSEXIST = 130;
+constexpr int CONTROL_SUBSTATUS = 140;
+constexpr int CONTROL_SERVICELIST = 150;
+constexpr int CONTROL_MANUALSEARCH = 160;
+} // namespace
 
 /*! \brief simple job to retrieve a directory and store a string (language)
  */

--- a/xbmc/video/dialogs/GUIDialogSubtitles.h
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.h
@@ -50,6 +50,14 @@ protected:
   void Download(const CFileItem &subtitle);
   void OnDownloadComplete(const CFileItemList *items, const std::string &language);
 
+
+  /*!
+   \brief Called when the context menu is requested on a subtitle service
+   present on the list of installed subtitle addons
+   \param itemIdx the index of the selected subtitle service on the list
+  */
+  void OnSubtitleServiceContextMenu(int itemIdx);
+
   void SetSubtitles(const std::string &subtitle);
 
   CCriticalSection m_critsection;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The subtitle dialog (the dialog you use to download subtitles) lack context menu items on the list of available subtitle services. One of the things that annoys me the most after a fresh kodi installation, regarding subtitles, is the fact that I constantly forget that some of the services (such as opensubtitles) requires authentication. To be able to fill the credentials, and if you've just started playing some media content, you'd have to close the dialog, close the subtitle settings dialog, move back to the Kodi main window, get to the addon browser, find the subtitle addon in question and then configure it...and afterwards, repeat the playback process. We should be able to do it rigth from the subtitles dialog.

On the other hand, subtitle services are also prone to change (and get broken) over time. You usually only notice this when you attempt to download subtitles after playback has started. So, it'd be great if we could also disable those addons right from the same dialog.

That's what this PR does. It adds context menu items to the list of services displayed on the subtitles dialog, enabling 2 items: "Settings" and "Disable"

@CastagnaIT can you take a look?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve user experience, mostly mine :)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime tested

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
They should be able to access subtitle addon settings right from the subtitle dialog. They can also disable subtitle addons if for some reason they don't work anymore.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7375276/135729150-fadaffdc-bb48-431e-829f-f49f3a58a23b.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
