### PR TITLE
[AEsinkAUDIOTRACK] Fix TrueHD buffer size/frame duration IEC and RAW

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -139,6 +139,8 @@ protected:
     SKIP_SWAP,
   } m_swapState;
 
+  std::vector<uint8_t> m_mergeBuffer;
+
   std::string m_deviceFriendlyName;
   std::string m_device;
   std::vector<AE::AESinkInfo> m_sinkInfoList;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -763,6 +763,9 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   uint8_t *out_buf = buffer;
   int size = frames * m_format.m_frameSize;
 
+  // TrueHD IEC has 12 audio units (half packet and half duration) on CDVDAudioCodecPassthrough
+  double ratio = (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD) ? 2.0 : 1.0;
+
   // write as many frames of audio as we can fit into our internal buffer.
   int written = 0;
   int loop_written = 0;
@@ -828,7 +831,12 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
         }
       }
       else
-        m_duration_written += ((double) loop_written / m_format.m_frameSize) / m_format.m_sampleRate;
+      {
+        double duration =
+            (static_cast<double>(loop_written) / m_format.m_frameSize) / m_format.m_sampleRate;
+        duration /= ratio;
+        m_duration_written += duration;
+      }
 
       // just try again to care for fragmentation
       if (written < size)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -7,13 +7,15 @@
  */
 
 #include "DVDAudioCodecPassthrough.h"
+
 #include "DVDCodecs/DVDCodecs.h"
 #include "DVDStreamInfo.h"
 #include "utils/log.h"
 
 #include <algorithm>
 
-extern "C" {
+extern "C"
+{
 #include <libavcodec/avcodec.h>
 }
 
@@ -26,6 +28,7 @@ CDVDAudioCodecPassthrough::CDVDAudioCodecPassthrough(CProcessInfo &processInfo, 
   CDVDAudioCodec(processInfo)
 {
   m_format.m_streamInfo.m_type = streamType;
+  m_deviceIsRAW = processInfo.WantsRawPassthrough();
 }
 
 CDVDAudioCodecPassthrough::~CDVDAudioCodecPassthrough(void)
@@ -61,6 +64,9 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
 
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
       m_codecName = "pt-truehd";
+
+      CLog::Log(LOGDEBUG, "CDVDAudioCodecPassthrough::{} - passthrough output device is {}",
+                __func__, m_deviceIsRAW ? "RAW" : "IEC");
       break;
 
     default:
@@ -177,7 +183,7 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
 
   if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
   {
-    if (m_trueHDBuffer.size() < TRUEHD_BUF_SIZE)
+    if (m_trueHDBuffer.empty())
     {
       m_trueHDBuffer.resize(TRUEHD_BUF_SIZE);
       m_trueHDoffset = 0;
@@ -192,8 +198,11 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
     m_trueHDframes++;
 
     // Only 12 audio units are packed in the buffer to avoid overflows and reduce latency.
-    // Compensates for the small increased latency in CAEBitstreamPacker::PackTrueHD
-    if (m_trueHDframes == 12)
+    // Compensates for the small increased latency in CAEBitstreamPacker::PackTrueHD (IEC)
+    // Android IEC packer (RAW) needs 24 audio units.
+    const int nFrames = m_deviceIsRAW ? 24 : 12;
+
+    if (m_trueHDframes == nFrames)
     {
       m_dataSize = TRUEHD_BUF_SIZE;
       m_trueHDoffset = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -52,5 +52,5 @@ private:
   std::vector<uint8_t> m_trueHDBuffer;
   unsigned int m_trueHDoffset = 0;
   unsigned int m_trueHDframes = 0;
+  bool m_deviceIsRAW{false};
 };
-

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -71,6 +71,7 @@ public:
   void SetAudioBitsPerSample(int bitsPerSample);
   int GetAudioBitsPerSample();
   virtual bool AllowDTSHDDecode();
+  virtual bool WantsRawPassthrough() { return false; }
 
   // render info
   void SetRenderClockSync(bool enabled);

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
@@ -8,6 +8,10 @@
 
 #include "ProcessInfoAndroid.h"
 
+#include "ServiceBroker.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+
 using namespace VIDEOPLAYER;
 
 CProcessInfo* CProcessInfoAndroid::Create()
@@ -23,4 +27,15 @@ void CProcessInfoAndroid::Register()
 EINTERLACEMETHOD CProcessInfoAndroid::GetFallbackDeintMethod()
 {
   return EINTERLACEMETHOD::VS_INTERLACEMETHOD_DEINTERLACE_HALF;
+}
+
+bool CProcessInfoAndroid::WantsRawPassthrough()
+{
+  const std::string device = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+      CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE);
+
+  if (std::string::npos != device.find("(RAW)"))
+    return true;
+
+  return false;
 }

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
@@ -13,14 +13,15 @@
 
 namespace VIDEOPLAYER
 {
-  class CProcessInfoAndroid : public CProcessInfo
-  {
-  public:
-    CProcessInfoAndroid() = default;
-    static CProcessInfo* Create();
-    static void Register();
-    EINTERLACEMETHOD GetFallbackDeintMethod() override;
 
-  //protected:
-  };
-}
+class CProcessInfoAndroid : public CProcessInfo
+{
+public:
+  CProcessInfoAndroid() = default;
+  static CProcessInfo* Create();
+  static void Register();
+  EINTERLACEMETHOD GetFallbackDeintMethod() override;
+  bool WantsRawPassthrough() override;
+};
+
+} // namespace VIDEOPLAYER


### PR DESCRIPTION
## Description
- Fixes no audio output using Android IEC packer (RAW) with TrueHD.
- Fixes micro-stuttering using Kodi IEC packer with TrueHD.

## Motivation and context
https://github.com/xbmc/xbmc/pull/20339 has produced some regressions on Android due the way AEsinkAUDIOTRACK handles HD formats and because it is the only platform that uses the RAW packer.

**NOTE:** This PR only addresses the two issues mentioned in description.  The rest of micro stuttering issues with other audio formats (AC3, DTS, DTS-MA, E-AC3) are resolved in another PR already merged: https://github.com/xbmc/xbmc/pull/20127

## How has this been tested?
Runtime tested on Shield TV Pro 2019

## What is the effect on users?
See Description

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
