### PR TITLE
[Coverity] Check return value from GetAddon

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -1049,9 +1049,12 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
   if (addon != NULL)
   {
     AddonPtr addon2;
-    CServiceBroker::GetAddonMgr().GetAddon(addonID, addon2, ADDON_UNKNOWN, OnlyEnabled::YES);
+    bool success =
+        CServiceBroker::GetAddonMgr().GetAddon(addonID, addon2, ADDON_UNKNOWN, OnlyEnabled::YES);
     if (msg.empty())
-      msg = g_localizeStrings.Get(addon2 != NULL ? 113 : 114);
+    {
+      msg = g_localizeStrings.Get(addon2 != nullptr && success ? 113 : 114);
+    }
 
     activity = EventPtr(new CAddonManagementEvent(addon, EventLevel::Error, msg));
     if (IsModal())

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -734,8 +734,12 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
 
   m_item = std::make_shared<CFileItem>(*item);
   m_localAddon.reset();
-  CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon, ADDON_UNKNOWN,
-                                         OnlyEnabled::NO);
+  if (CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon,
+                                             ADDON_UNKNOWN, OnlyEnabled::NO))
+  {
+    CLog::Log(LOGDEBUG, "{} - Addon with id {} not found locally.", __FUNCTION__,
+              item->GetAddonInfo()->ID());
+  }
   return true;
 }
 

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -76,13 +76,17 @@ bool CEncoderFFmpeg::Init(AddonToKodiFuncTable_AudioEncoder& callbacks)
   }
 
   AddonPtr addon;
-  CServiceBroker::GetAddonMgr().GetAddon(
-      CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
-          CSettings::SETTING_AUDIOCDS_ENCODER),
-      addon, ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::YES);
-  if (addon)
+  std::string addonId = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+      CSettings::SETTING_AUDIOCDS_ENCODER);
+  bool success = CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON::ADDON_UNKNOWN,
+                                                        ADDON::OnlyEnabled::YES);
+  if (success && addon)
   {
     m_Format->bit_rate = (128+32*strtol(addon->GetSetting("bitrate").c_str(), NULL, 10))*1000;
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "{} - Could not get addon: {}", __FUNCTION__, addonId);
   }
 
   /* add a stream to it */

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -154,9 +154,9 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       ADDON::AddonPtr addon;
       if (!info.GetData3().empty())
       {
-        CServiceBroker::GetAddonMgr().GetAddon(info.GetData3(), addon, ADDON::ADDON_UNKNOWN,
-                                               ADDON::OnlyEnabled::YES);
-        if (!addon)
+        bool success = CServiceBroker::GetAddonMgr().GetAddon(
+            info.GetData3(), addon, ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::YES);
+        if (!success || !addon)
           break;
 
         if (info.m_info == SYSTEM_ADDON_TITLE)

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -252,12 +252,19 @@ static int RunScript(const std::vector<std::string>& params)
       }
       else
       {
-        //Run a random extension point (old behaviour).
-        CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_UNKNOWN, OnlyEnabled::YES);
-        scriptpath = addon->LibPath();
-        CLog::Log(LOGWARNING,
-                  "RunScript called for a non-script addon '{}'. This behaviour is deprecated.",
-                  params[0]);
+        // Run a random extension point (old behaviour).
+        if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_UNKNOWN,
+                                                   OnlyEnabled::YES))
+        {
+          scriptpath = addon->LibPath();
+          CLog::Log(LOGWARNING,
+                    "RunScript called for a non-script addon '{}'. This behaviour is deprecated.",
+                    params[0]);
+        }
+        else
+        {
+          CLog::Log(LOGERROR, "{} - Could not get addon: {}", __FUNCTION__, params[0]);
+        }
       }
     }
     else

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -179,11 +179,18 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
         && selectedAddonId != currentScraperId)
     {
       AddonPtr scraperAddon;
-      CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon, ADDON_UNKNOWN,
-                                             OnlyEnabled::YES);
-      m_albumscraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
-      SetupView();
-      SetFocus(settingId);
+      if (CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon, ADDON_UNKNOWN,
+                                                 OnlyEnabled::YES))
+      {
+        m_albumscraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
+        SetupView();
+        SetFocus(settingId);
+      }
+      else
+      {
+        CLog::Log(LOGERROR, "{} - Could not get settings for addon: {}", __FUNCTION__,
+                  selectedAddonId);
+      }
     }
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER)
@@ -197,11 +204,17 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
         && selectedAddonId != currentScraperId)
     {
       AddonPtr scraperAddon;
-      CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon, ADDON_UNKNOWN,
-                                             OnlyEnabled::YES);
-      m_artistscraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
-      SetupView();
-      SetFocus(settingId);
+      if (CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon, ADDON_UNKNOWN,
+                                                 OnlyEnabled::YES))
+      {
+        m_artistscraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
+        SetupView();
+        SetFocus(settingId);
+      }
+      else
+      {
+        CLog::Log(LOGERROR, "{} - Could not get addon: {}", __FUNCTION__, selectedAddonId);
+      }
     }
   }
   else if (settingId == SETTING_ALBUMSCRAPER_SETTINGS)

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -248,12 +248,18 @@ void CGUIDialogContentSettings::OnSettingAction(const std::shared_ptr<const CSet
         && selectedAddonId != currentScraperId)
     {
       AddonPtr scraperAddon;
-      CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon, ADDON::ADDON_UNKNOWN,
-                                             ADDON::OnlyEnabled::YES);
-      m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
-
-      SetupView();
-      SetFocusToSetting(SETTING_SCRAPER_LIST);
+      if (CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon,
+                                                 ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::YES))
+      {
+        m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
+        SetupView();
+        SetFocusToSetting(SETTING_SCRAPER_LIST);
+      }
+      else
+      {
+        CLog::Log(LOGERROR, "{} - Could not get settings for addon: {}", __FUNCTION__,
+                  selectedAddonId);
+      }
     }
   }
   else if (settingId == SETTING_SCRAPER_SETTINGS)

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -423,9 +423,16 @@ void CGUIDialogSubtitles::OnSubtitleServiceContextMenu(int itemIdx)
     case SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_SETTINGS:
     {
       AddonPtr addon;
-      CServiceBroker::GetAddonMgr().GetAddon(service->GetProperty("Addon.ID").asString(), addon,
-                                             ADDON_SUBTITLE_MODULE, OnlyEnabled::YES);
-      CGUIDialogAddonSettings::ShowForAddon(addon);
+      if (CServiceBroker::GetAddonMgr().GetAddon(service->GetProperty("Addon.ID").asString(), addon,
+                                                 ADDON_SUBTITLE_MODULE, OnlyEnabled::YES))
+      {
+        CGUIDialogAddonSettings::ShowForAddon(addon);
+      }
+      else
+      {
+        CLog::Log(LOGERROR, "{} - Could not open settings for addon: {}", __FUNCTION__,
+                  service->GetProperty("Addon.ID").asString());
+      }
       break;
     }
     case SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_DISABLE:

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -37,9 +37,9 @@ void CGUIWindowScreensaverDim::UpdateVisibility()
     {
       m_visible = true;
       ADDON::AddonPtr info;
-      CServiceBroker::GetAddonMgr().GetAddon(usedId, info, ADDON::ADDON_SCREENSAVER,
-                                             ADDON::OnlyEnabled::YES);
-      if (info && !info->GetSetting("level").empty())
+      bool success = CServiceBroker::GetAddonMgr().GetAddon(usedId, info, ADDON::ADDON_SCREENSAVER,
+                                                            ADDON::OnlyEnabled::YES);
+      if (success && info && !info->GetSetting("level").empty())
         m_newDimLevel = 100.0f - (float)atof(info->GetSetting("level").c_str());
       else
         m_newDimLevel = 100.0f;


### PR DESCRIPTION
## Description

Fixes a new warning generated on coverity introduced by https://github.com/xbmc/xbmc/pull/20228
The return value of `GetAddon` must be checked for success.

Also addresses all the other cases, see https://github.com/xbmc/xbmc/pull/20286#issuecomment-939404896