### PR TITLE
[gui] fix 'italics cut off' regression

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -612,7 +612,7 @@ float CGUIFontTTF::GetTextWidthInternal(const vecText& text, std::vector<Glyph>&
       // If last character in line, we want to add render width
       // and not advance distance - this makes sure that italic text isn't
       // choped on the end (as render width is larger than advance then).
-      if (it == glyphs.end())
+      if (std::next(it) == glyphs.end())
         width += std::max(c->right - c->left + c->offsetX, c->advance);
       else if ((c->letter & 0xffff) == static_cast<character_t>('\t'))
         width += GetTabSpaceLength();


### PR DESCRIPTION
## Description
pr https://github.com/xbmc/xbmc/pull/19765 introduced a small glitch. any italics label in the gui got cut off on the right side.

the crux is lying here:
https://github.com/xbmc/xbmc/blob/1fb18c82c775d0c93221a473b1c1d1d7c8bfa749/xbmc/guilib/GUIFontTTF.cpp#L612-L616

`(it == glyphs.end())` can never be true in that for-loop.

## How has this been tested?
linux

## What is the effect on users?
italics don't get cut off any more

## Screenshots (if appropriate):
cut off (there are labels where it is even more obvious, e.g. pvr section):
![before](https://user-images.githubusercontent.com/58829855/140396328-dd7c041b-6962-42c4-af16-f48dee4bf1b7.png)

corrected:
![after](https://user-images.githubusercontent.com/58829855/140396379-a6d10971-69f1-465c-a03b-5110ec28afd3.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

the backport pr for https://github.com/xbmc/xbmc/pull/19765 is pending right here https://github.com/xbmc/xbmc/pull/19944  but i've no idea if it's intended to bring it in or it has been cancelled