### PR TITLE
[tools/depends] bump libjpeg-turbo 2.1.1

### DIFF
--- a/tools/depends/native/libjpeg-turbo/01-disable-executables.patch
+++ b/tools/depends/native/libjpeg-turbo/01-disable-executables.patch
@@ -1,130 +1,118 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -592,18 +592,6 @@
-       set_target_properties(turbojpeg PROPERTIES
+@@ -203,6 +203,9 @@
+ boolean_number(WITH_TURBOJPEG)
+ option(WITH_FUZZ "Build fuzz targets" FALSE)
+ 
++option(ENABLE_TESTS "Enable testing targets" FALSE)
++boolean_number(ENABLE_TESTS)
++
+ macro(report_option var desc)
+   if(${var})
+     message(STATUS "${desc} enabled (${var} = ${${var}})")
+@@ -646,6 +649,7 @@
          LINK_FLAGS "${TJMAPFLAG}${TJMAPFILE}")
      endif()
--
--    add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
--    target_link_libraries(tjunittest turbojpeg)
--
--    add_executable(tjbench tjbench.c tjutil.c)
--    target_link_libraries(tjbench turbojpeg)
--    if(UNIX)
--      target_link_libraries(tjbench m)
--    endif()
--
--    add_executable(tjexample tjexample.c)
--    target_link_libraries(tjexample turbojpeg)
+ 
++if(ENABLE_TESTS)
+     add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
+     target_link_libraries(tjunittest turbojpeg)
+ 
+@@ -657,6 +661,7 @@
+ 
+     add_executable(tjexample tjexample.c)
+     target_link_libraries(tjexample turbojpeg)
++endif()
    endif()
  
    if(ENABLE_STATIC)
-@@ -615,16 +603,6 @@
+@@ -668,7 +673,7 @@
      if(NOT MSVC)
        set_target_properties(turbojpeg-static PROPERTIES OUTPUT_NAME turbojpeg)
      endif()
 -
--    add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
--      md5/md5hl.c)
--    target_link_libraries(tjunittest-static turbojpeg-static)
--
--    add_executable(tjbench-static tjbench.c tjutil.c)
--    target_link_libraries(tjbench-static turbojpeg-static)
--    if(UNIX)
--      target_link_libraries(tjbench-static m)
--    endif()
++if(ENABLE_TESTS)
+     add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
+       md5/md5hl.c)
+     target_link_libraries(tjunittest-static turbojpeg-static)
+@@ -678,6 +683,7 @@
+     if(UNIX)
+       target_link_libraries(tjbench-static m)
+     endif()
++endif()
    endif()
  endif()
  
-@@ -639,33 +617,11 @@
+@@ -692,6 +698,7 @@
    set(DJPEG_BMP_SOURCES wrbmp.c wrtarga.c)
  endif()
  
--if(ENABLE_STATIC)
--  add_executable(cjpeg-static cjpeg.c cdjpeg.c rdgif.c rdppm.c rdswitch.c
--    ${CJPEG_BMP_SOURCES})
--  set_property(TARGET cjpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
--  target_link_libraries(cjpeg-static jpeg-static)
++if(ENABLE_TESTS)
+ if(ENABLE_STATIC)
+   add_executable(cjpeg-static cjpeg.c cdjpeg.c rdgif.c rdppm.c rdswitch.c
+     ${CJPEG_BMP_SOURCES})
+@@ -711,11 +718,12 @@
+ add_executable(rdjpgcom rdjpgcom.c)
+ 
+ add_executable(wrjpgcom wrjpgcom.c)
 -
--  add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrgif.c
--    wrppm.c ${DJPEG_BMP_SOURCES})
--  set_property(TARGET djpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
--  target_link_libraries(djpeg-static jpeg-static)
--
--  add_executable(jpegtran-static jpegtran.c cdjpeg.c rdswitch.c transupp.c)
--  target_link_libraries(jpegtran-static jpeg-static)
--  set_property(TARGET jpegtran-static PROPERTY COMPILE_FLAGS "${USE_SETMODE}")
--endif()
--
--add_executable(rdjpgcom rdjpgcom.c)
--
--add_executable(wrjpgcom wrjpgcom.c)
--
++endif()
  
  ###############################################################################
  # TESTS
  ###############################################################################
++if(ENABLE_TESTS)
  
--add_subdirectory(md5)
+ if(WITH_FUZZ)
+   add_subdirectory(fuzz)
+@@ -1431,7 +1439,7 @@
+       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tjbenchtest)
+   endif()
+ endif()
 -
- if(MSVC_IDE OR XCODE)
-   set(OBJDIR "\${CTEST_CONFIGURATION_TYPE}/")
- else()
-@@ -1337,7 +1293,7 @@
++endif()
  
- if(WITH_TURBOJPEG)
-   if(ENABLE_SHARED)
--    install(TARGETS turbojpeg tjbench
-+    install(TARGETS turbojpeg
+ ###############################################################################
+ # INSTALLATION
+@@ -1446,8 +1454,10 @@
        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-@@ -1350,15 +1306,6 @@
-   if(ENABLE_STATIC)
-     install(TARGETS turbojpeg-static ARCHIVE
-       DESTINATION ${CMAKE_INSTALL_LIBDIR})
--    if(NOT ENABLE_SHARED)
--      if(MSVC_IDE OR XCODE)
--        set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
--      else()
--        set(DIR ${CMAKE_CURRENT_BINARY_DIR})
--      endif()
--      install(PROGRAMS ${DIR}/tjbench-static${EXE}
--        DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
--    endif()
++if(ENABLE_TESTS)
+     install(TARGETS tjbench
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++endif()
+     if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
+       CMAKE_C_LINKER_SUPPORTS_PDB)
+       install(FILES "$<TARGET_PDB_FILE:turbojpeg>"
+@@ -1464,8 +1474,10 @@
+       else()
+         set(DIR ${CMAKE_CURRENT_BINARY_DIR})
+       endif()
++      if(ENABLE_TESTS)
+       install(PROGRAMS ${DIR}/tjbench-static${EXE}
+         DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
++      endif()
+     endif()
    endif()
    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg.h
-     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-@@ -1366,23 +1313,8 @@
- 
- if(ENABLE_STATIC)
-   install(TARGETS jpeg-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
--  if(NOT ENABLE_SHARED)
--    if(MSVC_IDE OR XCODE)
--      set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
--    else()
--      set(DIR ${CMAKE_CURRENT_BINARY_DIR})
--    endif()
--    install(PROGRAMS ${DIR}/cjpeg-static${EXE}
--      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME cjpeg${EXE})
--    install(PROGRAMS ${DIR}/djpeg-static${EXE}
--      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME djpeg${EXE})
--    install(PROGRAMS ${DIR}/jpegtran-static${EXE}
--      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jpegtran${EXE})
--  endif()
+@@ -1476,6 +1488,7 @@
+   install(TARGETS jpeg-static EXPORT ${CMAKE_PROJECT_NAME}Targets
+     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++if(ENABLE_TESTS)
+   if(NOT ENABLE_SHARED)
+     if(MSVC_IDE OR XCODE)
+       set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
+@@ -1490,8 +1503,11 @@
+       DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jpegtran${EXE})
+   endif()
  endif()
++endif()
  
--install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
--
++if(ENABLE_TESTS)
+ install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++endif()
+ 
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
    ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.txt
-   ${CMAKE_CURRENT_SOURCE_DIR}/tjexample.c
-@@ -1398,8 +1330,6 @@
- if(UNIX OR MINGW)
-   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cjpeg.1
-     ${CMAKE_CURRENT_SOURCE_DIR}/djpeg.1 ${CMAKE_CURRENT_SOURCE_DIR}/jpegtran.1
--    ${CMAKE_CURRENT_SOURCE_DIR}/rdjpgcom.1
--    ${CMAKE_CURRENT_SOURCE_DIR}/wrjpgcom.1
-     DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
- endif()
- install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgscripts/libjpeg.pc

--- a/tools/depends/native/libjpeg-turbo/Makefile
+++ b/tools/depends/native/libjpeg-turbo/Makefile
@@ -5,7 +5,7 @@ DEPS= ../../Makefile.include Makefile 01-disable-executables.patch
 
 # lib name, version
 LIBNAME=libjpeg-turbo
-VERSION=2.0.4
+VERSION=2.1.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 

--- a/tools/depends/target/libjpeg-turbo/01-disable-executables.patch
+++ b/tools/depends/target/libjpeg-turbo/01-disable-executables.patch
@@ -1,130 +1,118 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -592,18 +592,6 @@
-       set_target_properties(turbojpeg PROPERTIES
+@@ -203,6 +203,9 @@
+ boolean_number(WITH_TURBOJPEG)
+ option(WITH_FUZZ "Build fuzz targets" FALSE)
+ 
++option(ENABLE_TESTS "Enable testing targets" FALSE)
++boolean_number(ENABLE_TESTS)
++
+ macro(report_option var desc)
+   if(${var})
+     message(STATUS "${desc} enabled (${var} = ${${var}})")
+@@ -646,6 +649,7 @@
          LINK_FLAGS "${TJMAPFLAG}${TJMAPFILE}")
      endif()
--
--    add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
--    target_link_libraries(tjunittest turbojpeg)
--
--    add_executable(tjbench tjbench.c tjutil.c)
--    target_link_libraries(tjbench turbojpeg)
--    if(UNIX)
--      target_link_libraries(tjbench m)
--    endif()
--
--    add_executable(tjexample tjexample.c)
--    target_link_libraries(tjexample turbojpeg)
+ 
++if(ENABLE_TESTS)
+     add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
+     target_link_libraries(tjunittest turbojpeg)
+ 
+@@ -657,6 +661,7 @@
+ 
+     add_executable(tjexample tjexample.c)
+     target_link_libraries(tjexample turbojpeg)
++endif()
    endif()
  
    if(ENABLE_STATIC)
-@@ -615,16 +603,6 @@
+@@ -668,7 +673,7 @@
      if(NOT MSVC)
        set_target_properties(turbojpeg-static PROPERTIES OUTPUT_NAME turbojpeg)
      endif()
 -
--    add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
--      md5/md5hl.c)
--    target_link_libraries(tjunittest-static turbojpeg-static)
--
--    add_executable(tjbench-static tjbench.c tjutil.c)
--    target_link_libraries(tjbench-static turbojpeg-static)
--    if(UNIX)
--      target_link_libraries(tjbench-static m)
--    endif()
++if(ENABLE_TESTS)
+     add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
+       md5/md5hl.c)
+     target_link_libraries(tjunittest-static turbojpeg-static)
+@@ -678,6 +683,7 @@
+     if(UNIX)
+       target_link_libraries(tjbench-static m)
+     endif()
++endif()
    endif()
  endif()
  
-@@ -639,33 +617,11 @@
+@@ -692,6 +698,7 @@
    set(DJPEG_BMP_SOURCES wrbmp.c wrtarga.c)
  endif()
  
--if(ENABLE_STATIC)
--  add_executable(cjpeg-static cjpeg.c cdjpeg.c rdgif.c rdppm.c rdswitch.c
--    ${CJPEG_BMP_SOURCES})
--  set_property(TARGET cjpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
--  target_link_libraries(cjpeg-static jpeg-static)
++if(ENABLE_TESTS)
+ if(ENABLE_STATIC)
+   add_executable(cjpeg-static cjpeg.c cdjpeg.c rdgif.c rdppm.c rdswitch.c
+     ${CJPEG_BMP_SOURCES})
+@@ -711,11 +718,12 @@
+ add_executable(rdjpgcom rdjpgcom.c)
+ 
+ add_executable(wrjpgcom wrjpgcom.c)
 -
--  add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrgif.c
--    wrppm.c ${DJPEG_BMP_SOURCES})
--  set_property(TARGET djpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
--  target_link_libraries(djpeg-static jpeg-static)
--
--  add_executable(jpegtran-static jpegtran.c cdjpeg.c rdswitch.c transupp.c)
--  target_link_libraries(jpegtran-static jpeg-static)
--  set_property(TARGET jpegtran-static PROPERTY COMPILE_FLAGS "${USE_SETMODE}")
--endif()
--
--add_executable(rdjpgcom rdjpgcom.c)
--
--add_executable(wrjpgcom wrjpgcom.c)
--
++endif()
  
  ###############################################################################
  # TESTS
  ###############################################################################
++if(ENABLE_TESTS)
  
--add_subdirectory(md5)
+ if(WITH_FUZZ)
+   add_subdirectory(fuzz)
+@@ -1431,7 +1439,7 @@
+       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tjbenchtest)
+   endif()
+ endif()
 -
- if(MSVC_IDE OR XCODE)
-   set(OBJDIR "\${CTEST_CONFIGURATION_TYPE}/")
- else()
-@@ -1337,7 +1293,7 @@
++endif()
  
- if(WITH_TURBOJPEG)
-   if(ENABLE_SHARED)
--    install(TARGETS turbojpeg tjbench
-+    install(TARGETS turbojpeg
+ ###############################################################################
+ # INSTALLATION
+@@ -1446,8 +1454,10 @@
        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-@@ -1350,15 +1306,6 @@
-   if(ENABLE_STATIC)
-     install(TARGETS turbojpeg-static ARCHIVE
-       DESTINATION ${CMAKE_INSTALL_LIBDIR})
--    if(NOT ENABLE_SHARED)
--      if(MSVC_IDE OR XCODE)
--        set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
--      else()
--        set(DIR ${CMAKE_CURRENT_BINARY_DIR})
--      endif()
--      install(PROGRAMS ${DIR}/tjbench-static${EXE}
--        DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
--    endif()
++if(ENABLE_TESTS)
+     install(TARGETS tjbench
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++endif()
+     if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
+       CMAKE_C_LINKER_SUPPORTS_PDB)
+       install(FILES "$<TARGET_PDB_FILE:turbojpeg>"
+@@ -1464,8 +1474,10 @@
+       else()
+         set(DIR ${CMAKE_CURRENT_BINARY_DIR})
+       endif()
++      if(ENABLE_TESTS)
+       install(PROGRAMS ${DIR}/tjbench-static${EXE}
+         DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
++      endif()
+     endif()
    endif()
    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg.h
-     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-@@ -1366,23 +1313,8 @@
- 
- if(ENABLE_STATIC)
-   install(TARGETS jpeg-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
--  if(NOT ENABLE_SHARED)
--    if(MSVC_IDE OR XCODE)
--      set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
--    else()
--      set(DIR ${CMAKE_CURRENT_BINARY_DIR})
--    endif()
--    install(PROGRAMS ${DIR}/cjpeg-static${EXE}
--      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME cjpeg${EXE})
--    install(PROGRAMS ${DIR}/djpeg-static${EXE}
--      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME djpeg${EXE})
--    install(PROGRAMS ${DIR}/jpegtran-static${EXE}
--      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jpegtran${EXE})
--  endif()
+@@ -1476,6 +1488,7 @@
+   install(TARGETS jpeg-static EXPORT ${CMAKE_PROJECT_NAME}Targets
+     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++if(ENABLE_TESTS)
+   if(NOT ENABLE_SHARED)
+     if(MSVC_IDE OR XCODE)
+       set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
+@@ -1490,8 +1503,11 @@
+       DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jpegtran${EXE})
+   endif()
  endif()
++endif()
  
--install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
--
++if(ENABLE_TESTS)
+ install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++endif()
+ 
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
    ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.txt
-   ${CMAKE_CURRENT_SOURCE_DIR}/tjexample.c
-@@ -1398,8 +1330,6 @@
- if(UNIX OR MINGW)
-   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cjpeg.1
-     ${CMAKE_CURRENT_SOURCE_DIR}/djpeg.1 ${CMAKE_CURRENT_SOURCE_DIR}/jpegtran.1
--    ${CMAKE_CURRENT_SOURCE_DIR}/rdjpgcom.1
--    ${CMAKE_CURRENT_SOURCE_DIR}/wrjpgcom.1
-     DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
- endif()
- install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgscripts/libjpeg.pc

--- a/tools/depends/target/libjpeg-turbo/02-fix-gas-preprocessor-with-ccache.patch
+++ b/tools/depends/target/libjpeg-turbo/02-fix-gas-preprocessor-with-ccache.patch
@@ -1,5 +1,0 @@
---- a/simd/gas-preprocessor.in
-+++ b/simd/gas-preprocessor.in
-@@ -1 +1,2 @@
-+#!/bin/sh
- gas-preprocessor.pl @CMAKE_ASM_COMPILER@ ${1+"$@"}

--- a/tools/depends/target/libjpeg-turbo/Makefile
+++ b/tools/depends/target/libjpeg-turbo/Makefile
@@ -1,9 +1,9 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile 01-disable-executables.patch 02-fix-gas-preprocessor-with-ccache.patch
+DEPS= ../../Makefile.include Makefile 01-disable-executables.patch
 
 # lib name, version
 LIBNAME=libjpeg-turbo
-VERSION=2.0.5
+VERSION=2.1.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 
@@ -18,7 +18,6 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../01-disable-executables.patch
-	cd $(PLATFORM); patch -p1 -i ../02-fix-gas-preprocessor-with-ccache.patch
 	cd $(PLATFORM); $(CMAKE) -B build -DCMAKE_ASM_NASM_COMPILER:FILEPATH=$(NATIVEPREFIX)/bin/yasm -DENABLE_SHARED:BOOL=OFF -DWITH_JPEG8:BOOL=ON
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
## Description
Bump libjpeg-turbo 2.1.1

## Motivation and context
Dependency bumps

libjpeg-turbo no longer uses gas-preprocessor apparently as per https://github.com/libjpeg-turbo/libjpeg-turbo/blob/18edeff4e87ab5c2450d81be8eeb0e6f29003756/simd/CMakeLists.txt#L268-L274

Have changed the patch to patch IN an ENABLE_TESTS cmake option (default off for us of course). Little bit easier to maintain adding smaller sections than removing large chunks

@wsnipex another tarball thanks

## How has this been tested?
build osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
