### PR TITLE
[Estuary] Skin settings: Add possibility to show/hide the different PVR widgets.

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -109,10 +109,10 @@ msgctxt "#31015"
 msgid "Recent recordings"
 msgstr ""
 
-#. home screen channel widget: recently played tv channels. (please note that in some non-english languages #31018 and #31016 might not be equal)
+#. home screen channel widget: recently watched tv channels. (please note that in some non-english languages #31018 and #31016 might not be equal)
 #: /xml/Home.xml
 msgctxt "#31016"
-msgid "Recently played channels"
+msgid "Recent channels"
 msgstr ""
 
 #: /xml/DialogVideoInfo.xml
@@ -120,10 +120,10 @@ msgctxt "#31017"
 msgid "Rated"
 msgstr ""
 
-#. home screen channel widget: recently played radio channels. (please note that in some non-english languages #31018 and #31016 might not be equal)
+#. home screen channel widget: recently listened radio channels. (please note that in some non-english languages #31018 and #31016 might not be equal)
 #: /xml/Home.xml
 msgctxt "#31018"
-msgid "Recently played channels"
+msgid "Recent channels"
 msgstr ""
 
 #: /xml/Home.xml /xml/MyWeather.xml
@@ -806,4 +806,88 @@ msgstr ""
 #: /xml/Variables.xml
 msgctxt "#31169"
 msgid "Artwork related settings."
+msgstr ""
+
+#. Label for "TV" settings section
+#: /xml/SkinSettings.xml
+msgctxt "#31170"
+msgid "TV"
+msgstr ""
+
+#. Label for "Radio" settings section
+#: /xml/SkinSettings.xml
+msgctxt "#31171"
+msgid "Radio"
+msgstr ""
+
+#. "TV" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31172"
+msgid "Show 'Recent channels' widget"
+msgstr ""
+
+#. "Radio" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31173"
+msgid "Show 'Recent channels' widget"
+msgstr ""
+
+#. "TV" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31174"
+msgid "Show 'Recent recordings' widget"
+msgstr ""
+
+#. "Radio" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31175"
+msgid "Show 'Recent recordings' widget"
+msgstr ""
+
+#. "TV" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31176"
+msgid "Show 'Timers' widget"
+msgstr ""
+
+#. "Radio" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31177"
+msgid "Show 'Timers' widget"
+msgstr ""
+
+#. "TV" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31178"
+msgid "Show 'TV channel groups' widget"
+msgstr ""
+
+#. "Radio" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31179"
+msgid "Show 'Radio channel groups' widget"
+msgstr ""
+
+#. "TV" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31180"
+msgid "Show 'Saved searches' widget"
+msgstr ""
+
+#. "Radio" settings section, label for show/hide widget setting
+#: /xml/SkinSettings.xml
+msgctxt "#31181"
+msgid "Show 'Saved searches' widget"
+msgstr ""
+
+#. Description label for skin settings area
+#: /xml/Variables.xml
+msgctxt "#31182"
+msgid "TV related settings"
+msgstr ""
+
+#. Description label for skin settings area
+#: /xml/Variables.xml
+msgctxt "#31183"
+msgid "Radio related settings"
 msgstr ""

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -377,14 +377,14 @@
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="list_id" value="12900"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(tv_show_recent_channels_widget)">
 							<param name="content_path" value="pvr://channels/tv/*?view=lastplayed"/>
 							<param name="sortby" value="lastplayed"/>
 							<param name="sortorder" value="descending"/>
 							<param name="widget_header" value="$LOCALIZE[31016]"/>
 							<param name="list_id" value="12200"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(tv_show_recent_recordings_widget)">
 							<param name="content_path" value="pvr://recordings/tv/active?view=flat"/>
 							<param name="sortby" value="date"/>
 							<param name="sortorder" value="descending"/>
@@ -393,7 +393,7 @@
 							<param name="label" value="$INFO[ListItem.ChannelName]"/>
 							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)]"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(tv_show_timers_widget)">
 							<param name="content_path" value="pvr://timers/tv/timers/?view=hidedisabled"/>
 							<param name="sortorder" value="ascending"/>
 							<param name="sortby" value="date"/>
@@ -403,14 +403,14 @@
 							<param name="label" value="$INFO[ListItem.Date]"/>
 							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)] - $INFO[ListItem.ChannelName]"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(tv_show_channelgroups_widget)">
 							<param name="content_path" value="pvr://channels/tv"/>
 							<param name="widget_header" value="$LOCALIZE[19173]"/>
 							<param name="widget_target" value="tvguide"/>
 							<param name="list_id" value="12500"/>
 							<param name="item_treshold" value="1"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(tv_show_saved_searches_widget)">
 							<param name="content_path" value="pvr://search/tv/savedsearches"/>
 							<param name="sortorder" value="descending"/>
 							<param name="sortby" value="date"/>
@@ -443,14 +443,14 @@
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="list_id" value="13900"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(radio_show_recent_channels_widget)">
 							<param name="content_path" value="pvr://channels/radio/*?view=lastplayed"/>
 							<param name="sortby" value="lastplayed"/>
 							<param name="sortorder" value="descending"/>
 							<param name="widget_header" value="$LOCALIZE[31018]"/>
 							<param name="list_id" value="13200"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(radio_show_recent_recordings_widget)">
 							<param name="content_path" value="pvr://recordings/radio/active?view=flat"/>
 							<param name="sortby" value="date"/>
 							<param name="sortorder" value="descending"/>
@@ -459,7 +459,7 @@
 							<param name="label" value="$INFO[ListItem.ChannelName]"/>
 							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)]"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(radio_show_timers_widget)">
 							<param name="content_path" value="pvr://timers/radio/timers/?view=hidedisabled"/>
 							<param name="sortorder" value="ascending"/>
 							<param name="sortby" value="date"/>
@@ -469,14 +469,14 @@
 							<param name="label" value="$INFO[ListItem.Date]"/>
 							<param name="label2" value="$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)] - $INFO[ListItem.ChannelName]"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(radio_show_channelgroups_widget)">
 							<param name="content_path" value="pvr://channels/radio"/>
 							<param name="widget_header" value="$LOCALIZE[19174]"/>
 							<param name="widget_target" value="radioguide"/>
 							<param name="list_id" value="13500"/>
 							<param name="item_treshold" value="1"/>
 						</include>
-						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+						<include content="WidgetListPVR" condition="System.HasPVRAddon + !Skin.HasSetting(radio_show_saved_searches_widget)">
 							<param name="content_path" value="pvr://search/radio/savedsearches"/>
 							<param name="sortorder" value="descending"/>
 							<param name="sortby" value="date"/>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -251,6 +251,90 @@
 					<onclick>Skin.ToggleSetting(HomeMenuNoWeatherButton)</onclick>
 				</control>
 			</control>
+			<control type="grouplist" id="620">
+				<top>133</top>
+				<left>0</left>
+				<right>0</right>
+				<bottom>140</bottom>
+				<onleft>9000</onleft>
+				<onright>60</onright>
+				<onup>620</onup>
+				<pagecontrol>60</pagecontrol>
+				<ondown>620</ondown>
+				<visible>Container(9000).HasFocus(4)</visible>
+				<control type="radiobutton" id="621">
+					<label>$LOCALIZE[31172]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(tv_show_recent_channels_widget)</selected>
+					<onclick>Skin.ToggleSetting(tv_show_recent_channels_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="622">
+					<label>$LOCALIZE[31174]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(tv_show_recent_recordings_widget)</selected>
+					<onclick>Skin.ToggleSetting(tv_show_recent_recordings_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="623">
+					<label>$LOCALIZE[31176]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(tv_show_timers_widget)</selected>
+					<onclick>Skin.ToggleSetting(tv_show_timers_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="624">
+					<label>$LOCALIZE[31178]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(tv_show_channelgroups_widget)</selected>
+					<onclick>Skin.ToggleSetting(tv_show_channelgroups_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="625">
+					<label>$LOCALIZE[31180]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(tv_show_saved_searches_widget)</selected>
+					<onclick>Skin.ToggleSetting(tv_show_saved_searches_widget)</onclick>
+				</control>
+			</control>
+			<control type="grouplist" id="630">
+				<top>133</top>
+				<left>0</left>
+				<right>0</right>
+				<bottom>140</bottom>
+				<onleft>9000</onleft>
+				<onright>60</onright>
+				<onup>630</onup>
+				<pagecontrol>60</pagecontrol>
+				<ondown>630</ondown>
+				<visible>Container(9000).HasFocus(5)</visible>
+				<control type="radiobutton" id="631">
+					<label>$LOCALIZE[31173]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(radio_show_recent_channels_widget)</selected>
+					<onclick>Skin.ToggleSetting(radio_show_recent_channels_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="632">
+					<label>$LOCALIZE[31175]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(radio_show_recent_recordings_widget)</selected>
+					<onclick>Skin.ToggleSetting(radio_show_recent_recordings_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="633">
+					<label>$LOCALIZE[31177]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(radio_show_timers_widget)</selected>
+					<onclick>Skin.ToggleSetting(radio_show_timers_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="634">
+					<label>$LOCALIZE[31179]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(radio_show_channelgroups_widget)</selected>
+					<onclick>Skin.ToggleSetting(radio_show_channelgroups_widget)</onclick>
+				</control>
+				<control type="radiobutton" id="635">
+					<label>$LOCALIZE[31181]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(radio_show_saved_searches_widget)</selected>
+					<onclick>Skin.ToggleSetting(radio_show_saved_searches_widget)</onclick>
+				</control>
+			</control>
 			<control type="image">
 				<description>Dialog Header image</description>
 				<left>0</left>
@@ -322,6 +406,14 @@
 					</item>
 					<item id="3">
 						<label>$LOCALIZE[31159]</label>
+						<onclick>noop</onclick>
+					</item>
+					<item id="4">
+						<label>$LOCALIZE[31170]</label>
+						<onclick>noop</onclick>
+					</item>
+					<item id="5">
+						<label>$LOCALIZE[31171]</label>
 						<onclick>noop</onclick>
 					</item>
 				</content>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -287,6 +287,8 @@
 		<value condition="Container(9000).HasFocus(1)">$LOCALIZE[31129]</value>
 		<value condition="Container(9000).HasFocus(2)">$LOCALIZE[31130]</value>
 		<value condition="Container(9000).HasFocus(3)">$LOCALIZE[31169]</value>
+		<value condition="Container(9000).HasFocus(4)">$LOCALIZE[31182]</value>
+		<value condition="Container(9000).HasFocus(5)">$LOCALIZE[31183]</value>
 	</variable>
 	<variable name="VolumeIconVar">
 		<value condition="Player.Muted">dialogs/volume/mute.png</value>


### PR DESCRIPTION
The feature to be able to activate and deactivate the widgets displayed on the different Estuary Home screen sections was planned by the original author of Estuary but was not implemented so far. I thought it would be a good idea to start with realizing this feature for the two PVR sections of the home screen - TV and Radio. This PR could serve as a template for the other home screen sections.

The new settings pages:


![screenshot00003](https://user-images.githubusercontent.com/3226626/142065586-f79a971f-a779-41a1-9a2f-ef3fedc77f42.png)

![screenshot00004](https://user-images.githubusercontent.com/3226626/142065255-71bf85de-2de3-4711-832d-f2d5ed650077.png)

Example - TV section with only Saved searches widget:

![screenshot00006](https://user-images.githubusercontent.com/3226626/142065574-d61b74ce-d436-425c-80b5-1d5cf026021b.png)

Runtime-tested on macOS and Android, latest Kodi master.

@ronie mind looking at the skin changes?