### PR TITLE
[subtitle] load .sup file like other external subtitles.

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2279,62 +2279,6 @@ std::string CUtil::GetVobSubIdxFromSub(const std::string& vobSub)
   return std::string();
 }
 
-void CUtil::ScanForExternalDemuxSub(const std::string& videoPath, std::vector<std::string>& vecSubtitles)
-{
-  CFileItem item(videoPath, false);
-  if (item.IsInternetStream()
-    || item.IsPlayList()
-    || item.IsLiveTV()
-    || item.IsPVR()
-    || !item.IsVideo())
-    return;
-
-  std::string strBasePath;
-  std::string strSubtitle;
-
-  GetVideoBasePathAndFileName(videoPath, strBasePath, strSubtitle);
-
-  CFileItemList items;
-  const std::vector<std::string> common_sub_dirs = { "subs", "subtitles", "vobsubs", "sub", "vobsub", "subtitle" };
-  const std::string demuxSubExtensions = ".sup";
-  GetItemsToScan(strBasePath, demuxSubExtensions, common_sub_dirs, items);
-
-  const std::string customPath = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
-      CSettings::SETTING_SUBTITLES_CUSTOMPATH);
-
-  if (!CMediaSettings::GetInstance().GetAdditionalSubtitleDirectoryChecked() &&
-      !customPath.empty()) // to avoid checking non-existent directories (network) every time..
-  {
-    if (!CServiceBroker::GetNetwork().IsAvailable() && !URIUtils::IsHD(customPath))
-    {
-      CLog::Log(LOGINFO, "CUtil::CacheSubtitles: disabling alternate subtitle directory for this "
-                         "session, it's inaccessible");
-      CMediaSettings::GetInstance().SetAdditionalSubtitleDirectoryChecked(-1); // disabled
-    }
-    else if (!CDirectory::Exists(customPath))
-    {
-      CLog::Log(LOGINFO, "CUtil::CacheSubtitles: disabling alternate subtitle directory for this "
-                         "session, it's nonexistent");
-      CMediaSettings::GetInstance().SetAdditionalSubtitleDirectoryChecked(-1); // disabled
-    }
-    else
-      CMediaSettings::GetInstance().SetAdditionalSubtitleDirectoryChecked(1);
-  }
-
-  if (CMediaSettings::GetInstance().GetAdditionalSubtitleDirectoryChecked() == 1)
-  {
-    std::string strPath2 = customPath;
-    URIUtils::AddSlashAtEnd(strPath2);
-    int flags = DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO;
-    CFileItemList moreItems;
-    CDirectory::GetDirectory(strPath2, moreItems, demuxSubExtensions, flags);
-    items.Append(moreItems);
-  }
-
-  std::vector<std::string> exts = StringUtils::Split(demuxSubExtensions, "|");
-  ScanPathsForAssociatedItems(strSubtitle, items, exts, vecSubtitles);
-}
-
 void CUtil::ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio)
 {
   CFileItem item(videoPath, false);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -87,7 +87,6 @@ public:
   *   \param[out] vecAudio A vector containing the full paths of all found external audio files.
   */
   static void ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio);
-  static void ScanForExternalDemuxSub(const std::string& videoPath, std::vector<std::string>& vecSubtitles);
   static int64_t ToInt64(uint32_t high, uint32_t low);
   static std::string GetNextFilename(const std::string &fn_template, int max);
   static std::string GetNextPathname(const std::string &path_template, int max);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -44,7 +44,6 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
     std::vector<std::string> filenames;
     filenames.push_back(file);
     CUtil::ScanForExternalAudio(file, filenames);
-    CUtil::ScanForExternalDemuxSub(file, filenames);
     if (filenames.size() >= 2)
     {
       return CreateInputStream(pPlayer, fileitem, filenames);

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -659,7 +659,7 @@ BuildObject(CFileItem&                    item,
             /* Hardcoded check for extension is not the best way, but it can't be allowed to pass all
                subtitle extension (ex. rar or zip). There are the most popular extensions support by UPnP devices.*/
             if (ext == "txt" || ext == "srt" || ext == "ssa" || ext == "ass" || ext == "sub" ||
-                ext == "smi" || ext == "vtt")
+                ext == "smi" || ext == "vtt" || ext == "sup")
             {
                 subtitles.push_back(filenames[i]);
             }

--- a/xbmc/platform/darwin/ios/Info.plist.in
+++ b/xbmc/platform/darwin/ios/Info.plist.in
@@ -395,6 +395,7 @@
 					<string>aqt</string>
 					<string>jss</string>
 					<string>ass</string>
+					<string>sup</string>
 					<string>vtt</string>
 					<string>idx</string>
 					<string>ifo</string>

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -410,7 +410,7 @@ void CAdvancedSettings::Initialize()
   m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.xspf|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf|.m4b|.dtshd";
   m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.udf|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.001|.wpl|.xspf|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.mpl|.webm|.bdmv|.bdm|.wtv|.trp|.f4v";
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|"
-                          ".ass|.vtt|.idx|.ifo|.zip";
+                          ".ass|.vtt|.idx|.ifo|.zip|.sup";
   m_discStubExtensions = ".disc";
   // internal music extensions
   m_musicExtensions += "|.cdda";

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -126,10 +126,10 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
   }
 
   std::string strMask =
-      ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.aqt|.jss|.ass|.vtt|.idx|.zip";
+      ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.aqt|.jss|.ass|.vtt|.idx|.zip|.sup";
 
   if (g_application.GetCurrentPlayer() == "VideoPlayer")
-    strMask = ".srt|.zip|.ifo|.smi|.sub|.idx|.ass|.ssa|.vtt|.txt";
+    strMask = ".srt|.zip|.ifo|.smi|.sub|.idx|.ass|.ssa|.vtt|.txt|.sup";
 
   strMask += extras;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Scan .sup file use `ScanForExternalSubtitles` and support to load .sup file in `GUIDialogSubtitleSettings`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://forum.kodi.tv/showthread.php?tid=356403

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
