### PR TITLE
CDVDOverlayImage: cleanup

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -267,8 +267,8 @@ CDVDOverlay* CDVDOverlayCodecFFmpeg::GetOverlay()
     overlay->iPTSStopTime  = m_StopTime;
     overlay->replace  = true;
     overlay->linesize = rect.w;
-    overlay->data     = (uint8_t*)malloc(rect.w * rect.h);
-    overlay->palette  = (uint32_t*)malloc(rect.nb_colors*4);
+    overlay->data = std::vector<uint8_t>(rect.w * rect.h);
+    overlay->palette = std::vector<uint32_t>(rect.nb_colors);
     overlay->palette_colors = rect.nb_colors;
     overlay->x        = rect.x;
     overlay->y        = rect.y;
@@ -280,7 +280,7 @@ CDVDOverlay* CDVDOverlayCodecFFmpeg::GetOverlay()
     overlay->source_height = m_height;
 
     uint8_t* s = rect.data[0];
-    uint8_t* t = overlay->data;
+    uint8_t* t = overlay->data.data();
     for(int i=0;i<rect.h;i++)
     {
       memcpy(t, s, rect.w);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
@@ -20,8 +20,8 @@ class CDVDOverlayImage : public CDVDOverlay
 public:
   CDVDOverlayImage() : CDVDOverlay(DVDOVERLAY_TYPE_IMAGE)
   {
-    data = NULL;
-    palette = NULL;
+    data = {};
+    palette = {};
     palette_colors = 0;
     linesize = 0;
     x = 0;
@@ -32,45 +32,19 @@ public:
     source_height = 0;
   }
 
-  CDVDOverlayImage(const CDVDOverlayImage& src)
-    : CDVDOverlay(src)
-  {
-    data    = (uint8_t*)malloc(src.linesize * src.height);
-    memcpy(data, src.data, src.linesize * src.height);
-
-    if(src.palette)
-    {
-      palette = (uint32_t*)malloc(src.palette_colors * 4);
-      memcpy(palette, src.palette, src.palette_colors * 4);
-    }
-    else
-      palette = NULL;
-
-    palette_colors = src.palette_colors;
-    linesize       = src.linesize;
-    x              = src.x;
-    y              = src.y;
-    width          = src.width;
-    height         = src.height;
-    source_width   = src.source_width;
-    source_height  = src.source_height;
-
-  }
-
   CDVDOverlayImage(const CDVDOverlayImage& src, int sub_x, int sub_y, int sub_w, int sub_h)
   : CDVDOverlay(src)
   {
     int bpp;
-    if(src.palette)
+    if (!src.palette.empty())
     {
       bpp = 1;
-      palette = (uint32_t*)malloc(src.palette_colors * 4);
-      memcpy(palette, src.palette, src.palette_colors * 4);
+      palette = src.palette;
     }
     else
     {
       bpp = 4;
-      palette = NULL;
+      palette = {};
     }
 
     palette_colors = src.palette_colors;
@@ -82,10 +56,10 @@ public:
     source_width   = src.source_width;
     source_height  = src.source_height;
 
-    data = (uint8_t*)malloc(sub_h * linesize);
+    data = std::vector<uint8_t>(sub_h * linesize);
 
     uint8_t* s = src.data_at(sub_x, sub_y);
-    uint8_t* t = data;
+    uint8_t* t = data.data();
 
     for(int row = 0;row < sub_h; ++row)
     {
@@ -97,11 +71,7 @@ public:
     m_textureid = 0;
   }
 
-  ~CDVDOverlayImage() override
-  {
-    if(data) free(data);
-    if(palette) free(palette);
-  }
+  ~CDVDOverlayImage() override = default;
 
   CDVDOverlayImage* Clone() override
   {
@@ -111,18 +81,17 @@ public:
   uint8_t* data_at(int sub_x, int sub_y) const
   {
     int bpp;
-    if(palette)
+    if (!palette.empty())
       bpp = 1;
     else
       bpp = 4;
-    return &data[(sub_y - y)*linesize +
-                 (sub_x - x)*bpp];
+    return const_cast<uint8_t*>(&data[(sub_y - y) * linesize + (sub_x - x) * bpp]);
   }
 
-  uint8_t*  data;
+  std::vector<uint8_t> data;
   int    linesize;
 
-  uint32_t* palette;
+  std::vector<uint32_t> palette;
   int    palette_colors;
 
   int    x;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
@@ -20,16 +20,6 @@ class CDVDOverlayImage : public CDVDOverlay
 public:
   CDVDOverlayImage() : CDVDOverlay(DVDOVERLAY_TYPE_IMAGE)
   {
-    data = {};
-    palette = {};
-    palette_colors = 0;
-    linesize = 0;
-    x = 0;
-    y = 0;
-    width = 0;
-    height = 0;
-    source_width  = 0;
-    source_height = 0;
   }
 
   CDVDOverlayImage(const CDVDOverlayImage& src, int sub_x, int sub_y, int sub_w, int sub_h)
@@ -89,15 +79,15 @@ public:
   }
 
   std::vector<uint8_t> data;
-  int    linesize;
+  int linesize{0};
 
   std::vector<uint32_t> palette;
-  int    palette_colors;
+  int palette_colors{0};
 
-  int    x;
-  int    y;
-  int    width;
-  int    height;
-  int    source_width;
-  int    source_height;
+  int x{0};
+  int y{0};
+  int width{0};
+  int height{0};
+  int source_width{0};
+  int source_height{0};
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -73,19 +73,14 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, int width, int height)
     return;
 
   float u, v;
-  if(!LoadTexture(quads.size_x
-                , quads.size_y
-                , quads.size_x
-                , DXGI_FORMAT_R8_UNORM
-                , quads.data
-                , &u, &v
-                , &m_texture))
+  if (!LoadTexture(quads.size_x, quads.size_y, quads.size_x, DXGI_FORMAT_R8_UNORM,
+                   quads.data.data(), &u, &v, &m_texture))
   {
     return;
   }
 
-  Vertex* vt = new Vertex[6 * quads.count], *vt_orig = vt;
-  SQuad*  vs = quads.quad;
+  Vertex *vt = new Vertex[6 * quads.quad.size()], *vt_orig = vt;
+  SQuad* vs = quads.quad.data();
 
   float scale_u = u / quads.size_x;
   float scale_v = v / quads.size_y;
@@ -93,7 +88,7 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, int width, int height)
   float scale_x = 1.0f / width;
   float scale_y = 1.0f / height;
 
-  for (int i = 0; i < quads.count; i++)
+  for (size_t i = 0; i < quads.quad.size(); i++)
   {
     for (int s = 0; s < 6; s++)
     {
@@ -132,9 +127,10 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, int width, int height)
   }
 
   vt = vt_orig;
-  m_count = quads.count;
+  m_count = quads.quad.size();
 
-  if (!m_vertex.Create(D3D11_BIND_VERTEX_BUFFER, 6 * quads.count, sizeof(Vertex), DXGI_FORMAT_UNKNOWN, D3D11_USAGE_IMMUTABLE, vt))
+  if (!m_vertex.Create(D3D11_BIND_VERTEX_BUFFER, 6 * quads.quad.size(), sizeof(Vertex),
+                       DXGI_FORMAT_UNKNOWN, D3D11_USAGE_IMMUTABLE, vt))
   {
     CLog::Log(LOGERROR, "{} - failed to create vertex buffer", __FUNCTION__);
     m_texture.Release();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -277,13 +277,8 @@ COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, int width, int height)
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
 
-  LoadTexture(GL_TEXTURE_2D
-            , quads.size_x
-            , quads.size_y
-            , quads.size_x
-            , &m_u, &m_v
-            , true
-            , quads.data);
+  LoadTexture(GL_TEXTURE_2D, quads.size_x, quads.size_y, quads.size_x, &m_u, &m_v, true,
+              quads.data.data());
 
 
   float scale_u = m_u / quads.size_x;
@@ -292,13 +287,13 @@ COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, int width, int height)
   float scale_x = 1.0f / width;
   float scale_y = 1.0f / height;
 
-  m_count  = quads.count;
+  m_count = quads.quad.size();
   m_vertex = (VERTEX*)calloc(m_count * 4, sizeof(VERTEX));
 
   VERTEX* vt = m_vertex;
-  SQuad*  vs = quads.quad;
+  SQuad* vs = quads.quad.data();
 
-  for(int i=0; i < quads.count; i++)
+  for (size_t i = 0; i < quads.quad.size(); i++)
   {
     for(int s = 0; s < 4; s++)
     {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
@@ -52,12 +52,11 @@ namespace OVERLAY {
        GLfloat x, y, z;
     };
 
-   VERTEX* m_vertex;
-   int     m_count;
+    std::vector<VERTEX> m_vertex;
 
-   GLuint m_texture;
-   float  m_u;
-   float  m_v;
+    GLuint m_texture;
+    float m_u;
+    float m_v;
   };
 
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
@@ -172,6 +172,8 @@ bool convert_quad(ASS_Image* images, SQuads& quads, int max_x)
 
   // first calculate how many glyph we have and the total x length
 
+  int count{0};
+
   for(img = images; img; img = img->next)
   {
     // fully transparent or width or height is 0 -> not displayed
@@ -179,10 +181,10 @@ bool convert_quad(ASS_Image* images, SQuads& quads, int max_x)
       continue;
 
     quads.size_x += img->w + 1;
-    quads.count++;
+    count++;
   }
 
-  if (quads.count == 0)
+  if (count == 0)
     return false;
 
   if (quads.size_x > max_x)
@@ -216,11 +218,11 @@ bool convert_quad(ASS_Image* images, SQuads& quads, int max_x)
 
   // allocate space for the glyph positions and texturedata
 
-  quads.quad = static_cast<SQuad*>(calloc(quads.count, sizeof(SQuad)));
-  quads.data = static_cast<uint8_t*>(calloc(quads.size_x * quads.size_y, 1));
+  quads.quad = std::vector<SQuad>(count);
+  quads.data = std::vector<uint8_t>(quads.size_x * quads.size_y);
 
-  SQuad*   v    = quads.quad;
-  uint8_t* data = quads.data;
+  SQuad* v = quads.quad.data();
+  uint8_t* data = quads.data.data();
 
   int y = 0;
 
@@ -240,7 +242,7 @@ bool convert_quad(ASS_Image* images, SQuads& quads, int max_x)
       curr_y += y + 1;
       curr_x  = 0;
       y       = 0;
-      data    = quads.data + curr_y * quads.size_x;
+      data = quads.data.data() + curr_y * quads.size_x;
     }
 
     unsigned int r = ((color >> 24) & 0xff);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
@@ -43,12 +43,9 @@ static uint32_t build_rgba(int yuv[3], int alpha, bool mergealpha)
 }
 #undef clamp
 
-uint32_t* convert_rgba(CDVDOverlayImage* o, bool mergealpha)
+std::vector<uint32_t> convert_rgba(CDVDOverlayImage* o, bool mergealpha)
 {
-  uint32_t* rgba = (uint32_t*)malloc(o->width * o->height * sizeof(uint32_t));
-
-  if(!rgba)
-    return NULL;
+  std::vector<uint32_t> rgba(o->width * o->height);
 
   uint32_t palette[256] = {};
   for(int i = 0; i < o->palette_colors; i++)
@@ -65,14 +62,10 @@ uint32_t* convert_rgba(CDVDOverlayImage* o, bool mergealpha)
   return rgba;
 }
 
-uint32_t* convert_rgba(CDVDOverlaySpu* o, bool mergealpha
-                              , int& min_x, int& max_x
-                              , int& min_y, int& max_y)
+std::vector<uint32_t> convert_rgba(
+    CDVDOverlaySpu* o, bool mergealpha, int& min_x, int& max_x, int& min_y, int& max_y)
 {
-  uint32_t* rgba = (uint32_t*)malloc(o->width * o->height * sizeof(uint32_t));
-
-  if(!rgba)
-    return NULL;
+  std::vector<uint32_t> rgba(o->width * o->height);
 
   uint32_t palette[8];
   for(int i = 0; i < 4; i++)
@@ -105,7 +98,7 @@ uint32_t* convert_rgba(CDVDOverlaySpu* o, bool mergealpha
   min_y = o->height;
   max_y = 0;
 
-  trg = rgba;
+  trg = rgba.data();
   src = (uint16_t*)o->result;
 
   for (int y = 0; y < o->height; y++)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
@@ -29,15 +29,8 @@ namespace OVERLAY {
 
   struct SQuads
   {
-    SQuads()
-    {
-      data = {};
-      quad = {};
-      size_x = 0;
-      size_y = 0;
-    }
-    int      size_x;
-    int      size_y;
+    int size_x{0};
+    int size_y{0};
     std::vector<uint8_t> data;
     std::vector<SQuad> quad;
   };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
@@ -31,22 +31,15 @@ namespace OVERLAY {
   {
     SQuads()
     {
-      data = NULL;
-      quad = NULL;
+      data = {};
+      quad = {};
       size_x = 0;
       size_y = 0;
-      count  = 0;
-    }
-   ~SQuads()
-    {
-      free(data);
-      free(quad);
     }
     int      size_x;
     int      size_y;
-    int      count;
-    uint8_t* data;
-    SQuad*   quad;
+    std::vector<uint8_t> data;
+    std::vector<SQuad> quad;
   };
 
   std::vector<uint32_t> convert_rgba(CDVDOverlayImage* o, bool mergealpha);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <vector>
 
 class CDVDOverlayImage;
 class CDVDOverlaySpu;
@@ -48,10 +49,9 @@ namespace OVERLAY {
     SQuad*   quad;
   };
 
-  uint32_t* convert_rgba(CDVDOverlayImage* o, bool mergealpha);
-  uint32_t* convert_rgba(CDVDOverlaySpu*   o, bool mergealpha
-                       , int& min_x, int& max_x
-                       , int& min_y, int& max_y);
+  std::vector<uint32_t> convert_rgba(CDVDOverlayImage* o, bool mergealpha);
+  std::vector<uint32_t> convert_rgba(
+      CDVDOverlaySpu* o, bool mergealpha, int& min_x, int& max_x, int& min_y, int& max_y);
   bool      convert_quad(ASS_Image* images, SQuads& quads, int max_x);
   int       GetStereoscopicDepth();
 


### PR DESCRIPTION
This started as a simple task to remove malloc/free and spiraled into a bit more of a cleanup. It's also nice to remove the custom copy constructor.

I'm not 100% sure if all this works as I'm not even sure how to test all of it. I tested some subtitles that I have and also the overlay renderer using `ctrl+shift+o`.


Maybe @enen92 knows how to tests these different methods (subs?)