### PR TITLE
[tools/depends] Bump flatbuffers 2.0.0

### DIFF
--- a/tools/depends/native/flatbuffers/Makefile
+++ b/tools/depends/native/flatbuffers/Makefile
@@ -5,11 +5,15 @@ DEPS=../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=flatbuffers
-VERSION=1.12.0
+VERSION=2.0.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
 APP=$(PLATFORM)/build-cmake/flatc
+
+# BUILD Notes
+# When we go c++17, flatbuffers has FLATBUFFERS_BUILD_CPP17 to enable
+# If we bump cmake min req to 3.16, enable FLATBUFFERS_ENABLE_PCH
 
 ifeq ($(USE_CCACHE), yes)
   LAUNCHER=-DCMAKE_CXX_COMPILER_LAUNCHER=$(CCACHE)

--- a/tools/depends/target/flatbuffers/Makefile
+++ b/tools/depends/target/flatbuffers/Makefile
@@ -3,7 +3,7 @@ DEPS=Makefile
 
 # lib name, version
 LIBNAME=flatbuffers
-VERSION=1.12.0
+VERSION=2.0.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
## Description
Bump flatbuffers to 2.0.0

## Motivation and context
dependency bumps

@wsnipex another tarball at your leisure
@garbear just in case you want to test or anything. As discussed on slack, i dont think theres going to be any issues with our usage. Couldnt see any need for change with our cmake flags. Just a note when we go c++17, flatbuffers has an enable flag for it. If we ever bump cmake min req to 3.16, may want to enable FLATBUFFERS_ENABLE_PCH

## How has this been tested?
build osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
