### PR TITLE
[addons] display "manually installed" in dialog instead of empty string

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22335,10 +22335,14 @@ msgstr ""
 #. Text for yes/no dialog when silently uninstalling an addon
 #: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 msgctxt "#39028"
-msgid "Addon \"{0:s}\"[CR]Origin \"{1:s}\"[CR]Version \"{2:s}\"[CR]- will uninstall and be replaced. Would you like to proceed?"
+msgid "Addon: {0:s}[CR]Origin: {1:s}[CR]Version: {2:s}[CR]- will be uninstalled and replaced. Would you like to proceed?"
 msgstr ""
 
-#empty string with id 39029
+#. Text for yes/no dialog to indicate that an add-on was manually installed
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#39029"
+msgid "Manually installed"
+msgstr ""
 
 #. Media source, a filter and smart playlist rule option
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -438,10 +438,12 @@ void CGUIDialogAddonInfo::OnInstall()
   {
     if (m_localAddon->Origin() != origin && m_localAddon->Origin() != ORIGIN_SYSTEM)
     {
-      const std::string& header = g_localizeStrings.Get(19098); // Warning!
+      const std::string header = g_localizeStrings.Get(19098); // Warning!
+      const std::string origin =
+          !m_localAddon->Origin().empty() ? m_localAddon->Origin() : g_localizeStrings.Get(39029);
       const std::string text =
-          StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->ID(),
-                              m_localAddon->Origin(), m_localAddon->Version().asString());
+          StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->Name(), origin,
+                              m_localAddon->Version().asString());
 
       if (CGUIDialogYesNo::ShowAndGetInput(header, text))
       {


### PR DESCRIPTION
## Description
not a big deal but displaying an empty origin string is confusing when switching an add-on from 'manually installed' to repo version.

![screenshot00000](https://user-images.githubusercontent.com/58829855/139841981-b099beff-e969-437c-9fa5-bd6350e9f7ff.png)

display `manually installed` there.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
