### PR TITLE
[GUIDialogSimpleMenu] Fix infotag not showing for library bluray isos

### DIFF
--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -129,8 +129,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
     if (item_new->m_bIsFolder == false)
     {
       std::string original_path = item.GetDynPath();
-      item.Reset();
-      item = *item_new;
+      item.SetDynPath(item_new->GetDynPath());
       item.SetProperty("original_listitem_url", original_path);
       return true;
     }


### PR DESCRIPTION
## Description
When bluray iso's are added to the library and after attempting playback the simple menu will open and offer a selection of options to play. When selecting an option from the menu, the old fileitem is reset and replaced by the selected item. This will discard any infotag member of the original item as well as any other member variable.
Instead of doing this, just point the old item to the new dynpath after selection.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/20455

## How has this been tested?
BR iso on library, play it from any gui media list. Check that the item has the proper library infotags and the original title. After playback, playback history is set on the original item.
Also tested by playing the iso directly from a strm file - in this case the name of the file will be shown instead of the selected action. 

## What is the effect on users?
Library ISO's will retain the original info

## Screenshots (if appropriate):
**Before**
![image](https://user-images.githubusercontent.com/7375276/142737528-a32d0a94-f51c-4910-8f94-0492b9cdfb70.png)
![image](https://user-images.githubusercontent.com/7375276/142737546-de5938ab-a4d3-4385-a351-86979ba74faa.png)


**After**
![image](https://user-images.githubusercontent.com/7375276/142737470-2a0e7552-ff80-4de1-b9c0-5025040c2230.png)

![image](https://user-images.githubusercontent.com/7375276/142737489-062275f4-be54-498a-8dcc-154998c98d8d.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
