### PR TITLE
[addons] Use changelog.txt as an alternative to news XML tag

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -235,7 +235,7 @@ const std::string& CAddonInfo::GetTranslatedText(const std::unordered_map<std::s
   // find the language from the list that matches the current locale best
   std::string matchingLanguage = g_langInfo.GetLocale().FindBestMatch(locales);
   if (matchingLanguage.empty())
-    matchingLanguage = "en_GB";
+    matchingLanguage = KODI_ADDON_DEFAULT_LANGUAGE_CODE;
 
   auto const& translatedValue = locales.find(matchingLanguage);
   if (translatedValue != locales.end())

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -27,6 +27,12 @@ class CAddonInfo;
 typedef std::shared_ptr<CAddonInfo> AddonInfoPtr;
 typedef std::vector<AddonInfoPtr> AddonInfos;
 
+/*!
+ * Defines the default language code used as fallback in case the requested language is not
+ * available. Used, for instance, to handle content from addon.xml.
+ */
+constexpr const char* KODI_ADDON_DEFAULT_LANGUAGE_CODE = "en_GB";
+
 enum class AddonDisabledReason
 {
   /// @brief Special reason for returning all disabled addons.

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -331,7 +331,8 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
       if (element && element->GetText() != nullptr)
       {
         addon->m_lifecycleState = AddonLifecycleState::BROKEN;
-        addon->m_lifecycleStateDescription.emplace("en_gb", element->GetText());
+        addon->m_lifecycleStateDescription.emplace(KODI_ADDON_DEFAULT_LANGUAGE_CODE,
+                                                   element->GetText());
       }
 
       /* Parse addon.xml "<lifecyclestate">...</lifecyclestate>" */
@@ -384,7 +385,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
           CFile file;
           auto_buffer buf;
           if (file.LoadFile(changelog, buf) > 0)
-            addon->m_changelog["en_GB"].assign(buf.get(), buf.size());
+            addon->m_changelog[KODI_ADDON_DEFAULT_LANGUAGE_CODE].assign(buf.get(), buf.size());
         }
       }
     }
@@ -584,7 +585,8 @@ bool CAddonInfoBuilder::GetTextList(const TiXmlElement* element, const std::stri
         translatedValues.insert(std::make_pair(lang, text != nullptr ? text : ""));
     }
     else
-      translatedValues.insert(std::make_pair("en_GB", text != nullptr ? text : ""));
+      translatedValues.insert(
+          std::make_pair(KODI_ADDON_DEFAULT_LANGUAGE_CODE, text != nullptr ? text : ""));
   }
 
   return !translatedValues.empty();

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -118,6 +118,12 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
   }
 
   /*
+   * The function variable "repo" is only used when reading data stored on the internet.
+   * A boolean value is then set here for easier identification.
+   */
+  const bool isRepoXMLContent = !repo.datadir.empty();
+
+  /*
    * Parse addon.xml:
    * <addon id="???"
    *        name="???"
@@ -188,7 +194,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
   }
 
   std::string assetBasePath;
-  if (repo.artdir.empty() && !addonPath.empty())
+  if (!isRepoXMLContent && !addonPath.empty())
   {
     // Default for add-on information not loaded from repository
     assetBasePath = addonPath;
@@ -367,7 +373,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
        * whether it is an installed addon and read a changelog.txt as a
        * replacement, if available. */
       GetTextList(child, "news", addon->m_changelog);
-      if (addon->m_changelog.empty() && repo.artdir.empty() && !addonPath.empty())
+      if (addon->m_changelog.empty() && !isRepoXMLContent && !addonPath.empty())
       {
         using XFILE::auto_buffer;
         using XFILE::CFile;
@@ -428,7 +434,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
     {
       // Prevent log file entry if data is from repository, there normal on
       // addons for other OS's
-      if (repo.datadir.empty())
+      if (!isRepoXMLContent)
         CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: addon.xml from '{}' for binary type '{}' doesn't contain library and addon becomes ignored",
                       __FUNCTION__, addon->ID(), CAddonInfo::TranslateType(addon->m_mainType));
       return false;


### PR DESCRIPTION
## Description

In the event that the changes log (news) in addon.xml is empty, check whether it is an installed addon and read a changelog.txt as a replacement, if available.

Many addons use this "changelog.txt", but less use the `<news>` field in addon.xml, and nobody actually uses the translation path in it (once unknown and difficult to keep correct in the case of continuous changes).
Hence, this brings a fall back to reading the text file as a replacement.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context

This is second pull request try, by them before https://github.com/xbmc/xbmc/pull/20209 was Jenkins strange.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Here about this file https://github.com/xbmc/audiodecoder.sacd/blob/Matrix/audiodecoder.sacd/changelog.txt given to it:
![Bildschirmfoto von 2021-09-30 14-39-01](https://user-images.githubusercontent.com/6879739/135457690-f9491d8e-c958-4c15-b9a3-72214083c21b.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
