### PR TITLE
[gui] Allow tabs to text in GUI

### DIFF
--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -222,6 +222,8 @@ protected:
   CRenderSystemBase *m_renderSystem = nullptr;
 
 private:
+  float GetTabSpaceLength();
+
   virtual bool FirstBegin() = 0;
   virtual void LastEnd() = 0;
   CGUIFontTTF(const CGUIFontTTF&) = delete;


### PR DESCRIPTION
## Description

This change introduces the support of tabs in texts, which are then correctly displayed in the GUI with up to 4 spaces.

The new text variable for this is `[TABS] tab amount [/TABS]`, or direct use of the `\t`.

The background is to have larger text blocks more structured, as individual spaces are more difficult to lay in lines in the correct vertical order.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context

I once brought it into my binary addon system rework project and now thought of bringing it into master.
Really find it very useful in bigger things as a possibility.

Gosh. As a note to "xbmc/windows/GUIWindowSystemInfo.cpp", the thing really needs to be revised, because it doesn't really fit into international text styles :roll_eyes::smirk:.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

See test commit, but can also be direct inside strings.po.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Example before:
![Bildschirmfoto von 2021-10-03 13-21-38](https://user-images.githubusercontent.com/6879739/135751800-7caf79ab-a4fc-4602-b16e-d2cb06193577.png)
![Bildschirmfoto von 2021-10-03 13-27-14](https://user-images.githubusercontent.com/6879739/135751810-4af39f67-7994-4ca1-b767-f03aeb5afaf3.png)

Example after:
![Bildschirmfoto von 2021-10-03 13-20-56](https://user-images.githubusercontent.com/6879739/135751825-c826934f-8682-45a2-9748-2e8df80e3912.png)
![Bildschirmfoto von 2021-10-03 13-31-19](https://user-images.githubusercontent.com/6879739/135751843-0317d8ac-4f57-4465-a8a6-37bf44034b5a.png)
Note about first line, there it takes a bit longer, thats why not done for there :smile: 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
