### PR TITLE
[PVR] PVRGUIDirectory: Change TV/Radio categories order - put Guide a…

### DIFF
--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -68,15 +68,6 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
 
   const std::shared_ptr<CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
 
-  // Channels
-  item.reset(new CFileItem(
-      bRadio ? CPVRChannelsPath::PATH_RADIO_CHANNELS : CPVRChannelsPath::PATH_TV_CHANNELS, true));
-  item->SetLabel(g_localizeStrings.Get(19019)); // Channels
-  item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_CHANNELS
-                                                                             : WINDOW_TV_CHANNELS));
-  item->SetArt("icon", "DefaultPVRChannels.png");
-  results.Add(item);
-
   // EPG
   const bool bAnyClientSupportingEPG = clients->AnyClientSupportingEPG();
   if (bAnyClientSupportingEPG)
@@ -89,6 +80,15 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
     item->SetArt("icon", "DefaultPVRGuide.png");
     results.Add(item);
   }
+
+  // Channels
+  item.reset(new CFileItem(
+      bRadio ? CPVRChannelsPath::PATH_RADIO_CHANNELS : CPVRChannelsPath::PATH_TV_CHANNELS, true));
+  item->SetLabel(g_localizeStrings.Get(19019)); // Channels
+  item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_CHANNELS
+                                                                             : WINDOW_TV_CHANNELS));
+  item->SetArt("icon", "DefaultPVRChannels.png");
+  results.Add(item);
 
   // Recordings
   if (clients->AnyClientSupportingRecordings())


### PR DESCRIPTION
…t front, than Channels, Recordings, as before.

Meanwhile, Guide is the most used PVR window. Let's make it first item in the categories list. Before it was second, after Channels.

![screenshot00003](https://user-images.githubusercontent.com/3226626/141693606-cf1995c9-9d10-4834-bbe9-1b0b2775cac8.png)

@phunkyfish got some time for a code review?
