### PR TITLE
Revert PR20457 - XTimeUtils: Prevent array index out of bounds access in SystemTimeToFileTime

### DIFF
--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -177,7 +177,7 @@ int FileTimeToSystemTime(const FileTime* fileTime, SystemTime* systemTime)
   time_t ft = file.QuadPart;
 
   struct tm tm_ft;
-  gmtime_r(&ft,&tm_ft);
+  gmtime_r(&ft, &tm_ft);
 
   systemTime->year = tm_ft.tm_year + 1900;
   systemTime->month = tm_ft.tm_mon + 1;
@@ -221,7 +221,7 @@ int FileTimeToTimeT(const FileTime* localFileTime, time_t* pTimeT)
   time_t ft = fileTime.QuadPart;
 
   struct tm tm_ft;
-  localtime_r(&ft,&tm_ft);
+  localtime_r(&ft, &tm_ft);
 
   *pTimeT = mktime(&tm_ft);
   return 1;

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -111,10 +111,6 @@ int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime)
   static std::atomic_flag timegm_lock = ATOMIC_FLAG_INIT;
 #endif
 
-  // Prevent out of bounds access in dayoffset array
-  if (systemTime->month < 1 || systemTime->month > 12)
-    return 0;
-
   struct tm sysTime = {};
   sysTime.tm_year = systemTime->year - 1900;
   sysTime.tm_mon = systemTime->month - 1;

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -94,8 +94,7 @@ int FileTimeToLocalFileTime(const FileTime* fileTime, FileTime* localFileTime)
   time_t ft;
   struct tm tm_ft;
   FileTimeToTimeT(fileTime, &ft);
-  if (!localtime_r(&ft, &tm_ft))
-    return 0;
+  localtime_r(&ft, &tm_ft);
 
   l.QuadPart += static_cast<unsigned long long>(tm_ft.tm_gmtoff) * 10000000;
 
@@ -135,9 +134,6 @@ int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime)
 #else
   time_t t = timegm(&sysTime);
 #endif
-
-  if (t == -1 && errno != 0)
-    return 0;
 
   LARGE_INTEGER result;
   result.QuadPart = (long long)t * 10000000 + (long long)systemTime->milliseconds * 10000;
@@ -181,8 +177,7 @@ int FileTimeToSystemTime(const FileTime* fileTime, SystemTime* systemTime)
   time_t ft = file.QuadPart;
 
   struct tm tm_ft;
-  if (!gmtime_r(&ft, &tm_ft))
-    return 0;
+  gmtime_r(&ft,&tm_ft);
 
   systemTime->year = tm_ft.tm_year + 1900;
   systemTime->month = tm_ft.tm_mon + 1;
@@ -226,14 +221,10 @@ int FileTimeToTimeT(const FileTime* localFileTime, time_t* pTimeT)
   time_t ft = fileTime.QuadPart;
 
   struct tm tm_ft;
-  if (!localtime_r(&ft, &tm_ft))
-    return 0;
+  localtime_r(&ft,&tm_ft);
 
   *pTimeT = mktime(&tm_ft);
-  if (*pTimeT == -1 && errno != 0)
-    return 0;
-  else
-    return 1;
+  return 1;
 }
 
 int TimeTToFileTime(time_t timeT, FileTime* localFileTime)


### PR DESCRIPTION
As discussed in #20451 this causes a serious regression.