### PR TITLE
[tools/EventClients][OSXRemote] fix clang-analyze warning

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
+++ b/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
@@ -412,10 +412,11 @@ void XBMCClientWrapperImpl::populateMultiRemoteModeMap(){
   return [self initWithMode:DEFAULT_MODE serverAddress:@"localhost" port:9777 verbose: false];
 }
 - (id) initWithMode:(eRemoteMode) f_mode serverAddress:(NSString*) fp_server port:(int) f_port verbose:(bool) f_verbose{
-	if( ![super init] )
-		return nil;
-	mp_impl = new XBMCClientWrapperImpl(f_mode, [fp_server UTF8String], f_port, f_verbose);
-	return self;
+  self = [super init];
+  if (self)
+    mp_impl = new XBMCClientWrapperImpl(f_mode, [fp_server UTF8String], f_port, f_verbose);
+
+  return self;
 }
 
 - (void) setUniversalModeTimeout:(double) f_timeout{


### PR DESCRIPTION
## Description
Fix the following warning from clang-analyze

/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm:417:2: warning: Instance variable used while 'self' is not set to the result of '[(super or self) init...]'
    mp_impl = new XBMCClientWrapperImpl(f_mode, [fp_server UTF8String], f_port, f_verbose);
    ^~~~~~~
1 warning generated.

## Motivation and context
Fix some warnings provided by Clang-analyze

## How has this been tested?
Build osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
