### PR TITLE
[Subtitles][WebVTT] Add escape chars translations

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -161,12 +161,19 @@ std::string ConvertStyleToCloseTags(int flagTags[],
   return tags;
 }
 
-void TranslateDirectionalChars(std::string& text)
+void TranslateEscapeChars(std::string& text)
 {
-  StringUtils::Replace(text, "&lrm;", u8"\u200e");
-  StringUtils::Replace(text, "&rlm;", u8"\u200f");
-  StringUtils::Replace(text, "&#x2068;", u8"\u2068");
-  StringUtils::Replace(text, "&#x2069;", u8"\u2069");
+  if (text.find('&') != std::string::npos)
+  {
+    StringUtils::Replace(text, "&lrm;", u8"\u200e");
+    StringUtils::Replace(text, "&rlm;", u8"\u200f");
+    StringUtils::Replace(text, "&#x2068;", u8"\u2068");
+    StringUtils::Replace(text, "&#x2069;", u8"\u2069");
+    StringUtils::Replace(text, "&amp;", "&");
+    StringUtils::Replace(text, "&lt;", "<");
+    StringUtils::Replace(text, "&gt;", ">");
+    StringUtils::Replace(text, "&nbsp;", " ");
+  }
 }
 
 } // unnamed namespace
@@ -333,7 +340,7 @@ void CWebVTTHandler::DecodeLine(std::string line, std::vector<subtitleData>* sub
         if (!m_subtitleData.text.empty())
           m_subtitleData.text += "\n";
 
-        TranslateDirectionalChars(line);
+        TranslateEscapeChars(line);
 
         // We need to calculate the text position right here,
         // when we have the first subtitle text line


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add missing escape chars translations,
i have found them in the old webvtt documentation https://www.w3.org/2013/07/webvtt.html

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some subtitles in Net***x make use of escape chars, then this fixes #20446

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have replied the same situation explained in the Issue thread (note, this require ISAdaptive webvtt PR not merged yet)
or else can be tested with external files

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
e.g. display `&` instead of `&amp;`

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
