### PR TITLE
[backport] Fix issue 20421 - UWP Xbox Python add-ons permission error

### DIFF
--- a/cmake/scripts/windowsstore/Install.cmake
+++ b/cmake/scripts/windowsstore/Install.cmake
@@ -1,0 +1,10 @@
+# Fix UWP addons security issue caused by empty __init__.py Python Lib files packaged with Kodi
+set(uwp_pythonlibinit_filepattern "${DEPENDENCIES_DIR}/bin/Python/Lib/__init__.py")
+file(GLOB_RECURSE uwp_pythonlibinit_foundfiles "${uwp_pythonlibinit_filepattern}")
+foreach(uwp_pythonlibinit_file ${uwp_pythonlibinit_foundfiles})
+    file(SIZE "${uwp_pythonlibinit_file}" uwp_pythonlibinit_filesize)
+    if(${uwp_pythonlibinit_filesize} EQUAL 0)
+        message("Adding hash comment character in the following empty file: ${uwp_pythonlibinit_file}")
+        file(APPEND ${uwp_pythonlibinit_file} "#")
+    endif()
+endforeach()


### PR DESCRIPTION
## Description
backport of #20501

## Motivation and context

## How has this been tested?

## What is the effect on users?

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
