### PR TITLE
[Subtitles] Suport rgba font colors

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.h
@@ -17,6 +17,7 @@
 #define FLAG_UNDERLINE 2
 #define FLAG_COLOR 3
 #define FLAG_LANGUAGE 4
+#define FLAG_ALPHA 5
 
 class CDVDSubtitleStream;
 class CRegExp;
@@ -59,5 +60,5 @@ public:
 private:
   CRegExp* m_tags;
   CRegExp* m_tagOptions;
-  bool m_flag[5];
+  bool m_flag[6];
 };

--- a/xbmc/utils/ColorUtils.h
+++ b/xbmc/utils/ColorUtils.h
@@ -10,6 +10,8 @@
 
 #include "Color.h"
 
+#include <string>
+
 class ColorUtils
 {
   public:

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1491,6 +1491,20 @@ bool StringUtils::IsInteger(const std::string& str)
   return i == str.size() && n > 0;
 }
 
+std::string StringUtils::InvertStringHexByte(const std::string& byteHex)
+{
+  std::stringstream invertedByteString;
+  invertedByteString << std::hex << (std::stol(byteHex, nullptr, 16) ^ 0xFF);
+  if (invertedByteString.str().size() > 1)
+  {
+    return invertedByteString.str();
+  }
+  else
+  {
+    return "0" + invertedByteString.str();
+  }
+}
+
 int StringUtils::asciidigitvalue(char chr)
 {
   if (!isasciidigit(chr))

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -269,6 +269,12 @@ public:
    */
   static bool IsInteger(const std::string& str);
 
+  /*! \brief Provided a byte hex representation as a string (e.g. FF) returns the inverted byte value as a zero-padded string (00)
+   \param byteHex the byte hex representation (e.g. FF)
+   \return a string containing the inverted byte (e.g. 00)
+   */
+  static std::string InvertStringHexByte(const std::string& byteHex);
+
   /* The next several isasciiXX and asciiXXvalue functions are locale independent (US-ASCII only),
    * as opposed to standard ::isXX (::isalpha, ::isdigit...) which are locale dependent.
    * Next functions get parameter as char and don't need double cast ((int)(unsigned char) is required for standard functions). */


### PR DESCRIPTION
## Description
Pops up now and then as a feature request, this adds rgba color support to text based subtitles (namely SRT which inherits the same tagger as the SAMI format).
Would be nice if someone could look into the added utility function. Not sure if there is an alternative, more performant, approach.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/18917

## How has this been tested?
With a srt external subtitle that provides rgba colors.
In this sub, the top line should render with full opacity (green colour) while the second line should render with ~50% opacity (green colour).
```
3
00:00:21,628 --> 00:00:24,064
<font color="#00ff00ff">I think I've got more</font>
<font color="#00ff0050">than enough. Thanks.</font>
```

## What is the effect on users?
RGBA colours should now work in srt subs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7375276/136837305-fd31a7a5-9049-413a-b29a-7698b1d1955c.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
