### PR TITLE
Fix issue 20421 - UWP Xbox Python add-ons permission error

### DIFF
--- a/cmake/scripts/windowsstore/Install.cmake
+++ b/cmake/scripts/windowsstore/Install.cmake
@@ -1,0 +1,10 @@
+# Fix UWP addons security issue caused by empty __init__.py Python Lib files packaged with Kodi
+set(uwp_pythonlibinit_filepattern "${DEPENDENCIES_DIR}/bin/Python/Lib/__init__.py")
+file(GLOB_RECURSE uwp_pythonlibinit_foundfiles "${uwp_pythonlibinit_filepattern}")
+foreach(uwp_pythonlibinit_file ${uwp_pythonlibinit_foundfiles})
+    file(SIZE "${uwp_pythonlibinit_file}" uwp_pythonlibinit_filesize)
+    if(${uwp_pythonlibinit_filesize} EQUAL 0)
+        message("Adding hash comment character in the following empty file: ${uwp_pythonlibinit_file}")
+        file(APPEND ${uwp_pythonlibinit_file} "#")
+    endif()
+endforeach()


### PR DESCRIPTION
## Description
With Kodi Matrix 19.3 on Xbox in retail mode, the external add-ons may get "Permission denied" error related to __init__.py files.
The problem appear when Kodi Python add-on script present in User folder (updated add-on OR a not built-in add-on) depend on a Kodi Python library present in Application Folder (built-in Python library packaged with Kodi release).
In Kodi UWP compilation process, this fix will add a hash comment character in empty __init__.py Python Lib files.
This fix will only run for the Xbox platform compilation.

## Motivation and context
In love with Kodi and free Open Source projects.
Here, i want to fix the current most critical Kodi Xbox issue safely.
See more info here: https://forum.kodi.tv/showthread.php?tid=365157

## How has this been tested?
Using my Xbox Series X with Kodi 19.3 matrix branch code in Retail mode (cannot be reproduced in dev mode).
Was able to reproduce the issue with my "private Kodi 19.3 release" in Retail mode.
After that, i was able to introduce and test this fix on my "private Kodi 19.3 release" in Retail mode.
I tested with Youtube add-on which require "urllib" built-in Kodi Python library and this fix work fine (fix the issue).
See open source code with the included fix here (this is my "private Kodi 19.3 release" source): https://github.com/Chicopower/xbmc/tree/XBMCBetaTesting-Matrix

## What is the effect on users?
With this fix, Kodi Xbox users will be able to use their external Python add-ons without "Permission denied" add-on crash related to __init__.py files.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [ x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
