### PR TITLE
[addons][audioencoder] rework CEncoderFFmpeg to become working again

### DIFF
--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -79,7 +79,7 @@ bool CCDDARipJob::DoWork()
   std::unique_ptr<CEncoder> encoder{};
   if (!reader.Open(m_input, READ_CACHED) || !(encoder = SetupEncoder(reader)))
   {
-    CLog::Log(LOGERROR, "CCDDARipJob::{} - Opening failed");
+    CLog::Log(LOGERROR, "CCDDARipJob::{} - Opening failed", __func__);
     return false;
   }
 

--- a/xbmc/cdrip/EncoderFFmpeg.h
+++ b/xbmc/cdrip/EncoderFFmpeg.h
@@ -35,15 +35,18 @@ public:
 private:
   static int avio_write_callback(void* opaque, uint8_t* buf, int buf_size);
   static int64_t avio_seek_callback(void* opaque, int64_t offset, int whence);
+
   void SetTag(const std::string& tag, const std::string& value);
   bool WriteFrame();
+  AVSampleFormat GetInputFormat(int inBitsPerSample);
+  std::string FFmpegErrorToString(int err);
 
-  AVFormatContext* m_Format{nullptr};
-  AVCodecContext* m_CodecCtx{nullptr};
-  SwrContext* m_SwrCtx{nullptr};
-  AVStream* m_Stream{nullptr};
-  AVSampleFormat m_InFormat;
-  AVSampleFormat m_OutFormat;
+  AVFormatContext* m_formatCtx{nullptr};
+  AVCodecContext* m_codecCtx{nullptr};
+  SwrContext* m_swrCtx{nullptr};
+  AVStream* m_stream{nullptr};
+  AVSampleFormat m_inFormat;
+  AVSampleFormat m_outFormat;
 
   /* From libavformat/avio.h:
    * The buffer size is very important for performance.
@@ -51,17 +54,20 @@ private:
    * blocksize.
    * For others a typical size is a cache page, e.g. 4kb.
    */
-  unsigned char m_BCBuffer[4096];
+  static constexpr size_t BUFFER_SIZE = 4096;
+  uint8_t* m_bcBuffer{nullptr};
 
-  unsigned int m_NeededFrames;
-  size_t m_NeededBytes;
-  uint8_t* m_Buffer{nullptr};
-  size_t m_BufferSize{0};
-  AVFrame* m_BufferFrame{nullptr};
-  uint8_t* m_ResampledBuffer{nullptr};
-  size_t m_ResampledBufferSize{0};
-  AVFrame* m_ResampledFrame{nullptr};
-  bool m_NeedConversion{false};
+  unsigned int m_neededFrames{0};
+  size_t m_neededBytes{0};
+  uint8_t* m_buffer{nullptr};
+  size_t m_bufferSize{0};
+  AVFrame* m_bufferFrame{nullptr};
+  uint8_t* m_resampledBuffer{nullptr};
+  size_t m_resampledBufferSize{0};
+  AVFrame* m_resampledFrame{nullptr};
+  bool m_needConversion{false};
+  int64_t m_samplesCount{0};
+  int64_t m_samplesCountMultiply{1000};
 };
 
 } /* namespace CDRIP */


### PR DESCRIPTION
## Description

At the beginning I only wanted to update it to have the current ffmpeg correct, but I noticed that it no longer worked in the previous version and therefore completely revised it.

In order to avoid the large number of ffmpeg free calls in the event of a failed initialization, I used a try / catch so that it only has to be done in one place.

It's just got really thick with changes :sweat_smile:.

At the moment the commits from https://github.com/xbmc/xbmc/pull/20428 are still in it, as it is based on this, after the other request is in it will be cleaned up here.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
