### PR TITLE
[PVR] Fix detection of duplicate lines in RDS text.

### DIFF
--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -668,7 +668,7 @@ void CPVRRadioRDSInfoTag::Info::Add(const std::string& text)
   std::string tmp = Trim(text);
   g_charsetConverter.unknownToUTF8(tmp);
 
-  if (std::find(m_data.begin(), m_data.end(), text) != m_data.end())
+  if (std::find(m_data.begin(), m_data.end(), tmp) != m_data.end())
     return;
 
   if (m_data.size() >= 10)


### PR DESCRIPTION
A stupid mistake preventing to detect and withdraw of duplicate RDS text lines. As the trimmed and converted line is stored, we must check existing lines against the new text after trimming and converting it.

@phunkyfish a nobrainer for a quick review.