### PR TITLE
Allow overriding APP_PACKAGE

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -682,7 +682,13 @@ macro(core_find_versions)
   string(TOUPPER ${APP_APP_NAME} APP_NAME_UC)
   set(COMPANY_NAME ${APP_COMPANY_NAME})
   set(APP_VERSION ${APP_VERSION_MAJOR}.${APP_VERSION_MINOR})
-  set(APP_PACKAGE ${APP_APP_PACKAGE})
+  # Let Flatpak builders etc override APP_PACKAGE
+  # NOTE: We cannot declare an option() in top-level CMakeLists.txt
+  # because of CMP0077.
+  if(NOT APP_PACKAGE)
+    set(APP_PACKAGE ${APP_APP_PACKAGE})
+  endif()
+  list(APPEND final_message "App package: ${APP_PACKAGE}")
   if(APP_VERSION_TAG)
     set(APP_VERSION ${APP_VERSION}-${APP_VERSION_TAG})
     string(TOLOWER ${APP_VERSION_TAG} APP_VERSION_TAG_LC)


### PR DESCRIPTION
## Description

This PR allows Flatpak packagers to specify custom package name used in metainfo file.

## Motivation and context

Following #20142 @razzeee expressed concerns about inability to change APP_PACKAGE hardcoded in `version.txt`

## How has this been tested?

Building Kodi with `-DAPP_PACKAGE=tv.kodi.Kodi` and without the setting

## What is the effect on users?

It is for developers and packagers only

## Screenshots (if appropriate):

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
