### PR TITLE
[clang-analyze] Fix assorted clang-analyze warnings

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -516,7 +516,7 @@ OSStatus CAESinkDARWINOSX::renderCallback(AudioDeviceID inDevice, const AudioTim
       {
         for (unsigned int i = startIdx; i < endIdx; i++)
         {
-          int16_t src;
+          int16_t src = 0;
           sink->m_buffer->Read((unsigned char *)&src, sizeof(int16_t), i);
           if (i < outOutputData->mNumberBuffers && outOutputData->mBuffers[i].mData)
           {

--- a/xbmc/cores/AudioEngine/Sinks/darwin/CoreAudioHelpers.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/darwin/CoreAudioHelpers.cpp
@@ -13,7 +13,7 @@
 // Helper Functions
 std::string GetError(OSStatus error)
 {
-  char buffer[128];
+  char buffer[128] = {};
 
   *(UInt32 *)(buffer + 1) = CFSwapInt32HostToBig(error);
   if (isprint(buffer[1]) && isprint(buffer[2]) &&

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1479,7 +1479,7 @@ extern "C"
 
   int dll_fgetpos(FILE* stream, fpos_t* pos)
   {
-    fpos64_t tmpPos;
+    fpos64_t tmpPos = {};
     int ret;
 
     ret = dll_fgetpos64(stream, &tmpPos);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -138,6 +138,7 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   // Get screen parameters
   float screenWidth;
   float screenHeight;
+  //! @Todo screenPixelRatio unused - Possibly due to display integer scaling according to Garbear
   float screenPixelRatio;
 
   if (scaleMode == SCALINGMETHOD::NEAREST && stretchMode == STRETCHMODE::Original &&

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -184,7 +184,7 @@ void CDVDAudioCodecFFmpeg::GetData(DVDAudioFrame &frame)
 {
   frame.nb_frames = 0;
 
-  uint8_t* data[16];
+  uint8_t* data[16]{};
   int bytes = GetData(data);
   if (!bytes)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -92,7 +92,6 @@ void CDVDAudioCodecPassthrough::Dispose()
 
 bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
 {
-  int used = 0;
   if (m_backlogSize)
   {
     m_dataSize = m_bufferSize;
@@ -134,7 +133,7 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
       return true;
 
     m_dataSize = m_bufferSize;
-    used = m_parser.AddData(pData, iSize, &m_buffer, &m_dataSize);
+    int used = m_parser.AddData(pData, iSize, &m_buffer, &m_dataSize);
     m_bufferSize = std::max(m_bufferSize, m_dataSize);
 
     if (used != iSize)
@@ -146,7 +145,6 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
       }
       m_backlogSize = iSize - used;
       memcpy(m_backlogBuffer, pData + used, m_backlogSize);
-      used = iSize;
     }
   }
   else if (pData)
@@ -158,7 +156,6 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
     }
     memcpy(m_backlogBuffer + m_backlogSize, pData, iSize);
     m_backlogSize += iSize;
-    used = iSize;
   }
 
   if (!m_dataSize)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -96,7 +96,7 @@ void CDVDVideoPPFFmpeg::Process(VideoPicture* pPicture)
   }
 
   uint8_t* srcPlanes[YuvImage::MAX_PLANES], *dstPlanes[YuvImage::MAX_PLANES];
-  int srcStrides[YuvImage::MAX_PLANES];
+  int srcStrides[YuvImage::MAX_PLANES]{};
   pSource->videoBuffer->GetPlanes(srcPlanes);
   pSource->videoBuffer->GetStrides(srcStrides);
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -278,7 +278,7 @@ int CDVDInputStreamNavigator::Read(uint8_t* buf, int buf_size)
     return -1;
   }
 
-  int iBytesRead;
+  int iBytesRead = 0;
 
   int NOPcount = 0;
   while (true)
@@ -500,7 +500,8 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
         // information only when necessary and update the decoding/displaying
         // accordingly.
 
-        uint32_t pos, len;
+        uint32_t pos = 0;
+        uint32_t len = 0;
 
         m_dll.dvdnav_current_title_info(m_dvdnav, &m_iTitle, &m_iPart);
         m_dll.dvdnav_get_number_of_titles(m_dvdnav, &m_iTitleCount);
@@ -721,7 +722,7 @@ void CDVDInputStreamNavigator::SelectButton(int iButton)
 
 int CDVDInputStreamNavigator::GetCurrentButton()
 {
-  int button;
+  int button = 0;
   if (m_dvdnav)
   {
     m_dll.dvdnav_get_current_highlight(m_dvdnav, &button);
@@ -1617,7 +1618,8 @@ VideoStreamInfo CDVDInputStreamNavigator::GetVideoStreamInfo()
 
   info.angles = GetAngleCount();
   info.videoAspectRatio = GetVideoAspectRatio();
-  uint32_t width, height = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
   GetVideoResolution(&width, &height);
 
   info.width = static_cast<int>(width);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1765,8 +1765,6 @@ bool CLinuxRendererGL::UploadTexture(int index)
 
   if (!m_buffers[index].loaded)
   {
-    ret = false;
-
     YuvImage &dst = m_buffers[index].image;
     YuvImage src;
     m_buffers[index].videoBuffer->GetPlanes(src.plane);

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -474,7 +474,9 @@ void CGUIDialogMediaFilter::InitializeSettings()
 
       if (filter.settingType == SettingType::Integer)
       {
-        int min, interval, max;
+        int min = 0;
+        int interval = 0;
+        int max = 0;
         GetRange(filter, min, interval, max);
 
         // don't create the filter if there's no real range
@@ -495,7 +497,9 @@ void CGUIDialogMediaFilter::InitializeSettings()
       }
       else if (filter.settingType == SettingType::Number)
       {
-        float min, interval, max;
+        float min = 0;
+        float interval = 0;
+        float max = 0;
         GetRange(filter, min, interval, max);
 
         // don't create the filter if there's no real range

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -82,7 +82,6 @@ std::list<std::string> CNfsConnection::GetExportList(const CURL& url)
 #else
   exportlist = mount_getexports(m_resolvedHostName.c_str());
 #endif
-  tmp = exportlist;
 
   for (tmp = exportlist; tmp != NULL; tmp = tmp->ex_next)
   {


### PR DESCRIPTION
## Description
Fix various warnings from a clang-analyze report on macos build.

## Motivation and context
Fix some warnings from clang-analyze. This is only some of the low hanging warnings

## How has this been tested?
build osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
