### PR TITLE
CDVDOverlayCodec: make messages an enum class

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
@@ -15,11 +15,20 @@
 #include "PlatformDefs.h"
 
 // VC_ messages, messages can be combined
-#define OC_ERROR    0x00000001  // an error occurred, no other messages will be returned
-#define OC_BUFFER   0x00000002  // the decoder needs more data
-#define OC_OVERLAY  0x00000004  // the decoder decoded an overlay, call Decode(NULL, 0) again to parse the rest of the data
-#define OC_DONE \
-  0x00000008 // the decoder has decoded the packet, no overlay will be provided because the previous one is still valid
+enum class OverlayMessage
+{
+  // an error occurred, no other messages will be returned
+  OC_ERROR = 0x00000001,
+
+  // the decoder needs more data
+  OC_BUFFER = 0x00000002,
+
+  // the decoder decoded an overlay, call Decode(NULL, 0) again to parse the rest of the data
+  OC_OVERLAY = 0x00000004,
+
+  // the decoder has decoded the packet, no overlay will be provided because the previous one is still valid
+  OC_DONE = 0x00000008,
+};
 
 class CDVDOverlay;
 class CDVDStreamInfo;
@@ -48,7 +57,7 @@ public:
    * returns one or a combination of VC_ messages
    * pData and iSize can be NULL, this means we should flush the rest of the data.
    */
-  virtual int Decode(DemuxPacket *pPacket) = 0;
+  virtual OverlayMessage Decode(DemuxPacket* pPacket) = 0;
 
   /*
    * Reset the decoder.

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
@@ -71,7 +71,7 @@ public:
   /*
    * return codecs name
    */
-  virtual const char* GetName() { return m_codecName.c_str(); }
+  const std::string& GetName() const { return m_codecName; }
 
 protected:
   /*

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
@@ -55,10 +55,10 @@ void CDVDOverlayCodecCCText::Dispose()
   }
 }
 
-int CDVDOverlayCodecCCText::Decode(DemuxPacket* pPacket)
+OverlayMessage CDVDOverlayCodecCCText::Decode(DemuxPacket* pPacket)
 {
   if (!pPacket)
-    return OC_ERROR;
+    return OverlayMessage::OC_ERROR;
 
   uint8_t* data = pPacket->pData;
   std::string text((char*)data, (char*)(data + pPacket->iSize));
@@ -120,7 +120,7 @@ int CDVDOverlayCodecCCText::Decode(DemuxPacket* pPacket)
   else
     CLog::Log(LOGERROR, "{} - Failed to initialize tag converter", __FUNCTION__);
 
-  return m_pOverlay ? OC_DONE : OC_OVERLAY;
+  return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
 }
 
 void CDVDOverlayCodecCCText::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.h
@@ -20,7 +20,7 @@ public:
   CDVDOverlayCodecCCText();
   ~CDVDOverlayCodecCCText() override;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
-  int Decode(DemuxPacket* pPacket) override;
+  OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
   CDVDOverlay* GetOverlay() override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -118,10 +118,10 @@ void CDVDOverlayCodecFFmpeg::Dispose()
   avcodec_free_context(&m_pCodecContext);
 }
 
-int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
+OverlayMessage CDVDOverlayCodecFFmpeg::Decode(DemuxPacket* pPacket)
 {
   if (!m_pCodecContext || !pPacket)
-    return 1;
+    return OverlayMessage::OC_ERROR;
 
   int gotsub = 0, len = 0;
 
@@ -132,7 +132,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
   {
     CLog::Log(LOGERROR, "CDVDOverlayCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
               strerror(errno));
-    return OC_ERROR;
+    return OverlayMessage::OC_ERROR;
   }
 
   avpkt->data = pPacket->pData;
@@ -150,7 +150,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
   {
     CLog::Log(LOGERROR, "{} - avcodec_decode_subtitle returned failure", __FUNCTION__);
     Flush();
-    return OC_ERROR;
+    return OverlayMessage::OC_ERROR;
   }
 
   if (len != size)
@@ -158,7 +158,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
               __FUNCTION__);
 
   if (!gotsub)
-    return OC_BUFFER;
+    return OverlayMessage::OC_BUFFER;
 
   double pts_offset = 0.0;
 
@@ -186,7 +186,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
 
   m_SubtitleIndex = 0;
 
-  return OC_OVERLAY;
+  return OverlayMessage::OC_OVERLAY;
 }
 
 void CDVDOverlayCodecFFmpeg::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.h
@@ -24,7 +24,7 @@ public:
   CDVDOverlayCodecFFmpeg();
   ~CDVDOverlayCodecFFmpeg() override;
   bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
-  int Decode(DemuxPacket *pPacket) override;
+  OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
   CDVDOverlay* GetOverlay() override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -50,10 +50,10 @@ void CDVDOverlayCodecSSA::Dispose()
   }
 }
 
-int CDVDOverlayCodecSSA::Decode(DemuxPacket* pPacket)
+OverlayMessage CDVDOverlayCodecSSA::Decode(DemuxPacket* pPacket)
 {
   if (!pPacket)
-    return OC_ERROR;
+    return OverlayMessage::OC_ERROR;
 
   double pts = pPacket->dts != DVD_NOPTS_VALUE ? pPacket->dts : pPacket->pts;
   // libass only has a precision of msec
@@ -102,7 +102,7 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket* pPacket)
     m_libass->DecodeDemuxPkt((char*)data, size, pts, duration);
   }
 
-  return m_pOverlay ? OC_DONE : OC_OVERLAY;
+  return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
 }
 
 void CDVDOverlayCodecSSA::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
@@ -20,7 +20,7 @@ public:
   CDVDOverlayCodecSSA();
   ~CDVDOverlayCodecSSA() override;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
-  int Decode(DemuxPacket* pPacket) override;
+  OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
   CDVDOverlay* GetOverlay() override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -31,7 +31,7 @@
   do \
   { \
     if ((end - pos) < static_cast<std::ptrdiff_t>(x)) \
-      return OC_ERROR; \
+      return OverlayMessage::OC_ERROR; \
   } while (0)
 
 // NOTE: None of these macros check for buffer overflow
@@ -103,7 +103,7 @@ void CDVDOverlayCodecTX3G::Dispose()
   }
 }
 
-int CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
+OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
 {
   double PTSStartTime = 0;
   double PTSStopTime = 0;
@@ -253,7 +253,7 @@ int CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
   }
 
   if (strUTF8.empty())
-    return OC_BUFFER;
+    return OverlayMessage::OC_BUFFER;
 
   if (strUTF8[strUTF8.size() - 1] == '\n')
     strUTF8.erase(strUTF8.size() - 1);
@@ -282,7 +282,7 @@ int CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
 
   AddSubtitle(strUTF8.c_str(), PTSStartTime, PTSStopTime);
 
-  return m_pOverlay ? OC_DONE : OC_OVERLAY;
+  return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
 }
 
 void CDVDOverlayCodecTX3G::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.h
@@ -19,7 +19,7 @@ public:
   CDVDOverlayCodecTX3G();
   ~CDVDOverlayCodecTX3G() override;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
-  int Decode(DemuxPacket* pPacket) override;
+  OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
   CDVDOverlay* GetOverlay() override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -49,10 +49,10 @@ void CDVDOverlayCodecText::Dispose()
   }
 }
 
-int CDVDOverlayCodecText::Decode(DemuxPacket* pPacket)
+OverlayMessage CDVDOverlayCodecText::Decode(DemuxPacket* pPacket)
 {
   if (!pPacket)
-    return OC_ERROR;
+    return OverlayMessage::OC_ERROR;
 
   uint8_t* data = pPacket->pData;
   char* start = (char*)data;
@@ -87,7 +87,7 @@ int CDVDOverlayCodecText::Decode(DemuxPacket* pPacket)
   else
     CLog::Log(LOGERROR, "{} - Failed to initialize tag converter", __FUNCTION__);
 
-  return m_pOverlay ? OC_DONE : OC_OVERLAY;
+  return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
 }
 
 void CDVDOverlayCodecText::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
@@ -25,7 +25,7 @@ public:
   CDVDOverlayCodecText();
   ~CDVDOverlayCodecText() override;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
-  int Decode(DemuxPacket* pPacket) override;
+  OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
   CDVDOverlay* GetOverlay() override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -47,9 +47,9 @@ void CVideoPlayerSubtitle::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priori
 
     if (m_pOverlayCodec)
     {
-      int result = m_pOverlayCodec->Decode(pPacket);
+      OverlayMessage result = m_pOverlayCodec->Decode(pPacket);
 
-      if(result == OC_OVERLAY)
+      if (result == OverlayMessage::OC_OVERLAY)
       {
         CDVDOverlay* overlay;
 


### PR DESCRIPTION
This makes the overlay codec messages an enum class. This makes it much easier to read and avoids polluting the global namespace with defines. This also changes the `Decode` method to return `OCMessage`.

I've also included another simple commit to change GetName() to be `const std::string& GetName() const`