### PR TITLE
[Estuary] TopBar: Fix end time not completely hidden under certain conditions

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -146,7 +146,7 @@
 			</control>
 		</control>
 		<control type="group">
-			<animation effect="slide" end="0,-90" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>
+			<animation effect="slide" end="0,-200" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>
 			<animation effect="slide" start="0,-200" end="0,0" time="300" tween="cubic" easing="out">VisibleChange</animation>
 			<visible>Player.ShowInfo | Window.IsActive(fullscreeninfo) | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(PVR.ChannelNumberInput) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide) + ![Player.Seeking | Player.DisplayAfterSeek | Player.Forwarding | Player.Rewinding | Player.Paused]</visible>
 			<depth>DepthBars</depth>


### PR DESCRIPTION
To reproduce:

1. Start playback of a TV channel. 
2. Hit Enter in fullscreen mode to show Player controls
3. Open the channels OSD dialog from Player controls.
4. Hit "i" to open the Guide Info dialog

=> Top right corner => "Ends at" label not completely hidden.

![screenshot00004](https://user-images.githubusercontent.com/3226626/142773845-034ae753-a558-4c69-bded-ee0b7fd67668.png)

@ronie when you find some time for a review.