### PR TITLE
Fix date of checking addons repositories updates

### DIFF
--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -233,7 +233,7 @@ void CRepositoryUpdater::ScheduleUpdate()
     return;
 
   int delta{1};
-  const auto nextCheck = ClosestNextCheck();
+  const auto nextCheck = std::max(CDateTime::GetCurrentDateTime(), ClosestNextCheck());
   if (nextCheck.IsValid())
   {
     // Repos were already checked once and we know when to check next


### PR DESCRIPTION
## Description
Bug calculating the date of the next update addons repositories. There is no check if the nextCheck value in the past. 

## Motivation and context
auto-updates need working correctly 

## How has this been tested?
on Addonds.db:
```
update  repo  set nextcheck ='2021-10-01 00:00:00';
```
after restart kodi in logs:
```
DEBUG <general>: CRepositoryUpdater: closest next update check at 10/01/2021 12:00:00 AM (in 1809748 s)
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
