### PR TITLE
Fix tests comparing floats

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp
@@ -8,6 +8,7 @@
 
 
 #include "cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h"
+#include "xbmc/utils/MathUtils.h"
 
 #include <iostream>
 
@@ -59,6 +60,20 @@ void DebugPrint(Matrix4 matrix)
   }
 
   std::cout << "===== Matrix End =====" << std::endl;
+}
+
+template<uint8_t Order>
+bool CompareMatrices(CMatrix<Order>& matrixA, CMatrix<Order>& matrixB, float threshold)
+{
+  bool result = true;
+  for (unsigned int i = 0; i < Order; i++)
+  {
+    for (unsigned int j = 0; j < Order; j++)
+    {
+      result &= MathUtils::FloatEquals(matrixA[i][j], matrixB[i][j], threshold);
+    }
+  }
+  return result;
 }
 
 std::array<std::array<float, 4>, 4> bt709_8bit =
@@ -128,21 +143,21 @@ TEST(TestConvertMatrix, YUV2RGB)
   yuvMat = convMat.GetYuvMat();
   DebugPrint(yuvMat);
 
-  EXPECT_EQ(bt709Mat_8bit, yuvMat);
+  EXPECT_TRUE(CompareMatrices(bt709Mat_8bit, yuvMat, 0.0001f));
 
   convMat.SetSourceBitDepth(10)
          .SetSourceTextureBitDepth(8);
   yuvMat = convMat.GetYuvMat();
   DebugPrint(yuvMat);
 
-  EXPECT_EQ(bt709Mat_10bit, yuvMat);
+  EXPECT_TRUE(CompareMatrices(bt709Mat_10bit, yuvMat, 0.0001f));
 
   convMat.SetSourceBitDepth(10)
          .SetSourceTextureBitDepth(10);
   yuvMat = convMat.GetYuvMat();
   DebugPrint(yuvMat);
 
-  EXPECT_EQ(bt709Mat_10bit_texture, yuvMat);
+  EXPECT_TRUE(CompareMatrices(bt709Mat_10bit_texture, yuvMat, 0.0001f));
 }
 
 TEST(TestConvertMatrix, ColorSpaceConversion)
@@ -155,14 +170,14 @@ TEST(TestConvertMatrix, ColorSpaceConversion)
   primMat = convMat.GetPrimMat();
   DebugPrint(primMat);
 
-  EXPECT_EQ(bt601_to_bt709_Mat, primMat);
+  EXPECT_TRUE(CompareMatrices(bt601_to_bt709_Mat, primMat, 0.0001f));
 
   convMat.SetSourceColorPrimaries(AVCOL_PRI_BT2020)
          .SetDestinationColorPrimaries(AVCOL_PRI_BT709);
   primMat = convMat.GetPrimMat();
   DebugPrint(primMat);
 
-  EXPECT_EQ(bt2020_to_bt709_Mat, primMat);
+  EXPECT_TRUE(CompareMatrices(bt2020_to_bt709_Mat, primMat, 0.0001f));
 }
 
 // clang-format on


### PR DESCRIPTION
## Description

Fix ters comparing structures containing floating point values.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes Debian build failures caused by color conversion and EDL tests.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Debian experimental by uploading of 20.0~alpha1 to Debian archive.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Builds become available for i386 and x32.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
