### PR TITLE
[VideoOSD] Add autoclose setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -674,6 +674,7 @@ msgid "Free"
 msgstr ""
 
 #: addons/skin.estuary/xml/Includes.xml
+#: system/settings/settings.xml
 msgctxt "#157"
 msgid "Video"
 msgstr ""
@@ -2227,6 +2228,8 @@ msgctxt "#477"
 msgid "Unable to load playlist"
 msgstr ""
 
+#. label for "OSD" setting category
+#: system/settings/settings.xml
 msgctxt "#478"
 msgid "OSD"
 msgstr ""
@@ -22904,4 +22907,34 @@ msgstr ""
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#39174"
 msgid "Display supported HDR types"
+msgstr ""
+
+#. Description of settings category "OSD" with label #478
+#: system/settings/settings.xml
+msgctxt "#39175"
+msgid "This category contains all the on screen display (OSD) related settings."
+msgstr ""
+
+#. Automatically close video OSD bool setting in Settings/Interface/OSD
+#: system/settings/settings.xml
+msgctxt "#39176"
+msgid "Automatically close video OSD"
+msgstr ""
+
+#. Help text for "Automatically close video OSD" setting in Settings/Interface/OSD
+#: system/settings/settings.xml
+msgctxt "#39177"
+msgid "The video OSD window will be automatically closed if visible after a specified time"
+msgstr ""
+
+#. Video OSD autoclose time (seconds) in Settings/Interface/OSD
+#: system/settings/settings.xml
+msgctxt "#39178"
+msgid "Video OSD autoclose time (seconds)"
+msgstr ""
+
+#. Help text for setting "Video OSD autoclose time (seconds)" of label #39178
+#: system/settings/settings.xml
+msgctxt "#39179"
+msgid "The time in seconds for the video OSD to be automatically closed"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3700,6 +3700,31 @@
         </setting>
       </group>
     </category>
+    <category id="osd" label="478" help="39175">
+      <group id="1" label="157">
+        <setting id="osd.autoclosevideoosd" type="boolean" label="39176" help="39177">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+          <dependencies>
+            <dependency type="enable" on="property" operator="!is" name="isplaying" />
+          </dependencies>
+        </setting>
+        <setting id="osd.autoclosevideoosdtime" type="integer" parent="osd.autoclosevideoosd" label="39178" help="39179">
+          <level>2</level>
+          <default>5</default>
+          <constraints>
+            <minimum>2</minimum>
+            <step>1</step>
+            <maximum>60</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="osd.autoclosevideoosd">true</dependency>
+          </dependencies>
+          <control type="slider" format="integer" />
+        </setting>
+      </group>
+    </category>
     <category id="regional" label="14222" help="36113">
       <group id="1" label="14218">
         <setting id="locale.language" type="addon" label="248" help="36114">

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -447,6 +447,8 @@ constexpr const char* CSettings::SETTING_GENERAL_ADDONBROKENFILTER;
 constexpr const char* CSettings::SETTING_SOURCE_VIDEOS;
 constexpr const char* CSettings::SETTING_SOURCE_MUSIC;
 constexpr const char* CSettings::SETTING_SOURCE_PICTURES;
+constexpr const char* CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSD;
+constexpr const char* CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSDTIME;
 //! @todo: remove in c++17
 
 bool CSettings::Initialize()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -65,6 +65,8 @@ public:
   static constexpr auto SETTING_SCREENSAVER_TIME = "screensaver.time";
   static constexpr auto SETTING_SCREENSAVER_USEMUSICVISINSTEAD = "screensaver.usemusicvisinstead";
   static constexpr auto SETTING_SCREENSAVER_USEDIMONPAUSE = "screensaver.usedimonpause";
+  static constexpr auto SETTING_OSD_AUTOCLOSEVIDEOOSD = "osd.autoclosevideoosd";
+  static constexpr auto SETTING_OSD_AUTOCLOSEVIDEOOSDTIME = "osd.autoclosevideoosdtime";
   static constexpr auto SETTING_WINDOW_WIDTH = "window.width";
   static constexpr auto SETTING_WINDOW_HEIGHT = "window.height";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS = "videolibrary.showunwatchedplots";

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -16,6 +16,8 @@
 #include "guilib/WindowIDs.h"
 #include "input/InputManager.h"
 #include "input/actions/ActionIDs.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 
 using namespace PVR;
 
@@ -56,6 +58,19 @@ bool CGUIDialogVideoOSD::OnAction(const CAction &action)
   }
 
   return CGUIDialog::OnAction(action);
+}
+
+void CGUIDialogVideoOSD::OnInitWindow()
+{
+  std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  if (settings)
+  {
+    if (settings->GetBool(CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSD))
+    {
+      SetAutoClose(settings->GetInt(CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSDTIME) * 1000);
+    }
+  }
+  CGUIDialog::OnInitWindow();
 }
 
 EVENT_RESULT CGUIDialogVideoOSD::OnMouseEvent(const CPoint &point, const CMouseEvent &event)

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.h
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.h
@@ -18,6 +18,7 @@ public:
   ~CGUIDialogVideoOSD(void) override;
 
   void FrameMove() override;
+  void OnInitWindow() override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
 protected:


### PR DESCRIPTION
## Description
Any modern video player (or video application) autocloses the video OSD after a small period of inactivity by the user. In KODI this seems to be skin dependent. Some skins implement the feature, others do not. Personally, I think this has a broader scope than skins (it defines behaviour not visual aspect) and should be provided as an option in the application itself.

- I am even unsure if it shouldn't be enabled by default (currently it's off). What do you think?
- Also unsure about the location of the setting. Does a new category "Video OSD" make sense? It's odd to be under "Skin"

## Motivation and context
There are too many clicks involved in the OSD, usually the user just wants to watch its own media. For instance, when downloading a subtitle or selecting a subtitle, the OSD buttons will be left on the screen and the user has to explicitly hit back to watch the content.

## How has this been tested?
Runtime tested

## What is the effect on users?
Slicker user experience if the new setting is enabled

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7375276/136280572-1eb9e1e5-ddb5-4fe8-8c96-a0da62c008cc.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
