### PR TITLE
Fix CMake warning about case-sensitive CWiid

### DIFF
--- a/cmake/modules/FindCWiid.cmake
+++ b/cmake/modules/FindCWiid.cmake
@@ -25,7 +25,7 @@ find_library(CWIID_LIBRARY NAMES cwiid
 set(CWIID_VERSION ${PC_CWIID_VERSION})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CWIID
+find_package_handle_standard_args(CWiid
                                   REQUIRED_VARS CWIID_LIBRARY CWIID_INCLUDE_DIR
                                   VERSION_VAR CWIID_VERSION)
 


### PR DESCRIPTION
## Description

Fix the following CMake warning:

```
CMake Warning (dev) at /usr/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (CWIID) does
  not match the name of the calling package (CWiid).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/modules/FindCWiid.cmake:28 (find_package_handle_standard_args)
  cmake/scripts/linux/ExtraTargets.cmake:11 (find_package)
  CMakeLists.txt:447 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found CWIID: /usr/lib/libcwiid.so (found version "0.6.00")
CMake Warning (dev) at /usr/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (CWIID) does
  not match the name of the calling package (CWiid).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/modules/FindCWiid.cmake:28 (find_package_handle_standard_args)
  tools/EventClients/Clients/WiiRemote/CMakeLists.txt:4 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## Motivation and context

I decided to fix that warning introduced in recent CMake builds to avoid
later breakage that will be hard to debug.

## How has this been tested?

Built 19.2 with this,patch, performed installation of `kodi-eventclients-wiiremote`

## What is the effect on users?

Negligible, it is more for developers.

## Screenshots (if appropriate):

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
