### PR TITLE
[VideoPlayerAudio][EDL] Fix edl mute (credits: fernetmenta)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1648,7 +1648,9 @@ void CVideoPlayer::ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket)
   }
 
   m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
-  m_CurrentAudio.packets++;
+
+  if (!drop)
+    m_CurrentAudio.packets++;
 }
 
 void CVideoPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
@@ -1672,7 +1674,9 @@ void CVideoPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
     drop = true;
 
   m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
-  m_CurrentVideo.packets++;
+
+  if (!drop)
+    m_CurrentVideo.packets++;
 }
 
 void CVideoPlayer::ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -385,9 +385,14 @@ void CVideoPlayerAudio::Process()
       DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
       bool bPacketDrop = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacketDrop();
 
-      if (bPacketDrop ||
-          (!m_processInfo.IsTempoAllowed(static_cast<float>(m_speed)/DVD_PLAYSPEED_NORMAL) &&
-           m_syncState == IDVDStreamPlayer::SYNC_INSYNC))
+      if (bPacketDrop)
+      {
+        m_syncState = IDVDStreamPlayer::SYNC_STARTING;
+        continue;
+      }
+
+      if (!m_processInfo.IsTempoAllowed(static_cast<float>(m_speed) / DVD_PLAYSPEED_NORMAL) &&
+          m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
       {
         continue;
       }


### PR DESCRIPTION
## Description
When the videoplayer is processing EDL markings (either scene skips or mute actions), audio packets are explicitly dropped while ActiveAE is active:

https://github.com/xbmc/xbmc/blob/9b080490af7838c10be233c627279d977e8fd101/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L1639-L1650

As the `VideoPlayerAudio` is still in sync mode (although packets are dropped), it marks the stream as stalled when the default sync period finishes:

https://github.com/xbmc/xbmc/blob/34c1c01498447a3dd98f1a8325e8a85d88be99be/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp#L274-L278

As we are effectively dropping packets, the VPA syncstate must be changed to SYNC_STARTED as soon as the first packet is dropped. It will move to SYNC_INSYNC as soon as the next audio packet reaches VPA.

Should fix EDL scene skips and mute actions resetting the stream.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/17328
Fix https://github.com/xbmc/xbmc/issues/18875
Fix https://github.com/xbmc/xbmc/issues/15186

## How has this been tested?
Runtime tested, several edl configurations. Mostly the one in the wiki

```
5.3   7.1    0
15    16.7   1
420   822    3
1     255.3  2
720.1        2
```

## What is the effect on users?
Restore EDL functionality, broken since leia.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
