### PR TITLE
Texture: Fix memory leak on Android

### DIFF
--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -212,6 +212,7 @@ std::unique_ptr<CTexture> CTexture::LoadFromFile(const std::string& texturePath,
 
       std::unique_ptr<CTexture> texture = CTexture::CreateTexture();
       texture->LoadFromMemory(width, height, width*4, XB_FMT_RGBA8, true, inputBuff);
+      delete[] inputBuff;
       return texture;
     }
   }

--- a/xbmc/platform/android/filesystem/AndroidAppFile.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppFile.cpp
@@ -139,17 +139,17 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
     return 0;
   }
 
-  *width = info.width;
-  *height = info.height;
-
-  int imgsize = *width * *height * 4;
-  *lpBuf = new unsigned char[imgsize];
-
   AndroidBitmap_lockPixels(env, bmp.get_raw(), &bitmapBuf);
   if (bitmapBuf)
   {
+    const int imgsize = info.width * info.height * 4;
+    *lpBuf = new unsigned char[imgsize];
+    *width = info.width;
+    *height = info.height;
+
     memcpy(*lpBuf, bitmapBuf, imgsize);
     AndroidBitmap_unlockPixels(env, bmp.get_raw());
+
     return imgsize;
   }
   return 0;


### PR DESCRIPTION
Fixes memory leak on Android that was introduced in 61662026a9 (PR #20229).

## Description
As above.

## Motivation and context
Memleaks are baaaaad...

## How has this been tested?
It hasn't, don't have an Android.

## What is the effect on users?
Possibly excessive memory usage in Android.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
