### PR TITLE
[audio] fix new warning

### DIFF
--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -138,15 +138,16 @@ void CGUIAudioManager::PlayWindowSound(int id, WINDOW_SOUND event)
   if (it==m_windowSoundMap.end())
     return;
 
-  const auto& sound = [&]() {
-    switch (event)
-    {
-      case SOUND_INIT:
-        return it->second.initSound;
-      case SOUND_DEINIT:
-        return it->second.deInitSound;
-    }
-  }();
+  std::shared_ptr<IAESound> sound;
+  switch (event)
+  {
+    case SOUND_INIT:
+      sound = it->second.initSound;
+      break;
+    case SOUND_DEINIT:
+      sound = it->second.deInitSound;
+      break;
+  }
 
   if (!sound)
     return;


### PR DESCRIPTION
## Description
this should fix the new warning of https://github.com/xbmc/xbmc/pull/20170
i didn't spot a red jenkins tick on the original pr..
@neo1973 might want to fix it differently - i'm open

```
xbmc/guilib/GUIAudioManager.cpp: In lambda function:
xbmc/guilib/GUIAudioManager.cpp:149:3: warning: control reaches end of non-void function [-Wreturn-type]
  149 |   }();
      |   ^
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
