### PR TITLE
xbmc/utils/CMakeList.txt: Add missing XTimeUtils.h

### DIFF
--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -164,7 +164,8 @@ set(HEADERS ActorProtocol.h
             VC1BitstreamParser.h
             Vector.h
             XBMCTinyXML.h
-            XMLUtils.h)
+            XMLUtils.h
+            XTimeUtils.h)
 
 if(XSLT_FOUND)
   list(APPEND SOURCES XSLTUtils.cpp)


### PR DESCRIPTION
Adds a missing header file to xbmc/utils/CMakeList.txt. 

