### PR TITLE
[Estuary] Home screen: TV/Radio: On click, open the Guide window, not the Channel window

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -931,7 +931,7 @@
 						<item>
 							<label>$LOCALIZE[19020]</label>
 							<property name="menu_id">$NUMBER[12000]</property>
-							<onclick>ActivateWindow(TVChannels)</onclick>
+							<onclick>ActivateWindow(TVGuide)</onclick>
 							<thumb>icons/sidemenu/livetv.png</thumb>
 							<property name="id">livetv</property>
 							<visible>!Skin.HasSetting(HomeMenuNoTVButton)</visible>
@@ -939,7 +939,7 @@
 						<item>
 							<label>$LOCALIZE[19021]</label>
 							<property name="menu_id">$NUMBER[13000]</property>
-							<onclick>ActivateWindow(RadioChannels)</onclick>
+							<onclick>ActivateWindow(RadioGuide)</onclick>
 							<thumb>icons/sidemenu/radio.png</thumb>
 							<property name="id">radio</property>
 							<visible>!Skin.HasSetting(HomeMenuNoRadioButton)</visible>


### PR DESCRIPTION
We had this request several times in the forum. People prefer Guide over Channels, so lets make Guide the default target for Estuary's Home screen TV/Radio category click action.

@ronie do the skin changes look okay to you. ;-)