### PR TITLE
[ios/tvos] fallout from #20216 - MPMediaItem artwork

### DIFF
--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -179,7 +179,7 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
           item[@"artist"] = @[item[@"title"]];
           item[@"title"] = @(epg_title.c_str());
         }
-        auto epg_icon = epg_now->Icon();
+        auto epg_icon = epg_now->ClientIconPath();
         if (!epg_icon.empty())
         {
           // If we have the TV show icon, use it instead of the channel logo.


### PR DESCRIPTION
## Description
Fix a build failure for ios/tvos introduced after @ksooo's work with #20216  

```
05:13:50 /Users/Shared/jenkins/workspace/IOS-ARM64/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm:182:34: error: no member named 'Icon' in 'PVR::CPVREpgInfoTag'
05:13:50         auto epg_icon = epg_now->Icon();
05:13:50                         ~~~~~~~  ^
05:13:50 1 error generated.
05:13:50
```

## Motivation and context
Fixes build failure on ios

## How has this been tested?
To be - Hoping @sy6sy2 might have a quick setup to test its working as intended and getting the correct icon.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
