### PR TITLE
[Subtitles] Reworked line parsing to handle files formatted with CR return chars

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
@@ -103,7 +103,7 @@ OverlayMessage CDVDOverlayCodecCCText::Decode(DemuxPacket* pPacket)
         if (m_changePrevStopTime)
           ChangeSubtitleStopTime(m_prevSubId, PTSStartTime);
 
-        m_prevSubId = AddSubtitle(text.c_str(), PTSStartTime, PTSStopTime);
+        m_prevSubId = AddSubtitle(text, PTSStartTime, PTSStopTime);
         m_changePrevStopTime = true;
       }
     }
@@ -121,6 +121,15 @@ OverlayMessage CDVDOverlayCodecCCText::Decode(DemuxPacket* pPacket)
     CLog::Log(LOGERROR, "{} - Failed to initialize tag converter", __FUNCTION__);
 
   return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
+}
+
+void CDVDOverlayCodecCCText::PostProcess(std::string& text)
+{
+  // The data that come from InputStream could contains \r chars
+  // we have to remove them all because it causes to display empty box "tofu"
+  //! @todo This must be removed after the rework of the CC decoders
+  StringUtils::Replace(text, "\r", "");
+  CSubtitlesAdapter::PostProcess(text);
 }
 
 void CDVDOverlayCodecCCText::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.h
@@ -25,6 +25,9 @@ public:
   void Flush() override;
   CDVDOverlay* GetOverlay() override;
 
+  // Specialization of CSubtitlesAdapter
+  void PostProcess(std::string& text) override;
+
 private:
   void Dispose() override;
   CDVDOverlay* m_pOverlay;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -248,12 +248,16 @@ OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
   if (strUTF8.empty())
     return OverlayMessage::OC_BUFFER;
 
-  if (strUTF8[strUTF8.size() - 1] == '\n')
-    strUTF8.erase(strUTF8.size() - 1);
-
-  AddSubtitle(strUTF8.c_str(), PTSStartTime, PTSStopTime);
+  AddSubtitle(strUTF8, PTSStartTime, PTSStopTime);
 
   return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
+}
+
+void CDVDOverlayCodecTX3G::PostProcess(std::string& text)
+{
+  if (text[text.size() - 1] == '\n')
+    text.erase(text.size() - 1);
+  CSubtitlesAdapter::PostProcess(text);
 }
 
 void CDVDOverlayCodecTX3G::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.h
@@ -24,6 +24,9 @@ public:
   void Flush() override;
   CDVDOverlay* GetOverlay() override;
 
+  // Specialization of CSubtitlesAdapter
+  void PostProcess(std::string& text) override;
+
 private:
   void Dispose() override;
   CDVDOverlay* m_pOverlay{nullptr};

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -82,12 +82,20 @@ OverlayMessage CDVDOverlayCodecText::Decode(DemuxPacket* pPacket)
   {
     TagConv.ConvertLine(text);
     TagConv.CloseTag(text);
-    AddSubtitle(text.c_str(), PTSStartTime, PTSStopTime);
+    AddSubtitle(text, PTSStartTime, PTSStopTime);
   }
   else
     CLog::Log(LOGERROR, "{} - Failed to initialize tag converter", __FUNCTION__);
 
   return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
+}
+
+void CDVDOverlayCodecText::PostProcess(std::string& text)
+{
+  // The data that come from InputStream could contains \r chars
+  // we have to remove them all because it causes to display empty box "tofu"
+  StringUtils::Replace(text, "\r", "");
+  CSubtitlesAdapter::PostProcess(text);
 }
 
 void CDVDOverlayCodecText::Reset()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
@@ -30,6 +30,9 @@ public:
   void Flush() override;
   CDVDOverlay* GetOverlay() override;
 
+  // Specialization of CSubtitlesAdapter
+  void PostProcess(std::string& text) override;
+
 private:
   void Dispose() override;
   CDVDOverlay* m_pOverlay;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -11,6 +11,7 @@
 #include "DVDDemux.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 class CDVDOverlayCodecFFmpeg;
@@ -79,9 +80,9 @@ private:
     }
   };
 
-  bool ParseLangIdx(SState& state, char* line);
-  bool ParseDelay(SState& state, char* line);
-  bool ParseId(SState& state, char* line);
-  bool ParseExtra(SState& state, char* line);
-  bool ParseTimestamp(SState& state, char* line);
+  bool ParseLangIdx(SState& state, std::string& line);
+  bool ParseDelay(SState& state, std::string& line);
+  bool ParseId(SState& state, std::string& line);
+  bool ParseExtra(SState& state, std::string& line);
+  bool ParseTimestamp(SState& state, std::string& line);
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
@@ -23,7 +23,7 @@
 
 CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
 {
-  char line[1024];
+  std::string line;
   int i;
 
   std::unique_ptr<CDVDSubtitleStream> pStream(new CDVDSubtitleStream());
@@ -34,24 +34,25 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
 
   for (int t = 0; t < 256; t++)
   {
-    if (pStream->ReadLine(line, sizeof(line)))
+    if (pStream->ReadLine(line))
     {
-      if ((sscanf (line, "{%d}{}", &i)==1) ||
-          (sscanf (line, "{%d}{%d}", &i, &i)==2))
+      if ((sscanf(line.c_str(), "{%d}{}", &i) == 1) ||
+          (sscanf(line.c_str(), "{%d}{%d}", &i, &i) == 2))
       {
-        return new CDVDSubtitleParserMicroDVD(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserMicroDVD(std::move(pStream), strFile);
       }
-      else if (sscanf(line, "[%d][%d]", &i, &i) == 2)
+      else if (sscanf(line.c_str(), "[%d][%d]", &i, &i) == 2)
       {
-        return new CDVDSubtitleParserMPL2(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserMPL2(std::move(pStream), strFile);
       }
-      else if (sscanf(line, "%d:%d:%d%*c%d --> %d:%d:%d%*c%d", &i, &i, &i, &i, &i, &i, &i, &i) == 8)
+      else if (sscanf(line.c_str(), "%d:%d:%d%*c%d --> %d:%d:%d%*c%d", &i, &i, &i, &i, &i, &i, &i,
+                      &i) == 8)
       {
-        return new CDVDSubtitleParserSubrip(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserSubrip(std::move(pStream), strFile);
       }
-      else if (sscanf(line, "%d:%d:%d:", &i, &i, &i) == 3)
+      else if (sscanf(line.c_str(), "%d:%d:%d:", &i, &i, &i) == 3)
       {
-        return new CDVDSubtitleParserVplayer(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserVplayer(std::move(pStream), strFile);
       }
       else if (!StringUtils::CompareNoCase(line, "!: This is a Sub Station Alpha v", 32) ||
                !StringUtils::CompareNoCase(line, "ScriptType: v4.00", 17) ||
@@ -59,15 +60,15 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
                !StringUtils::CompareNoCase(line, "Dialogue: ", 10) ||
                !StringUtils::CompareNoCase(line, "[Events]", 8))
       {
-        return new CDVDSubtitleParserSSA(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserSSA(std::move(pStream), strFile);
       }
-      else if (strstr (line, "<SAMI>"))
+      else if (line == "<SAMI>")
       {
-        return new CDVDSubtitleParserSami(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserSami(std::move(pStream), strFile);
       }
-      else if (strstr(line, "WEBVTT"))
+      else if (!StringUtils::CompareNoCase(line, "WEBVTT", 6))
       {
-        return new CSubtitleParserWebVTT(std::move(pStream), strFile.c_str());
+        return new CSubtitleParserWebVTT(std::move(pStream), strFile);
       }
     }
     else

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
@@ -74,7 +74,7 @@ protected:
   {
     if(m_pStream)
     {
-      if(m_pStream->Seek(0, SEEK_SET) == 0)
+      if (m_pStream->Seek(0))
         return true;
     }
     else

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
@@ -13,6 +13,8 @@
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "utils/RegExp.h"
 
+#include <cstdlib>
+
 CDVDSubtitleParserMPL2::CDVDSubtitleParserMPL2(std::unique_ptr<CDVDSubtitleStream>&& stream,
                                                const std::string& filename)
   : CDVDSubtitleParserText(std::move(stream), filename, "MPL2 Subtitle Parser"),
@@ -36,30 +38,26 @@ bool CDVDSubtitleParserMPL2::Open(CDVDStreamInfo& hints)
   // MPL2 is time-based, with 0.1s accuracy
   m_framerate = DVD_TIME_BASE / 10.0;
 
-  char line[1024];
-
   CRegExp reg;
-  if (!reg.RegComp("\\[([0-9]+)\\]\\[([0-9]+)\\]"))
+  if (!reg.RegComp("\\[([0-9]+)\\]\\[([0-9]+)\\](.+)"))
     return false;
   CDVDSubtitleTagMicroDVD TagConv;
+  std::string line;
 
-  while (m_pStream->ReadLine(line, sizeof(line)))
+  while (m_pStream->ReadLine(line))
   {
-    if ((strlen(line) > 0) && (line[strlen(line) - 1] == '\r'))
-      line[strlen(line) - 1] = 0;
-
     int pos = reg.RegFind(line);
     if (pos > -1)
     {
-      std::string text(line + pos + reg.GetFindLen());
       std::string startFrame(reg.GetMatch(1));
       std::string endFrame(reg.GetMatch(2));
+      std::string text(reg.GetMatch(3));
 
-      double iPTSStartTime = m_framerate * atoi(startFrame.c_str());
-      double iPTSStopTime = m_framerate * atoi(endFrame.c_str());
+      double iPTSStartTime = m_framerate * std::atoi(startFrame.c_str());
+      double iPTSStopTime = m_framerate * std::atoi(endFrame.c_str());
 
       TagConv.ConvertLine(text);
-      AddSubtitle(text.c_str(), iPTSStartTime, iPTSStopTime);
+      AddSubtitle(text, iPTSStartTime, iPTSStopTime);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
@@ -14,6 +14,8 @@
 #include "utils/RegExp.h"
 #include "utils/log.h"
 
+#include <cstdlib>
+
 CDVDSubtitleParserMicroDVD::CDVDSubtitleParserMicroDVD(std::unique_ptr<CDVDSubtitleStream>&& stream,
                                                        const std::string& filename)
   : CDVDSubtitleParserText(std::move(stream), filename, "MicroDVD Subtitle Parser"),
@@ -43,30 +45,26 @@ bool CDVDSubtitleParserMicroDVD::Open(CDVDStreamInfo& hints)
   else
     m_framerate = DVD_TIME_BASE / 25.0;
 
-  char line[1024];
-
   CRegExp reg;
-  if (!reg.RegComp("\\{([0-9]+)\\}\\{([0-9]+)\\}"))
+  if (!reg.RegComp("\\{([0-9]+)\\}\\{([0-9]+)\\}(.+)"))
     return false;
   CDVDSubtitleTagMicroDVD TagConv;
+  std::string line;
 
-  while (m_pStream->ReadLine(line, sizeof(line)))
+  while (m_pStream->ReadLine(line))
   {
-    if ((strlen(line) > 0) && (line[strlen(line) - 1] == '\r'))
-      line[strlen(line) - 1] = 0;
-
     int pos = reg.RegFind(line);
     if (pos > -1)
     {
-      std::string text(line + pos + reg.GetFindLen());
       std::string startFrame(reg.GetMatch(1));
       std::string endFrame(reg.GetMatch(2));
+      std::string text(reg.GetMatch(3));
 
-      double iPTSStartTime = m_framerate * atoi(startFrame.c_str());
-      double iPTSStopTime = m_framerate * atoi(endFrame.c_str());
+      double iPTSStartTime = m_framerate * std::atoi(startFrame.c_str());
+      double iPTSStopTime = m_framerate * std::atoi(endFrame.c_str());
 
       TagConv.ConvertLine(text);
-      AddSubtitle(text.c_str(), iPTSStartTime, iPTSStopTime);
+      AddSubtitle(text, iPTSStartTime, iPTSStopTime);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -30,8 +30,8 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo& hints)
   if (!CDVDSubtitleParserText::Open())
     return false;
 
-  std::string buffer = m_pStream->m_stringstream.str();
-  if (!m_libass->CreateTrack(const_cast<char*>(buffer.c_str()), buffer.length()))
+  const std::string& data = m_pStream->GetData();
+  if (!m_libass->CreateTrack(const_cast<char*>(data.c_str()), data.length()))
     return false;
 
   CDVDOverlaySSA* overlay = new CDVDOverlaySSA(m_libass);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.cpp
@@ -35,20 +35,18 @@ bool CDVDSubtitleParserSubrip::Open(CDVDStreamInfo& hints)
   if (!TagConv.Init())
     return false;
 
-  char line[1024];
-  std::string currLine;
+  std::string line;
 
-  while (m_pStream->ReadLine(line, sizeof(line)))
+  while (m_pStream->ReadLine(line))
   {
-    currLine = line;
-    StringUtils::Trim(currLine);
+    StringUtils::Trim(line);
 
-    if (currLine.length() > 0)
+    if (line.length() > 0)
     {
       char sep;
       int hh1, mm1, ss1, ms1, hh2, mm2, ss2, ms2;
-      int c = sscanf(currLine.c_str(), "%d%c%d%c%d%c%d --> %d%c%d%c%d%c%d\n", &hh1, &sep, &mm1,
-                     &sep, &ss1, &sep, &ms1, &hh2, &sep, &mm2, &sep, &ss2, &sep, &ms2);
+      int c = sscanf(line.c_str(), "%d%c%d%c%d%c%d --> %d%c%d%c%d%c%d\n", &hh1, &sep, &mm1, &sep,
+                     &ss1, &sep, &ms1, &hh2, &sep, &mm2, &sep, &ss2, &sep, &ms2);
 
       if (c == 1)
       {
@@ -62,25 +60,24 @@ bool CDVDSubtitleParserSubrip::Open(CDVDStreamInfo& hints)
             ((double)(((hh2 * 60 + mm2) * 60) + ss2) * 1000 + ms2) * (DVD_TIME_BASE / 1000);
 
         std::string convText;
-        while (m_pStream->ReadLine(line, sizeof(line)))
+        while (m_pStream->ReadLine(line))
         {
-          currLine.assign(line);
-          StringUtils::Trim(currLine);
+          StringUtils::Trim(line);
 
           // empty line, next subtitle is about to start
-          if (currLine.length() <= 0)
+          if (line.length() <= 0)
             break;
 
           if (convText.size() > 0)
             convText += "\n";
-          TagConv.ConvertLine(currLine);
-          convText += currLine;
+          TagConv.ConvertLine(line);
+          convText += line;
         }
 
         if (!convText.empty())
         {
           TagConv.CloseTag(convText);
-          AddSubtitle(convText.c_str(), iPTSStartTime, iPTSStopTime);
+          AddSubtitle(convText, iPTSStartTime, iPTSStopTime);
         }
       }
     }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/CharArrayParser.h"
+
 #include <sstream>
 #include <string>
 #include <vector>
@@ -30,12 +32,34 @@ public:
    */
   bool IsIncompatible(CDVDInputStream* pInputStream, std::vector<uint8_t>& buf, size_t* bytesRead);
 
-  int Read(char* buf, int buf_size);
-  long Seek(long offset, int whence);
+  /*!
+   *  \brief Read some data of specified length, from the current position
+   *  \param length The length of data to be read
+   *  \return The string read
+   */
+  std::string Read(int length);
 
-  char* ReadLine(char* pBuffer, int iLen);
-  //wchar* ReadLineW(wchar* pBuffer, int iLen) { return NULL; }
+  /*!
+   *  \brief Change the current data position to the specified offset
+   *  \param offset The new position
+   *  \return True if success, otherwise false
+   */
+  bool Seek(int offset);
 
-  std::stringstream m_stringstream;
+  /*!
+   *  \brief Read a line of data
+   *  \param[OUT] line The data read
+   *  \return True if read, otherwise false if EOF
+   */
+  bool ReadLine(std::string& line);
+
+  /*!
+   *  \brief Get the full data
+   *  \return The data
+   */
+  const std::string& GetData() { return m_subtitleData; }
+
+private:
+  std::string m_subtitleData;
+  CCharArrayParser m_arrayParser;
 };
-

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagMicroDVD.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagMicroDVD.cpp
@@ -162,13 +162,4 @@ void CDVDSubtitleTagMicroDVD::ConvertLine(std::string& strUTF8)
       }
     }
   }
-
-  if (strUTF8.empty())
-    return;
-
-  if (strUTF8[strUTF8.size() - 1] == '\n')
-    strUTF8.erase(strUTF8.size() - 1);
-
-  // We have to remove all \r because it causes the line to display empty box "tofu"
-  StringUtils::Replace(strUTF8, "\r", "");
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -202,17 +202,11 @@ void CDVDSubtitleTagSami::ConvertLine(std::string& strUTF8, const char* langClas
     strUTF8.clear();
     return;
   }
-  if (strUTF8[strUTF8.size() - 1] == '\n')
-    strUTF8.erase(strUTF8.size() - 1);
 
   std::wstring wStrHtml, wStr;
   g_charsetConverter.utf8ToW(strUTF8, wStrHtml, false);
   HTML::CHTMLUtil::ConvertHTMLToW(wStrHtml, wStr);
   g_charsetConverter.wToUTF8(wStr, strUTF8);
-
-  // Many subtitle formats use \r\n as line break,
-  // we have to remove all \r because it causes the line to display empty box "tofu"
-  StringUtils::Replace(strUTF8, "\r", "");
 }
 
 void CDVDSubtitleTagSami::CloseTag(std::string& text)
@@ -247,16 +241,15 @@ void CDVDSubtitleTagSami::CloseTag(std::string& text)
 
 void CDVDSubtitleTagSami::LoadHead(CDVDSubtitleStream* samiStream)
 {
-  char cLine[1024];
   bool inSTYLE = false;
   CRegExp reg(true);
   if (!reg.RegComp("\\.([a-z]+)[ \t]*\\{[ \t]*name:([^;]*?);[ \t]*lang:([^;]*?);[ "
                    "\t]*SAMIType:([^;]*?);[ \t]*\\}"))
     return;
 
-  while (samiStream->ReadLine(cLine, sizeof(cLine)))
+  std::string line;
+  while (samiStream->ReadLine(line))
   {
-    std::string line = cLine;
     StringUtils::Trim(line);
 
     if (StringUtils::EqualsNoCase(line, "<BODY>"))

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
@@ -30,17 +30,18 @@ bool CSubtitlesAdapter::Initialize()
   return m_libass->CreateTrack() && m_libass->CreateStyle();
 }
 
-int CSubtitlesAdapter::AddSubtitle(const char* text, double startTime, double stopTime)
+int CSubtitlesAdapter::AddSubtitle(std::string& text, double startTime, double stopTime)
 {
   return AddSubtitle(text, startTime, stopTime, nullptr);
 }
 
-int CSubtitlesAdapter::AddSubtitle(const char* text,
+int CSubtitlesAdapter::AddSubtitle(std::string& text,
                                    double startTime,
                                    double stopTime,
                                    KODI::SUBTITLES::subtitleOpts* opts)
 {
-  int ret = m_libass->AddEvent(text, startTime, stopTime, opts);
+  PostProcess(text);
+  int ret = m_libass->AddEvent(text.c_str(), startTime, stopTime, opts);
   if (ret == ASS_NO_ID)
     return NO_SUBTITLE_ID;
   return ret;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
@@ -11,6 +11,7 @@
 #include "SubtitlesStyle.h"
 
 #include <memory>
+#include <string>
 
 class CDVDOverlay;
 class CDVDSubtitlesLibass;
@@ -31,20 +32,22 @@ public:
 
   /*!
   * \brief Add a subtitle
+  * \param text The subtitle text
   * \param startTime The PTS start time of the subtitle
   * \param stopTime The PTS stop time of the subtitle
   * \return Return the subtitle ID, otherwise NO_SUBTITLE_ID if fails
   */
-  int AddSubtitle(const char* text, double startTime, double stopTime);
+  int AddSubtitle(std::string& text, double startTime, double stopTime);
 
   /*!
   * \brief Add a subtitle with supplementary options
+  * \param text The subtitle text
   * \param startTime The PTS start time of the subtitle
   * \param stopTime The PTS stop time of the subtitle
   * \param opts Subtitle options
   * \return Return the subtitle ID, otherwise NO_SUBTITLE_ID if fails
   */
-  int AddSubtitle(const char* text,
+  int AddSubtitle(std::string& text,
                   double startTime,
                   double stopTime,
                   KODI::SUBTITLES::subtitleOpts* opts);
@@ -74,6 +77,14 @@ public:
   void FlushSubtitles();
 
   CDVDOverlay* CreateOverlay();
+
+protected:
+  /*!
+  * \brief Post processing of subtitle, will be called before processing
+  *        AddSubtitle method
+  * \param text The subtitle text
+  */
+  virtual void PostProcess(std::string& text){};
 
 private:
   std::shared_ptr<CDVDSubtitlesLibass> m_libass;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
@@ -22,7 +22,7 @@ class CSubtitlesAdapter
 {
 public:
   CSubtitlesAdapter();
-  ~CSubtitlesAdapter();
+  virtual ~CSubtitlesAdapter();
 
   /*!
   * \brief Initialize the subtitles adapter

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -76,14 +76,15 @@ enum FlagTags
   FLAG_TAG_COUNT
 };
 
-bool ValidateSignature(const char* data, const char* signature)
+bool ValidateSignature(const std::string& data, const char* signature)
 {
-  if (std::strlen(data) > std::strlen(signature))
+  const size_t signatureLen = std::strlen(signature);
+  if (data.size() > signatureLen)
   {
-    if (std::strncmp(data, signature, std::strlen(signature)) == 0)
+    if (data.compare(0, signatureLen, signature) == 0)
     {
       // Check if last char is valid
-      if (std::strchr(signatureLastChars, data[std::strlen(signature)]) != nullptr)
+      if (std::strchr(signatureLastChars, data[signatureLen]) != nullptr)
         return true;
     }
   }
@@ -217,10 +218,10 @@ bool CWebVTTHandler::Initialize()
   return true;
 }
 
-bool CWebVTTHandler::CheckSignature(const char* buffer)
+bool CWebVTTHandler::CheckSignature(const std::string& data)
 {
   // Check the sequence of chars to identify WebVTT signature
-  if (ValidateSignature(buffer, signatureCharsBOM) || ValidateSignature(buffer, signatureChars))
+  if (ValidateSignature(data, signatureCharsBOM) || ValidateSignature(data, signatureChars))
     return true;
 
   CLog::Log(LOGERROR, "{} - WebVTT signature not valid", __FUNCTION__);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -133,7 +133,7 @@ public:
   /*!
   * \brief Verify the validity of the WebVTT signature
   */
-  bool CheckSignature(const char* buffer);
+  bool CheckSignature(const std::string& data);
 
   /*!
   * \brief Decode a line of the WebVTT text data

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -72,10 +72,10 @@ void CDebugRenderer::SetInfo(DEBUG_INFO_PLAYER& info)
   // provide a way to allow fixed on-screen text display
   // without use all these fixed values.
   m_adapter->FlushSubtitles();
-  m_adapter->AddSubtitle(info.audio.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(info.video.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(info.player.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(info.vsync.c_str(), 0., 5000000.);
+  m_adapter->AddSubtitle(info.audio, 0., 5000000.);
+  m_adapter->AddSubtitle(info.video, 0., 5000000.);
+  m_adapter->AddSubtitle(info.player, 0., 5000000.);
+  m_adapter->AddSubtitle(info.vsync, 0., 5000000.);
 }
 
 void CDebugRenderer::SetInfo(DEBUG_INFO_VIDEO& video, DEBUG_INFO_RENDER& render)
@@ -89,12 +89,12 @@ void CDebugRenderer::SetInfo(DEBUG_INFO_VIDEO& video, DEBUG_INFO_RENDER& render)
   // provide a way to allow fixed on-screen text display
   // without use all these fixed values.
   m_adapter->FlushSubtitles();
-  m_adapter->AddSubtitle(video.videoSource.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(video.metaPrim.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(video.metaLight.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(video.shader.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(render.renderFlags.c_str(), 0., 5000000.);
-  m_adapter->AddSubtitle(render.videoOutput.c_str(), 0., 5000000.);
+  m_adapter->AddSubtitle(video.videoSource, 0., 5000000.);
+  m_adapter->AddSubtitle(video.metaPrim, 0., 5000000.);
+  m_adapter->AddSubtitle(video.metaLight, 0., 5000000.);
+  m_adapter->AddSubtitle(video.shader, 0., 5000000.);
+  m_adapter->AddSubtitle(render.renderFlags, 0., 5000000.);
+  m_adapter->AddSubtitle(render.videoOutput, 0., 5000000.);
 }
 
 void CDebugRenderer::Render(CRect& src, CRect& dst, CRect& view)

--- a/xbmc/utils/CharArrayParser.h
+++ b/xbmc/utils/CharArrayParser.h
@@ -85,6 +85,26 @@ public:
   std::string ReadNextString(int length);
 
   /*!
+   * \brief Reads the next chars array of specified length (it is assumed that
+   * the caller has already checked the availability of the data for its length)
+   * \param length The length to be read
+   * \param data[OUT] The data read
+   * \return True if success, otherwise false
+   */
+  bool ReadNextArray(int length, char* data);
+
+  /*!
+   * \brief Reads a line of text.
+   * A line is considered to be terminated by any one of a carriage return ('\\r'),
+   * a line feed ('\\n'), or a carriage return followed by a line feed ('\\r\\n'),
+   * this method discards leading UTF-8 byte order marks, if present.
+   * \param line [OUT] The line read without line-termination characters
+   * \return True if read, otherwise false if the end of the data has already
+   *         been reached
+   */
+  bool ReadNextLine(std::string& line);
+
+  /*!
    * \brief Get the current data
    * \return The char pointer to the current data
    */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
WebVTT subtitles can have files formatted with CR return chars only (then without LF), but currently the subtitle data is passed by using `std::stringstream` (DVDSubtitleStream.cpp) that not provide an easy way to identify and read a line of text data when it can be formatted in different ways: `\n` `\r\n` `\r`

I have found a solution by taking inspiration on exoplayer then instead use `std::stringstream` we will use the `CCharArrayParser`.

Since, however, in most cases the data is always managed with `std::string`, i have also done a cleanup by removing the multiple `char` arrays/pointers conversions replacing them with `std::string` which makes more clean.

Other related changes:
- Removed `StringUtils::Replace(currText, "\r", "");` was used to prevent to display empty box "tofu" not more needed because the `CCharArrayParser` take care to not include return chars with ReadLine method. (except to DVDOverlayCodecText.cpp and DVDOverlayCodecCCText.cpp)
- Fixed loading of WebVTT files when have a description in-line with the header

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the PR #20500 it has been pointed out that Kodi does not support the ability to read files formatted with CR return chars only, which are currently characteristic of WebVTT.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In general way by loading the variuos subtitle types

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Read WebVTT files formatted with CR return chars

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
