### PR TITLE
[Windows] Updates SystemInfo to recognize Windows 11

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -697,6 +697,10 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
       osNameVer.append("10");
       appendWindows10NameVersion(osNameVer);
       break;
+    case WindowsVersionWin11:
+      osNameVer.append("11");
+      appendWindows10NameVersion(osNameVer);
+      break;
     case WindowsVersionFuture:
       osNameVer.append("Unknown future version");
       break;
@@ -869,6 +873,8 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin10_1909;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 19041)
         m_WinVer = WindowsVersionWin10_2004;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 22000)
+        m_WinVer = WindowsVersionWin11;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber > 19041)
         m_WinVer = WindowsVersionWin10_Future;
       /* Insert checks for new Windows versions here */

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -83,6 +83,7 @@ public:
     WindowsVersionWin10_1909,   // Windows 10 1909
     WindowsVersionWin10_2004,   // Windows 10 2004
     WindowsVersionWin10_Future, // Windows 10 future build
+    WindowsVersionWin11,        // Windows 11
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code
   };


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20101

## Motivation and context
This is not purely a fix, but if Windows 11 is incorrectly detected as Windows 10 it can be interpreted as a bug.

## What is the effect on users?
Identifies Windows 11 at system info and debug logs.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
