### PR TITLE
AESinkPipewire: Fix uninitialized variable usage

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -355,7 +355,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   }
 
   pw_stream_state state;
-  while (state != PW_STREAM_STATE_PAUSED)
+  do
   {
     state = stream->GetState();
     if (state == PW_STREAM_STATE_PAUSED)
@@ -364,7 +364,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
     CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - waiting", __FUNCTION__);
 
     loop->Wait();
-  }
+  } while (state != PW_STREAM_STATE_PAUSED);
 
   CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - initialized", __FUNCTION__);
 


### PR DESCRIPTION
## Description
Fixes this warning with clang 12.0.1:

```
AESinkPipewire.cpp:351:7: warning: variable 'state' is used uninitialized
whenever 'if' condition is false [-Wsometimes-uninitialized]
  if (!stream->Connect(id, info))
      ^~~~~~~~~~~~~~~~~~~~~~~~~~
AESinkPipewire.cpp:358:10: note: uninitialized use occurs here
  while (state != PW_STREAM_STATE_PAUSED)
         ^~~~~
AESinkPipewire.cpp:351:3: note: remove the 'if' if its condition is always true
  if (!stream->Connect(id, info))
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
AESinkPipewire.cpp:357:3: note: variable 'state' is declared here
  pw_stream_state state;
  ^
1 warning generated.
```

## Motivation and context
Warning and undefined behaviour aren't nice.

## How has this been tested?
Compiles without warnings.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
