### PR TITLE
XbtFile: Fix logic error introduced in PR20229

### DIFF
--- a/xbmc/filesystem/XbtFile.cpp
+++ b/xbmc/filesystem/XbtFile.cpp
@@ -165,7 +165,7 @@ ssize_t CXbtFile::Read(void* lpBuf, size_t uiBufSize)
     const CXBTFFrame& frame = frames[m_frameIndex];
 
     // check if we have already unpacked the current frame
-    if (!m_unpackedFrames[m_frameIndex].empty())
+    if (m_unpackedFrames[m_frameIndex].empty())
     {
       // unpack the data from the current frame
       std::vector<uint8_t> unpackedFrame =


### PR DESCRIPTION
This regression was introduced in c0ece1436f with #20229.

## Description
See this discussion from here: https://github.com/xbmc/xbmc/pull/20229#issuecomment-966191541

## Motivation and context
Stop Kodi from crashing.

## How has this been tested?
Doesn't crash anymore on Linux Wayland. See https://github.com/xbmc/xbmc/pull/20229#issuecomment-968005422 to reproduce the issue.

## What is the effect on users?
See above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
