### PR TITLE
[Estuary] Home screen: Fix context menu y position

### DIFF
--- a/addons/skin.estuary/xml/DialogContextMenu.xml
+++ b/addons/skin.estuary/xml/DialogContextMenu.xml
@@ -5,7 +5,6 @@
 	<coordinates>
 		<left>0</left>
 		<top>0</top>
-		<origin x="50%" y="400">Window.IsActive(Home)</origin>
 	</coordinates>
 	<controls>
 		<control type="image">
@@ -27,7 +26,7 @@
 			<onclick>Action(close)</onclick>
 		</control>
 		<control type="group">
-			<animation effect="slide" end="-225" time="0" condition="Window.IsActive(home)">conditional</animation>
+			<animation effect="slide" end="0,175" time="0" condition="Window.IsActive(home)">conditional</animation>
 			<control type="image" id="999">
 				<description>background image</description>
 				<left>0</left>


### PR DESCRIPTION
…  so that the menu fits completely on 16:9 screen even if it has more than 12 items.

![IMG_5896](https://user-images.githubusercontent.com/3226626/142428347-42ec9a70-4ce0-45fd-89f2-b0b5c898fab5.JPG)

@howie-f fyi

@ronie have some time for yet another code review?