### PR TITLE
[clang-analyze] ServiceBroker EventLog use pointer instead of reference

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -248,9 +248,16 @@ CDatabaseManager& CServiceBroker::GetDatabaseManager()
   return g_application.m_ServiceManager->GetDatabaseManager();
 }
 
-CEventLog& CServiceBroker::GetEventLog()
+CEventLog* CServiceBroker::GetEventLog()
 {
-  return g_serviceBroker.m_pSettingsComponent->GetProfileManager()->GetEventLog();
+  if (!g_serviceBroker.m_pSettingsComponent)
+    return nullptr;
+
+  auto profileManager = g_serviceBroker.m_pSettingsComponent->GetProfileManager();
+  if (!profileManager)
+    return nullptr;
+
+  return &profileManager->GetEventLog();
 }
 
 CMediaManager& CServiceBroker::GetMediaManager()

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -136,7 +136,7 @@ public:
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();
   static CDatabaseManager &GetDatabaseManager();
-  static CEventLog &GetEventLog();
+  static CEventLog* GetEventLog();
   static CMediaManager& GetMediaManager();
 
   static CGUIComponent* GetGUI();

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -94,8 +94,12 @@ void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* j
               "", g_localizeStrings.Get(24001), g_localizeStrings.Get(24061),
               TOAST_DISPLAY_TIME, false, TOAST_DISPLAY_TIME);
 
+        auto eventLog = CServiceBroker::GetEventLog();
         for (const auto &addon : updates)
-          CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(addon, 24068)));
+        {
+          if (eventLog)
+            eventLog->Add(EventPtr(new CAddonManagementEvent(addon, 24068)));
+        }
       }
     }
 

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -456,8 +456,10 @@ bool CAddonDll::CheckAPIVersion(int type)
 
     if (CServiceBroker::GetGUI())
     {
-      CEventLog &eventLog = CServiceBroker::GetEventLog();
-      eventLog.AddWithNotification(EventPtr(new CNotificationEvent(Name(), 24152, EventLevel::Error)));
+      CEventLog* eventLog = CServiceBroker::GetEventLog();
+      if (eventLog)
+        eventLog->AddWithNotification(
+            EventPtr(new CNotificationEvent(Name(), 24152, EventLevel::Error)));
     }
 
     return false;

--- a/xbmc/events/windows/GUIWindowEventLog.cpp
+++ b/xbmc/events/windows/GUIWindowEventLog.cpp
@@ -44,7 +44,10 @@ bool CGUIWindowEventLog::OnMessage(CGUIMessage& message)
     // check if we should clear all items
     if (iControl == CONTROL_BUTTON_CLEAR)
     {
-      CServiceBroker::GetEventLog().Clear(CViewStateSettings::GetInstance().GetEventLevel(), CViewStateSettings::GetInstance().ShowHigherEventLevels());
+      auto eventLog = CServiceBroker::GetEventLog();
+      if (eventLog)
+        eventLog->Clear(CViewStateSettings::GetInstance().GetEventLevel(),
+                        CViewStateSettings::GetInstance().ShowHigherEventLevels());
 
       // refresh the list
       Refresh(true);
@@ -142,7 +145,11 @@ void CGUIWindowEventLog::GetContextButtons(int itemNumber, CContextButtons &butt
   if (eventIdentifier.empty())
     return;
 
-  EventPtr eventPtr = CServiceBroker::GetEventLog().Get(eventIdentifier);
+  auto eventLog = CServiceBroker::GetEventLog();
+  if (!eventLog)
+    return;
+
+  EventPtr eventPtr = eventLog->Get(eventIdentifier);
   if (eventPtr == nullptr)
     return;
 
@@ -239,7 +246,11 @@ bool CGUIWindowEventLog::OnDelete(const CFileItemPtr& item)
   if (eventIdentifier.empty())
     return false;
 
-  CServiceBroker::GetEventLog().Remove(eventIdentifier);
+  auto eventLog = CServiceBroker::GetEventLog();
+  if (!eventLog)
+    return false;
+
+  eventLog->Remove(eventIdentifier);
   return true;
 }
 
@@ -252,7 +263,11 @@ bool CGUIWindowEventLog::OnExecute(const CFileItemPtr& item)
   if (eventIdentifier.empty())
     return false;
 
-  const EventPtr eventPtr = CServiceBroker::GetEventLog().Get(eventIdentifier);
+  auto eventLog = CServiceBroker::GetEventLog();
+  if (!eventLog)
+    return false;
+
+  const EventPtr eventPtr = eventLog->Get(eventIdentifier);
   if (eventPtr == nullptr)
     return false;
 

--- a/xbmc/filesystem/EventsDirectory.cpp
+++ b/xbmc/filesystem/EventsDirectory.cpp
@@ -21,12 +21,12 @@ bool CEventsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   items.ClearProperties();
   items.SetContent("events");
 
-  CEventLog& log = CServiceBroker::GetEventLog();
+  auto log = CServiceBroker::GetEventLog();
   Events events;
 
   std::string hostname = url.GetHostName();
   if (hostname.empty())
-    events = log.Get();
+    events = log->Get();
   else
   {
     bool includeHigherLevels = false;
@@ -43,7 +43,7 @@ bool CEventsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     EventLevel level = CEventLog::EventLevelFromString(hostname);
 
     // get the events of the specified level(s)
-    events = log.Get(level, includeHigherLevels);
+    events = log->Get(level, includeHigherLevels);
   }
 
   for (const auto& eventItem : events)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -12606,8 +12606,10 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
     // "Importing song history {1} of {2} songs matched", total - unmatched, total)
     std::string strLine =
         StringUtils::Format(g_localizeStrings.Get(38353), total - unmatched, total);
-    CServiceBroker::GetEventLog().Add(
-        EventPtr(new CNotificationEvent(20197, strLine, EventLevel::Information)));
+
+    auto eventLog = CServiceBroker::GetEventLog();
+    if (eventLog)
+      eventLog->Add(EventPtr(new CNotificationEvent(20197, strLine, EventLevel::Information)));
 
     return true;
   }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1318,11 +1318,13 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
       }
       else
       {
-        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
-            MediaTypeAlbum, album.strPath, 24146,
-            StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeAlbum, album.strAlbum),
-            CScraperUrl::GetThumbUrl(album.thumbURL.GetFirstUrlByType()),
-            CURL::GetRedacted(album.strPath), EventLevel::Warning)));
+        auto eventLog = CServiceBroker::GetEventLog();
+        if (eventLog)
+          eventLog->Add(EventPtr(new CMediaLibraryEvent(
+              MediaTypeAlbum, album.strPath, 24146,
+              StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeAlbum, album.strAlbum),
+              CScraperUrl::GetThumbUrl(album.thumbURL.GetFirstUrlByType()),
+              CURL::GetRedacted(album.strPath), EventLevel::Warning)));
       }
     }
   }
@@ -1386,11 +1388,13 @@ CMusicInfoScanner::UpdateDatabaseArtistInfo(CArtist& artist,
       }
       else
       {
-        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
-            MediaTypeArtist, artist.strPath, 24146,
-            StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeArtist, artist.strArtist),
-            CScraperUrl::GetThumbUrl(artist.thumbURL.GetFirstUrlByType()),
-            CURL::GetRedacted(artist.strPath), EventLevel::Warning)));
+        auto eventLog = CServiceBroker::GetEventLog();
+        if (eventLog)
+          eventLog->Add(EventPtr(new CMediaLibraryEvent(
+              MediaTypeArtist, artist.strPath, 24146,
+              StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeArtist, artist.strArtist),
+              CScraperUrl::GetThumbUrl(artist.thumbURL.GetFirstUrlByType()),
+              CURL::GetRedacted(artist.strPath), EventLevel::Warning)));
       }
     }
   }

--- a/xbmc/pvr/PVREventLogJob.cpp
+++ b/xbmc/pvr/PVREventLogJob.cpp
@@ -35,8 +35,11 @@ bool CPVREventLogJob::DoWork()
         event.m_bError ? CGUIDialogKaiToast::Error : CGUIDialogKaiToast::Info, event.m_label.c_str(), event.m_msg, 5000, true);
 
     // Write event log entry.
-    CServiceBroker::GetEventLog().Add(
-      std::make_shared<CNotificationEvent>(event.m_label, event.m_msg, event.m_icon, event.m_bError ? EventLevel::Error : EventLevel::Information));
+    auto eventLog = CServiceBroker::GetEventLog();
+    if (eventLog)
+      eventLog->Add(std::make_shared<CNotificationEvent>(event.m_label, event.m_msg, event.m_icon,
+                                                         event.m_bError ? EventLevel::Error
+                                                                        : EventLevel::Information));
   }
   return true;
 }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1919,8 +1919,10 @@ void CPVRClient::cb_recording_notification(void* kodiInstance,
     // display a notification for 5 seconds
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, strLine1, strLine2, 5000,
                                           false);
-    CServiceBroker::GetEventLog().Add(
-        EventPtr(new CNotificationEvent(client->Name(), strLine1, client->Icon(), strLine2)));
+    auto eventLog = CServiceBroker::GetEventLog();
+    if (eventLog)
+      eventLog->Add(
+          EventPtr(new CNotificationEvent(client->Name(), strLine1, client->Icon(), strLine2)));
 
     CLog::LogFC(LOGDEBUG, LOGPVR, "Recording {} on client '{}'. name='{}' filename='{}'",
                 bOnOff ? "started" : "finished", client->Name(), strName, strFileName);

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -63,10 +63,15 @@ void CAlarmClock::Start(const std::string& strName, float n_secs, const std::str
       labelAlarmClock,
       StringUtils::Format(g_localizeStrings.Get(labelStarted), static_cast<int>(event.m_fSecs) / 60,
                           static_cast<int>(event.m_fSecs) % 60)));
-  if (bSilent)
-    CServiceBroker::GetEventLog().Add(alarmClockActivity);
-  else
-    CServiceBroker::GetEventLog().AddWithNotification(alarmClockActivity);
+
+  auto eventLog = CServiceBroker::GetEventLog();
+  if (eventLog)
+  {
+    if (bSilent)
+      eventLog->Add(alarmClockActivity);
+    else
+      eventLog->AddWithNotification(alarmClockActivity);
+  }
 
   event.watch.StartZero();
   CSingleLock lock(m_events);
@@ -109,10 +114,14 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
   if (iter->second.m_strCommand.empty() || static_cast<float>(iter->second.m_fSecs) > elapsed)
   {
     EventPtr alarmClockActivity(new CNotificationEvent(labelAlarmClock, strMessage));
-    if (bSilent)
-      CServiceBroker::GetEventLog().Add(alarmClockActivity);
-    else
-      CServiceBroker::GetEventLog().AddWithNotification(alarmClockActivity);
+    auto eventLog = CServiceBroker::GetEventLog();
+    if (eventLog)
+    {
+      if (bSilent)
+        eventLog->Add(alarmClockActivity);
+      else
+        eventLog->AddWithNotification(alarmClockActivity);
+    }
   }
   else
   {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -492,11 +492,14 @@ namespace VIDEO
           mediaType = MediaTypeTvShow;
         else if (info2->Content() == CONTENT_MUSICVIDEOS)
           mediaType = MediaTypeMusicVideo;
-        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
-            mediaType, pItem->GetPath(), 24145,
-            StringUtils::Format(g_localizeStrings.Get(24147), mediaType,
-                                URIUtils::GetFileName(pItem->GetPath())),
-            pItem->GetArt("thumb"), CURL::GetRedacted(pItem->GetPath()), EventLevel::Warning)));
+
+        auto eventLog = CServiceBroker::GetEventLog();
+        if (eventLog)
+          eventLog->Add(EventPtr(new CMediaLibraryEvent(
+              mediaType, pItem->GetPath(), 24145,
+              StringUtils::Format(g_localizeStrings.Get(24147), mediaType,
+                                  URIUtils::GetFileName(pItem->GetPath())),
+              pItem->GetArt("thumb"), CURL::GetRedacted(pItem->GetPath()), EventLevel::Warning)));
       }
 
       pURL = NULL;


### PR DESCRIPTION
## Description
Clang-analyzer detects the possibility of potential object pointer being null in
CServiceBroker::GetEventLog(). As we return a reference, its expected a reference is never
null. change to a pointer and do null checks

```
macos/xbmc/ServiceBroker.cpp:253:10: warning: Called C++ object pointer is null
  return g_serviceBroker.m_pSettingsComponent->GetProfileManager()->GetEventLog();
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

## Motivation and context
Clang-analyze warning fixes.
Not sure if this would be the best way, but the m_pSettingsComponent can potentially be nullptr (std::unique_ptr) as well as GetProfileManager (std::shared_ptr).

## How has this been tested?
build/runtime osx. Eventlog still logs/deletes entries

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
