### PR TITLE
[Playlist] dont use istream directly to a tinyxml structure

### DIFF
--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -289,8 +289,9 @@ bool CPlayListASX::LoadData(std::istream& stream)
   }
   else
   {
+    std::string asxstream(std::istreambuf_iterator<char>(stream), {});
     CXBMCTinyXML xmlDoc;
-    stream >> xmlDoc;
+    xmlDoc.Parse(asxstream, TIXML_DEFAULT_ENCODING);
 
     if (xmlDoc.Error())
     {
@@ -299,6 +300,9 @@ bool CPlayListASX::LoadData(std::istream& stream)
     }
 
     TiXmlElement *pRootElement = xmlDoc.RootElement();
+
+    if (!pRootElement)
+      return false;
 
     // lowercase every element
     TiXmlNode *pNode = pRootElement;


### PR DESCRIPTION
## Description
Turn istream into a std::string to handle large buffers #20305

## Motivation and context
Fixes #20305

the >> operator of istream does no bounds checking and hangs/eventually crashes with large inputs as seen with the POC provided. Instead look to bring the istream into a std::string and then parse the string with tinyxml into the CXBMCTinyXML structure.

## How has this been tested?
OSX with the provided POC in #20305, and another "good" sample asx file.
The POC errors out with the xmldoc.Error check. Good sample is processed correctly.

## What is the effect on users?
No crash with a malicious asx file

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
