### PR TITLE
[addons] fix win32 builds by use of ATTR_APIENTRY and reduce line length about ATTRIBUTE_FORCEINLINE

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -61,11 +61,15 @@
 
 // Generic helper definitions for shared library support
 //@{
-#if defined _WIN32 || defined __CYGWIN__
+#if defined _WIN32 || defined _WIN64 || defined __CYGWIN__
 #define ATTR_DLL_IMPORT __declspec(dllimport)
 #define ATTR_DLL_EXPORT __declspec(dllexport)
 #define ATTR_DLL_LOCAL
+#ifdef _WIN64
 #define ATTR_APIENTRY __stdcall
+#else
+#define ATTR_APIENTRY __cdecl
+#endif
 #else
 #if __GNUC__ >= 4
 #define ATTR_DLL_IMPORT __attribute__((visibility("default")))

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -45,17 +45,17 @@
 // Generic helper definitions for inline function support
 //@{
 #ifdef _MSC_VER
-#define ATTRIBUTE_FORCEINLINE __forceinline
+#define ATTR_FORCEINLINE __forceinline
 #elif defined(__GNUC__)
-#define ATTRIBUTE_FORCEINLINE inline __attribute__((__always_inline__))
+#define ATTR_FORCEINLINE inline __attribute__((__always_inline__))
 #elif defined(__CLANG__)
 #if __has_attribute(__always_inline__)
-#define ATTRIBUTE_FORCEINLINE inline __attribute__((__always_inline__))
+#define ATTR_FORCEINLINE inline __attribute__((__always_inline__))
 #else
-#define ATTRIBUTE_FORCEINLINE inline
+#define ATTR_FORCEINLINE inline
 #endif
 #else
-#define ATTRIBUTE_FORCEINLINE inline
+#define ATTR_FORCEINLINE inline
 #endif
 //@}
 
@@ -88,6 +88,7 @@
 #endif
 
 // Fallbacks to old
+#define ATTRIBUTE_FORCEINLINE ATTR_FORCEINLINE
 #define ATTRIBUTE_DLL_IMPORT ATTR_DLL_IMPORT
 #define ATTRIBUTE_DLL_EXPORT ATTR_DLL_EXPORT
 #define ATTRIBUTE_DLL_LOCAL ATTR_DLL_LOCAL


### PR DESCRIPTION
## Description

Commit 1:
--------------------
**[addons] fix win32 builds by use of ATTR_APIENTRY**

There before was as __stdcall by windows builds, but as this not works by 32 bit becomes now a new `#ifdef` added to separate between 32 and 64 bit.
The 64 bit uses "__stdcall" and the 32 bit "__cdecl".

Related error before was:
```
cannot convert from 'bool (__cdecl *)(KODI_ADDON_AUDIODECODER_HDL,const char *)' to 'PFN_KODI_ADDON_AUDIODECODER_SUPPORTS_FILE_V1'
```
Commit 2:
--------------------
**[addons] reduce line length about ATTRIBUTE_FORCEINLINE**

This reduce the length about ATTRIBUTE_FORCEINLINE to ATTR_FORCEINLINE. The others before ATTR_APIENTRY and ATTR_DLL_... was already reduced in length. For here now to have equal.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
