### PR TITLE
[Subtitles] SamiTag always consider first 3 bytes for color

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -101,9 +101,10 @@ void CDVDSubtitleTagSami::ConvertLine(std::string& strUTF8, const char* langClas
         if (tagOptionName == "color")
         {
           m_flag[FLAG_COLOR] = true;
-          if (tagOptionValue[0] == '#' && tagOptionValue.size() == 7)
+          if (tagOptionValue[0] == '#' && tagOptionValue.size() >= 7)
           {
             tagOptionValue.erase(0, 1);
+            tagOptionValue.erase(6, tagOptionValue.size());
             colorHex = tagOptionValue;
           }
           else if (tagOptionValue.size() == 6)


### PR DESCRIPTION
## Description
Alternative to https://github.com/xbmc/xbmc/pull/20303. Although we couldn't find any information about alpha channel being supported in srt/sami formats Kodi, unlike other media players, still has borked colours if the provided color has more than 3 bytes (6 alphanumeric chars). In the example below:

```
﻿1
00:00:01,042 --> 00:00:04,078
<font color="#00ffffff">straight back to our front door.</font>
<font color="#00ff00">To you, Mica, Pearl.</font>

2
00:00:12,906 --> 00:00:17,906
<font color="#00ff00ff">And to Raymond. No-one is safe.</font>
```

For `#00ffffff` and `#00ff00ff` in the example above, Kodi ends up feeding the following colorhex:

![image](https://user-images.githubusercontent.com/7375276/136923369-818c5705-4d9d-4bc4-a388-71b85942a13f.png)

This may result in borked colors when we likely want to take the first 3 bytes and ignore the rest (that in this particular case results in cyan and green).

## Motivation and context
Close https://github.com/xbmc/xbmc/issues/18917

## What is the effect on users?
Hopefully better handling the provided subs have bad handling of colours

## Screenshots (if appropriate):

For the first subtitle:

**VLC**
![image](https://user-images.githubusercontent.com/7375276/136923895-4172e109-73bb-4ab7-8e69-46e6eec4e171.png)

**Kodi Master**
![image](https://user-images.githubusercontent.com/7375276/136923947-50666138-56d6-454b-8bd6-c28b0e75ddfd.png)

**This PR**
![image](https://user-images.githubusercontent.com/7375276/136923993-6dd8f46c-4e5a-4929-8d8b-604df0348a8b.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
