### PR TITLE
XTimeUtils: Prevent array index out of bounds access in SystemTimeToFileTime

### DIFF
--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -110,6 +110,10 @@ int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime)
   static std::atomic_flag timegm_lock = ATOMIC_FLAG_INIT;
 #endif
 
+  // Prevent out of bounds access in dayoffset array
+  if (systemTime->month < 1 || systemTime->month > 12)
+    return 0;
+
   struct tm sysTime = {};
   sysTime.tm_year = systemTime->year - 1900;
   sysTime.tm_mon = systemTime->month - 1;

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -94,7 +94,8 @@ int FileTimeToLocalFileTime(const FileTime* fileTime, FileTime* localFileTime)
   time_t ft;
   struct tm tm_ft;
   FileTimeToTimeT(fileTime, &ft);
-  localtime_r(&ft, &tm_ft);
+  if (!localtime_r(&ft, &tm_ft))
+    return 0;
 
   l.QuadPart += static_cast<unsigned long long>(tm_ft.tm_gmtoff) * 10000000;
 
@@ -139,6 +140,9 @@ int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime)
   time_t t = timegm(&sysTime);
 #endif
 
+  if (t == -1 && errno != 0)
+    return 0;
+
   LARGE_INTEGER result;
   result.QuadPart = (long long)t * 10000000 + (long long)systemTime->milliseconds * 10000;
   result.QuadPart += WIN32_TIME_OFFSET;
@@ -181,7 +185,8 @@ int FileTimeToSystemTime(const FileTime* fileTime, SystemTime* systemTime)
   time_t ft = file.QuadPart;
 
   struct tm tm_ft;
-  gmtime_r(&ft,&tm_ft);
+  if (!gmtime_r(&ft, &tm_ft))
+    return 0;
 
   systemTime->year = tm_ft.tm_year + 1900;
   systemTime->month = tm_ft.tm_mon + 1;
@@ -225,10 +230,14 @@ int FileTimeToTimeT(const FileTime* localFileTime, time_t* pTimeT)
   time_t ft = fileTime.QuadPart;
 
   struct tm tm_ft;
-  localtime_r(&ft,&tm_ft);
+  if (!localtime_r(&ft, &tm_ft))
+    return 0;
 
   *pTimeT = mktime(&tm_ft);
-  return 1;
+  if (*pTimeT == -1 && errno != 0)
+    return 0;
+  else
+    return 1;
 }
 
 int TimeTToFileTime(time_t timeT, FileTime* localFileTime)


### PR DESCRIPTION
## Description
Prevent array index out of bounds access if invalid date is passed to SystemTimeToFileTime on POSIX systems.

## Motivation and context
A video addon was passing a date in the wrong format to Kodi resulting in this array index out of bounds access:
```
=================================================================
==29104==ERROR: AddressSanitizer: global-buffer-overflow on address 0x563a73d6ebb0 at pc 0x563a6a4151ee bp 0x7efdfa7b70b0 sp 0x7efdfa7b70a8
READ of size 4 at 0x563a73d6ebb0 thread T105 (LanguageInvoker)
    #0 0x563a6a4151ed in KODI::TIME::SystemTimeToFileTime(KODI::TIME::SystemTime const*, KODI::TIME::FileTime*) xbmc/platform/posix/XTimeUtils.cpp:121:21
    #1 0x563a6e6de924 in CDateTime::ToFileTime(KODI::TIME::SystemTime const&, KODI::TIME::FileTime&) const xbmc/XBDateTime.cpp:635:10
    #2 0x563a6e6e09aa in CDateTime::SetDateTime(int, int, int, int, int, int) xbmc/XBDateTime.cpp:791:13
    #3 0x563a6e6ebcbf in CDateTime::SetDate(int, int, int) xbmc/XBDateTime.cpp:797:10
    #4 0x563a6e6ea5b1 in CDateTime::SetFromDBDate(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) xbmc/XBDateTime.cpp:1052:10
    #5 0x563a6e6e8e4a in CDateTime::SetFromDateString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) xbmc/XBDateTime.cpp:687:7
    #6 0x563a6a0e86b3 in XBMCAddon::xbmc::InfoTagVideo::setFirstAiredRaw(CVideoInfoTag*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) xbmc/interfaces/legacy/InfoTagVideo.cpp:944:22
    #7 0x563a6a138097 in XBMCAddon::xbmcgui::ListItem::setInfo(char const*, XBMCAddon::Dictionary<XBMCAddon::Alternative<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<XBMCAddon::Alternative<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, XBMCAddon::Tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, XBMCAddon::tuple_null_type, XBMCAddon::tuple_null_type, XBMCAddon::tuple_null_type> >, std::allocator<XBMCAddon::Alternative<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, XBMCAddon::Tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, XBMCAddon::tuple_null_type, XBMCAddon::tuple_null_type, XBMCAddon::tuple_null_type> > > > > > const&) xbmc/interfaces/legacy/ListItem.cpp:516:15
    #8 0x563a69c32733 in PythonBindings::xbmcgui_XBMCAddon_xbmcgui_ListItem_setInfo(PythonBindings::PyHolder*, _object*, _object*) /home/mark/Coding/Repos/kodi-git/build/build/swig/AddonModuleXbmcgui.i.cpp:1916:11
    #9 0x7efe31957edd  (/usr/lib/libpython3.9.so.1.0+0x148edd)
    #10 0x7efe31940332 in _PyObject_MakeTpCall (/usr/lib/libpython3.9.so.1.0+0x131332)
    #11 0x7efe3193c3be in _PyEval_EvalFrameDefault (/usr/lib/libpython3.9.so.1.0+0x12d3be)
    #12 0x7efe31935fd8  (/usr/lib/libpython3.9.so.1.0+0x126fd8)
    #13 0x7efe31947b8d in _PyFunction_Vectorcall (/usr/lib/libpython3.9.so.1.0+0x138b8d)
    #14 0x7efe319568a3  (/usr/lib/libpython3.9.so.1.0+0x1478a3)
    #15 0x7efe3193818a in _PyEval_EvalFrameDefault (/usr/lib/libpython3.9.so.1.0+0x12918a)
    #16 0x7efe3194796a in _PyFunction_Vectorcall (/usr/lib/libpython3.9.so.1.0+0x13896a)
    #17 0x7efe3193758d in _PyEval_EvalFrameDefault (/usr/lib/libpython3.9.so.1.0+0x12858d)
    #18 0x7efe3194796a in _PyFunction_Vectorcall (/usr/lib/libpython3.9.so.1.0+0x13896a)
    #19 0x7efe3193758d in _PyEval_EvalFrameDefault (/usr/lib/libpython3.9.so.1.0+0x12858d)
    #20 0x7efe3194796a in _PyFunction_Vectorcall (/usr/lib/libpython3.9.so.1.0+0x13896a)
    #21 0x7efe3193758d in _PyEval_EvalFrameDefault (/usr/lib/libpython3.9.so.1.0+0x12858d)
    #22 0x7efe31935fd8  (/usr/lib/libpython3.9.so.1.0+0x126fd8)
    #23 0x7efe31935c40 in _PyEval_EvalCodeWithName (/usr/lib/libpython3.9.so.1.0+0x126c40)
    #24 0x7efe319ecae2 in PyEval_EvalCode (/usr/lib/libpython3.9.so.1.0+0x1ddae2)
    #25 0x7efe319fc9f3  (/usr/lib/libpython3.9.so.1.0+0x1ed9f3)
    #26 0x7efe319f86ca  (/usr/lib/libpython3.9.so.1.0+0x1e96ca)
    #27 0x7efe318a62d2  (/usr/lib/libpython3.9.so.1.0+0x972d2)
    #28 0x7efe31919ea3 in PyRun_FileExFlags (/usr/lib/libpython3.9.so.1.0+0x10aea3)
    #29 0x563a69f32112 in CPythonInvoker::executeScript(_IO_FILE*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, _object*) xbmc/interfaces/python/PythonInvoker.cpp:443:3
    #30 0x563a69f2d314 in CPythonInvoker::execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >, std::allocator<std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > > > const&) xbmc/interfaces/python/PythonInvoker.cpp:334:9
    #31 0x563a69f289ce in CPythonInvoker::execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) xbmc/interfaces/python/PythonInvoker.cpp:160:10
    #32 0x563a70531f53 in ILanguageInvoker::Execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) xbmc/interfaces/generic/ILanguageInvoker.cpp:29:10
    #33 0x563a69f2837d in CPythonInvoker::Execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) xbmc/interfaces/python/PythonInvoker.cpp:148:28
    #34 0x563a70536642 in CLanguageInvokerThread::Process() xbmc/interfaces/generic/LanguageInvokerThread.cpp:107:16
    #35 0x563a70536ff8 in non-virtual thunk to CLanguageInvokerThread::Process() xbmc/interfaces/generic/LanguageInvokerThread.cpp
    #36 0x563a6c460121 in CThread::Action() xbmc/threads/Thread.cpp:273:5
    #37 0x563a6c462b07 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/threads/Thread.cpp:139:18
    #38 0x563a6c461c11 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:61:14
    #39 0x563a6c4616f5 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:96:14
    #40 0x563a6c461593 in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:253:13
    #41 0x563a6c461358 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:260:11
    #42 0x563a6c460f88 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > > >::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:211:13
    #43 0x7efe2e8393c3 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:82:18
    #44 0x7efe3213c258 in start_thread (/usr/lib/libpthread.so.0+0x9258)
    #45 0x7efe2f3965e2 in clone (/usr/lib/libc.so.6+0xfe5e2)

0x563a73d6ebb0 is located 0 bytes to the right of global variable 'dayoffset' defined in 'xbmc/platform/posix/XTimeUtils.cpp:108:20' (0x563a73d6eb80) of size 48
SUMMARY: AddressSanitizer: global-buffer-overflow xbmc/platform/posix/XTimeUtils.cpp:121:21 in KODI::TIME::SystemTimeToFileTime(KODI::TIME::SystemTime const*, KODI::TIME::FileTime*)
Shadow bytes around the buggy address:
  0x0ac7ce7a5d20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac7ce7a5d30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac7ce7a5d40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac7ce7a5d50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac7ce7a5d60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0ac7ce7a5d70: 00 00 00 00 00 00[f9]f9 f9 f9 f9 f9 00 00 00 00
  0x0ac7ce7a5d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac7ce7a5d90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac7ce7a5da0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac7ce7a5db0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f9
  0x0ac7ce7a5dc0: f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
Thread T105 (LanguageInvoker) created by T104 (waiting) here:
    #0 0x563a69438bf4 in pthread_create (/home/mark/Coding/Repos/kodi-git/build/kodi-wayland+0x258bebf4)
    #1 0x7efe2e8396aa in __gthread_create /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x7efe2e8396aa in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x563a6c45d869 in CThread::Create(bool) xbmc/threads/Thread.cpp:97:20
    #4 0x563a70534d15 in CLanguageInvokerThread::execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) xbmc/interfaces/generic/LanguageInvokerThread.cpp:59:5
    #5 0x563a70531f53 in ILanguageInvoker::Execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) xbmc/interfaces/generic/ILanguageInvoker.cpp:29:10
    #6 0x563a70543f6c in CScriptInvocationManager::ExecuteAsync(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<ILanguageInvoker> const&, std::shared_ptr<ADDON::IAddon> const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, int) xbmc/interfaces/generic/ScriptInvocationManager.cpp:290:18
    #7 0x563a7054141a in CScriptInvocationManager::ExecuteAsync(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<ADDON::IAddon> const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, int) xbmc/interfaces/generic/ScriptInvocationManager.cpp:238:10
    #8 0x563a705698d2 in CScriptRunner::ExecuteScript(std::shared_ptr<ADDON::IAddon> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, bool) xbmc/interfaces/generic/ScriptRunner.cpp:86:58
    #9 0x563a70567387 in CScriptRunner::RunScriptInternal(std::shared_ptr<ADDON::IAddon> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, bool, bool) xbmc/interfaces/generic/ScriptRunner.cpp:109:18
    #10 0x563a70567bb0 in CScriptRunner::RunScript(std::shared_ptr<ADDON::IAddon> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, bool) xbmc/interfaces/generic/ScriptRunner.cpp:45:10
    #11 0x563a70bc24e6 in CRunningScriptsHandler<XFILE::CPluginDirectory>::RunScript(XFILE::CPluginDirectory*, std::shared_ptr<ADDON::IAddon> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) xbmc/interfaces/generic/RunningScriptsHandler.h:50:34
    #12 0x563a70ba8a6d in XFILE::CPluginDirectory::StartScript(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) xbmc/filesystem/PluginDirectory.cpp:94:10
    #13 0x563a70bbbfd9 in XFILE::CPluginDirectory::GetDirectory(CURL const&, CFileItemList&) xbmc/filesystem/PluginDirectory.cpp:403:18
    #14 0x563a70a715c1 in XFILE::CDirectory::GetDirectory(CURL const&, std::shared_ptr<XFILE::IDirectory> const&, CFileItemList&, XFILE::CDirectory::CHints const&) xbmc/filesystem/Directory.cpp:197:30
    #15 0x563a70a6fd90 in XFILE::CDirectory::GetDirectory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<XFILE::IDirectory> const&, CFileItemList&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) xbmc/filesystem/Directory.cpp:138:10
    #16 0x563a70c46338 in XFILE::CVirtualDirectory::GetDirectory(CURL const&, CFileItemList&, bool, bool) xbmc/filesystem/VirtualDirectory.cpp:70:16
    #17 0x563a6bbae482 in (anonymous namespace)::CGetDirectoryItems::Run() xbmc/windows/GUIMediaWindow.cpp:92:22
    #18 0x563a6c45fc25 in CThread::Process() xbmc/threads/Thread.cpp:212:18
    #19 0x563a6d286b7a in CBusyWaiter::Process() xbmc/dialogs/GUIDialogBusy.cpp:58:14
    #20 0x563a6c460121 in CThread::Action() xbmc/threads/Thread.cpp:273:5
    #21 0x563a6c462b07 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/threads/Thread.cpp:139:18
    #22 0x563a6c461c11 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:61:14
    #23 0x563a6c4616f5 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/invoke.h:96:14
    #24 0x563a6c461593 in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:253:13
    #25 0x563a6c461358 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:260:11
    #26 0x563a6c460f88 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > > >::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/std_thread.h:211:13
    #27 0x7efe2e8393c3 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:82:18

Thread T104 (waiting) created by T0 here:
    #0 0x563a69438bf4 in pthread_create (/home/mark/Coding/Repos/kodi-git/build/kodi-wayland+0x258bebf4)
    #1 0x7efe2e8396aa in __gthread_create /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x7efe2e8396aa in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x563a6c45d869 in CThread::Create(bool) xbmc/threads/Thread.cpp:97:20
    #4 0x563a6d285d38 in CBusyWaiter::Wait(unsigned int, bool) xbmc/dialogs/GUIDialogBusy.cpp:36:5
    #5 0x563a6d282721 in CGUIDialogBusy::Wait(IRunnable*, unsigned int, bool) xbmc/dialogs/GUIDialogBusy.cpp:69:15
    #6 0x563a6bbad863 in CGUIMediaWindow::WaitGetDirectoryItems((anonymous namespace)::CGetDirectoryItems&) xbmc/windows/GUIMediaWindow.cpp:2264:10
    #7 0x563a6bb7a378 in CGUIMediaWindow::GetDirectoryItems(CURL&, CFileItemList&, bool) xbmc/windows/GUIMediaWindow.cpp:2231:10
    #8 0x563a6bb76e0e in CGUIMediaWindow::GetDirectory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CFileItemList&) xbmc/windows/GUIMediaWindow.cpp:756:10
    #9 0x563a6b25dc42 in CGUIWindowVideoBase::GetDirectory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CFileItemList&) xbmc/video/windows/GUIWindowVideoBase.cpp:1320:35
    #10 0x563a6b29c248 in CGUIWindowVideoNav::GetDirectory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CFileItemList&) xbmc/video/windows/GUIWindowVideoNav.cpp:361:39
    #11 0x563a6bb7c826 in CGUIMediaWindow::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) xbmc/windows/GUIMediaWindow.cpp:843:8
    #12 0x563a6b25d269 in CGUIWindowVideoBase::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) xbmc/video/windows/GUIWindowVideoBase.cpp:1308:25
    #13 0x563a6b29a939 in CGUIWindowVideoNav::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) xbmc/video/windows/GUIWindowVideoNav.cpp:324:29
    #14 0x563a6bb85ea0 in CGUIMediaWindow::Refresh(bool) xbmc/windows/GUIMediaWindow.cpp:968:8
    #15 0x563a6bb618fe in CGUIMediaWindow::OnMessage(CGUIMessage&) xbmc/windows/GUIMediaWindow.cpp:575:9
    #16 0x563a6b225522 in CGUIWindowVideoBase::OnMessage(CGUIMessage&) xbmc/video/windows/GUIWindowVideoBase.cpp:124:31
    #17 0x563a6b291e3d in CGUIWindowVideoNav::OnMessage(CGUIMessage&) xbmc/video/windows/GUIWindowVideoNav.cpp:119:33
    #18 0x563a6d0a9aac in CGUIWindowManager::SendMessage(CGUIMessage&, int) xbmc/guilib/GUIWindowManager.cpp:558:21
    #19 0x563a6d0cf7f0 in CGUIWindowManager::DispatchThreadMessages() xbmc/guilib/GUIWindowManager.cpp:1526:7
    #20 0x563a6e1f632d in CApplication::Process() xbmc/Application.cpp:4080:48
    #21 0x563a6e6d9e2f in CXBApplicationEx::Run(CAppParamParser const&) xbmc/XBApplicationEx.cpp:62:5
    #22 0x563a6c5cf406 in XBMC_Run xbmc/platform/xbmc.cpp:64:26
    #23 0x563a69503c8e in main xbmc/platform/posix/main.cpp:61:10
    #24 0x7efe2f2bfb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

==29104==ABORTING
```
The second commit adds some error checking after some time functions are called.

## How has this been tested?
Invalid dates from the addon don't cause out of bound access anymore.

## What is the effect on users?
Could have caused crashed or other unpredictable behaviour.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
