### PR TITLE
[Fix] Reworked TrueHD MAT packer to support high bitrate Atmos streams (fix audio dropouts)

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -940,13 +940,13 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
         {
           if (frames == 61440)
           {
-            int offset;
-            int len;
-            for (int i=0; i<24; i++)
+            for (int i = 0, of = 0; i < 12; i++)
             {
-              offset = i*2560;
-              len = (*(buffer[0] + offset+2560-2) << 8) + *(buffer[0] + offset+2560-1);
-              m_packer->Pack(m_sinkFormat.m_streamInfo, buffer[0] + offset, len);
+              // calculates length of each audio unit using raw data of stream
+              const uint16_t len = ((*(buffer[0] + of) & 0x0F) << 8 | *(buffer[0] + of + 1)) << 1;
+
+              m_packer->Pack(m_sinkFormat.m_streamInfo, buffer[0] + of, len);
+              of += len;
             }
           }
           else
@@ -996,17 +996,18 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
     {
       if (m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD && frames == 61440)
       {
-        int offset;
-        int len;
         unsigned int size = 0;
         mergebuffer.reset(new uint8_t[MAX_IEC61937_PACKET]);
         p_mergebuffer = mergebuffer.get();
-        for (int i=0; i<24; i++)
+
+        for (int i = 0, offset = 0; i < 12; i++)
         {
-          offset = i*2560;
-          len = (*(buffer[0] + offset+2560-2) << 8) + *(buffer[0] + offset+2560-1);
+          // calculates length of each audio unit using raw data of stream
+          uint16_t len = ((*(buffer[0] + offset) & 0x0F) << 8 | *(buffer[0] + offset + 1)) << 1;
+
           memcpy(&(mergebuffer.get())[size], buffer[0] + offset, len);
           size += len;
+          offset += len;
         }
         buffer = &p_mergebuffer;
         totalFrames = size / m_sinkFormat.m_frameSize;

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -10,31 +10,25 @@
 
 #include "AEPackIEC61937.h"
 #include "AEStreamInfo.h"
+#include "Util.h"
 #include "utils/log.h"
 
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
-#define BURST_HEADER_SIZE       8
-#define TRUEHD_FRAME_OFFSET     2560
-#define MAT_MIDDLE_CODE_OFFSET -4
-#define MAT_FRAME_SIZE          61424
-#define EAC3_MAX_BURST_PAYLOAD_SIZE (24576 - BURST_HEADER_SIZE)
+extern "C"
+{
+#include <libavutil/intreadwrite.h>
+}
 
-CAEBitstreamPacker::CAEBitstreamPacker() :
-  m_trueHD   (NULL),
-  m_dtsHD    (NULL),
-  m_eac3     (NULL)
+CAEBitstreamPacker::CAEBitstreamPacker()
 {
   Reset();
 }
 
 CAEBitstreamPacker::~CAEBitstreamPacker()
 {
-  delete[] m_trueHD;
-  delete[] m_dtsHD;
-  delete[] m_eac3;
 }
 
 void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
@@ -127,7 +121,6 @@ uint8_t* CAEBitstreamPacker::GetBuffer()
 void CAEBitstreamPacker::Reset()
 {
   m_dataSize = 0;
-  m_trueHDPos = 0;
   m_pauseDuration = 0;
   m_packedBuffer[0] = 0;
 }
@@ -135,60 +128,146 @@ void CAEBitstreamPacker::Reset()
 /* we need to pack 24 TrueHD audio units into the unknown MAT format before packing into IEC61937 */
 void CAEBitstreamPacker::PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size)
 {
-  /* magic MAT format values, meaning is unknown at this point */
-  static const uint8_t mat_start_code [20] = { 0x07, 0x9E, 0x00, 0x03, 0x84, 0x01, 0x01, 0x01, 0x80, 0x00, 0x56, 0xA5, 0x3B, 0xF4, 0x81, 0x83, 0x49, 0x80, 0x77, 0xE0 };
-  static const uint8_t mat_middle_code[12] = { 0xC3, 0xC1, 0x42, 0x49, 0x3B, 0xFA, 0x82, 0x83, 0x49, 0x80, 0x77, 0xE0 };
-  static const uint8_t mat_end_code   [16] = { 0xC3, 0xC2, 0xC0, 0xC4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x97, 0x11 };
-
   /* create the buffer if it doesn't already exist */
-  if (!m_trueHD)
+  if (m_trueHD[0].size() == 0)
   {
-    m_trueHD    = new uint8_t[MAT_FRAME_SIZE];
-    m_trueHDPos = 0;
+    m_trueHD[0].resize(MAT_FRAME_SIZE);
+    m_trueHD[1].resize(MAT_FRAME_SIZE);
+    m_thd = {};
   }
 
-  /* setup the frame for the data */
-  if (m_trueHDPos == 0)
+  if (size < 10)
+    return;
+
+  uint8_t* pBuf = m_trueHD[m_thd.bufferIndex].data();
+  const uint8_t* pData = data;
+
+  int totalFrameSize = size;
+  int dataRem = size;
+  int paddingRem = 0;
+  int ratebits = 0;
+  int nextCodeIdx = 0;
+  uint16_t inputTiming = 0;
+  bool havePacket = false;
+
+  if (AV_RB24(data + 4) == 0xf8726f)
   {
-    memset(m_trueHD, 0, MAT_FRAME_SIZE);
-    memcpy(m_trueHD, mat_start_code, sizeof(mat_start_code));
-    memcpy(m_trueHD + (12 * TRUEHD_FRAME_OFFSET) - BURST_HEADER_SIZE + MAT_MIDDLE_CODE_OFFSET, mat_middle_code, sizeof(mat_middle_code));
-    memcpy(m_trueHD + MAT_FRAME_SIZE - sizeof(mat_end_code), mat_end_code, sizeof(mat_end_code));
+    /* major sync unit, fetch sample rate */
+    if (data[7] == 0xba)
+      ratebits = data[8] >> 4;
+    else if (data[7] == 0xbb)
+      ratebits = data[9] >> 4;
+    else
+      return;
+
+    m_thd.samplesPerFrame = 40 << (ratebits & 3);
   }
 
-  size_t offset;
-  if (m_trueHDPos == 0 )
-    offset = (m_trueHDPos * TRUEHD_FRAME_OFFSET) + sizeof(mat_start_code);
-  else if (m_trueHDPos == 12)
-    offset = (m_trueHDPos * TRUEHD_FRAME_OFFSET) + sizeof(mat_middle_code) - BURST_HEADER_SIZE + MAT_MIDDLE_CODE_OFFSET;
-  else
-    offset = (m_trueHDPos * TRUEHD_FRAME_OFFSET) - BURST_HEADER_SIZE;
+  if (!m_thd.samplesPerFrame)
+    return;
 
-  int maxSize = TRUEHD_FRAME_OFFSET;
-  if (m_trueHDPos == 0)
-    maxSize -= static_cast<int>(sizeof(mat_start_code)) + BURST_HEADER_SIZE;
-  else if (m_trueHDPos == 11)
-    maxSize -= -MAT_MIDDLE_CODE_OFFSET;
-  else if (m_trueHDPos == 12)
-    maxSize -= static_cast<int>(sizeof(mat_middle_code)) + MAT_MIDDLE_CODE_OFFSET;
-  else if (m_trueHDPos == 23)
-    maxSize -= static_cast<int>(sizeof(mat_end_code)) + (24 * TRUEHD_FRAME_OFFSET - MAT_FRAME_SIZE);
+  inputTiming = AV_RB16(data + 2);
 
-  if (size > maxSize)
+  if (m_thd.prevFrameSize)
   {
-    CLog::Log(LOGERROR, "CAEBitstreamPacker::PackTrueHD - truncating TrueHD frame of {} bytes",
-              size);
-    size = maxSize;
+    uint16_t deltaSamples = inputTiming - m_thd.prevFrameTime;
+    /*
+     * One multiple-of-48kHz frame is 1/1200 sec and the IEC 61937 rate
+     * is 768kHz = 768000*4 bytes/sec.
+     * The nominal space per frame is therefore
+     * (768000*4 bytes/sec) * (1/1200 sec) = 2560 bytes.
+     * For multiple-of-44.1kHz frames: 1/1102.5 sec, 705.6kHz, 2560 bytes.
+     *
+     * 2560 is divisible by samplesPerFrame.
+     */
+    int deltaBytes = deltaSamples * 2560 / m_thd.samplesPerFrame;
+
+    /* padding needed before this frame */
+    paddingRem = deltaBytes - m_thd.prevFrameSize;
+
+    /* sanity check */
+    if (paddingRem < 0 || paddingRem >= MAT_FRAME_SIZE / 2)
+    {
+      m_thd = {}; // recovering after seek
+      return;
+    }
   }
 
-  memcpy(m_trueHD + offset, data, size);
+  for (nextCodeIdx = 0; nextCodeIdx < ARRAY_SIZE(MatCodes); nextCodeIdx++)
+    if (m_thd.bufferFilled <= MatCodes[nextCodeIdx].pos)
+      break;
 
-  /* if we have a full frame */
-  if (++m_trueHDPos == 24)
+  if (nextCodeIdx >= ARRAY_SIZE(MatCodes))
+    return;
+
+  while (paddingRem || dataRem || MatCodes[nextCodeIdx].pos == m_thd.bufferFilled)
   {
-    m_trueHDPos = 0;
-    m_dataSize  = CAEPackIEC61937::PackTrueHD(m_trueHD, MAT_FRAME_SIZE, m_packedBuffer);
+    if (MatCodes[nextCodeIdx].pos == m_thd.bufferFilled)
+    {
+      /* time to insert MAT code */
+      int codeLen = MatCodes[nextCodeIdx].len;
+      int codeLenRemaining = codeLen;
+      memcpy(pBuf + MatCodes[nextCodeIdx].pos, MatCodes[nextCodeIdx].code, codeLen);
+      m_thd.bufferFilled += codeLen;
+
+      nextCodeIdx++;
+      if (nextCodeIdx == ARRAY_SIZE(MatCodes))
+      {
+        nextCodeIdx = 0;
+
+        /* this was the last code, move to the next MAT frame */
+        havePacket = true;
+        m_thd.outputBuffer = pBuf;
+        m_thd.bufferIndex ^= 1;
+        pBuf = m_trueHD[m_thd.bufferIndex].data();
+        m_thd.bufferFilled = 0;
+
+        /* inter-frame gap has to be counted as well, add it */
+        codeLenRemaining += MAT_PKT_OFFSET - MAT_FRAME_SIZE;
+      }
+
+      if (paddingRem)
+      {
+        /* consider the MAT code as padding */
+        const int countedAsPadding = std::min(paddingRem, codeLenRemaining);
+        paddingRem -= countedAsPadding;
+        codeLenRemaining -= countedAsPadding;
+      }
+      /* count the remainder of the code as part of frame size */
+      if (codeLenRemaining)
+        totalFrameSize += codeLenRemaining;
+    }
+
+    if (paddingRem)
+    {
+      const int paddingLen = std::min(MatCodes[nextCodeIdx].pos - m_thd.bufferFilled, paddingRem);
+
+      memset(pBuf + m_thd.bufferFilled, 0, paddingLen);
+      m_thd.bufferFilled += paddingLen;
+      paddingRem -= paddingLen;
+
+      if (paddingRem)
+        continue; /* time to insert MAT code */
+    }
+
+    if (dataRem)
+    {
+      const int dataLen = std::min(MatCodes[nextCodeIdx].pos - m_thd.bufferFilled, dataRem);
+
+      memcpy(pBuf + m_thd.bufferFilled, pData, dataLen);
+      m_thd.bufferFilled += dataLen;
+      pData += dataLen;
+      dataRem -= dataLen;
+    }
   }
+
+  m_thd.prevFrameSize = totalFrameSize;
+  m_thd.prevFrameTime = inputTiming;
+
+  if (!havePacket)
+    return;
+
+  m_dataSize = CAEPackIEC61937::PackTrueHD(m_thd.outputBuffer, MAT_FRAME_SIZE, m_packedBuffer);
 }
 
 void CAEBitstreamPacker::PackDTSHD(CAEStreamInfo &info, uint8_t* data, int size)
@@ -198,17 +277,17 @@ void CAEBitstreamPacker::PackDTSHD(CAEStreamInfo &info, uint8_t* data, int size)
 
   if (dataSize > m_dtsHDSize)
   {
-    delete[] m_dtsHD;
     m_dtsHDSize = dataSize;
-    m_dtsHD     = new uint8_t[dataSize];
-    memcpy(m_dtsHD, dtshd_start_code, sizeof(dtshd_start_code));
+    m_dtsHD.resize(dataSize);
+    memcpy(m_dtsHD.data(), dtshd_start_code, sizeof(dtshd_start_code));
   }
 
   m_dtsHD[sizeof(dtshd_start_code) + 0] = ((uint16_t)size & 0xFF00) >> 8;
   m_dtsHD[sizeof(dtshd_start_code) + 1] = ((uint16_t)size & 0x00FF);
-  memcpy(m_dtsHD + sizeof(dtshd_start_code) + 2, data, size);
+  memcpy(m_dtsHD.data() + sizeof(dtshd_start_code) + 2, data, size);
 
-  m_dataSize = CAEPackIEC61937::PackDTSHD(m_dtsHD, dataSize, m_packedBuffer, info.m_dtsPeriod);
+  m_dataSize =
+      CAEPackIEC61937::PackDTSHD(m_dtsHD.data(), dataSize, m_packedBuffer, info.m_dtsPeriod);
 }
 
 void CAEBitstreamPacker::PackEAC3(CAEStreamInfo &info, uint8_t* data, int size)
@@ -231,22 +310,22 @@ void CAEBitstreamPacker::PackEAC3(CAEStreamInfo &info, uint8_t* data, int size)
   {
     /* multiple frames needed to achieve 6 blocks as required by IEC 61937-3:2007 */
 
-    if (m_eac3 == NULL)
-      m_eac3 = new uint8_t[EAC3_MAX_BURST_PAYLOAD_SIZE];
+    if (m_eac3.size() == 0)
+      m_eac3.resize(EAC3_MAX_BURST_PAYLOAD_SIZE);
 
     unsigned int newsize = m_eac3Size + size;
     bool overrun = newsize > EAC3_MAX_BURST_PAYLOAD_SIZE;
 
     if (!overrun)
     {
-      memcpy(m_eac3 + m_eac3Size, data, size);
+      memcpy(m_eac3.data() + m_eac3Size, data, size);
       m_eac3Size = newsize;
       m_eac3FramesCount++;
     }
 
     if (m_eac3FramesCount >= m_eac3FramesPerBurst || overrun)
     {
-      m_dataSize = CAEPackIEC61937::PackEAC3(m_eac3, m_eac3Size, m_packedBuffer);
+      m_dataSize = CAEPackIEC61937::PackEAC3(m_eac3.data(), m_eac3Size, m_packedBuffer);
       m_eac3Size = 0;
       m_eac3FramesCount = 0;
     }

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -13,6 +13,51 @@
 
 #include <list>
 #include <stdint.h>
+#include <vector>
+
+#define MAT_CODE(position, data) \
+  { \
+    position, data, sizeof(data) \
+  }
+
+namespace
+{
+constexpr auto BURST_HEADER_SIZE = 8;
+constexpr auto EAC3_MAX_BURST_PAYLOAD_SIZE = 24576 - BURST_HEADER_SIZE;
+
+constexpr auto MAT_PKT_OFFSET = 61440;
+constexpr auto MAT_FRAME_SIZE = 61424;
+
+/* magic MAT format values, meaning is unknown at this point */
+const uint8_t mat_start_code[20] = {
+    0x07, 0x9E, 0x00, 0x03, 0x84, 0x01, 0x01, 0x01, 0x80, 0x00,
+    0x56, 0xA5, 0x3B, 0xF4, 0x81, 0x83, 0x49, 0x80, 0x77, 0xE0,
+};
+const uint8_t mat_middle_code[12] = {
+    0xC3, 0xC1, 0x42, 0x49, 0x3B, 0xFA, 0x82, 0x83, 0x49, 0x80, 0x77, 0xE0,
+};
+const uint8_t mat_end_code[16] = {
+    0xC3, 0xC2, 0xC0, 0xC4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x97, 0x11,
+};
+
+const struct
+{
+  int pos;
+  const uint8_t* code;
+  unsigned int len;
+} MatCodes[] = {MAT_CODE(0, mat_start_code), MAT_CODE(30708, mat_middle_code),
+                MAT_CODE(MAT_FRAME_SIZE - sizeof(mat_end_code), mat_end_code)};
+
+struct TrueHD
+{
+  int prevFrameSize;
+  int samplesPerFrame;
+  int bufferFilled;
+  int bufferIndex;
+  uint16_t prevFrameTime;
+  uint8_t* outputBuffer;
+};
+} // unnamed namespace
 
 class CAEStreamInfo;
 
@@ -36,16 +81,16 @@ private:
   void PackEAC3(CAEStreamInfo &info, uint8_t* data, int size);
 
   /* we keep the trueHD and dtsHD buffers separate so that we can handle a fast stream switch */
-  uint8_t      *m_trueHD;
-  unsigned int  m_trueHDPos = 0;
+  std::vector<uint8_t> m_trueHD[2];
+  TrueHD m_thd{};
 
-  uint8_t      *m_dtsHD;
-  unsigned int  m_dtsHDSize = 0;
+  std::vector<uint8_t> m_dtsHD;
+  unsigned int m_dtsHDSize = 0;
 
-  uint8_t      *m_eac3;
-  unsigned int  m_eac3Size = 0;
-  unsigned int  m_eac3FramesCount = 0;
-  unsigned int  m_eac3FramesPerBurst = 0;
+  std::vector<uint8_t> m_eac3;
+  unsigned int m_eac3Size = 0;
+  unsigned int m_eac3FramesCount = 0;
+  unsigned int m_eac3FramesPerBurst = 0;
 
   unsigned int  m_dataSize = 0;
   uint8_t       m_packedBuffer[MAX_IEC61937_PACKET];

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -61,7 +61,7 @@ CAEStreamParser::CAEStreamParser() :
   av_crc_init(m_crcTrueHD, 0, 16, 0x2D, sizeof(m_crcTrueHD));
 }
 
-double CAEStreamInfo::GetDuration() const
+double CAEStreamInfo::GetDuration(bool paPlayer /*= false*/) const
 {
   double duration = 0;
   switch (m_type)
@@ -81,6 +81,8 @@ double CAEStreamInfo::GetDuration() const
       else
         rate = 176400;
       duration = 3840.0 / rate;
+      if (paPlayer)
+        duration /= 2;
       break;
     case STREAM_TYPE_DTS_512:
     case STREAM_TYPE_DTSHD_CORE:

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -22,7 +22,7 @@ extern "C" {
 class CAEStreamInfo
 {
 public:
-  double GetDuration() const;
+  double GetDuration(bool paPlayer = false) const;
   bool operator==(const CAEStreamInfo& info) const;
 
   enum DataType

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -17,7 +17,10 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
-#define TRUEHD_BUF_SIZE 61440
+namespace
+{
+constexpr auto TRUEHD_BUF_SIZE = 61440;
+}
 
 CDVDAudioCodecPassthrough::CDVDAudioCodecPassthrough(CProcessInfo &processInfo, CAEStreamInfo::DataType streamType) :
   CDVDAudioCodec(processInfo)
@@ -57,7 +60,6 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
       break;
 
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
-      m_trueHDBuffer.reset(new uint8_t[TRUEHD_BUF_SIZE]);
       m_codecName = "pt-truehd";
       break;
 
@@ -139,7 +141,7 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
     {
       if (m_backlogBufferSize < static_cast<unsigned int>(iSize - used))
       {
-        m_backlogBufferSize = std::max(61440, iSize - used);
+        m_backlogBufferSize = std::max(TRUEHD_BUF_SIZE, iSize - used);
         m_backlogBuffer = static_cast<uint8_t*>(realloc(m_backlogBuffer, m_backlogBufferSize));
       }
       m_backlogSize = iSize - used;
@@ -151,7 +153,7 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
   {
     if (m_backlogBufferSize < (m_backlogSize + iSize))
     {
-      m_backlogBufferSize = std::max(61440, static_cast<int>(m_backlogSize + iSize));
+      m_backlogBufferSize = std::max(TRUEHD_BUF_SIZE, static_cast<int>(m_backlogSize + iSize));
       m_backlogBuffer = static_cast<uint8_t*>(realloc(m_backlogBuffer, m_backlogBufferSize));
     }
     memcpy(m_backlogBuffer + m_backlogSize, pData, iSize);
@@ -178,27 +180,27 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
 
   if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
   {
-    if (!m_trueHDoffset)
-      memset(m_trueHDBuffer.get(), 0, TRUEHD_BUF_SIZE);
-
-    if (m_dataSize > 2560 - 2)
+    if (m_trueHDBuffer.size() < TRUEHD_BUF_SIZE)
     {
-      CLog::Log(LOGERROR,
-                "CDVDAudioCodecPassthrough::AddData - truncating TrueHD frame of {} bytes",
-                m_dataSize);
-      m_dataSize = 2560 - 2;
-    }
-    memcpy(&(m_trueHDBuffer.get())[m_trueHDoffset], m_buffer, m_dataSize);
-    uint8_t highByte = (m_dataSize >> 8) & 0xFF;
-    uint8_t lowByte = m_dataSize & 0xFF;
-    m_trueHDBuffer[m_trueHDoffset+2560-2] = highByte;
-    m_trueHDBuffer[m_trueHDoffset+2560-1] = lowByte;
-    m_trueHDoffset += 2560;
-
-    if (m_trueHDoffset / 2560 == 24)
-    {
-      m_dataSize = m_trueHDoffset;
+      m_trueHDBuffer.resize(TRUEHD_BUF_SIZE);
       m_trueHDoffset = 0;
+    }
+
+    if (m_trueHDoffset == 0)
+      m_trueHDframes = 0;
+
+    memcpy(m_trueHDBuffer.data() + m_trueHDoffset, m_buffer, m_dataSize);
+    m_trueHDoffset += m_dataSize;
+
+    m_trueHDframes++;
+
+    // Only 12 audio units are packed in the buffer to avoid overflows and reduce latency.
+    // Compensates for the small increased latency in CAEBitstreamPacker::PackTrueHD
+    if (m_trueHDframes == 12)
+    {
+      m_dataSize = TRUEHD_BUF_SIZE;
+      m_trueHDoffset = 0;
+      m_trueHDframes = 0;
     }
     else
       m_dataSize = 0;
@@ -230,7 +232,7 @@ int CDVDAudioCodecPassthrough::GetData(uint8_t** dst)
     AddData(DemuxPacket());
 
   if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
-    *dst = m_trueHDBuffer.get();
+    *dst = m_trueHDBuffer.data();
   else
     *dst = m_buffer;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -14,7 +14,7 @@
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 
 #include <list>
-#include <memory>
+#include <vector>
 
 class CProcessInfo;
 
@@ -49,7 +49,8 @@ private:
   std::string m_codecName;
 
   // TrueHD specifics
-  std::unique_ptr<uint8_t[]> m_trueHDBuffer;
+  std::vector<uint8_t> m_trueHDBuffer;
   unsigned int m_trueHDoffset = 0;
+  unsigned int m_trueHDframes = 0;
 };
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -837,7 +837,8 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
       if (si->m_audioFormat.m_dataFormat != AE_FMT_RAW)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
-        free_space = (double) si->m_stream->GetSpace() * si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
+        free_space = (double)si->m_stream->GetSpace() *
+                     si->m_audioFormat.m_streamInfo.GetDuration(true) / 1000;
 
       freeBufferTime = std::max(freeBufferTime , free_space);
     }
@@ -885,7 +886,8 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 * si->m_audioFormat.m_streamInfo.m_sampleRate;
+      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration(true) / 1000 *
+                          si->m_audioFormat.m_streamInfo.m_sampleRate;
     }
   }
 


### PR DESCRIPTION
## Description
Reworked TrueHD MAT packer to support high bitrate Atmos streams (fix audio dropouts).

Fixes https://github.com/xbmc/xbmc/issues/16704

## Motivation and context
This is a follow up of https://github.com/xbmc/xbmc/pull/17068 referenced  PR only fix crashes but not audio dropouts.

@anssih says:

> However, audio dropouts still remain. To fix those, the TrueHD packet
> offsets will need to be dynamically scaled based on the input_timing
> field (TrueHD bytes 2-3) which allows determining the amount of time
> required between the previous frame and the current frame.

This PR basically does the aforementioned. Lets handle audio chunks of arbitrary length and variable offsets throughout the entire chain (CDVDAudioCodecPassthrough, CActiveAESink, CAEBitstreamPacker and IEC packer).

The hardest work is in MAT packer and luckily there is already a code in ffmpeg that has been able to adapt.

Seems also exist a secondary bug: 
After fixing the main issue of audio chunks > 2560 bytes that causes dropouts at specific timestamps, there are still smaller but more random dropouts....

I have solved this by reducing the number of consecutive audio chunks (basic audio units) that are stored in the buffer from 24 which is the "nominal" value to 12. I guess some part of code can't handle buffers of `TRUEHD_BUF_SIZE 61440` bytes length due some bug and memory gets corrupted/overwritten under some specific conditions when all or most of the available space is used.

## How has this been tested?
Runtime tested on RTX 2060 + Denon AVR and  Intel NUC8i3BEK + Denon AVR (Windows x64 only)
As code touched is common in all platforms should fix audio dropouts on Android and Linux too.

Forum feedback is positive 😃
https://forum.kodi.tv/showthread.php?tid=327153&pid=3065548#pid3065548

## What is the effect on users?
Fixes audio dropouts playing high bitrate TrueHD Atmos streams.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
