### PR TITLE
[CMAKE] Fix "*-EXECUTABLE_NOTFOUND" if absolute path to file specified

### DIFF
--- a/cmake/modules/FindJsonSchemaBuilder.cmake
+++ b/cmake/modules/FindJsonSchemaBuilder.cmake
@@ -31,11 +31,13 @@ if(NOT TARGET JsonSchemaBuilder::JsonSchemaBuilder)
   else()
     if(WITH_JSONSCHEMABUILDER)
       get_filename_component(_jsbpath ${WITH_JSONSCHEMABUILDER} ABSOLUTE)
+      get_filename_component(_jsbpath ${_jsbpath} DIRECTORY)
       find_program(JSONSCHEMABUILDER_EXECUTABLE NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
-                                                PATHS ${_jsbpath})
+                                                HINTS ${_jsbpath})
 
       include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(JsonSchemaBuilder DEFAULT_MSG JSONSCHEMABUILDER_EXECUTABLE)
+      find_package_handle_standard_args(JsonSchemaBuilder "Could not find '${APP_NAME_LC}-JsonSchemaBuilder' or 'JsonSchemaBuilder' executable in ${_jsbpath} supplied by -DWITH_JSONSCHEMABUILDER. Make sure the executable file name matches these names!"
+                                        JSONSCHEMABUILDER_EXECUTABLE)
       if(JSONSCHEMABUILDER_FOUND)
         add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
         set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES

--- a/cmake/modules/FindTexturePacker.cmake
+++ b/cmake/modules/FindTexturePacker.cmake
@@ -31,11 +31,13 @@ if(NOT TARGET TexturePacker::TexturePacker)
   else()
     if(WITH_TEXTUREPACKER)
       get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
+      get_filename_component(_tppath ${_tppath} DIRECTORY)
       find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
-                                            PATHS ${_tppath})
+                                            HINTS ${_tppath})
 
       include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(TexturePacker DEFAULT_MSG TEXTUREPACKER_EXECUTABLE)
+      find_package_handle_standard_args(TexturePacker "Could not find '${APP_NAME_LC}-TexturePacker' or 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER. Make sure the executable file name matches these names!"
+                                        TEXTUREPACKER_EXECUTABLE)
       if(TEXTUREPACKER_FOUND)
         add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
         set_target_properties(TexturePacker::TexturePacker PROPERTIES


### PR DESCRIPTION
## Description

Fixes broken handling of `WITH_*` CMake configuration options:

  * `find_program` expects directory in PATHS and HINTS while `WITH_*` option is an absolute path to file.

  * `PATHS` in `find_program` is the last resort option which     declares hardcoded guesses utilized after all cached paths then directories specified by `HINTS`.

  * The filename passed via `WITH_*` can differ from `TexturePacker` or `${APP_NAME_LC}-TexturePacker`

This commit splits the full pathname to directory and filename then "searches" the filename in the directory, confirming file
exists there and is executable.

## Motivation and context

Fix the stupid and hard-detectable flaw that made me to force-push previous PR 7 times :(

## How has this been tested?

Cross-building Debian package.

## What is the effect on users?

Negligible

## Screenshots (if appropriate):

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed