### PR TITLE
[WSDiscovery] fix race condition wsdiscovery and profile networkstart message

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -159,6 +159,10 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params, const std::str
   m_mediaManager.reset(new CMediaManager());
   m_mediaManager->Initialize();
 
+#if defined(HAS_FILESYSTEM_SMB)
+  m_WSDiscovery = WSDiscovery::IWSDiscovery::GetInstance();
+#endif
+
   if (!m_Platform->InitStageTwo())
     return false;
 
@@ -192,10 +196,6 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
 
   m_playerCoreFactory.reset(new CPlayerCoreFactory(*profileManager));
 
-#if defined(HAS_FILESYSTEM_SMB)
-  m_WSDiscovery = WSDiscovery::IWSDiscovery::GetInstance();
-#endif
-
   if (!m_Platform->InitStageThree())
     return false;
 
@@ -206,10 +206,6 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
 void CServiceManager::DeinitStageThree()
 {
   init_level = 2;
-
-#if defined(HAS_FILESYSTEM_SMB)
-  m_WSDiscovery.reset();
-#endif
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
   m_DetectDVDType->StopThread();
   m_DetectDVDType.reset();
@@ -224,6 +220,10 @@ void CServiceManager::DeinitStageThree()
 void CServiceManager::DeinitStageTwo()
 {
   init_level = 1;
+
+#if defined(HAS_FILESYSTEM_SMB)
+  m_WSDiscovery.reset();
+#endif
 
   m_weatherManager.reset();
   m_powerManager.reset();


### PR DESCRIPTION
## Description
Initstagethree is too late for wsdiscovery instance creation as its required to be created before profiles are used, as LoadProfile sends the message SERVICES_UP to start network services.
Unsure why testing on osx, and other user testing on linux didnt showup, but here we are.

## Motivation and context
Fix crash

## How has this been tested?
iOS

## What is the effect on users?
Fix a crash a user experienced on rbpi device

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
