### PR TITLE
[addons] cleanup "kodi/c-api/addon_base.h" macros

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -65,6 +65,7 @@
 #define ATTR_DLL_IMPORT __declspec(dllimport)
 #define ATTR_DLL_EXPORT __declspec(dllexport)
 #define ATTR_DLL_LOCAL
+#define ATTR_APIENTRY __stdcall
 #else
 #if __GNUC__ >= 4
 #define ATTR_DLL_IMPORT __attribute__((visibility("default")))
@@ -75,6 +76,11 @@
 #define ATTR_DLL_EXPORT
 #define ATTR_DLL_LOCAL
 #endif
+#define ATTR_APIENTRY
+#endif
+
+#ifndef ATTR_APIENTRYP
+#define ATTR_APIENTRYP ATTR_APIENTRY*
 #endif
 
 // Fallbacks to old

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -62,21 +62,26 @@
 // Generic helper definitions for shared library support
 //@{
 #if defined _WIN32 || defined __CYGWIN__
-#define ATTRIBUTE_DLL_IMPORT __declspec(dllimport)
-#define ATTRIBUTE_DLL_EXPORT __declspec(dllexport)
-#define ATTRIBUTE_DLL_LOCAL
+#define ATTR_DLL_IMPORT __declspec(dllimport)
+#define ATTR_DLL_EXPORT __declspec(dllexport)
+#define ATTR_DLL_LOCAL
 #else
 #if __GNUC__ >= 4
-#define ATTRIBUTE_DLL_IMPORT __attribute__ ((visibility ("default")))
-#define ATTRIBUTE_DLL_EXPORT __attribute__ ((visibility ("default")))
-#define ATTRIBUTE_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+#define ATTR_DLL_IMPORT __attribute__((visibility("default")))
+#define ATTR_DLL_EXPORT __attribute__((visibility("default")))
+#define ATTR_DLL_LOCAL __attribute__((visibility("hidden")))
 #else
-#define ATTRIBUTE_DLL_IMPORT
-#define ATTRIBUTE_DLL_EXPORT
-#define ATTRIBUTE_DLL_LOCAL
+#define ATTR_DLL_IMPORT
+#define ATTR_DLL_EXPORT
+#define ATTR_DLL_LOCAL
 #endif
 #endif
-#define ATTRIBUTE_HIDDEN ATTRIBUTE_DLL_LOCAL // Fallback to old
+
+// Fallbacks to old
+#define ATTRIBUTE_DLL_IMPORT ATTR_DLL_IMPORT
+#define ATTRIBUTE_DLL_EXPORT ATTR_DLL_EXPORT
+#define ATTRIBUTE_DLL_LOCAL ATTR_DLL_LOCAL
+#define ATTRIBUTE_HIDDEN ATTR_DLL_LOCAL
 //@}
 
 // Hardware specific device context interface

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -90,6 +90,18 @@
 #define ATTRIBUTE_HIDDEN ATTR_DLL_LOCAL
 //@}
 
+#ifdef _WIN32 // windows
+#if !defined(_SSIZE_T_DEFINED) && !defined(HAVE_SSIZE_T)
+typedef intptr_t ssize_t;
+#define _SSIZE_T_DEFINED
+#endif // !_SSIZE_T_DEFINED
+#ifndef SSIZE_MAX
+#define SSIZE_MAX INTPTR_MAX
+#endif // !SSIZE_MAX
+#else // Linux, Mac, FreeBSD
+#include <sys/types.h>
+#endif // TARGET_POSIX
+
 // Hardware specific device context interface
 #define ADDON_HARDWARE_CONTEXT void*
 


### PR DESCRIPTION
## Description

Another pull request for the rework project, this cleans up and expands the macros so that they can be used better.
Since nothing has changed in the API itself and everything continues to work, there are no version increases in it.

Are also in https://github.com/xbmc/xbmc/pull/20317 and stored here to keep things clearer, other request will be updated after this is in here.

Commit 1:
---------------------
**[addons] rename ` #define ATTRIBUTE_...` to shorter with `ATTR_`**

During the revision, I noticed that after a while it can have a major impact on clang cleanup and style, especially on the upcoming typedef's for sandbox API.

This shortens the associated, but there is still a temporary fallback, which will be removed in the very near future.

Commit 2:
---------------------
**[addons] add new macro ATTR_APIENTRY(P) to handle function pointers**

There is an important background to this and to have it OS independent of the required function pointers and to be able to use it more cleanly in typedefs.

Example where comes:
```c
  typedef enum PVR_ERROR(ATTR_APIENTRYP PFN_KODI_ADDON_PVR_GET_CAPABILITIES_V1)(
      KODI_ADDON_PVR_HDL hdl, struct KODI_ADDON_PVR_CAPABILITIES* capabilities);

...
    PFN_KODI_ADDON_PVR_GET_CAPABILITIES_V1 get_capabilities;

```

Audio decoder add-on system will come in the near future, which then already needs this.


Commit 3:
---------------------
**[addons] make SSIZE_T available for all OS via addon_bash.h**

This adds the necessary macro in addon_base.h.

The reason for this is that the revised API will have stricter guidelines and, for example, a size value of a memory must always appear as `size_t` or` ssize_t`, otherwise an auto-creation script cannot recognize in which cont

It is currently also available at filesystem.h, but will continue to work due to checks and will be removed there with API rework.


<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
