### PR TITLE
AndroidMediaCodec: Fallback to HEVC if Dolby Vision is not fully supp…

### DIFF
--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "settings/lib/ISettingCallback.h"
+#include "utils/HDRCapabilities.h"
 #include "windowing/Resolution.h"
 
 #include <string>
@@ -31,6 +32,8 @@ public:
   static const std::string SETTING_LIMITGUI;
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
+  static bool SupportsMediaCodecMimeType(const std::string& mimeType);
+
   // Android specific HDR type mapping
   // https://developer.android.com/reference/android/view/Display.HdrCapabilities#constants_1
   enum HDRTypes
@@ -41,12 +44,13 @@ public:
     HDR10_PLUS = 4
   };
 
-  std::vector<int> GetDisplaySupportedHdrTypes() const;
+  static std::vector<int> GetDisplaySupportedHdrTypes();
+  static CHDRCapabilities GetDisplayHDRCapabilities();
 
 protected:
   mutable int m_width;
   mutable int m_height;
 
 private:
-  void LogDisplaySupportedHdrTypes() const;
+  static void LogDisplaySupportedHdrTypes();
 };

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -328,20 +328,5 @@ std::unique_ptr<WINDOWING::IOSScreenSaver> CWinSystemAndroid::GetOSScreenSaverIm
 
 CHDRCapabilities CWinSystemAndroid::GetDisplayHDRCapabilities() const
 {
-  CHDRCapabilities caps;
-  const std::vector<int> types = m_android->GetDisplaySupportedHdrTypes();
-
-  if (std::find(types.begin(), types.end(), CAndroidUtils::HDRTypes::HDR10) != types.end())
-    caps.SetHDR10();
-
-  if (std::find(types.begin(), types.end(), CAndroidUtils::HDRTypes::HLG) != types.end())
-    caps.SetHLG();
-
-  if (std::find(types.begin(), types.end(), CAndroidUtils::HDRTypes::HDR10_PLUS) != types.end())
-    caps.SetHDR10Plus();
-
-  if (std::find(types.begin(), types.end(), CAndroidUtils::HDRTypes::DOLBY_VISION) != types.end())
-    caps.SetDolbyVision();
-
-  return caps;
+  return CAndroidUtils::GetDisplayHDRCapabilities();
 }


### PR DESCRIPTION
…rted

## Description
Allow Dolby Vision playback through MediaCodec only if the playback chain fully supports it.
This assumes minimum Dolby Vision compatibility, which is usually profile 5 on Android devices.

## Motivation and context
Avoid falling back to a software decoder in case the Android device doesn't support Dolby Vision.

This is mostly to avoid breaking compatibility when the hinted codec_tag is `dvhe`/`dvh1`, etc.
Otherwise, the mime type tested would always be `video/dolby-vision`, without ever trying for regular HEVC hardware acceleration.

## How has this been tested?
Tested on a FireTV Stick 4K Max.
With HDR adaptive enabled, both display and mediacodec support Dolby Vision.
When disabling HDR, only the display compatibility is forced to false by the device.

On a 2019 FireTV Stick connected to a standard HDTV:
`CDVDVideoCodecAndroidMediaCodec::Open Dolby Vision support: Display false, MediaCodec: false`
And it correctly picks the hardware HEVC decoder (though it fails configuring because it doesn't support 10 bit.)

## What is the effect on users?
Should avoid problems related to HDR10 fallback for non Dolby Vision setups, with no negative effect.

Currently, only inputstream.adaptive is using the hints so the change shouldn't do much if anything at all.
I can't get the `video/dolby-vision` mimetype at all without an extra patch for local files/strms, if the CodecID is not already `dvhe`.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
