### PR TITLE
LinuxRenderer: cleanups

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -105,7 +105,7 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
 
   for (auto &fence : m_fences)
   {
-    fence = GL_NONE;
+    fence = {};
   }
 
   return CLinuxRendererGL::Configure(picture, fps, orientation);
@@ -271,7 +271,7 @@ void CRendererVAAPI::AfterRenderHook(int idx)
   if (glIsSync(m_fences[idx]))
   {
     glDeleteSync(m_fences[idx]);
-    m_fences[idx] = GL_NONE;
+    m_fences[idx] = {};
   }
   m_fences[idx] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 }
@@ -286,7 +286,7 @@ bool CRendererVAAPI::NeedBuffer(int idx)
     if (state == GL_SIGNALED)
     {
       glDeleteSync(m_fences[idx]);
-      m_fences[idx] = GL_NONE;
+      m_fences[idx] = {};
     }
     else
     {
@@ -302,7 +302,7 @@ void CRendererVAAPI::ReleaseBuffer(int idx)
   if (glIsSync(m_fences[idx]))
   {
     glDeleteSync(m_fences[idx]);
-    m_fences[idx] = GL_NONE;
+    m_fences[idx] = {};
   }
   if (m_isVAAPIBuffer)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
@@ -62,7 +62,7 @@ bool CRendererVDPAU::Configure(const VideoPicture &picture, float fps, unsigned 
   }
   for (auto &fence : m_fences)
   {
-    fence = GL_NONE;
+    fence = {};
   }
 
   return CLinuxRendererGL::Configure(picture, fps, orientation);
@@ -90,7 +90,7 @@ bool CRendererVDPAU::NeedBuffer(int idx)
     if (state == GL_SIGNALED)
     {
       glDeleteSync(m_fences[idx]);
-      m_fences[idx] = GL_NONE;
+      m_fences[idx] = {};
     }
     else
     {
@@ -115,7 +115,7 @@ void CRendererVDPAU::ReleaseBuffer(int idx)
   if (glIsSync(m_fences[idx]))
   {
     glDeleteSync(m_fences[idx]);
-    m_fences[idx] = GL_NONE;
+    m_fences[idx] = {};
   }
   m_vdpauTextures[idx].Unmap();
   CLinuxRendererGL::ReleaseBuffer(idx);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -339,9 +339,9 @@ void CLinuxRendererGL::CalculateTextureSourceRects(int source, int num_planes)
       if(field != FIELD_FULL)
       {
         /* correct for field offsets and chroma offsets */
-        float offset_y = 0.5;
+        float offset_y = 0.5f;
         if(plane != 0)
-          offset_y += 0.5;
+          offset_y += 0.5f;
         if(field == FIELD_BOT)
           offset_y *= -1;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -48,10 +48,6 @@ enum RenderQuality
   RQ_MULTIPASS,
 };
 
-#define PLANE_Y 0
-#define PLANE_U 1
-#define PLANE_V 2
-
 #define FIELD_FULL 0
 #define FIELD_TOP 1
 #define FIELD_BOT 2

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -35,14 +35,6 @@ class CTexture;
 namespace Shaders { class BaseYUV2RGBGLSLShader; }
 namespace Shaders { class BaseVideoFilterShader; }
 
-struct DRAWRECT
-{
-  float left;
-  float top;
-  float right;
-  float bottom;
-};
-
 enum RenderMethod
 {
   RENDER_GLSL=0x01,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -41,16 +41,6 @@ CLinuxRendererGLES::CLinuxRendererGLES()
 
   m_renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
 
-#if HAS_GLES >= 3
-  unsigned int verMajor, verMinor;
-  m_renderSystem->GetRenderVersion(verMajor, verMinor);
-
-  if (verMajor >= 3)
-  {
-    m_pixelStoreKey = GL_UNPACK_ROW_LENGTH;
-  }
-#endif
-
 #if defined (GL_UNPACK_ROW_LENGTH_EXT)
   if (m_renderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -32,14 +32,6 @@ class CTexture;
 namespace Shaders { class BaseYUV2RGBGLSLShader; }
 namespace Shaders { class BaseVideoFilterShader; }
 
-struct DRAWRECT
-{
-  float left;
-  float top;
-  float right;
-  float bottom;
-};
-
 enum RenderMethod
 {
   RENDER_GLSL = 0x01,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -475,20 +475,24 @@ void COverlayTextureGL::Render(SRenderState& state)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-  DRAWRECT rd;
+  CRect rd;
   if (m_pos == POSITION_RELATIVE)
   {
-    rd.top = state.y - state.height * 0.5f;
-    rd.bottom = state.y + state.height * 0.5f;
-    rd.left = state.x - state.width * 0.5f;
-    rd.right = state.x + state.width * 0.5f;
+    float top = state.y - state.height * 0.5f;
+    float bottom = state.y + state.height * 0.5f;
+    float left = state.x - state.width * 0.5f;
+    float right = state.x + state.width * 0.5f;
+
+    rd.SetRect(left, top, right, bottom);
   }
   else
   {
-    rd.top     = state.y;
-    rd.bottom  = state.y + state.height;
-    rd.left    = state.x;
-    rd.right   = state.x + state.width;
+    float top = state.y;
+    float bottom = state.y + state.height;
+    float left = state.x;
+    float right   = state.x + state.width;
+
+    rd.SetRect(left, top, right, bottom);
   }
 
 #if defined(HAS_GL)
@@ -519,26 +523,26 @@ void COverlayTextureGL::Render(SRenderState& state)
   glUniform4f(uniColLoc,(col[0]), (col[1]), (col[2]), (col[3]));
 
   // Setup vertex position values
-  vertex[0].x = rd.left;
-  vertex[0].y = rd.top;
+  vertex[0].x = rd.x1;
+  vertex[0].y = rd.y1;
   vertex[0].z = 0;
   vertex[0].u1 = 0.0f;
   vertex[0].v1 = 0.0;
 
-  vertex[1].x = rd.right;
-  vertex[1].y = rd.top;
+  vertex[1].x = rd.x2;
+  vertex[1].y = rd.y1;
   vertex[1].z = 0;
   vertex[1].u1 = m_u;
   vertex[1].v1 = 0.0f;
 
-  vertex[2].x = rd.right;
-  vertex[2].y = rd.bottom;
+  vertex[2].x = rd.x2;
+  vertex[2].y = rd.y2;
   vertex[2].z = 0;
   vertex[2].u1 = m_u;
   vertex[2].v1 = m_v;
 
-  vertex[3].x = rd.left;
-  vertex[3].y = rd.bottom;
+  vertex[3].x = rd.x1;
+  vertex[3].y = rd.y2;
   vertex[3].z = 0;
   vertex[3].u1 = 0.0f;
   vertex[3].v1 = m_v;
@@ -593,10 +597,10 @@ void COverlayTextureGL::Render(SRenderState& state)
 
   glUniform4f(uniColLoc,(col[0]), (col[1]), (col[2]), (col[3]));
   // Setup vertex position values
-  ver[0][0] = ver[3][0] = rd.left;
-  ver[0][1] = ver[1][1] = rd.top;
-  ver[1][0] = ver[2][0] = rd.right;
-  ver[2][1] = ver[3][1] = rd.bottom;
+  ver[0][0] = ver[3][0] = rd.x1;
+  ver[0][1] = ver[1][1] = rd.y1;
+  ver[1][0] = ver[2][0] = rd.x2;
+  ver[2][1] = ver[3][1] = rd.y2;
 
   // Setup texture coordinates
   tex[0][0] = tex[0][1] = tex[1][1] = tex[3][0] = 0.0f;


### PR DESCRIPTION
The `HAS_GLES >= 3` check isn't needed as we just check for the extension below. We don't advertise GLES3 support so we should be consistent here. If a driver doesn't expose the extension for whatever reason that isn't our problem :)

The type for `GLSync` is defined as
```
typedef struct __GLsync *GLsync;
```
This is an opaque structure and we shouldn't be setting it to an int. Let's use the default initialization to handle that.

The `struct DRAWRECT` seems to do what we already have functionality for. Lets just use `CRect` instead.

The defines for `PLANE_*` aren't used anywhere (for GL/ES) so let's drop them .

Finally a commit to fix an implicit conversion from float to double.