### PR TITLE
[addons][settings] Add support to "colorbutton" setting

### DIFF
--- a/addons/skin.estouchy/xml/DialogAddonSettings.xml
+++ b/addons/skin.estouchy/xml/DialogAddonSettings.xml
@@ -139,6 +139,13 @@
 			<align>center</align>
 			<aligny>center</aligny>
 		</control>
+		<control type="colorbutton" id="15">
+			<description>Default ColorButton</description>
+			<posx>0</posx>
+			<posy>0</posy>
+			<height>70</height>
+			<font>font25</font>
+		</control>
 		<control type="sliderex" id="13">
 			<description>Default Slider</description>
 			<height>70</height>

--- a/addons/skin.estuary/xml/Defaults.xml
+++ b/addons/skin.estuary/xml/Defaults.xml
@@ -116,7 +116,7 @@
 		<pulseonselect>no</pulseonselect>
 	</default>
 	<default type="colorbutton">
-		<colorwidth>170</colorwidth>
+		<colorwidth>150</colorwidth>
 		<colorheight>76</colorheight>
 		<texturecolormask>buttons/color-button-box.png</texturecolormask>
 		<texturecolordisabledmask colordiffuse="disabled">buttons/color-button-box.png</texturecolordisabledmask>

--- a/addons/skin.estuary/xml/DialogAddonSettings.xml
+++ b/addons/skin.estuary/xml/DialogAddonSettings.xml
@@ -97,6 +97,10 @@
 				<description>Default Label</description>
 				<include>DefaultSettingLabel</include>
 			</control>
+			<control type="colorbutton" id="15">
+				<description>Default ColorButton</description>
+				<include>DefaultSettingButton</include>
+			</control>
 			<control type="grouplist" id="9000">
 				<left>1510</left>
 				<top>92</top>

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -401,6 +401,7 @@ void CAddonSettings::InitializeControls()
   GetSettingsManager()->RegisterSettingControl("slider", this);
   GetSettingsManager()->RegisterSettingControl("range", this);
   GetSettingsManager()->RegisterSettingControl("title", this);
+  GetSettingsManager()->RegisterSettingControl("colorbutton", this);
 }
 
 void CAddonSettings::InitializeConditions()

--- a/xbmc/dialogs/GUIDialogColorPicker.cpp
+++ b/xbmc/dialogs/GUIDialogColorPicker.cpp
@@ -168,7 +168,7 @@ void CGUIDialogColorPicker::LoadColors(const std::string filePath)
     for (auto& color : colors)
     {
       CFileItem* item = new CFileItem(color.first);
-      item->SetLabel2(StringUtils::Format("{:8x}", color.second.colorARGB));
+      item->SetLabel2(StringUtils::Format("{:08X}", color.second.colorARGB));
       m_vecList->Add(CFileItemPtr(item));
     }
   }

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -159,10 +159,14 @@ void CGUIButtonControl::ProcessText(unsigned int currentTime)
   CRect label2RenderRect = m_label2.GetRenderRect();
 
   float renderWidth = GetWidth();
-  bool changed = m_label.SetMaxRect(m_posX, m_posY, renderWidth, m_height);
+  float renderTextWidth = renderWidth;
+  if (m_labelMaxWidth > 0 && m_labelMaxWidth < renderWidth)
+    renderTextWidth = m_labelMaxWidth;
+
+  bool changed = m_label.SetMaxRect(m_posX, m_posY, renderTextWidth, m_height);
   changed |= m_label.SetText(m_info.GetLabel(m_parentID));
   changed |= m_label.SetScrolling(HasFocus());
-  changed |= m_label2.SetMaxRect(m_posX, m_posY, renderWidth, m_height);
+  changed |= m_label2.SetMaxRect(m_posX, m_posY, renderTextWidth, m_height);
   changed |= m_label2.SetText(m_info2.GetLabel(m_parentID));
 
   // text changed - images need resizing

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -80,6 +80,11 @@ protected:
   virtual void RenderText();
   virtual CGUILabel::COLOR GetTextColor() const;
 
+  /*!
+   * \brief Set the maximum width for the left label
+   */
+  void SetMaxWidth(float labelMaxWidth) { m_labelMaxWidth = labelMaxWidth; }
+
   std::unique_ptr<CGUITexture> m_imgFocus;
   std::unique_ptr<CGUITexture> m_imgNoFocus;
   unsigned int  m_focusCounter;
@@ -87,6 +92,7 @@ protected:
 
   float m_minWidth;
   float m_maxWidth;
+  float m_labelMaxWidth{0};
 
   KODI::GUILIB::GUIINFO::CGUIInfoLabel  m_info;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel  m_info2;

--- a/xbmc/guilib/GUIColorButtonControl.cpp
+++ b/xbmc/guilib/GUIColorButtonControl.cpp
@@ -37,6 +37,8 @@ CGUIColorButtonControl::CGUIColorButtonControl(int parentID,
   m_imgColorDisabledMask->SetAspectRatio(CAspectRatio::AR_KEEP);
   m_imgBoxColor = UTILS::COLOR::NONE;
   ControlType = GUICONTROL_COLORBUTTON;
+  // offsetX is like a left/right padding, "hex" label does not require high values
+  m_labelInfo.GetLabelInfo().offsetX = 2;
 }
 
 CGUIColorButtonControl::CGUIColorButtonControl(const CGUIColorButtonControl& control)
@@ -182,11 +184,13 @@ void CGUIColorButtonControl::RenderInfoText()
 void CGUIColorButtonControl::ProcessInfoText(unsigned int currentTime)
 {
   CRect labelRenderRect = m_labelInfo.GetRenderRect();
-  bool changed = m_labelInfo.SetText(StringUtils::Format("#{:8x}", m_imgBoxColor));
+  bool changed = m_labelInfo.SetText(StringUtils::Format("#{:08X}", m_imgBoxColor));
   // Set Label X position based on image mask control position
-  changed = m_labelInfo.SetMaxRect(m_imgColorMask->GetXPosition() - 300, m_posY, 300, m_height);
-  changed |= m_labelInfo.SetScrolling(HasFocus());
-  changed |= m_labelInfo.SetAlign(XBFONT_RIGHT | (m_label.GetLabelInfo().align & XBFONT_CENTER_Y));
+  float textWidth = m_labelInfo.GetTextWidth() + 2 * m_labelInfo.GetLabelInfo().offsetX;
+  float textPosX = m_imgColorMask->GetXPosition() - textWidth;
+  changed = m_labelInfo.SetMaxRect(textPosX, m_posY, textWidth, m_height);
+  // Limit the width for the left label to avoid text overlapping
+  SetMaxWidth(textPosX);
 
   // text changed - images need resizing
   if (m_minWidth && (m_labelInfo.GetRenderRect() != labelRenderRect))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add "colorbutton" setting support to the addons settings dialog

This change include also some fixes and improvements:
- The hex color value is now shown in the preview as uppercase for better reading
- Fixed missing leading zeros in hex values
- Fixed text overlapping when the left label has a long text
- Removed hardcoded width in the "hex" label control, now is automatically determined

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I had added with previous subtitles PR a new `colorbutton` control setting,
this change allow the addons to use this new setting

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Estuary & Estuchy skin
Python addon XML setting example:

```xml
<setting id="test36.color" type="string" label="32035" help="">
	<level>0</level>
	<default>FF000000</default> <!-- Black -->
	<control type="colorbutton" />
</setting>
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better display on settings
Addons can use the new feature in settings

## Screenshots (if appropriate):
An example from addon settings with long text on left label
![immagine](https://user-images.githubusercontent.com/3257156/138546851-851597d3-860e-48dd-975f-131bbf8964d8.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
