### PR TITLE
CGUITexture: register GUITexture use

### DIFF
--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -14,6 +14,11 @@
 #include "utils/StringUtils.h"
 #include "windowing/GraphicContext.h"
 
+#include <stdexcept>
+
+CreateGUITextureFunc CGUITexture::m_createGUITextureFunc;
+DrawQuadFunc CGUITexture::m_drawQuadFunc;
+
 CTextureInfo::CTextureInfo()
 {
   orientation = 0;
@@ -25,6 +30,35 @@ CTextureInfo::CTextureInfo(const std::string &file):
 {
   orientation = 0;
   useLarge = false;
+}
+
+void CGUITexture::Register(const CreateGUITextureFunc& createFunction,
+                           const DrawQuadFunc& drawQuadFunction)
+{
+  m_createGUITextureFunc = createFunction;
+  m_drawQuadFunc = drawQuadFunction;
+}
+
+CGUITexture* CGUITexture::CreateTexture(
+    float posX, float posY, float width, float height, const CTextureInfo& texture)
+{
+  if (!m_createGUITextureFunc)
+    throw std::runtime_error(
+        "No GUITexture Create function available. Did you forget to register?");
+
+  return m_createGUITextureFunc(posX, posY, width, height, texture);
+}
+
+void CGUITexture::DrawQuad(const CRect& coords,
+                           UTILS::COLOR::Color color,
+                           CTexture* texture,
+                           const CRect* texCoords)
+{
+  if (!m_drawQuadFunc)
+    throw std::runtime_error(
+        "No GUITexture DrawQuad function available. Did you forget to register?");
+
+  m_drawQuadFunc(coords, color, texture, texCoords);
 }
 
 CGUITexture::CGUITexture(

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -13,6 +13,8 @@
 #include "utils/ColorUtils.h"
 #include "utils/Geometry.h"
 
+#include <functional>
+
 // image alignment for <aspect>keep</aspect>, <aspect>scale</aspect> or <aspect>center</aspect>
 #define ASPECT_ALIGN_CENTER  0
 #define ASPECT_ALIGN_LEFT    1
@@ -60,10 +62,21 @@ public:
   std::string filename;        // main texture file
 };
 
+class CGUITexture;
+
+using CreateGUITextureFunc = std::function<CGUITexture*(
+    float posX, float posY, float width, float height, const CTextureInfo& texture)>;
+using DrawQuadFunc = std::function<void(
+    const CRect& coords, UTILS::COLOR::Color color, CTexture* texture, const CRect* texCoords)>;
+
 class CGUITexture
 {
 public:
   virtual ~CGUITexture() = default;
+
+  static void Register(const CreateGUITextureFunc& createFunction,
+                       const DrawQuadFunc& drawQuadFunction);
+
   static CGUITexture* CreateTexture(
       float posX, float posY, float width, float height, const CTextureInfo& texture);
   virtual CGUITexture* Clone() const = 0;
@@ -180,4 +193,8 @@ protected:
 
   CTextureArray m_diffuse;
   CTextureArray m_texture;
+
+private:
+  static CreateGUITextureFunc m_createGUITextureFunc;
+  static DrawQuadFunc m_drawQuadFunc;
 };

--- a/xbmc/guilib/GUITextureD3D.cpp
+++ b/xbmc/guilib/GUITextureD3D.cpp
@@ -17,7 +17,12 @@
 
 using namespace DirectX;
 
-CGUITexture* CGUITexture::CreateTexture(
+void CGUITextureD3D::Register()
+{
+  CGUITexture::Register(CGUITextureD3D::CreateTexture, CGUITextureD3D::DrawQuad);
+}
+
+CGUITexture* CGUITextureD3D::CreateTexture(
     float posX, float posY, float width, float height, const CTextureInfo& texture)
 {
   return new CGUITextureD3D(posX, posY, width, height, texture);
@@ -132,10 +137,10 @@ void CGUITextureD3D::Draw(float *x, float *y, float *z, const CRect &texture, co
   pGUIShader->DrawQuad(verts[0], verts[1], verts[2], verts[3]);
 }
 
-void CGUITexture::DrawQuad(const CRect& rect,
-                           UTILS::COLOR::Color color,
-                           CTexture* texture,
-                           const CRect* texCoords)
+void CGUITextureD3D::DrawQuad(const CRect& rect,
+                              UTILS::COLOR::Color color,
+                              CTexture* texture,
+                              const CRect* texCoords)
 {
   unsigned numViews = 0;
   ID3D11ShaderResourceView* views = nullptr;

--- a/xbmc/guilib/GUITextureD3D.h
+++ b/xbmc/guilib/GUITextureD3D.h
@@ -14,6 +14,15 @@
 class CGUITextureD3D : public CGUITexture
 {
 public:
+  static void Register();
+  static CGUITexture* CreateTexture(
+      float posX, float posY, float width, float height, const CTextureInfo& texture);
+
+  static void DrawQuad(const CRect& coords,
+                       UTILS::COLOR::Color color,
+                       CTexture* texture = nullptr,
+                       const CRect* texCoords = nullptr);
+
   CGUITextureD3D(float posX, float posY, float width, float height, const CTextureInfo& texture);
   ~CGUITextureD3D() override = default;
 

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -18,7 +18,12 @@
 
 #include <cstddef>
 
-CGUITexture* CGUITexture::CreateTexture(
+void CGUITextureGL::Register()
+{
+  CGUITexture::Register(CGUITextureGL::CreateTexture, CGUITextureGL::DrawQuad);
+}
+
+CGUITexture* CGUITextureGL::CreateTexture(
     float posX, float posY, float width, float height, const CTextureInfo& texture)
 {
   return new CGUITextureGL(posX, posY, width, height, texture);
@@ -245,10 +250,10 @@ void CGUITextureGL::Draw(float *x, float *y, float *z, const CRect &texture, con
   }
 }
 
-void CGUITexture::DrawQuad(const CRect& rect,
-                           UTILS::COLOR::Color color,
-                           CTexture* texture,
-                           const CRect* texCoords)
+void CGUITextureGL::DrawQuad(const CRect& rect,
+                             UTILS::COLOR::Color color,
+                             CTexture* texture,
+                             const CRect* texCoords)
 {
   CRenderSystemGL *renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
   if (texture)

--- a/xbmc/guilib/GUITextureGL.h
+++ b/xbmc/guilib/GUITextureGL.h
@@ -20,6 +20,15 @@ class CRenderSystemGL;
 class CGUITextureGL : public CGUITexture
 {
 public:
+  static void Register();
+  static CGUITexture* CreateTexture(
+      float posX, float posY, float width, float height, const CTextureInfo& texture);
+
+  static void DrawQuad(const CRect& coords,
+                       UTILS::COLOR::Color color,
+                       CTexture* texture = nullptr,
+                       const CRect* texCoords = nullptr);
+
   CGUITextureGL(float posX, float posY, float width, float height, const CTextureInfo& texture);
   ~CGUITextureGL() override = default;
 

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -19,7 +19,12 @@
 
 #include <cstddef>
 
-CGUITexture* CGUITexture::CreateTexture(
+void CGUITextureGLES::Register()
+{
+  CGUITexture::Register(CGUITextureGLES::CreateTexture, CGUITextureGLES::DrawQuad);
+}
+
+CGUITexture* CGUITextureGLES::CreateTexture(
     float posX, float posY, float width, float height, const CTextureInfo& texture)
 {
   return new CGUITextureGLES(posX, posY, width, height, texture);
@@ -226,10 +231,10 @@ void CGUITextureGLES::Draw(float *x, float *y, float *z, const CRect &texture, c
   }
 }
 
-void CGUITexture::DrawQuad(const CRect& rect,
-                           UTILS::COLOR::Color color,
-                           CTexture* texture,
-                           const CRect* texCoords)
+void CGUITextureGLES::DrawQuad(const CRect& rect,
+                               UTILS::COLOR::Color color,
+                               CTexture* texture,
+                               const CRect* texCoords)
 {
   CRenderSystemGLES *renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
   if (texture)

--- a/xbmc/guilib/GUITextureGLES.h
+++ b/xbmc/guilib/GUITextureGLES.h
@@ -29,6 +29,15 @@ class CRenderSystemGLES;
 class CGUITextureGLES : public CGUITexture
 {
 public:
+  static void Register();
+  static CGUITexture* CreateTexture(
+      float posX, float posY, float width, float height, const CTextureInfo& texture);
+
+  static void DrawQuad(const CRect& coords,
+                       UTILS::COLOR::Color color,
+                       CTexture* texture = nullptr,
+                       const CRect* texCoords = nullptr);
+
   CGUITextureGLES(float posX, float posY, float width, float height, const CTextureInfo& texture);
   ~CGUITextureGLES() override = default;
 

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -95,6 +95,8 @@ bool CRenderSystemDX::InitRenderSystem()
     version += (decimal % 16) * std::pow(10, round);
   m_RenderVersion = StringUtils::Format("{:.1f}", static_cast<float>(version) / 10.0f);
 
+  CGUITextureD3D::Register();
+
   return true;
 }
 

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -9,6 +9,7 @@
 #include "RenderSystemGL.h"
 
 #include "filesystem/File.h"
+#include "guilib/GUITextureGL.h"
 #include "rendering/MatrixGL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
@@ -106,6 +107,8 @@ bool CRenderSystemGL::InitRenderSystem()
   }
 
   InitialiseShaders();
+
+  CGUITextureGL::Register();
 
   return true;
 }

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -9,6 +9,7 @@
 #include "RenderSystemGLES.h"
 
 #include "guilib/DirtyRegion.h"
+#include "guilib/GUITextureGLES.h"
 #include "rendering/MatrixGL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -99,6 +100,8 @@ bool CRenderSystemGLES::InitRenderSystem()
   m_bRenderCreated = true;
 
   InitialiseShaders();
+
+  CGUITextureGLES::Register();
 
   return true;
 }


### PR DESCRIPTION
This adds a registration system for GUITexture. The reason for this is to provide flexibility in the future when we will be able to build with multiple render systems.

I don't love the need to register the DrawQuad static method but I wasn't sure how else to handle that and am open to suggestions. I do think it turned out pretty clean though.