### PR TITLE
[addons][strings] display "manually installed" in dialog & fix some spelling

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15796,28 +15796,28 @@ msgctxt "#24163"
 msgid "Match Apple tvOS Standard (Siri remote)"
 msgstr ""
 
-#. Header text for yes/no dialog about enable of broken addon
+#. Header text for yes/no dialog about enable of broken add-on
 #: xbmc/addons/gui/GUIHelpers.cpp
 msgctxt "#24164"
-msgid "Addon \"{0:s}\" broken"
+msgid "Add-on \"{0:s}\" broken"
 msgstr ""
 
-#. Yes/no dialog text with addon broken string value and to ask for use
+#. Yes/no dialog text with add-on broken string value and to ask for use
 #: xbmc/addons/gui/GUIHelpers.cpp
 msgctxt "#24165"
-msgid "Addon marked as broken with following note:[CR][B][I]{0:s}[/I][/B][CR][CR]Do you want to enable?"
+msgid "Add-on marked as broken with following note:[CR][B][I]{0:s}[/I][/B][CR][CR]Do you want to enable?"
 msgstr ""
 
-#. Header text for yes/no dialog about enable of deprecated addon
+#. Header text for yes/no dialog about enable of deprecated add-on
 #: xbmc/addons/gui/GUIHelpers.cpp
 msgctxt "#24166"
-msgid "Addon \"{0:s}\" deprecated"
+msgid "Add-on \"{0:s}\" deprecated"
 msgstr ""
 
-#. Yes/no dialog text with addon deprecated string value and to ask for use
+#. Yes/no dialog text with add-on deprecated string value and to ask for use
 #: xbmc/addons/gui/GUIHelpers.cpp
 msgctxt "#24167"
-msgid "Addon marked as deprecated with following note:[CR][B][I]{0:s}[/I][/B][CR][CR]Do you want to enable?"
+msgid "Add-on marked as deprecated with following note:[CR][B][I]{0:s}[/I][/B][CR][CR]Do you want to enable?"
 msgstr ""
 
 #. Notification event to show addon marked as deprecated.
@@ -22167,10 +22167,10 @@ msgctxt "#39027"
 msgid "Sortname"
 msgstr ""
 
-#. Text for yes/no dialog when silently uninstalling an addon
+#. Text for yes/no dialog when silently uninstalling an add-on
 #: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 msgctxt "#39028"
-msgid "Addon: {0:s}[CR]Origin: {1:s}[CR]Version: {2:s}[CR]- will be uninstalled and replaced. Would you like to proceed?"
+msgid "Add-on: {0:s}[CR]Origin: {1:s}[CR]Version: {2:s}[CR]- will be uninstalled and replaced. Would you like to proceed?"
 msgstr ""
 
 #. Text for yes/no dialog to indicate that an add-on was manually installed

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14924,7 +14924,7 @@ msgid "Click \"OK\" when playback has ended"
 msgstr ""
 
 #empty strings from id 23105 to 23999
-#strings 24000 thru 24299 reserved for the Add-ons framework
+#strings 24000 thru 24299 reserved for the add-ons framework
 
 #: xbmc/addons/GUIDialogAddonSettings.cpp
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -15109,7 +15109,7 @@ msgctxt "#24034"
 msgid "Check for updates"
 msgstr ""
 
-#: Name of an Add-on category
+#: Name of an add-on category
 #: xbmc/addons/Addon.cpp
 msgctxt "#24035"
 msgid "Image collections"
@@ -15164,7 +15164,7 @@ msgstr ""
 #. Used as an event log description for add-ons failed to install from zip
 #: xbmc/addons/AddonInstaller.cpp
 msgctxt "#24045"
-msgid "Failed to install Add-on from zip file"
+msgid "Failed to install add-on from zip file"
 msgstr ""
 
 #: xbmc/addons/GUIDialogAddonInfo.cpp
@@ -15659,10 +15659,10 @@ msgctxt "#24138"
 msgid "Update"
 msgstr ""
 
-#. Label for the action provided by addon management events to jump to a specific Add-on
+#. Label for the action provided by addon management events to jump to a specific add-on
 #: xbmc/events/AddonManagementEvent.cpp
 msgctxt "#24139"
-msgid "View Add-on"
+msgid "View add-on"
 msgstr ""
 
 #. Label for the action provided by media library events to jump to a specific path/file
@@ -15686,7 +15686,7 @@ msgstr ""
 #. Installing the addon from zip file located at <path to zip file> failed due to an invalid structure.
 #: xbmc/addons/AddonInstaller.cpp
 msgctxt "#24143"
-msgid "Installing the Add-on from zip file located at {0:s} failed due to an invalid structure."
+msgid "Installing the add-on from zip file located at {0:s} failed due to an invalid structure."
 msgstr ""
 
 #. Used as an event log description for add-ons that have been uninstalled
@@ -16585,7 +16585,7 @@ msgstr ""
 #strings 30000 thru 30999 reserved for plug-ins and plug-in settings
 #strings 31000 thru 31999 reserved for skins
 #strings 32000 thru 32999 reserved for scripts
-#strings 33000 thru 33999 reserved for common strings used in Add-ons
+#strings 33000 thru 33999 reserved for common strings used in add-ons
 
 #: unknown
 msgctxt "#33001"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22170,10 +22170,14 @@ msgstr ""
 #. Text for yes/no dialog when silently uninstalling an addon
 #: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 msgctxt "#39028"
-msgid "Addon \"{0:s}\"[CR]Origin \"{1:s}\"[CR]Version \"{2:s}\"[CR]- will uninstall and be replaced. Would you like to proceed?"
+msgid "Addon: {0:s}[CR]Origin: {1:s}[CR]Version: {2:s}[CR]- will be uninstalled and replaced. Would you like to proceed?"
 msgstr ""
 
-#empty string with id 39029
+#. Text for yes/no dialog to indicate that an add-on was manually installed
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#39029"
+msgid "Manually installed"
+msgstr ""
 
 #. Media source, a filter and smart playlist rule option
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -440,10 +440,12 @@ void CGUIDialogAddonInfo::OnInstall()
   {
     if (m_localAddon->Origin() != origin && m_localAddon->Origin() != ORIGIN_SYSTEM)
     {
-      const std::string& header = g_localizeStrings.Get(19098); // Warning!
+      const std::string header = g_localizeStrings.Get(19098); // Warning!
+      const std::string origin =
+          !m_localAddon->Origin().empty() ? m_localAddon->Origin() : g_localizeStrings.Get(39029);
       const std::string text =
-          StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->ID(),
-                              m_localAddon->Origin(), m_localAddon->Version().asString());
+          StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->Name(), origin,
+                              m_localAddon->Version().asString());
 
       if (CGUIDialogYesNo::ShowAndGetInput(header, text))
       {


### PR DESCRIPTION
## Description
backports https://github.com/xbmc/xbmc/pull/20453 / https://github.com/xbmc/xbmc/pull/20514
it's a simple cherry-pick of the respective pr's

as @gade01 points out we still update core strings for Kodi Matrix and the _"Warning Dialog: changing origin"_ needs correction

## Screenshots:

fixed version:
no more `Origin: ""` if at was a manual install

![139926628-956e3836-b614-4253-ae72-8532a2fbfdbe](https://user-images.githubusercontent.com/58829855/142779941-6a98955e-fba1-472e-be59-6a10baca0279.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
