### PR TITLE
Add RISC-V support to system info

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -992,6 +992,8 @@ const std::string& CSysInfo::GetKernelCpuFamily(void)
         kernelCpuFamily = "s390";
       else if (machine.compare(0, 3, "ppc", 3) == 0 || machine.compare(0, 5, "power", 5) == 0)
         kernelCpuFamily = "PowerPC";
+      else if (machine.compare(0, 5, "riscv", 5) == 0)
+        kernelCpuFamily = "RISC-V";
     }
 #endif
     if (kernelCpuFamily.empty())
@@ -1370,6 +1372,8 @@ std::string CSysInfo::GetBuildTargetCpuFamily(void)
   return "s390";
 #elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__) || defined(__ppc__) || defined(__ppc64__) || defined(_M_PPC)
   return "PowerPC";
+#elif defined(__riscv)
+  return "RISC-V";
 #else
   return "unknown CPU family";
 #endif


### PR DESCRIPTION
## Description

Backport of #20394 

## Motivation and context

This should have been a part of #20323 but I missed these two functions applying supplied `debdiff` file and tests fail on official Debian buildd for riscv64.

## How has this been tested?

Built for Debian by @aurel32 

## What is the effect on users?

Only if they use riscv64 port.

## Screenshots (if appropriate):

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed