### PR TITLE
[addons] fix C4996 error on UWP build by use of strdup and few other fixes

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -719,11 +719,12 @@ private:
       std::string mimetype;
       size_t size = 0;
       const uint8_t* mem = cppTag.GetCoverArtByMem(size, mimetype);
-      if (mem)
+      if (mem && size > 0)
       {
         tag->cover_art_mem_mimetype = strdup(mimetype.c_str());
         tag->cover_art_mem_size = size;
         tag->cover_art_mem = static_cast<uint8_t*>(malloc(size));
+        memcpy(tag->cover_art_mem, mem, size);
       }
       else
       {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -742,8 +742,7 @@ private:
     return static_cast<CInstanceAudioDecoder*>(hdl)->TrackCount(file);
   }
 
-  std::vector<AudioEngineChannel> m_channelList;
-  AddonInstance_AudioDecoder* m_instanceData;
+  AddonInstance_AudioDecoder* m_instanceData{nullptr};
 };
 
 } /* namespace addon */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -691,6 +691,10 @@ private:
                                     const char* file,
                                     struct KODI_ADDON_AUDIODECODER_INFO_TAG* tag)
   {
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif // _WIN32
     kodi::addon::AudioDecoderInfoTag cppTag;
     bool ret = static_cast<CInstanceAudioDecoder*>(hdl)->ReadTag(file, cppTag);
     if (ret)
@@ -727,6 +731,9 @@ private:
       }
     }
     return ret;
+#ifdef _WIN32
+#pragma warning(pop)
+#endif // _WIN32
   }
 
   inline static int ADDON_track_count(const KODI_ADDON_AUDIODECODER_HDL hdl, const char* file)


### PR DESCRIPTION
## Description

This adds `#pragma warning(disable : 4996)` to fix build errors on Windows UWP where warnings declared as errors.

Is stupid that Microsoft prevent use of strdup (know thats normally posix only), but to bring then _strdup :face_with_rolling_eyes:.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
