### PR TITLE
[Subtitles][Webvtt] Fix wrong text position case due to "manual" position setting

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -38,6 +38,7 @@ public:
     m_textureid = 0;
     m_enableTextAlign = false;
     m_overlayContainerFlushable = true;
+    m_setForcedMargins = false;
   }
 
   CDVDOverlay(const CDVDOverlay& src)
@@ -51,6 +52,7 @@ public:
     m_textureid = 0;
     m_enableTextAlign = src.m_enableTextAlign;
     m_overlayContainerFlushable = src.m_overlayContainerFlushable;
+    m_setForcedMargins = src.m_setForcedMargins;
   }
 
   virtual ~CDVDOverlay()
@@ -118,6 +120,15 @@ public:
    */
   bool IsOverlayContainerFlushable() { return m_overlayContainerFlushable; }
 
+  /*
+   * \brief Specify if the margins are handled by the subtitle codec/parser.
+   */
+  void SetForcedMargins(bool setForcedMargins) { m_setForcedMargins = setForcedMargins; }
+
+  /*
+   * \brief Return true if the margins are handled by the subtitle codec/parser.
+   */
+  bool IsForcedMargins() { return m_setForcedMargins; }
 
   double iPTSStartTime;
   double iPTSStopTime;
@@ -129,6 +140,7 @@ protected:
   DVDOverlayType m_type;
   bool m_enableTextAlign;
   bool m_overlayContainerFlushable;
+  bool m_setForcedMargins;
 
 private:
   std::atomic_int m_references;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -138,5 +138,6 @@ CDVDOverlay* COverlayCodecWebVTT::GetOverlay()
     return nullptr;
   m_pOverlay = CreateOverlay();
   m_pOverlay->SetOverlayContainerFlushable(false);
+  m_pOverlay->SetForcedMargins(true);
   return m_pOverlay->Acquire();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
@@ -8,6 +8,7 @@
 
 #include "SubtitleParserWebVTT.h"
 
+#include "DVDCodecs/Overlay/DVDOverlay.h"
 #include "SubtitlesStyle.h"
 #include "cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h"
 #include "utils/StringUtils.h"
@@ -72,7 +73,9 @@ bool CSubtitleParserWebVTT::Open(CDVDStreamInfo& hints)
     AddSubtitle(subData.text.c_str(), subData.startTime, subData.stopTime, &opts);
   }
 
-  m_collection.Add(CreateOverlay());
+  CDVDOverlay* overlay = CreateOverlay();
+  overlay->SetForcedMargins(true);
+  m_collection.Add(overlay);
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -388,11 +388,29 @@ COverlay* CRenderer::ConvertLibass(CDVDOverlayLibass* o,
   // Set position of subtitles based on video calibration settings
   if (subAlign == SUBTITLE_ALIGN_MANUAL)
   {
-    rOpts.usePosition = true;
-    RESOLUTION_INFO res;
-    res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
-        CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
-    rOpts.position = 100.0 - (double)(res.iSubtitles - res.Overscan.top) * 100 / res.iHeight;
+    if (o->IsForcedMargins())
+    {
+      // rOpts.position can invalidate the text positions to subtitles that make
+      // use of margins to position text on the screen then in this case
+      // we allow to set it only when position overrides are enabled
+      int overrideStyles = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
+      if (overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::POSITIONS ||
+          overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS)
+        rOpts.usePosition = true;
+    }
+    else
+    {
+      rOpts.usePosition = true;
+    }
+    if (rOpts.usePosition)
+    {
+      RESOLUTION_INFO res;
+      res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
+          CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
+      rOpts.position =
+          100.0 - static_cast<double>(res.iSubtitles - res.Overscan.top) * 100 / res.iHeight;
+    }
   }
 
   // Set the horizontal text alignment (currently used to improve readability on CC subtitles only)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When kodi have `Manual` subtitle position set, 
libass `ass_set_line_position` is used to change the vertical text position on screen to match the caibration bar,
but this cause side effects with the text positions with subtitle format like Webvtt, because it use the margins to change the text position on screen.
Specifically this happens only when we have a forced aligment tag that set the text to bottom (e.g. `{\\an2}` ) in this case, ass_set_line_position influence the text position invalidating the webvtt margins management.
Differently if forced aligment tag like top (e.g. `{\\an8}`) is used, then the `ass_set_line_position` call will be fully ignored, i think because `ass_set_line_position` works only with bottom case.

This is not so bad because happens only if `Manual` kodi subtilte position is set, but this side effect invalidate the purpose of the kodi "override subtitle style positions" setting, this inconsistency is not so pleasant.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug reported by @scott967 and founds later

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 - With a vtt file with CRLF ending chars (windows format type)
 - With a vtt without cue settings to test the position bug

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
