### PR TITLE
[Estuary] Fix PVR Guide window breadcrumb.

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -425,8 +425,8 @@
 		<value>$LOCALIZE[19021] / $LOCALIZE[19019] / $INFO[Control.GetLabel(29)]</value>
 	</variable>
 	<variable name="BreadcrumbsPVRGuideVar">
-		<value condition="Window.IsActive(TVGuide)">$LOCALIZE[19020] / $INFO[Control.GetLabel(29)] - $INFO[Control.GetLabel(30)]</value>
-		<value>$LOCALIZE[19021] / $INFO[Control.GetLabel(29)] - $INFO[Control.GetLabel(30)]</value>
+		<value condition="Window.IsActive(TVGuide)">$LOCALIZE[19020] / $LOCALIZE[19069] / $INFO[Control.GetLabel(30)]</value>
+		<value>$LOCALIZE[19021] / $LOCALIZE[19069] / $INFO[Control.GetLabel(30)]</value>
 	</variable>
 	<variable name="BreadcrumbsPVRRecordingsVar">
 		<value condition="Window.IsActive(TVRecordings) + String.Contains(Control.GetLabel(7),*)">$LOCALIZE[19020] / $LOCALIZE[19017]$INFO[Control.GetLabel(30), / ] - $LOCALIZE[19179]</value>


### PR DESCRIPTION
All PVR windows except the Guide window follow a common scheme for the breadcrumb shown in the top left of Estuary screen:

`(TV|Radio) / <component-name> / <cpmponent-specific-info>`

This PR changes the breadcrumb for the Guide window to also use this scheme. I think the mismatch is a leftover from times where the Guide window had different views, like timeline, currently playing, etc. These views were removed years ago. 

<img width="1679" alt="Screenshot 2021-10-02 at 19 49 52" src="https://user-images.githubusercontent.com/3226626/135746611-3d41a8da-34b7-44f5-9217-588845fe6133.png">

@ronie another request for a review.