### PR TITLE
[VideoPlayerAudio] Flush audiosink when dropping audio packets (edl m…

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -387,6 +387,12 @@ void CVideoPlayerAudio::Process()
 
       if (bPacketDrop)
       {
+        if (m_syncState != IDVDStreamPlayer::SYNC_STARTING)
+        {
+          m_audioSink.Drain();
+          m_audioSink.Flush();
+          audioframe.nb_frames = 0;
+        }
         m_syncState = IDVDStreamPlayer::SYNC_STARTING;
         continue;
       }


### PR DESCRIPTION
…ute)

## Description
Follow up to https://github.com/xbmc/xbmc/pull/20293 - in the proximity of edl mute ranges it seems VPA tries to keep up with the dropped packets and audio sort of accelerates or jumps forward. The behaviour was described here: https://github.com/xbmc/xbmc/pull/20293#issuecomment-971239711
This happens because the sink still has a small buffer of packets, hence make sure the sink is flushed when audio packets are intentionally dropped (as the case of EDL mute). It was confirmed fixed by the issue reporter.

@FernetMenta, again, it seems the only way for this to go forward is with your help/review. Can you please take a look if possible? Is the change acceptable or do you foresee any regressions for other use cases?

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/17328

## How has this been tested?
With the sample provided by @lilgandhi1199 on https://github.com/xbmc/xbmc/issues/17328

## What is the effect on users?
EDL mute sections should be fixed in addition to 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
