### PR TITLE
AESinkAudioTrack: Use min_buffer periods

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -503,17 +503,20 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       }
       else
       {
-        // aim at 200 ms buffer and 50 ms periods
+        // aim at 200 ms buffer and 50 ms periods but at least two periods of min_buffer
+        m_min_buffer_size *= 2;
         m_audiotrackbuffer_sec =
             static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
+
+        int c = 2;
         while (m_audiotrackbuffer_sec < 0.15)
         {
           m_min_buffer_size += min_buffer;
+          c++;
           m_audiotrackbuffer_sec =
               static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
         }
-        // division by 4 -> 4 periods into one buffer
-        m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / 4;
+        m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / c;
       }
     }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -34,7 +34,7 @@ using namespace jni;
 // is the max TrueHD package
 const unsigned int MAX_RAW_AUDIO_BUFFER_HD = 61440;
 const unsigned int MAX_RAW_AUDIO_BUFFER = 16384;
-const unsigned int MOVING_AVERAGE_MAX_MEMBERS = 5;
+const unsigned int MOVING_AVERAGE_MAX_MEMBERS = 3;
 const uint64_t UINT64_LOWER_BYTES = 0x00000000FFFFFFFF;
 const uint64_t UINT64_UPPER_BYTES = 0xFFFFFFFF00000000;
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -702,6 +702,11 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   }
 
   delay += m_hw_delay;
+
+  // stop smoothing if we have the new API available
+  if (m_hw_delay != 0)
+    m_linearmovingaverage.clear();
+
   if (usesAdvancedLogging)
   {
     CLog::Log(LOGINFO, "Combined Delay: {} ms", delay * 1000);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -704,7 +704,9 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   delay += m_hw_delay;
 
   // stop smoothing if we have the new API available
-  if (m_hw_delay != 0)
+  // though normal RAW still is really bad delay wise
+  bool rawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
+  if ((m_hw_delay != 0) && !rawPt)
     m_linearmovingaverage.clear();
 
   if (usesAdvancedLogging)


### PR DESCRIPTION
This is a backport of #20127

Was tested by some 100 people already. I would like to have it in Matrix, so that nightlies after the 19.3 release have "all in" if possible. Furthermore I don't have to maintain two different version between 20 and 19.

All the changes are fixes.