### PR TITLE
pipewire: use Create functions to initialize const structs in constructor

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
@@ -21,7 +21,7 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireCore::CPipewireCore(pw_context* context)
+CPipewireCore::CPipewireCore(pw_context* context) : m_coreEvents(CreateCoreEvents())
 {
   m_core.reset(pw_context_connect(context, nullptr, 0));
   if (!m_core)
@@ -54,6 +54,15 @@ void CPipewireCore::OnCoreDone(void* userdata, uint32_t id, int seq)
 
   if (core->GetSync() == seq)
     loop->Signal(false);
+}
+
+pw_core_events CPipewireCore::CreateCoreEvents()
+{
+  pw_core_events coreEvents = {};
+  coreEvents.version = PW_VERSION_CORE_EVENTS;
+  coreEvents.done = OnCoreDone;
+
+  return coreEvents;
 }
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
@@ -35,15 +35,9 @@ public:
 private:
   static void OnCoreDone(void* userdata, uint32_t id, int seq);
 
-  const pw_core_events m_coreEvents = {.version = PW_VERSION_CORE_EVENTS,
-                                       .info = nullptr,
-                                       .done = OnCoreDone,
-                                       .ping = nullptr,
-                                       .error = nullptr,
-                                       .remove_id = nullptr,
-                                       .bound_id = nullptr,
-                                       .add_mem = nullptr,
-                                       .remove_mem = nullptr};
+  static pw_core_events CreateCoreEvents();
+
+  const pw_core_events m_coreEvents;
 
   spa_hook m_coreListener;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -23,7 +23,7 @@ namespace PIPEWIRE
 {
 
 CPipewireNode::CPipewireNode(pw_registry* registry, uint32_t id, const char* type)
-  : CPipewireProxy(registry, id, type, PW_VERSION_NODE)
+  : CPipewireProxy(registry, id, type, PW_VERSION_NODE), m_nodeEvents(CreateNodeEvents())
 {
 }
 
@@ -190,6 +190,16 @@ void CPipewireNode::Param(void* userdata,
   node->Parse(SPA_POD_TYPE(param), SPA_POD_BODY(param), SPA_POD_BODY_SIZE(param));
 
   loop->Signal(false);
+}
+
+pw_node_events CPipewireNode::CreateNodeEvents()
+{
+  pw_node_events nodeEvents = {};
+  nodeEvents.version = PW_VERSION_NODE_EVENTS;
+  nodeEvents.info = Info;
+  nodeEvents.param = Param;
+
+  return nodeEvents;
 }
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -55,8 +55,9 @@ private:
                     uint32_t next,
                     const struct spa_pod* param);
 
-  const pw_node_events m_nodeEvents = {
-      .version = PW_VERSION_NODE_EVENTS, .info = Info, .param = Param};
+  static pw_node_events CreateNodeEvents();
+
+  const pw_node_events m_nodeEvents;
 
   spa_hook m_objectListener;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
@@ -25,6 +25,7 @@ CPipewireProxy::CPipewireProxy(pw_registry* registry,
                                uint32_t id,
                                const char* type,
                                uint32_t version)
+  : m_proxyEvents(CreateProxyEvents())
 {
   m_proxy.reset(reinterpret_cast<pw_proxy*>(pw_registry_bind(registry, id, type, version, 0)));
   if (!m_proxy)
@@ -60,6 +61,16 @@ void CPipewireProxy::Removed(void* userdata)
   auto AE = CServiceBroker::GetActiveAE();
   if (AE)
     AE->DeviceCountChange("PIPEWIRE");
+}
+
+pw_proxy_events CPipewireProxy::CreateProxyEvents()
+{
+  pw_proxy_events proxyEvents = {};
+  proxyEvents.version = PW_VERSION_PROXY_EVENTS;
+  proxyEvents.bound = Bound;
+  proxyEvents.removed = Removed;
+
+  return proxyEvents;
 }
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
@@ -41,12 +41,9 @@ private:
   static void Bound(void* userdata, uint32_t id);
   static void Removed(void* userdata);
 
-  const pw_proxy_events m_proxyEvents = {.version = PW_VERSION_PROXY_EVENTS,
-                                         .destroy = nullptr,
-                                         .bound = Bound,
-                                         .removed = Removed,
-                                         .done = nullptr,
-                                         .error = nullptr};
+  static pw_proxy_events CreateProxyEvents();
+
+  const pw_proxy_events m_proxyEvents;
 
   spa_hook m_proxyListener;
 };

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -25,7 +25,7 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireRegistry::CPipewireRegistry(pw_core* core)
+CPipewireRegistry::CPipewireRegistry(pw_core* core) : m_registryEvents(CreateRegistryEvents())
 {
   m_registry.reset(pw_core_get_registry(core, PW_VERSION_REGISTRY, 0));
   if (!m_registry)
@@ -94,6 +94,16 @@ void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
 
     globals.erase(global);
   }
+}
+
+pw_registry_events CPipewireRegistry::CreateRegistryEvents()
+{
+  pw_registry_events registryEvents = {};
+  registryEvents.version = PW_VERSION_REGISTRY_EVENTS;
+  registryEvents.global = OnGlobalAdded;
+  registryEvents.global_remove = OnGlobalRemoved;
+
+  return registryEvents;
 }
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -39,11 +39,9 @@ private:
                             const struct spa_dict* props);
   static void OnGlobalRemoved(void* userdata, uint32_t id);
 
-  const pw_registry_events m_registryEvents = {
-      .version = PW_VERSION_REGISTRY_EVENTS,
-      .global = OnGlobalAdded,
-      .global_remove = OnGlobalRemoved,
-  };
+  static pw_registry_events CreateRegistryEvents();
+
+  const pw_registry_events m_registryEvents;
 
   spa_hook m_registryListener;
   struct PipewireRegistryDeleter

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -25,7 +25,7 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireStream::CPipewireStream(pw_core* core)
+CPipewireStream::CPipewireStream(pw_core* core) : m_streamEvents(CreateStreamEvents())
 {
   m_stream.reset(pw_stream_new(core, nullptr, pw_properties_new(nullptr, nullptr)));
   if (!m_stream)
@@ -143,6 +143,17 @@ void CPipewireStream::Drained(void* userdata)
   CLog::Log(LOGDEBUG, "CPipewireStream::{}", __FUNCTION__);
 
   loop->Signal(false);
+}
+
+pw_stream_events CPipewireStream::CreateStreamEvents()
+{
+  pw_stream_events streamEvents = {};
+  streamEvents.version = PW_VERSION_STREAM_EVENTS;
+  streamEvents.state_changed = StateChanged;
+  streamEvents.process = Process;
+  streamEvents.drained = Drained;
+
+  return streamEvents;
 }
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -53,16 +53,9 @@ private:
   static void Process(void* userdata);
   static void Drained(void* userdata);
 
-  const pw_stream_events m_streamEvents = {.version = PW_VERSION_STREAM_EVENTS,
-                                           .destroy = nullptr,
-                                           .state_changed = StateChanged,
-                                           .control_info = nullptr,
-                                           .io_changed = nullptr,
-                                           .param_changed = nullptr,
-                                           .add_buffer = nullptr,
-                                           .remove_buffer = nullptr,
-                                           .process = Process,
-                                           .drained = Drained};
+  static pw_stream_events CreateStreamEvents();
+
+  const pw_stream_events m_streamEvents;
 
   spa_hook m_streamListener;
 


### PR DESCRIPTION
This started as just a quest to fix the following warning:
```
warning: missing initializer for member ‘pw_stream_events::command’ [-Wmissing-field-initializers]
```
I decided to go further and make it uniform across the entire pipewire codebase.

The old behaviour bit me in the butt because the pipewire interface added a new function pointer to their struct (I think). The code in this PR should be more future proof.

Basically just adding a helper method for each class that needs to initialize a `const struct`, then call that method in the class constructor.