### PR TITLE
[GL/GLES] use enum class for shader methods

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -68,24 +68,42 @@ bool CRenderContext::IsExtSupported(const char* extension)
 #if defined(HAS_GL) || defined(HAS_GLES)
 namespace
 {
-static ESHADERMETHOD TranslateShaderMethod(GL_SHADER_METHOD method)
+
+#ifdef HAS_GL
+static ShaderMethodGL TranslatShaderMethodGL(GL_SHADER_METHOD method)
 {
   switch (method)
   {
     case GL_SHADER_METHOD::DEFAULT:
-      return SM_DEFAULT;
+      return ShaderMethodGL::SM_DEFAULT;
     case GL_SHADER_METHOD::TEXTURE:
-      return SM_TEXTURE;
-#if defined(HAS_GLES)
-    case GL_SHADER_METHOD::TEXTURE_NOALPHA:
-      return SM_TEXTURE_NOALPHA;
-#endif
+      return ShaderMethodGL::SM_TEXTURE;
     default:
       break;
   }
 
-  return SM_DEFAULT;
+  return ShaderMethodGL::SM_DEFAULT;
 }
+#endif
+#ifdef HAS_GLES
+static ShaderMethodGLES TranslatShaderMethodGLES(GL_SHADER_METHOD method)
+{
+  switch (method)
+  {
+    case GL_SHADER_METHOD::DEFAULT:
+      return ShaderMethodGLES::SM_DEFAULT;
+    case GL_SHADER_METHOD::TEXTURE:
+      return ShaderMethodGLES::SM_TEXTURE;
+    case GL_SHADER_METHOD::TEXTURE_NOALPHA:
+      return ShaderMethodGLES::SM_TEXTURE_NOALPHA;
+    default:
+      break;
+  }
+
+  return ShaderMethodGLES::SM_DEFAULT;
+}
+#endif
+
 } // namespace
 #endif
 
@@ -94,11 +112,11 @@ void CRenderContext::EnableGUIShader(GL_SHADER_METHOD method)
 #if defined(HAS_GL)
   CRenderSystemGL* rendering = dynamic_cast<CRenderSystemGL*>(m_rendering);
   if (rendering != nullptr)
-    rendering->EnableShader(TranslateShaderMethod(method));
+    rendering->EnableShader(TranslatShaderMethodGL(method));
 #elif HAS_GLES >= 2
   CRenderSystemGLES* renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
   if (renderingGLES != nullptr)
-    renderingGLES->EnableGUIShader(TranslateShaderMethod(method));
+    renderingGLES->EnableGUIShader(TranslatShaderMethodGLES(method));
 #endif
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -219,7 +219,7 @@ void CRendererDRMPRIMEGLES::DrawBlackBars()
   if (!renderSystem)
     return;
 
-  renderSystem->EnableGUIShader(SM_DEFAULT);
+  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_DEFAULT);
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint uniCol = renderSystem->GUIShaderGetUniCol();
 
@@ -311,7 +311,7 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
 
   glBindTexture(GL_TEXTURE_EXTERNAL_OES, buf.texture.GetTexture());
 
-  renderSystem->EnableGUIShader(SM_TEXTURE_RGBA_OES);
+  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE_RGBA_OES);
 
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
   GLuint vertexVBO;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
@@ -122,7 +122,7 @@ bool CRendererMediaCodec::RenderHook(int index)
 
   if (m_currentField != FIELD_FULL)
   {
-    renderSystem->EnableGUIShader(SM_TEXTURE_RGBA_BOB_OES);
+    renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES);
     GLint   fieldLoc = renderSystem->GUIShaderGetField();
     GLint   stepLoc = renderSystem->GUIShaderGetStep();
 
@@ -134,7 +134,7 @@ bool CRendererMediaCodec::RenderHook(int index)
     glUniform1f(stepLoc, 1.0f / (float)plane.texheight);
   }
   else
-    renderSystem->EnableGUIShader(SM_TEXTURE_RGBA_OES);
+    renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE_RGBA_OES);
 
   GLint   contrastLoc = renderSystem->GUIShaderGetContrast();
   glUniform1f(contrastLoc, m_videoSettings.m_Contrast * 0.02f);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -550,7 +550,7 @@ void CLinuxRendererGL::DrawBlackBars()
   Svertex vertices[24];
   GLubyte count = 0;
 
-  m_renderSystem->EnableShader(SM_DEFAULT);
+  m_renderSystem->EnableShader(ShaderMethodGL::SM_DEFAULT);
   GLint posLoc = m_renderSystem->ShaderGetPos();
   GLint uniCol = m_renderSystem->ShaderGetUniCol();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -406,7 +406,7 @@ void CLinuxRendererGLES::DrawBlackBars()
   if (!renderSystem)
     return;
 
-  renderSystem->EnableGUIShader(SM_DEFAULT);
+  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_DEFAULT);
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint uniCol = renderSystem->GUIShaderGetUniCol();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -359,7 +359,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
 
 #ifdef HAS_GL
   CRenderSystemGL* renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableShader(SM_FONTS);
+  renderSystem->EnableShader(ShaderMethodGL::SM_FONTS);
   GLint posLoc  = renderSystem->ShaderGetPos();
   GLint colLoc  = renderSystem->ShaderGetCol();
   GLint tex0Loc = renderSystem->ShaderGetCoord0();
@@ -408,7 +408,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
 
 #else
   CRenderSystemGLES* renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableGUIShader(SM_FONTS);
+  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_FONTS);
   GLint posLoc  = renderSystem->GUIShaderGetPos();
   GLint colLoc  = renderSystem->GUIShaderGetCol();
   GLint tex0Loc = renderSystem->GUIShaderGetCoord0();
@@ -497,9 +497,9 @@ void COverlayTextureGL::Render(SRenderState& state)
   int glslMajor, glslMinor;
   renderSystem->GetGLSLVersion(glslMajor, glslMinor);
   if (glslMajor >= 2 || (glslMajor == 1 && glslMinor >= 50))
-    renderSystem->EnableShader(SM_TEXTURE_LIM);
+    renderSystem->EnableShader(ShaderMethodGL::SM_TEXTURE_LIM);
   else
-    renderSystem->EnableShader(SM_TEXTURE);
+    renderSystem->EnableShader(ShaderMethodGL::SM_TEXTURE);
 
   GLint posLoc = renderSystem->ShaderGetPos();
   GLint tex0Loc = renderSystem->ShaderGetCoord0();
@@ -572,7 +572,7 @@ void COverlayTextureGL::Render(SRenderState& state)
 
 #else
   CRenderSystemGLES* renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableGUIShader(SM_TEXTURE);
+  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE);
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint colLoc = renderSystem->GUIShaderGetCol();
   GLint tex0Loc = renderSystem->GUIShaderGetCoord0();

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -120,7 +120,7 @@ void CGUIFontTTFGL::LastEnd()
 {
 #ifdef HAS_GL
   CRenderSystemGL* renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableShader(SM_FONTS);
+  renderSystem->EnableShader(ShaderMethodGL::SM_FONTS);
 
   GLint posLoc = renderSystem->ShaderGetPos();
   GLint colLoc = renderSystem->ShaderGetCol();
@@ -174,7 +174,7 @@ void CGUIFontTTFGL::LastEnd()
 #else
   // GLES 2.0 version.
   CRenderSystemGLES* renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableGUIShader(SM_FONTS);
+  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_FONTS);
 
   GLint posLoc  = renderSystem->GUIShaderGetPos();
   GLint colLoc  = renderSystem->GUIShaderGetCol();

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -57,11 +57,11 @@ void CGUITextureGL::Begin(UTILS::COLOR::Color color)
   {
     if (m_col[0] == 255 && m_col[1] == 255 && m_col[2] == 255 && m_col[3] == 255 )
     {
-      m_renderSystem->EnableShader(SM_MULTI);
+      m_renderSystem->EnableShader(ShaderMethodGL::SM_MULTI);
     }
     else
     {
-      m_renderSystem->EnableShader(SM_MULTI_BLENDCOLOR);
+      m_renderSystem->EnableShader(ShaderMethodGL::SM_MULTI_BLENDCOLOR);
     }
 
     hasAlpha |= m_diffuse.m_textures[0]->HasAlpha();
@@ -72,11 +72,11 @@ void CGUITextureGL::Begin(UTILS::COLOR::Color color)
   {
     if (m_col[0] == 255 && m_col[1] == 255 && m_col[2] == 255 && m_col[3] == 255)
     {
-      m_renderSystem->EnableShader(SM_TEXTURE_NOBLEND);
+      m_renderSystem->EnableShader(ShaderMethodGL::SM_TEXTURE_NOBLEND);
     }
     else
     {
-      m_renderSystem->EnableShader(SM_TEXTURE);
+      m_renderSystem->EnableShader(ShaderMethodGL::SM_TEXTURE);
     }
   }
 
@@ -274,9 +274,9 @@ void CGUITexture::DrawQuad(const CRect& rect,
   }vertex[4];
 
   if (texture)
-    renderSystem->EnableShader(SM_TEXTURE);
+    renderSystem->EnableShader(ShaderMethodGL::SM_TEXTURE);
   else
-    renderSystem->EnableShader(SM_DEFAULT);
+    renderSystem->EnableShader(ShaderMethodGL::SM_DEFAULT);
 
   GLint posLoc = renderSystem->ShaderGetPos();
   GLint tex0Loc = renderSystem->ShaderGetCoord0();

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -65,11 +65,11 @@ void CGUITextureGLES::Begin(UTILS::COLOR::Color color)
   {
     if (m_col[0] == 255 && m_col[1] == 255 && m_col[2] == 255 && m_col[3] == 255 )
     {
-      m_renderSystem->EnableGUIShader(SM_MULTI);
+      m_renderSystem->EnableGUIShader(ShaderMethodGLES::SM_MULTI);
     }
     else
     {
-      m_renderSystem->EnableGUIShader(SM_MULTI_BLENDCOLOR);
+      m_renderSystem->EnableGUIShader(ShaderMethodGLES::SM_MULTI_BLENDCOLOR);
     }
 
     hasAlpha |= m_diffuse.m_textures[0]->HasAlpha();
@@ -81,11 +81,11 @@ void CGUITextureGLES::Begin(UTILS::COLOR::Color color)
   {
     if (m_col[0] == 255 && m_col[1] == 255 && m_col[2] == 255 && m_col[3] == 255)
     {
-      m_renderSystem->EnableGUIShader(SM_TEXTURE_NOBLEND);
+      m_renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE_NOBLEND);
     }
     else
     {
-      m_renderSystem->EnableGUIShader(SM_TEXTURE);
+      m_renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE);
     }
   }
 
@@ -249,9 +249,9 @@ void CGUITexture::DrawQuad(const CRect& rect,
   GLubyte idx[4] = {0, 1, 3, 2};        //determines order of triangle strip
 
   if (texture)
-    renderSystem->EnableGUIShader(SM_TEXTURE);
+    renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE);
   else
-    renderSystem->EnableGUIShader(SM_DEFAULT);
+    renderSystem->EnableGUIShader(ShaderMethodGLES::SM_DEFAULT);
 
   GLint posLoc   = renderSystem->GUIShaderGetPos();
   GLint tex0Loc  = renderSystem->GUIShaderGetCoord0();

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -854,11 +854,11 @@ void CSlideShowPic::Render(float* x, float* y, CTexture* pTexture, UTILS::COLOR:
     glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
     glEnable(GL_BLEND);
 
-    renderSystem->EnableShader(SM_TEXTURE);
+    renderSystem->EnableShader(ShaderMethodGL::SM_TEXTURE);
   }
   else
   {
-    renderSystem->EnableShader(SM_DEFAULT);
+    renderSystem->EnableShader(ShaderMethodGL::SM_DEFAULT);
   }
 
   float u1 = 0, u2 = 1, v1 = 0, v2 = 1;
@@ -954,11 +954,11 @@ void CSlideShowPic::Render(float* x, float* y, CTexture* pTexture, UTILS::COLOR:
     glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
     glEnable(GL_BLEND);          // Turn Blending On
 
-    renderSystem->EnableGUIShader(SM_TEXTURE);
+    renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE);
   }
   else
   {
-    renderSystem->EnableGUIShader(SM_DEFAULT);
+    renderSystem->EnableGUIShader(ShaderMethodGLES::SM_DEFAULT);
   }
 
   float u1 = 0, u2 = 1, v1 = 0, v2 = 1;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -610,95 +610,100 @@ void CRenderSystemGL::InitialiseShaders()
     defines += "#define KODI_LIMITED_RANGE 1\n";
   }
 
-  m_pShader[SM_DEFAULT].reset(new CGLShader("gl_shader_vert_default.glsl", "gl_shader_frag_default.glsl", defines));
-  if (!m_pShader[SM_DEFAULT]->CompileAndLink())
+  m_pShader[ShaderMethodGL::SM_DEFAULT].reset(
+      new CGLShader("gl_shader_vert_default.glsl", "gl_shader_frag_default.glsl", defines));
+  if (!m_pShader[ShaderMethodGL::SM_DEFAULT]->CompileAndLink())
   {
-    m_pShader[SM_DEFAULT]->Free();
-    m_pShader[SM_DEFAULT].reset();
+    m_pShader[ShaderMethodGL::SM_DEFAULT]->Free();
+    m_pShader[ShaderMethodGL::SM_DEFAULT].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_default.glsl - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE].reset(new CGLShader("gl_shader_frag_texture.glsl", defines));
-  if (!m_pShader[SM_TEXTURE]->CompileAndLink())
+  m_pShader[ShaderMethodGL::SM_TEXTURE].reset(
+      new CGLShader("gl_shader_frag_texture.glsl", defines));
+  if (!m_pShader[ShaderMethodGL::SM_TEXTURE]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE]->Free();
-    m_pShader[SM_TEXTURE].reset();
+    m_pShader[ShaderMethodGL::SM_TEXTURE]->Free();
+    m_pShader[ShaderMethodGL::SM_TEXTURE].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture.glsl - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_LIM].reset(new CGLShader("gl_shader_frag_texture_lim.glsl", defines));
-  if (!m_pShader[SM_TEXTURE_LIM]->CompileAndLink())
+  m_pShader[ShaderMethodGL::SM_TEXTURE_LIM].reset(
+      new CGLShader("gl_shader_frag_texture_lim.glsl", defines));
+  if (!m_pShader[ShaderMethodGL::SM_TEXTURE_LIM]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE_LIM]->Free();
-    m_pShader[SM_TEXTURE_LIM].reset();
+    m_pShader[ShaderMethodGL::SM_TEXTURE_LIM]->Free();
+    m_pShader[ShaderMethodGL::SM_TEXTURE_LIM].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture_lim.glsl - compile and link failed");
   }
 
-  m_pShader[SM_MULTI].reset(new CGLShader("gl_shader_frag_multi.glsl", defines));
-  if (!m_pShader[SM_MULTI]->CompileAndLink())
+  m_pShader[ShaderMethodGL::SM_MULTI].reset(new CGLShader("gl_shader_frag_multi.glsl", defines));
+  if (!m_pShader[ShaderMethodGL::SM_MULTI]->CompileAndLink())
   {
-    m_pShader[SM_MULTI]->Free();
-    m_pShader[SM_MULTI].reset();
+    m_pShader[ShaderMethodGL::SM_MULTI]->Free();
+    m_pShader[ShaderMethodGL::SM_MULTI].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_multi.glsl - compile and link failed");
   }
 
-  m_pShader[SM_FONTS].reset(new CGLShader("gl_shader_frag_fonts.glsl", defines));
-  if (!m_pShader[SM_FONTS]->CompileAndLink())
+  m_pShader[ShaderMethodGL::SM_FONTS].reset(new CGLShader("gl_shader_frag_fonts.glsl", defines));
+  if (!m_pShader[ShaderMethodGL::SM_FONTS]->CompileAndLink())
   {
-    m_pShader[SM_FONTS]->Free();
-    m_pShader[SM_FONTS].reset();
+    m_pShader[ShaderMethodGL::SM_FONTS]->Free();
+    m_pShader[ShaderMethodGL::SM_FONTS].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_fonts.glsl - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_NOBLEND].reset(new CGLShader("gl_shader_frag_texture_noblend.glsl", defines));
-  if (!m_pShader[SM_TEXTURE_NOBLEND]->CompileAndLink())
+  m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND].reset(
+      new CGLShader("gl_shader_frag_texture_noblend.glsl", defines));
+  if (!m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE_NOBLEND]->Free();
-    m_pShader[SM_TEXTURE_NOBLEND].reset();
+    m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND]->Free();
+    m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture_noblend.glsl - compile and link failed");
   }
 
-  m_pShader[SM_MULTI_BLENDCOLOR].reset(new CGLShader("gl_shader_frag_multi_blendcolor.glsl", defines));
-  if (!m_pShader[SM_MULTI_BLENDCOLOR]->CompileAndLink())
+  m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR].reset(
+      new CGLShader("gl_shader_frag_multi_blendcolor.glsl", defines));
+  if (!m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR]->CompileAndLink())
   {
-    m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-    m_pShader[SM_MULTI_BLENDCOLOR].reset();
+    m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR]->Free();
+    m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_multi_blendcolor.glsl - compile and link failed");
   }
 }
 
 void CRenderSystemGL::ReleaseShaders()
 {
-  if (m_pShader[SM_DEFAULT])
-    m_pShader[SM_DEFAULT]->Free();
-  m_pShader[SM_DEFAULT].reset();
+  if (m_pShader[ShaderMethodGL::SM_DEFAULT])
+    m_pShader[ShaderMethodGL::SM_DEFAULT]->Free();
+  m_pShader[ShaderMethodGL::SM_DEFAULT].reset();
 
-  if (m_pShader[SM_TEXTURE])
-    m_pShader[SM_TEXTURE]->Free();
-  m_pShader[SM_TEXTURE].reset();
+  if (m_pShader[ShaderMethodGL::SM_TEXTURE])
+    m_pShader[ShaderMethodGL::SM_TEXTURE]->Free();
+  m_pShader[ShaderMethodGL::SM_TEXTURE].reset();
 
-  if (m_pShader[SM_TEXTURE_LIM])
-    m_pShader[SM_TEXTURE_LIM]->Free();
-  m_pShader[SM_TEXTURE_LIM].reset();
+  if (m_pShader[ShaderMethodGL::SM_TEXTURE_LIM])
+    m_pShader[ShaderMethodGL::SM_TEXTURE_LIM]->Free();
+  m_pShader[ShaderMethodGL::SM_TEXTURE_LIM].reset();
 
-  if (m_pShader[SM_MULTI])
-    m_pShader[SM_MULTI]->Free();
-  m_pShader[SM_MULTI].reset();
+  if (m_pShader[ShaderMethodGL::SM_MULTI])
+    m_pShader[ShaderMethodGL::SM_MULTI]->Free();
+  m_pShader[ShaderMethodGL::SM_MULTI].reset();
 
-  if (m_pShader[SM_FONTS])
-    m_pShader[SM_FONTS]->Free();
-  m_pShader[SM_FONTS].reset();
+  if (m_pShader[ShaderMethodGL::SM_FONTS])
+    m_pShader[ShaderMethodGL::SM_FONTS]->Free();
+  m_pShader[ShaderMethodGL::SM_FONTS].reset();
 
-  if (m_pShader[SM_TEXTURE_NOBLEND])
-    m_pShader[SM_TEXTURE_NOBLEND]->Free();
-  m_pShader[SM_TEXTURE_NOBLEND].reset();
+  if (m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND])
+    m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND]->Free();
+  m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND].reset();
 
-  if (m_pShader[SM_MULTI_BLENDCOLOR])
-    m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-  m_pShader[SM_MULTI_BLENDCOLOR].reset();
+  if (m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR])
+    m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR]->Free();
+  m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR].reset();
 }
 
-void CRenderSystemGL::EnableShader(ESHADERMETHOD method)
+void CRenderSystemGL::EnableShader(ShaderMethodGL method)
 {
   m_method = method;
   if (m_pShader[m_method])
@@ -717,7 +722,7 @@ void CRenderSystemGL::DisableShader()
   {
     m_pShader[m_method]->Disable();
   }
-  m_method = SM_DEFAULT;
+  m_method = ShaderMethodGL::SM_DEFAULT;
 }
 
 GLint CRenderSystemGL::ShaderGetPos()

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -610,8 +610,8 @@ void CRenderSystemGL::InitialiseShaders()
     defines += "#define KODI_LIMITED_RANGE 1\n";
   }
 
-  m_pShader[ShaderMethodGL::SM_DEFAULT].reset(
-      new CGLShader("gl_shader_vert_default.glsl", "gl_shader_frag_default.glsl", defines));
+  m_pShader[ShaderMethodGL::SM_DEFAULT] = std::make_unique<CGLShader>(
+      "gl_shader_vert_default.glsl", "gl_shader_frag_default.glsl", defines);
   if (!m_pShader[ShaderMethodGL::SM_DEFAULT]->CompileAndLink())
   {
     m_pShader[ShaderMethodGL::SM_DEFAULT]->Free();
@@ -619,8 +619,8 @@ void CRenderSystemGL::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_default.glsl - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGL::SM_TEXTURE].reset(
-      new CGLShader("gl_shader_frag_texture.glsl", defines));
+  m_pShader[ShaderMethodGL::SM_TEXTURE] =
+      std::make_unique<CGLShader>("gl_shader_frag_texture.glsl", defines);
   if (!m_pShader[ShaderMethodGL::SM_TEXTURE]->CompileAndLink())
   {
     m_pShader[ShaderMethodGL::SM_TEXTURE]->Free();
@@ -628,8 +628,8 @@ void CRenderSystemGL::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture.glsl - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGL::SM_TEXTURE_LIM].reset(
-      new CGLShader("gl_shader_frag_texture_lim.glsl", defines));
+  m_pShader[ShaderMethodGL::SM_TEXTURE_LIM] =
+      std::make_unique<CGLShader>("gl_shader_frag_texture_lim.glsl", defines);
   if (!m_pShader[ShaderMethodGL::SM_TEXTURE_LIM]->CompileAndLink())
   {
     m_pShader[ShaderMethodGL::SM_TEXTURE_LIM]->Free();
@@ -637,7 +637,8 @@ void CRenderSystemGL::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture_lim.glsl - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGL::SM_MULTI].reset(new CGLShader("gl_shader_frag_multi.glsl", defines));
+  m_pShader[ShaderMethodGL::SM_MULTI] =
+      std::make_unique<CGLShader>("gl_shader_frag_multi.glsl", defines);
   if (!m_pShader[ShaderMethodGL::SM_MULTI]->CompileAndLink())
   {
     m_pShader[ShaderMethodGL::SM_MULTI]->Free();
@@ -645,7 +646,8 @@ void CRenderSystemGL::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_multi.glsl - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGL::SM_FONTS].reset(new CGLShader("gl_shader_frag_fonts.glsl", defines));
+  m_pShader[ShaderMethodGL::SM_FONTS] =
+      std::make_unique<CGLShader>("gl_shader_frag_fonts.glsl", defines);
   if (!m_pShader[ShaderMethodGL::SM_FONTS]->CompileAndLink())
   {
     m_pShader[ShaderMethodGL::SM_FONTS]->Free();
@@ -653,8 +655,8 @@ void CRenderSystemGL::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_fonts.glsl - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND].reset(
-      new CGLShader("gl_shader_frag_texture_noblend.glsl", defines));
+  m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND] =
+      std::make_unique<CGLShader>("gl_shader_frag_texture_noblend.glsl", defines);
   if (!m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND]->CompileAndLink())
   {
     m_pShader[ShaderMethodGL::SM_TEXTURE_NOBLEND]->Free();
@@ -662,8 +664,8 @@ void CRenderSystemGL::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture_noblend.glsl - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR].reset(
-      new CGLShader("gl_shader_frag_multi_blendcolor.glsl", defines));
+  m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR] =
+      std::make_unique<CGLShader>("gl_shader_frag_multi_blendcolor.glsl", defines);
   if (!m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR]->CompileAndLink())
   {
     m_pShader[ShaderMethodGL::SM_MULTI_BLENDCOLOR]->Free();

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -12,12 +12,12 @@
 #include "rendering/RenderSystem.h"
 #include "utils/ColorUtils.h"
 
-#include <array>
+#include <map>
 #include <memory>
 
 #include "system_gl.h"
 
-enum ESHADERMETHOD
+enum class ShaderMethodGL
 {
   SM_DEFAULT = 0,
   SM_TEXTURE,
@@ -25,8 +25,7 @@ enum ESHADERMETHOD
   SM_MULTI,
   SM_FONTS,
   SM_TEXTURE_NOBLEND,
-  SM_MULTI_BLENDCOLOR,
-  SM_MAX
+  SM_MULTI_BLENDCOLOR
 };
 
 class CRenderSystemGL : public CRenderSystemBase
@@ -74,7 +73,7 @@ public:
   void ResetGLErrors();
 
   // shaders
-  void EnableShader(ESHADERMETHOD method);
+  void EnableShader(ShaderMethodGL method);
   void DisableShader();
   GLint ShaderGetPos();
   GLint ShaderGetCol();
@@ -101,7 +100,7 @@ protected:
 
   GLint m_viewPort[4];
 
-  std::array<std::unique_ptr<CGLShader>, SM_MAX> m_pShader;
-  ESHADERMETHOD m_method = SM_DEFAULT;
+  std::map<ShaderMethodGL, std::unique_ptr<CGLShader>> m_pShader;
+  ShaderMethodGL m_method = ShaderMethodGL::SM_DEFAULT;
   GLuint m_vertexArray = GL_NONE;
 };

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -384,8 +384,8 @@ void CRenderSystemGLES::InitialiseShaders()
     defines += "#define KODI_LIMITED_RANGE 1\n";
   }
 
-  m_pShader[ShaderMethodGLES::SM_DEFAULT].reset(
-      new CGLESShader("gles_shader.vert", "gles_shader_default.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_DEFAULT] =
+      std::make_unique<CGLESShader>("gles_shader.vert", "gles_shader_default.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_DEFAULT]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_DEFAULT]->Free();
@@ -393,8 +393,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_default.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_TEXTURE].reset(
-      new CGLESShader("gles_shader_texture.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_TEXTURE] =
+      std::make_unique<CGLESShader>("gles_shader_texture.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_TEXTURE]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_TEXTURE]->Free();
@@ -402,7 +402,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_texture.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_MULTI].reset(new CGLESShader("gles_shader_multi.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_MULTI] =
+      std::make_unique<CGLESShader>("gles_shader_multi.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_MULTI]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_MULTI]->Free();
@@ -410,7 +411,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_multi.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_FONTS].reset(new CGLESShader("gles_shader_fonts.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_FONTS] =
+      std::make_unique<CGLESShader>("gles_shader_fonts.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_FONTS]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_FONTS]->Free();
@@ -418,8 +420,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_fonts.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND].reset(
-      new CGLESShader("gles_shader_texture_noblend.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND] =
+      std::make_unique<CGLESShader>("gles_shader_texture_noblend.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND]->Free();
@@ -427,8 +429,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_texture_noblend.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR].reset(
-      new CGLESShader("gles_shader_multi_blendcolor.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR] =
+      std::make_unique<CGLESShader>("gles_shader_multi_blendcolor.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR]->Free();
@@ -436,8 +438,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_multi_blendcolor.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA].reset(
-      new CGLESShader("gles_shader_rgba.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA] =
+      std::make_unique<CGLESShader>("gles_shader_rgba.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA]->Free();
@@ -445,8 +447,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR].reset(
-      new CGLESShader("gles_shader_rgba_blendcolor.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR] =
+      std::make_unique<CGLESShader>("gles_shader_rgba_blendcolor.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR]->Free();
@@ -454,8 +456,8 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_blendcolor.frag - compile and link failed");
   }
 
-  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB].reset(
-      new CGLESShader("gles_shader_rgba_bob.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB] =
+      std::make_unique<CGLESShader>("gles_shader_rgba_bob.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB]->Free();
@@ -465,8 +467,8 @@ void CRenderSystemGLES::InitialiseShaders()
 
   if (IsExtSupported("GL_OES_EGL_image_external"))
   {
-    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES].reset(
-        new CGLESShader("gles_shader_rgba_oes.frag", defines));
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES] =
+        std::make_unique<CGLESShader>("gles_shader_rgba_oes.frag", defines);
     if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES]->CompileAndLink())
     {
       m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES]->Free();
@@ -475,8 +477,8 @@ void CRenderSystemGLES::InitialiseShaders()
     }
 
 
-    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES].reset(
-        new CGLESShader("gles_shader_rgba_bob_oes.frag", defines));
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES] =
+        std::make_unique<CGLESShader>("gles_shader_rgba_bob_oes.frag", defines);
     if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES]->CompileAndLink())
     {
       m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES]->Free();
@@ -485,8 +487,8 @@ void CRenderSystemGLES::InitialiseShaders()
     }
   }
 
-  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA].reset(
-      new CGLESShader("gles_shader_texture_noalpha.frag", defines));
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA] =
+      std::make_unique<CGLESShader>("gles_shader_texture_noalpha.frag", defines);
   if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA]->CompileAndLink())
   {
     m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA]->Free();

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -384,159 +384,169 @@ void CRenderSystemGLES::InitialiseShaders()
     defines += "#define KODI_LIMITED_RANGE 1\n";
   }
 
-  m_pShader[SM_DEFAULT].reset(new CGLESShader("gles_shader.vert", "gles_shader_default.frag", defines));
-  if (!m_pShader[SM_DEFAULT]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_DEFAULT].reset(
+      new CGLESShader("gles_shader.vert", "gles_shader_default.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_DEFAULT]->CompileAndLink())
   {
-    m_pShader[SM_DEFAULT]->Free();
-    m_pShader[SM_DEFAULT].reset();
+    m_pShader[ShaderMethodGLES::SM_DEFAULT]->Free();
+    m_pShader[ShaderMethodGLES::SM_DEFAULT].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_default.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE].reset(new CGLESShader("gles_shader_texture.frag", defines));
-  if (!m_pShader[SM_TEXTURE]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_TEXTURE].reset(
+      new CGLESShader("gles_shader_texture.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_TEXTURE]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE]->Free();
-    m_pShader[SM_TEXTURE].reset();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE]->Free();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_texture.frag - compile and link failed");
   }
 
-  m_pShader[SM_MULTI].reset(new CGLESShader("gles_shader_multi.frag", defines));
-  if (!m_pShader[SM_MULTI]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_MULTI].reset(new CGLESShader("gles_shader_multi.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_MULTI]->CompileAndLink())
   {
-    m_pShader[SM_MULTI]->Free();
-    m_pShader[SM_MULTI].reset();
+    m_pShader[ShaderMethodGLES::SM_MULTI]->Free();
+    m_pShader[ShaderMethodGLES::SM_MULTI].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_multi.frag - compile and link failed");
   }
 
-  m_pShader[SM_FONTS].reset(new CGLESShader("gles_shader_fonts.frag", defines));
-  if (!m_pShader[SM_FONTS]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_FONTS].reset(new CGLESShader("gles_shader_fonts.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_FONTS]->CompileAndLink())
   {
-    m_pShader[SM_FONTS]->Free();
-    m_pShader[SM_FONTS].reset();
+    m_pShader[ShaderMethodGLES::SM_FONTS]->Free();
+    m_pShader[ShaderMethodGLES::SM_FONTS].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_fonts.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_NOBLEND].reset(new CGLESShader("gles_shader_texture_noblend.frag", defines));
-  if (!m_pShader[SM_TEXTURE_NOBLEND]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND].reset(
+      new CGLESShader("gles_shader_texture_noblend.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE_NOBLEND]->Free();
-    m_pShader[SM_TEXTURE_NOBLEND].reset();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND]->Free();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_texture_noblend.frag - compile and link failed");
   }
 
-  m_pShader[SM_MULTI_BLENDCOLOR].reset(new CGLESShader("gles_shader_multi_blendcolor.frag", defines));
-  if (!m_pShader[SM_MULTI_BLENDCOLOR]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR].reset(
+      new CGLESShader("gles_shader_multi_blendcolor.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR]->CompileAndLink())
   {
-    m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-    m_pShader[SM_MULTI_BLENDCOLOR].reset();
+    m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR]->Free();
+    m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_multi_blendcolor.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_RGBA].reset(new CGLESShader("gles_shader_rgba.frag", defines));
-  if (!m_pShader[SM_TEXTURE_RGBA]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA].reset(
+      new CGLESShader("gles_shader_rgba.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE_RGBA]->Free();
-    m_pShader[SM_TEXTURE_RGBA].reset();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA]->Free();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR].reset(new CGLESShader("gles_shader_rgba_blendcolor.frag", defines));
-  if (!m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR].reset(
+      new CGLESShader("gles_shader_rgba_blendcolor.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR]->Free();
-    m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR].reset();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR]->Free();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_blendcolor.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_RGBA_BOB].reset(new CGLESShader("gles_shader_rgba_bob.frag", defines));
-  if (!m_pShader[SM_TEXTURE_RGBA_BOB]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB].reset(
+      new CGLESShader("gles_shader_rgba_bob.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE_RGBA_BOB]->Free();
-    m_pShader[SM_TEXTURE_RGBA_BOB].reset();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB]->Free();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_bob.frag - compile and link failed");
   }
 
   if (IsExtSupported("GL_OES_EGL_image_external"))
   {
-    m_pShader[SM_TEXTURE_RGBA_OES].reset(new CGLESShader("gles_shader_rgba_oes.frag", defines));
-    if (!m_pShader[SM_TEXTURE_RGBA_OES]->CompileAndLink())
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES].reset(
+        new CGLESShader("gles_shader_rgba_oes.frag", defines));
+    if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES]->CompileAndLink())
     {
-      m_pShader[SM_TEXTURE_RGBA_OES]->Free();
-      m_pShader[SM_TEXTURE_RGBA_OES].reset();
+      m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES]->Free();
+      m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES].reset();
       CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_oes.frag - compile and link failed");
     }
 
 
-    m_pShader[SM_TEXTURE_RGBA_BOB_OES].reset(new CGLESShader("gles_shader_rgba_bob_oes.frag", defines));
-    if (!m_pShader[SM_TEXTURE_RGBA_BOB_OES]->CompileAndLink())
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES].reset(
+        new CGLESShader("gles_shader_rgba_bob_oes.frag", defines));
+    if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES]->CompileAndLink())
     {
-      m_pShader[SM_TEXTURE_RGBA_BOB_OES]->Free();
-      m_pShader[SM_TEXTURE_RGBA_BOB_OES].reset();
+      m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES]->Free();
+      m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES].reset();
       CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_bob_oes.frag - compile and link failed");
     }
   }
 
-  m_pShader[SM_TEXTURE_NOALPHA].reset(new CGLESShader("gles_shader_texture_noalpha.frag", defines));
-  if (!m_pShader[SM_TEXTURE_NOALPHA]->CompileAndLink())
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA].reset(
+      new CGLESShader("gles_shader_texture_noalpha.frag", defines));
+  if (!m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA]->CompileAndLink())
   {
-    m_pShader[SM_TEXTURE_NOALPHA]->Free();
-    m_pShader[SM_TEXTURE_NOALPHA].reset();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA]->Free();
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_texture_noalpha.frag - compile and link failed");
   }
 }
 
 void CRenderSystemGLES::ReleaseShaders()
 {
-  if (m_pShader[SM_DEFAULT])
-    m_pShader[SM_DEFAULT]->Free();
-  m_pShader[SM_DEFAULT].reset();
+  if (m_pShader[ShaderMethodGLES::SM_DEFAULT])
+    m_pShader[ShaderMethodGLES::SM_DEFAULT]->Free();
+  m_pShader[ShaderMethodGLES::SM_DEFAULT].reset();
 
-  if (m_pShader[SM_TEXTURE])
-    m_pShader[SM_TEXTURE]->Free();
-  m_pShader[SM_TEXTURE].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE].reset();
 
-  if (m_pShader[SM_MULTI])
-    m_pShader[SM_MULTI]->Free();
-  m_pShader[SM_MULTI].reset();
+  if (m_pShader[ShaderMethodGLES::SM_MULTI])
+    m_pShader[ShaderMethodGLES::SM_MULTI]->Free();
+  m_pShader[ShaderMethodGLES::SM_MULTI].reset();
 
-  if (m_pShader[SM_FONTS])
-    m_pShader[SM_FONTS]->Free();
-  m_pShader[SM_FONTS].reset();
+  if (m_pShader[ShaderMethodGLES::SM_FONTS])
+    m_pShader[ShaderMethodGLES::SM_FONTS]->Free();
+  m_pShader[ShaderMethodGLES::SM_FONTS].reset();
 
-  if (m_pShader[SM_TEXTURE_NOBLEND])
-    m_pShader[SM_TEXTURE_NOBLEND]->Free();
-  m_pShader[SM_TEXTURE_NOBLEND].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOBLEND].reset();
 
-  if (m_pShader[SM_MULTI_BLENDCOLOR])
-    m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-  m_pShader[SM_MULTI_BLENDCOLOR].reset();
+  if (m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR])
+    m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR]->Free();
+  m_pShader[ShaderMethodGLES::SM_MULTI_BLENDCOLOR].reset();
 
-  if (m_pShader[SM_TEXTURE_RGBA])
-    m_pShader[SM_TEXTURE_RGBA]->Free();
-  m_pShader[SM_TEXTURE_RGBA].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA].reset();
 
-  if (m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR])
-    m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR]->Free();
-  m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR].reset();
 
-  if (m_pShader[SM_TEXTURE_RGBA_BOB])
-    m_pShader[SM_TEXTURE_RGBA_BOB]->Free();
-  m_pShader[SM_TEXTURE_RGBA_BOB].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB].reset();
 
-  if (m_pShader[SM_TEXTURE_RGBA_OES])
-    m_pShader[SM_TEXTURE_RGBA_OES]->Free();
-  m_pShader[SM_TEXTURE_RGBA_OES].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES].reset();
 
-  if (m_pShader[SM_TEXTURE_RGBA_BOB_OES])
-    m_pShader[SM_TEXTURE_RGBA_BOB_OES]->Free();
-  m_pShader[SM_TEXTURE_RGBA_BOB_OES].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES].reset();
 
-  if (m_pShader[SM_TEXTURE_NOALPHA])
-    m_pShader[SM_TEXTURE_NOALPHA]->Free();
-  m_pShader[SM_TEXTURE_NOALPHA].reset();
+  if (m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA])
+    m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA]->Free();
+  m_pShader[ShaderMethodGLES::SM_TEXTURE_NOALPHA].reset();
 }
 
-void CRenderSystemGLES::EnableGUIShader(ESHADERMETHOD method)
+void CRenderSystemGLES::EnableGUIShader(ShaderMethodGLES method)
 {
   m_method = method;
   if (m_pShader[m_method])
@@ -555,7 +565,7 @@ void CRenderSystemGLES::DisableGUIShader()
   {
     m_pShader[m_method]->Disable();
   }
-  m_method = SM_DEFAULT;
+  m_method = ShaderMethodGLES::SM_DEFAULT;
 }
 
 GLint CRenderSystemGLES::GUIShaderGetPos()

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -12,11 +12,11 @@
 #include "rendering/RenderSystem.h"
 #include "utils/ColorUtils.h"
 
-#include <array>
+#include <map>
 
 #include "system_gl.h"
 
-enum ESHADERMETHOD
+enum class ShaderMethodGLES
 {
   SM_DEFAULT,
   SM_TEXTURE,
@@ -29,8 +29,7 @@ enum ESHADERMETHOD
   SM_TEXTURE_RGBA_BLENDCOLOR,
   SM_TEXTURE_RGBA_BOB,
   SM_TEXTURE_RGBA_BOB_OES,
-  SM_TEXTURE_NOALPHA,
-  SM_MAX
+  SM_TEXTURE_NOALPHA
 };
 
 class CRenderSystemGLES : public CRenderSystemBase
@@ -73,7 +72,7 @@ public:
 
   void InitialiseShaders();
   void ReleaseShaders();
-  void EnableGUIShader(ESHADERMETHOD method);
+  void EnableGUIShader(ShaderMethodGLES method);
   void DisableGUIShader();
 
   GLint GUIShaderGetPos();
@@ -99,8 +98,8 @@ protected:
 
   std::string m_RenderExtensions;
 
-  std::array<std::unique_ptr<CGLESShader>, SM_MAX> m_pShader;
-  ESHADERMETHOD m_method = SM_DEFAULT;
+  std::map<ShaderMethodGLES, std::unique_ptr<CGLESShader>> m_pShader;
+  ShaderMethodGLES m_method = ShaderMethodGLES::SM_DEFAULT;
 
   GLint      m_viewPort[4];
 };


### PR DESCRIPTION
Currently it can be a bit confusing when looking at the shader methods to see what's available for GL or GLES. Let's use an enum class to make this more clear. This will also allow the possibility in the future to allow building with both enums.

I've also added two commits to switch use to `std::make_unique`