### PR TITLE
Fix various typos in docs, user-facing code, and source comments

### DIFF
--- a/addons/metadata.generic.albums/lib/musicbrainz.py
+++ b/addons/metadata.generic.albums/lib/musicbrainz.py
@@ -65,7 +65,7 @@ def musicbrainz_albumfind(data, artist, album):
         if item.get('score'):
             releasescore = item['score'] / 100.0
             # if the release is in the releasegroup with most releases, it is considered the most accurate one
-            # (this also helps with prefering official releases over bootlegs, assuming there are more variations of an official release than of a bootleg)
+            # (this also helps with preferring official releases over bootlegs, assuming there are more variations of an official release than of a bootleg)
             if item['release-group']['id'] not in topgroups:
                 releasescore -= 0.001
             # if the release is an album, prefer it over singles/ep's
@@ -151,7 +151,7 @@ def musicbrainz_albumart(data):
             discartdata['preview'] = item['thumbnails']['small']
             discartdata['aspect'] = 'discart'
             extras.append(discartdata)
-        # exculde spine+back images
+        # exclude spine+back images
         if 'Spine' in item['types'] and len(item['types']) == 1:
             spinedata = {}
             spinedata['image'] = item['image']

--- a/addons/metadata.local/addon.xml
+++ b/addons/metadata.local/addon.xml
@@ -22,7 +22,7 @@
              language="multi"
              library="local.xml"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en_GB">Local Infomation only pseudo-scraper</summary>
+    <summary lang="en_GB">Local Information only pseudo-scraper</summary>
     <description lang="en_GB">Use local information only</description>
     <platform>all</platform>
     <license>GPL-2.0-only</license>

--- a/addons/metadata.themoviedb.org/changelog.txt
+++ b/addons/metadata.themoviedb.org/changelog.txt
@@ -176,7 +176,7 @@ Version bump for Krypton
 - fixed: movies without release date won't find
 
 [B]3.0.7[/B]
-- fixed: keep originaltitle; IMDb ID; remove TMDb title fallback, because it became obsolate
+- fixed: keep originaltitle; IMDb ID; remove TMDb title fallback, because it became obsolete
 
 [B]3.0.6[/B]
 - updated chinese translation

--- a/addons/webinterface.default/lib/video-js/video.js
+++ b/addons/webinterface.default/lib/video-js/video.js
@@ -2264,7 +2264,7 @@ var Component = function () {
   /**
    * Clears a timeout that gets created via `window.setTimeout` or
    * {@link Component#setTimeout}. If you set a timeout via {@link Component#setTimeout}
-   * use this function instead of `window.clearTimout`. If you don't your dispose
+   * use this function instead of `window.clearTimeout`. If you don't your dispose
    * listener will not get cleaned up until {@link Component#dispose}!
    *
    * @param {number} timeoutId
@@ -10608,7 +10608,7 @@ var Player = function (_Component) {
    * dragging it along the progress bar.
    *
    * @param {boolean} [isScrubbing]
-   *        wether the user is or is not scrubbing
+   *        whether the user is or is not scrubbing
    *
    * @return {boolean|Player}
    *         A instance of the player that called this function when setting,
@@ -12276,7 +12276,7 @@ var Player = function (_Component) {
   };
 
   /**
-   * Determine wether or not flexbox is supported
+   * Determine whether or not flexbox is supported
    *
    * @return {boolean}
    *         - true if flexbox is supported
@@ -16130,7 +16130,7 @@ Html5.resetMediaElement = function (el) {
 
 /**
  * Get the value of the `error` from the media element. `error` indicates any
- * MediaError that may have occured during playback. If error returns null there is no
+ * MediaError that may have occurred during playback. If error returns null there is no
  * current error.
  *
  * @method Html5#error
@@ -17128,7 +17128,7 @@ var Tech = function (_Component) {
    * Returns the `TimeRange`s that have been played through for the current source.
    *
    * > NOTE: This implementation is incomplete. It does not track the played `TimeRange`.
-   *         It only checks wether the source has played at all or not.
+   *         It only checks whether the source has played at all or not.
    *
    * @return {TimeRange}
    *         - A single time range if this video has played
@@ -17654,7 +17654,7 @@ Tech.prototype.audioTracks_; // eslint-disable-line
 Tech.prototype.videoTracks_; // eslint-disable-line
 
 /**
- * Boolean indicating wether the `Tech` supports volume control.
+ * Boolean indicating whether the `Tech` supports volume control.
  *
  * @type {boolean}
  * @default
@@ -17662,7 +17662,7 @@ Tech.prototype.videoTracks_; // eslint-disable-line
 Tech.prototype.featuresVolumeControl = true;
 
 /**
- * Boolean indicating wether the `Tech` support fullscreen resize control.
+ * Boolean indicating whether the `Tech` support fullscreen resize control.
  * Resizing plugins using request fullscreen reloads the plugin
  *
  * @type {boolean}
@@ -17671,7 +17671,7 @@ Tech.prototype.featuresVolumeControl = true;
 Tech.prototype.featuresFullscreenResize = false;
 
 /**
- * Boolean indicating wether the `Tech` supports changing the speed at which the video
+ * Boolean indicating whether the `Tech` supports changing the speed at which the video
  * plays. Examples:
  *   - Set player to play 2x (twice) as fast
  *   - Set player to play 0.5x (half) as fast
@@ -17682,7 +17682,7 @@ Tech.prototype.featuresFullscreenResize = false;
 Tech.prototype.featuresPlaybackRate = false;
 
 /**
- * Boolean indicating wether the `Tech` supports the `progress` event. This is currently
+ * Boolean indicating whether the `Tech` supports the `progress` event. This is currently
  * not triggered by video-js-swf. This will be used to determine if
  * {@link Tech#manualProgressOn} should be called.
  *
@@ -17692,7 +17692,7 @@ Tech.prototype.featuresPlaybackRate = false;
 Tech.prototype.featuresProgressEvents = false;
 
 /**
- * Boolean indicating wether the `Tech` supports the `timeupdate` event. This is currently
+ * Boolean indicating whether the `Tech` supports the `timeupdate` event. This is currently
  * not triggered by video-js-swf. This will be used to determine if
  * {@link Tech#manualTimeUpdates} should be called.
  *
@@ -17702,7 +17702,7 @@ Tech.prototype.featuresProgressEvents = false;
 Tech.prototype.featuresTimeupdateEvents = false;
 
 /**
- * Boolean indicating wether the `Tech` supports the native `TextTrack`s.
+ * Boolean indicating whether the `Tech` supports the native `TextTrack`s.
  * This will help us integrate with native `TextTrack`s if the browser supports them.
  *
  * @type {boolean}
@@ -19016,7 +19016,7 @@ var TextTrackDisplay = function (_Component) {
   };
 
   /**
-   * Add an {@link Texttrack} to to the {@link Tech}s {@link TextTrackList}.
+   * Add an {@link Texttrack} to the {@link Tech}s {@link TextTrackList}.
    *
    * @param {TextTrack} track
    *        Text track object to be added to the list.

--- a/cmake/scripts/common/AddonHelpers.dox
+++ b/cmake/scripts/common/AddonHelpers.dox
@@ -11,7 +11,7 @@ process the construction.
 
 --------------------------------------------------------------------------------
 
-<b>Here a minmal example of the for addon used CMakeLists.txt:</b>
+<b>Here's a minimal example of the addon used for CMakeLists.txt:</b>
 
 ~~~~~~~~~~~~~{.cmake}
 cmake_minimum_required(VERSION 3.5)

--- a/cmake/scripts/common/CheckTargetPlatform.cmake
+++ b/cmake/scripts/common/CheckTargetPlatform.cmake
@@ -48,7 +48,7 @@ endfunction()
 
 function(check_install_permissions install_dir have_perms)
   # param[in] install_dir directory to check for write permissions
-  # param[out] have_perms wether we have permissions to install to install_dir
+  # param[out] have_perms whether we have permissions to install to install_dir
 
   set(testfile_lib ${install_dir}/lib/kodi/.cmake-inst-test)
   set(testfile_share ${install_dir}/share/kodi/.cmake-inst-test)

--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -573,7 +573,7 @@ function(core_find_git_rev stamp)
   else()
     find_package(Git)
     if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
-      # get tree status i.e. clean working tree vs dirty (uncommited or unstashed changes, etc.)
+      # get tree status i.e. clean working tree vs dirty (uncommitted or unstashed changes, etc.)
       execute_process(COMMAND ${GIT_EXECUTABLE} update-index --ignore-submodules -q --refresh
                       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
       execute_process(COMMAND ${GIT_EXECUTABLE} diff-files --ignore-submodules --quiet --

--- a/cmake/scripts/common/ProjectMacros.cmake
+++ b/cmake/scripts/common/ProjectMacros.cmake
@@ -3,7 +3,7 @@
 # Pack a skin xbt file
 # Arguments:
 #   input  input directory to pack
-#   output ouput xbt file
+#   output output xbt file
 # On return:
 #   xbt is added to ${XBT_FILES}
 function(pack_xbt input output)

--- a/cmake/treedata/windowsstore/subdirs.txt
+++ b/cmake/treedata/windowsstore/subdirs.txt
@@ -7,8 +7,8 @@ xbmc/platform/win10                    platform/win10
 xbmc/platform/win10/filesystem         platform/win10/filesystem
 xbmc/platform/win10/network            platform/win10/network
 xbmc/platform/win10/peripherals        platform/win10/peripherals
-xbmc/platform/win10/powermanagement    platfrom/win10/powermanagement
-xbmc/platform/win10/storage            platfrom/win10/storage
+xbmc/platform/win10/powermanagement    platform/win10/powermanagement
+xbmc/platform/win10/storage            platform/win10/storage
 xbmc/platform/win32/filesystem         platform/win32/filesystem
 xbmc/platform/win32/utils              platform/win32/utils
 xbmc/rendering/dx                      rendering/dx

--- a/docs/codeofconduct/ModeratorGuidelines.md
+++ b/docs/codeofconduct/ModeratorGuidelines.md
@@ -36,7 +36,7 @@ As suggested by keith on the slack channel, I thought it might be useful to have
 - Also if you move a thread, leave a note in it to say that you've done so.
 - Discussions isn't for support requests - that's what the main support sections are for.
 - Threads moved to off-topic can still be posted to by anyone, but normal users cannot start threads in that section.
-- If you bin a thread that contains dodgy links, please remember to edit it and remove them. The bin is publically visible, so can be harvested for such things by enterprising idiots.
+- If you bin a thread that contains dodgy links, please remember to edit it and remove them. The bin is publicly visible, so can be harvested for such things by enterprising idiots.
 
 **Warnings and banning**
 - Banning someone is an extreme measure, and should only be done "off the cuff" for short-term duration (certainly no more than a 2 week ban, ideally less) as a direct result of threatening or insulting behaviour (for the latter, something that goes materially beyond a simple breach of 2.1 of the Forum Rules).

--- a/project/Win32BuildSetup/genNsisInstaller.nsi
+++ b/project/Win32BuildSetup/genNsisInstaller.nsi
@@ -372,7 +372,7 @@ Function .onInit
   ${Endif}
   ${If} $HotFixID != ""
     nsExec::ExecToStack 'cmd /Q /C "%SYSTEMROOT%\System32\wbem\wmic.exe /?"'
-    Pop $0 ; return value (it always 0 even if an error occured)
+    Pop $0 ; return value (it always 0 even if an error occurred)
     Pop $1 ; command output
     ${If} $0 != 0
     ${OrIf} $1 == ""
@@ -380,7 +380,7 @@ Function .onInit
       Quit
     ${EndIf}
     nsExec::ExecToStack 'cmd /Q /C "%SYSTEMROOT%\System32\findstr.exe /?"'
-    Pop $0 ; return value (it always 0 even if an error occured)
+    Pop $0 ; return value (it always 0 even if an error occurred)
     Pop $1 ; command output
     ${If} $0 != 0
     ${OrIf} $1 == ""
@@ -388,7 +388,7 @@ Function .onInit
       Quit
     ${EndIf}
     nsExec::ExecToStack 'cmd /Q /C "%SYSTEMROOT%\System32\wbem\wmic.exe qfe get hotfixid | %SYSTEMROOT%\System32\findstr.exe "^KB$HotFixID[^0-9]""'
-    Pop $0 ; return value (it always 0 even if an error occured)
+    Pop $0 ; return value (it always 0 even if an error occurred)
     Pop $1 ; command output
     ${If} $0 != 0
     ${OrIf} $1 == ""

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -22,7 +22,7 @@
 <!--   eg <b>ActivateWindow(Music)</b>                                       -->
 <!-- would automatically go to Music on the press of the B button.           -->
 <!--                                                                         -->
-<!-- Buttons can be overloaded with hold durations, in miliseconds:          -->
+<!-- Buttons can be overloaded with hold durations, in milliseconds:         -->
 <!--   <joystick profile="game.controller.default">                          -->
 <!--     <a>Select</a>                                                       -->
 <!--     <a holdtime="500">ContextMenu</a>                                   -->

--- a/tools/EventClients/Clients/WiiRemote/CWIID_WiiRemote.cpp
+++ b/tools/EventClients/Clients/WiiRemote/CWIID_WiiRemote.cpp
@@ -60,7 +60,8 @@ void CWiiRemote::MessageCallback(cwiid_wiimote_t *wiiremote, int mesg_count, uni
 
 /* The MessageCallback for the Wiiremote.
    This callback is used for error reports, mainly to see if the connection has been broken
-   This callback is also used for getting the IR sources, if this is done in update as with buttons we usually only get 1 IR source at a time wich is much harder to calculate */
+   This callback is also used for getting the IR sources, if this is done in update as with
+   buttons we usually only get 1 IR source at a time which is much harder to calculate */
 void CWiiRemote::MessageCallback(cwiid_wiimote_t *wiiremote, int mesg_count, union cwiid_mesg mesg[], struct timespec *timestamp)
 {
   for (int i=0; i < mesg_count; i++)
@@ -399,7 +400,7 @@ void CWiiRemote::DisconnectNow(bool startConnectThread)
 
 #ifdef CWIID_OLD
 /* This is a harsh check if there really is a connection, It will mainly be used in CWIID < 6.0
-   as it doesn't report connect error, wich is needed to see if the Wiiremote suddenly disconnected.
+   as it doesn't report connect error, which is needed to see if the Wiiremote suddenly disconnected.
    This could possible be done with bluetooth specific queries but I cannot find how to do it.  */
 bool CWiiRemote::CheckConnection()
 {
@@ -571,7 +572,7 @@ void CWiiRemote::ProcessNunchuck(struct cwiid_nunchuk_mesg &Nunchuck)
   }
 }
 
-/* Tell cwiid wich data will be reported */
+/* Tell cwiid which data will be reported */
 void CWiiRemote::SetRptMode()
 { //Sets our wiiremote to report something, for example IR, Buttons
 #ifdef CWIID_OLD

--- a/tools/codegenerator/SwigTypeParser.groovy
+++ b/tools/codegenerator/SwigTypeParser.groovy
@@ -146,7 +146,7 @@ public class SwigTypeParser
    }
 
    /**
-    * This will resolve typedefs anbd handle qualifiers, pointers,
+    * This will resolve typedefs and handle qualifiers, pointers,
     *  references, and typedef of typedefs to resolve all the way down to the
     *  most basic types.
     */

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -36,7 +36,7 @@ if(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
     set(CMAKE_MACOSX_BUNDLE YES)
     set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
     # Need to set this attribute to "" in order to
-    # complety disable code signing
+    # completely disable code signing
     # see: https://gitlab.kitware.com/cmake/cmake/issues/19112
     set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
     if(CORE_PLATFORM_NAME STREQUAL tvos)

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -135,7 +135,7 @@ void CAppParamParser::ParseArg(const std::string &arg)
     else
     {
       std::cout << "Selected logging target not available: " << arg << std::endl;
-      std::cout << "    Available log targest:";
+      std::cout << "    Available log targets:";
       for (const auto& logTarget : availableLogTargets)
         std::cout << " " << logTarget;
       std::cout << std::endl;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -335,7 +335,7 @@ bool CApplication::Create(const CAppParamParser &params)
   m_pSettingsComponent.reset(new CSettingsComponent());
   m_pSettingsComponent->Init(params);
 
-  // Announement service
+  // Announcement service
   m_pAnnouncementManager = std::make_shared<ANNOUNCEMENT::CAnnouncementManager>();
   m_pAnnouncementManager->Start();
   CServiceBroker::RegisterAnnouncementManager(m_pAnnouncementManager);
@@ -4604,7 +4604,7 @@ void CApplication::UpdateCurrentPlayArt()
 {
   if (!m_appPlayer.IsPlayingAudio())
     return;
-  //Clear and reload the art for the currenty playing item to show updated  art on OSD
+  //Clear and reload the art for the currently playing item to show updated art on OSD
   m_itemCurrentFile->ClearArt();
   CMusicThumbLoader loader;
   loader.LoadItem(m_itemCurrentFile.get());
@@ -4674,7 +4674,7 @@ bool CApplication::SetLanguage(const std::string &strLanguage)
 
 bool CApplication::LoadLanguage(bool reload)
 {
-  // load the configured langauge
+  // load the configured language
   if (!g_langInfo.SetLanguage("", reload))
     return false;
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -429,8 +429,8 @@ private:
   mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
 
   CCriticalSection m_frameMoveGuard;              /*!< critical section for synchronizing GUI actions from inside and outside (python) */
-  std::atomic_uint m_WaitingExternalCalls;        /*!< counts threads wich are waiting to be processed in FrameMove */
-  unsigned int m_ProcessedExternalCalls = 0;          /*!< counts calls wich are processed during one "door open" cycle in FrameMove */
+  std::atomic_uint m_WaitingExternalCalls;        /*!< counts threads which are waiting to be processed in FrameMove */
+  unsigned int m_ProcessedExternalCalls = 0;      /*!< counts calls which are processed during one "door open" cycle in FrameMove */
   unsigned int m_ProcessedExternalDecay = 0;      /*!< counts to close door after a few frames of no python activity */
   CApplicationPlayer m_appPlayer;
   CEvent m_playerEvent;

--- a/xbmc/AutoSwitch.cpp
+++ b/xbmc/AutoSwitch.cpp
@@ -119,7 +119,7 @@ bool CAutoSwitch::ByFiles(bool bHideParentDirItems, const CFileItemList& vecItem
   bool bThumbs = false;
   int iCompare = 0;
 
-  // parent directorys are visible, increment
+  // parent directories are visible, increment
   if (!bHideParentDirItems)
   {
     iCompare = 1;

--- a/xbmc/DynamicDll.h
+++ b/xbmc/DynamicDll.h
@@ -212,8 +212,8 @@ public: \
 //
 //  DEFINE_FUNC_ALIGNED 0-X
 //
-//  Defines a function for an export from a dll, wich
-//  require a aligned stack on function call
+//  Defines a function for an export from a dll, which
+//  requires an aligned stack on function call
 //  Use DEFINE_FUNC_ALIGNED for each function to be resolved.
 //
 //  result:  Result of the function
@@ -233,7 +233,7 @@ public: \
 //    __asm sub esp, [s];
 //    __asm and esp, ~15;
 //    __asm add esp, [s]
-//    m_test(p1, p2, p3);  //return value will still be correct aslong as we don't mess with it
+//    m_test(p1, p2, p3);  //return value will still be correct as long as we don't mess with it
 //    __asm mov esp,[o];
 //  };
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2067,7 +2067,7 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
       }
       if ( tag.Loaded() && oneFilePerTrack && ! ( tag.GetAlbum().empty() || tag.GetArtist().empty() || tag.GetTitle().empty() ) )
       {
-        // If there are multiple files in a cue file, the tags from the files should be prefered if they exist.
+        // If there are multiple files in a cue file, the tags from the files should be preferred if they exist.
         scannedItems.Add(CFileItemPtr(new CFileItem(song, tag)));
       }
       else

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2352,7 +2352,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///                  _string_,
 ///     @return The year of release of the song with an offset `number` with
 ///     respect to the current playing song.
-///     @param number - the offset numbet with respect to the current song.
+///     @param number - the offset number with respect to the current song.
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`MusicPlayer.Position(number).Year`</b>,
@@ -2360,7 +2360,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///                  _string_,
 ///     @return The year of release of the song with an offset `number` with
 ///     respect to the start of the playlist.
-///     @param number - the offset numbet with respect to the start of the
+///     @param number - the offset number with respect to the start of the
 ///     playlist.
 ///     <p>
 ///   }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1637,7 +1637,7 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///   \table_row3{   <b>`System.StereoscopicMode`</b>,
 ///                  \anchor System_StereoscopicMode
 ///                  _string_,
-///     @return The prefered stereoscopic mode.
+///     @return The preferred stereoscopic mode.
 ///     @note Configured in settings > video > playback).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link System_StereoscopicMode
@@ -2137,7 +2137,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     where any_custom_role could be an instrument violin or some other production activity e.g. sound engineer.
 ///     The roles listed (composer\, arranger etc.) are standard ones but there are many possible.
 ///     Music file tagging allows for the musicians and all other people involved in the recording to be added\, Kodi
-///     will gathers and stores that data\, and it is availlable to GUI.
+///     will gathers and stores that data\, and it is available to GUI.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link MusicPlayer_Property_Role_Mixer `MusicPlayer.Property(Role.Mixer)`\endlink
 ///     <p>
@@ -6646,7 +6646,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.AlbumStatus`</b>,
 ///                  \anchor ListItem_AlbumStatus
 ///                  _string_,
-///     @return The Musicbrainz release status of the album (offical, bootleg, promotion etc)
+///     @return The Musicbrainz release status of the album (official, bootleg, promotion etc)
 ///     <p><hr>
 ///     @skinning_v19 **[New Infolabel]** \link ListItem_AlbumStatus `ListItem.AlbumStatus`\endlink
 ///   }

--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -70,6 +70,6 @@ protected:
   bool m_showDialog = false; //!< Whether or not to show progress bar dialog
   CGUIDialogProgressBarHandle* m_handle = nullptr; //!< Progress bar handle
   bool m_bRunning = false; //!< Whether or not scanner is running
-  bool m_bCanInterrupt = false; //!< Whether or not scanner is currently interruptable
+  bool m_bCanInterrupt = false; //!< Whether or not scanner is currently interruptible
   bool m_bClean = false; //!< Whether or not to perform cleaning during scanning
 };

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -318,7 +318,7 @@ bool CPlayListPlayer::Play(int iSong,
               CURL::GetRedacted(item->GetDynPath()));
     playlist.SetUnPlayable(m_iCurrentSong);
 
-    // abort on 100 failed CONSECTUTIVE songs
+    // abort on 100 failed CONSECUTIVE songs
     if (!m_iFailedSongs)
       m_failedSongsStart = playAttempt;
     m_iFailedSongs++;

--- a/xbmc/SectionLoader.cpp
+++ b/xbmc/SectionLoader.cpp
@@ -19,7 +19,7 @@
 //  delay for unloading dll's
 #define UNLOAD_DELAY 30*1000 // 30 sec.
 
-//Define this to get loggin on all calls to load/unload sections/dlls
+//Define this to get logging on all calls to load/unload sections/dlls
 //#define LOGALL
 
 CSectionLoader::CSectionLoader(void) = default;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -709,7 +709,7 @@ int64_t CUtil::ToInt64(uint32_t high, uint32_t low)
 /*!
   \brief Finds next unused filename that matches padded int format identifier provided
   \param[in]  fn_template    filename template consisting of a padded int format identifier (eg screenshot%03d)
-  \param[in]  max            maximum number to search for avaialble name
+  \param[in]  max            maximum number to search for available name
   \return "" on failure, string next available name matching format identifier on success
 */
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -143,14 +143,14 @@ public:
 
   static double AlbumRelevance(const std::string& strAlbumTemp1, const std::string& strAlbum1, const std::string& strArtistTemp1, const std::string& strArtist1);
   static bool MakeShortenPath(std::string StrInput, std::string& StrOutput, size_t iTextMaxLength);
-  /*! \brief Checks wether the supplied path supports Write file operations (e.g. Rename, Delete, ...)
+  /*! \brief Checks whether the supplied path supports Write file operations (e.g. Rename, Delete, ...)
 
    \param strPath the path to be checked
 
    \return true if Write file operations are supported, false otherwise
    */
   static bool SupportsWriteFileOperations(const std::string& strPath);
-  /*! \brief Checks wether the supplied path supports Read file operations (e.g. Copy, ...)
+  /*! \brief Checks whether the supplied path supports Read file operations (e.g. Copy, ...)
 
    \param strPath the path to be checked
 

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -319,7 +319,7 @@ std::string CScraper::InternalRun(const std::string &function,
         m_parser.m_param[i].empty())
       return "";
   }
-  // put the 'extra' parameterts into the parser parameter list too
+  // put the 'extra' parameters into the parser parameter list too
   if (extras)
   {
     for (size_t j = 0; j < extras->size(); ++j)

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -56,7 +56,7 @@ void CBinaryAddonBase::ReleaseAddon(IAddonInstanceHandler* handler)
 
   m_activeAddonHandlers.erase(presentHandler);
 
-  // if no handler is present anymore reset and delete the add-on class on informations
+  // if no handler is present anymore reset and delete the add-on class on information
   if (m_activeAddonHandlers.empty())
   {
     m_activeAddon.reset();

--- a/xbmc/addons/interfaces/AudioEngine.h
+++ b/xbmc/addons/interfaces/AudioEngine.h
@@ -46,7 +46,7 @@ struct Interface_AudioEngine
                                                  unsigned int options);
 
   /**
-   * This method will remove the specifyed stream from the engine.
+   * This method will remove the specified stream from the engine.
    * For OSX/IOS this is essential to reconfigure the audio output.
    * @param[in] streamHandle The stream to be altered
    */

--- a/xbmc/addons/kodi-dev-kit/doxygen/General/DoxygenOnAddon.dox
+++ b/xbmc/addons/kodi-dev-kit/doxygen/General/DoxygenOnAddon.dox
@@ -79,7 +79,7 @@ Start doxygen documentation for add-ons always with `///` and on Kodi itself wit
 - \verbatim /// @throws ERROR_TYPE                    ERROR_TEXT\endverbatim - If also exception becomes handled, can you use this for description.
 - \verbatim /// TEXT_FIELD\endverbatim - Add a much bigger text there if needed.
 - \verbatim /// ------------------\endverbatim - Use this to define a field line, e.g. if you add example add this always before, further must you make two empty lines before to prevent add of them on string before!
-- \verbatim /// ~~~~~~~~~~~~~ \endverbatim - Here can you define a code example which must start and end with the defination string, also can you define the code style with e.g. <b>{.py}</b> for Python or <b>{.cpp}</b> for CPP code on the first line of them.
+- \verbatim /// ~~~~~~~~~~~~~ \endverbatim - Here can you define a code example which must start and end with the definition string, also can you define the code style with e.g. <b>{.py}</b> for Python or <b>{.cpp}</b> for CPP code on the first line of them.
 
 @note Start all `VALUE_TEXT` at same character to hold a clean code on <c>*.cpp</c> or <c>*.h</c> files.\n\n
       The `#ifdef DOXYGEN_SHOULD_USE_THIS` on example above can be becomes used

--- a/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_python.dox
@@ -39,7 +39,7 @@ uses a handful of custom modules to expose Kodi functionality to Python.
 | \ref python_xbmcgui    "xbmcgui"    | Offers classes and functions that manipulate the Graphical User Interface through windows, dialogs, and various control widgets.
 | \ref python_xbmcplugin "xbmcplugin" | Offers classes and functions that allow a developer to present information through Kodi's standard menu structure. While plugins don't have the same flexibility as scripts, they boast significantly quicker development time and a more consistent user experience.
 | \ref python_xbmcaddon  "xbmcaddon"  | Offers classes and functions that manipulate the add-on settings, information and localization.
-| \ref python_xbmcvfs    "xbmcvfs"    | Offers classes and functions that alow access to the Virtual File Server (VFS) which you can use to manipulate files and folders.
+| \ref python_xbmcvfs    "xbmcvfs"    | Offers classes and functions that allow access to the Virtual File Server (VFS) which you can use to manipulate files and folders.
 | \ref python_xbmcwsgi   "xbmcwsgi"   | The [<b>Web Server Gateway Interface (WSGI)</b>](https://en.wikipedia.org/wiki/Web_Server_Gateway_Interface) is a specification for simple and universal interface between web servers and web applications or frameworks for the Python programming language.
 | \ref python_xbmcdrm    "xbmcdrm"    | Offers classes and functions to create and manipulate a DRM CryptoSession .
 

--- a/xbmc/addons/kodi-dev-kit/doxygen/main.txt
+++ b/xbmc/addons/kodi-dev-kit/doxygen/main.txt
@@ -28,7 +28,7 @@ Currently support Kodi Add-Ons based upon Python and C++.
 In the distribution of the library  you find the two directories *tutorials*
 and *examples*. They contain subdirectories for the packages...
 The demos use third party libraries for the graphical user interface. The
-examples don't have this dependency and most examples are refered to in the
+examples don't have this dependency and most examples are referred to in the
 user manual.
 
 #### License

--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -713,7 +713,7 @@ inline std::string ATTRIBUTE_HIDDEN GetBaseUserPath(const std::string& append = 
 /// @note In addition, in this function, for a given folder, the add-on path
 /// itself, but its parent.
 ///
-/// @return Kodi's sytem library path where related addons are installed.
+/// @return Kodi's system library path where related addons are installed.
 ///
 inline std::string ATTRIBUTE_HIDDEN GetLibPath()
 {
@@ -1391,9 +1391,9 @@ inline void* GetInterface(const std::string& name, const std::string& version)
 ///                               There have addon needed values and functions
 ///                               to Kodi and addon must set his functions there
 ///                               for Kodi.
-///     @param[in] globalApiVersion This give the main version @ref ADDON_GLOBAL_VERSION_MAIN
+///     @param[in] globalApiVersion This gives the main version @ref ADDON_GLOBAL_VERSION_MAIN
 ///                                 where currently on Kodi's side.<br>
-///                                 This is unsued on addon as there also other
+///                                 This is unused on addon as there's also other
 ///                                 special callback functions for.<br>
 ///                                 Only thought for future use if needed earlier.
 ///     @param[in] unused This is a not used value\, only there to have in case of

--- a/xbmc/addons/kodi-dev-kit/include/kodi/AudioEngine.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AudioEngine.h
@@ -259,7 +259,7 @@ class ATTRIBUTE_HIDDEN CAEStream
 public:
   //==========================================================================
   /// @ingroup cpp_kodi_audioengine_CAEStream
-  /// @brief Contructs new class to an Kodi IAEStream in the format specified.
+  /// @brief Constructs new class to a Kodi IAEStream in the format specified.
   ///
   /// @param[in] format       The data format the incoming audio will be in
   ///                         (e.g. @ref AUDIOENGINE_FMT_S16LE)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
@@ -218,7 +218,7 @@ public:
 /// @ingroup cpp_kodi_vfs_Defs
 /// @brief **Cache information status**\n
 /// Used on kodi::vfs::CFile::IoControlGetCacheStatus() to get running cache
-/// status of proccessed stream.
+/// status of processed stream.
 ///
 ///@{
 class ATTRIBUTE_HIDDEN CacheStatus
@@ -766,7 +766,7 @@ private:
 /// ...
 /// std::string directory = "C:\\my_dir";
 /// bool ret = kodi::vfs::CreateDirectory(directory);
-/// fprintf(stderr, "Directory '%s' successfull created: %s\n", directory.c_str(), ret ? "yes" : "no");
+/// fprintf(stderr, "Directory '%s' successfully created: %s\n", directory.c_str(), ret ? "yes" : "no");
 /// ...
 /// ~~~~~~~~~~~~~
 ///
@@ -1026,7 +1026,7 @@ inline bool ATTRIBUTE_HIDDEN StatFile(const std::string& filename, kodi::vfs::Fi
 ///   if (!successed)
 ///     kodi::gui::DialogOK::ShowAndGetInput("Error", "Delete of File", filename, "failed!");
 ///   else
-///     kodi::gui::DialogOK::ShowAndGetInput("Information", "Delete of File", filename, "successfull done.");
+///     kodi::gui::DialogOK::ShowAndGetInput("Information", "Delete of File", filename, "successfully done.");
 /// }
 /// ~~~~~~~~~~~~~
 ///
@@ -1352,7 +1352,7 @@ inline bool ATTRIBUTE_HIDDEN GetDiskSpace(const std::string& path,
 
 //==============================================================================
 /// @ingroup cpp_kodi_vfs_General
-/// @brief Return the file name from given complate path string.
+/// @brief Return the file name from given complete path string.
 ///
 /// @param[in] path The complete path include file and directory
 /// @return Filename from path
@@ -1378,7 +1378,7 @@ inline std::string ATTRIBUTE_HIDDEN GetFileName(const std::string& path)
 
 //==============================================================================
 /// @ingroup cpp_kodi_vfs_General
-/// @brief Return the directory name from given complate path string.
+/// @brief Return the directory name from given complete path string.
 ///
 /// @param[in] path The complete path include file and directory
 /// @return Directory name from path
@@ -2221,7 +2221,7 @@ public:
   /// @brief To check a running stream on file for state of his cache.
   ///
   /// @param[in] status Information about current cache status
-  /// @return true if successfull done, false otherwise
+  /// @return true if successfully done, false otherwise
   ///
   ///
   /// @copydetails cpp_kodi_vfs_Defs_CacheStatus_Help
@@ -2242,7 +2242,7 @@ public:
   /// @brief Unsigned int with speed limit for caching in bytes per second.
   ///
   /// @param[in] rate Cache rate size to use
-  /// @return true if successfull done, false otherwise
+  /// @return true if successfully done, false otherwise
   ///
   bool IoControlSetCacheRate(unsigned int rate)
   {
@@ -2260,7 +2260,7 @@ public:
   /// @brief Enable/disable retry within the protocol handler (if supported).
   ///
   /// @param[in] retry To set the retry, true for use, false for not
-  /// @return true if successfull done, false otherwise
+  /// @return true if successfully done, false otherwise
   ///
   bool IoControlSetRetry(bool retry)
   {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/General.h
@@ -635,7 +635,7 @@ inline bool ATTRIBUTE_HIDDEN IsAddonAvailable(const std::string& id,
 
 //==============================================================================
 /// \ingroup cpp_kodi
-/// @brief Get current Kodi informations and versions, returned data from the following
+/// @brief Get current Kodi information and versions, returned data from the following
 /// <b><tt>kodi_version_t version; kodi::KodiVersion(version);</tt></b>
 /// is e.g.:
 /// ~~~~~~~~~~~~~{.cpp}

--- a/xbmc/addons/kodi-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/General.h
@@ -28,7 +28,7 @@ typedef struct kodi_version_t
   int minor;
   /// The Revision contains a id and the build date, e.g. 20170706-c6b22fe217-dirty
   std::string revision;
-  /// The version canditate e.g. alpha, beta or release
+  /// The version candidate e.g. alpha, beta or release
   std::string tag;
   /// The revision of tag before
   std::string tag_revision;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/Network.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/Network.h
@@ -245,7 +245,7 @@ inline std::string ATTRIBUTE_HIDDEN URLEncode(const std::string& url)
 ///
 /// @param[in] hostName   The code of the message to get.
 /// @param[out] ipAddress Returned address
-/// @return true if successfull
+/// @return true if successful
 ///
 ///
 /// ------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -515,7 +515,7 @@ public:
   /// @param[out] format Data format for output stream, see
   ///                    @ref cpp_kodi_audioengine_Defs_AudioEngineFormat for
   ///                    available values
-  /// @param[out] channellist Channel mapping for output streamm, see
+  /// @param[out] channellist Channel mapping for output stream, see
   ///                         @ref cpp_kodi_audioengine_Defs_AudioEngineChannel
   ///                         for available values
   /// @return true if successfully done, otherwise false

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -794,7 +794,7 @@ public:
   /// @brief To get with @ref SetBlockAlign changed values.
   unsigned int GetBlockAlign() const { return m_cStructure->m_BlockAlign; }
 
-  /// @brief To set stream crypto session informations.
+  /// @brief To set stream crypto session information.
   ///
   /// @param[in] cryptoSession The with @ref cpp_kodi_addon_inputstream_Defs_Interface_StreamCryptoSession setable info
   ///
@@ -1528,7 +1528,7 @@ public:
   ///         then, the add-on should call @ref AllocateDemuxPacket "AllocateDemuxPacket(0)" on the
   ///         callback, and set the streamid to DMX_SPECIALID_STREAMCHANGE and
   ///         return the value.
-  ///         The add-on should return <b>`nullptr`</b> if an error occured.
+  ///         The add-on should return <b>`nullptr`</b> if an error occurred.
   ///
   /// @remarks Return <b>`nullptr`</b> if this add-on won't provide this function.
   ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VFS.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VFS.h
@@ -634,7 +634,7 @@ public:
   /// @brief To check a running stream on file for state of his cache.
   ///
   /// @param[in] status Information about current cache status
-  /// @return true if successfull done, false otherwise
+  /// @return true if successfully done, false otherwise
   ///
   ///
   /// @copydetails cpp_kodi_vfs_Defs_CacheStatus_Help
@@ -651,7 +651,7 @@ public:
   /// @brief Unsigned int with speed limit for caching in bytes per second.
   ///
   /// @param[in] rate Cache rate size to use
-  /// @return true if successfull done, false otherwise
+  /// @return true if successfully done, false otherwise
   ///
   virtual bool IoControlSetCacheRate(kodi::addon::VFSFileHandle context, unsigned int rate)
   {
@@ -664,7 +664,7 @@ public:
   /// @brief Enable/disable retry within the protocol handler (if supported).
   ///
   /// @param[in] retry To set the retry, true for use, false for not
-  /// @return true if successfull done, false otherwise
+  /// @return true if successfully done, false otherwise
   ///
   virtual bool IoControlSetRetry(kodi::addon::VFSFileHandle context, bool retry) { return false; }
   //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -311,7 +311,7 @@ public:
   /// @ingroup cpp_kodi_addon_videocodec
   /// @brief Reconfigure the decoder, returns true on success
   ///
-  /// Decoders not capable of runnung multiple instances may be capable of reconfiguring
+  /// Decoders not capable of running multiple instances may be capable of reconfiguring
   /// the running instance. If Reconfigure returns false, player will close / open
   /// the decoder
   ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
@@ -56,8 +56,8 @@ public:
   /// | **Provider name** | `std::string` | @ref PVRProvider::SetName "SetName" | @ref PVRProvider::GetName "GetName" | *required to set*
   /// | **Provider type** | @ref PVR_PROVIDER_TYPE | @ref PVRProvider::SetType "SetType" | @ref PVRProvider::GetType "GetType" | *optional*
   /// | **Icon path** | `std::string` | @ref PVRProvider::SetIconPath "SetIconPath" | @ref PVRProvider::GetIconPath "GetIconPath" | *optional*
-  /// | **Countries** | `std::vecotr<std::string>` | @ref PVRProvider::SetCountries "SetCountries" | @ref PVRProvider::GetCountries "GetCountries" | *optional*
-  /// | **Langauges** | `std::vecotr<std::string>` | @ref PVRProvider::SetLanguages "SetLanguages" | @ref PVRProvider::GetLanguages "GetLanguages" | *optional*
+  /// | **Countries** | `std::vector<std::string>` | @ref PVRProvider::SetCountries "SetCountries" | @ref PVRProvider::GetCountries "GetCountries" | *optional*
+  /// | **Languages** | `std::vector<std::string>` | @ref PVRProvider::SetLanguages "SetLanguages" | @ref PVRProvider::GetLanguages "GetLanguages" | *optional*
   ///
 
   /// @addtogroup cpp_kodi_addon_pvr_Defs_PVRProvider

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
@@ -272,7 +272,7 @@ extern "C"
     /// @brief **2 :** To set stream is unspecified
     INPUTSTREAM_COLORSPACE_UNSPECIFIED = 2,
 
-    /// @brief **2 :** To set stream is unkown
+    /// @brief **2 :** To set stream is unknown
     /// @note Same as @ref INPUTSTREAM_COLORSPACE_UNSPECIFIED
     INPUTSTREAM_COLORSPACE_UNKNOWN = INPUTSTREAM_COLORSPACE_UNSPECIFIED, // compatibility
 
@@ -398,7 +398,7 @@ extern "C"
   ///@{
   enum INPUTSTREAM_COLORRANGE
   {
-    /// @brief **0 :** To define as unkown
+    /// @brief **0 :** To define as unknown
     INPUTSTREAM_COLORRANGE_UNKNOWN = 0,
 
     /// @brief **1 :** The normal 219*2^(n-8) "MPEG" YUV ranges

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_crypto.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_crypto.h
@@ -87,11 +87,11 @@ extern "C"
     /// @brief Flags for later use.
     uint16_t flags;
 
-    /// @brief @ref numSubSamples uint16_t's wich define the size of clear size
+    /// @brief @ref numSubSamples uint16_t's which define the size of clear size
     /// of a subsample.
     uint16_t* clearBytes;
 
-    /// @brief @ref numSubSamples uint32_t's wich define the size of cipher size
+    /// @brief @ref numSubSamples uint32_t's which define the size of cipher size
     /// of a subsample.
     uint32_t* cipherBytes;
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
@@ -510,7 +510,7 @@ extern "C"
     /// @brief Type relative pointer
     JOYSTICK_FEATURE_TYPE_RELPOINTER,
 
-    /// @brief Type absolut pointer
+    /// @brief Type absolute pointer
     JOYSTICK_FEATURE_TYPE_ABSPOINTER,
 
     /// @brief Type wheel

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
@@ -210,7 +210,7 @@ extern "C"
     PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE = (1 << 23),
 
     /// @brief __0000 0001 0000 0000 0000 0000 0000 0000__ :\n This type supports 'any channel', for example when defining a timer
-    /// rule that should match any channel instaed of a particular channel.
+    /// rule that should match any channel instead of a particular channel.
     PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL = (1 << 24),
 
     /// @brief __0000 0010 0000 0000 0000 0000 0000 0000__ :\n This type should not appear on any create menus which don't provide

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
@@ -27,7 +27,7 @@ extern "C"
     /// @brief Noop
     VC_NONE = 0,
 
-    /// @brief An error occured, no other messages will be returned
+    /// @brief An error occurred, no other messages will be returned
     VC_ERROR,
 
     /// @brief The decoder needs more data

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -74,7 +74,7 @@ extern "C"
     ADDON_READ_NO_CACHE = 0x08,
 
     /// @brief **0000 0001 0000** :\n
-    /// Calcuate bitrate for file while reading.
+    /// Calculate bitrate for file while reading.
     ADDON_READ_BITRATE = 0x10,
 
     /// @brief **0000 0010 0000** :\n

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/general.h
@@ -28,7 +28,7 @@ extern "C"
     STD_KB_BUTTONS_MAX_ROWS = 4,
     /// Keyboard layout type, this for initial standard
     STD_KB_MODIFIER_KEY_NONE = 0x00,
-    /// Keyboard layout type, this for shift controled layout (uppercase)
+    /// Keyboard layout type, this for shift controlled layout (uppercase)
     STD_KB_MODIFIER_KEY_SHIFT = 0x01,
     /// Keyboard layout type, this to show symbols
     STD_KB_MODIFIER_KEY_SYMBOL = 0x02

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/ListItem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/ListItem.h
@@ -316,7 +316,7 @@ public:
   //============================================================================
   /// @ingroup cpp_kodi_gui_windows_listitem
   /// @brief To control selection of item in list (also multiple selection,
-  /// in list on serveral items possible).
+  /// in list on several items possible).
   ///
   /// @param[in] selected if true becomes set as selected
   ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/Window.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/Window.h
@@ -154,7 +154,7 @@ public:
   /// @ingroup cpp_kodi_gui_windows_window
   /// @brief Show this window.
   ///
-  /// Shows this window by activating it, calling close() after it wil activate
+  /// Shows this window by activating it, calling close() after it will activate
   /// the current window again.
   ///
   /// @note If your Add-On ends this window will be closed to. To show it forever,
@@ -717,17 +717,17 @@ public:
   ///   {
   ///     case ADDON_ACTION_PREVIOUS_MENU:
   ///     case ADDON_ACTION_NAV_BACK:
-  ///       printf("action recieved: previous");
+  ///       printf("action received: previous");
   ///       Close();
   ///       return true;
   ///     case ADDON_ACTION_SHOW_INFO:
-  ///       printf("action recieved: show info");
+  ///       printf("action received: show info");
   ///       break;
   ///     case ADDON_ACTION_STOP:
-  ///       printf("action recieved: stop");
+  ///       printf("action received: stop");
   ///       break;
   ///     case ADDON_ACTION_PAUSE:
-  ///       printf("action recieved: pause");
+  ///       printf("action received: pause");
   ///       break;
   ///     default:
   ///       break;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/dialogs/Keyboard.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/dialogs/Keyboard.h
@@ -231,7 +231,7 @@ inline bool ATTRIBUTE_HIDDEN ShowAndGetNewPassword(std::string& newPassword,
 ///   ret = ::kodi::gui::dialogs::Keyboard::ShowAndVerifyPassword(password, "Demo password call for PW 'kodi'", i, 0);
 ///   if (ret == 0)
 ///   {
-///     fprintf(stderr, "Password successfull confirmed after '%i' tries\n", i+1);
+///     fprintf(stderr, "Password successfully confirmed after '%i' tries\n", i+1);
 ///     break;
 ///   }
 ///   else if (ret < 0)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/dialogs/Numeric.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/dialogs/Numeric.h
@@ -106,7 +106,7 @@ inline bool ATTRIBUTE_HIDDEN ShowAndVerifyNewPassword(std::string& newPassword)
 ///   ret = kodi::gui::dialogs::Numeric::ShowAndVerifyPassword(password, "Demo numeric password call for PW '1234'", i);
 ///   if (ret == 0)
 ///   {
-///     fprintf(stderr, "Numeric password successfull confirmed after '%i' tries\n", i+1);
+///     fprintf(stderr, "Numeric password successfully confirmed after '%i' tries\n", i+1);
 ///     break;
 ///   }
 ///   else if (ret < 0)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/gl/Shader.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/gl/Shader.h
@@ -421,7 +421,7 @@ public:
   /// @ingroup cpp_kodi_gui_helpers_gl_CShaderProgram
   /// @brief To activate the shader and use it on the GPU.
   ///
-  /// @return true if enable was successfull done
+  /// @return true if enable was successfully done
   ///
   ///
   /// @note During this call, the @ref OnEnabled stored in the child is also
@@ -480,7 +480,7 @@ public:
   /// @ingroup cpp_kodi_gui_helpers_gl_CShaderProgram
   /// @brief Used to check if shader has been loaded before.
   ///
-  /// @return true if enable was successfull done
+  /// @return true if enable was successfully done
   ///
   /// @note The CompileAndLink call sets these values
   ///
@@ -534,7 +534,7 @@ public:
   /// @brief Optional function to exchange data between CPU and GPU while
   /// activating the shader
   ///
-  /// @return true if enable was successfull done
+  /// @return true if enable was successfully done
   ///
   virtual bool OnEnabled() { return true; }
   //--------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -47,7 +47,7 @@
 // for example: class A { bool log_string(int logLevel, const char* functionName, const char* format, ...) PARAM3_PRINTF_FORMAT; };
 #define PARAM3_PRINTF_FORMAT __attribute__((format(printf, 3, 4)))
 
-// for use in functions that take printf format string as fourth parameter and additional printf parameters as fith parameter
+// for use in functions that take printf format string as fourth parameter and additional printf parameters as fifth parameter
 // note: all non-static class member functions take pointer to class object as hidden first parameter
 // for example: class A { bool log_string(int logLevel, const char* functionName, int component, const char* format, ...) PARAM4_PRINTF_FORMAT; };
 #define PARAM4_PRINTF_FORMAT __attribute__((format(printf, 4, 5)))

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -1666,10 +1666,10 @@ public:
   /// std::string refstr = "test";
   ///
   /// ret = kodi::tools::StringUtils::StartsWith(refstr, "te");
-  /// fprintf(stderr, "Excpect true for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect true for here and is '%s'\n", ret ? "true" : "false");
   ///
   /// ret = kodi::tools::StringUtils::StartsWith(refstr, "abc");
-  /// fprintf(stderr, "Excpect false for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect false for here and is '%s'\n", ret ? "true" : "false");
   /// ~~~~~~~~~~~~~
   ///
   inline static bool StartsWith(const std::string& str1, const std::string& str2)
@@ -1732,13 +1732,13 @@ public:
   /// std::string refstr = "test";
   ///
   /// ret = kodi::tools::StringUtils::StartsWithNoCase(refstr, "te");
-  /// fprintf(stderr, "Excpect true for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect true for here and is '%s'\n", ret ? "true" : "false");
   ///
   /// ret = kodi::tools::StringUtils::StartsWithNoCase(refstr, "TEs");
-  /// fprintf(stderr, "Excpect true for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect true for here and is '%s'\n", ret ? "true" : "false");
   ///
   /// ret = kodi::tools::StringUtils::StartsWithNoCase(refstr, "abc");
-  /// fprintf(stderr, "Excpect false for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect false for here and is '%s'\n", ret ? "true" : "false");
   /// ~~~~~~~~~~~~~
   ///
   inline static bool StartsWithNoCase(const std::string& str1, const std::string& str2)
@@ -1802,10 +1802,10 @@ public:
   /// std::string refstr = "test";
   ///
   /// ret = kodi::tools::StringUtils::EndsWith(refstr, "st");
-  /// fprintf(stderr, "Excpect true for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect true for here and is '%s'\n", ret ? "true" : "false");
   ///
   /// ret = kodi::tools::StringUtils::EndsWith(refstr, "abc");
-  /// fprintf(stderr, "Excpect false for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect false for here and is '%s'\n", ret ? "true" : "false");
   /// ~~~~~~~~~~~~~
   ///
   inline static bool EndsWith(const std::string& str1, const std::string& str2)
@@ -1852,10 +1852,10 @@ public:
   /// std::string refstr = "test";
   ///
   /// ret = kodi::tools::StringUtils::EndsWithNoCase(refstr, "ST");
-  /// fprintf(stderr, "Excpect true for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect true for here and is '%s'\n", ret ? "true" : "false");
   ///
   /// ret = kodi::tools::StringUtils::EndsWithNoCase(refstr, "ABC");
-  /// fprintf(stderr, "Excpect false for here and is '%s'\n", ret ? "true" : "false");
+  /// fprintf(stderr, "Expect false for here and is '%s'\n", ret ? "true" : "false");
   /// ~~~~~~~~~~~~~
   ///
   inline static bool EndsWithNoCase(const std::string& str1, const std::string& str2)
@@ -2251,7 +2251,7 @@ public:
   //============================================================================
   /// @brief Check a string for another text.
   ///
-  /// @param[in] str String to seach for keywords
+  /// @param[in] str String to search for keywords
   /// @param[in] keywords List of keywords to search in text
   /// @return true if string contains word in list
   ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/Timer.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/Timer.h
@@ -225,7 +225,7 @@ public:
   /// @defgroup cpp_kodi_tools_CTimer_CB class ITimerCallback
   /// @ingroup cpp_kodi_tools_CTimer
   /// @brief **Callback class of timer**\n
-  /// To give on contructor by @ref CTimer(kodi::tools::CTimer::ITimerCallback* callback)
+  /// To give on constructor by @ref CTimer(kodi::tools::CTimer::ITimerCallback* callback)
   ///
   class ITimerCallback
   {
@@ -239,7 +239,7 @@ public:
 
     //==========================================================================
     /// @ingroup cpp_kodi_tools_CTimer_CB
-    /// @brief Callback function to implement if constuctor @ref CTimer(kodi::tools::CTimer::ITimerCallback* callback)
+    /// @brief Callback function to implement if constructor @ref CTimer(kodi::tools::CTimer::ITimerCallback* callback)
     /// is used and this as parent on related class
     ///
     /// ----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/tools/code-generator/src/commitChanges.py
+++ b/xbmc/addons/kodi-dev-kit/tools/code-generator/src/commitChanges.py
@@ -32,7 +32,7 @@ def CommitChanges(options):
         )
         quit(1)
 
-    Log.PrintBegin("Perfom GIT update check")
+    Log.PrintBegin("Perform GIT update check")
     Log.PrintResult(Result.SEE_BELOW)
 
     contains_devkit_change = False
@@ -67,7 +67,7 @@ def CommitChanges(options):
     # Hack place two to reset about before
     subprocess.run(["git", "reset", "HEAD"], check=True, stdout=subprocess.PIPE).stdout
 
-    Log.PrintBegin("Perfom GIT commit")
+    Log.PrintBegin("Perform GIT commit")
     if contains_devkit_change:
         # Add changed or added files to git
         for x in changes_list:

--- a/xbmc/addons/test/TestAddonVersion.cpp
+++ b/xbmc/addons/test/TestAddonVersion.cpp
@@ -231,7 +231,7 @@ TEST_F(TestAddonVersion, LessThan)
   // ref: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
   // Python addons use this kind of versioning particularly for script.module
   // addons. The "same" version number may exist in different branches or
-  // targetting different kodi versions while keeping consistency with the
+  // targeting different kodi versions while keeping consistency with the
   // upstream module version. The addon version available in upper repos
   // (let's say matrix) must have a higher version than the one stored in
   // lower branches (e.g. leia) so that users receive the addon update

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -63,7 +63,7 @@ bool CCDDARipJob::DoWork()
 {
   CLog::Log(LOGINFO, "CCDDARipJob::{} - Start ripping track {} to {}", __func__, m_input, m_output);
 
-  // if we are ripping to a samba share, rip it to hd first and then copy it it the share
+  // if we are ripping to a samba share, rip it to hd first and then copy it to the share
   CFileItem file(m_output, false);
   if (file.IsRemote())
     m_output = SetupTempFile();

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -187,7 +187,7 @@ public:
   virtual void SetAmplification(float amplify) = 0;
 
   /**
-   * Sets the stream ffmpeg informations if present.
+   * Sets the stream ffmpeg information if present.
    + @param profile
    * @param matrix_encoding
    * @param audio_service_type

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -678,7 +678,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
       uint64_t stamp = m_timestampPos;
       stamp += (1ULL << 32);
       stamphead = (stamp & UINT64_UPPER_BYTES) | stamphead;
-      CLog::Log(LOGDEBUG, "Wraparound happend old: {} new: {}", m_timestampPos, stamphead);
+      CLog::Log(LOGDEBUG, "Wraparound happened old: {} new: {}", m_timestampPos, stamphead);
     }
     m_timestampPos = stamphead;
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -343,7 +343,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
 void CAESinkDARWINOSX::SetHogMode(bool on)
 {
   //! @todo Auto hogging sets this for us. Figure out how/when to turn it off or use it
-  //! It appears that leaving this set will aslo restore the previous stream format when the
+  //! It appears that leaving this set will also restore the previous stream format when the
   //! Application exits. If auto hogging is set and we try to set hog mode, we will deadlock
   //! From the SDK docs: "If the AudioDevice is in a non-mixable mode, the HAL will automatically take hog mode on behalf of the first process to start an IOProc."
   //!

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -65,7 +65,7 @@ static void dumpAVAudioSessionProperties()
             static_cast<long>([mySession outputNumberOfChannels]));
   // maximumOutputNumberOfChannels provides hints to tvOS audio settings
   // if 2, then audio is set to two channel stereo. iOS return this unless hdmi connected
-  // if 6, then audio is set to Digial Dolby 5.1 OR hdmi path detected sink can only handle 6 channels.
+  // if 6, then audio is set to Digital Dolby 5.1 OR hdmi path detected sink can only handle 6 channels.
   // if 8, then audio is set to Best Quality AND hdmi path detected sink can handle 8 channels.
   CLog::Log(LOGINFO, "{} maximumOutputNumberOfChannels {}", __PRETTY_FUNCTION__,
             static_cast<long>([mySession maximumOutputNumberOfChannels]));
@@ -363,7 +363,7 @@ unsigned int CAAudioUnitSink::write(uint8_t* data, unsigned int frames, unsigned
     if (!m_started)
       timeout = 4500;
 
-    // we are using a timer here for beeing sure for timeouts
+    // we are using a timer here for being sure for timeouts
     // condvar can be woken spuriously as signaled
     XbmcThreads::EndTime timer(timeout);
     condVar.wait(mutex, std::chrono::milliseconds(timeout));
@@ -437,7 +437,7 @@ bool CAAudioUnitSink::setupAudio()
   CLog::Log(LOGINFO, "{} setting buffer duration to {:f}", __PRETTY_FUNCTION__, bufferseconds);
   setAVAudioSessionProperties(bufferseconds, samplerate, channels);
 
-  // Get the real output samplerate, the requested might not avaliable
+  // Get the real output samplerate, the requested might not available
   Float64 realisedSampleRate = [[AVAudioSession sharedInstance] sampleRate];
   if (m_outputFormat.mSampleRate != realisedSampleRate)
   {
@@ -746,12 +746,12 @@ bool CAESinkDARWINTVOS::Initialize(AEAudioFormat& format, std::string& device)
     CAChannelIndex channel_index = CAChannel_PCM_6CHAN;
     if (maxChannels == 6 && format.m_channelLayout.Count() == 6)
     {
-      // if 6, then audio is set to Digial Dolby 5.1, need to use DD mapping
+      // if 6, then audio is set to Digital Dolby 5.1, need to use DD mapping
       channel_index = CAChannel_PCM_DD5_1;
     }
     else if (format.m_channelLayout.Count() == 5)
     {
-      // if 5, then audio is set to Digial Dolby 5.0, need to use DD mapping
+      // if 5, then audio is set to Digital Dolby 5.0, need to use DD mapping
       channel_index = CAChannel_PCM_DD5_1;
     }
     else

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -733,14 +733,14 @@ std::string CAESinkDirectSound::GetDefaultDevice()
   EXIT_ON_FAILURE(hr, "Could not allocate WASAPI device enumerator")
 
   hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, pDevice.GetAddressOf());
-  EXIT_ON_FAILURE(hr, "Retrival of audio endpoint enumeration failed.")
+  EXIT_ON_FAILURE(hr, "Retrieval of audio endpoint enumeration failed.")
 
   hr = pDevice->OpenPropertyStore(STGM_READ, pProperty.GetAddressOf());
   EXIT_ON_FAILURE(hr, "Retrieval of DirectSound endpoint properties failed.")
 
   PropVariantInit(&varName);
   hr = pProperty->GetValue(PKEY_AudioEndpoint_FormFactor, &varName);
-  EXIT_ON_FAILURE(hr, "Retrival of DirectSound endpoint form factor failed.")
+  EXIT_ON_FAILURE(hr, "Retrieval of DirectSound endpoint form factor failed.")
 
   aeDeviceType = winEndpoints[(EndpointFormFactor)varName.uiVal].aeDeviceType;
   PropVariantClear(&varName);

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -259,7 +259,7 @@ void CAEStreamParser::GetPacket(uint8_t **buffer, unsigned int *bufferSize)
 
 /*
   This function looks for sync words across the types in parallel, and only does an exhaustive
-  test if it finds a syncword. Once sync has been established, the relevent sync function sets
+  test if it finds a syncword. Once sync has been established, the relevant sync function sets
   m_syncFunc to itself. This function will only be called again if total sync is lost, which
   allows is to switch stream types on the fly much like a real receiver does.
 */

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -109,7 +109,7 @@ public:
   float GetPlayPercentage();
 
   /*!
-   * \brief Get the minumum time
+   * \brief Get the minimum time
    *
    * This will be zero for a typical video. With timeshift, this is the time,
    * in ms, that the player can go back. This can be before the start time.
@@ -119,7 +119,7 @@ public:
   /*!
    * \brief Get the maximum time
    *
-   * This is the maximun time, in ms, that the player can skip forward. For a
+   * This is the maximum time, in ms, that the player can skip forward. For a
    * typical video, this will be the total length. For live TV without
    * timeshift this is zero, and for live TV with timeshift this will be the
    * buffer ahead.

--- a/xbmc/cores/DllLoader/DllLoader.cpp
+++ b/xbmc/cores/DllLoader/DllLoader.cpp
@@ -113,7 +113,7 @@ DllLoader::~DllLoader()
     delete entry;
   }
 
-  // can't unload a system dll, as this might be happing during xbmc destruction
+  // can't unload a system dll, as this might be happening during xbmc destruction
   if(!m_bSystemDll)
   {
     DllLoaderContainer::UnRegisterDll(this);

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -84,7 +84,7 @@ protected:
   void SetExports(Export* exports) { m_pStaticExports = exports; }
 
 protected:
-  // Just pointers; dont' delete...
+  // Just pointers; don't delete...
   ImportDirTable_t *ImportDirTable;
   ExportDirTable_t *ExportDirTable;
   bool m_bTrack;

--- a/xbmc/cores/DllLoader/DllLoaderContainer.cpp
+++ b/xbmc/cores/DllLoader/DllLoaderContainer.cpp
@@ -49,7 +49,7 @@
 #define ENV_PATH ENV_PARTIAL_PATH
 #endif
 
-//Define this to get loggin on all calls to load/unload of dlls
+//Define this to get logging on all calls to load/unload of dlls
 //#define LOGALL
 
 

--- a/xbmc/cores/DllLoader/coff.cpp
+++ b/xbmc/cores/DllLoader/coff.cpp
@@ -443,7 +443,7 @@ void* CoffLoader::RVA2Data(unsigned long RVA)
    || RVA >= SectionHeader[Sctn].VirtualAddress + SectionHeader[Sctn].VirtualSize)
   {
     // RVA2Section is lying, let's use base address of dll instead, only works if
-    // DLL has been loaded fully into memory, wich we normally do
+    // DLL has been loaded fully into memory, which we normally do
     return (void*)(RVA + (unsigned long)hModule);
   }
   return SectionData[Sctn] + RVA - SectionHeader[Sctn].VirtualAddress;

--- a/xbmc/cores/DllLoader/coff.h
+++ b/xbmc/cores/DllLoader/coff.h
@@ -11,7 +11,7 @@
 //#pragma message("including coff.h")
 //
 //      COFF -- Common Object File Format
-//          Used commonly by Un*x and is imbedded in Windows PE
+//          Used commonly by Un*x and is embedded in Windows PE
 //          file format.
 //
 

--- a/xbmc/cores/DllLoader/dll.cpp
+++ b/xbmc/cores/DllLoader/dll.cpp
@@ -61,7 +61,7 @@ extern "C" HMODULE __stdcall dllLoadLibraryExtended(const char* lib_file, const 
 
   if (sourcedll)
   {
-    /* also check for invalid paths wich begin with a \ */
+    /* also check for invalid paths which begin with a \ */
     if( libpath[0] == '\0' || libpath[0] == PATH_SEPARATOR_CHAR )
     {
       /* use calling dll's path as base address for this call */

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -885,7 +885,7 @@ extern "C"
       return ret;
     }
 
-    // we have a valid data struture. get next item!
+    // we have a valid data structure. get next item!
     int iItem = vecDirsOpen[found].curr_index;
     if (iItem+1 < vecDirsOpen[found].items.Size()) // we have a winner!
     {
@@ -1429,7 +1429,7 @@ extern "C"
       if (pFile != NULL)
       {
         int len = strlen(tmp);
-        // replace all '\n' occurences with '\r\n'...
+        // replace all '\n' occurrences with '\r\n'...
         char tmp2[2048];
         int j = 0;
         for (int i = 0; i < len; i++)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -99,7 +99,7 @@ private:
   virtual void ManageRenderArea(const IRenderBuffer& renderBuffer);
 
   /*!
-   * \brief Performs whatever nessesary after a frame has been rendered
+   * \brief Performs whatever necessary after a frame has been rendered
    */
   void PostRender();
 

--- a/xbmc/cores/RetroPlayer/savestates/ISavestate.h
+++ b/xbmc/cores/RetroPlayer/savestates/ISavestate.h
@@ -63,7 +63,7 @@ public:
   /// @name Game properties
   ///{
   /*!
-   * \brief The name of the file beloning to this savestate's game
+   * \brief The name of the file belonging to this savestate's game
    */
   virtual std::string GameFileName() const = 0;
   ///}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -165,7 +165,7 @@ bool CDVDAudioCodecFFmpeg::AddData(const DemuxPacket &packet)
 
   int ret = avcodec_send_packet(m_pCodecContext, avpkt);
 
-  //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+  //! @todo: properly handle avpkt side_data. this works around our improper use of the side_data
   // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
   // and storing our own AVPacket. This will require some extensive changes.
   av_buffer_unref(&avpkt->buf);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -187,7 +187,7 @@ OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
         styleRec.textColorARGB = UTILS::COLOR::ConvertToARGB(sampleData.ReadNextUnsignedInt());
         styleRec.textColorAlphaCh = (styleRec.textColorARGB & 0xFF000000) >> 24;
         // clamp bgnChar/bgnChar to textLength, we alloc enough space above and
-        // this fixes borken encoders that do not handle endChar correctly.
+        // this fixes broken encoders that do not handle endChar correctly.
         if (styleRec.startChar > textLength)
           styleRec.startChar = textLength;
         if (styleRec.endChar > textLength)
@@ -232,7 +232,7 @@ OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
       }
     }
 
-    if (*curPos == '{') // erase unsupport tags
+    if (*curPos == '{') // erase unsupported tags
       skipChars = true;
 
     // Skip all \r because it causes the line to display empty box "tofu"

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
@@ -38,7 +38,7 @@ private:
 
   /*!
    * @brief All picture members can be expected to be set correctly except decodedData and pts.
-   * GetFrameBuffer has to set decodedData to a valid memory adress and return true.
+   * GetFrameBuffer has to set decodedData to a valid memory address and return true.
    * In case buffer allocation fails, return false.
    */
   bool GetFrameBuffer(VIDEOCODEC_PICTURE &picture);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -126,14 +126,14 @@ public:
 
   /**
    * Open the decoder, returns true on success
-   * Decoders not capable of runnung multiple instances should return false in case
+   * Decoders not capable of running multiple instances should return false in case
    * there is already a instance open
    */
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) = 0;
 
   /**
    * Reconfigure the decoder, returns true on success
-   * Decoders not capable of runnung multiple instances may be capable of reconfiguring
+   * Decoders not capable of running multiple instances may be capable of reconfiguring
    * the running instance. If Reconfigure returns false, player will close / open
    * the decoder
    */

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1152,7 +1152,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
     // try to fetch an input buffer
     if (m_indexInputBuffer < 0)
     {
-      m_indexInputBuffer = m_codec->dequeueInputBuffer(5000 /*timout*/);
+      m_indexInputBuffer = m_codec->dequeueInputBuffer(5000 /*timeout*/);
       if (xbmc_jnienv()->ExceptionCheck())
       {
         xbmc_jnienv()->ExceptionClear();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -389,7 +389,7 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
 
   int ret = avcodec_send_packet(m_pCodecContext, avpkt);
 
-  //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+  //! @todo: properly handle avpkt side_data. this works around our improper use of the side_data
   // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
   // and storing our own AVPacket. This will require some extensive changes.
   av_buffer_unref(&avpkt->buf);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -584,7 +584,7 @@ bool CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
 
   int ret = avcodec_send_packet(m_pCodecContext, avpkt);
 
-  //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+  //! @todo: properly handle avpkt side_data. this works around our improper use of the side_data
   // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
   // and storing our own AVPacket. This will require some extensive changes.
   av_buffer_unref(&avpkt->buf);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -440,7 +440,7 @@ bool CContext::GetFormatAndConfig(AVCodecContext* avctx, D3D11_VIDEO_DECODER_DES
       HRESULT res = m_pD3D11Device->CheckVideoDecoderFormat(mode.guid, render_targets_dxgi[j], &format_supported);
       if (FAILED(res) || !format_supported)
       {
-        CLog::LogFunction(LOGINFO, "DXVA", "Ouput format {} is not supported by '{}'",
+        CLog::LogFunction(LOGINFO, "DXVA", "Output format {} is not supported by '{}'",
                           render_targets_dxgi[j], mode.name);
         continue;
       }

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
@@ -492,7 +492,7 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedD
            pSPU->width, pSPU->height, pSPU->x, pSPU->y );
 
   // forced spu's (menu overlays) retrieve their alpha/color information from InputStreamNavigator::GetCurrentButtonInfo
-  // also they may contain completely covering data wich is supposed to be hidden normally
+  // also they may contain completely covering data which is supposed to be hidden normally
   // since whole spu is drawn, if this is done for forced, that may be displayed
   // so we must trust what is given
   if( !pSPU->bForced )

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1734,7 +1734,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           }
           else
           {
-            // Note: libass only supports a single font directory to look for aditional fonts
+            // Note: libass only supports a single font directory to look for additional fonts
             // (c.f. ass_set_fonts_dir). To support both user defined fonts (those placed in
             // special://home/media/Fonts/) and fonts extracted by the demuxer, make it extract
             // fonts to the user directory with a known, easy to identify, prefix (tmp.font.*).

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -35,7 +35,7 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
         avPkt->side_data = static_cast<AVPacketSideData*>(pPacket->pSideData);
         avPkt->side_data_elems = pPacket->iSideDataElems;
 
-        //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+        //! @todo: properly handle avpkt side_data. this works around our improper use of the side_data
         // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
         // and storing our own AVPacket. This will require some extensive changes.
 
@@ -103,7 +103,7 @@ void CDVDDemuxUtils::StoreSideData(DemuxPacket *pkt, AVPacket *src)
   pkt->pSideData = avPkt->side_data;
   pkt->iSideDataElems = avPkt->side_data_elems;
 
-  //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+  //! @todo: properly handle avpkt side_data. this works around our improper use of the side_data
   // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
   // and storing our own AVPacket. This will require some extensive changes.
   av_buffer_unref(&avPkt->buf);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -576,7 +576,7 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
           break;
         }
 
-        /* if we have any buttons or are not in vts domain we assume we are in meny */
+        /* if we have any buttons or are not in vts domain we assume we are in menu */
         bool menu = pci->hli.hl_gi.hli_ss || (0 == m_dll.dvdnav_is_domain_vts(m_dvdnav));
         if (menu != m_bInMenu)
         {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvd_reader.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvd_reader.h
@@ -37,7 +37,7 @@ struct iovec
 /**
  * The DVD access interface.
  *
- * This file contains the functions that form the interface to to
+ * This file contains the functions that form the interface to
  * reading files located on a DVD.
  */
 
@@ -105,7 +105,7 @@ typedef struct {
  *   path/vts_01_1.vob
  *
  * @param path Specifies the the device, file or directory to be used.
- * @return If successful a a read handle is returned. Otherwise 0 is returned.
+ * @return If successful a read handle is returned. Otherwise 0 is returned.
  *
  * dvd = DVDOpen(path);
  */
@@ -171,7 +171,7 @@ int DVDFileStat(dvd_reader_t *, int, dvd_read_domain_t, dvd_stat_t *);
  * @param dvd  A dvd read handle.
  * @param titlenum Which Video Title Set should be used, VIDEO_TS is 0.
  * @param domain Which domain.
- * @return If successful a a file read handle is returned, otherwise 0.
+ * @return If successful a file read handle is returned, otherwise 0.
  *
  * dvd_file = DVDOpenFile(dvd, titlenum, domain); */
 dvd_file_t *DVDOpenFile( dvd_reader_t *, int, dvd_read_domain_t );

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvdnav_internal.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvdnav_internal.h
@@ -82,7 +82,7 @@ static inline int _private_gettimeofday( struct timeval *tv, void *tz )
 #endif
 
 typedef enum {
-  DSI_ILVU_PRE   = 1 << 15, /* set during the last 3 VOBU preceeding an interleaved block. */
+  DSI_ILVU_PRE   = 1 << 15, /* set during the last 3 VOBU preceding an interleaved block. */
   DSI_ILVU_BLOCK = 1 << 14, /* set for all VOBU in an interleaved block */
   DSI_ILVU_FIRST = 1 << 13, /* set for the first VOBU for a given angle or scene within a ILVU, or the first VOBU in the preparation (PREU) sequence */
   DSI_ILVU_LAST  = 1 << 12, /* set for the last VOBU for a given angle or scene within a ILVU, or the last VOBU in the preparation (PREU) sequence */

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/nav_types.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/nav_types.h
@@ -107,7 +107,7 @@ typedef struct {
 
 /**
  * Button Color Information Table
- * Each entry being a 32bit word that contains the color indexs and alpha
+ * Each entry being a 32bit word that contains the color indexes and alpha
  * values to use.  They are all represented by 4 bit number and stored
  * like this [Ci3, Ci2, Ci1, Ci0, A3, A2, A1, A0].   The actual palette
  * that the indexes reference is in the PGC.

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
@@ -25,7 +25,7 @@ public:
   /*!
   * \brief Adds an overlay into the container by processing the existing overlay collection first
   *
-  * \details Processes the overlay collection whenever a new overlay is added. Usefull to change
+  * \details Processes the overlay collection whenever a new overlay is added. Useful to change
   * the overlay's PTS values of previously added overlays if the collection itself is sequential. This
   * is, for example, the case of ASS subtitles in which a single call to ass_render_frame generates all
   * the subtitle images on a single call even if two subtitles exist at the same time frame. Other cases

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -53,7 +53,7 @@ std::string GetDefaultFontPath(std::string& font)
   return "";
 }
 
-// Convert RGB/ARGB to RGBA by appling also the opacity value
+// Convert RGB/ARGB to RGBA by also applying the opacity value
 COLOR::Color ConvColor(COLOR::Color argbColor, int opacity = 100)
 {
   return COLOR::ConvertToRGBA(COLOR::ChangeOpacity(argbColor, (100.0f - opacity) / 100.0f));
@@ -298,7 +298,7 @@ void CDVDSubtitlesLibass::ApplyStyle(style subStyle, renderOpts opts)
         (subStyle.assOverrideStyles == OverrideStyles::STYLES ||
          subStyle.assOverrideStyles == OverrideStyles::STYLES_POSITIONS))
     {
-      // With styles overrided the PlayResY will be changed to 288
+      // With styles overridden the PlayResY will be changed to 288
       playResY = 288;
       scale = 288. / 720;
     }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
@@ -83,7 +83,7 @@ CDVDOverlay* CSubtitlesAdapter::CreateOverlay()
 
   // Side effects that happens when you create each overlay based on each Libass Event:
   // - A small delay when switching on/off the overlay renderer, cause subtitles
-  //   flickering when Events have close timing. A possibile cause of the
+  //   flickering when Events have close timing. A possible cause of the
   //   delay could be the async implementation of overlay management chain.
   // - When an overlay disable the renderer, Libass has no possibility to
   //   complete the rendering of text animations (not sure if related to previous problem)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -748,7 +748,7 @@ void CWebVTTHandler::CalculateTextPosition(std::string& subtitleText)
   }
 
   // The vertical margin should always referred from the top to simulate
-  // the corrent cue box position without a cue box.
+  // the current cue box position without a cue box.
   // But if the vertical margin is too high and the text size is very large,
   // in some cases the text could go off-screen.
   // To try ensure that the text does not go off-screen,

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTISOHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTISOHandler.cpp
@@ -21,7 +21,7 @@
 // WebVTT in MP4 encapsulated subtitles (ISO/IEC 14496-30:2014)
 // This format type that differ from the text WebVTT, it makes use
 // of ISO BMFF byte stream where the data are enclosed in boxes (first 4 byte
-// speficy the size and next 4 byte specify the type).
+// specify the size and next 4 byte specify the type).
 // Start/Stop times info are not included, the start time is the current pts
 // provided from the decoder, the stop time is defined from the pts of the next
 // packages (depends from the box type).

--- a/xbmc/cores/VideoPlayer/PTSTracker.cpp
+++ b/xbmc/cores/VideoPlayer/PTSTracker.cpp
@@ -253,7 +253,7 @@ bool CPtsTracker::CheckPattern(std::vector<double>& pattern)
 }
 
 //calculate how long each frame should last from the saved pattern
-//Retreive also information of max and min frame rate duration, for VFR files case
+//also retrieve information of max and min frame rate duration, for VFR files case
 double CPtsTracker::CalcFrameDuration()
 {
   if (!m_pattern.empty())

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4078,7 +4078,7 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
           // if we remember the old vobunits boundaries
           // when a packet comes out of demuxer that has
           // pts values outside that boundary, it belongs
-          // to the new vobunit, wich has new timestamps
+          // to the new vobunit, which has new timestamps
           UpdatePlayState(0);
       }
       break;

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -1451,7 +1451,7 @@ unsigned int CDVDRadioRDSData::DecodeRTPlus(uint8_t *msgElement, unsigned int le
           printf("  RTp-Unkn. : %02i - %s\n", rtp_typ[i], m_RTPlus_Temptext);
           break;
 #endif // RDS_IMPROVE_CHECK
-        /// Unused and not needed data informations
+        /// Unused and not needed data information
         case RTPLUS_STATIONNAME_SHORT:  //!< Must be rechecked under DAB
         case RTPLUS_INFO_DATE_TIME:
           break;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -664,7 +664,7 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
     m_picture.iDuration = frametime;
 
     // validate picture timing,
-    // if both dts/pts invalid, use pts calulated from picture.iDuration
+    // if both dts/pts invalid, use pts calculated from picture.iDuration
     // if pts invalid use dts, else use picture.pts as passed
     if (m_picture.dts == DVD_NOPTS_VALUE && m_picture.pts == DVD_NOPTS_VALUE)
     {
@@ -711,7 +711,7 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
       }
     }
 
-    // if frame has a pts (usually originiating from demux packet), use that
+    // if frame has a pts (usually originating from demux packet), use that
     if (m_picture.pts != DVD_NOPTS_VALUE)
     {
       pts = m_picture.pts;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -158,7 +158,7 @@ void CBaseRenderer::CalcDestRect(float offsetX,
   }
   else
   {
-    // maximize the movie hight
+    // maximize the movie height
     newHeight = std::min(width, height);
     newWidth = newHeight / outputFrameRatio;
     if (newWidth > width)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
@@ -100,7 +100,7 @@ public:
   bool CheckConfiguration(int cmsToken, AVColorPrimaries srcPrimaries);
 
   /*!
-  \brief Get a 3D LUT dimention and data size for video color correction
+  \brief Get a 3D LUT dimension and data size for video color correction
   \param format required format of CLUT data
   \param clutSize pointer to CLUT resolution
   \param dataSize pointer to CLUT data size

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
@@ -42,7 +42,7 @@ public:
         if (m_mat[i][j] == other.m_mat[i][j])
           continue;
 
-        // some floating point comparisions should be done by checking if the difference is within a tolerance
+        // some floating point comparisons should be done by checking if the difference is within a tolerance
         if (std::abs(m_mat[i][j] - other.m_mat[i][j]) <=
             (std::max(std::abs(other.m_mat[i][j]), std::abs(m_mat[i][j])) * 1e-2f))
           continue;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -632,7 +632,7 @@ inline void PAPlayer::ProcessStreams(double &freeBufferTime)
         /* if it was the last stream */
         if (itt == m_streams.end())
         {
-          /* if it didnt trigger the next queue item */
+          /* if it didn't trigger the next queue item */
           if (!si->m_prepareTriggered)
           {
             if (si->m_waitOnDrain)

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -664,7 +664,7 @@ std::string MysqlDatabase::vprepare(const char *format, va_list args)
 #define etPERCENT     8 /* Percent symbol. %% */
 #define etCHARX       9 /* Characters. %c */
 /* The rest are extensions, not normally found in printf() */
-#define etSQLESCAPE  10 /* Strings with '\'' doubled. Stings with '\\' escaped.  %q */
+#define etSQLESCAPE  10 /* Strings with '\'' doubled. Strings with '\\' escaped.  %q */
 #define etSQLESCAPE2 11 /* Strings with '\'' doubled and enclosed in '',
                           NULL pointers replaced by SQL NULL.  %Q */
 #define etPOINTER    14 /* The %p conversion */

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -713,7 +713,7 @@ void CCurlFile::SetRequestHeaders(CReadState* state)
 void CCurlFile::SetCorrectHeaders(CReadState* state)
 {
   CHttpHeader& h = state->m_httpheader;
-  /* workaround for shoutcast server wich doesn't set content type on standard mp3 */
+  /* workaround for shoutcast server which doesn't set content type on standard mp3 */
   if( h.GetMimeType().empty() )
   {
     if( !h.GetValue("icy-notice1").empty()
@@ -781,8 +781,8 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
       url2.SetOptions("");
     }
 
-    /* this is uggly, depending on from where   */
-    /* we get the link it may or may not be     */
+    /* this is ugly, depending on where we get  */
+    /* the link from, it may or may not be      */
     /* url encoded. if handed from ftpdirectory */
     /* it won't be so let's handle that case    */
 
@@ -1610,8 +1610,8 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
 
     // Note: CURLINFO_CONTENT_TYPE returns the last received content-type response header value.
     // In case there is authentication required there might be multiple requests involved and if
-    // the last request whch actually returns the data does not return a content-type header, but
-    // one of the preceeding requests, CURLINFO_CONTENT_TYPE returns not the content type of the
+    // the last request which actually returns the data does not return a content-type header, but
+    // one of the preceding requests, CURLINFO_CONTENT_TYPE returns not the content type of the
     // actual resource requested! m_state contains only the values of the last request, which is
     // what we want here.
     const std::string mimeType = m_state->m_httpheader.GetMimeType();
@@ -1888,7 +1888,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
       case CURLM_CALL_MULTI_PERFORM:
       {
         // we don't keep calling here as that can easily overwrite our buffer which we want to avoid
-        // docs says we should call it soon after, but aslong as we are reading data somewhere
+        // docs says we should call it soon after, but as long as we are reading data somewhere
         // this aught to be soon enough. should stay in socket otherwise
         continue;
       }

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -98,7 +98,7 @@ public:
   /*!
   \brief Recursively removes the directory
   \param url Directory to remove.
-  \return Returns \e false if not succesful
+  \return Returns \e false if not successful
   */
   virtual bool RemoveRecursive(const CURL& url) { return false; }
 

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -100,7 +100,7 @@ public:
   virtual void Flush() { }
   virtual int Truncate(int64_t size) { return -1; }
 
-  /* Returns the minium size that can be read from input stream.   *
+  /* Returns the minimum size that can be read from input stream.  *
    * For example cdrom access where access could be sector based.  *
    * This will cause file system to buffer read requests, to       *
    * to meet the requirement of CFile.                             *

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -327,7 +327,7 @@ void CNfsConnection::Deinit()
     m_pNfsContext = NULL;
   }
   clearMembers();
-  // clear any keep alive timouts on deinit
+  // clear any keep alive timeouts on deinit
   m_KeepAliveTimeouts.clear();
 }
 
@@ -335,7 +335,7 @@ void CNfsConnection::Deinit()
 void CNfsConnection::CheckIfIdle()
 {
   /* We check if there are open connections. This is done without a lock to not halt the mainthread. It should be thread safe as
-   worst case scenario is that m_OpenConnections could read 0 and then changed to 1 if this happens it will enter the if wich will lead to another check, wich is locked.  */
+   worst case scenario is that m_OpenConnections could read 0 and then changed to 1 if this happens it will enter the if which will lead to another check, which is locked.  */
   if (m_OpenConnections == 0 && m_pNfsContext != NULL)
   { /* I've set the the maximum IDLE time to be 1 min and 30 sec. */
     CSingleLock lock(*this);
@@ -473,7 +473,7 @@ void CNfsConnection::AddIdleConnection()
 {
   CSingleLock lock(*this);
   m_OpenConnections--;
-  /* If we close a file we reset the idle timer so that we don't have any wierd behaviours if a user
+  /* If we close a file we reset the idle timer so that we don't have any weird behaviours if a user
    leaves the movie paused for a long while and then press stop */
   m_IdleTimeout = 180;
 }

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -394,7 +394,7 @@ void CNfsConnection::resetKeepAlive(const std::string& _exportPath, struct nfsfh
     m_lastAccessedTime = std::chrono::steady_clock::now();
   }
 
-  //adds new keys - refreshs existing ones
+  //adds new keys - refreshes existing ones
   m_KeepAliveTimeouts[_pFileHandle].exportPath = _exportPath;
   m_KeepAliveTimeouts[_pFileHandle].refreshCounter = KEEP_ALIVE_TIMEOUT;
 }
@@ -406,7 +406,7 @@ void CNfsConnection::keepAlive(const std::string& _exportPath, struct nfsfh* _pF
 {
   uint64_t offset = 0;
   char buffer[32];
-  // this also refreshs the last accessed time for the context
+  // this also refreshes the last accessed time for the context
   // true forces a cachehit regardless the context is timedout
   // on this call we are sure its not timedout even if the last accessed
   // time suggests it.

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -124,7 +124,7 @@ bool GetDirectoryFromTxtRecords(const CZeroconfBrowser::ZeroconfService& zerocon
 
       //add slash at end of path since it has to be a folder
       URIUtils::AddSlashAtEnd(path);
-      //this is the full path includeing remote stuff (e.x. nfs://ip/path
+      //this is the full path including remote stuff (e.x. nfs://ip/path
       item->SetPath(urlStr + path);
       //remove the slash at the end of the path or GetFileName will not give the last dir
       URIUtils::RemoveSlashAtEnd(path);

--- a/xbmc/games/controllers/types/ControllerGrid.h
+++ b/xbmc/games/controllers/types/ControllerGrid.h
@@ -108,7 +108,7 @@ private:
    * \brief Draw a controller to the column at the specified height
    *
    * \param port The controller's port node
-   * \param height The hight to draw the controller at
+   * \param height The height to draw the controller at
    * \param column[in/out] The column to draw to
    * \param grid[in/out] The grid to add additional columns to
    *

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -429,7 +429,7 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
   int size = av_image_fill_arrays(pictureRGB->data, pictureRGB->linesize, NULL, AV_PIX_FMT_RGB32, width, height, 16);
   if (size < 0)
   {
-    CLog::LogF(LOGERROR, "Could not allocate AVFrame member with {} x {} pixes", width, height);
+    CLog::LogF(LOGERROR, "Could not allocate AVFrame member with {} x {} pixels", width, height);
     av_frame_free(&pictureRGB);
     return false;
   }

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -238,7 +238,7 @@ bool CGUIControlGroup::OnMessage(CGUIMessage& message)
     break;
   }
   bool handled(false);
-  //not intented for any specific control, send to all childs and our base handler.
+  //not intended for any specific control, send to all childs and our base handler.
   if (message.GetControlId() == 0)
   {
     for (auto *control : m_children)

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -224,7 +224,7 @@ void CGUIFont::DrawScrollingText(float x,
   CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
 }
 
-// remaps unsupported font glpyhs to other suitable ones
+// remaps unsupported font glyphs to other suitable ones
 wchar_t CGUIFont::RemapGlyph(wchar_t letter)
 {
   if (letter == 0x2019 || letter == 0x2018) return 0x0027;  // single quotes

--- a/xbmc/guilib/GUILabelControl.dox
+++ b/xbmc/guilib/GUILabelControl.dox
@@ -39,10 +39,10 @@ size, colour, location and contents of the text to be displayed.
 
 --------------------------------------------------------------------------------
 \section Label_Control_sect2 Auto size labels
-Wrapping your label in a grouplist with the auto width and appropriate minium and
-maximum values. Allows the labels width to dynamically change relative to how
-long the label text is. This allows a image or other control to be aligned to
-the right of the actual label text no matter how wide the label is.
+Wrapping your label in a grouplist with the auto width and appropriate minimum
+and maximum values. Allows the labels width to dynamically change relative to
+how long the label text is. This allows a image or other control to be aligned
+to the right of the actual label text no matter how wide the label is.
 
 ~~~~~~~~~~~~~
    <width min="29" max="200">auto</width>

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -150,7 +150,7 @@
 #define GUI_MSG_REFRESH_TIMER  50
 
  /*!
- \brief Called if state has changed wich could lead to GUI changes
+ \brief Called if state has changed which could lead to GUI changes
  */
 #define GUI_MSG_STATE_CHANGED  51
 

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -73,7 +73,7 @@ public:
   float GetClipYFactor(void) const { return m_clipYFactor;  }
   float GetClipYOffset(void) const { return m_clipYOffset;  }
 
-  // need to use aligned allocation bacause we use XMMATRIX in structures.
+  // need to use aligned allocation because we use XMMATRIX in structures.
   void* operator new (size_t size)
   {
     void* ptr = KODI::MEMORY::AlignedMalloc(size, __alignof(CGUIShaderDX));

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1397,7 +1397,7 @@ void CGUIWindowManager::DeInitialize()
 {
   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
-  // Need a copy bacause addon-dialogs remove itself on Close()
+  // Need a copy because addon-dialogs removes itself on Close()
   std::unordered_map<int, CGUIWindow*> closeMap(m_mapWindows);
   for (const auto& entry : closeMap)
   {

--- a/xbmc/guilib/Shader.h
+++ b/xbmc/guilib/Shader.h
@@ -124,11 +124,11 @@ namespace Shaders {
     // compile and link the shaders
     virtual bool CompileAndLink() = 0;
 
-    // override to to perform custom tasks on successful compilation
+    // override to perform custom tasks on successful compilation
     // and linkage. E.g. obtaining handles to shader attributes.
     virtual void OnCompiledAndLinked() {}
 
-    // override to to perform custom tasks before shader is enabled
+    // override to perform custom tasks before shader is enabled
     // and after it is disabled. Return false in OnDisabled() to
     // disable shader.
     // E.g. setting attributes, disabling texture unites, etc

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -469,7 +469,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = false;
       return true;
     case SYSTEM_ETHERNET_LINK_ACTIVE:
-      // wtf: not implementated - always returns true?!
+      // wtf: not implemented - always returns true?!
       value = true;
       return true;
     case SYSTEM_PLATFORM_LINUX:

--- a/xbmc/input/InputTranslator.h
+++ b/xbmc/input/InputTranslator.h
@@ -20,7 +20,7 @@ public:
   /*!
    * \brief Get the closest cardinal direction to the given vector
    *
-   * This function assumes a right-handed cartesian coordinate system; postive
+   * This function assumes a right-handed cartesian coordinate system; positive
    * X is right, positive Y is up.
    *
    * Ties are resolved in the clockwise direction: (0.5, 0.5) will resolve to
@@ -38,7 +38,7 @@ public:
    * \brief Get the closest cardinal or intercardinal direction to the given
    *        vector
    *
-   * This function assumes a right-handed cartesian coordinate system; postive
+   * This function assumes a right-handed cartesian coordinate system; positive
    * X is right, positive Y is up.
    *
    * Ties are resolved in the clockwise direction.

--- a/xbmc/input/joysticks/DriverPrimitive.h
+++ b/xbmc/input/joysticks/DriverPrimitive.h
@@ -154,7 +154,7 @@ public:
   unsigned int Range() const { return m_range; }
 
   /*!
-   * \brief The keybord symbol (valid for keys)
+   * \brief The keyboard symbol (valid for keys)
    */
   KEYBOARD::KeySymbol Keycode() const { return m_keycode; }
 

--- a/xbmc/input/joysticks/interfaces/IButtonMap.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMap.h
@@ -317,7 +317,7 @@ public:
 
   /*!
    * \brief Revert changes to the button map since the last time it was loaded
-   *        or commited to disk
+   *        or committed to disk
    */
   virtual void RevertButtonMap() = 0;
 };

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -238,7 +238,7 @@ Avoiding breaking change to original ExportLibrary routine parameters
 *           params[1] = export type "singlefile", "separate", or "library".
 *           params[2] = path of destination folder.
 *           params[3,...] = "unscraped" to include unscraped items
-*           params[3,...] = "overwrite" to overwrite exitsing files.
+*           params[3,...] = "overwrite" to overwrite existing files.
 *           params[3,...] = "artwork" to include images such as thumbs and fanart.
 *           params[3,...] = "skipnfo" to not include nfo files (just art).
 *           params[3,...] = "ablums" to include albums.
@@ -378,7 +378,7 @@ static int SearchVideoLibrary(const std::vector<std::string>& params)
 ///     @param[in] exportFiletype        "singlefile"\, "separate" or "library".
 ///     @param[in] path                  Path to destination folder.
 ///     @param[in] unscraped             Add "unscraped" to include unscraped items.
-///     @param[in] overwrite             Add "overwrite" to overwrite exitsing files.
+///     @param[in] overwrite             Add "overwrite" to overwrite existing files.
 ///     @param[in] artwork               Add "artwork" to include images such as thumbs and fanart.
 ///     @param[in] skipnfo               Add "skipnfo" to not include nfo files(just art).
 ///     @param[in] albums                Add "ablums" to include albums.

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -74,7 +74,7 @@ void CScriptInvocationManager::Uninitialize()
   // execute Process() once more to handle the remaining scripts
   Process();
 
-  // it is safe to relese early, thread must be in m_scripts too
+  // it is safe to release early, thread must be in m_scripts too
   m_lastInvokerThread = nullptr;
 
   // make sure all scripts are done

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -2241,7 +2241,7 @@
     "transport": "Response",
     "permission": "ReadData",
     "params": [
-      { "name": "broadcastid", "$ref": "Library.Id", "required": true, "description": "the id of the broadcast to to check for playability" }
+      { "name": "broadcastid", "$ref": "Library.Id", "required": true, "description": "the id of the broadcast to check for playability" }
     ],
     "returns":  "boolean"
   },

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -91,7 +91,7 @@ using namespace xbmcgui;
       }
       else
       {
-        // for backwards compatability in python scripts
+        // for backwards compatibility in python scripts
         PyObject* o1 = PyLong_FromLong(a1->id);
         return PyObject_RichCompare(o1, obj2, method);
       }

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -60,7 +60,7 @@ public:
   virtual void Reset() {}
 
   /*! \brief Free all GUI resources allocated by the items.
-   \param immediately true to free resources imediately, free resources async later otherwise.
+   \param immediately true to free resources immediately, free resources async later otherwise.
    */
   virtual void FreeResources(bool immediately) {}
 

--- a/xbmc/media/decoderfilter/DecoderFilterManager.cpp
+++ b/xbmc/media/decoderfilter/DecoderFilterManager.cpp
@@ -52,7 +52,7 @@ bool CDecoderFilter::isValid(const CDVDStreamInfo& streamInfo) const
   if ((flags & m_flags) != flags)
     return false;
 
-  // remove codec pitch for comparision
+  // remove codec pitch for comparison
   if (m_minHeight && (streamInfo.height & ~31) <= m_minHeight)
     return false;
 

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -300,7 +300,7 @@ public:
    * \param [in,out] payload this is a void pointer that is meant to send larger objects to the receiver
    *             what to send depends on the message
    * \param [in] strParam value depends on the message being sent, remains for backward compat
-   * \param [in] params value depends on the message being sent, kept for backward compatiblity
+   * \param [in] params value depends on the message being sent, kept for backward compatibility
    * \return meaning of the return varies based on the message
    */
   int SendMsg(uint32_t messageId, int param1, int param2, void* payload, std::string strParam, std::vector<std::string> params);
@@ -366,7 +366,7 @@ public:
    * \param [in,out] payload this is a void pointer that is meant to send larger objects to the receiver
    *             what to send depends on the message
    * \param [in] strParam value depends on the message being sent, remains for backward compat
-   * \param [in] params value depends on the message being sent, kept for backward compatiblity
+   * \param [in] params value depends on the message being sent, kept for backward compatibility
    */
   void PostMsg(uint32_t messageId, int param1, int param2, void* payload, std::string strParam, std::vector<std::string> params);
 

--- a/xbmc/messaging/helpers/DialogHelper.h
+++ b/xbmc/messaging/helpers/DialogHelper.h
@@ -65,7 +65,7 @@ DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noL
                                    CVariant yesLabel = CVariant(), uint32_t autoCloseTimeout = 0);
 
 /*!
-\brief This is a helper method to send a threadmessage to open a Yes/No dialog box with a cutom button
+\brief This is a helper method to send a threadmessage to open a Yes/No dialog box with a custom button
 
 \param[in]  heading           The text to display as the dialog box header
 \param[in]  text              The text to display in the dialog body

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -78,11 +78,11 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
     const std::vector<std::string> separators{ " feat. ", ";", ":", "|", "#", "/", ",", "&" };
 
     // Establish tag consistency
-    // Do the number of musicbrainz ids and *both* number of names and number of hints mis-match?
+    // Do the number of musicbrainz ids and *both* number of names and number of hints mismatch?
     if (albumartistHints.size() != mbids.size() && names.size() != mbids.size())
     {
-      // Tags mis-match - report it and then try to fix
-      CLog::Log(LOGDEBUG, "Mis-match in song file albumartist tags: {} mbid {} name album: {} {}",
+      // Tags mismatch - report it and then try to fix
+      CLog::Log(LOGDEBUG, "Mismatch in song file albumartist tags: {} mbid {} name album: {} {}",
                 (int)mbids.size(), (int)names.size(), strAlbum, strArtistDesc);
       /*
       Most likely we have no hints and a single artist name like "Artist1 feat. Artist2"
@@ -95,7 +95,7 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
       musicbrainz so ignore them but raise warning.
       */
 
-      // Do hints exist yet mis-match
+      // Do hints exist yet mismatch
       if (!albumartistHints.empty() && albumartistHints.size() != mbids.size())
       {
         if (names.size() == mbids.size())
@@ -109,10 +109,10 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
           // Extra hints, discard them.
           albumartistHints.resize(mbids.size());
       }
-      // Do hints not exist or still mis-match, try album artists
+      // Do hints not exist or still mismatch, try album artists
       if (albumartistHints.size() != mbids.size())
         albumartistHints = names;
-      // Still mis-match, try splitting the hints (now artists) until have matching number
+      // Still mismatch, try splitting the hints (now artists) until have matching number
       if (albumartistHints.size() < mbids.size())
         albumartistHints = StringUtils::SplitMulti(albumartistHints, separators, mbids.size());
       // Try matching on artists or artist hints field, if it is reliable
@@ -142,7 +142,7 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
     }
     else
     { // Either hints or album artists (or both) name matches number of musicbrainz id
-      // If hints mis-match, use album artists
+      // If hints mismatch, use album artists
       if (albumartistHints.size() != mbids.size())
         albumartistHints = names;
     }
@@ -216,9 +216,9 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
    a manual refresh of album information uses either the mbid as derived from tags or the album
    and artist names, not any previously scraped mbid.
 
-   When overwritting the data derived from tags, AND the original and scraped album have the same
+   When overwriting the data derived from tags, AND the original and scraped album have the same
    Musicbrainz album ID, then merging is used to keep Kodi up to date with changes in the Musicbrainz
-   database including album artist credits, song artist credits and song titles. However it is ony
+   database including album artist credits, song artist credits and song titles. However it is only
    appropriate when the music files are tagged with mbids, these are taken as definative, scraped
    mbids can not be depended on in this way.
 
@@ -250,7 +250,7 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
    Scraping can return different album artists from the originals derived from tags, even when
    doing a lookup on artist name.
 
-   When overwritting the data derived from tags, AND the original and scraped album have the same
+   When overwriting the data derived from tags, AND the original and scraped album have the same
    Musicbrainz album ID, then merging an album replaces both the album artsts and the song artists
    with those scraped (providing they are not empty).
 
@@ -321,7 +321,7 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
   iVotes = source.iVotes;
 
   /*
-   When overwritting the data derived from tags, AND the original and scraped album have the same
+   When overwriting the data derived from tags, AND the original and scraped album have the same
    Musicbrainz album ID, update the local songs with scaped Musicbrainz information including the
    artist credits.
   */
@@ -381,7 +381,7 @@ const std::string CAlbum::GetAlbumArtistString() const
 
 const std::string CAlbum::GetAlbumArtistSort() const
 {
-  //The stored artist sort name string takes precidence but a
+  //The stored artist sort name string takes precedence but a
   //value could be created from individual sort names held in artistcredits
   if (!strArtistSort.empty())
     return strArtistSort;

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -245,7 +245,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
       AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Title, Year| empty, empty
       AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
       AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrack, "%D"));
-      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
       AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
       AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T - %A", "%r"));  // Title - Artist, UserRating
       AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
@@ -274,7 +274,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
       AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
       AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Title, Year| empty, empty
       AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrack, "%D"));
-      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
       AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
       AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T - %A", "%r"));  // Title - Artist, UserRating
       AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
@@ -361,16 +361,16 @@ CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItem
     std::string strTrack=settings->GetString(CSettings::SETTING_MUSICFILES_TRACKFORMAT);
     AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrack, "%D"));  // Userdefined, Duration| empty, empty
     AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-    AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
-    AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
-    AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Titel, Year| empty, empty
+    AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
+    AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
+    AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Title, Year| empty, empty
     AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrack, "%D"));
-    AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
-    AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Titel, Artist, Rating| empty, empty
+    AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+    AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title, Artist, Rating| empty, empty
     AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T - %A", "%r"));  // Title - Artist, UserRating
     AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
     AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%T - %A", "%a"));  // Title - Artist, DateAdded | empty, empty
-    AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Titel - Artist, PlayCount
+    AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Title - Artist, PlayCount
     if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
         CSettings::SETTING_MUSICLIBRARY_USEORIGINALDATE))
       AddSortMethod(SortByOrigDate, 38079,
@@ -458,12 +458,12 @@ CGUIViewStateMusicPlaylist::CGUIViewStateMusicPlaylist(const CFileItemList& item
   AddSortMethod(SortByPlaylistOrder, 559, LABEL_MASKS(strTrack, "%D"));
   AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrack, "%D"));  // Userdefined, Duration| empty, empty
   AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-  AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
-  AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
-  AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Titel, Year| empty, empty
+  AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
+  AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
+  AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Title, Year| empty, empty
   AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrack, "%D"));
-  AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel - Artist, Duration| empty, empty
-  AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Titel - Artist, Rating| empty, empty
+  AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Title - Artist, Duration| empty, empty
+  AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating| empty, empty
   AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T - %A", "%r"));  // Title - Artist, UserRating
   SetSortMethod(SortByPlaylistOrder);
   const CViewState *viewState = CViewStateSettings::GetInstance().Get("musicfiles");
@@ -543,7 +543,7 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
       AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
       AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
       AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist(year), Title, Year| empty, empty
-      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
       AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
 
       SetSortMethod(SortByLabel);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2540,7 +2540,7 @@ bool CMusicDatabase::AddSongGenres(int idSong, const std::vector<std::string>& g
     std::vector<std::string> modgenres = genres;
     for (auto& strGenre : modgenres)
     {
-      int idGenre = AddGenre(strGenre); // Genre string trimed and matched case insensitively
+      int idGenre = AddGenre(strGenre); // Genre string trimmed and matched case-insensitively
       strSQL = PrepareSQL("INSERT INTO song_genre (idGenre, idSong, iOrder) VALUES(%i,%i,%i)",
                           idGenre, idSong, index++);
       if (!ExecuteQuery(strSQL))
@@ -2773,7 +2773,7 @@ bool CMusicDatabase::GetGenresByArtist(int idArtist, CFileItem* item)
         return false;
       if (m_pDS->num_rows() == 0)
       {
-        //No song genres, but query sucessfull
+        //No song genres, but query successful
         m_pDS->close();
         return true;
       }
@@ -2816,7 +2816,7 @@ bool CMusicDatabase::GetGenresByAlbum(int idAlbum, CFileItem* item)
       return false;
     if (m_pDS->num_rows() == 0)
     {
-      //No song genres, but query sucessfull
+      //No song genres, but query successful
       m_pDS->close();
       return true;
     }
@@ -4510,7 +4510,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
     ret = ERROR_REORG_ARTIST;
     goto error;
   }
-  //Genres, roles and info settings progess in one step
+  //Genres, roles and info settings progress in one step
   if (progressDialog)
   {
     progressDialog->SetLine(1, CVariant{322});
@@ -6556,7 +6556,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
     extFilter.AppendField(JSONtoDBArtist[0].fieldDB);
     dbfieldindex.emplace_back(0); // Output "artist"
 
-    // Check each otional artist db field that could be retrieved (not "artist")
+    // Check each optional artist db field that could be retrieved (not "artist")
     for (unsigned int i = 1; i < NUM_ARTIST_FIELDS; i++)
     {
       bool foundJSON = fields.find(JSONtoDBArtist[i].fieldJSON) != fields.end();
@@ -7268,7 +7268,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
     if (fields.find(JSONtoDBAlbum[0].fieldJSON) != fields.end())
       dbfieldindex.emplace_back(0); // Output "title"
     else
-      dbfieldindex.emplace_back(-1); // fetch but not outout
+      dbfieldindex.emplace_back(-1); // fetch but not output
 
     // Check each optional album db field that could be retrieved (not label)
     for (unsigned int i = 1; i < NUM_ALBUM_FIELDS; i++)
@@ -8310,7 +8310,7 @@ std::string CMusicDatabase::AlphanumericSortSQL(const std::string& strField,
   Use custom collation ALPHANUM in SQLite. This handles natural number order, case sensitivity
   and locale UFT-8 order for accents using the same functionality as fileitem list sorting.
   Natural number order is not significant for where clause comparison and use of calculated fields
-  means there is no advantage in defining as column defualt in table create than per query (which
+  means there is no advantage in defining as column default in table create than per query (which
   also makes looking at the db with other tools difficult).
 
   MySQL does not have callback collation, but all tables are defined with utf8_general_ci an
@@ -9262,7 +9262,7 @@ void CMusicDatabase::UpdateTables(int version)
                 "bScrapedMBID INTEGER NOT NULL DEFAULT 0, "
                 "idInfoSetting INTEGER NOT NULL DEFAULT 0, "
                 "dateAdded TEXT, dateNew TEXT, dateModified TEXT)");
-    // Concatentate fanart URLs into strImage field
+    // Concatenate fanart URLs into strImage field
     // Prepare SQL to convert CONCAT to || in SQLite
     m_pDS->exec(PrepareSQL("INSERT INTO artist_new "
                            "(idArtist, strArtist, strMusicBrainzArtistID, "
@@ -9287,7 +9287,7 @@ void CMusicDatabase::UpdateTables(int version)
     m_pDS->exec("DROP TABLE artist");
     m_pDS->exec("ALTER TABLE artist_new RENAME TO artist");
   }
-  // Set the verion of tag scanning required.
+  // Set the version of tag scanning required.
   // Not every schema change requires the tags to be rescanned, set to the highest schema version
   // that needs this. Forced rescanning (of music files that have not changed since they were
   // previously scanned) also accommodates any changes to the way tags are processed
@@ -9533,7 +9533,7 @@ bool CMusicDatabase::GetAlbumPaths(int idAlbum, std::vector<std::pair<std::strin
     // b) <album>/cd1, <album>/cd2 etc. for disc sets
     // but does *not* return any path when albums are mixed together. That could be because of
     // deliberate file organisation, or (more likely) because of a tagging error in album name
-    // or Musicbrainzalbumid. Thus it avoids finding somme generic music path.
+    // or Musicbrainzalbumid. Thus it avoids finding some generic music path.
     strSQL = PrepareSQL("SELECT DISTINCT strPath, song.idPath FROM song "
                         "JOIN path ON song.idPath = path.idPath "
                         "WHERE song.idAlbum = %ld "
@@ -10234,7 +10234,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
     }
 
     // Get data from returned rows
-    // Item has source ID in MusicInfotag, multipath in path, and indiviual paths in property
+    // Item has source ID in MusicInfotag, multipath in path, and individual paths in property
     CVariant sourcePaths(CVariant::VariantTypeArray);
     int idSource = -1;
     while (!m_pDS->eof())
@@ -10315,7 +10315,7 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
         return false;
       if (m_pDS->num_rows() == 0)
       {
-        //No sources, but query sucessfull
+        //No sources, but query successful
         m_pDS->close();
         return true;
       }
@@ -11898,7 +11898,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
             if (settings.m_artwork)
             {
               // Save art in album folder
-              // Note thumb resoluton may be lower than original when overwriting
+              // Note thumb resolution may be lower than original when overwriting
               std::map<std::string, std::string> artwork;
               std::string savedArtfile;
               if (GetArtForItem(album.idAlbum, MediaTypeAlbum, artwork))
@@ -13112,7 +13112,7 @@ int CMusicDatabase::GetOrderFilter(const std::string& type,
         filter.AppendField(sortSQL); // Add artistsortname as scalar query field
         iFieldsAdded++;
       }
-      // Natural number case insensitve sort
+      // Natural number case-insensitive sort
       filter.AppendOrder(AlphanumericSortSQL(name, sorting.sortOrder));
     }
     else if (StringUtils::EndsWith(name, "strAlbum") || StringUtils::EndsWith(name, "strTitle"))
@@ -13124,11 +13124,11 @@ int CMusicDatabase::GetOrderFilter(const std::string& type,
         filter.AppendField(sortSQL); // Add sortname as scalar query field
         iFieldsAdded++;
       }
-      // Natural number case insensitve sort
+      // Natural number case-insensitive sort
       filter.AppendOrder(AlphanumericSortSQL(name, sorting.sortOrder));
     }
     else if (StringUtils::EndsWith(name, "strGenres"))
-      // Natural number case insensitve sort
+      // Natural number case-insensitive sort
       filter.AppendOrder(AlphanumericSortSQL(name, sorting.sortOrder));
     else
       filter.AppendOrder(name + DESC);

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -178,7 +178,7 @@ public:
     \param song [in/out] the song to update, artist ids are returned in artist credits
     \param bArtists to update artist credits and contributors, default is true
     \param bArtists to check and log if artist links have changed, default is true
-    \return true if sucessfull
+    \return true if successful
    */
   bool UpdateSong(CSong& song, bool bArtists = true, bool bArtistLinks = true);
 
@@ -957,7 +957,7 @@ private:
                                const std::string& strField,
                                const std::string& strSortField);
 
-  /*! \brief Build SQL for sorting field naturally and case insensitvely (in SQLite).
+  /*! \brief Build SQL for sorting field naturally and case-insensitively (in SQLite).
   \param strField field name
   \param sortOrder the sort order
   \return SQL string e.g.
@@ -973,7 +973,7 @@ private:
 
   /*! \brief Initially fills source table from sources.xml for use only at
   migration of db from an earlier version than 72
-  returns true when successfuly done
+  returns true when successfully done
   */
   bool MigrateSources();
 

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -196,7 +196,7 @@ namespace MUSIC_UTILS
     }
   }
 
-  // Add art types currently assigned to to the media item
+  // Add art types currently assigned to the media item
   void AddCurrentArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag,
     CMusicDatabase& db)
   {

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -16,7 +16,7 @@ namespace MUSIC_UTILS
   Input is a fileitem list, with each item having an "arttype" property
   e.g. "thumb", current art URL (if art exists), and label. One of these art types
   can be selected, or a new art type added. The new art type is added as a new item
-  in the list, as well as retuned as the selected art type.
+  in the list, as well as returned as the selected art type.
   \param artitems [in/out] a fileitem list to display
   \return the selected art type e.g. "fanart" or empty string when cancelled.
   \sa FillArtTypesList
@@ -67,7 +67,7 @@ namespace MUSIC_UTILS
   std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
 
   /*! \brief Validate string is acceptable as the name of an additional art type
-  - limited length, and ascii alphanumberic charaters only
+  - limited length, and ascii alphanumberic characters only
   \param potentialArtType [in] potential art type name
  \return true if the art type is valid
  */

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -99,8 +99,8 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
     // Establish tag consistency - do the number of musicbrainz ids and number of names in hints or artist match
     if (mbids.size() != artistHints.size() && mbids.size() != names.size())
     {
-      // Tags mis-match - report it and then try to fix
-      CLog::Log(LOGDEBUG, "Mis-match in song file tags: {} mbid {} names {} {}", (int)mbids.size(),
+      // Tags mismatch - report it and then try to fix
+      CLog::Log(LOGDEBUG, "Mismatch in song file tags: {} mbid {} names {} {}", (int)mbids.size(),
                 (int)names.size(), strTitle, strArtistDesc);
       /*
         Most likely we have no hints and a single artist name like "Artist1 feat. Artist2"
@@ -112,7 +112,7 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
         separators so attempt to split them. Or we could have more hints or artist names than
         musicbrainz id so ignore them but raise warning.
       */
-      // Do hints exist yet mis-match
+      // Do hints exist yet mismatch
       if (artistHints.size() > 0 &&
         artistHints.size() != mbids.size())
       {
@@ -127,10 +127,10 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
           // Extra hints, discard them.
           artistHints.resize(mbids.size());
       }
-      // Do hints not exist or still mis-match, try artists
+      // Do hints not exist or still mismatch, try artists
       if (artistHints.size() != mbids.size())
         artistHints = names;
-      // Still mis-match, try splitting the hints (now artists) until have matching number
+      // Still mismatch, try splitting the hints (now artists) until have matching number
       if (artistHints.size() < mbids.size())
       {
         artistHints = StringUtils::SplitMulti(artistHints, separators, mbids.size());
@@ -138,7 +138,7 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
     }
     else
     { // Either hints or artist names (or both) matches number of musicbrainz id
-      // If hints mis-match, use artists
+      // If hints mismatch, use artists
       if (artistHints.size() != mbids.size())
         artistHints = names;
     }
@@ -300,7 +300,7 @@ const std::vector<std::string> CSong::GetArtist() const
 
 const std::string CSong::GetArtistSort() const
 {
-  //The stored artist sort name string takes precidence but a
+  //The stored artist sort name string takes precedence but a
   //value could be created from individual sort names held in artistcredits
   if (!strArtistSort.empty())
     return strArtistSort;

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -120,7 +120,7 @@ public:
   void AppendArtistRole(const CMusicRole& musicRole);
 
   /*! \brief Set album artist vector.
-   Album artist is held local to song until album created for inital processing only.
+   Album artist is held local to song until album created for initial processing only.
    Normalised album artist data belongs to album and is stored in album artist credits
   \param album artist names as a vector of strings
   */

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -446,7 +446,7 @@ bool CGUIDialogMusicInfo::SetItem(CFileItem* item)
   // In a separate job fetch info and fill list of art types.
   int jobid = CJobManager::GetInstance().AddJob(new CGetInfoJob(), nullptr, CJob::PRIORITY_LOW);
 
-  // Wait to get all data before show, allowing user to to cancel if fetch is slow
+  // Wait to get all data before show, allowing user to cancel if fetch is slow
   if (!CGUIDialogBusy::WaitOnEvent(m_event, TIME_TO_BUSY_DIALOG))
   {
     // Cancel job still waiting in queue (unlikely)
@@ -618,7 +618,7 @@ void CGUIDialogMusicInfo::RefreshInfo()
     return;
   }
 
-  // Show message when scraper was unsuccesfull
+  // Show message when scraper was unsuccessful
   if (!HasScrapedInfo())
   {
     if (m_bArtistInfo)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -138,7 +138,7 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
         // Send a message to all windows to tell them to update the fileitem
         // This communicates the rating change to the music lib window, current playlist and OSD.
         // The music lib window item is updated to but changes to the rating when it is the sort
-        // do not show on screen until refresh() that fetchs the list from scratch, sorts etc.
+        // do not show on screen until refresh() that fetches the list from scratch, sorts etc.
         CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_song);
         CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
       }
@@ -283,7 +283,7 @@ bool CGUIDialogSongInfo::SetSong(CFileItem* item)
   // In a separate job fetch song info and fill list of art types.
   int jobid = CJobManager::GetInstance().AddJob(new CGetSongInfoJob(), nullptr, CJob::PRIORITY_LOW);
 
-  // Wait to get all data before show, allowing user to to cancel if fetch is slow
+  // Wait to get all data before show, allowing user to cancel if fetch is slow
   if (!CGUIDialogBusy::WaitOnEvent(m_event, TIME_TO_BUSY_DIALOG))
   {
     // Cancel job still waiting in queue (unlikely)

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -849,7 +849,7 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
           album artist as the artist with Musicbrainz ID 89ad4ac3-39f7-470e-963a-56509c546377.
           If adding this artist for the first time then the name will be set to either the primary
           artist read from tags when 3a, or the localized value for "various artists" when not 3a.
-          This means that tag values are no longer translated into the current langauge.
+          This means that tag values are no longer translated into the current language.
           */
           album.artistCredits.emplace_back(various, VARIOUSARTISTS_MBID);
         else
@@ -1347,7 +1347,7 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
 
   // Check album art.
   // Fill any gaps with local art files or use first available from scraped URL list (when it has
-  // been successfuly scraped) as controlled by whitelist. Do this even when no info added
+  // been successfully scraped) as controlled by whitelist. Do this even when no info added
   // (cancelled, not found or error), there may be new local art files.
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
           CSettings::SETTING_MUSICLIBRARY_ARTWORKLEVEL) !=
@@ -1417,7 +1417,7 @@ CMusicInfoScanner::UpdateDatabaseArtistInfo(CArtist& artist,
 
   // Check artist art.
   // Fill any gaps with local art files, or use first available from scraped
-  // list (when it has been successfuly scraped). Do this even when no info
+  // list (when it has been successfully scraped). Do this even when no info
   // added (cancelled, not found or error), there may be new local art files.
   // Get individual artist subfolder within the Artist Information Folder
   m_musicDatabase.GetArtistPath(artist, artist.strPath);
@@ -2169,7 +2169,7 @@ bool CMusicInfoScanner::AddLocalArtwork(std::map<std::string, std::string>& art,
                   CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                       CSettings::SETTING_MUSICLIBRARY_USEALLLOCALART));
 
-  // Not useall and empty whiltelist means no extra art is picked up from either place
+  // Not useall and empty whitelist means no extra art is picked up from either place
   if (!bUseAll && whitelistarttypes.empty())
     return false;
 
@@ -2260,7 +2260,7 @@ bool CMusicInfoScanner::AddRemoteArtwork(std::map<std::string, std::string>& art
                   CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                       CSettings::SETTING_MUSICLIBRARY_USEALLREMOTEART));
 
-  // not useall and empty whiltelist means no extra art is picked up from either place
+  // not useall and empty whitelist means no extra art is picked up from either place
   if (!bUseAll && whitelistarttypes.empty())
     return false;
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -170,7 +170,7 @@ protected:
 
   /*! \brief Add extra remote artwork for albums and artists
   This common utility fills the gaps in artwork using the first available art of each type from the
-  possibile art URL results of previous scraping.
+  possible art URL results of previous scraping.
   The art types applied are determined by whitelist and usealllocalart settings.
   \param art [in/out] map of art type and file location (URL or path) pairs
   \param mediaType [in] artist or album
@@ -183,7 +183,7 @@ protected:
 
   /*! \brief Add art for an artist
   This scans the given folder for local art and/or applies the first available art of each type
-  from the possibile art URLs previously scraped. Art is added to any already stored by previous
+  from the possible art URLs previously scraped. Art is added to any already stored by previous
   scanning etc.The art types processed are determined by whitelist and other art settings.
   When usealllocalart is enabled then all local image files are applied as art (providing name is
   valid for an art type), and then the URL list of remote art is checked adding the first available
@@ -197,7 +197,7 @@ protected:
 
   /*! \brief Add art for an album
   This scans the album folder, and any disc set subfolders, for local art and/or applies the first
-  available art of each type from the possibile art URLs previously scraped. Only those subfolders
+  available art of each type from the possible art URLs previously scraped. Only those subfolders
   beneath the album folder containing music files tagged with same unique disc number are scanned.
   Art is added to any already stored by previous scanning, only "thumb" is optionally replaced.
   The art types processed are determined by whitelist and other art settings. When usealllocalart is

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -169,7 +169,7 @@ std::string CMusicInfoTag::GetYearString() const
 {
   /* Get year as YYYY from release or original dates depending on setting
      This is how GUI and by year sorting swiches to using original year.
-     For ripper and non-library items (libray entries have both values):
+     For ripper and non-library items (library entries have both values):
      when release date missing try to fallback to original date
      when original date missing use release date
   */
@@ -795,7 +795,7 @@ void CMusicInfoTag::SetArtist(const CArtist& artist)
 void CMusicInfoTag::SetAlbum(const CAlbum& album)
 {
   Clear();
-  //Set all artist infomation from album artist credits and artist description
+  //Set all artist information from album artist credits and artist description
   SetArtistDesc(album.GetAlbumArtistString());
   SetArtist(album.GetAlbumArtist());
   SetArtistSort(album.GetAlbumArtistSort());
@@ -839,7 +839,7 @@ void CMusicInfoTag::SetSong(const CSong& song)
   Clear();
   SetTitle(song.strTitle);
   SetGenre(song.genre);
-  /* Set all artist infomation from song artist credits and artist description.
+  /* Set all artist information from song artist credits and artist description.
      During processing e.g. Cue Sheets, song may only have artist description string
      rather than a fully populated artist credits vector.
   */

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1105,7 +1105,7 @@ void CGUIWindowMusicBase::OnInitWindow()
 {
   CGUIMediaWindow::OnInitWindow();
   // Prompt for rescan of library to read music file tags that were not processed by previous versions
-  // and accomodate any changes to the way some tags are processed
+  // and accommodate any changes to the way some tags are processed
   if (m_musicdatabase.GetMusicNeedsTagScan() != 0)
   {
     if (CServiceBroker::GetGUI()

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -261,7 +261,7 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
           msgctxt = 38068;
         if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 20195 }, msgctxt)) // Change information provider, confirm for all shown
         {
-          // Set scraper for all items on curent view.
+          // Set scraper for all items on current view.
           std::string strPath = "musicdb://";
           if (content == CONTENT_ARTISTS)
             strPath += "artists";
@@ -296,7 +296,7 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
           else
             settings->SetString(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER, scraper->ID());
           settings->Save();
-          // Clear all item specifc settings
+          // Clear all item specific settings
           if (content == CONTENT_ARTISTS)
             result = m_musicdatabase.SetScraperAll("musicdb://artists/", nullptr);
           else
@@ -897,7 +897,7 @@ void CGUIWindowMusicNav::AddSearchFolder()
     }
     if (!haveSearchSource && needSearchSource)
     {
-      // add earch share
+      // add search share
       CMediaSource share;
       share.strName=g_localizeStrings.Get(137); // Search
       share.strPath = "musicsearch://";

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -48,7 +48,7 @@
 #define DEFAULT_TIMEOUT_SEC (5*60)           // at least 5 minutes between each magic packets
 #define DEFAULT_WAIT_FOR_ONLINE_SEC_1 (40)   // wait at 40 seconds after sending magic packet
 #define DEFAULT_WAIT_FOR_ONLINE_SEC_2 (40)   // same for extended wait
-#define DEFAULT_WAIT_FOR_SERVICES_SEC (5)    // wait 5 seconds after host go online to launch file sharing deamons
+#define DEFAULT_WAIT_FOR_SERVICES_SEC (5)    // wait 5 seconds after host go online to launch file sharing daemons
 
 static CDateTime upnpInitReady;
 
@@ -471,7 +471,7 @@ bool CWakeOnAccess::WakeUpHost(const std::string& hostName, const std::string& c
 
   if (FindOrTouchHostEntry(hostName, upnpMode, server))
   {
-    CLog::Log(LOGINFO, "WakeOnAccess [{}] trigged by accessing : {}", server.friendlyName,
+    CLog::Log(LOGINFO, "WakeOnAccess [{}] triggered by accessing : {}", server.friendlyName,
               customMessage);
 
     NestDetect nesting ; // detect recursive calls on gui thread..
@@ -551,7 +551,7 @@ bool CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
   // we have ping response ; just add extra wait-for-services before returning if requested
 
   {
-    WaitCondition waitObj ; // wait uninterruptable fixed time for services ..
+    WaitCondition waitObj ; // wait uninterruptible fixed time for services ..
 
     dlg.ShowAndWait (waitObj, server.wait_services_sec, LOCALIZED(13032));
 
@@ -624,7 +624,7 @@ static void AddHost (const std::string& host, std::vector<std::string>& hosts)
 {
   for (const auto& it : hosts)
     if (StringUtils::EqualsNoCase(host, it))
-      return; // allready there ..
+      return; // already there ..
 
   if (!host.empty())
     hosts.push_back(host);

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -75,7 +75,7 @@ CWebServer::CWebServer()
   pthread_attr_getstack(&attr, &stack_addr, &m_thread_stacksize);
   pthread_attr_destroy(&attr);
   // double the stack size under darwin, not sure why yet
-  // but it stoped crashing using Kodi iOS remote -> play video.
+  // but it stopped crashing using Kodi iOS remote -> play video.
   // non-darwin will pass a value of zero which means 'system default'
   m_thread_stacksize *= 2;
   m_logger->debug("increasing thread stack to {}", m_thread_stacksize);

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -74,7 +74,7 @@ public:
   static CZeroconf* GetInstance();
   // release the singleton; (save to call multiple times)
   static void   ReleaseInstance();
-  // returns false if ReleaseInstance() was called befores
+  // returns false if ReleaseInstance() was called before
   static bool   IsInstantiated() { return  smp_instance != 0; }
   // win32: process results from the bonjour daemon
   virtual void  ProcessResults() {}

--- a/xbmc/network/ZeroconfBrowser.h
+++ b/xbmc/network/ZeroconfBrowser.h
@@ -111,7 +111,7 @@ public:
   static CZeroconfBrowser* GetInstance();
   // release the singleton; (save to call multiple times)
   static void ReleaseInstance();
-  // returns false if ReleaseInstance() was called befores
+  // returns false if ReleaseInstance() was called before
   static bool IsInstantiated() { return  smp_instance != 0; }
 
   virtual void ProcessResults() {}

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -675,7 +675,7 @@ BuildObject(CFileItem&                    item,
         {
           std::string preferredLanguage{"en"};
 
-          /* trying to find subtitle with prefered language settings */
+          /* trying to find subtitle with preferred language settings */
           auto setting = settings->GetSetting("locale.subtitlelanguage");
           if (!setting)
             CLog::Log(LOGERROR, "Failed to load setting for: {}", "locale.subtitlelanguage");
@@ -696,7 +696,7 @@ BuildObject(CFileItem&                    item,
               break;
             }
             }
-            /* if not found subtitle with prefered language, get the first one */
+            /* if not found subtitle with preferred language, get the first one */
             if (subtitlePath.empty())
             {
                 subtitlePath = subtitles[0];

--- a/xbmc/pictures/ExifParse.cpp
+++ b/xbmc/pictures/ExifParse.cpp
@@ -15,7 +15,7 @@
 //--------------------------------------------------------------------------
 
 // Note: Jhead supports TAG_MAKER_NOTE exif field,
-//       but that is ommited for now - to make porting easier and addition smaller
+//       but that is omitted for now - to make porting easier and addition smaller
 
 #include "ExifParse.h"
 

--- a/xbmc/pictures/JpegParse.cpp
+++ b/xbmc/pictures/JpegParse.cpp
@@ -123,7 +123,7 @@ bool CJpegParse::GetSection (CFile& infile, const unsigned short sectionLength)
 
 //--------------------------------------------------------------------------
 // Deallocate memory allocated in GetSection. This function must always
-// be paired by a preceeding GetSection call.
+// be paired by a preceding GetSection call.
 //--------------------------------------------------------------------------
 void CJpegParse::ReleaseSection (void)
 {
@@ -245,7 +245,7 @@ bool CJpegParse::ExtractInfo (CFile& infile)
 
       case M_JFIF:
         // Regular jpegs always have this tag, exif images have the exif
-        // marker instead, althogh ACDsee will write images with both markers.
+        // marker instead, although ACDsee will write images with both markers.
         // this program will re-create this marker on absence of exif marker.
         // hence no need to keep the copy from the file.
       // fall through to default case

--- a/xbmc/platform/android/filesystem/AndroidAppFile.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppFile.cpp
@@ -135,7 +135,7 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
 
   if (info.stride != info.width * 4)
   {
-    CLog::Log(LOGWARNING, "CFileAndroidApp::ReadIcon: Usupported icon format {}", info.format);
+    CLog::Log(LOGWARNING, "CFileAndroidApp::ReadIcon: Unsupported icon format {}", info.format);
     return 0;
   }
 

--- a/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.mm
+++ b/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.mm
@@ -79,7 +79,7 @@
     dict[MPNowPlayingInfoPropertyPlaybackQueueCount] = total;
 
   /*! @Todo additional properties?
-   other properities can be set:
+   other properties can be set:
    MPMediaItemPropertyAlbumTrackCount
    MPMediaItemPropertyComposer
    MPMediaItemPropertyDiscCount

--- a/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
+++ b/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
@@ -164,7 +164,7 @@ void CZeroconfDarwin::registerCallback(CFNetServiceRef theService, CFStreamError
     CZeroconfDarwin* p_this = reinterpret_cast<CZeroconfDarwin*>(info);
     switch(error->error) {
       case kCFNetServicesErrorCollision:
-        CLog::Log(LOGERROR, "CZeroconfDarwin::registerCallback name collision occured");
+        CLog::Log(LOGERROR, "CZeroconfDarwin::registerCallback name collision occurred");
         break;
       default:
         CLog::Log(LOGERROR,

--- a/xbmc/platform/darwin/peripherals/Input_Gamecontroller.mm
+++ b/xbmc/platform/darwin/peripherals/Input_Gamecontroller.mm
@@ -47,7 +47,7 @@ struct PlayerControllerState
   CCriticalSection m_controllerMutex;
 }
 
-#pragma mark - Notificaton Observer
+#pragma mark - Notification Observer
 
 - (void)addModeSwitchObserver
 {

--- a/xbmc/platform/darwin/tvos/TVOSDisplayManager.mm
+++ b/xbmc/platform/darwin/tvos/TVOSDisplayManager.mm
@@ -181,7 +181,7 @@
       // when isDisplayModeSwitchInProgress == NO, we have switched
       // and stablized. We might have switched to some other
       // rate than what we requested. setting preferredDisplayCriteria is
-      // only a request. For example, 30Hz might only be avaliable in HDR
+      // only a request. For example, 30Hz might only be available in HDR
       // and asking for 30Hz/SDR might result in 60Hz/SDR and
       // g_graphicsContext.SetFPS needs the actual refresh rate.
       refreshRate = [self getDisplayRate];

--- a/xbmc/platform/darwin/tvos/XBMCApplication.mm
+++ b/xbmc/platform/darwin/tvos/XBMCApplication.mm
@@ -54,7 +54,7 @@
 {
   // This function occurs:
   //  * on the first start of Kodi
-  //  * when Kodi has been activated after a beeing suspending by applicationWillResignActive()
+  //  * when Kodi has been activated after being suspended by applicationWillResignActive()
   //  * when Kodi has been foregrounded after applicationDidEnterBackground()
 }
 

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
@@ -69,7 +69,7 @@ bool CTVOSDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   // The directory request will point to the right path '.../home/userdata/..'
   // so we ask for files in ending directory, if we get xml file paths back
   // then we are re-vectoring them to persistent storage and need to
-  // create CFileItems that will tranlate into CTVOSFile object later
+  // create CFileItems that will translate into CTVOSFile object later
   // when accessed.
 
   // GetDirectoryContents will return full paths

--- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
+++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
@@ -160,7 +160,7 @@ bool CLogindUPowerSyscall::LogindSetPowerState(const char *state)
 {
   CDBusMessage message(LOGIND_DEST, LOGIND_PATH, LOGIND_IFACE, state);
   // The user_interaction boolean parameters can be used to control
-  // wether PolicyKit should interactively ask the user for authentication
+  // whether PolicyKit should interactively ask the user for authentication
   // credentials if it needs to.
   message.AppendArgument(false);
   return message.SendSystem() != NULL;

--- a/xbmc/platform/posix/XHandle.cpp
+++ b/xbmc/platform/posix/XHandle.cpp
@@ -34,7 +34,7 @@ CXHandle::CXHandle(HandleType nType)
 
 CXHandle::CXHandle(const CXHandle &src)
 {
-  // we shouldnt get here EVER. however, if we do - try to make the best. copy what we can
+  // we shouldn't get here EVER. however, if we do - try to make the best. copy what we can
   // and most importantly - not share any pointer.
   CLog::Log(LOGWARNING, "{}, copy handle.", __FUNCTION__);
 

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -155,7 +155,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         struct stat info = {};
         if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_sambastatfiles)
         {
-          // make sure we use the authenticated path wich contains any default username
+          // make sure we use the authenticated path which contains any default username
           const std::string strFullName = strAuth + smb.URLEncode(strFile);
 
           lock.Enter();
@@ -170,7 +170,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
             char value[20];
             // We poll for extended attributes which symbolizes bits but split up into a string. Where 0x02 is hidden and 0x12 is hidden directory.
-            // According to the libsmbclient.h it's supposed to return 0 if ok, or the length of the string. It seems always to return the length wich is 4
+            // According to the libsmbclient.h it's supposed to return 0 if ok, or the length of the string. It seems always to return the length which is 4
             if (smbc_getxattr(strFullName.c_str(), "system.dos_attr.mode", value, sizeof(value)) > 0)
             {
               long longvalue = strtol(value, NULL, 16);

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -281,7 +281,7 @@ std::string CSMB::URLEncode(const std::string &value)
 void CSMB::CheckIfIdle()
 {
 /* We check if there are open connections. This is done without a lock to not halt the mainthread. It should be thread safe as
-   worst case scenario is that m_OpenConnections could read 0 and then changed to 1 if this happens it will enter the if wich will lead to another check, wich is locked.  */
+   worst case scenario is that m_OpenConnections could read 0 and then changed to 1 if this happens it will enter the if which will lead to another check, which is locked.  */
   if (m_OpenConnections == 0)
   { /* I've set the the maximum IDLE time to be 1 min and 30 sec. */
     CSingleLock lock(*this);
@@ -318,7 +318,7 @@ void CSMB::AddIdleConnection()
 {
   CSingleLock lock(*this);
   m_OpenConnections--;
-  /* If we close a file we reset the idle timer so that we don't have any wierd behaviours if a user
+  /* If we close a file we reset the idle timer so that we don't have any weird behaviours if a user
      leaves the movie paused for a long while and then press stop */
   m_IdleTimeout = 180;
 }

--- a/xbmc/platform/posix/utils/SharedMemory.cpp
+++ b/xbmc/platform/posix/utils/SharedMemory.cpp
@@ -61,7 +61,7 @@ CFileHandle CSharedMemory::Open()
 CFileHandle CSharedMemory::OpenMemfd()
 {
 #if defined(SYS_memfd_create) && defined(HAVE_LINUX_MEMFD)
-  // This is specific to Linux >= 3.17, but preffered over shm_create if available
+  // This is specific to Linux >= 3.17, but preferred over shm_create if available
   // because it is race-free
   int fd = syscall(SYS_memfd_create, "kodi", MFD_CLOEXEC);
   if (fd < 0)

--- a/xbmc/platform/win10/Environment.cpp
+++ b/xbmc/platform/win10/Environment.cpp
@@ -7,7 +7,7 @@
  */
 
 /**
- * \file platfrom\win10\Environment.cpp
+ * \file platform\win10\Environment.cpp
  * \brief Implements CEnvironment WinRT specified class functions.
  */
 

--- a/xbmc/platform/win10/Win10App.cpp
+++ b/xbmc/platform/win10/Win10App.cpp
@@ -78,7 +78,7 @@ void App::Run()
   {
     // fix the case then window opened in FS, but current setting is RES_WINDOW
     // the proper way is make window params related to setting, but in this setting isn't loaded yet
-    // perhaps we should observe setting changes and change window's Preffered props
+    // perhaps we should observe setting changes and change window's Preferred props
     bool fullscreen = ApplicationView::GetForCurrentView().IsFullScreenMode();
 
     CAppParamParser appParamParser;

--- a/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
@@ -338,7 +338,7 @@ bool CWinLibraryFile::OpenIntenal(const CURL &url, FileAccessMode mode)
   catch (const winrt::hresult_error& ex)
   {
     std::string error = FromW(ex.message().c_str());
-    CLog::LogF(LOGERROR, "an exception occurs while openning a file '{}' (mode: {}) : {}",
+    CLog::LogF(LOGERROR, "an exception occurs while opening a file '{}' (mode: {}) : {}",
                url.GetRedacted(), mode == FileAccessMode::Read ? "r" : "rw", error);
     return false;
   }
@@ -379,7 +379,7 @@ StorageFile CWinLibraryFile::GetFile(const CURL& url)
     winrt::hstring token = GetTokenFromList(url, list);
     if (token.empty())
     {
-      // serach in MRU list
+      // search in MRU list
       list = StorageApplicationPermissions::MostRecentlyUsedList();
       token = GetTokenFromList(url, list);
     }

--- a/xbmc/platform/win32/dirent.h
+++ b/xbmc/platform/win32/dirent.h
@@ -537,7 +537,7 @@ dirent_next(
             /* Got a file */
             p = &dirp->data;
         } else {
-            /* The very last entry has been processed or an error occured */
+            /* The very last entry has been processed or an error occurred */
             FindClose (dirp->handle);
             dirp->handle = INVALID_HANDLE_VALUE;
             p = NULL;

--- a/xbmc/powermanagement/IPowerSyscall.h
+++ b/xbmc/powermanagement/IPowerSyscall.h
@@ -27,7 +27,7 @@ class IPowerSyscall
 public:
   /**\brief Called by power manager to create platform power system adapter
   *
-  * This method used to create platfrom specified power system adapter
+  * This method used to create platform specified power system adapter
   */
   static IPowerSyscall* CreateInstance();
   static void RegisterPowerSyscall(CreatePowerSyscallFunc createFunc);

--- a/xbmc/profiles/Profile.h
+++ b/xbmc/profiles/Profile.h
@@ -59,7 +59,7 @@ public:
   bool canWriteSources() const { return m_bCanWriteSources; }
   bool hasAddons() const { return m_bAddons; }
   /**
-   \brief Returns wich settings levels are locked for the current profile
+   \brief Returns which settings levels are locked for the current profile
    \sa LOCK_LEVEL::SETTINGS_LOCK
    */
   LOCK_LEVEL::SETTINGS_LOCK settingsLockLevel() const { return m_locks.settings; }

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -24,7 +24,7 @@ using namespace XFILE;
 
 CGUIViewStateWindowPrograms::CGUIViewStateWindowPrograms(const CFileItemList& items) : CGUIViewState(items)
 {
-  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%K", "%I", "%L", ""),  // Titel, Size | Foldername, empty
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%K", "%I", "%L", ""),  // Title, Size | Foldername, empty
     CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
 
   const CViewState *viewState = CViewStateSettings::GetInstance().Get("programs");

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -729,7 +729,7 @@ PVR_ERROR CPVRClient::SetEPGMaxFutureDays(int iFutureDays)
 // This class wraps an EPG_TAG (PVR Addon API struct) to ensure that the string members of
 // that struct, which are const char pointers, stay valid until the EPG_TAG gets destructed.
 // Please note that this struct is also used to transfer huge amount of EPG_TAGs from
-// addon to Kodi. Thus, changing the struct to contain char arrays is not recommened,
+// addon to Kodi. Thus, changing the struct to contain char arrays is not recommended,
 // because this would lead to huge amount of string copies when transferring epg data
 // from addon to Kodi.
 class CAddonEpgTag : public EPG_TAG

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -778,7 +778,7 @@ public:
   PVR_ERROR SeekLiveStream(int64_t iFilePosition, int iWhence, int64_t& iPosition);
 
   /*!
-   * @brief Get the lenght of the currently playing live stream, if any.
+   * @brief Get the length of the currently playing live stream, if any.
    * @param iLength The total length of the stream that's currently being read or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
@@ -892,7 +892,7 @@ public:
   PVR_ERROR SeekRecordedStream(int64_t iFilePosition, int iWhence, int64_t& iPosition);
 
   /*!
-   * @brief Get the lenght of the currently playing recording stream, if any.
+   * @brief Get the length of the currently playing recording stream, if any.
    * @param iLength The total length of the stream that's currently being read or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -348,7 +348,7 @@ namespace PVR
     void OnSystemSleep();
 
     /*!
-     * @brief Propagate "system wakup" event to clients
+     * @brief Propagate "system wakeup" event to clients
      */
     void OnSystemWake();
 

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -369,7 +369,7 @@ namespace PVR
      * Get the EPG tag that was previously active on this channel.
      * Will return an empty tag if there is none.
      *
-     * @return The EPG tag that was previously activ.
+     * @return The EPG tag that was previously active.
      */
     std::shared_ptr<CPVREpgInfoTag> GetEPGPrevious() const;
 

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -432,7 +432,7 @@ namespace PVR
     unsigned int Flags() const { return m_iFlags; }
 
     /*!
-     * @brief Split the given string into tokens. Interpretes occurences of EPG_STRING_TOKEN_SEPARATOR in the string as separator.
+     * @brief Split the given string into tokens. Interprets occurrences of EPG_STRING_TOKEN_SEPARATOR in the string as separator.
      * @param str The string to tokenize.
      * @return the tokens.
      */

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.h
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.h
@@ -38,7 +38,7 @@ public:
   virtual ~CPVRGUIDirectory() = default;
 
   /*!
-   * @brief Check existense of this directory.
+   * @brief Check existence of this directory.
    * @return True if the directory exists, false otherwise.
    */
   bool Exists() const;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -717,7 +717,7 @@ void CGUIEPGGridContainer::UpdateItems()
     {
       channelUid = prevSelectedEpgTag->UniqueChannelID();
 
-      // As gap tags do not have a unique broadcast id, we will look for the real tag preceeding
+      // As gap tags do not have a unique broadcast id, we will look for the real tag preceding
       // the gap tag and add the respective offset to restore the gap tag selection, assuming that
       // the real tag is still the predecessor of the gap tag after the grid model update.
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -632,7 +632,7 @@ int CGUIEPGGridContainerModel::GetBlock(const CDateTime& datetime) const
     diff = (datetime - m_gridStart).GetSecondsTotal(); // block is after grid start
 
   // Note: Subtract 1 second from diff to ensure that events ending exactly at block boundary
-  //       are unambigious. Example: An event ending at 5:00:00 shall be mapped to block 9 and
+  //       are unambiguous. Example: An event ending at 5:00:00 shall be mapped to block 9 and
   //       an event starting at 5:00:00 shall be mapped to block 10, not both at block 10.
   //       Only exception is grid end, because there is no successor.
   if (datetime >= m_gridEnd)

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -2335,7 +2335,7 @@ namespace PVR
                              19309); // (Auto-close of this reminder will schedule a recording...)
       else if (m_settings.GetBoolValue(CSettings::SETTING_PVRREMINDERS_AUTOSWITCH))
         text += "\n\n" + g_localizeStrings.Get(
-                             19331); // (Auto-close of this reminder will swicth to channel...)
+                             19331); // (Auto-close of this reminder will switch to channel...)
     }
     else
     {

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -151,7 +151,7 @@ namespace PVR
 
     /*!
      * @brief Get the timer rule for a given timer
-     * @param item containg an item to query the timer rule for. item must be a timer or an epg tag.
+     * @param item containing an item to query the timer rule for. item must be a timer or an epg tag.
      * @return The timer rule item, or nullptr if none was found.
      */
     std::shared_ptr<CFileItem> GetTimerRule(const std::shared_ptr<CFileItem>& item) const;
@@ -403,7 +403,7 @@ namespace PVR
     /*!
      * @brief Get a channel group member for the given channel, either from the currently active
      * group or if not found there, from the 'all channels' group.
-     * @param cahnnel the channel.
+     * @param channel the channel.
      * @return the group member or nullptr if not found.
      */
     std::shared_ptr<CPVRChannelGroupMember> GetChannelGroupMember(
@@ -575,7 +575,7 @@ namespace PVR
     /*!
      * @brief Start playback of the given item.
      * @param bFullscreen start playback fullscreen or not.
-     * @param epgProps propeties to be used instead of calling to the client if supplied.
+     * @param epgProps properties to be used instead of calling to the client if supplied.
      * @param item containing a channel or a recording.
      */
     void StartPlayback(CFileItem* item,

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
@@ -29,13 +29,13 @@ namespace PVR
 
     /*!
      * @brief Select the next channel in currently playing channel group, relative to the currently selected channel.
-     * @param eSwitchMode controls whether only the channel info OSD is triggered or whther additionally a (delayed) channel switch will be done.
+     * @param eSwitchMode controls whether only the channel info OSD is triggered or whether additionally a (delayed) channel switch will be done.
      */
     void SelectNextChannel(ChannelSwitchMode eSwitchMode);
 
     /*!
      * @brief Select the previous channel in currently playing channel group, relative to the currently selected channel.
-     * @param eSwitchMode controls whether only the channel info OSD is triggered or whther additionally a (delayed) channel switch will be done.
+     * @param eSwitchMode controls whether only the channel info OSD is triggered or whether additionally a (delayed) channel switch will be done.
      */
     void SelectPreviousChannel(ChannelSwitchMode eSwitchMode);
 

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.h
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.h
@@ -42,7 +42,7 @@ namespace PVR
     void UpdateProgress(const std::string& strText, int iCurrent, int iMax);
 
     /*!
-     * @brief Destroy the progress dialog. This happens asynchrounous, instance must not be touched anymore after calling this method.
+     * @brief Destroy the progress dialog. This happens asynchronous, instance must not be touched anymore after calling this method.
      */
     void DestroyProgress();
 

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -134,7 +134,7 @@ bool CPVRProviders::Update()
   }
 
   // Default client providers are the add-ons themselves, we retrieve both enabled
-  // and disbled add-ons as we don't want them removed from the DB
+  // and disabled add-ons as we don't want them removed from the DB
   CPVRProviders newAddonProviderList;
   std::vector<int> disabledClients;
   std::vector<CVariant> clientProviderInfos =

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -11,8 +11,8 @@
 /*
  * DESCRIPTION:
  *
- * CPVRRecordingInfoTag is part of the Kodi PVR system to support recording entrys,
- * stored on a other Backend like VDR or MythTV.
+ * CPVRRecordingInfoTag is part of the Kodi PVR system to support recording entries,
+ * stored on another Backend like VDR or MythTV.
  *
  * The recording information tag holds data about name, length, recording time
  * and so on of recorded stream stored on the backend.
@@ -168,7 +168,7 @@ namespace PVR
 
     /*!
      * @brief Update this recording's size. The value will be obtained from the backend if it supports server-side size retrieval.
-     * @return true if the the updated value is differnt, false otherwise.
+     * @return true if the the updated value is different, false otherwise.
      */
     bool UpdateRecordingSize();
 

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -144,7 +144,7 @@ std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string& 
   strUsePath.erase(0, strUnescapedDirectoryPath.size());
   strUsePath = TrimSlashes(strUsePath);
 
-  /* check for more occurences */
+  /* check for more occurrences */
   size_t iDelimiter = strUsePath.find('/');
   if (iDelimiter == std::string::npos)
     strReturn = strUsePath;

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -297,7 +297,7 @@ bool DX::DeviceResources::SetFullScreen(bool fullscreen, RESOLUTION_INFO& res)
     }
   }
 
-  // resize backbuffer to proper hanlde fullscreen/stereo transition
+  // resize backbuffer to proper handle fullscreen/stereo transition
   if (recreate)
     ResizeBuffers();
 
@@ -868,7 +868,7 @@ void DX::DeviceResources::OnDeviceLost(bool removed)
     // the most of resources like textures and buffers try to
     // receive and save their status from current device.
     // `removed` means that we have no possibility
-    // to use the device anymore, tell all resouces about this.
+    // to use the device anymore, tell all resources about this.
     res->OnDestroyDevice(removed);
   }
 }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -990,7 +990,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   if (pTrailerMatching)
     GetCustomRegexps(pTrailerMatching, m_trailerMatchRegExps);
 
-  //everything thats a trailer is not a movie
+  //everything that's a trailer is not a movie
   m_moviesExcludeFromScanRegExps.insert(m_moviesExcludeFromScanRegExps.end(),
                                         m_trailerMatchRegExps.begin(),
                                         m_trailerMatchRegExps.end());

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -359,7 +359,7 @@ bool CMediaSourceSettings::GetSource(const std::string &category, const TiXmlNod
     return false;
 
   std::vector<std::string> verifiedPaths;
-  // disallowed for files, or theres only a single path in the vector
+  // disallowed for files, or there's only a single path in the vector
   if (StringUtils::EqualsNoCase(category, "files") || vecPaths.size() == 1)
     verifiedPaths.push_back(vecPaths[0]);
   // multiple paths?

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -1430,7 +1430,7 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
     // get allowempty (needs to be parsed before parsing the default value)
     XMLUtils::GetBoolean(constraints, SETTING_XML_ELM_ALLOWEMPTY, m_allowEmpty);
 
-    // Values other than those in options contraints allowed to be added
+    // Values other than those in options constraints allowed to be added
     XMLUtils::GetBoolean(constraints, SETTING_XML_ELM_ALLOWNEWOPTION, m_allowNewOption);
 
     // get the entries

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1061,7 +1061,7 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
     settingId = setting->GetReferencedId();
 
   const TiXmlElement* settingElement = nullptr;
-  // try to split the setting identifier into category and subsetting identifer (v1-)
+  // try to split the setting identifier into category and subsetting identifier (v1-)
   std::string categoryTag, settingTag;
   if (ParseSettingIdentifier(settingId, categoryTag, settingTag))
   {

--- a/xbmc/storage/IStorageProvider.h
+++ b/xbmc/storage/IStorageProvider.h
@@ -53,7 +53,7 @@ public:
 
   /**\brief Called by media manager to create platform storage provider
   *
-  * This method used to create platfrom specified storage provider
+  * This method used to create platform specified storage provider
   */
   static IStorageProvider* CreateInstance();
 };

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -369,7 +369,7 @@ bool CBitstreamConverter::Open(enum AVCodecID codec, uint8_t *in_extradata, int 
           {
             CLog::Log(LOGINFO, "CBitstreamConverter::Open annexb to bitstream init");
             // video content is from x264 or from bytestream h264 (AnnexB format)
-            // NAL reformating to bitstream format needed
+            // NAL reformatting to bitstream format needed
             AVIOContext *pb;
             if (avio_open_dyn_buf(&pb) < 0)
               return false;

--- a/xbmc/utils/Fanart.cpp
+++ b/xbmc/utils/Fanart.cpp
@@ -146,7 +146,7 @@ bool CFanart::ParseColors(const std::string &colorsIn, std::string &colorsOut)
   // 1: The TVDB RGB Int Triplets, pipe separate with leading/trailing pipes "|68,69,59|69,70,58|78,78,68|"
 
   // Essentially we read the colors in using the proper format, and store them in our own fixed temporary format (3 DWORDS), and then
-  // write them back in in the specified format.
+  // write them back in the specified format.
 
   if (colorsIn.empty())
     return false;

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -152,7 +152,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
   // Check auto-mounted sources
   VECSOURCES sources;
   CServiceBroker::GetMediaManager().GetRemovableDrives(
-      sources); // Sources returned allways have m_allowsharing = true
+      sources); // Sources returned always have m_allowsharing = true
   //! @todo Make sharing of auto-mounted sources user configurable
   int sourceIndex = CUtil::GetMatchingSource(realPath, sources, isSource);
   if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources.size()) &&
@@ -214,7 +214,7 @@ CDateTime CFileUtils::GetModificationDate(const int& code, const std::string& st
           addedTime =
               std::min(static_cast<time_t>(buffer.st_ctime), static_cast<time_t>(buffer.st_mtime));
       }
-      // Perfer the earliest of ctime and mtime, fallback to other
+      // Prefer the earliest of ctime and mtime, fallback to other
       else
       {
         addedTime =

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1152,7 +1152,7 @@ int64_t StringUtils::AlphaNumericCompare(const wchar_t* left, const wchar_t* rig
       else
       {
         // Fetch collation facet from locale to do comparison of wide char although on some
-        // platforms this is not langauge specific but just compares unicode
+        // platforms this is not language specific but just compares unicode
         const std::collate<wchar_t>& coll =
             std::use_facet<std::collate<wchar_t>>(g_langInfo.GetSystemLocale());
         int cmp_res = coll.compare(&lc, &lc + 1, &rc, &rc + 1);
@@ -1331,7 +1331,7 @@ int StringUtils::AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, 
       else
       {
         // Fetch collation facet from locale to do comparison of wide char although on some
-        // platforms this is not langauge specific but just compares unicode
+        // platforms this is not language specific but just compares unicode
         const std::collate<wchar_t>& coll =
             std::use_facet<std::collate<wchar_t>>(g_langInfo.GetSystemLocale());
         int cmp_res = coll.compare(&lc, &lc + 1, &rc, &rc + 1);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -100,7 +100,7 @@ bool URIUtils::HasExtension(const std::string& strFileName, const std::string& s
   std::string::const_reverse_iterator itExtensions = strExtensions.rbegin();
   while (itExtensions != strExtensions.rend())
   {
-    // Iterate backwards over strFileName untill we hit a '.' or a mismatch
+    // Iterate backwards over strFileName until we hit a '.' or a mismatch
     for (std::string::const_reverse_iterator itFileName = strFileName.rbegin();
          itFileName != strFileName.rend() && itExtensions != strExtensions.rend() &&
          tolower(*itFileName) == *itExtensions;

--- a/xbmc/utils/params_check_macros.h
+++ b/xbmc/utils/params_check_macros.h
@@ -25,7 +25,7 @@
 // for example: class A { bool log_string(int logLevel, const char* functionName, const char* format, ...) PARAM3_PRINTF_FORMAT; }
 #define PARAM3_PRINTF_FORMAT __attribute__((format(printf,3,4)))
 
-// for use in functions that take printf format string as fourth parameter and additional printf parameters as fith parameter
+// for use in functions that take printf format string as fourth parameter and additional printf parameters as fifth parameter
 // note: all non-static class member functions take pointer to class object as hidden first parameter
 // for example: class A { bool log_string(int logLevel, const char* functionName, int component, const char* format, ...) PARAM4_PRINTF_FORMAT; }
 #define PARAM4_PRINTF_FORMAT __attribute__((format(printf,4,5)))

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -266,9 +266,9 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         AddSortMethod(SortByArtist, sortAttributes, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
         AddSortMethod(SortByArtistThenYear, sortAttributes, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Title, Year| empty, empty
         AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year| empty, empty
-        AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+        AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
         AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%T - %A", "%a"));  // Title - Artist, DateAdded | empty, empty
-        AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Titel - Artist, PlayCount
+        AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Title - Artist, PlayCount
         AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T - %A", "%O")); // Title - Artist, MPAARating
         AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T - %A", "%r"));  // Title - Artist, UserRating
 
@@ -480,9 +480,9 @@ CGUIViewStateVideoMusicVideos::CGUIViewStateVideoMusicVideos(const CFileItemList
   AddSortMethod(SortByArtist, sortAttributes, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
   AddSortMethod(SortByArtistThenYear, sortAttributes, 578, LABEL_MASKS("%A - %T", "%Y"));  // Artist, Title, Year| empty, empty
   AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year| empty, empty
-  AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+  AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
   AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%T - %A", "%a"));  // Title - Artist, DateAdded | empty, empty
-  AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Titel - Artist, PlayCount
+  AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Title - Artist, PlayCount
   AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T - %A", "%O")); // Title - Artist, MPAARating
   AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T - %A", "%r"));  // Title - Artist, UserRating
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -217,10 +217,10 @@ void CVideoDatabase::CreateForeignLinkIndex(const char *table, const char *forei
 
 void CVideoDatabase::CreateAnalytics()
 {
-  /* indexes should be added on any columns that are used in in  */
+  /* indexes should be added on any columns that are used in     */
   /* a where or a join. primary key on a column is the same as a */
   /* unique index on that column, so there is no need to add any */
-  /* index if no other columns are refered                       */
+  /* index if no other columns are referred                      */
 
   /* order of indexes are important, for an index to be considered all  */
   /* columns up to the column in question have to have been specified   */
@@ -3347,7 +3347,7 @@ void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath, 
     if (nullptr == m_pDS)
       return;
 
-    /* a little bit uggly, we clear first bookmark that is within one second of given */
+    /* a little bit ugly, we clear first bookmark that is within one second of given */
     /* should be no problem since we never add bookmarks that are closer than that   */
     double mintime = bookmark.timeInSeconds - 0.5;
     double maxtime = bookmark.timeInSeconds + 0.5;
@@ -11077,7 +11077,7 @@ CDateTime CVideoDatabase::GetDateAdded(const std::string& filename,
 {
   if (!dateAdded.IsValid())
   {
-    // supress warnings if we have plugin source
+    // suppress warnings if we have plugin source
     if (!URIUtils::IsPlugin(filename))
     {
       const auto dateAddedSetting =

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
@@ -31,7 +31,7 @@ public:
    \brief Creates a bookmark of the currently playing video file.
 
           NOTE: sends a GUI_MSG_REFRESH_LIST message to DialogVideoBookmark on success
-   \return True if creation of bookmark was succesful
+   \return True if creation of bookmark was successful
    \sa OnAddEpisodeBookmark
    */
   static bool OnAddBookmark();

--- a/xbmc/windowing/GraphicContext.h
+++ b/xbmc/windowing/GraphicContext.h
@@ -82,7 +82,7 @@ public:
 
   void Flip(bool rendered, bool videoLayer);
 
-  // gfx contect interface
+  // gfx context interface
   int GetWidth() const;
   int GetHeight() const;
   bool SetViewPort(float fx, float fy , float fwidth, float fheight, bool intersectPrevious = false);

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -135,7 +135,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
     // allow resolutions that are exact and have the correct refresh rate
-    // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+    // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
     if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
          (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
@@ -169,7 +169,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
       // allow resolutions that are exact and have double the refresh rate
-      // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+      // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
       if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
            (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
           (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
@@ -208,7 +208,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
       // allow resolutions that are exact and have 2.5 times the refresh rate
-      // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+      // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
       if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
            (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
           (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -84,7 +84,7 @@ CGBMUtils::CGBMDevice::CGBMSurface::CGBMSurfaceBuffer* CGBMUtils::CGBMDevice::CG
     /*
      * We want to use call_once here because we want it to be logged the first time that
      * we have to release buffers. This means that the maximum amount of buffers had been reached.
-     * For mesa this should be 4 buffers but it may vary accross other implementations.
+     * For mesa this should be 4 buffers but it may vary across other implementations.
      */
     std::call_once(
         flag, [this]() { CLog::Log(LOGDEBUG, "CGBMUtils - using {} buffers", m_buffers.size()); });

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -233,8 +233,8 @@ bool CWinSystemTVOS::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool b
 
 bool CWinSystemTVOS::SwitchToVideoMode(int width, int height, double refreshrate)
 {
-  /*! @todo Currently support SDR dynamic range only. HDR shouldnt be done during a
-   *  modeswitch. Look to create supplemental method to handle sdr/hdr enable
+  /*! @todo Currently support SDR dynamic range only. HDR shouldn't be done during
+   *  a modeswitch. Look to create supplemental method to handle sdr/hdr enable
    */
   [g_xbmcController.displayManager displayRateSwitch:refreshrate
                                     withDynamicRange:0 /*dynamicRange*/];

--- a/xbmc/windowing/wayland/Seat.cpp
+++ b/xbmc/windowing/wayland/Seat.cpp
@@ -227,7 +227,7 @@ void CSeat::HandlePointerCapability()
   };
   // Wayland groups pointer events, but right now there is no benefit in
   // treating them in groups. The main use case for doing so seems to be
-  // multi-axis (i.e. diagnoal) scrolling, but we do not support this anyway.
+  // multi-axis (i.e. diagonal) scrolling, but we do not support this anyway.
   /*m_pointer.on_frame() = [this]()
   {
 

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -611,7 +611,7 @@ bool CWinSystemWayland::SetResolutionExternal(bool fullScreen, RESOLUTION_INFO c
 bool CWinSystemWayland::ResizeWindow(int, int, int, int)
 {
   // CGraphicContext is "smart" and calls ResizeWindow or SetFullScreen depending
-  // on some state like wheter we were already full screen. But actually the processing
+  // on some state like whether we were already fullscreen. But actually the processing
   // here is always identical, so we are using a common function to handle both.
   auto& res = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);
   // The newWidth/newHeight parameters are taken from RES_WINDOW anyway, so we can just

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -249,7 +249,7 @@ bool CWinSystemWin10::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
   {
     if (state == WINDOW_STATE_WINDOWED) // go to a windowed state
     {
-      // need to restore resoultion if it was changed to not native
+      // need to restore resolution if it was changed to not native
       // because we do not support resolution change in windowed mode
       RestoreDesktopResolution();
     }

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -535,7 +535,7 @@ bool CWinSystemWin32::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
 
     if (state == WINDOW_STATE_WINDOWED) // go to a windowed state
     {
-      // need to restore resoultion if it was changed to not native
+      // need to restore resolution if it was changed to not native
       // because we do not support resolution change in windowed mode
       RestoreDesktopResolution(newMonitor);
     }

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -312,7 +312,7 @@ void CWinSystemWin32DX::InitHooks(IDXGIOutput* pOutput)
           }
           else
           {
-            CLog::Log(LOGDEBUG, __FUNCTION__": Unable ot install and activate D3D11 hook.");
+            CLog::Log(LOGDEBUG, __FUNCTION__": Unable to install and activate D3D11 hook.");
             s_fnOpenAdapter10_2 = nullptr;
             FreeLibrary(m_hDriverModule);
             m_hDriverModule = nullptr;

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -141,7 +141,7 @@ void CGUIWindowHome::OnJobComplete(unsigned int jobID, bool success, CJob *job)
     CSingleLock lockMe(*this);
 
     // the job is finished.
-    // did one come in in the meantime?
+    // did one come in the meantime?
     flag = m_cumulativeUpdateFlag;
     m_recentlyAddedRunning = false; /// we're done.
   }


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./lib/libUPnP/Neptune -L bloaded,busses,inout,lod,medias,parm`