### PR TITLE
[tools/depends] minor android configure updates

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -4,9 +4,12 @@ find_program(AAPT_EXECUTABLE aapt PATHS ${SDK_BUILDTOOLS_PATH})
 if(NOT AAPT_EXECUTABLE)
   message(FATAL_ERROR "Could NOT find aapt executable")
 endif()
-find_program(DX_EXECUTABLE dx PATHS ${SDK_BUILDTOOLS_PATH})
-if(NOT DX_EXECUTABLE)
-  message(FATAL_ERROR "Could NOT find dx executable")
+find_program(D8_EXECUTABLE d8 PATHS ${SDK_BUILDTOOLS_PATH})
+if(NOT D8_EXECUTABLE)
+  find_program(DX_EXECUTABLE dx PATHS ${SDK_BUILDTOOLS_PATH})
+  if(NOT DX_EXECUTABLE)
+    message(FATAL_ERROR "Could NOT find dx or d8 executable")
+  endif()
 endif()
 find_program(ZIPALIGN_EXECUTABLE zipalign PATHS ${SDK_BUILDTOOLS_PATH})
 if(NOT ZIPALIGN_EXECUTABLE)
@@ -177,6 +180,7 @@ foreach(target apk obb apk-unsigned apk-obb apk-obb-unsigned apk-noobb apk-clean
               STRIP=${CMAKE_STRIP}
               AAPT=${AAPT_EXECUTABLE}
               DX=${DX_EXECUTABLE}
+              D8=${D8_EXECUTABLE}
               ZIPALIGN=${ZIPALIGN_EXECUTABLE}
               ${target}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/android/packaging

--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -28,6 +28,7 @@ TARGET_PLATFORM=@target_platform@
 RENDER_SYSTEM=@app_rendersystem@
 AAPT=@AAPT@
 DX=@DX@
+D8=@D8@
 ZIPALIGN=@ZIPALIGN@
 
 HAS_ZLIB=@has_zlib@

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -184,8 +184,9 @@ case $build in
     host_includes+=" -isysroot $native_sdk_path"
 
     CC_FOR_BUILD=[`$use_xcrun --find clang`]
-    CXX_FOR_BUILD=[`$use_xcrun --find clang++`]
+    use_build_toolchain=[`$CC_FOR_BUILD --version | grep InstalledDir | awk '{ print $2}'`]
 
+    # Android NDK currently only x86_64 prebuilts - Arctic Fox 2020.3.1
     android_toolchain_name="darwin-x86_64"
 
     if test "x$prefix" = "xNONE"; then
@@ -205,14 +206,13 @@ fi
 AC_PATH_PROG([RANLIB_FOR_BUILD], [ranlib], ranlib, $PATH_FOR_BUILD)
 AC_PATH_PROG([LD_FOR_BUILD], [ld], ld, $PATH_FOR_BUILD)
 AC_PATH_PROG([AR_FOR_BUILD], [ar], ar, $PATH_FOR_BUILD)
-AC_PATH_PROG([READELF_FOR_BUILD], [readelf], readelf, $PATH_FOR_BUILD)
+AC_PATH_PROG([READELF_FOR_BUILD], [readelf],, $PATH_FOR_BUILD)
 AC_PATH_PROG([STRIP_FOR_BUILD], [strip], strip, $PATH_FOR_BUILD)
 AC_PATH_PROG([AS_FOR_BUILD], [as], as, $PATH_FOR_BUILD)
 AC_PATH_PROG([NM_FOR_BUILD], [nm], nm, $PATH_FOR_BUILD)
 AC_PATH_PROG([OBJDUMP_FOR_BUILD], [objdump], objdump, $PATH_FOR_BUILD)
-AC_PATH_PROG([CC_FOR_BUILD],[clang gcc llvm-gcc $platform_cc], gcc, $PATH_FOR_BUILD)
-AC_PATH_PROG([CXX_FOR_BUILD],[clang++ g++ llvm-g++ $platform_cxx], g++, $PATH_FOR_BUILD)
-
+AC_PATH_PROG([CC_FOR_BUILD],[clang gcc llvm-gcc], gcc, $PATH_FOR_BUILD)
+AC_PATH_PROG([CXX_FOR_BUILD],[clang++ g++ llvm-g++], g++, $PATH_FOR_BUILD)
 
 platform_cc=gcc
 platform_cxx=g++
@@ -222,6 +222,9 @@ case $host in
     use_toolchain="${use_toolchain:-$use_ndk_path/toolchains/llvm/prebuilt/$android_toolchain_name}"
     platform_cc=$use_host$use_ndk_api-clang
     platform_cxx=$use_host$use_ndk_api-clang++
+
+    platform_tool_prefix=llvm-
+
     case $host in
       arm*-*linux-android*)
         platform_cc=armv7a-linux-androideabi$use_ndk_api-clang
@@ -230,23 +233,24 @@ case $host in
   ;;
   *darwin*)
     CC=[`$use_xcrun --find clang`]
-    CXX=[`$use_xcrun --find clang++`]
+    platform_cxx=clang++
+    use_toolchain=[`$CC --version | grep InstalledDir | awk '{ print $2}'`]
 esac
 
-if test -n $use_build_toolchain; then
+if test -n $use_toolchain; then
   PATH_FOR_HOST=$use_toolchain:$use_toolchain/usr/bin:$use_toolchain/bin:$PATH
 else
   PATH_FOR_HOST=$PATH
 fi
 
-AC_PATH_TOOL([RANLIB], [ranlib],, $PATH_FOR_HOST)
-AC_PATH_TOOL([LD], [ld],, $PATH_FOR_HOST)
-AC_PATH_TOOL([AR], [ar],, $PATH_FOR_HOST)
-AC_PATH_TOOL([READELF], [readelf],, $PATH_FOR_HOST)
-AC_PATH_TOOL([STRIP], [strip],, $PATH_FOR_HOST)
-AC_PATH_TOOL([AS], [as],, $PATH_FOR_HOST)
-AC_PATH_TOOL([NM], [nm],, $PATH_FOR_HOST)
-AC_PATH_TOOL([OBJDUMP], [objdump],, $PATH_FOR_HOST)
+AC_PATH_TOOL([RANLIB], [${platform_tool_prefix}ranlib],, $PATH_FOR_HOST)
+AC_PATH_TOOL([LD], [${platform_tool_prefix}ld],, $PATH_FOR_HOST)
+AC_PATH_TOOL([AR], [${platform_tool_prefix}ar],, $PATH_FOR_HOST)
+AC_PATH_TOOL([READELF], [${platform_tool_prefix}readelf],, $PATH_FOR_HOST)
+AC_PATH_TOOL([STRIP], [${platform_tool_prefix}strip],, $PATH_FOR_HOST)
+AC_PATH_TOOL([AS], [${platform_tool_prefix}as],, $PATH_FOR_HOST)
+AC_PATH_TOOL([NM], [${platform_tool_prefix}nm],, $PATH_FOR_HOST)
+AC_PATH_TOOL([OBJDUMP], [${platform_tool_prefix}objdump],, $PATH_FOR_HOST)
 AC_PATH_TOOL([CC],[$platform_cc],,$PATH_FOR_HOST)
 AC_PATH_TOOL([CXX],[$platform_cxx],,$PATH_FOR_HOST)
 

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -535,9 +535,12 @@ if test "$platform_os" == "android"; then
     AC_MSG_ERROR("Missing program: aapt")
   fi
 
-  AC_PATH_PROG(DX,dx,"no",$build_tools_path)
-  if test "x$DX" = "xno" ; then
-    AC_MSG_ERROR("Missing program: dx")
+  AC_PATH_PROG(D8,d8,"no",$build_tools_path)
+  if test "x$D8" = "xno" ; then
+    AC_PATH_PROG(DX,dx,"no",$build_tools_path)
+    if test "x$DX" = "xno" ; then
+      AC_MSG_ERROR("Missing program: dx or d8")
+    fi
   fi
 
   AC_PATH_PROG(ZIPALIGN,zipalign,"no",$build_tools_path)


### PR DESCRIPTION
## Description
With current android SDK/NDK, binaries are llvm prefixed
In addition, dx was deprecated and removed in favor of d8

## Motivation and context
Looking to bring in a tested android build environment on macos.
This is just some minors on the way

## How has this been tested?
Configure/build aarch64-android with current NDK 23.1.7779620 and with SDK 24/31

## What is the effect on users?
NA

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
