### PR TITLE
GL/ES Shader class namespacing

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -52,6 +52,7 @@
 #define PBO_OFFSET 16
 
 using namespace Shaders;
+using namespace Shaders::GL;
 
 static const GLubyte stipple_weave[] = {
   0x00, 0x00, 0x00, 0x00,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -33,7 +33,13 @@ class CRenderSystemGL;
 
 class CTexture;
 namespace Shaders { class BaseYUV2RGBGLSLShader; }
-namespace Shaders { class BaseVideoFilterShader; }
+namespace Shaders
+{
+namespace GL
+{
+class BaseVideoFilterShader;
+}
+} // namespace Shaders
 
 struct DRAWRECT
 {
@@ -214,7 +220,7 @@ protected:
   CPictureBuffer m_buffers[NUM_BUFFERS];
 
   Shaders::BaseYUV2RGBGLSLShader *m_pYUVShader = nullptr;
-  Shaders::BaseVideoFilterShader *m_pVideoFilterShader = nullptr;
+  Shaders::GL::BaseVideoFilterShader* m_pVideoFilterShader = nullptr;
   ESCALINGMETHOD m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
   ESCALINGMETHOD m_scalingMethodGui = VS_SCALINGMETHOD_MAX;
   bool m_useDithering;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -32,11 +32,11 @@ class CRenderCapture;
 class CRenderSystemGL;
 
 class CTexture;
-namespace Shaders { class BaseYUV2RGBGLSLShader; }
 namespace Shaders
 {
 namespace GL
 {
+class BaseYUV2RGBGLSLShader;
 class BaseVideoFilterShader;
 }
 } // namespace Shaders
@@ -219,7 +219,7 @@ protected:
   // field index 0 is full image, 1 is odd scanlines, 2 is even scanlines
   CPictureBuffer m_buffers[NUM_BUFFERS];
 
-  Shaders::BaseYUV2RGBGLSLShader *m_pYUVShader = nullptr;
+  Shaders::GL::BaseYUV2RGBGLSLShader* m_pYUVShader = nullptr;
   Shaders::GL::BaseVideoFilterShader* m_pVideoFilterShader = nullptr;
   ESCALINGMETHOD m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
   ESCALINGMETHOD m_scalingMethodGui = VS_SCALINGMETHOD_MAX;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -899,7 +899,7 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
   glActiveTexture(GL_TEXTURE0);
   VerifyGLState();
 
-  Shaders::BaseYUV2RGBGLSLShader *pYUVShader;
+  Shaders::GLES::BaseYUV2RGBGLSLShader* pYUVShader;
   if (field != FIELD_FULL)
   {
     pYUVShader = m_pYUVBobShader;
@@ -1053,7 +1053,7 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field)
   glActiveTexture(GL_TEXTURE0);
   VerifyGLState();
 
-  Shaders::BaseYUV2RGBGLSLShader *pYUVShader = m_pYUVProgShader;
+  Shaders::GLES::BaseYUV2RGBGLSLShader* pYUVShader = m_pYUVProgShader;
   // make sure the yuv shader is loaded and ready to go
   if (!pYUVShader || (!pYUVShader->OK()))
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -31,6 +31,7 @@
 #include "windowing/WinSystem.h"
 
 using namespace Shaders;
+using namespace Shaders::GLES;
 
 CLinuxRendererGLES::CLinuxRendererGLES()
 {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -29,11 +29,11 @@ class CRenderCapture;
 class CRenderSystemGLES;
 
 class CTexture;
-namespace Shaders { class BaseYUV2RGBGLSLShader; }
 namespace Shaders
 {
 namespace GLES
 {
+class BaseYUV2RGBGLSLShader;
 class BaseVideoFilterShader;
 }
 } // namespace Shaders
@@ -202,8 +202,8 @@ protected:
                  unsigned width,  unsigned height,
                  int stride, int bpp, void* data);
 
-  Shaders::BaseYUV2RGBGLSLShader *m_pYUVProgShader{nullptr};
-  Shaders::BaseYUV2RGBGLSLShader *m_pYUVBobShader{nullptr};
+  Shaders::GLES::BaseYUV2RGBGLSLShader* m_pYUVProgShader{nullptr};
+  Shaders::GLES::BaseYUV2RGBGLSLShader* m_pYUVBobShader{nullptr};
   Shaders::GLES::BaseVideoFilterShader* m_pVideoFilterShader{nullptr};
   ESCALINGMETHOD m_scalingMethod{VS_SCALINGMETHOD_LINEAR};
   ESCALINGMETHOD m_scalingMethodGui{VS_SCALINGMETHOD_MAX};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -30,7 +30,13 @@ class CRenderSystemGLES;
 
 class CTexture;
 namespace Shaders { class BaseYUV2RGBGLSLShader; }
-namespace Shaders { class BaseVideoFilterShader; }
+namespace Shaders
+{
+namespace GLES
+{
+class BaseVideoFilterShader;
+}
+} // namespace Shaders
 
 struct DRAWRECT
 {
@@ -198,7 +204,7 @@ protected:
 
   Shaders::BaseYUV2RGBGLSLShader *m_pYUVProgShader{nullptr};
   Shaders::BaseYUV2RGBGLSLShader *m_pYUVBobShader{nullptr};
-  Shaders::BaseVideoFilterShader *m_pVideoFilterShader{nullptr};
+  Shaders::GLES::BaseVideoFilterShader* m_pVideoFilterShader{nullptr};
   ESCALINGMETHOD m_scalingMethod{VS_SCALINGMETHOD_LINEAR};
   ESCALINGMETHOD m_scalingMethodGui{VS_SCALINGMETHOD_MAX};
   bool m_fullRange;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -20,7 +20,7 @@
 
 #define TEXTARGET GL_TEXTURE_1D
 
-using namespace Shaders;
+using namespace Shaders::GL;
 
 //////////////////////////////////////////////////////////////////////
 // BaseVideoFilterShader - base class for video filter shaders

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.h
@@ -16,44 +16,59 @@
 
 namespace Shaders {
 
-  class BaseVideoFilterShader : public CGLSLShaderProgram
+namespace GL
+{
+
+class BaseVideoFilterShader : public CGLSLShaderProgram
+{
+public:
+  BaseVideoFilterShader();
+  ~BaseVideoFilterShader() override;
+  virtual bool GetTextureFilter(GLint& filter) { return false; }
+
+  void SetSourceTexture(GLint ytex) { m_sourceTexUnit = ytex; }
+  void SetWidth(int w)
   {
-  public:
-    BaseVideoFilterShader();
-    ~BaseVideoFilterShader() override;
-    virtual bool GetTextureFilter(GLint& filter) { return false; }
+    m_width = w;
+    m_stepX = w > 0 ? 1.0f / w : 0;
+  }
+  void SetHeight(int h)
+  {
+    m_height = h;
+    m_stepY = h > 0 ? 1.0f / h : 0;
+  }
+  void SetNonLinStretch(float stretch) { m_stretch = stretch; }
+  void SetAlpha(GLfloat alpha) { m_alpha = alpha; }
 
-    void SetSourceTexture(GLint ytex) { m_sourceTexUnit = ytex; }
-    void SetWidth(int w) { m_width  = w; m_stepX = w>0?1.0f/w:0; }
-    void SetHeight(int h) { m_height = h; m_stepY = h>0?1.0f/h:0; }
-    void SetNonLinStretch(float stretch) { m_stretch = stretch; }
-    void SetAlpha(GLfloat alpha) { m_alpha= alpha; }
+  GLint GetVertexLoc() { return m_hVertex; }
+  GLint GetCoordLoc() { return m_hCoord; }
 
-    GLint GetVertexLoc() { return m_hVertex; }
-    GLint GetCoordLoc() { return m_hCoord; }
+  void SetMatrices(const GLfloat* p, const GLfloat* m)
+  {
+    m_proj = p;
+    m_model = m;
+  }
 
-    void SetMatrices(const GLfloat *p, const GLfloat *m) { m_proj = p; m_model = m; }
+protected:
+  int m_width;
+  int m_height;
+  float m_stepX;
+  float m_stepY;
+  float m_stretch;
+  GLfloat m_alpha;
+  GLint m_sourceTexUnit;
+  const GLfloat* m_proj = nullptr;
+  const GLfloat* m_model = nullptr;
 
-  protected:
-    int m_width;
-    int m_height;
-    float m_stepX;
-    float m_stepY;
-    float m_stretch;
-    GLfloat m_alpha;
-    GLint m_sourceTexUnit;
-    const GLfloat *m_proj = nullptr;
-    const GLfloat *m_model = nullptr;
-
-    // shader attribute handles
-    GLint m_hSourceTex;
-    GLint m_hStepXY;
-    GLint m_hStretch = -1;
-    GLint m_hAlpha = -1;
-    GLint m_hVertex = -1;
-    GLint m_hCoord = -1;
-    GLint m_hProj = -1;
-    GLint m_hModel = -1;
+  // shader attribute handles
+  GLint m_hSourceTex;
+  GLint m_hStepXY;
+  GLint m_hStretch = -1;
+  GLint m_hAlpha = -1;
+  GLint m_hVertex = -1;
+  GLint m_hCoord = -1;
+  GLint m_hProj = -1;
+  GLint m_hModel = -1;
   };
 
   class ConvolutionFilterShader : public BaseVideoFilterShader
@@ -79,7 +94,7 @@ namespace Shaders {
     bool m_floattex; //if float textures are supported
     GLint m_internalformat;
 
-    Shaders::GLSLOutput *m_glslOutput;
+    GLSLOutput* m_glslOutput;
   };
 
   class StretchFilterShader : public BaseVideoFilterShader
@@ -97,6 +112,7 @@ namespace Shaders {
       bool OnEnabled() override;
   };
 
+  } // namespace GL
 } // end namespace
 
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
@@ -18,7 +18,7 @@
 #include <math.h>
 #include <string>
 
-using namespace Shaders;
+using namespace Shaders::GLES;
 
 //////////////////////////////////////////////////////////////////////
 // BaseVideoFilterShader - base class for video filter shaders

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.h
@@ -15,41 +15,55 @@
 
 namespace Shaders {
 
-  class BaseVideoFilterShader : public CGLSLShaderProgram
+namespace GLES
+{
+class BaseVideoFilterShader : public CGLSLShaderProgram
+{
+public:
+  BaseVideoFilterShader();
+  void OnCompiledAndLinked() override;
+  bool OnEnabled() override;
+  virtual void SetSourceTexture(GLint ytex) { m_sourceTexUnit = ytex; }
+  virtual void SetWidth(int w)
   {
-  public:
-    BaseVideoFilterShader();
-    void OnCompiledAndLinked() override;
-    bool OnEnabled() override;
-    virtual void SetSourceTexture(GLint ytex) { m_sourceTexUnit = ytex; }
-    virtual void SetWidth(int w) { m_width  = w; m_stepX = w>0?1.0f/w:0; }
-    virtual void SetHeight(int h) { m_height = h; m_stepY = h>0?1.0f/h:0; }
-    virtual bool GetTextureFilter(GLint& filter) { return false; }
-    virtual GLint GetVertexLoc() { return m_hVertex; }
-    virtual GLint GetcoordLoc() { return m_hcoord; }
-    virtual void SetMatrices(const GLfloat *p, const GLfloat *m) { m_proj = p; m_model = m; }
-    virtual void SetAlpha(GLfloat alpha)             { m_alpha = alpha; }
+    m_width = w;
+    m_stepX = w > 0 ? 1.0f / w : 0;
+  }
+  virtual void SetHeight(int h)
+  {
+    m_height = h;
+    m_stepY = h > 0 ? 1.0f / h : 0;
+  }
+  virtual bool GetTextureFilter(GLint& filter) { return false; }
+  virtual GLint GetVertexLoc() { return m_hVertex; }
+  virtual GLint GetcoordLoc() { return m_hcoord; }
+  virtual void SetMatrices(const GLfloat* p, const GLfloat* m)
+  {
+    m_proj = p;
+    m_model = m;
+  }
+  virtual void SetAlpha(GLfloat alpha) { m_alpha = alpha; }
 
-  protected:
-    int m_width;
-    int m_height;
-    float m_stepX;
-    float m_stepY;
-    GLint m_sourceTexUnit;
+protected:
+  int m_width;
+  int m_height;
+  float m_stepX;
+  float m_stepY;
+  GLint m_sourceTexUnit;
 
-    // shader attribute handles
-    GLint m_hSourceTex;
-    GLint m_hStepXY;
+  // shader attribute handles
+  GLint m_hSourceTex;
+  GLint m_hStepXY;
 
-    GLint m_hVertex;
-    GLint m_hcoord;
-    GLint m_hProj;
-    GLint m_hModel;
-    GLint m_hAlpha;
+  GLint m_hVertex;
+  GLint m_hcoord;
+  GLint m_hProj;
+  GLint m_hModel;
+  GLint m_hAlpha;
 
-    const GLfloat *m_proj;
-    const GLfloat *m_model;
-    GLfloat  m_alpha;
+  const GLfloat* m_proj;
+  const GLfloat* m_model;
+  GLfloat m_alpha;
   };
 
   class ConvolutionFilterShader : public BaseVideoFilterShader
@@ -83,5 +97,6 @@ namespace Shaders {
       bool OnEnabled() override;
   };
 
+  } // namespace GLES
 } // end namespace
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <utility>
 
-using namespace Shaders;
+using namespace Shaders::GL;
 
 //////////////////////////////////////////////////////////////////////
 // BaseYUV2RGBGLSLShader - base class for GLSL YUV2RGB shaders

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -25,6 +25,8 @@ extern "C" {
 class CConvertMatrix;
 
 namespace Shaders {
+namespace GL
+{
 
 class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
 {
@@ -152,5 +154,6 @@ protected:
   ESCALINGMETHOD m_scaling = VS_SCALINGMETHOD_LANCZOS3_FAST;
 };
 
+} // namespace GL
 } // end namespace
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -17,7 +17,7 @@
 #include <sstream>
 #include <string>
 
-using namespace Shaders;
+using namespace Shaders::GLES;
 
 //////////////////////////////////////////////////////////////////////
 // BaseYUV2RGBGLSLShader - base class for GLSL YUV2RGB shaders

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -20,9 +20,11 @@ extern "C" {
 }
 
 namespace Shaders {
+namespace GLES
+{
 
-  class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
-  {
+class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
+{
   public:
     BaseYUV2RGBGLSLShader(EShaderFormat format,
                           AVColorPrimaries dst,
@@ -132,4 +134,5 @@ namespace Shaders {
     GLint m_hField;
   };
 
+  } // namespace GLES
 } // end namespace


### PR DESCRIPTION
Currently we define `BaseYUV2RGBGLSLShader` and `BaseVideoFilterShader` and their derived classes for both GL and GLES. Let's namespace these classes so it's more clear what is used where. This will also allow us to build with both classes in the future.

clang-format introduced some whitespace changes so best view with whitespace changes enabled or simply click this [link](https://github.com/xbmc/xbmc/pull/20481/files?w=1)