### PR TITLE
[PVR] Fix 'GetDirectory - Error getting pvr://search/(tv|radio)/saved…

### DIFF
--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -217,12 +217,14 @@ bool CPVRGUIDirectory::GetDirectory(CFileItemList& results) const
   }
 
   const CPVREpgSearchPath path(m_url.Get());
-  if (path.IsValid() && CServiceBroker::GetPVRManager().IsStarted())
+  if (path.IsValid())
   {
-    if (path.IsSavedSearchesRoot())
-      return GetSavedSearchesDirectory(path.IsRadio(), results);
-    else
-      return true; // handled by search window
+    if (CServiceBroker::GetPVRManager().IsStarted())
+    {
+      if (path.IsSavedSearchesRoot())
+        return GetSavedSearchesDirectory(path.IsRadio(), results);
+    }
+    return true;
   }
 
   return false;


### PR DESCRIPTION
…searches' error on Kodi startup.

Fallout from #20530. It is not an error if PVR Manager is not up at first call - see the other cases in the affected member function.

Runtime-tested on macOS and Android, latest master.

@phunkyfish when/if you find some time for a review...