### PR TITLE
[Backport] GSoC fixes

### DIFF
--- a/tools/windows/prepare-binary-addons-dev.bat
+++ b/tools/windows/prepare-binary-addons-dev.bat
@@ -18,7 +18,7 @@ FOR %%b IN (%*) DO (
 SETLOCAL DisableDelayedExpansion
 
 rem set Visual C++ build environment
-call "%VS140COMNTOOLS%..\..\VC\bin\amd64_x86\vcvarsamd64_x86.bat" || call "%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
+call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat" || call "%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
 
 SET WORKDIR=%WORKSPACE%
 
@@ -76,7 +76,7 @@ IF "%addon%" NEQ "" (
 )
 
 rem execute cmake to generate Visual Studio 12 project files
-cmake "%ADDONS_PATH%" -G "Visual Studio 14" ^
+cmake "%ADDONS_PATH%" -G "Visual Studio 16 2019" ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%SCRIPTS_PATH%/CFlagOverrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%SCRIPTS_PATH%/CXXFlagOverrides.cmake" ^

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
@@ -45,7 +45,7 @@ bool CGUIDialogAxisDetection::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonM
                                                    const JOYSTICK::CDriverPrimitive& primitive)
 {
   if (primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS)
-    AddAxis(buttonMap->DeviceName(), primitive.Index());
+    AddAxis(buttonMap->Location(), primitive.Index());
 
   return true;
 }
@@ -66,19 +66,19 @@ bool CGUIDialogAxisDetection::AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) co
 void CGUIDialogAxisDetection::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap,
                                          unsigned int axisIndex)
 {
-  AddAxis(buttonMap->DeviceName(), axisIndex);
+  AddAxis(buttonMap->Location(), axisIndex);
 }
 
-void CGUIDialogAxisDetection::AddAxis(const std::string& deviceName, unsigned int axisIndex)
+void CGUIDialogAxisDetection::AddAxis(const std::string& deviceLocation, unsigned int axisIndex)
 {
   auto it = std::find_if(m_detectedAxes.begin(), m_detectedAxes.end(),
-                         [&deviceName, axisIndex](const AxisEntry& axis) {
-                           return axis.first == deviceName && axis.second == axisIndex;
+                         [&deviceLocation, axisIndex](const AxisEntry& axis) {
+                           return axis.first == deviceLocation && axis.second == axisIndex;
                          });
 
   if (it == m_detectedAxes.end())
   {
-    m_detectedAxes.emplace_back(std::make_pair(deviceName, axisIndex));
+    m_detectedAxes.emplace_back(std::make_pair(deviceLocation, axisIndex));
     m_captureEvent.Set();
   }
 }

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
@@ -39,7 +39,7 @@ protected:
   void OnClose(bool bAccepted) override {}
 
 private:
-  void AddAxis(const std::string& deviceName, unsigned int axisIndex);
+  void AddAxis(const std::string& deviceLocation, unsigned int axisIndex);
 
   // Axis types
   using DeviceName = std::string;

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -62,21 +62,21 @@ bool CGUIDialogIgnoreInput::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonMap
                                                  const JOYSTICK::CDriverPrimitive& primitive)
 {
   // Check if we have already started capturing primitives for a device
-  const bool bHasDevice = !m_deviceName.empty();
+  const bool bHasDevice = !m_location.empty();
 
   // If a primitive comes from a different device, ignore it
-  if (bHasDevice && m_deviceName != buttonMap->DeviceName())
+  if (bHasDevice && m_location != buttonMap->Location())
   {
-    CLog::Log(LOGDEBUG, "%s: ignoring input from device %s", buttonMap->ControllerID().c_str(),
-              buttonMap->DeviceName().c_str());
+    CLog::Log(LOGDEBUG, "{}: ignoring input from device {}", buttonMap->ControllerID(),
+              buttonMap->Location());
     return false;
   }
 
   if (!bHasDevice)
   {
-    CLog::Log(LOGDEBUG, "%s: capturing input for device %s", buttonMap->ControllerID().c_str(),
-              buttonMap->DeviceName().c_str());
-    m_deviceName = buttonMap->DeviceName();
+    CLog::Log(LOGDEBUG, "{}: capturing input for device {}", buttonMap->ControllerID(),
+              buttonMap->Location());
+    m_location = buttonMap->Location();
   }
 
   if (AddPrimitive(primitive))
@@ -96,10 +96,10 @@ void CGUIDialogIgnoreInput::OnClose(bool bAccepted)
     {
       // See documentation of IButtonMapCallback::ResetIgnoredPrimitives()
       // for why this call is needed
-      if (m_deviceName.empty())
+      if (m_location.empty())
         callback.second->ResetIgnoredPrimitives();
 
-      if (m_deviceName.empty() || m_deviceName == callback.first)
+      if (m_location.empty() || m_location == callback.first)
         callback.second->SaveButtonMap();
     }
     else

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
@@ -40,7 +40,7 @@ protected:
 private:
   bool AddPrimitive(const JOYSTICK::CDriverPrimitive& primitive);
 
-  std::string m_deviceName;
+  std::string m_location;
   std::vector<JOYSTICK::CDriverPrimitive> m_capturedPrimitives;
 };
 } // namespace GAME

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -48,7 +48,7 @@ void CGUIConfigurationWizard::InitializeState(void)
   m_throttleDirection = JOYSTICK::THROTTLE_DIRECTION::NONE;
   m_history.clear();
   m_lateAxisDetected = false;
-  m_deviceName.clear();
+  m_location.clear();
 }
 
 void CGUIConfigurationWizard::Run(const std::string& strControllerId,
@@ -205,7 +205,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
   bool bHandled = false;
 
   // Abort if another controller cancels the prompt
-  if (IsMapping() && !IsMapping(buttonMap->DeviceName()))
+  if (IsMapping() && !IsMapping(buttonMap->Location()))
   {
     //! @todo This only succeeds for game.controller.default; no actions are
     //        currently defined for other controllers
@@ -282,8 +282,8 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
         }
         else
         {
-          CLog::Log(LOGDEBUG, "%s: mapping feature \"%s\" for device %s", m_strControllerId.c_str(),
-                    feature.Name().c_str(), buttonMap->DeviceName().c_str());
+          CLog::Log(LOGDEBUG, "{}: mapping feature \"{}\" for device {}", m_strControllerId,
+                    feature.Name(), buttonMap->Location());
 
           switch (feature.Type())
           {
@@ -338,9 +338,9 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
 
           m_inputEvent.Set();
 
-          if (m_deviceName.empty())
+          if (m_location.empty())
           {
-            m_deviceName = buttonMap->DeviceName();
+            m_location = buttonMap->Location();
             m_bIsKeyboard = (primitive.Type() == PRIMITIVE_TYPE::KEY);
           }
         }
@@ -443,12 +443,12 @@ bool CGUIConfigurationWizard::OnAction(unsigned int actionId)
 
 bool CGUIConfigurationWizard::IsMapping() const
 {
-  return !m_deviceName.empty();
+  return !m_location.empty();
 }
 
-bool CGUIConfigurationWizard::IsMapping(const std::string& deviceName) const
+bool CGUIConfigurationWizard::IsMapping(const std::string& location) const
 {
-  return m_deviceName == deviceName;
+  return m_location == location;
 }
 
 void CGUIConfigurationWizard::InstallHooks(void)

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -78,7 +78,7 @@ private:
   void InitializeState(void);
 
   bool IsMapping() const;
-  bool IsMapping(const std::string& deviceName) const;
+  bool IsMapping(const std::string& location) const;
 
   void InstallHooks(void);
   void RemoveHooks(void);
@@ -99,7 +99,7 @@ private:
   JOYSTICK::THROTTLE_DIRECTION m_throttleDirection;
   std::set<JOYSTICK::CDriverPrimitive> m_history; // History to avoid repeated features
   bool m_lateAxisDetected; // Set to true if an axis is detected during button mapping
-  std::string m_deviceName; // Name of device that we're mapping
+  std::string m_location; // Peripheral location of device that we're mapping
   bool m_bIsKeyboard = false; // True if we're mapping keyboard keys
   CCriticalSection m_stateMutex;
 

--- a/xbmc/input/joysticks/interfaces/IButtonMap.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMap.h
@@ -41,11 +41,11 @@ public:
   virtual std::string ControllerID(void) const = 0;
 
   /*!
-   * \brief The name of the peripheral associated with this button map
+   * \brief The Location of the peripheral associated with this button map
    *
-   * \return The peripheral's name
+   * \return The peripheral's location
    */
-  virtual std::string DeviceName(void) const = 0;
+  virtual std::string Location(void) const = 0;
 
   /*!
    * \brief Load the button map into memory

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -38,9 +38,9 @@ CAddonButtonMap::~CAddonButtonMap(void)
     addon->UnregisterButtonMap(this);
 }
 
-std::string CAddonButtonMap::DeviceName(void) const
+std::string CAddonButtonMap::Location(void) const
 {
-  return m_device->DeviceName();
+  return m_device->Location();
 }
 
 bool CAddonButtonMap::Load(void)
@@ -65,7 +65,7 @@ bool CAddonButtonMap::Load(void)
   if (bSuccess)
     driverMap = CreateLookupTable(features);
   else
-    CLog::Log(LOGDEBUG, "Failed to load button map for \"%s\"", m_device->DeviceName().c_str());
+    CLog::Log(LOGDEBUG, "Failed to load button map for \"{}\"", m_device->Location());
 
   {
     CSingleLock lock(m_mutex);

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -31,7 +31,7 @@ public:
   // Implementation of IButtonMap
   std::string ControllerID(void) const override { return m_strControllerId; }
 
-  std::string DeviceName(void) const override;
+  std::string Location(void) const override;
 
   bool Load(void) override;
 


### PR DESCRIPTION
## Description

This PR backports the two fixes from https://github.com/xbmc/xbmc/pull/20075:

* One fix from GSoC 2017 - https://github.com/garbear/xbmc/pull/86
* Controller fix from GSoC 2020 - https://github.com/garbear/xbmc/pull/119

## Motivation and context

Responsibility of backporting fixes

## How has this been tested?

Build succeeds. The GSoC 2020 commit is identical to the merged GSoC 2020 PR, so I don't expect breakage.

## What is the effect on users?

* Fixed similar controllers interfering with each other while button mapping

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
