### PR TITLE
[pvr] correctly support fallback for providers from custom client provider to default provider

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -830,6 +830,11 @@ bool CPVRChannel::HasClientProvider() const
 
 std::shared_ptr<CPVRProvider> CPVRChannel::GetProvider() const
 {
-  return CServiceBroker::GetPVRManager().Providers()->GetByClient(m_iClientId,
-                                                                  m_iClientProviderUid);
+  auto provider =
+      CServiceBroker::GetPVRManager().Providers()->GetByClient(m_iClientId, m_iClientProviderUid);
+
+  if (!provider)
+    provider = GetDefaultProvider();
+
+  return provider;
 }

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -465,16 +465,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         if (!recording->Channel())
         {
           auto provider = recording->GetProvider();
-          if (provider->GetIconPath().empty())
-          {
-            provider = recording->GetDefaultProvider();
-            if (!provider->GetIconPath().empty())
-            {
-              strValue = provider->GetIconPath();
-              return true;
-            }
-          }
-          else
+          if (!provider->GetIconPath().empty())
           {
             strValue = provider->GetIconPath();
             return true;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -652,6 +652,11 @@ bool CPVRRecording::HasClientProvider() const
 
 std::shared_ptr<CPVRProvider> CPVRRecording::GetProvider() const
 {
-  return CServiceBroker::GetPVRManager().Providers()->GetByClient(m_iClientId,
-                                                                  m_iClientProviderUniqueId);
+  auto provider = CServiceBroker::GetPVRManager().Providers()->GetByClient(
+      m_iClientId, m_iClientProviderUniqueId);
+
+  if (!provider)
+    provider = GetDefaultProvider();
+
+  return provider;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A provider should always be available for a Channel or recording as if a custom one is not available then the PVR add-on provider should be selected. This PR provides fallback logic to ensure this is the case.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The missing fallback logic caused a crash to happen in the GUI logic for recordings and providers.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On MacOSX

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
