### PR TITLE
Allow override of default player by inputstream add-ons

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_constants.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_constants.h
@@ -18,6 +18,16 @@
 #define STREAM_PROPERTY_INPUTSTREAM "inputstream"
 
 /// @ingroup cpp_kodi_addon_inputstream_Defs_StreamConstants
+/// @brief The name of the default player to use for this inputstream add-on that
+/// should be used by Kodi to play the stream.
+///
+/// Leave blank to use Kodi's built-in player selection mechanism.
+/// Permitted values are:
+/// - "videodefaultplayer"
+/// - "audiodefaultplayer"
+#define STREAM_PROPERTY_INPUTSTREAM_PLAYER "inputstream-player"
+
+/// @ingroup cpp_kodi_addon_inputstream_Defs_StreamConstants
 /// @brief Identification string for an input stream.
 ///
 /// This value can be used in addition to @ref STREAM_PROPERTY_INPUTSTREAM. It is

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
@@ -161,6 +161,16 @@ extern "C"
   ///
   #define PVR_STREAM_PROPERTY_INPUTSTREAM STREAM_PROPERTY_INPUTSTREAM
 
+  /// @brief To define in stream properties the player the inputstream add-on
+  /// should use.
+  ///
+  /// Leave blank to use Kodi's built-in player selection mechanism.
+  /// Permitted values are:
+  /// - "videodefaultplayer"
+  /// - "audiodefaultplayer"
+  ///
+  #define PVR_STREAM_PROPERTY_INPUTSTREAM_PLAYER STREAM_PROPERTY_INPUTSTREAM_PLAYER
+
   /// @brief Identification string for an input stream.
   ///
   /// This value can be used in addition to @ref PVR_STREAM_PROPERTY_INPUTSTREAM.

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -107,7 +107,7 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.0.1"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.0.2"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.0.1"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
@@ -129,7 +129,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "8.0.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "8.0.1"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "8.0.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -13,6 +13,7 @@
 #include "PlayerSelectionRule.h"
 #include "URL.h"
 #include "cores/IPlayerCallback.h"
+#include "cores/VideoPlayer/Interface/InputStreamConstants.h"
 #include "cores/paplayer/PAPlayer.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "guilib/LocalizeStrings.h"
@@ -98,6 +99,30 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
 
   CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers({})", CURL::GetRedacted(item.GetDynPath()));
 
+  enum class ForcedPlayer
+  {
+    NONE,
+    VIDEO_DEFAULT,
+    AUDIO_DEFAULT
+  };
+
+  ForcedPlayer defaultInputstreamPlayerOverride = ForcedPlayer::NONE;
+
+  // If we are using an inpustream add-on
+  if (!item.GetProperty(STREAM_PROPERTY_INPUTSTREAM).empty())
+  {
+    if (!item.GetProperty(STREAM_PROPERTY_INPUTSTREAM_PLAYER).empty())
+    {
+      const std::string inputstreamPlayerOverride =
+          item.GetProperty(STREAM_PROPERTY_INPUTSTREAM_PLAYER).asString();
+
+      if (inputstreamPlayerOverride == "videodefaultplayer")
+        defaultInputstreamPlayerOverride = ForcedPlayer::VIDEO_DEFAULT;
+      else if ((inputstreamPlayerOverride == "audiodefaultplayer"))
+        defaultInputstreamPlayerOverride = ForcedPlayer::AUDIO_DEFAULT;
+    }
+  }
+
   std::vector<std::string>validPlayers;
   GetPlayers(validPlayers);
 
@@ -111,7 +136,12 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
 
   // Set video default player. Check whether it's video first (overrule audio and
   // game check). Also push these players in case it is NOT audio or game either.
-  if (item.IsVideo() || (!item.IsAudio() && !item.IsGame()))
+  //
+  // If an inputstream add-on is used, first check if we have an override to use
+  // "videodefaultplayer"
+  if (defaultInputstreamPlayerOverride == ForcedPlayer::VIDEO_DEFAULT ||
+      (defaultInputstreamPlayerOverride == ForcedPlayer::NONE &&
+       (item.IsVideo() || (!item.IsAudio() && !item.IsGame()))))
   {
     int idx = GetPlayerIndex("videodefaultplayer");
     if (idx > -1)
@@ -127,7 +157,8 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
 
   // Set audio default player
   // Pushback all audio players in case we don't know the type
-  if (item.IsAudio())
+  if (defaultInputstreamPlayerOverride == ForcedPlayer::AUDIO_DEFAULT ||
+      (defaultInputstreamPlayerOverride == ForcedPlayer::NONE && item.IsAudio()))
   {
     int idx = GetPlayerIndex("audiodefaultplayer");
     if (idx > -1)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Allow the player used by inputstream add-ons to be overriden to use either the default video or audio player.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Radio channels played using ffmpegdirect cannot leverage timeshift as they do not use VideoPlayer like the rest of PVR.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On OSX with iptvsimple.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
