### PR TITLE
[Subtitles] Fix RTL direction with adapted subtitles

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -30,6 +30,8 @@ constexpr int ASS_BORDER_STYLE_OUTLINE = 1; // Outline + drop shadow
 constexpr int ASS_BORDER_STYLE_BOX = 3; // Box + drop shadow
 constexpr int ASS_BORDER_STYLE_SQUARE_BOX = 4; // Square box + outline
 
+constexpr int ASS_FONT_ENCODING_AUTO = -1;
+
 // Directory where user defined fonts are located (and where mkv fonts are extracted to)
 constexpr const char* userFontPath = "special://home/media/Fonts/";
 // Directory where Kodi bundled fonts (default ones like Arial or Teletext) are located
@@ -320,6 +322,10 @@ void CDVDSubtitlesLibass::ApplyStyle(style subStyle, renderOpts opts)
       // Extra space between characters causes the underlined
       // text line to become more discontinuous (test on LibAss 15.1)
       style->Spacing = 0;
+
+      // Set automatic paragraph direction (not VSFilter-compatible)
+      // to fix wrong RTL text direction when there are unicode chars
+      style->Encoding = ASS_FONT_ENCODING_AUTO;
 
       bool isFontBold =
           (subStyle.fontStyle == FontStyle::BOLD || subStyle.fontStyle == FontStyle::BOLD_ITALIC);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
RTL subtitles are displayed wrongly, i have compared WebVTT subtitle case from Kodi 19

Current (wrong):
![shintel_wrong](https://user-images.githubusercontent.com/3257156/140076069-158b3756-af81-434b-bb7b-dd6bfbf0cdd8.jpg)

After (right):
![shintel_good](https://user-images.githubusercontent.com/3257156/140076129-54d285bb-c091-440e-b33a-0b6c3bbdd73f.jpg)

The PR is as draft because is still needed to test:
- [x] Native ASS RTL subs with overrides set, to check possible side effects
seems no big differences libass handle only -1 (auto) and all others cases use always same encoding
- [ ] Should be good to know if on linux has same effect (currently i cannot test on linux)
- [x] To check SRT case, to check possible side effects
no difference found

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An user has tried the new WebVTT implementation with the ISAdaptive PR (not merged yet) and has report the wrong text displayed

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with hebrew Net***x subtitles

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Can display RTL subs in right way

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
