### PR TITLE
[nfs] change connection timeout to 30sec

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -429,7 +429,7 @@ void CAdvancedSettings::Initialize()
 
   m_userAgent = g_sysinfo.GetUserAgent();
 
-  m_nfsTimeout = 5;
+  m_nfsTimeout = 30;
   m_nfsRetries = -1;
 
   m_initialized = true;


### PR DESCRIPTION
## Description
Change the connection timeout of the nfs client to 30 sec.

## Motivation and context
Since https://github.com/xbmc/xbmc/pull/15686 kodi fails to playback files from a nfs share if the hdd needs to spin up. The 5 sec timeout is set too short, its not enough time to spin up a HDD. For samba kodi uses a [30sec timeout](https://github.com/CvH/xbmc/blob/c82dcac90fa7112b657b42c587fa13ee38ebbb4c/xbmc/settings/AdvancedSettings.cpp#L262).

## How has this been tested?
Putting the values into advancedsettings.xml
```
<advancedsettings version="1.0">
  <network>
    <nfstimeout>30</nfstimeout>
  </network>
</advancedsettings>
```

## What is the effect on users?
No errors anymore if the HDD at the NAS needs to spin up before playback.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed


needs changes to the wiki https://kodi.wiki/view/Advancedsettings.xml#network