### PR TITLE
[PAPlayer] use CURL value instead of extension by CodecFactory::CreateCodec

### DIFF
--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -17,9 +17,9 @@
 
 using namespace ADDON;
 
-ICodec* CodecFactory::CreateCodec(const std::string &strFileType)
+ICodec* CodecFactory::CreateCodec(const CURL& urlFile)
 {
-  std::string fileType = strFileType;
+  std::string fileType = urlFile.GetFileType();
   StringUtils::ToLower(fileType);
 
   std::vector<AddonInfoPtr> addonInfos;
@@ -110,6 +110,6 @@ ICodec* CodecFactory::CreateCodecDemux(const CFileItem& file, unsigned int filec
     return dvdcodec;
   }
   else
-    return CreateCodec(urlFile.GetFileType());
+    return CreateCodec(urlFile);
 }
 

--- a/xbmc/cores/paplayer/CodecFactory.h
+++ b/xbmc/cores/paplayer/CodecFactory.h
@@ -17,7 +17,7 @@ class CodecFactory
 public:
   CodecFactory() = default;
   virtual ~CodecFactory() = default;
-  static ICodec* CreateCodec(const std::string &type);
+  static ICodec* CreateCodec(const CURL& urlFile);
   static ICodec* CreateCodecDemux(const CFileItem& file, unsigned int filecache);
 };
 


### PR DESCRIPTION
## Description

Before was only a string with extension given, this makes it then hard for the binary addons to check about support of asked file. As now the CURL is used is also the full path available and addon can check it.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
With https://github.com/xbmc/xbmc/pull/20443 the requirement as std::string was removed and now can use CURL direct.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

With audiodecoder addons, as them the only one where needs the filetype.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
