### PR TITLE
[Subtitles] Add support to OpenType font type (OTF)

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -532,7 +532,7 @@
             <options>charsets</options>
           </constraints>
           <dependencies>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="list" format="string" />
         </setting>
@@ -561,7 +561,7 @@
             </options>
           </constraints>
           <dependencies>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="list" format="string" />
         </setting>
@@ -569,7 +569,7 @@
           <level>3</level>
           <default>FFFFFFFF</default> <!-- White -->
           <dependencies>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="colorbutton" />
         </setting>
@@ -577,7 +577,7 @@
           <level>3</level>
           <default>100</default>
           <dependencies>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
@@ -587,7 +587,7 @@
           <dependencies>
             <dependency type="enable">
               <and>
-                <condition on="property" name="IsUsingTTFSubtitles" setting="subtitles.font"/>
+                <condition on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font"/>
                 <condition setting="subtitles.backgroundtype" operator="!is">2</condition>
               </and>
             </dependency>
@@ -600,7 +600,7 @@
           <dependencies>
             <dependency type="enable">
               <and>
-                <condition on="property" name="IsUsingTTFSubtitles" setting="subtitles.font"/>
+                <condition on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font"/>
                 <condition setting="subtitles.backgroundtype" operator="!is">2</condition>
               </and>
             </dependency>
@@ -611,7 +611,7 @@
           <level>3</level>
           <default>0</default>
           <dependencies>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
@@ -627,7 +627,7 @@
             </options>
           </constraints>
           <dependencies>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="list" format="integer" />
         </setting>
@@ -641,7 +641,7 @@
                 <condition setting="subtitles.backgroundtype">3</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="colorbutton" />
         </setting>
@@ -655,7 +655,7 @@
                 <condition setting="subtitles.backgroundtype">3</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
@@ -669,7 +669,7 @@
                 <condition setting="subtitles.backgroundtype">2</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="colorbutton" />
         </setting>
@@ -683,7 +683,7 @@
                 <condition setting="subtitles.backgroundtype">2</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
@@ -697,7 +697,7 @@
                 <condition setting="subtitles.backgroundtype">2</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -812,6 +812,9 @@ public:
   VECFILEITEMS::const_iterator end() const { return m_items.end(); }
   VECFILEITEMS::const_iterator cbegin() const { return m_items.cbegin(); }
   VECFILEITEMS::const_iterator cend() const { return m_items.cend(); }
+  std::reverse_iterator<VECFILEITEMS::const_iterator> rbegin() const { return m_items.rbegin(); }
+  std::reverse_iterator<VECFILEITEMS::const_iterator> rend() const { return m_items.rend(); }
+
 private:
   void Sort(FILEITEMLISTCOMPARISONFUNC func);
   void FillSortFields(FILEITEMFILLFUNC func);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1023,9 +1023,9 @@ std::string CUtil::ValidatePath(const std::string &path, bool bFixDoubleSlashes 
   return result;
 }
 
-bool CUtil::IsUsingTTFSubtitles()
+bool CUtil::IsSupportedFontExtension(const std::string& fileName)
 {
-  return URIUtils::HasExtension(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SUBTITLES_FONT), ".ttf");
+  return URIUtils::HasExtension(fileName, ".ttf|.otf");
 }
 
 void CUtil::SplitExecFunction(const std::string &execString, std::string &function, std::vector<std::string> &parameters)

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -109,7 +109,12 @@ public:
 #endif
   static std::string ValidatePath(const std::string &path, bool bFixDoubleSlashes = false); ///< return a validated path, with correct directory separators.
 
-  static bool IsUsingTTFSubtitles();
+  /*!
+   * \brief Check if a filename contains a supported font extension.
+   * \param filename The filename to check
+   * \return True if it is supported, otherwise false
+   */
+  static bool IsSupportedFontExtension(const std::string& fileName);
 
   /*! \brief Split a comma separated parameter list into separate parameters.
    Takes care of the case where we may have a quoted string containing commas, or we may

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -124,12 +124,16 @@ bool IsMasterUser(const std::string& condition,
   return g_passwordManager.bMasterUser;
 }
 
-bool IsUsingTTFSubtitles(const std::string& condition,
-                         const std::string& value,
-                         const SettingConstPtr& setting,
-                         void* data)
+bool HasSubtitlesFontExtensions(const std::string& condition,
+                                const std::string& value,
+                                const SettingConstPtr& setting,
+                                void* data)
 {
-  return CUtil::IsUsingTTFSubtitles();
+  auto settingStr = std::dynamic_pointer_cast<const CSettingString>(setting);
+  if (!settingStr)
+    return false;
+
+  return CUtil::IsSupportedFontExtension(settingStr->GetValue());
 }
 
 bool ProfileCanWriteDatabase(const std::string& condition,
@@ -436,7 +440,8 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isfullscreen",                  IsFullscreen));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("ishdrdisplay",                  IsHDRDisplay));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("ismasteruser",                  IsMasterUser));
-  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isusingttfsubtitles",           IsUsingTTFSubtitles));
+  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>(
+      "hassubtitlesfontextensions", HasSubtitlesFontExtensions));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("profilecanwritedatabase",       ProfileCanWriteDatabase));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("profilecanwritesources",        ProfileCanWriteSources));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("profilehasaddons",              ProfileHasAddons));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add support to use OpenType font type (.otf) with subtitles (Libass support it without problems),
for completeness i have also performed a test of loading (in forced way) OTF fonts with the Skin to check if they are correctly loaded with the GUI, see screenshots.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix issue #19399

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tried to set as font two type of OTF fonts:
![immagine](https://user-images.githubusercontent.com/3257156/142662784-c02b65c8-02e7-4ce2-a6a4-c13e71896d95.png)
as subtitle font and as Skin font by replacing the default TTF arial font

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Can use OTF fonts with subtitles

## Screenshots (if appropriate):
Subtitles:
![immagine](https://user-images.githubusercontent.com/3257156/142662989-cd8a833d-d7e7-4b30-a727-abf216214d03.png)
Skin:
![immagine](https://user-images.githubusercontent.com/3257156/142663012-83be63df-ef72-4869-b9c5-5ec5427b3a82.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
