### PR TITLE
[tools/depends][target] bump nghttp2 1.46.0

### DIFF
--- a/tools/depends/target/nghttp2/Makefile
+++ b/tools/depends/target/nghttp2/Makefile
@@ -3,11 +3,19 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=nghttp2
-VERSION=1.41.0
+VERSION=1.46.0
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.xz
 
 # configuration settings
-CONFIGURE=./configure --prefix=$(PREFIX) --enable-lib-only --disable-shared
+# no extra libs are required when using --enable-lib-only
+CONFIGURE=./configure --prefix=$(PREFIX) --enable-lib-only --disable-shared \
+            --without-jansson \
+            --without-libevent-openssl \
+            --without-libcares \
+            --without-libev \
+            --without-cunit \
+            --without-openssl \
+            --without-zlib
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 


### PR DESCRIPTION
## Description
Bump nghttp2 1.46.0

## Motivation and context
Dependency bump

@wsnipex another tarball thanks

As we only build/use lib, theres fairly minimal changes even though its a fairly large version bump
In the configure script, have explicitly set without-lib commands. Not sure if we should bother with that or not. The named libs are not used to build the lib only, and are only used for app/tests/etc.

## How has this been tested?
build osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
