### PR TITLE
spelling: 'dependency add-ons' are just 'add-ons'

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21186,31 +21186,31 @@ msgstr ""
 #. Menuitem at "Settings -> System -> Add-ons"
 #: ./system/settings/settings.xml
 msgctxt "#36638"
-msgid "Remove all orphaned dependencies"
+msgid "Remove all orphaned add-ons"
 msgstr ""
 
 #. Description of setting with label #36638 "Remove all orphaned dependencies"
 #: system/settings/settings.xml
 msgctxt "#36639"
-msgid "Remove all modules and support libraries that have been automatically installed as a dependency to other add-ons and are in an orphaned state."
+msgid "Remove all modules and support libraries that have been automatically installed and are in an orphaned state."
 msgstr ""
 
 #. Dialog caption
 #: xbmc/addons/AddonSystemSettings.cpp
 msgctxt "#36640"
-msgid "Orphaned dependencies"
+msgid "Orphaned add-ons"
 msgstr ""
 
-#. Dialog text if orphaned dependencies were found and removed
+#. Dialog text if orphaned add-ons were found and removed
 #: xbmc/addons/AddonSystemSettings.cpp
 msgctxt "#36641"
-msgid "The following orphaned dependency add-ons were removed from your system: {0:s}."
+msgid "The following orphaned add-ons were removed from your system: {0:s}."
 msgstr ""
 
-#. Dialog text if no more orphaned dependencies left on the system
+#. Dialog text if no more orphaned add-ons left on the system
 #: xbmc/addons/AddonSystemSettings.cpp
 msgctxt "#36642"
-msgid "No orphaned dependency add-ons to remove."
+msgid "No orphaned add-ons to remove."
 msgstr ""
 
 #empty strings from id 36643 to 36898

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -231,8 +231,8 @@ std::vector<std::string> CAddonInstaller::RemoveOrphanedDepsRecursively() const
       }
       else
       {
-        CLog::Log(LOGERROR, "CAddonMgr::{}: failed to remove orphaned dependency: {}", __FUNCTION__,
-                  dep->Name());
+        CLog::Log(LOGERROR, "CAddonMgr::{}: failed to remove orphaned add-on/dependency: {}",
+                  __func__, dep->Name());
       }
     }
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -114,9 +114,9 @@ public:
   bool RemoveDependency(const std::shared_ptr<IAddon>& dependsId) const;
 
   /*!
-   * \brief Removes all orphaned dependency add-ons recursively. Removal may orphan further
-   *        dependencies, so loop until no orphaned is left on the system
-   * \return Names of dependencies that have effectively been removed
+   * \brief Removes all orphaned add-ons recursively. Removal may orphan further
+   *        add-ons/dependencies, so loop until no orphaned is left on the system
+   * \return Names of add-ons that have effectively been removed
    */
   std::vector<std::string> RemoveOrphanedDepsRecursively() const;
 


### PR DESCRIPTION
## Description
follow up to https://github.com/xbmc/xbmc/pull/19843

## Motivation and context
phrase "dependency add-ons" is vaguely formulated. change to "add-ons"
mostly it's dependencies that get orphaned, but not always.
