### PR TITLE
[PVR] Fixed 'no PVR add-on enabled' error message. 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10858,7 +10858,7 @@ msgstr ""
 #. label for 'pvr configuration incomplete' information dialog text
 #: xbmc/pvr/windows/GUIWindowPVRBase.cpp
 msgctxt "#19272"
-msgid "You need a tuner, backend software, and an add-on for the backend to be able to use PVR. Please visit http://kodi.wiki/view/PVR to learn more."
+msgid "To use PVR you need to install, enable and configure a PVR add-on. Please visit http://kodi.wiki/view/PVR to learn more."
 msgstr ""
 
 #. Settings -> Interface -> Other -> Startup window value


### PR DESCRIPTION
Not every add-on needs a tuner and a backend software to work (iptvsimple, zattoo, teleboy, waipu, ...). I think this string is a leftover from the very early days of Kodi PVR... ;-)
