### PR TITLE
Upstreamed Debian patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ if(UNIX)
   option(ENABLE_INTERNAL_UDFREAD "Enable internal udfread?" OFF)
   option(ENABLE_INTERNAL_SPDLOG "Enable internal spdlog?" OFF)
 endif()
+# prefer kissfft from xbmc/contrib but let use system one on unices
+include(CMakeDependentOption)
+cmake_dependent_option(ENABLE_INTERNAL_KISSFFT "Enable internal kissfft?" ON "UNIX" ON)
 # System options
 if(NOT WIN32)
   option(WITH_ARCH              "build with given arch" OFF)
@@ -134,6 +137,7 @@ set(required_deps ASS
                   fstrcmp
                   HarfBuzz
                   Iconv
+                  KissFFT
                   LibDvd
                   Lzo2
                   OpenSSL>=1.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ if (NOT PLATFORMDEFS_DIR STREQUAL "")
 endif()
 
 find_package(PkgConfig)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED QUIET)
 list(APPEND DEPLIBS ${CMAKE_THREAD_LIBS_INIT})
 

--- a/cmake/modules/FindKissFFT.cmake
+++ b/cmake/modules/FindKissFFT.cmake
@@ -1,0 +1,46 @@
+#.rst:
+# FindKissFFT
+# ------------
+# Finds the KissFFT as a Fast Fourier Transformation (FFT) library
+#
+# This will define the following variables:
+#
+# KISSFFT_FOUND        - System has KissFFT
+# KISSFFT_INCLUDE_DIRS - the KissFFT include directory
+# KISSFFT_LIBRARIES    - the KissFFT libraries
+#
+
+if(ENABLE_INTERNAL_KISSFFT)
+  # KissFFT is located in xbmc/contrib/kissfft
+  set(KISSFFT_FOUND TRUE)
+  set(KISSFFT_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/xbmc/contrib")
+  message(STATUS "Found KissFFT: ${KISSFFT_INCLUDE_DIRS}")
+else()
+  find_package(PkgConfig)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_KISSFFT kissfft QUIET)
+  endif()
+
+  find_path(KISSFFT_INCLUDE_DIR kissfft/kiss_fft.h kissfft/kiss_fftr.h
+                            PATHS ${PC_KISSFFT_INCLUDEDIR})
+  find_library(KISSFFT_LIBRARY NAMES kissfft-float kissfft-int32 kissfft-int16 kissfft-simd
+                            PATHS ${PC_KISSFFT_LIBDIR})
+
+  # Check if all REQUIRED_VARS are satisfied and set KISSFFT_FOUND
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(KissFFT REQUIRED_VARS KISSFFT_INCLUDE_DIR KISSFFT_LIBRARY)
+
+  if(KISSFFT_FOUND)
+    set(KISSFFT_INCLUDE_DIRS ${KISSFFT_INCLUDE_DIR})
+    set(KISSFFT_LIBRARIES ${KISSFFT_LIBRARY})
+
+    if(NOT TARGET kissfft)
+      add_library(kissfft UNKNOWN IMPORTED)
+      set_target_properties(kissfft PROPERTIES
+                            IMPORTED_LOCATION "${KISSFFT_LIBRARY}"
+                            INTERFACE_INCLUDE_DIRECTORIES "${KISSFFT_INCLUDE_DIR}")
+    endif()
+  endif()
+
+  mark_as_advanced(KISSFFT_INCLUDE_DIR KISSFFT_LIBRARY)
+endif()

--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -167,3 +167,13 @@ endif()
 if(ENABLE_VDPAU)
   set(ENABLE_GLX ON CACHE BOOL "Enabling GLX" FORCE)
 endif()
+
+# Architecture endianness detector
+include(TestBigEndian)
+TEST_BIG_ENDIAN(ARCH_IS_BIGENDIAN)
+if(ARCH_IS_BIGENDIAN)
+  message(STATUS "Host architecture is big-endian")
+  list(APPEND ARCH_DEFINES "-DWORDS_BIGENDIAN=1")
+else()
+  message(STATUS "Host architecture is little-endian")
+endif()

--- a/xbmc/contrib/kissfft/CMakeLists.txt
+++ b/xbmc/contrib/kissfft/CMakeLists.txt
@@ -1,8 +1,10 @@
-set(SOURCES kiss_fft.c
-            kiss_fftr.c)
+if(ENABLE_INTERNAL_KISSFFT)
+  set(SOURCES kiss_fft.c
+              kiss_fftr.c)
 
-set(HEADERS _kiss_fft_guts.h
-            kiss_fft.h
-            kiss_fftr.h)
+  set(HEADERS _kiss_fft_guts.h
+              kiss_fft.h
+              kiss_fftr.h)
 
-core_add_library(kissfft)
+  core_add_library(kissfft)
+endif()

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -14,6 +14,7 @@
 // clang-format off
 #if defined(__linux__) && \
     !defined(__aarch64__) && \
+    !defined(__alpha__) && \
     !defined(__arc__) && \
     !defined(__arm__) && \
     !defined(__mips__) && \

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -21,6 +21,7 @@
     !defined(__or1k__) && \
     !defined(__riscv) && \
     !defined(__SH4__) && \
+    !defined(__s390x__) && \
     !defined(__sparc__) && \
     !defined(__xtensa__)
 #define USE_LDT_KEEPER

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -28,6 +28,7 @@
     !defined(__ppc__) && \
     !defined(__riscv) && \
     !defined(__SH4__) && \
+    !defined(__s390x__) && \
     !defined(__sparc__) && \
     !defined(__xtensa__)
 // clang-format on

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -20,6 +20,7 @@
 
 // clang-format off
 #if !defined(__aarch64__) && \
+    !defined(__alpha__) &&\
     !defined(__arc__) &&\
     !defined(__arm__) && \
     !defined(__mips__) && \

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -23,6 +23,7 @@
 
 // clang-format off
 #if defined(__aarch64__) || \
+    defined(__alpha__) || \
     defined(__arc__) || \
     defined(__arm__) || \
     defined(_M_ARM) || \

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -32,6 +32,7 @@
     defined(__ppc__) || \
     defined(__riscv) || \
     defined(__SH4__) || \
+    defined(__s390x__) || \
     defined(__sparc__) || \
     defined(__xtensa__)
 #define DISABLE_MATHUTILS_ASM_ROUND_INT

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -940,8 +940,8 @@ int CSysInfo::GetKernelBitness(void)
     {
       std::string machine(un.machine);
       if (machine == "x86_64" || machine == "amd64" || machine == "arm64" || machine == "aarch64" ||
-          machine == "ppc64" || machine == "ia64" || machine == "mips64" || machine == "s390x" ||
-          machine == "riscv64")
+          machine == "ppc64" || machine == "ppc64el" || machine == "ppc64le" || machine == "ia64" ||
+          machine == "mips64" || machine == "s390x" || machine == "riscv64")
         kernelBitness = 64;
       else
         kernelBitness = 32;

--- a/xbmc/utils/rfft.h
+++ b/xbmc/utils/rfft.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "contrib/kissfft/kiss_fftr.h"
-
 #include <vector>
+
+#include <kissfft/kiss_fftr.h>
 
 //! \brief Class performing a RFFT of interleaved stereo data.
 class RFFT


### PR DESCRIPTION
## Description

Upstream the Debian patch after `s390x` support was added in 19.0.

## Motivation and context

I forgot to add one patch to relevant issue 19109. After @aurel32 upstreamed his riscv64 patch,
I decided that other patches can follow.

## How has this been tested?

Built 19.2 on 12 architectures and 20.0 nightly on 3.

## What is the effect on users?

It is mostly for package maintainers.

## Screenshots (if appropriate):

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
