### PR TITLE
[addons] use about extension/mimetype GUI list a description label

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13861,7 +13861,19 @@ msgctxt "#21345"
 msgid "Uncategorized"
 msgstr ""
 
-#empty strings from id 21346 to 21357
+#. Used to give heading list entry for an file extension description, e.g. to show as 'Extension: ".mp3"'
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#21346"
+msgid "Extension: \"{0:s}\""
+msgstr ""
+
+#. Used to give heading list entry for an mimetype description, e.g. to show as 'MIME type: "audio/mpeg3"'
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#21347"
+msgid "MIME type: \"{0:s}\""
+msgstr ""
+
+#empty strings from id 21348 to 21357
 
 #: system/settings/settings.xml
 msgctxt "#21358"

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -752,7 +752,15 @@ void CGUIDialogAddonInfo::ShowSupportList()
     if (StringUtils::EndsWith(entry.m_name, KODI_ADDON_AUDIODECODER_TRACK_EXT))
       continue;
 
-    const CFileItemPtr item = std::make_shared<CFileItem>(entry.m_name);
+    std::string label;
+    if (entry.m_type == AddonSupportType::Extension)
+      label = StringUtils::Format(g_localizeStrings.Get(21346), entry.m_name);
+    else if (entry.m_type == AddonSupportType::Mimetype)
+      label = StringUtils::Format(g_localizeStrings.Get(21347), entry.m_name);
+    else
+      label = entry.m_name;
+
+    const CFileItemPtr item = std::make_shared<CFileItem>(label);
     item->SetLabel2(entry.m_description);
     if (!entry.m_icon.empty())
       item->SetArt("icon", entry.m_icon);


### PR DESCRIPTION
## Description

Taken from https://github.com/xbmc/xbmc/pull/20508 as independent and not relates to imagedecoder addon interface.

This done to identify more easy by used what it means, with e.g. ".mp3" mostly easy, but think are users present where nothing know relationship about "audio/mpeg3".

With here becomes this as begin text added on list entry.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

![Bildschirmfoto vom 2021-11-13 14-53-34](https://user-images.githubusercontent.com/6879739/141656109-029bb683-0d4c-4ac6-98b4-bc03130f9219.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
