### PR TITLE
[backport] XTimeUtils: Prevent array index out of bounds access in SystemTimeToFileTime

### DIFF
--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -110,6 +110,10 @@ int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime)
   static std::atomic_flag timegm_lock = ATOMIC_FLAG_INIT;
 #endif
 
+  // Prevent out of bounds access in dayoffset array
+  if (systemTime->month < 1 || systemTime->month > 12)
+    return 0;
+
   struct tm sysTime = {};
   sysTime.tm_year = systemTime->year - 1900;
   sysTime.tm_mon = systemTime->month - 1;

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -94,7 +94,8 @@ int FileTimeToLocalFileTime(const FileTime* fileTime, FileTime* localFileTime)
   time_t ft;
   struct tm tm_ft;
   FileTimeToTimeT(fileTime, &ft);
-  localtime_r(&ft, &tm_ft);
+  if (!localtime_r(&ft, &tm_ft))
+    return 0;
 
   l.QuadPart += static_cast<unsigned long long>(tm_ft.tm_gmtoff) * 10000000;
 
@@ -139,6 +140,9 @@ int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime)
   time_t t = timegm(&sysTime);
 #endif
 
+  if (t == -1 && errno != 0)
+    return 0;
+
   LARGE_INTEGER result;
   result.QuadPart = (long long)t * 10000000 + (long long)systemTime->milliseconds * 10000;
   result.QuadPart += WIN32_TIME_OFFSET;
@@ -181,7 +185,8 @@ int FileTimeToSystemTime(const FileTime* fileTime, SystemTime* systemTime)
   time_t ft = file.QuadPart;
 
   struct tm tm_ft;
-  gmtime_r(&ft,&tm_ft);
+  if (!gmtime_r(&ft, &tm_ft))
+    return 0;
 
   systemTime->year = tm_ft.tm_year + 1900;
   systemTime->month = tm_ft.tm_mon + 1;
@@ -225,10 +230,14 @@ int FileTimeToTimeT(const FileTime* localFileTime, time_t* pTimeT)
   time_t ft = fileTime.QuadPart;
 
   struct tm tm_ft;
-  localtime_r(&ft,&tm_ft);
+  if (!localtime_r(&ft, &tm_ft))
+    return 0;
 
   *pTimeT = mktime(&tm_ft);
-  return 1;
+  if (*pTimeT == -1 && errno != 0)
+    return 0;
+  else
+    return 1;
 }
 
 int TimeTToFileTime(time_t timeT, FileTime* localFileTime)


### PR DESCRIPTION
## Description
Backport of #20451.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
