### PR TITLE
[backport][addons] fix CFileExtensionProvider::GetAddonFileFolderExtensions & fix extension update in case about addon change

### DIFF
--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -203,9 +203,8 @@ void CFileExtensionProvider::SetAddonExtensions(const TYPE& type)
     }
   }
 
-  m_addonExtensions.insert(make_pair(type, StringUtils::Join(extensions, "|")));
-  if (!fileFolderExtensions.empty())
-    m_addonFileFolderExtensions.insert(make_pair(type, StringUtils::Join(fileFolderExtensions, "|")));
+  m_addonExtensions[type] = StringUtils::Join(extensions, "|");
+  m_addonFileFolderExtensions[type] = StringUtils::Join(fileFolderExtensions, "|");
 }
 
 void CFileExtensionProvider::OnAddonEvent(const AddonEvent& event)

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -156,8 +156,8 @@ std::string CFileExtensionProvider::GetAddonExtensions(const TYPE &type) const
 
 std::string CFileExtensionProvider::GetAddonFileFolderExtensions(const TYPE &type) const
 {
-  auto it = m_addonExtensions.find(type);
-  if (it != m_addonExtensions.end())
+  auto it = m_addonFileFolderExtensions.find(type);
+  if (it != m_addonFileFolderExtensions.end())
     return it->second;
 
   return "";


### PR DESCRIPTION
## Description

The wrong list was probably used there by mistake, m_addonFileFolderExtensions is also available, but this has not yet been used at any point.

Commit 2:
----------------------
**[addons] fix extension update in case about addon change**

Previously "insert" was used there alone. If changes are made, this does not cause any function, as the given identification is already set! Therefore an addon update / installation / deinstallation could never work in this context.

Here it is changed to use [] as set.

This means that a VFS or audio decoder add-on can be used immediately after its installation and no longer needs Kodi restart.


Backport about https://github.com/xbmc/xbmc/pull/20320

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
