### PR TITLE
[addons] fix sorting and avoid crash due to non-deterministic comparison

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -798,18 +798,36 @@ void CGUIDialogAddonInfo::BuildDependencyList()
     m_depsInstalledWithAvailable.emplace_back(dep, addonInstalled, addonAvailable);
   }
 
-  // sort criteria in dialog:
-  // 1. optional add-ons to top
-  // 2. scripts/modules to bottom
   std::sort(m_depsInstalledWithAvailable.begin(), m_depsInstalledWithAvailable.end(),
             [](const auto& a, const auto& b) {
+              // 1. "not installed/available" go to the bottom first
+              const bool depAInstalledOrAvailable =
+                  a.m_installed != nullptr || a.m_available != nullptr;
+              const bool depBInstalledOrAvailable =
+                  b.m_installed != nullptr || b.m_available != nullptr;
+
+              if (depAInstalledOrAvailable != depBInstalledOrAvailable)
+              {
+                return !depAInstalledOrAvailable;
+              }
+
+              // 2. then optional add-ons to top
               if (a.m_depInfo.optional != b.m_depInfo.optional)
               {
                 return a.m_depInfo.optional;
               }
 
+              // 3. scripts/modules to bottom
               const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
-              return (depA && depA->MainType() != ADDON_SCRIPT_MODULE);
+              const std::shared_ptr<IAddon>& depB = b.m_installed ? b.m_installed : b.m_available;
+
+              if (depA && depB && depA->MainType() != depB->MainType())
+              {
+                return depA->MainType() != ADDON_SCRIPT_MODULE;
+              }
+
+              // 4. finally order by addon-id
+              return a.m_depInfo.id < b.m_depInfo.id;
             });
 }
 


### PR DESCRIPTION
## Description
follow up to https://github.com/xbmc/xbmc/pull/19805

## Motivation and context
comparison lambda caused crash on Windows in debug mode

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
