### PR TITLE
[backport][addons][audiodecoder] fix conflict problems if Kodi and addon supports same

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1048,7 +1048,8 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
   }
 
   if (CServiceBroker::IsBinaryAddonCacheUp() &&
-      IsType(CServiceBroker::GetFileExtensionProvider().GetFileFolderExtensions().c_str()))
+      IsType(CServiceBroker::GetFileExtensionProvider().GetFileFolderExtensions().c_str()) &&
+      CServiceBroker::GetFileExtensionProvider().CanOperateExtension(m_strPath))
     return true;
 
   if(types & EFILEFOLDER_TYPE_ONBROWSE)

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -58,6 +58,13 @@ public:
    */
   bool EncodedHostName(const std::string& protocol) const;
 
+  /*!
+   * @brief Returns true if related provider can operate related file
+   *
+   * @note Thought for cases e.g. by ISO, where can be a video or also a SACD.
+   */
+  bool CanOperateExtension(const std::string& path) const;
+
 private:
   std::string GetAddonExtensions(const ADDON::TYPE &type) const;
   std::string GetAddonFileFolderExtensions(const ADDON::TYPE &type) const;


### PR DESCRIPTION
Backport about https://github.com/xbmc/xbmc/pull/20278

## Description

This change deals with the problems that occur with ISOs when using Video ISO and SACD ISO. The associated addon then comes into conflict with Kodi's way.

With this, the add-on is called up first to ensure correct use. If it fails then Kodi's own way of processing is used.

The change is still small at the moment and relates only to audio decoder addons, which can support multiple tracks in one file (similar to an archive file).

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
Relates to this issues:
- https://github.com/xbmc/audiodecoder.sacd/issues/18 (The bad in german :smirk:)
- https://github.com/xbmc/audiodecoder.sacd/issues/14
- https://github.com/xbmc/audiodecoder.sacd/issues/11

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
