### PR TITLE
[darwin] improve OS version info

### DIFF
--- a/xbmc/platform/darwin/osx/Info.plist.in
+++ b/xbmc/platform/darwin/osx/Info.plist.in
@@ -22,6 +22,12 @@
 	<string>@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@.@APP_VERSION_TAG_LC@</string>
 	<key>CFBundleVersion</key>
 	<string>r####</string>
+	<!-- delete after raising SDK to 11 or later -->
+	<key>LSEnvironment</key>
+	<dict>
+		<key>SYSTEM_VERSION_COMPAT</key>
+		<string></string>
+	</dict>
 	<key>LSMinimumSystemVersion</key>
 	<string>@CMAKE_OSX_DEPLOYMENT_TARGET@</string>
 	<key>CFBundleSignature</key>

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -725,8 +725,11 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
     osNameVer.append(" unknown");
 #elif defined(TARGET_WINDOWS_STORE)
   osNameVer = GetKernelName() + " " + GetOsVersion();
-#elif defined(TARGET_FREEBSD) || defined(TARGET_DARWIN)
+#elif defined(TARGET_FREEBSD)
   osNameVer = GetOsName() + " " + GetOsVersion();
+#elif defined(TARGET_DARWIN)
+  osNameVer = StringUtils::Format("{} {} ({})", GetOsName(), GetOsVersion(),
+                                  CDarwinUtils::GetOSVersionString());
 #elif defined(TARGET_ANDROID)
   osNameVer =
       GetOsName() + " " + GetOsVersion() + " API level " + std::to_string(CJNIBuild::SDK_INT);

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -598,7 +598,7 @@ std::string CSysInfo::GetOsName(bool emptyIfUnknown /* = false*/)
 #elif defined(TARGET_DARWIN_TVOS)
     osName = "tvOS";
 #elif defined(TARGET_DARWIN_OSX)
-    osName = "OS X";
+    osName = "macOS";
 #elif defined (TARGET_ANDROID)
     osName = "Android";
 #elif defined(TARGET_LINUX)
@@ -1268,7 +1268,7 @@ std::string CSysInfo::GetBuildDate()
 std::string CSysInfo::GetBuildTargetPlatformName(void)
 {
 #if defined(TARGET_DARWIN_OSX)
-  return "OS X";
+  return "macOS";
 #elif defined(TARGET_DARWIN_IOS)
   return "iOS";
 #elif defined(TARGET_DARWIN_TVOS)

--- a/xbmc/utils/test/TestSystemInfo.cpp
+++ b/xbmc/utils/test/TestSystemInfo.cpp
@@ -107,8 +107,10 @@ TEST_F(TestSystemInfo, GetOsName)
   EXPECT_STREQ("tvOS", g_sysinfo.GetOsName(false).c_str())
       << "'GetOsName(false)' must return 'tvOS'";
 #elif defined(TARGET_DARWIN_OSX)
-  EXPECT_STREQ("OS X", g_sysinfo.GetOsName(true).c_str()) << "'GetOsName(true)' must return 'OS X'";
-  EXPECT_STREQ("OS X", g_sysinfo.GetOsName(false).c_str()) << "'GetOsName(false)' must return 'OS X'";
+  EXPECT_STREQ("macOS", g_sysinfo.GetOsName(true).c_str())
+      << "'GetOsName(true)' must return 'macOS'";
+  EXPECT_STREQ("macOS", g_sysinfo.GetOsName(false).c_str())
+      << "'GetOsName(false)' must return 'macOS'";
 #elif defined(TARGET_ANDROID)
   EXPECT_STREQ("Android", g_sysinfo.GetOsName(true).c_str()) << "'GetOsName(true)' must return 'Android'";
   EXPECT_STREQ("Android", g_sysinfo.GetOsName(false).c_str()) << "'GetOsName(false)' must return 'Android'";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
1. Renames `OS X` to `macOS`
2. Enables reading real macOS version for macOS >= 11 (Big Sur and later)
3. Displays additional OS version info.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When app is compiled with macOS SDK < 11, then OS version on macOS >= 11 is reported as `10.16` regardless of the real one. To solve it without raising SDK, `SYSTEM_VERSION_COMPAT` environment variable must be unset or set to 0. More on this: https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/

Besides, full OS version including build number is now shown on all Darwin OSs in System Info and log.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime tested with a build from jenkins before creating the PR: https://mirrors.kodi.tv/test-builds/osx/x86_64/kodi-20211031-da416c64-macos-version-x86_64.dmg

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users are now able to see correct macOS version when running on Big Sur and later.

## Screenshots (if appropriate):

macOS:
![Screenshot 2021-10-31 at 20 25 25](https://user-images.githubusercontent.com/1557784/139595383-cec3f37c-76ec-4855-9711-82874cedbfe3.png)

iOS:
![Screen Shot 2021-10-31 at 20 33 50](https://user-images.githubusercontent.com/1557784/139595389-8db79b9f-0ca9-47fa-8cc3-81d0799b121e.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
