### PR TITLE
VideoDb/MusicDb: Change mysql default collation

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -226,7 +226,7 @@ int MysqlDatabase::connect(bool create_new) {
         int ret;
 
         snprintf(sqlcmd, sizeof(sqlcmd),
-                 "CREATE DATABASE `%s` CHARACTER SET utf8 COLLATE utf8_general_ci", db.c_str());
+                 "CREATE DATABASE `%s` CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci", db.c_str());
         if ( (ret=query_with_reconnect(sqlcmd)) != MYSQL_OK )
         {
           throw DbErrors("Can't create new database: '%s' (%d)", db.c_str(), ret);
@@ -320,7 +320,7 @@ int MysqlDatabase::copy(const char *backup_name) {
     }
 
     // create the new database
-    snprintf(sql, sizeof(sql), "CREATE DATABASE `%s` CHARACTER SET utf8 COLLATE utf8_general_ci",
+    snprintf(sql, sizeof(sql), "CREATE DATABASE `%s` CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci",
              backup_name);
     if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
     {
@@ -1569,14 +1569,14 @@ int MysqlDataset::exec(const std::string &sql) {
     || ci_find(qry, "CREATE TEMPORARY TABLE") != std::string::npos )
   {
     // If CREATE TABLE ... SELECT Syntax is used we need to add the encoding after the table before the select
-    // e.g. CREATE TABLE x CHARACTER SET utf8 COLLATE utf8_general_ci [AS] SELECT * FROM y
+    // e.g. CREATE TABLE x CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci [AS] SELECT * FROM y
     if ((loc = qry.find(" AS SELECT ")) != std::string::npos ||
         (loc = qry.find(" SELECT ")) != std::string::npos)
     {
-      qry = qry.insert(loc, " CHARACTER SET utf8 COLLATE utf8_general_ci");
+      qry = qry.insert(loc, " CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci");
     }
     else
-      qry += " CHARACTER SET utf8 COLLATE utf8_general_ci";
+      qry += " CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci";
   }
 
   CLog::Log(LOGDEBUG, "Mysql execute: {}", qry);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -551,7 +551,7 @@ void CMusicDatabase::CreateNativeDBFunctions()
     return;
   CLog::Log(LOGINFO, "Create native MySQL/MariaDB functions");
   /* Functions to do the natural number sorting and all ascii symbol char at top adjustments to
-     default utf8_general_ci collation that SQLite does via a collation sequence callback
+     default utf8mb4_unicode_ci collation that SQLite does via a collation sequence callback
      function to StringUtils::AlphaNumericCompare
      !@todo: the video needs these defined too for sorting in DB, then creation can be made common
   */
@@ -8311,8 +8311,8 @@ std::string CMusicDatabase::AlphanumericSortSQL(const std::string& strField,
   means there is no advantage in defining as column defualt in table create than per query (which
   also makes looking at the db with other tools difficult).
 
-  MySQL does not have callback collation, but all tables are defined with utf8_general_ci an
-  "ascii folding" case insensitive collation. Natural sorting is provided via native functions
+  MySQL does not have callback collation, but all tables are defined with utf8mb4_unicode_ci a
+  case insensitive collation. Natural sorting is provided via native functions
   stored in the db.
   */
   std::string DESC;


### PR DESCRIPTION
## Description

According to research on the subject the correct way
for modern systems seems to be to use utf8mb4_unicode_ci.

Fixes: https://github.com/xbmc/xbmc/issues/16328

## Motivation and context
Tries to address: https://github.com/xbmc/xbmc/issues/16328


## How has this been tested?
Untested at this moment.

## What is the effect on users?
Stores more characters and should also have better
sorting abilities across languages.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@DaveTBlake there is an important part missing and that has to do with our StringUtils. Do you have any idea if it's possible to do the thing you did, with the utf8mb4_unicode_ci collation?