### PR TITLE
Added ETC1/ETC2/ASTC texture support for GL/GLES

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -80,6 +80,20 @@ bool CTextureCacheJob::CacheTexture(CTexture** out_texture)
   CTexture* texture = LoadImage(image, width, height, additional_info, true);
   if (texture)
   {
+    if (texture->GetFormat() == XB_FMT_ETC1 ||
+        texture->GetFormat() == XB_FMT_ETC2_R ||
+        texture->GetFormat() == XB_FMT_ETC2_RGB ||
+        texture->GetFormat() == XB_FMT_ETC2_RGBA ||
+        texture->GetFormat() == XB_FMT_ASTC_4x4 ||
+        texture->GetFormat() == XB_FMT_ASTC_8x8)
+    {
+      CLog::Log(LOGDEBUG, "Not caching image '%s'", CURL::GetRedacted(image).c_str());
+      if (out_texture) // caller wants the texture
+        *out_texture = texture;
+      else
+        delete texture;
+      return true;
+    }
     if (texture->HasAlpha())
       m_details.file = m_cachePath + ".png";
     else

--- a/xbmc/guilib/ASTCImage.cpp
+++ b/xbmc/guilib/ASTCImage.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ASTCImage.h"
+
+#include "filesystem/File.h"
+#include "TextureFormats.h"
+#include "Texture.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <string.h>
+
+using namespace XFILE;
+
+bool CASTCImage::ReadFile(const std::string &inputFile)
+{
+  CFile file;
+  uint8_t descriptor[4];
+  uint8_t block_x;
+  uint8_t block_y;
+  uint8_t block_z;
+  uint8_t dim_x[3];
+  uint8_t dim_y[3];
+  uint8_t dim_z[3];
+  uint32_t depth;
+
+  if (!file.Open(inputFile))
+    return false;
+
+  if (file.GetLength() <= 16)
+    return false;
+
+  if (file.Read(&descriptor, 4) != 4)
+    return false;
+  if (file.Read(&block_x, 1) != 1)
+    return false;
+  if (file.Read(&block_y, 1) != 1)
+    return false;
+  if (file.Read(&block_z, 1) != 1)
+    return false;
+  if (file.Read(&dim_x[0], 1) != 1)
+    return false;
+  if (file.Read(&dim_x[1], 1) != 1)
+    return false;
+  if (file.Read(&dim_x[2], 1) != 1)
+    return false;
+
+  if (file.Read(&dim_y[0], 1) != 1)
+    return false;
+  if (file.Read(&dim_y[1], 1) != 1)
+    return false;
+  if (file.Read(&dim_y[2], 1) != 1)
+    return false;
+
+  if (file.Read(&dim_z[0], 1) != 1)
+    return false;
+  if (file.Read(&dim_z[1], 1) != 1)
+    return false;
+  if (file.Read(&dim_z[2], 1) != 1)
+    return false;
+
+  uint8_t magic[4] = {0x13, 0xAB, 0xA1, 0x5C};
+
+  if (!std::equal(descriptor, descriptor+4, magic))
+  {
+    CLog::Log(LOGERROR, "{}: Error parsing ASTC file: wrong magic", __PRETTY_FUNCTION__);
+    return false;
+  }
+
+  if (block_x == 4 && block_y == 4 && block_z == 1)
+    m_format = XB_FMT_ASTC_4x4;
+  else if (block_x == 8 && block_y == 8 && block_z == 1)
+    m_format = XB_FMT_ASTC_8x8;
+  else
+  {
+    CLog::Log(LOGERROR, "{}: Error parsing ASTC file: unsupported block size - {}x{}x{}", __PRETTY_FUNCTION__, block_x, block_y, block_z);
+    return false;
+  }
+
+  m_width = dim_x[0] + (dim_x[1] << 8) + (dim_x[2] << 16);
+  m_height = dim_y[0] + (dim_y[1] << 8) + (dim_y[2] << 16);
+  depth = dim_z[0] + (dim_z[1] << 8) + (dim_z[2] << 16);
+
+  if (depth != 1)
+  {
+    CLog::Log(LOGERROR, "{}: Error parsing ASTC file: depth invalid", __PRETTY_FUNCTION__);
+    return false;
+  }
+
+  m_size = file.GetLength() - 16;
+  m_data.resize(m_size);
+  file.Read(m_data.data(), m_size);
+  return true;
+}

--- a/xbmc/guilib/ASTCImage.h
+++ b/xbmc/guilib/ASTCImage.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+class CASTCImage
+{
+public:
+  CASTCImage() = default;
+  ~CASTCImage() = default;
+
+  unsigned int GetWidth() const { return m_width; }
+  unsigned int GetHeight() const { return m_height; }
+  unsigned int GetFormat() const { return m_format; }
+  unsigned int GetSize() const { return m_size; }
+  //unsigned char *GetData() const { return m_data; }
+  const char *GetData() const { return m_data.data(); }
+
+  bool ReadFile(const std::string &file);
+
+private:
+  unsigned int m_width = 0;
+  unsigned int m_height = 0;
+  unsigned int m_size = 0;
+  unsigned int m_format = 0;
+  //unsigned char *m_data;
+  std::vector<char> m_data;
+};

--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES DDSImage.cpp
+set(SOURCES ASTCImage.cpp
+            DDSImage.cpp
             DirtyRegionSolvers.cpp
             DirtyRegionTracker.cpp
             FFmpegImage.cpp
@@ -61,6 +62,7 @@ set(SOURCES DDSImage.cpp
             imagefactory.cpp
             IWindowManagerCallback.cpp
             LocalizeStrings.cpp
+            PKMImage.cpp
             StereoscopicsManager.cpp
             TextureBundle.cpp
             TextureBundleXBT.cpp
@@ -70,7 +72,8 @@ set(SOURCES DDSImage.cpp
             XBTF.cpp
             XBTFReader.cpp)
 
-set(HEADERS DDSImage.h
+set(HEADERS ASTCImage.h
+            DDSImage.h
             DirtyRegion.h
             DirtyRegionSolvers.h
             DirtyRegionTracker.h
@@ -144,6 +147,7 @@ set(HEADERS DDSImage.h
             ISliderCallback.h
             IWindowManagerCallback.h
             LocalizeStrings.h
+            PKMImage.h
             StereoscopicsManager.h
             Texture.h
             TextureBundle.h

--- a/xbmc/guilib/PKMImage.cpp
+++ b/xbmc/guilib/PKMImage.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PKMImage.h"
+
+#include "filesystem/File.h"
+#include "TextureFormats.h"
+#include "Texture.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <string.h>
+
+using namespace XFILE;
+
+bool CPKMImage::ReadFile(const std::string &inputFile)
+{
+  CFile file;
+  uint8_t descriptor[6];
+  uint16_t format;
+  uint16_t width;
+  uint16_t height;
+  uint16_t originalWidth;
+  uint16_t originalHeight;
+
+  if (!file.Open(inputFile))
+    return false;
+
+  if (file.GetLength() <= 16)
+    return false;
+  if (file.Read(&descriptor, 6) != 6)
+    return false;
+  if (file.Read(&format, 2) != 2)
+    return false;
+  if (file.Read(&width, 2) != 2)
+    return false;
+  if (file.Read(&height, 2) != 2)
+    return false;
+  if (file.Read(&originalWidth, 2) != 2)
+    return false;
+  if (file.Read(&originalHeight, 2) != 2)
+    return false;
+
+  std::swap(reinterpret_cast<uint8_t *>(&format)[0], reinterpret_cast<uint8_t *>(&format)[1]);
+  std::swap(reinterpret_cast<uint8_t *>(&height)[0], reinterpret_cast<uint8_t *>(&height)[1]);
+  std::swap(reinterpret_cast<uint8_t *>(&width)[0], reinterpret_cast<uint8_t *>(&width)[1]);
+
+  uint8_t magicPKM10[6] = {0x50, 0x4B, 0x4D, 0x20, 0x31, 0x30};
+  uint8_t magicPKM20[6] = {0x50, 0x4B, 0x4D, 0x20, 0x32, 0x30};
+
+  if (std::equal(descriptor, descriptor+6, magicPKM10))
+  {
+    if (format == 0)
+      m_format = XB_FMT_ETC1;
+    else
+    {
+      CLog::Log(LOGERROR, "{}: Error parsing PKM10 file: unknown format {}", __PRETTY_FUNCTION__, format);
+      return false;
+    }
+  }
+  else if (std::equal(descriptor, descriptor+6, magicPKM20))
+  {
+    if (format == 1)
+      m_format = XB_FMT_ETC2_RGB;
+    else if (format == 3)
+      m_format = XB_FMT_ETC2_RGBA;
+    else if (format == 5)
+      m_format = XB_FMT_ETC2_R;
+    else
+    {
+      CLog::Log(LOGERROR, "{}: Error parsing PKM20 file: unknown format {}", __PRETTY_FUNCTION__, format);
+      return false;
+    }
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "{}: Error parsing PKM file: wrong magic", __PRETTY_FUNCTION__);
+    return false;
+  }
+
+  m_width = width;
+  m_height = height;
+  m_size = file.GetLength() - 16;
+  m_data.resize(m_size);
+  file.Read(m_data.data(), m_size);
+  return true;
+}

--- a/xbmc/guilib/PKMImage.h
+++ b/xbmc/guilib/PKMImage.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+class CPKMImage
+{
+public:
+  CPKMImage() = default;
+  ~CPKMImage() = default;
+
+  unsigned int GetWidth() const { return m_width; }
+  unsigned int GetHeight() const { return m_height; }
+  unsigned int GetFormat() const { return m_format; }
+  unsigned int GetSize() const { return m_size; }
+  const char *GetData() const { return m_data.data(); }
+
+  bool ReadFile(const std::string &file);
+
+private:
+  unsigned int m_width = 0;
+  unsigned int m_height = 0;
+  unsigned int m_size = 0;
+  unsigned int m_format = 0;
+  std::vector<char> m_data;
+};

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -83,8 +83,10 @@ public:
   virtual void DestroyTextureObject() = 0;
   virtual void LoadToGPU() = 0;
   virtual void BindToUnit(unsigned int unit) = 0;
+  virtual bool IsTexSupported(uint32_t textureFormat) const = 0;
 
   unsigned char* GetPixels() const { return m_pixels; }
+  unsigned int GetFormat() const { return m_format; }
   unsigned int GetPitch() const { return GetPitch(m_textureWidth); }
   unsigned int GetRows() const { return GetRows(m_textureHeight); }
   unsigned int GetTextureWidth() const { return m_textureWidth; }

--- a/xbmc/guilib/TextureDX.cpp
+++ b/xbmc/guilib/TextureDX.cpp
@@ -187,3 +187,30 @@ void CDXTexture::LoadToGPU()
 void CDXTexture::BindToUnit(unsigned int unit)
 {
 }
+
+bool CDXTexture::IsTexSupported(uint32_t textureFormat) const
+{
+  switch(textureFormat) // FIXME: actually probe for supported formats
+  {
+    case XB_FMT_UNKNOWN:
+    case XB_FMT_DXT1:
+    case XB_FMT_DXT3:
+    case XB_FMT_DXT5:
+    case XB_FMT_DXT5_YCoCg:
+    case XB_FMT_A8R8G8B8:
+    case XB_FMT_A8:
+    case XB_FMT_RGBA8:
+    case XB_FMT_RGB8:
+    case XB_FMT_OPAQUE:
+      return true;
+    case XB_FMT_ETC1:
+    case XB_FMT_ETC2_R:
+    case XB_FMT_ETC2_RGB:
+    case XB_FMT_ETC2_RGBA:
+    case XB_FMT_ASTC_4x4:
+    case XB_FMT_ASTC_8x8:
+      return false;
+    default:
+      return true;
+  }
+}

--- a/xbmc/guilib/TextureDX.h
+++ b/xbmc/guilib/TextureDX.h
@@ -24,6 +24,7 @@ public:
   void DestroyTextureObject();
   virtual void LoadToGPU();
   void BindToUnit(unsigned int unit);
+  bool IsTexSupported(uint32_t textureFormat) const override;
 
   ID3D11Texture2D* GetTextureObject()
   {

--- a/xbmc/guilib/TextureFormats.h
+++ b/xbmc/guilib/TextureFormats.h
@@ -19,4 +19,10 @@
 #define XB_FMT_A8         32
 #define XB_FMT_RGBA8      64
 #define XB_FMT_RGB8      128
+#define XB_FMT_ETC1      256
+#define XB_FMT_ETC2_R    512
+#define XB_FMT_ETC2_RGB 1024
+#define XB_FMT_ETC2_RGBA 2048
+#define XB_FMT_ASTC_4x4 4096 // LDR version
+#define XB_FMT_ASTC_8x8 8192 // LDR version
 #define XB_FMT_OPAQUE  65536

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -25,6 +25,7 @@ public:
   void DestroyTextureObject() override;
   void LoadToGPU() override;
   void BindToUnit(unsigned int unit) override;
+  bool IsTexSupported(uint32_t textureFormat) const override;
 
 protected:
   GLuint m_texture = 0;


### PR DESCRIPTION
## Description
This PR adds initial support for ETC/ETC2/ASTC compression on GL and GLES.

Textures can now be supplied via the file extensions ".etc1" (PKM 10), ".etc2" (PKM 20) and ".astc" (ASTC). https://developer.arm.com/tools-and-software/graphics-and-gaming/mali-texture-compression-tool can create such textures.

## Motivation and context
Low end platforms are usually pretty memory bandwidth bound, and rendering large RGBA textures (like the background textures of Estuary) is very costly. ETC1 compression is available on virtually every device, so at least RGB textures can be used there. ETC2 and ASTC feature better compression and alpha channel support.

Ideally, some logic to select the most suitable texture will have to be put in place. In this state, only textures explicitly defined in the skin can be used.

Also, the texture packer needs to be updated to include such textures in the .xbt file format.

## How has this been tested?
On my main PC with an RX 570, it ran fine. ETC1/2/ASTC were displayed properly. The latter format is decoded by Mesa before it had been send to the GPU, as AMD features no hardware support for it.
On a Raspberry Pi 4, ETC1/2 displayed correctly too. ASTC is not supported.

## What is the effect on users?
Effects should be none, as no such textures were used before.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
