### PR TITLE
[BACKPORT][CMAKE] TexturePacker and JSONSchemaBuilder finders fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ foreach(skin ${SKINS})
 endforeach()
 
 add_custom_target(pack-skins ALL
-                  DEPENDS TexturePacker::TexturePacker export-files ${XBT_FILES})
+                  DEPENDS TexturePacker::TexturePacker::Executable export-files ${XBT_FILES})
 set_target_properties(pack-skins PROPERTIES FOLDER "Build Utilities")
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/system/players/VideoPlayer)

--- a/cmake/modules/FindJsonSchemaBuilder.cmake
+++ b/cmake/modules/FindJsonSchemaBuilder.cmake
@@ -13,17 +13,26 @@
 
 if(NOT TARGET JsonSchemaBuilder::JsonSchemaBuilder)
   if(KODI_DEPENDSBUILD)
+    get_filename_component(_jsbpath "${NATIVEPREFIX}/bin" ABSOLUTE)
+    find_program(JSONSCHEMABUILDER_EXECUTABLE NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
+                                   HINTS ${_jsbpath})
+
     add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
     set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
-                                                       IMPORTED_LOCATION "${NATIVEPREFIX}/bin/JsonSchemaBuilder")
+                                                       IMPORTED_LOCATION "${JSONSCHEMABUILDER_EXECUTABLE}")
   elseif(CORE_SYSTEM_NAME STREQUAL windowsstore)
+    get_filename_component(_jsbpath "${DEPENDENCIES_DIR}/bin/json-rpc" ABSOLUTE)
+    find_program(JSONSCHEMABUILDER_EXECUTABLE NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
+                                              HINTS ${_jsbpath})
+
     add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
     set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
-                                                       IMPORTED_LOCATION "${DEPENDENCIES_DIR}/bin/json-rpc/JsonSchemaBuilder")
+                                                       IMPORTED_LOCATION "${JSONSCHEMABUILDER_EXECUTABLE}")
   else()
     if(WITH_JSONSCHEMABUILDER)
       get_filename_component(_jsbpath ${WITH_JSONSCHEMABUILDER} ABSOLUTE)
-      find_program(JSONSCHEMABUILDER_EXECUTABLE JsonSchemaBuilder PATHS ${_jsbpath})
+      find_program(JSONSCHEMABUILDER_EXECUTABLE NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
+                                                PATHS ${_jsbpath})
 
       include(FindPackageHandleStandardArgs)
       find_package_handle_standard_args(JsonSchemaBuilder DEFAULT_MSG JSONSCHEMABUILDER_EXECUTABLE)

--- a/cmake/modules/FindJsonSchemaBuilder.cmake
+++ b/cmake/modules/FindJsonSchemaBuilder.cmake
@@ -31,11 +31,13 @@ if(NOT TARGET JsonSchemaBuilder::JsonSchemaBuilder)
   else()
     if(WITH_JSONSCHEMABUILDER)
       get_filename_component(_jsbpath ${WITH_JSONSCHEMABUILDER} ABSOLUTE)
+      get_filename_component(_jsbpath ${_jsbpath} DIRECTORY)
       find_program(JSONSCHEMABUILDER_EXECUTABLE NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
-                                                PATHS ${_jsbpath})
+                                                HINTS ${_jsbpath})
 
       include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(JsonSchemaBuilder DEFAULT_MSG JSONSCHEMABUILDER_EXECUTABLE)
+      find_package_handle_standard_args(JsonSchemaBuilder "Could not find '${APP_NAME_LC}-JsonSchemaBuilder' or 'JsonSchemaBuilder' executable in ${_jsbpath} supplied by -DWITH_JSONSCHEMABUILDER. Make sure the executable file name matches these names!"
+                                        JSONSCHEMABUILDER_EXECUTABLE)
       if(JSONSCHEMABUILDER_FOUND)
         add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
         set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES

--- a/cmake/modules/FindTexturePacker.cmake
+++ b/cmake/modules/FindTexturePacker.cmake
@@ -13,17 +13,26 @@
 
 if(NOT TARGET TexturePacker::TexturePacker)
   if(KODI_DEPENDSBUILD)
+    get_filename_component(_tppath "${NATIVEPREFIX}/bin" ABSOLUTE)
+    find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
+                                          HINTS ${_tppath})
+
     add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
     set_target_properties(TexturePacker::TexturePacker PROPERTIES
-                                                       IMPORTED_LOCATION "${NATIVEPREFIX}/bin/TexturePacker")
+                                                       IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
   elseif(WIN32)
+    get_filename_component(_tppath "${DEPENDENCIES_DIR}/tools/TexturePacker" ABSOLUTE)
+    find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker.exe" TexturePacker.exe
+                                          HINTS ${_tppath})
+
     add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
     set_target_properties(TexturePacker::TexturePacker PROPERTIES
-                                                       IMPORTED_LOCATION "${DEPENDENCIES_DIR}/tools/TexturePacker/TexturePacker.exe")
+                                                       IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
   else()
     if(WITH_TEXTUREPACKER)
       get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
-      find_program(TEXTUREPACKER_EXECUTABLE TexturePacker PATHS ${_tppath})
+      find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
+                                            PATHS ${_tppath})
 
       include(FindPackageHandleStandardArgs)
       find_package_handle_standard_args(TexturePacker DEFAULT_MSG TEXTUREPACKER_EXECUTABLE)

--- a/cmake/modules/FindTexturePacker.cmake
+++ b/cmake/modules/FindTexturePacker.cmake
@@ -31,11 +31,13 @@ if(NOT TARGET TexturePacker::TexturePacker)
   else()
     if(WITH_TEXTUREPACKER)
       get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
+      get_filename_component(_tppath ${_tppath} DIRECTORY)
       find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
-                                            PATHS ${_tppath})
+                                            HINTS ${_tppath})
 
       include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(TexturePacker DEFAULT_MSG TEXTUREPACKER_EXECUTABLE)
+      find_package_handle_standard_args(TexturePacker "Could not find '${APP_NAME_LC}-TexturePacker' or 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER. Make sure the executable file name matches these names!"
+                                        TEXTUREPACKER_EXECUTABLE)
       if(TEXTUREPACKER_FOUND)
         add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
         set_target_properties(TexturePacker::TexturePacker PROPERTIES

--- a/cmake/modules/FindTexturePacker.cmake
+++ b/cmake/modules/FindTexturePacker.cmake
@@ -9,44 +9,82 @@
 #
 # This will define the following (imported) targets::
 #
-#   TexturePacker::TexturePacker   - The TexturePacker executable
+#   TexturePacker::TexturePacker::Executable   - The TexturePacker executable participating in build
+#   TexturePacker::TexturePacker::Installable  - The TexturePacker executable shipped in the Kodi package
 
-if(NOT TARGET TexturePacker::TexturePacker)
+if(NOT TARGET TexturePacker::TexturePacker::Executable)
   if(KODI_DEPENDSBUILD)
     get_filename_component(_tppath "${NATIVEPREFIX}/bin" ABSOLUTE)
     find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
                                           HINTS ${_tppath})
 
-    add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
-    set_target_properties(TexturePacker::TexturePacker PROPERTIES
-                                                       IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
+    add_executable(TexturePacker::TexturePacker::Executable IMPORTED GLOBAL)
+    set_target_properties(TexturePacker::TexturePacker::Executable PROPERTIES
+                                          IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
+    message(STATUS "External TexturePacker for KODI_DEPENDSBUILD will be executed during build: ${TEXTUREPACKER_EXECUTABLE}")
   elseif(WIN32)
     get_filename_component(_tppath "${DEPENDENCIES_DIR}/tools/TexturePacker" ABSOLUTE)
     find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker.exe" TexturePacker.exe
                                           HINTS ${_tppath})
 
-    add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
-    set_target_properties(TexturePacker::TexturePacker PROPERTIES
-                                                       IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
+    add_executable(TexturePacker::TexturePacker::Executable IMPORTED GLOBAL)
+    set_target_properties(TexturePacker::TexturePacker::Executable PROPERTIES
+                                          IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
+    message(STATUS "External TexturePacker for WIN32 will be executed during build: ${TEXTUREPACKER_EXECUTABLE}")
   else()
     if(WITH_TEXTUREPACKER)
       get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
       get_filename_component(_tppath ${_tppath} DIRECTORY)
       find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
-                                            HINTS ${_tppath})
+                                          HINTS ${_tppath})
+
+      # Use external TexturePacker executable if found
+      if(TEXTUREPACKER_EXECUTABLE)
+        add_executable(TexturePacker::TexturePacker::Executable IMPORTED GLOBAL)
+        set_target_properties(TexturePacker::TexturePacker::Executable PROPERTIES
+                                          IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
+        message(STATUS "Found external TexturePacker: ${TEXTUREPACKER_EXECUTABLE}")
+      else()
+        # Warn about external TexturePacker supplied but not fail fatally
+        # because we might have internal TexturePacker executable built
+        # and unset TEXTUREPACKER_EXECUTABLE variable
+        message(WARNING "Could not find '${APP_NAME_LC}-TexturePacker' or 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER. Make sure the executable file name matches these names!")
+        unset(TEXTUREPACKER_EXECUTABLE)
+      endif()
+    endif()
+
+    # Ship TexturePacker only on Linux and FreeBSD
+    if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      set(INTERNAL_TEXTUREPACKER_INSTALLABLE TRUE)
+    endif()
+
+    # Use it during build if build architecture is same as host
+    # (not cross-compiling) and TEXTUREPACKER_EXECUTABLE is not found
+    if(CORE_HOST_IS_TARGET AND NOT TEXTUREPACKER_EXECUTABLE)
+      set(INTERNAL_TEXTUREPACKER_EXECUTABLE TRUE)
+    endif()
+
+    # Build and install internal TexturePacker if needed
+    if (INTERNAL_TEXTUREPACKER_EXECUTABLE OR INTERNAL_TEXTUREPACKER_INSTALLABLE)
+      add_subdirectory(${CMAKE_SOURCE_DIR}/tools/depends/native/TexturePacker build/texturepacker)
+      message(STATUS "Building internal TexturePacker")
+    endif()
+
+    if(INTERNAL_TEXTUREPACKER_INSTALLABLE)
+      add_executable(TexturePacker::TexturePacker::Installable ALIAS TexturePacker)
+      message(STATUS "Shipping internal TexturePacker")
+    endif()
+
+    if(INTERNAL_TEXTUREPACKER_EXECUTABLE)
+      add_executable(TexturePacker::TexturePacker::Executable ALIAS TexturePacker)
+      message(STATUS "Internal TexturePacker will be executed during build")
+    else()
+      message(STATUS "External TexturePacker will be executed during build: ${TEXTUREPACKER_EXECUTABLE}")
 
       include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(TexturePacker "Could not find '${APP_NAME_LC}-TexturePacker' or 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER. Make sure the executable file name matches these names!"
-                                        TEXTUREPACKER_EXECUTABLE)
-      if(TEXTUREPACKER_FOUND)
-        add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
-        set_target_properties(TexturePacker::TexturePacker PROPERTIES
-                                                           IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
-      endif()
-      mark_as_advanced(TEXTUREPACKER)
-    else()
-      add_subdirectory(${CMAKE_SOURCE_DIR}/tools/depends/native/TexturePacker build/texturepacker)
-      add_executable(TexturePacker::TexturePacker ALIAS TexturePacker)
+      find_package_handle_standard_args(TexturePacker DEFAULT_MSG TEXTUREPACKER_EXECUTABLE)
     endif()
+
+    mark_as_advanced(INTERNAL_TEXTUREPACKER_EXECUTABLE INTERNAL_TEXTUREPACKER_INSTALLABLE TEXTUREPACKER)
   endif()
 endif()

--- a/cmake/scripts/common/ProjectMacros.cmake
+++ b/cmake/scripts/common/ProjectMacros.cmake
@@ -11,7 +11,7 @@ function(pack_xbt input output)
   get_filename_component(dir ${output} DIRECTORY)
   add_custom_command(OUTPUT  ${output}
                      COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-                     COMMAND TexturePacker::TexturePacker
+                     COMMAND TexturePacker::TexturePacker::Executable
                      ARGS    -input ${input}
                              -output ${output}
                              -dupecheck

--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -154,8 +154,8 @@ install(FILES ${CMAKE_SOURCE_DIR}/privacy-policy.txt
         COMPONENT kodi)
 
 # Install kodi-tools-texturepacker
-if(NOT WITH_TEXTUREPACKER)
-  install(PROGRAMS $<TARGET_FILE:TexturePacker::TexturePacker>
+if(INTERNAL_TEXTUREPACKER_INSTALLABLE)
+  install(PROGRAMS $<TARGET_FILE:TexturePacker::TexturePacker::Installable>
           DESTINATION ${bindir}
           COMPONENT kodi-tools-texturepacker)
 endif()


### PR DESCRIPTION
## Description

Partial backport of #20414 and #20424 without renaming shipped TexturePacker

## Motivation and context

Fixes cross-compiling issues on Debian and other Unix like systems

## How has this been tested?

Built 20.0 + 19,3 cross for armhf on amd64 and natively for amd64

## What is the effect on users?

It is developer change

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
