### PR TITLE
[VideoPlayerAudio][EDL] Fix edl mute

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1645,7 +1645,9 @@ void CVideoPlayer::ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket)
   }
 
   m_VideoPlayerAudio->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
-  m_CurrentAudio.packets++;
+
+  if (!drop)
+    m_CurrentAudio.packets++;
 }
 
 void CVideoPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
@@ -1669,7 +1671,9 @@ void CVideoPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
     drop = true;
 
   m_VideoPlayerVideo->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
-  m_CurrentVideo.packets++;
+
+  if (!drop)
+    m_CurrentVideo.packets++;
 }
 
 void CVideoPlayer::ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -393,6 +393,12 @@ void CVideoPlayerAudio::Process()
       if (bPacketDrop)
       {
         pMsg->Release();
+        if (m_syncState != IDVDStreamPlayer::SYNC_STARTING)
+        {
+          m_audioSink.Drain();
+          m_audioSink.Flush();
+          audioframe.nb_frames = 0;
+        }
         m_syncState = IDVDStreamPlayer::SYNC_STARTING;
         continue;
       }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -390,9 +390,15 @@ void CVideoPlayerAudio::Process()
       DemuxPacket* pPacket = static_cast<CDVDMsgDemuxerPacket*>(pMsg)->GetPacket();
       bool bPacketDrop  = static_cast<CDVDMsgDemuxerPacket*>(pMsg)->GetPacketDrop();
 
-      if (bPacketDrop ||
-          (!m_processInfo.IsTempoAllowed(static_cast<float>(m_speed)/DVD_PLAYSPEED_NORMAL) &&
-           m_syncState == IDVDStreamPlayer::SYNC_INSYNC))
+      if (bPacketDrop)
+      {
+        pMsg->Release();
+        m_syncState = IDVDStreamPlayer::SYNC_STARTING;
+        continue;
+      }
+
+      if (!m_processInfo.IsTempoAllowed(static_cast<float>(m_speed) / DVD_PLAYSPEED_NORMAL) &&
+          m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
       {
         pMsg->Release();
         continue;


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/20293 and https://github.com/xbmc/xbmc/pull/20547 for Matrix 19.4
Should restore EDL mute zones, broken since Leia.
