### PR TITLE
xbmcaddon::Settings: remove use of dynamic exceptions

### DIFF
--- a/xbmc/interfaces/legacy/Settings.cpp
+++ b/xbmc/interfaces/legacy/Settings.cpp
@@ -96,7 +96,7 @@ Settings::Settings(std::shared_ptr<CSettingsBase> settings) : settings(std::move
 {
 }
 
-bool Settings::getBool(const char* id) throw(XBMCAddon::WrongTypeException)
+bool Settings::getBool(const char* id)
 {
   bool value = false;
   if (!GetSettingValue<CSettingBool>(settings, id, value))
@@ -105,7 +105,7 @@ bool Settings::getBool(const char* id) throw(XBMCAddon::WrongTypeException)
   return value;
 }
 
-int Settings::getInt(const char* id) throw(XBMCAddon::WrongTypeException)
+int Settings::getInt(const char* id)
 {
   int value = 0;
   if (!GetSettingValue<CSettingInt>(settings, id, value))
@@ -114,7 +114,7 @@ int Settings::getInt(const char* id) throw(XBMCAddon::WrongTypeException)
   return value;
 }
 
-double Settings::getNumber(const char* id) throw(XBMCAddon::WrongTypeException)
+double Settings::getNumber(const char* id)
 {
   double value = 0.0;
   if (!GetSettingValue<CSettingNumber>(settings, id, value))
@@ -123,7 +123,7 @@ double Settings::getNumber(const char* id) throw(XBMCAddon::WrongTypeException)
   return value;
 }
 
-String Settings::getString(const char* id) throw(XBMCAddon::WrongTypeException)
+String Settings::getString(const char* id)
 {
   std::string value;
   if (!GetSettingValue<CSettingString>(settings, id, value))
@@ -132,7 +132,7 @@ String Settings::getString(const char* id) throw(XBMCAddon::WrongTypeException)
   return value;
 }
 
-std::vector<bool> Settings::getBoolList(const char* id) throw(XBMCAddon::WrongTypeException)
+std::vector<bool> Settings::getBoolList(const char* id)
 {
   const auto transform = [](const CVariant& value) { return value.asBoolean(); };
   std::vector<bool> values;
@@ -142,7 +142,7 @@ std::vector<bool> Settings::getBoolList(const char* id) throw(XBMCAddon::WrongTy
   return values;
 }
 
-std::vector<int> Settings::getIntList(const char* id) throw(XBMCAddon::WrongTypeException)
+std::vector<int> Settings::getIntList(const char* id)
 {
   const auto transform = [](const CVariant& value) { return value.asInteger32(); };
   std::vector<int> values;
@@ -152,7 +152,7 @@ std::vector<int> Settings::getIntList(const char* id) throw(XBMCAddon::WrongType
   return values;
 }
 
-std::vector<double> Settings::getNumberList(const char* id) throw(XBMCAddon::WrongTypeException)
+std::vector<double> Settings::getNumberList(const char* id)
 {
   const auto transform = [](const CVariant& value) { return value.asDouble(); };
   std::vector<double> values;
@@ -162,7 +162,7 @@ std::vector<double> Settings::getNumberList(const char* id) throw(XBMCAddon::Wro
   return values;
 }
 
-std::vector<String> Settings::getStringList(const char* id) throw(XBMCAddon::WrongTypeException)
+std::vector<String> Settings::getStringList(const char* id)
 {
   const auto transform = [](const CVariant& value) { return value.asString(); };
   std::vector<std::string> values;
@@ -172,60 +172,56 @@ std::vector<String> Settings::getStringList(const char* id) throw(XBMCAddon::Wro
   return values;
 }
 
-void Settings::setBool(const char* id, bool value) throw(XBMCAddon::WrongTypeException)
+void Settings::setBool(const char* id, bool value)
 {
   if (!SetSettingValue<CSettingBool>(settings, id, value))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"boolean\" for \"%s\"", id);
   settings->Save();
 }
 
-void Settings::setInt(const char* id, int value) throw(XBMCAddon::WrongTypeException)
+void Settings::setInt(const char* id, int value)
 {
   if (!SetSettingValue<CSettingInt>(settings, id, value))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"integer\" for \"%s\"", id);
   settings->Save();
 }
 
-void Settings::setNumber(const char* id, double value) throw(XBMCAddon::WrongTypeException)
+void Settings::setNumber(const char* id, double value)
 {
   if (!SetSettingValue<CSettingNumber>(settings, id, value))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"number\" for \"%s\"", id);
   settings->Save();
 }
 
-void Settings::setString(const char* id, const String& value) throw(XBMCAddon::WrongTypeException)
+void Settings::setString(const char* id, const String& value)
 {
   if (!SetSettingValue<CSettingString>(settings, id, value))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"string\" for \"%s\"", id);
   settings->Save();
 }
 
-void Settings::setBoolList(const char* id,
-                           const std::vector<bool>& values) throw(XBMCAddon::WrongTypeException)
+void Settings::setBoolList(const char* id, const std::vector<bool>& values)
 {
   if (!SetSettingValueList<CSettingBool>(settings, id, values))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"list[boolean]\" for \"%s\"", id);
   settings->Save();
 }
 
-void Settings::setIntList(const char* id,
-                          const std::vector<int>& values) throw(XBMCAddon::WrongTypeException)
+void Settings::setIntList(const char* id, const std::vector<int>& values)
 {
   if (!SetSettingValueList<CSettingInt>(settings, id, values))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"list[integer]\" for \"%s\"", id);
   settings->Save();
 }
 
-void Settings::setNumberList(const char* id,
-                             const std::vector<double>& values) throw(XBMCAddon::WrongTypeException)
+void Settings::setNumberList(const char* id, const std::vector<double>& values)
 {
   if (!SetSettingValueList<CSettingNumber>(settings, id, values))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"list[number]\" for \"%s\"", id);
   settings->Save();
 }
 
-void Settings::setStringList(const char* id,
-                             const std::vector<String>& values) throw(XBMCAddon::WrongTypeException)
+void Settings::setStringList(const char* id, const std::vector<String>& values)
 {
   if (!SetSettingValueList<CSettingString>(settings, id, values))
     throw XBMCAddon::WrongTypeException("Invalid setting type \"list[string]\" for \"%s\"", id);

--- a/xbmc/interfaces/legacy/Settings.h
+++ b/xbmc/interfaces/legacy/Settings.h
@@ -84,7 +84,7 @@ public:
   ///
   getBool(...);
 #else
-  bool getBool(const char* id) throw(XBMCAddon::WrongTypeException);
+  bool getBool(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -110,7 +110,7 @@ public:
   ///
   getInt(...);
 #else
-  int getInt(const char* id) throw(XBMCAddon::WrongTypeException);
+  int getInt(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -136,7 +136,7 @@ public:
   ///
   getNumber(...);
 #else
-  double getNumber(const char* id) throw(XBMCAddon::WrongTypeException);
+  double getNumber(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -162,7 +162,7 @@ public:
   ///
   getString(...);
 #else
-  String getString(const char* id) throw(XBMCAddon::WrongTypeException);
+  String getString(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -188,7 +188,7 @@ public:
   ///
   getBoolList(...);
 #else
-  std::vector<bool> getBoolList(const char* id) throw(XBMCAddon::WrongTypeException);
+  std::vector<bool> getBoolList(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -214,7 +214,7 @@ public:
   ///
   getIntList(...);
 #else
-  std::vector<int> getIntList(const char* id) throw(XBMCAddon::WrongTypeException);
+  std::vector<int> getIntList(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -240,7 +240,7 @@ public:
   ///
   getNumberList(...);
 #else
-  std::vector<double> getNumberList(const char* id) throw(XBMCAddon::WrongTypeException);
+  std::vector<double> getNumberList(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -266,7 +266,7 @@ public:
   ///
   getStringList(...);
 #else
-  std::vector<String> getStringList(const char* id) throw(XBMCAddon::WrongTypeException);
+  std::vector<String> getStringList(const char* id);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -296,7 +296,7 @@ public:
   ///
   setBool(...);
 #else
-  void setBool(const char* id, bool value) throw(XBMCAddon::WrongTypeException);
+  void setBool(const char* id, bool value);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -326,7 +326,7 @@ public:
   ///
   setInt(...);
 #else
-  void setInt(const char* id, int value) throw(XBMCAddon::WrongTypeException);
+  void setInt(const char* id, int value);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -356,7 +356,7 @@ public:
   ///
   setNumber(...);
 #else
-  void setNumber(const char* id, double value) throw(XBMCAddon::WrongTypeException);
+  void setNumber(const char* id, double value);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -386,7 +386,7 @@ public:
   ///
   setString(...);
 #else
-  void setString(const char* id, const String& value) throw(XBMCAddon::WrongTypeException);
+  void setString(const char* id, const String& value);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -416,8 +416,7 @@ public:
   ///
   setBoolList(...);
 #else
-  void setBoolList(const char* id,
-                   const std::vector<bool>& values) throw(XBMCAddon::WrongTypeException);
+  void setBoolList(const char* id, const std::vector<bool>& values);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -447,8 +446,7 @@ public:
   ///
   setIntList(...);
 #else
-  void setIntList(const char* id,
-                  const std::vector<int>& values) throw(XBMCAddon::WrongTypeException);
+  void setIntList(const char* id, const std::vector<int>& values);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -478,8 +476,7 @@ public:
   ///
   setNumberList(...);
 #else
-  void setNumberList(const char* id,
-                     const std::vector<double>& values) throw(XBMCAddon::WrongTypeException);
+  void setNumberList(const char* id, const std::vector<double>& values);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -509,8 +506,7 @@ public:
   ///
   setStringList(...);
 #else
-  void setStringList(const char* id,
-                     const std::vector<String>& values) throw(XBMCAddon::WrongTypeException);
+  void setStringList(const char* id, const std::vector<String>& values);
 #endif
 };
 


### PR DESCRIPTION
#19784 causes compilation warnings such as:
```
/home/lukas/Documents/git/xbmc/xbmc/interfaces/legacy/Settings.h:87:32: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
   87 |   bool getBool(const char* id) throw(XBMCAddon::WrongTypeException);
      |                                ^~~~~
```

This PR removes the dynamic exception and uses normal exception handling through `try/catch` blocks.

Having the empty `catch` block seems a bit ugly but I'm not sure if there is anything else we want to do (log it?).

You can see the changes without white space changes [HERE](https://github.com/xbmc/xbmc/pull/20268/files?w=1)