### PR TITLE
Add 19.3 release to Linux metainfo

### DIFF
--- a/tools/Linux/kodi.metainfo.xml.in
+++ b/tools/Linux/kodi.metainfo.xml.in
@@ -64,6 +64,7 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release date="2021-10-24" version="19.3-Matrix"/>
         <release date="2021-10-08" version="19.2-Matrix"/>
         <release date="2021-05-09" version="19.1-Matrix"/>
         <release date="2021-02-19" version="19.0-Matrix"/>


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/20415