### PR TITLE
GLUtils: add glFormatElementByteCount to KODI::UTILS::GL namespace

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -400,7 +400,7 @@ void CLinuxRendererGL::LoadPlane(CYuvPlane& plane, int type,
   if (plane.pbo)
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, plane.pbo);
 
-  int bps = bpp * glFormatElementByteCount(type);
+  int bps = bpp * KODI::UTILS::GL::glFormatElementByteCount(type);
 
   unsigned datatype;
   if (bpp == 2)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -284,7 +284,7 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
                                    int stride, int bpp, void* data)
 {
   const GLvoid *pixelData = data;
-  int bps = bpp * glFormatElementByteCount(type);
+  int bps = bpp * KODI::UTILS::GL::glFormatElementByteCount(type);
 
   glBindTexture(m_textureTarget, plane.id);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -55,7 +55,7 @@ static void LoadTexture(GLenum target
   GLenum externalFormat = alpha ? GL_RED : GL_BGRA;
 #endif
 
-  int bytesPerPixel = glFormatElementByteCount(externalFormat);
+  int bytesPerPixel = KODI::UTILS::GL::glFormatElementByteCount(externalFormat);
 
 #ifdef HAS_GLES
   bool bgraSupported = false;

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -229,7 +229,7 @@ void LogGraphicsInfo()
 #endif /* !HAS_GL */
 }
 
-int glFormatElementByteCount(GLenum format)
+int KODI::UTILS::GL::glFormatElementByteCount(GLenum format)
 {
   switch (format)
   {

--- a/xbmc/utils/GLUtils.h
+++ b/xbmc/utils/GLUtils.h
@@ -30,6 +30,7 @@ namespace GL
 
 void GlErrorCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 
+int glFormatElementByteCount(GLenum format);
 }
 }
 }
@@ -42,5 +43,3 @@ void _VerifyGLState(const char* szfile, const char* szfunction, int lineno);
 #endif
 
 void LogGraphicsInfo();
-
-int glFormatElementByteCount(GLenum format);


### PR DESCRIPTION
This method isn't a gl call so lets namespace it to avoid confusion.