### PR TITLE
Manage sounds and streams with smart pointers

### DIFF
--- a/xbmc/addons/interfaces/AudioEngine.cpp
+++ b/xbmc/addons/interfaces/AudioEngine.cpp
@@ -336,7 +336,7 @@ AEStreamHandle* Interface_AudioEngine::audioengine_make_stream(void* kodiBase,
   if (options & AUDIO_STREAM_AUTOSTART)
     kodiOption |= AESTREAM_AUTOSTART;
 
-  return engine->MakeStream(format, kodiOption);
+  return engine->MakeStream(format, kodiOption).release();
 }
 
 void Interface_AudioEngine::audioengine_free_stream(void* kodiBase, AEStreamHandle* streamHandle)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3277,7 +3277,9 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
 // Streams
 //-----------------------------------------------------------------------------
 
-IAEStream *CActiveAE::MakeStream(AEAudioFormat &audioFormat, unsigned int options, IAEClockCallback *clock)
+IAE::StreamPtr CActiveAE::MakeStream(AEAudioFormat& audioFormat,
+                                     unsigned int options,
+                                     IAEClockCallback* clock)
 {
   if (audioFormat.m_dataFormat <= AE_FMT_INVALID || audioFormat.m_dataFormat >= AE_FMT_MAX)
   {
@@ -3313,7 +3315,8 @@ IAEStream *CActiveAE::MakeStream(AEAudioFormat &audioFormat, unsigned int option
     bool success = reply->signal == CActiveAEControlProtocol::ACC;
     if (success)
     {
-      CActiveAEStream *stream = *(CActiveAEStream**)reply->data;
+      IAE::StreamPtr stream(*reinterpret_cast<CActiveAEStream**>(reply->data),
+                            IAEStreamDeleter(*this));
       reply->Release();
       return stream;
     }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -246,8 +246,9 @@ public:
   bool IsMuted() override;
 
   /* returns a new stream for data in the specified format */
-  IAEStream *MakeStream(AEAudioFormat &audioFormat, unsigned int options = 0, IAEClockCallback *clock = NULL) override;
-  bool FreeStream(IAEStream *stream, bool finish) override;
+  IAE::StreamPtr MakeStream(AEAudioFormat& audioFormat,
+                            unsigned int options = 0,
+                            IAEClockCallback* clock = NULL) override;
 
   /* returns a new sound object */
   IAE::SoundPtr MakeSound(const std::string& file) override;
@@ -273,6 +274,7 @@ public:
   void OnAppFocusChange(bool focus) override;
 
 private:
+  bool FreeStream(IAEStream* stream, bool finish) override;
   void FreeSound(IAESound* sound) override;
 
 protected:

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -250,8 +250,7 @@ public:
   bool FreeStream(IAEStream *stream, bool finish) override;
 
   /* returns a new sound object */
-  IAESound *MakeSound(const std::string& file) override;
-  void FreeSound(IAESound *sound) override;
+  IAE::SoundPtr MakeSound(const std::string& file) override;
 
   void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) override;
   bool SupportsRaw(AEAudioFormat &format) override;
@@ -272,6 +271,9 @@ public:
   void OnLostDisplay() override;
   void OnResetDisplay() override;
   void OnAppFocusChange(bool focus) override;
+
+private:
+  void FreeSound(IAESound* sound) override;
 
 protected:
   void PlaySound(CActiveAESound *sound);

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -25,15 +25,16 @@ typedef std::vector<AEDevice> AEDeviceList;
 /* forward declarations */
 class IAEStream;
 class IAESound;
+class IAESoundDeleter;
 class IAEPacketizer;
 class IAudioCallback;
 class IAEClockCallback;
 class CAEStreamInfo;
 
 /* sound options */
-#define AE_SOUND_OFF    0 /* disable sounds */
-#define AE_SOUND_IDLE   1 /* only play sounds while no streams are running */
-#define AE_SOUND_ALWAYS 2 /* always play sounds */
+#define AE_SOUND_OFF 0 /*! disable sounds */
+#define AE_SOUND_IDLE 1 /*! only play sounds while no streams are running */
+#define AE_SOUND_ALWAYS 2 /*! always play sounds */
 
 /* config options */
 #define AE_CONFIG_FIXED 1
@@ -42,18 +43,18 @@ class CAEStreamInfo;
 
 enum AEQuality
 {
-  AE_QUALITY_UNKNOWN    = -1, /* Unset, unknown or incorrect quality level */
-  AE_QUALITY_DEFAULT    =  0, /* Engine's default quality level */
+  AE_QUALITY_UNKNOWN = -1, /*! Unset, unknown or incorrect quality level */
+  AE_QUALITY_DEFAULT = 0, /*! Engine's default quality level */
 
   /* Basic quality levels */
-  AE_QUALITY_LOW        = 20, /* Low quality level */
-  AE_QUALITY_MID        = 30, /* Standard quality level */
-  AE_QUALITY_HIGH       = 50, /* Best sound processing quality */
+  AE_QUALITY_LOW = 20, /*! Low quality level */
+  AE_QUALITY_MID = 30, /*! Standard quality level */
+  AE_QUALITY_HIGH = 50, /*! Best sound processing quality */
 
   /* Optional quality levels */
-  AE_QUALITY_REALLYHIGH = 100, /* Uncompromised optional quality level,
+  AE_QUALITY_REALLYHIGH = 100, /*! Uncompromised optional quality level,
                                usually with unmeasurable and unnoticeable improvement */
-  AE_QUALITY_GPU        = 101, /* GPU acceleration */
+  AE_QUALITY_GPU = 101, /*! GPU acceleration */
 };
 
 struct SampleConfig
@@ -66,8 +67,8 @@ struct SampleConfig
   int dither_bits;
 };
 
-/**
- * IAE Interface
+/*!
+ * \brief IAE Interface
  */
 class IAE
 {
@@ -76,128 +77,151 @@ protected:
   IAE() = default;
   virtual ~IAE() = default;
 
-  /**
-   * Initializes the AudioEngine, called by CFactory when it is time to initialize the audio engine.
+  /*!
+   * \brief Initializes the AudioEngine, called by CFactory when it is time to initialize the audio engine.
+   *
    * Do not call this directly, CApplication will call this when it is ready
    */
   virtual void Start() = 0;
 public:
-  /**
-   * Called when the application needs to terminate the engine
+  /*!
+   * \brief Called when the application needs to terminate the engine
    */
   virtual void Shutdown() { }
 
-  /**
-   * Suspends output and de-initializes sink
+  /*!
+   * \brief Suspends output and de-initializes sink
+   *
    * Used to avoid conflicts with external players or to reduce power consumption
-   * @return True if successful
+   *
+   * \return True if successful
    */
   virtual bool Suspend() = 0;
 
-  /**
-   * Resumes output and re-initializes sink
+  /*!
+   * \brief Resumes output and re-initializes sink
+   *
    * Used to resume output from Suspend() state above
-   * @return True if successful
+   *
+   * \return True if successful
    */
   virtual bool Resume() = 0;
 
-  /**
-   * Get the current Suspend() state
+  /*!
+   * \brief Get the current Suspend() state
+   *
    * Used by players to determine if audio is being processed
    * Default is true so players drop audio or pause if engine unloaded
-   * @return True if processing suspended
+   *
+   * \return True if processing suspended
    */
   virtual bool IsSuspended() {return true;}
 
-  /**
-   * Returns the current master volume level of the AudioEngine
-   * @return The volume level between 0.0 and 1.0
+  /*!
+   * \brief Returns the current master volume level of the AudioEngine
+   *
+   * \return The volume level between 0.0 and 1.0
    */
   virtual float GetVolume() = 0;
 
-  /**
-   * Sets the master volume level of the AudioEngine
-   * @param volume The new volume level between 0.0 and 1.0
+  /*!
+   * \brief Sets the master volume level of the AudioEngine
+   *
+   * \param volume The new volume level between 0.0 and 1.0
    */
   virtual void SetVolume(const float volume) = 0;
 
-  /**
-   * Set the mute state (does not affect volume level value)
-   * @param enabled The mute state
+  /*!
+   * \brief Set the mute state (does not affect volume level value)
+   *
+   * \param enabled The mute state
    */
   virtual void SetMute(const bool enabled) = 0;
 
-  /**
-   * Get the current mute state
-   * @return The current mute state
+  /*!
+   * \brief Get the current mute state
+   *
+   * \return The current mute state
    */
   virtual bool IsMuted() = 0;
 
-  /**
-   * Creates and returns a new IAEStream in the format specified, this function should never fail
-   * @param audioFormat
-   * @param options A bit field of stream options (see: enum AEStreamOptions)
-   * @return a new IAEStream that will accept data in the requested format
+  /*!
+   * \brief Creates and returns a new IAEStream in the format specified, this function should never fail
+   *
+   * \param audioFormat
+   * \param options A bit field of stream options (see: enum AEStreamOptions)
+   * \return a new IAEStream that will accept data in the requested format
    */
   virtual IAEStream *MakeStream(AEAudioFormat &audioFormat, unsigned int options = 0, IAEClockCallback *clock = NULL) = 0;
 
-  /**
-   * This method will remove the specifyed stream from the engine.
+  /*!
+   * \brief This method will remove the specifyed stream from the engine.
+   *
    * For OSX/IOS this is essential to reconfigure the audio output.
-   * @param stream The stream to be altered
-   * @param finish if true AE will switch back to gui sound mode (if this is last stream)
-   * @return NULL
+   *
+   * \param stream The stream to be altered
+   * \param finish if true AE will switch back to gui sound mode (if this is last stream)
+   * \return NULL
    */
   virtual bool FreeStream(IAEStream *stream, bool finish) = 0;
 
-  /**
-   * Creates a new IAESound that is ready to play the specified file
-   * @param file The WAV file to load, this supports XBMC's VFS
-   * @return A new IAESound if the file could be loaded, otherwise NULL
+  /*!
+   * \brief Creates a new IAESound that is ready to play the specified file
+   *
+   * \param file The WAV file to load, this supports XBMC's VFS
+   * \return A new IAESound if the file could be loaded, otherwise NULL
    */
   virtual IAESound *MakeSound(const std::string &file) = 0;
 
-  /**
-   * Free the supplied IAESound object
-   * @param sound The IAESound object to free
+  /*!
+   * \brief Free the supplied IAESound object
+   *
+   * \param sound The IAESound object to free
    */
   virtual void FreeSound(IAESound *sound) = 0;
 
-  /**
-   * Enumerate the supported audio output devices
-   * @param devices The device list to append supported devices to
-   * @param passthrough True if only passthrough devices are wanted
+  /*!
+   * \brief Enumerate the supported audio output devices
+   *
+   * \param devices The device list to append supported devices to
+   * \param passthrough True if only passthrough devices are wanted
    */
   virtual void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) = 0;
 
-  /**
-   * Returns true if the AudioEngine supports AE_FMT_RAW streams for use with formats such as IEC61937
-   * @see CAEPackIEC61937::CAEPackIEC61937()
-   * @returns true if the AudioEngine is capable of RAW output
+  /*!
+   * \brief Returns true if the AudioEngine supports AE_FMT_RAW streams for use with formats such as IEC61937
+   *
+   * \see CAEPackIEC61937::CAEPackIEC61937()
+   *
+   * \returns true if the AudioEngine is capable of RAW output
    */
   virtual bool SupportsRaw(AEAudioFormat &format) { return false; }
 
-   /**
-   * Returns true if the AudioEngine supports drain mode which is not streaming silence when idle
-   * @returns true if the AudioEngine is capable of drain mode
+  /*!
+   * \brief Returns true if the AudioEngine supports drain mode which is not streaming silence when idle
+   *
+   * \returns true if the AudioEngine is capable of drain mode
    */
   virtual bool SupportsSilenceTimeout() { return false; }
 
-  /**
-   * Returns true if the AudioEngine is currently configured to extract the DTS Core from DTS-HD streams
-   * @returns true if the AudioEngine is currently configured to extract the DTS Core from DTS-HD streams
+  /*!
+   * \brief Returns true if the AudioEngine is currently configured to extract the DTS Core from DTS-HD streams
+   *
+   * \returns true if the AudioEngine is currently configured to extract the DTS Core from DTS-HD streams
    */
   virtual bool UsesDtsCoreFallback() { return false; }
 
-  /**
-   * Returns true if the AudioEngine is currently configured for stereo audio
-   * @returns true if the AudioEngine is currently configured for stereo audio
+  /*!
+   * \brief Returns true if the AudioEngine is currently configured for stereo audio
+   *
+   * \returns true if the AudioEngine is currently configured for stereo audio
    */
   virtual bool HasStereoAudioChannelCount() { return false; }
 
-  /**
-   * Returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
-   * @returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
+  /*!
+   * \brief Returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
+   *
+   * \returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
    */
   virtual bool HasHDAudioChannelCount() { return true; }
 
@@ -205,39 +229,42 @@ public:
 
   virtual void UnregisterAudioCallback(IAudioCallback* pCallback) {}
 
-  /**
-   * Returns true if AudioEngine supports specified quality level
-   * @return true if specified quality level is supported, otherwise false
+  /*!
+   * \brief Returns true if AudioEngine supports specified quality level
+   *
+   * \return true if specified quality level is supported, otherwise false
    */
   virtual bool SupportsQualityLevel(enum AEQuality level) { return false; }
 
-  /**
-   * AE decides whether this settings should be displayed
-   * @return true if AudioEngine wants to display this setting
+  /*!
+   * \brief AE decides whether this settings should be displayed
+   *
+   * \return true if AudioEngine wants to display this setting
    */
   virtual bool IsSettingVisible(const std::string &settingId) {return false; }
 
-  /**
-   * Instruct AE to keep configuration for a specified time
-   * @param millis time for which old configuration should be kept
+  /*!
+   * \brief Instruct AE to keep configuration for a specified time
+   *
+   * \param millis time for which old configuration should be kept
    */
   virtual void KeepConfiguration(unsigned int millis) {}
 
-  /**
-   * Instruct AE to re-initialize, e.g. after ELD change event
+  /*!
+   * \brief Instruct AE to re-initialize, e.g. after ELD change event
    */
   virtual void DeviceChange() {}
 
-  /**
-   * Instruct AE to re-initialize, e.g. after ELD change event
+  /*!
+   * \brief Instruct AE to re-initialize, e.g. after ELD change event
    */
   virtual void DeviceCountChange(const std::string& driver) {}
 
-  /**
-   * Get the current sink data format
+  /*!
+   * \brief Get the current sink data format
    *
-   * @param Current sink data format. For more details see AEAudioFormat.
-   * @return Returns true on success, else false.
+   * \param Current sink data format. For more details see AEAudioFormat.
+   * \return Returns true on success, else false.
    */
   virtual bool GetCurrentSinkFormat(AEAudioFormat &SinkFormat) { return false; }
 };

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -138,7 +138,6 @@ void CRetroPlayerAudio::CloseStream()
   {
     CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Closing audio stream");
 
-    CServiceBroker::GetActiveAE()->FreeStream(m_pAudioStream, true);
-    m_pAudioStream = nullptr;
+    m_pAudioStream.reset();
   }
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "IRetroPlayerStream.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
 
 #include <memory>
 
@@ -59,7 +60,7 @@ public:
 
 private:
   CRPProcessInfo& m_processInfo;
-  IAEStream* m_pAudioStream;
+  IAE::StreamPtr m_pAudioStream;
   bool m_bAudioEnabled;
 };
 } // namespace RETRO

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -34,8 +34,6 @@ CAudioSinkAE::CAudioSinkAE(CDVDClock *clock) : m_pClock(clock)
 CAudioSinkAE::~CAudioSinkAE()
 {
   CSingleLock lock (m_critSection);
-  if (m_pAudioStream)
-    CServiceBroker::GetActiveAE()->FreeStream(m_pAudioStream, true);
 }
 
 bool CAudioSinkAE::Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool needresampler)
@@ -73,7 +71,10 @@ void CAudioSinkAE::Destroy(bool finish)
   CSingleLock lock (m_critSection);
 
   if (m_pAudioStream)
-    CServiceBroker::GetActiveAE()->FreeStream(m_pAudioStream, finish);
+  {
+    m_pAudioStream.get_deleter().setFinish(finish);
+    m_pAudioStream.reset();
+  }
 
   m_pAudioStream = NULL;
   m_sampleRate = 0;

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
-#include "threads/CriticalSection.h"
-#include "PlatformDefs.h"
-
-#include "cores/AudioEngine/Utils/AEChannelInfo.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/Interfaces/AEStream.h"
+#include "cores/AudioEngine/Utils/AEChannelInfo.h"
+#include "threads/CriticalSection.h"
+
 #include <atomic>
+
+#include "PlatformDefs.h"
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -62,8 +64,7 @@ public:
   CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate, int profile);
 
 protected:
-
-  IAEStream *m_pAudioStream;
+  IAE::StreamPtr m_pAudioStream;
   double m_playingPts;
   double m_timeOfPts;
   double m_syncError;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -175,8 +175,7 @@ void PAPlayer::CloseAllStreams(bool fade/* = true */)
       if (si->m_stream)
       {
         CloseFileCB(*si);
-        CServiceBroker::GetActiveAE()->FreeStream(si->m_stream, true);
-        si->m_stream = NULL;
+        si->m_stream.reset();
       }
 
       si->m_decoder.Destroy();
@@ -191,8 +190,7 @@ void PAPlayer::CloseAllStreams(bool fade/* = true */)
       if (si->m_stream)
       {
         CloseFileCB(*si);
-        CServiceBroker::GetActiveAE()->FreeStream(si->m_stream, true);
-        si->m_stream = nullptr;
+        si->m_stream.reset();
       }
 
       si->m_decoder.Destroy();
@@ -475,7 +473,7 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
   {
     /* slave the stream for gapless */
     si->m_isSlaved = true;
-    m_currentStream->m_stream->RegisterSlave(si->m_stream);
+    m_currentStream->m_stream->RegisterSlave(si->m_stream.get());
   }
 
   /* fill the stream's buffer */
@@ -594,7 +592,6 @@ inline void PAPlayer::ProcessStreams(double &freeBufferTime)
     {
       itt = m_finishing.erase(itt);
       CloseFileCB(*si);
-      CServiceBroker::GetActiveAE()->FreeStream(si->m_stream, true);
       delete si;
       CLog::Log(LOGDEBUG, "PAPlayer::ProcessStreams - Stream Freed");
     }

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -10,6 +10,7 @@
 
 #include "AudioDecoder.h"
 #include "FileItem.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/Interfaces/IAudioCallback.h"
 #include "cores/IPlayer.h"
 #include "threads/CriticalSection.h"
@@ -102,7 +103,7 @@ private:
     int m_seekNextAtFrame;               /* the FF/RR sample to seek at */
     int m_seekFrame;                     /* the exact position to seek too, -1 for none */
 
-    IAEStream* m_stream;                 /* the playback stream */
+    IAE::StreamPtr m_stream; /* the playback stream */
     float m_volume;                      /* the initial volume level to set the stream to on creation */
 
     bool m_isSlaved;                     /* true if the stream has been slaved to another */

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -25,13 +25,6 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
-void CGUIAudioManager::IAESoundDeleter::operator()(IAESound* s)
-{
-  IAE* ae = CServiceBroker::GetActiveAE();
-  if (ae)
-    ae->FreeSound(s);
-}
-
 CGUIAudioManager::CGUIAudioManager()
 {
   m_settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -328,7 +321,7 @@ std::shared_ptr<IAESound> CGUIAudioManager::LoadSound(const std::string& filenam
   if (!ae)
     return nullptr;
 
-  std::shared_ptr<IAESound> sound(ae->MakeSound(filename), IAESoundDeleter());
+  std::shared_ptr<IAESound> sound(ae->MakeSound(filename));
   if (!sound)
     return nullptr;
 


### PR DESCRIPTION
## Description
This builds on #20170 and starts the smart pointer usage further down the stack.

All in all very straight forward, the only thing I'm not 100% sure about design wise is the access of the deleter to influence the behaviour on cleanup in `CAudioSinkAE::Destroy`, see also `IAEStreamDeleter::setFinish`.

## Motivation and context
Smart pointers everywhere :smile: 

## How has this been tested?
Runtime tested on Linux/Wayland.

## What is the effect on users?
N/A

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
