### PR TITLE
[GUIMediaWindow] Let the context menu action propagate through window

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -185,13 +185,6 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
     return true;
   }
 
-  // the non-contextual menu can be called at any time
-  if (action.GetID() == ACTION_CONTEXT_MENU && !m_viewControl.HasControl(GetFocusedControlID()))
-  {
-    OnPopupMenu(-1);
-    return true;
-  }
-
   if (CGUIWindow::OnAction(action))
     return true;
 


### PR DESCRIPTION
## Description
Currently GUIMediaWindow is explicitly dropping the context menu action (see -1)  if not in the default container not allowing it to propagate through the window to the respective control. This is most likely obsolete code that still dates back from when the repo was imported from svn (also, looks like a hack). I have no idea what this block of code does and I assume it was there for a reason...not sure if it's valid anymore.
In fact, the right mouse click forwards a different path and ends up propagating the event throughout the chain...showing the context menu.

Since I suppose we don't have anyone familiar with this code, I'd suggest to merge this and see what issues pop up. Hopefully none. 

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/20285

## How has this been tested?
See the instructions on the issue thread, using amber skin.
@roidy (the issue reporter) also tested this in several windows and didn't find any regressions

## What is the effect on users?
Context menu should work in multicontainer views

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7375276/136839172-ac2f3e73-65b4-4d1b-bb9e-107a77e551ad.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
