### PR TITLE
[Estuary][PVR] Timers homescreen widget

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -372,35 +372,6 @@
 					<control type="grouplist" id="12001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>12010</pagecontrol>
-						<control type="grouplist" id="12855">
-							<height>390</height>
-							<left>0</left>
-							<right>0</right>
-							<top>36</top>
-							<orientation>horizontal</orientation>
-							<visible>PVR.IsRecordingTV | PVR.HasNonRecordingTVTimer</visible>
-							<align>center</align>
-							<control type="group">
-								<width>674</width>
-								<visible>PVR.IsRecordingTV</visible>
-								<include content="PVRWidget">
-									<param name="icon" value="$INFO[PVR.TVNowRecordingChannelIcon]" />
-									<param name="header" value="$LOCALIZE[19158]" />
-									<param name="label1" value="$INFO[PVR.TVNowRecordingDateTime]" />
-									<param name="label2" value="$INFO[PVR.TVNowRecordingTitle][CR][COLOR=grey]$INFO[PVR.TVNowRecordingChannel][/COLOR]" />
-								</include>
-							</control>
-							<control type="group">
-								<width>674</width>
-								<visible>PVR.HasNonRecordingTVTimer</visible>
-								<include content="PVRWidget">
-									<param name="icon" value="$INFO[PVR.TVNextRecordingChannelIcon]" />
-									<param name="header" value="$LOCALIZE[19157]" />
-									<param name="label1" value="$INFO[PVR.TVNextRecordingDateTime]" />
-									<param name="label2" value="$INFO[PVR.TVNextRecordingTitle][CR][COLOR=grey]$INFO[PVR.TVNextRecordingChannel][/COLOR]" />
-								</include>
-							</control>
-						</control>
 						<include content="WidgetListCategories" condition="System.HasPVRAddon">
 							<param name="content_path" value="pvr://tv/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
@@ -423,10 +394,20 @@
 							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)]"/>
 						</include>
 						<include content="WidgetListChannels" condition="System.HasPVRAddon">
+							<param name="content_path" value="pvr://timers/tv/timers/?view=hidedisabled"/>
+							<param name="sortorder" value="ascending"/>
+							<param name="sortby" value="date"/>
+							<param name="widget_header" value="$LOCALIZE[19040]"/>
+							<param name="widget_target" value="tvtimers"/>
+							<param name="list_id" value="12400"/>
+							<param name="label" value="$INFO[ListItem.Date]"/>
+							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)] - $INFO[ListItem.ChannelName]"/>
+						</include>
+						<include content="WidgetListChannels" condition="System.HasPVRAddon">
 							<param name="content_path" value="pvr://channels/tv"/>
 							<param name="widget_header" value="$LOCALIZE[19173]"/>
 							<param name="widget_target" value="tvguide"/>
-							<param name="list_id" value="12400"/>
+							<param name="list_id" value="12500"/>
 							<param name="item_treshold" value="1"/>
 						</include>
 					</control>
@@ -449,35 +430,6 @@
 					<control type="grouplist" id="13001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>13010</pagecontrol>
-						<control type="grouplist" id="13855">
-							<height>390</height>
-							<left>0</left>
-							<right>0</right>
-							<top>36</top>
-							<orientation>horizontal</orientation>
-							<align>center</align>
-							<visible>PVR.IsRecordingRadio | PVR.HasNonRecordingRadioTimer</visible>
-							<control type="group">
-								<width>680</width>
-								<visible>PVR.IsRecordingRadio</visible>
-								<include content="PVRWidget">
-									<param name="icon" value="$INFO[PVR.RadioNowRecordingChannelIcon]" />
-									<param name="header" value="$LOCALIZE[19158]" />
-									<param name="label1" value="$INFO[PVR.RadioNowRecordingDateTime]" />
-									<param name="label2" value="$INFO[PVR.RadioNowRecordingTitle][CR][COLOR=grey]$INFO[PVR.RadioNowRecordingChannel][/COLOR]" />
-								</include>
-							</control>
-							<control type="group">
-								<visible>PVR.HasNonRecordingRadioTimer</visible>
-								<width>680</width>
-								<include content="PVRWidget">
-									<param name="icon" value="$INFO[PVR.RadioNextRecordingChannelIcon]" />
-									<param name="header" value="$LOCALIZE[19157]" />
-									<param name="label1" value="$INFO[PVR.RadioNextRecordingDateTime]" />
-									<param name="label2" value="$INFO[PVR.RadioNextRecordingTitle][CR][COLOR=grey]$INFO[PVR.RadioNextRecordingChannel][/COLOR]" />
-								</include>
-							</control>
-						</control>
 						<include content="WidgetListCategories" condition="System.HasPVRAddon">
 							<param name="content_path" value="pvr://radio/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
@@ -500,10 +452,20 @@
 							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)]"/>
 						</include>
 						<include content="WidgetListChannels" condition="System.HasPVRAddon">
+							<param name="content_path" value="pvr://timers/radio/timers/?view=hidedisabled"/>
+							<param name="sortorder" value="ascending"/>
+							<param name="sortby" value="date"/>
+							<param name="widget_header" value="$LOCALIZE[19040]"/>
+							<param name="widget_target" value="radiotimers"/>
+							<param name="list_id" value="13400"/>
+							<param name="label" value="$INFO[ListItem.Date]"/>
+							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)] - $INFO[ListItem.ChannelName]"/>
+						</include>
+						<include content="WidgetListChannels" condition="System.HasPVRAddon">
 							<param name="content_path" value="pvr://channels/radio"/>
 							<param name="widget_header" value="$LOCALIZE[19174]"/>
 							<param name="widget_target" value="radioguide"/>
-							<param name="list_id" value="13400"/>
+							<param name="list_id" value="13500"/>
 							<param name="item_treshold" value="1"/>
 						</include>
 					</control>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -477,7 +477,7 @@
 							<top>43</top>
 							<left>38</left>
 							<width>245</width>
-							<height>200</height>
+							<height>190</height>
 							<texture fallback="DefaultTVShows.png">$PARAM[icon]</texture>
 							<aspectratio>keep</aspectratio>
 						</control>
@@ -540,7 +540,7 @@
 							<top>43</top>
 							<left>38</left>
 							<width>245</width>
-							<height>200</height>
+							<height>190</height>
 							<texture fallback="DefaultTVShows.png">$PARAM[icon]</texture>
 							<aspectratio>keep</aspectratio>
 						</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -394,6 +394,8 @@
 	</variable>
 	<variable name="WallWatchedIconVar">
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
+		<value condition="ListItem.HasReminder">icons/pvr/timers/bell.png</value>
+		<value condition="ListItem.HasTimer">icons/pvr/timers/recording.png</value>
 		<value condition="ListItem.IsCollection">overlays/set.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
 		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -22,8 +22,7 @@
 #include "pictures/PictureThumbLoader.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRThumbLoader.h"
-#include "pvr/dialogs/GUIDialogPVRGuideInfo.h"
-#include "pvr/dialogs/GUIDialogPVRRecordingInfo.h"
+#include "pvr/guilib/PVRGUIActions.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
@@ -414,16 +413,12 @@ bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)
   auto fileItem = std::static_pointer_cast<CFileItem>(item);
 
   if (fileItem->HasAddonInfo())
+  {
     return CGUIDialogAddonInfo::ShowForItem(fileItem);
-  else if (fileItem->HasPVRRecordingInfoTag())
-  {
-    CGUIDialogPVRRecordingInfo::ShowFor(fileItem);
-    return true;
   }
-  else if (fileItem->HasPVRChannelInfoTag())
+  else if (fileItem->IsPVR())
   {
-    CGUIDialogPVRGuideInfo::ShowFor(fileItem);
-    return true;
+    return CServiceBroker::GetPVRManager().GUIActions()->OnInfo(fileItem);
   }
   else if (fileItem->HasVideoInfoTag())
   {

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -521,13 +521,12 @@ namespace
 {
 
 bool GetTimersRootDirectory(const CPVRTimersPath& path,
+                            bool bHideDisabled,
                             const std::vector<std::shared_ptr<CPVRTimerInfoTag>>& timers,
                             CFileItemList& results)
 {
   bool bRadio = path.IsRadio();
   bool bRules = path.IsRules();
-
-  bool bHideDisabled = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRTIMERS_HIDEDISABLEDTIMERS);
 
   for (const auto& timer : timers)
   {
@@ -545,14 +544,13 @@ bool GetTimersRootDirectory(const CPVRTimersPath& path,
 }
 
 bool GetTimersSubDirectory(const CPVRTimersPath& path,
+                           bool bHideDisabled,
                            const std::vector<std::shared_ptr<CPVRTimerInfoTag>>& timers,
                            CFileItemList& results)
 {
   bool bRadio = path.IsRadio();
   int iParentId = path.GetParentId();
   int iClientId = path.GetClientId();
-
-  bool bHideDisabled = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRTIMERS_HIDEDISABLEDTIMERS);
 
   std::shared_ptr<CFileItem> item;
 
@@ -578,19 +576,40 @@ bool GetTimersSubDirectory(const CPVRTimersPath& path,
 bool CPVRGUIDirectory::GetTimersDirectory(CFileItemList& results) const
 {
   const CPVRTimersPath path(m_url.GetWithoutOptions());
-  if (path.IsValid())
+  if (path.IsValid() && (path.IsTimersRoot() || path.IsTimerRule()))
   {
-    const std::vector<std::shared_ptr<CPVRTimerInfoTag>> timers = CServiceBroker::GetPVRManager().Timers()->GetAll();
+    bool bHideDisabled = false;
+    if (m_url.HasOption("view"))
+    {
+      const std::string view = m_url.GetOption("view");
+      if (view == "hidedisabled")
+      {
+        bHideDisabled = true;
+      }
+      else
+      {
+        CLog::LogF(LOGERROR, "Unsupported value '{}' for url parameter 'view'", view);
+        return false;
+      }
+    }
+    else
+    {
+      bHideDisabled = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_PVRTIMERS_HIDEDISABLEDTIMERS);
+    }
+
+    const std::vector<std::shared_ptr<CPVRTimerInfoTag>> timers =
+        CServiceBroker::GetPVRManager().Timers()->GetAll();
 
     if (path.IsTimersRoot())
     {
       /* Root folder containing either timer rules or timers. */
-      return GetTimersRootDirectory(path, timers, results);
+      return GetTimersRootDirectory(path, bHideDisabled, timers, results);
     }
     else if (path.IsTimerRule())
     {
       /* Sub folder containing the timers scheduled by the given timer rule. */
-      return GetTimersSubDirectory(path, timers, results);
+      return GetTimersSubDirectory(path, bHideDisabled, timers, results);
     }
   }
 

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -524,13 +524,6 @@ bool GetTimersRootDirectory(const CPVRTimersPath& path,
                             const std::vector<std::shared_ptr<CPVRTimerInfoTag>>& timers,
                             CFileItemList& results)
 {
-  std::shared_ptr<CFileItem> item(new CFileItem(CPVRTimersPath::PATH_ADDTIMER, false));
-  item->SetLabel(g_localizeStrings.Get(19026)); // "Add timer..."
-  item->SetLabelPreformatted(true);
-  item->SetSpecialSort(SortSpecialOnTop);
-  item->SetArt("icon", "DefaultTVShows.png");
-  results.Add(item);
-
   bool bRadio = path.IsRadio();
   bool bRules = path.IsRules();
 
@@ -542,7 +535,7 @@ bool GetTimersRootDirectory(const CPVRTimersPath& path,
         (bRules == timer->IsTimerRule()) &&
         (!bHideDisabled || (timer->m_state != PVR_TIMER_STATE_DISABLED)))
     {
-      item.reset(new CFileItem(timer));
+      const auto item = std::make_shared<CFileItem>(timer);
       const CPVRTimersPath timersPath(path.GetPath(), timer->m_iClientId, timer->m_iClientIndex);
       item->SetPath(timersPath.GetPath());
       results.Add(item);

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -2617,6 +2617,21 @@ namespace PVR
     }
   }
 
+  bool CPVRGUIActions::OnInfo(const std::shared_ptr<CFileItem>& item)
+  {
+    if (item->HasPVRRecordingInfoTag())
+    {
+      CGUIDialogPVRRecordingInfo::ShowFor(item);
+      return true;
+    }
+    else if (item->HasPVRChannelInfoTag() || item->HasPVRTimerInfoTag())
+    {
+      CGUIDialogPVRGuideInfo::ShowFor(item);
+      return true;
+    }
+    return false;
+  }
+
   void CPVRChannelSwitchingInputHandler::AppendChannelNumberCharacter(char cCharacter)
   {
     // special case. if only a single zero was typed in, switch to previously played channel.

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -441,6 +441,12 @@ namespace PVR
      */
     void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
 
+    /*!
+     * @brief Process info action for the given item.
+     * @param item The item.
+     */
+    bool OnInfo(const std::shared_ptr<CFileItem>& item);
+
   private:
     CPVRGUIActions(const CPVRGUIActions&) = delete;
     CPVRGUIActions const& operator=(CPVRGUIActions const&) = delete;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1279,11 +1279,11 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
       }
       break;
     case LISTITEM_HASTIMER:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
-        if (epgTag)
-          bValue = !!CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epgTag);
+        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        if (timer)
+          bValue = true;
         return true;
       }
       break;

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
+#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "pvr/PVRManager.h"
@@ -49,6 +50,21 @@ bool CGUIWindowPVRTimersBase::OnAction(const CAction& action)
     }
   }
   return CGUIWindowPVRBase::OnAction(action);
+}
+
+void CGUIWindowPVRTimersBase::OnPrepareFileItems(CFileItemList& items)
+{
+  const CPVRTimersPath path(m_vecItems->GetPath());
+  if (path.IsValid() && path.IsTimersRoot())
+  {
+    const auto item = std::make_shared<CFileItem>(CPVRTimersPath::PATH_ADDTIMER, false);
+    item->SetLabel(g_localizeStrings.Get(19026)); // "Add timer..."
+    item->SetLabelPreformatted(true);
+    item->SetSpecialSort(SortSpecialOnTop);
+    item->SetArt("icon", "DefaultTVShows.png");
+
+    items.AddFront(item, 0);
+  }
 }
 
 bool CGUIWindowPVRTimersBase::Update(const std::string& strDirectory, bool updateFilterPath /* = true */)

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
@@ -24,6 +24,7 @@ namespace PVR
 
     bool OnMessage(CGUIMessage& message) override;
     bool OnAction(const CAction& action) override;
+    void OnPrepareFileItems(CFileItemList& items) override;
     bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
     void UpdateButtons() override;
 


### PR DESCRIPTION
The existing "Now recording" and "Next recording" widgets are kind of style breakers as generally Estuary organizes Home screen information of any kind in "lists", not with static widgets periodically switching content.

This PR removes those old widgets and replaces them with a Timers widgets looking and functioning like Recently watched channels, Recent Recordings, Channel groups widgets.

![screenshot00001](https://user-images.githubusercontent.com/3226626/136832896-cec9bd3e-1f50-4c7e-9d43-223e435cc3b0.png)

@ronie do the skin changes look okay for you?
@phunkyfish  are the code changes good?