### PR TITLE
CRendererVAAPI: rename to GL and GLES specific classes

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
@@ -18,11 +18,11 @@ namespace VAAPI
 class IVaapiWinSystem;
 }
 
-class CRendererVAAPI : public CLinuxRendererGL
+class CRendererVAAPIGL : public CLinuxRendererGL
 {
 public:
-  CRendererVAAPI();
-  ~CRendererVAAPI() override;
+  CRendererVAAPIGL();
+  ~CRendererVAAPIGL() override;
 
   static CBaseRenderer* Create(CVideoBuffer *buffer);
   static void Register(VAAPI::IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -20,18 +20,22 @@
 using namespace VAAPI;
 using namespace KODI::UTILS::EGL;
 
-IVaapiWinSystem *CRendererVAAPI::m_pWinSystem = nullptr;
+IVaapiWinSystem* CRendererVAAPIGLES::m_pWinSystem = nullptr;
 
-CBaseRenderer* CRendererVAAPI::Create(CVideoBuffer *buffer)
+CBaseRenderer* CRendererVAAPIGLES::Create(CVideoBuffer* buffer)
 {
   CVaapiRenderPicture *vb = dynamic_cast<CVaapiRenderPicture*>(buffer);
   if (vb)
-    return new CRendererVAAPI();
+    return new CRendererVAAPIGLES();
 
   return nullptr;
 }
 
-void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor)
+void CRendererVAAPIGLES::Register(IVaapiWinSystem* winSystem,
+                                  VADisplay vaDpy,
+                                  EGLDisplay eglDisplay,
+                                  bool& general,
+                                  bool& deepColor)
 {
   general = deepColor = false;
 
@@ -56,14 +60,14 @@ void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDi
 
   if (general)
   {
-    VIDEOPLAYER::CRendererFactory::RegisterRenderer("vaapi", CRendererVAAPI::Create);
+    VIDEOPLAYER::CRendererFactory::RegisterRenderer("vaapi", CRendererVAAPIGLES::Create);
     m_pWinSystem = winSystem;
   }
 }
 
-CRendererVAAPI::CRendererVAAPI() = default;
+CRendererVAAPIGLES::CRendererVAAPIGLES() = default;
 
-CRendererVAAPI::~CRendererVAAPI()
+CRendererVAAPIGLES::~CRendererVAAPIGLES()
 {
   for (int i = 0; i < NUM_BUFFERS; ++i)
   {
@@ -71,7 +75,7 @@ CRendererVAAPI::~CRendererVAAPI()
   }
 }
 
-bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned int orientation)
+bool CRendererVAAPIGLES::Configure(const VideoPicture& picture, float fps, unsigned int orientation)
 {
   CVaapiRenderPicture *pic = dynamic_cast<CVaapiRenderPicture*>(picture.videoBuffer);
   if (pic->procPic.videoSurface != VA_INVALID_ID)
@@ -86,7 +90,8 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
   interop.glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress("glEGLImageTargetTexture2DOES");
   interop.eglDisplay = m_pWinSystem->GetEGLDisplay();
 
-  bool useVaapi2 = VAAPI::CVaapi2Texture::TestInteropGeneral(pic->vadsp, CRendererVAAPI::m_pWinSystem->GetEGLDisplay());
+  bool useVaapi2 = VAAPI::CVaapi2Texture::TestInteropGeneral(
+      pic->vadsp, CRendererVAAPIGLES::m_pWinSystem->GetEGLDisplay());
 
   for (auto &tex : m_vaapiTextures)
   {
@@ -103,13 +108,13 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
 
   for (auto& fence : m_fences)
   {
-    fence.reset(new CEGLFence(CRendererVAAPI::m_pWinSystem->GetEGLDisplay()));
+    fence.reset(new CEGLFence(CRendererVAAPIGLES::m_pWinSystem->GetEGLDisplay()));
   }
 
   return CLinuxRendererGLES::Configure(picture, fps, orientation);
 }
 
-bool CRendererVAAPI::ConfigChanged(const VideoPicture &picture)
+bool CRendererVAAPIGLES::ConfigChanged(const VideoPicture& picture)
 {
   CVaapiRenderPicture *pic = dynamic_cast<CVaapiRenderPicture*>(picture.videoBuffer);
   if (pic->procPic.videoSurface != VA_INVALID_ID && !m_isVAAPIBuffer)
@@ -118,7 +123,7 @@ bool CRendererVAAPI::ConfigChanged(const VideoPicture &picture)
   return false;
 }
 
-EShaderFormat CRendererVAAPI::GetShaderFormat()
+EShaderFormat CRendererVAAPIGLES::GetShaderFormat()
 {
   EShaderFormat ret = SHADER_NONE;
 
@@ -130,17 +135,17 @@ EShaderFormat CRendererVAAPI::GetShaderFormat()
   return ret;
 }
 
-bool CRendererVAAPI::LoadShadersHook()
+bool CRendererVAAPIGLES::LoadShadersHook()
 {
   return false;
 }
 
-bool CRendererVAAPI::RenderHook(int idx)
+bool CRendererVAAPIGLES::RenderHook(int idx)
 {
   return false;
 }
 
-bool CRendererVAAPI::CreateTexture(int index)
+bool CRendererVAAPIGLES::CreateTexture(int index)
 {
   if (!m_isVAAPIBuffer)
   {
@@ -165,7 +170,7 @@ bool CRendererVAAPI::CreateTexture(int index)
   return true;
 }
 
-void CRendererVAAPI::DeleteTexture(int index)
+void CRendererVAAPIGLES::DeleteTexture(int index)
 {
   ReleaseBuffer(index);
 
@@ -181,7 +186,7 @@ void CRendererVAAPI::DeleteTexture(int index)
   buf.fields[FIELD_FULL][2].id = 0;
 }
 
-bool CRendererVAAPI::UploadTexture(int index)
+bool CRendererVAAPIGLES::UploadTexture(int index)
 {
   if (!m_isVAAPIBuffer)
   {
@@ -238,17 +243,17 @@ bool CRendererVAAPI::UploadTexture(int index)
   return true;
 }
 
-void CRendererVAAPI::AfterRenderHook(int index)
+void CRendererVAAPIGLES::AfterRenderHook(int index)
 {
   m_fences[index]->CreateFence();
 }
 
-bool CRendererVAAPI::NeedBuffer(int index)
+bool CRendererVAAPIGLES::NeedBuffer(int index)
 {
   return !m_fences[index]->IsSignaled();
 }
 
-void CRendererVAAPI::ReleaseBuffer(int index)
+void CRendererVAAPIGLES::ReleaseBuffer(int index)
 {
   m_fences[index]->DestroyFence();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -30,11 +30,11 @@ namespace VAAPI
 class IVaapiWinSystem;
 }
 
-class CRendererVAAPI : public CLinuxRendererGLES
+class CRendererVAAPIGLES : public CLinuxRendererGLES
 {
 public:
-  CRendererVAAPI();
-  ~CRendererVAAPI() override;
+  CRendererVAAPIGLES();
+  ~CRendererVAAPIGLES() override;
 
   static CBaseRenderer* Create(CVideoBuffer *buffer);
   static void Register(VAAPI::IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor);

--- a/xbmc/windowing/X11/OptionalsReg.cpp
+++ b/xbmc/windowing/X11/OptionalsReg.cpp
@@ -14,7 +14,12 @@
 #if defined (HAVE_LIBVA)
 #include <va/va_x11.h>
 #include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
+#if defined(HAS_GL)
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h"
+#endif
+#if defined(HAS_GLES)
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h"
+#endif
 
 using namespace KODI::WINDOWING::X11;
 
@@ -60,13 +65,23 @@ void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
   VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
   EGLDisplay eglDpy = winSystem->eglDisplay;
   VADisplay vaDpy = vaGetDisplay(winSystem->dpy);
-  CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, deepColor);
+  CRendererVAAPIGL::Register(winSystem, vaDpy, eglDpy, general, deepColor);
 }
+#endif
 
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+{
+  EGLDisplay eglDpy = winSystem->eglDisplay;
+  VADisplay vaDpy = vaGetDisplay(winSystem->dpy);
+  CRendererVAAPIGLES::Register(winSystem, vaDpy, eglDpy, general, deepColor);
+}
+#endif
 }
 }
 }
@@ -100,7 +115,11 @@ void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
 }
 
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+{
+}
+
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
 }
 

--- a/xbmc/windowing/X11/OptionalsReg.h
+++ b/xbmc/windowing/X11/OptionalsReg.h
@@ -27,7 +27,12 @@ CVaapiProxy* VaapiProxyCreate();
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy);
 void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor);
+#endif
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor);
+#endif
 }
 }
 }

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -269,7 +269,7 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
                               static_cast<CGLContextEGL*>(m_pGLContext)->m_eglDisplay);
         bool general = false;
         bool deepColor = false;
-        VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+        VAAPIRegisterRenderGL(m_vaapiProxy.get(), general, deepColor);
         if (general)
         {
           VAAPIRegister(m_vaapiProxy.get(), deepColor);

--- a/xbmc/windowing/gbm/OptionalsReg.cpp
+++ b/xbmc/windowing/gbm/OptionalsReg.cpp
@@ -14,7 +14,12 @@
 #if defined (HAVE_LIBVA)
 #include <va/va_drm.h>
 #include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
+#if defined(HAS_GL)
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h"
+#endif
+#if defined(HAS_GLES)
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h"
+#endif
 
 namespace KODI
 {
@@ -64,11 +69,21 @@ void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
   VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
-  CRendererVAAPI::Register(winSystem, winSystem->vaDpy, winSystem->eglDisplay, general, deepColor);
+  CRendererVAAPIGL::Register(winSystem, winSystem->vaDpy, winSystem->eglDisplay, general,
+                             deepColor);
 }
+#endif
 
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+{
+  CRendererVAAPIGLES::Register(winSystem, winSystem->vaDpy, winSystem->eglDisplay, general,
+                               deepColor);
+}
+#endif
 }
 }
 }
@@ -105,11 +120,18 @@ void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 
 }
 
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
 
 }
+#endif
 
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+{
+}
+#endif
 }
 }
 }

--- a/xbmc/windowing/gbm/OptionalsReg.h
+++ b/xbmc/windowing/gbm/OptionalsReg.h
@@ -25,8 +25,12 @@ CVaapiProxy* VaapiProxyCreate(int fd);
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy);
 void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
-
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor);
+#endif
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor);
+#endif
 }
 }
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -60,7 +60,7 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   bool general, deepColor;
   m_vaapiProxy.reset(VaapiProxyCreate(m_DRM->GetRenderNodeFileDescriptor()));
   VaapiProxyConfig(m_vaapiProxy.get(), m_eglContext.GetEGLDisplay());
-  VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+  VAAPIRegisterRenderGL(m_vaapiProxy.get(), general, deepColor);
 
   if (general)
   {

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -64,7 +64,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   bool general, deepColor;
   m_vaapiProxy.reset(GBM::VaapiProxyCreate(m_DRM->GetRenderNodeFileDescriptor()));
   GBM::VaapiProxyConfig(m_vaapiProxy.get(), m_eglContext.GetEGLDisplay());
-  GBM::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+  GBM::VAAPIRegisterRenderGLES(m_vaapiProxy.get(), general, deepColor);
 
   if (general)
   {

--- a/xbmc/windowing/wayland/OptionalsReg.cpp
+++ b/xbmc/windowing/wayland/OptionalsReg.cpp
@@ -14,7 +14,12 @@
 #if defined(HAVE_LIBVA) && defined(HAS_EGL)
 #include <va/va_wayland.h>
 #include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
+#if defined(HAS_GL)
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h"
+#endif
+#if defined(HAS_GLES)
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h"
+#endif
 
 namespace KODI
 {
@@ -56,12 +61,23 @@ void VAAPIRegister(CVaapiProxy* winSystem, bool deepColor)
   VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void VAAPIRegisterRender(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
   EGLDisplay eglDpy = winSystem->eglDisplay;
   VADisplay vaDpy = vaGetDisplayWl(winSystem->dpy);
-  CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, deepColor);
+  CRendererVAAPIGL::Register(winSystem, vaDpy, eglDpy, general, deepColor);
 }
+#endif
+
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+{
+  EGLDisplay eglDpy = winSystem->eglDisplay;
+  VADisplay vaDpy = vaGetDisplayWl(winSystem->dpy);
+  CRendererVAAPIGLES::Register(winSystem, vaDpy, eglDpy, general, deepColor);
+}
+#endif
 
 } // namespace WAYLAND
 } // namespace WINDOWING
@@ -99,11 +115,18 @@ void VAAPIRegister(CVaapiProxy* winSystem, bool deepColor)
 
 }
 
-void VAAPIRegisterRender(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
 
 }
+#endif
 
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+{
+}
+#endif
 
 } // namespace WAYLAND
 } // namespace WINDOWING

--- a/xbmc/windowing/wayland/OptionalsReg.h
+++ b/xbmc/windowing/wayland/OptionalsReg.h
@@ -25,7 +25,12 @@ CVaapiProxy* VaapiProxyCreate();
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy);
 void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
+#if defined(HAS_GL)
+void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor);
+#endif
+#if defined(HAS_GLES)
+void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor);
+#endif
 
 } // namespace WAYLAND
 } // namespace WINDOWING

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -49,7 +49,7 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   m_vaapiProxy.reset(WAYLAND::VaapiProxyCreate());
   WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(), GetConnection()->GetDisplay(),
                             m_eglContext.GetEGLDisplay());
-  WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+  WAYLAND::VAAPIRegisterRenderGL(m_vaapiProxy.get(), general, deepColor);
   if (general)
   {
     WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -54,7 +54,7 @@ bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
   m_vaapiProxy.reset(WAYLAND::VaapiProxyCreate());
   WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(), GetConnection()->GetDisplay(),
                             m_eglContext.GetEGLDisplay());
-  WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+  WAYLAND::VAAPIRegisterRenderGLES(m_vaapiProxy.get(), general, deepColor);
   if (general)
   {
     WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);


### PR DESCRIPTION
This adds separation between the GL and GLES versions of `CRendererVAAPI`. Without this there would be symbol clashes in in the future.

I don't love the need to ifdef in the Optionals file but that's life for now.