### PR TITLE
[PVR][kodi-dev-kit] Warning cleanup from EDL Resize change

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/PVR.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/PVR.h
@@ -3096,12 +3096,12 @@ private:
     std::vector<PVREDLEntry> edlList;
     PVR_ERROR error = static_cast<CInstancePVRClient*>(instance->toAddon->addonInstance)
                           ->GetEPGTagEdl(tag, edlList);
-    if (edlList.size() > *size)
+    if (static_cast<int>(edlList.size()) > *size)
     {
       kodi::Log(
           ADDON_LOG_WARNING,
           "CInstancePVRClient::%s: Truncating %d EDL entries from client to permitted size %d",
-          __func__, edlList.size(), *size);
+          __func__, static_cast<int>(edlList.size()), *size);
       edlList.resize(*size);
     }
     *size = 0;
@@ -3247,12 +3247,12 @@ private:
     std::vector<PVREDLEntry> edlList;
     PVR_ERROR error = static_cast<CInstancePVRClient*>(instance->toAddon->addonInstance)
                           ->GetRecordingEdl(recording, edlList);
-    if (edlList.size() > *size)
+    if (static_cast<int>(edlList.size()) > *size)
     {
       kodi::Log(
           ADDON_LOG_WARNING,
           "CInstancePVRClient::%s: Truncating %d EDL entries from client to permitted size %d",
-          __func__, edlList.size(), *size);
+          __func__, static_cast<int>(edlList.size()), *size);
       edlList.resize(*size);
     }
     *size = 0;


### PR DESCRIPTION
## Description
Cleans up a couple PVR addon build warnings introduced with PR #[20009](https://github.com/xbmc/xbmc/pull/20009)

## Motivation and context
Hadn't updated to latest master branch in many months, noted this when I did.  MSVC and GCC compilers are flagging the comparison between signed and unsigned integer expressions in PVR.h.  clang compiler(s) do not flag it.

**MSVC:** 
```
xbmc\xbmc\addons\kodi-dev-kit\include\kodi\addon-instance\pvr.h(3099): warning C4018: '>': signed/unsigned mismatch
xbmc\xbmc\addons\kodi-dev-kit\include\kodi\addon-instance\pvr.h(3250): warning C4018: '>': signed/unsigned mismatch
```

**GCC:**
```
xbmc/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/PVR.h(3099,24): warning G2A2880C6: comparison between signed and unsigned integer expressions [-Wsign-compare]
xbmc/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/PVR.h(3250,24): warning G2A2880C6: comparison between signed and unsigned integer expressions [-Wsign-compare]
```

I also added the same static_cast<> to the kodi::Log() call to ensure the same logic is used to report the values being compared even though that was not being specifically flagged.  Happy to remove if undesirable, seemed to be reasonable as the format string indicates %d.

## How has this been tested?
Tested with the above noted compilers; the change resolves the compile warnings.

## What is the effect on users?
None; this is an addon build concern only.

## Screenshots (if appropriate):
N/A

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
