### PR TITLE
[PVR] Simplify: No need for CPVREpgContainer to have its own event source

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -188,8 +188,8 @@ void CPVRManagerJobQueue::ExecutePendingJobs()
   }
 }
 
-CPVRManager::CPVRManager() :
-    CThread("PVRManager"),
+CPVRManager::CPVRManager()
+  : CThread("PVRManager"),
     m_providers(new CPVRProviders),
     m_channelGroups(new CPVRChannelGroupsContainer),
     m_recordings(new CPVRRecordings),
@@ -197,16 +197,14 @@ CPVRManager::CPVRManager() :
     m_addons(new CPVRClients),
     m_guiInfo(new CPVRGUIInfo),
     m_guiActions(new CPVRGUIActions),
+    m_epgContainer(m_events),
     m_pendingUpdates(new CPVRManagerJobQueue),
     m_database(new CPVRDatabase),
     m_parentalTimer(new CStopWatch),
     m_playbackState(new CPVRPlaybackState),
-    m_settings({
-      CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
-      CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,
-      CSettings::SETTING_PVRPARENTAL_ENABLED,
-      CSettings::SETTING_PVRPARENTAL_DURATION
-    })
+    m_settings({CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
+                CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,
+                CSettings::SETTING_PVRPARENTAL_ENABLED, CSettings::SETTING_PVRPARENTAL_DURATION})
 {
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
   m_actionListener.Init(*this);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -432,6 +432,8 @@ namespace PVR
 
     bool IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel, bool bGenerallyLocked) const;
 
+    CEventSource<PVREvent> m_events;
+
     /** @name containers */
     //@{
     std::shared_ptr<CPVRProviders> m_providers; /*!< pointer to the providers container */
@@ -456,10 +458,7 @@ namespace PVR
 
     CCriticalSection m_startStopMutex; // mutex for protecting pvr manager's start/restart/stop sequence */
 
-    CEventSource<PVREvent> m_events;
-
     const std::shared_ptr<CPVRPlaybackState> m_playbackState;
-
     CPVRGUIActionListener m_actionListener;
     CPVRSettings m_settings;
   };

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -44,7 +44,6 @@ CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD()
 CGUIDialogPVRChannelsOSD::~CGUIDialogPVRChannelsOSD()
 {
   CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Unsubscribe(this);
 }
 
 bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
@@ -166,7 +165,6 @@ void CGUIDialogPVRChannelsOSD::Update()
 {
   CPVRManager& pvrMgr = CServiceBroker::GetPVRManager();
   pvrMgr.Events().Subscribe(this, &CGUIDialogPVRChannelsOSD::Notify);
-  pvrMgr.EpgContainer().Events().Subscribe(this, &CGUIDialogPVRChannelsOSD::Notify);
 
   const std::shared_ptr<CPVRChannel> channel = pvrMgr.PlaybackState()->GetPlayingChannel();
   if (channel)

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -43,10 +43,12 @@ namespace PVR
     friend class CPVREpgDatabase;
 
   public:
+    CPVREpgContainer() = delete;
+
     /*!
      * @brief Create a new EPG table container.
      */
-    CPVREpgContainer();
+    explicit CPVREpgContainer(CEventSource<PVREvent>& eventSource);
 
     /*!
      * @brief Destroy this instance.
@@ -58,11 +60,6 @@ namespace PVR
      * @return A pointer to the database instance.
      */
     std::shared_ptr<CPVREpgDatabase> GetEpgDatabase() const;
-
-    /*!
-     * @brief Query the events available for CEventStream
-     */
-    CEventStream<PVREvent>& Events() { return m_events; }
 
     /*!
      * @brief Start the EPG update thread.
@@ -353,7 +350,7 @@ namespace PVR
 
     bool m_bUpdateNotificationPending = false; /*!< true while an epg updated notification to observers is pending. */
     CPVRSettings m_settings;
-    CEventSource<PVREvent> m_events;
+    CEventSource<PVREvent>& m_events;
 
     std::atomic<bool> m_bSuspended = {false};
   };

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -124,14 +124,14 @@ void CPVRTimers::Start()
 {
   Stop();
 
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Subscribe(this, &CPVRTimers::Notify);
+  CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRTimers::Notify);
   Create();
 }
 
 void CPVRTimers::Stop()
 {
   StopThread();
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Unsubscribe(this);
+  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
 }
 
 bool CPVRTimers::Update()

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -45,13 +45,9 @@ CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio, int id, const 
   CGUIWindowPVRBase(bRadio, id, xmlFile),
   m_bShowHiddenChannels(false)
 {
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Subscribe(static_cast<CGUIWindowPVRBase*>(this), &CGUIWindowPVRBase::Notify);
 }
 
-CGUIWindowPVRChannelsBase::~CGUIWindowPVRChannelsBase()
-{
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Unsubscribe(this);
-}
+CGUIWindowPVRChannelsBase::~CGUIWindowPVRChannelsBase() = default;
 
 void CGUIWindowPVRChannelsBase::GetContextButtons(int itemNumber, CContextButtons& buttons)
 {

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -55,13 +55,10 @@ CGUIWindowPVRGuideBase::CGUIWindowPVRGuideBase(bool bRadio, int id, const std::s
 {
   m_bRefreshTimelineItems = false;
   m_bSyncRefreshTimelineItems = false;
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Subscribe(static_cast<CGUIWindowPVRBase*>(this), &CGUIWindowPVRBase::Notify);
 }
 
 CGUIWindowPVRGuideBase::~CGUIWindowPVRGuideBase()
 {
-  CServiceBroker::GetPVRManager().EpgContainer().Events().Unsubscribe(this);
-
   m_bRefreshTimelineItems = false;
   m_bSyncRefreshTimelineItems = false;
   StopRefreshTimelineItemsThread();

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -96,13 +96,10 @@ CGUIWindowPVRSearchBase::CGUIWindowPVRSearchBase(bool bRadio, int id, const std:
   CGUIWindowPVRBase(bRadio, id, xmlFile),
   m_bSearchConfirmed(false)
 {
-  CServiceBroker::GetPVRManager().Events().Subscribe(static_cast<CGUIWindowPVRBase*>(this),
-                                                     &CGUIWindowPVRBase::Notify);
 }
 
 CGUIWindowPVRSearchBase::~CGUIWindowPVRSearchBase()
 {
-  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
 }
 
 void CGUIWindowPVRSearchBase::GetContextButtons(int itemNumber, CContextButtons& buttons)


### PR DESCRIPTION
… Use PVR Manager's event source instead.

Runtime-tested on macOS and Android, latest master.

@phunkyfish mind taking a look at the code hanges?