### PR TITLE
[addons] allow auto pinning for manually installed add-ons

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -59,7 +59,8 @@ enum class AddonUpdateRule
 {
   ANY = 0, //!< used internally, not to be explicitly set
   USER_DISABLED_AUTO_UPDATE = 1, //!< automatic updates disabled via AddonInfo dialog
-  PIN_OLD_VERSION = 2 //!< user downgraded to an older version
+  PIN_OLD_VERSION = 2, //!< user downgraded to an older version
+  PIN_ZIP_INSTALL = 3, //!< user installed manually from zip
 };
 
 /*!


### PR DESCRIPTION
## Description
when an add-on is installed manually from zip-file - and the version being installed is lesser than the latest version available from repository - auto-update for this particular add-on will be deactivated.

## How has this been tested?
tested with `plugin.video.youtube` (version `6.8.18+matrix.1` was latest from the repo at this point in time)

```
first installed youtube add-on from official kodi repository:
DEBUG <general>: ADDONS: unpinned Addon: [plugin.video.youtube] Origin: [repository.xbmc.org] Version: [6.8.18+matrix.1] 

next installed 6.8.16+matrix.1 from downloaded zip-file
DEBUG <general>: ADDONS: pinned zip installed Addon: [plugin.video.youtube] Version: [6.8.16+matrix.1]

next installed 6.8.18+matrix.1 from downloaded zip-file
DEBUG <general>: ADDONS: unpinned zip installed Addon: [plugin.video.youtube] Version: [6.8.18+matrix.1]

finally reinstalled the current version from the repo:
DEBUG <general>: ADDONS: unpinned Addon: [plugin.video.youtube] Origin: [repository.xbmc.org] Version: [6.8.18+matrix.1] 
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

please @matthuisman @anxdpanic @phunkyfish for review and / or testing

i think this is working now like it was originally intended :-\
