### PR TITLE
CAppParamParser cleanup and improvment

### DIFF
--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -47,7 +47,7 @@ Arguments:
 
 } // namespace
 
-CAppParamParser::CAppParamParser() : m_playlist(new CFileItemList())
+CAppParamParser::CAppParamParser() : m_playlist(std::make_unique<CFileItemList>())
 {
 }
 

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -21,15 +21,6 @@
 #include <string>
 #include <vector>
 
-#if defined(TARGET_LINUX)
-namespace
-{
-std::vector<std::string> availableWindowSystems = CCompileInfo::GetAvailableWindowSystems();
-std::array<std::string, 1> availableLogTargets = {"console"};
-
-} // namespace
-#endif
-
 CAppParamParser::CAppParamParser()
 : m_logLevel(LOG_LEVEL_NORMAL),
   m_playlist(new CFileItemList())
@@ -75,20 +66,6 @@ void CAppParamParser::DisplayHelp()
   printf("  --test\t\tEnable test mode. [FILE] required.\n");
   printf("  --settings=<filename>\t\tLoads specified file after advancedsettings.xml replacing any settings specified\n");
   printf("  \t\t\t\tspecified file must exist in special://xbmc/system/\n");
-#if defined(TARGET_LINUX)
-  printf("  --windowing=<system>\tSelect which windowing method to use.\n");
-  printf("  \t\t\t\tAvailable window systems are:");
-  for (const auto& windowSystem : availableWindowSystems)
-    printf(" %s", windowSystem.c_str());
-  printf("\n");
-  printf("  --logging=<target>\tSelect which log target to use (log file will always be used in "
-         "conjunction).\n");
-  printf("  \t\t\t\tAvailable log targets are:");
-  for (const auto& logTarget : availableLogTargets)
-    printf(" %s", logTarget.c_str());
-  printf("\n");
-#endif
-  exit(0);
 }
 
 void CAppParamParser::ParseArg(const std::string &arg)
@@ -96,7 +73,10 @@ void CAppParamParser::ParseArg(const std::string &arg)
   if (arg == "-fs" || arg == "--fullscreen")
     m_startFullScreen = true;
   else if (arg == "-h" || arg == "--help")
+  {
     DisplayHelp();
+    exit(0);
+  }
   else if (arg == "-v" || arg == "--version")
     DisplayVersion();
   else if (arg == "--standalone")
@@ -109,40 +89,6 @@ void CAppParamParser::ParseArg(const std::string &arg)
     m_testmode = true;
   else if (arg.substr(0, 11) == "--settings=")
     m_settingsFile = arg.substr(11);
-#if defined(TARGET_LINUX)
-  else if (arg.substr(0, 12) == "--windowing=")
-  {
-    if (std::find(availableWindowSystems.begin(), availableWindowSystems.end(), arg.substr(12)) !=
-        availableWindowSystems.end())
-      m_windowing = arg.substr(12);
-    else
-    {
-      std::cout << "Selected window system not available: " << arg << std::endl;
-      std::cout << "    Available window systems:";
-      for (const auto& windowSystem : availableWindowSystems)
-        std::cout << " " << windowSystem;
-      std::cout << std::endl;
-      exit(0);
-    }
-  }
-  else if (arg.substr(0, 10) == "--logging=")
-  {
-    if (std::find(availableLogTargets.begin(), availableLogTargets.end(), arg.substr(10)) !=
-        availableLogTargets.end())
-    {
-      m_logTarget = arg.substr(10);
-    }
-    else
-    {
-      std::cout << "Selected logging target not available: " << arg << std::endl;
-      std::cout << "    Available log targets:";
-      for (const auto& logTarget : availableLogTargets)
-        std::cout << " " << logTarget;
-      std::cout << std::endl;
-      exit(0);
-    }
-  }
-#endif
   else if (arg.length() != 0 && arg[0] != '-')
   {
     const CFileItemPtr item = std::make_shared<CFileItem>(arg);

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -47,9 +47,7 @@ Arguments:
 
 } // namespace
 
-CAppParamParser::CAppParamParser()
-: m_logLevel(LOG_LEVEL_NORMAL),
-  m_playlist(new CFileItemList())
+CAppParamParser::CAppParamParser() : m_playlist(new CFileItemList())
 {
 }
 

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -21,6 +21,32 @@
 #include <string>
 #include <vector>
 
+namespace
+{
+
+constexpr const char* versionText =
+    R"""({0} Media Center {1}
+Copyright (C) {2} Team {0} - http://kodi.tv
+)""";
+
+constexpr const char* helpText =
+    R"""(Usage: {0} [OPTION]... [FILE]...
+
+Arguments:
+  -fs                   Runs {1} in full screen
+  --standalone          {1} runs in a stand alone environment without a window
+                        manager and supporting applications. For example, that
+                        enables network settings.
+  -p or --portable      {1} will look for configurations in install folder instead of ~/.{0}
+  --debug               Enable debug logging
+  --version             Print version information
+  --test                Enable test mode. [FILE] required.
+  --settings=<filename> Loads specified file after advancedsettings.xml replacing any settings specified
+                        specified file must exist in special://xbmc/system/
+)""";
+
+} // namespace
+
 CAppParamParser::CAppParamParser()
 : m_logLevel(LOG_LEVEL_NORMAL),
   m_playlist(new CFileItemList())
@@ -44,9 +70,8 @@ void CAppParamParser::Parse(const char* const* argv, int nArgs)
 
 void CAppParamParser::DisplayVersion()
 {
-  printf("%s Media Center %s\n", CSysInfo::GetVersion().c_str(), CSysInfo::GetAppName().c_str());
-  printf("Copyright (C) %s Team %s - http://kodi.tv\n",
-         CCompileInfo::GetCopyrightYears(), CSysInfo::GetAppName().c_str());
+  std::cout << StringUtils::Format(versionText, CSysInfo::GetAppName(), CSysInfo::GetVersion(),
+                                   CCompileInfo::GetCopyrightYears());
   exit(0);
 }
 
@@ -54,18 +79,8 @@ void CAppParamParser::DisplayHelp()
 {
   std::string lcAppName = CSysInfo::GetAppName();
   StringUtils::ToLower(lcAppName);
-  printf("Usage: %s [OPTION]... [FILE]...\n\n", lcAppName.c_str());
-  printf("Arguments:\n");
-  printf("  -fs\t\t\tRuns %s in full screen\n", CSysInfo::GetAppName().c_str());
-  printf("  --standalone\t\t%s runs in a stand alone environment without a window \n", CSysInfo::GetAppName().c_str());
-  printf("\t\t\tmanager and supporting applications. For example, that\n");
-  printf("\t\t\tenables network settings.\n");
-  printf("  -p or --portable\t%s will look for configurations in install folder instead of ~/.%s\n", CSysInfo::GetAppName().c_str(), lcAppName.c_str());
-  printf("  --debug\t\tEnable debug logging\n");
-  printf("  --version\t\tPrint version information\n");
-  printf("  --test\t\tEnable test mode. [FILE] required.\n");
-  printf("  --settings=<filename>\t\tLoads specified file after advancedsettings.xml replacing any settings specified\n");
-  printf("  \t\t\t\tspecified file must exist in special://xbmc/system/\n");
+
+  std::cout << StringUtils::Format(helpText, lcAppName, CSysInfo::GetAppName());
 }
 
 void CAppParamParser::ParseArg(const std::string &arg)

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "commons/ilog.h"
+
 #include <memory>
 #include <string>
 
@@ -25,7 +27,7 @@ public:
 
   const CFileItemList& GetPlaylist() const;
 
-  int m_logLevel;
+  int m_logLevel = LOG_LEVEL_NORMAL;
   bool m_startFullScreen = false;
   bool m_platformDirectories = true;
   bool m_testmode = false;

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -33,9 +33,11 @@ public:
   std::string m_windowing;
   std::string m_logTarget;
 
+protected:
+  virtual void ParseArg(const std::string& arg);
+  virtual void DisplayHelp();
+
 private:
-  void ParseArg(const std::string &arg);
-  void DisplayHelp();
   void DisplayVersion();
 
   std::string m_settingsFile;

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -27,20 +27,35 @@ public:
 
   const CFileItemList& GetPlaylist() const;
 
-  int m_logLevel = LOG_LEVEL_NORMAL;
-  bool m_startFullScreen = false;
-  bool m_platformDirectories = true;
-  bool m_testmode = false;
-  bool m_standAlone = false;
-  std::string m_windowing;
-  std::string m_logTarget;
+  void SetLogLevel(int logLevel) { m_logTarget = logLevel; }
+  void SetStartFullScreen(bool startFullScreen) { m_startFullScreen = startFullScreen; }
+  void SetPlatformDirectories(bool platformDirectories)
+  {
+    m_platformDirectories = platformDirectories;
+  }
+  void SetStandAlone(bool standAlone) { m_standAlone = standAlone; }
+
+  bool HasPlatformDirectories() const { return m_platformDirectories; }
+  bool IsTestMode() const { return m_testmode; }
+  bool IsStandAlone() const { return m_standAlone; }
+  const std::string& GetWindowing() const { return m_windowing; }
+  const std::string& GetLogTarget() const { return m_logTarget; }
 
 protected:
   virtual void ParseArg(const std::string& arg);
   virtual void DisplayHelp();
 
+  std::string m_windowing;
+  std::string m_logTarget;
+
 private:
   void DisplayVersion();
+
+  int m_logLevel = LOG_LEVEL_NORMAL;
+  bool m_startFullScreen = false;
+  bool m_platformDirectories = true;
+  bool m_testmode = false;
+  bool m_standAlone = false;
 
   std::string m_settingsFile;
   std::unique_ptr<CFileItemList> m_playlist;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -322,11 +322,11 @@ bool CApplication::Create(const CAppParamParser &params)
   // Grab a handle to our thread to be used later in identifying the render thread.
   m_threadID = CThread::GetCurrentThreadId();
 
-  m_bPlatformDirectories = params.m_platformDirectories;
-  m_bTestMode = params.m_testmode;
-  m_bStandalone = params.m_standAlone;
-  m_windowing = params.m_windowing;
-  m_logTarget = params.m_logTarget;
+  m_bPlatformDirectories = params.HasPlatformDirectories();
+  m_bTestMode = params.IsTestMode();
+  m_bStandalone = params.IsStandAlone();
+  m_windowing = params.GetWindowing();
+  m_logTarget = params.GetLogTarget();
 
   CServiceBroker::CreateLogging();
 

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -341,9 +341,9 @@ using namespace KODI::MESSAGING;
 
     CAppParamParser appParamParser;
 #ifdef _DEBUG
-    appParamParser.m_logLevel = LOG_LEVEL_DEBUG;
+    appParamParser.SetLogLevel(LOG_LEVEL_DEBUG);
 #else
-    appParamParser.m_logLevel = LOG_LEVEL_NORMAL;
+    appParamParser.SetLogLevel(LOG_LEVEL_NORMAL);
 #endif
 
     // Prevent child processes from becoming zombies on exit if not waited upon. See also Util::Command

--- a/xbmc/platform/freebsd/CMakeLists.txt
+++ b/xbmc/platform/freebsd/CMakeLists.txt
@@ -1,11 +1,13 @@
-set(SOURCES CPUInfoFreebsd.cpp
+set(SOURCES ../linux/AppParamParserLinux.cpp
+            CPUInfoFreebsd.cpp
             OptionalsReg.cpp
             ../linux/OptionalsReg.cpp
             ../linux/TimeUtils.cpp
             MemUtils.cpp
             PlatformFreebsd.cpp)
 
-set(HEADERS CPUInfoFreebsd.h
+set(HEADERS ../linux/AppParamParserLinux.cpp
+            CPUInfoFreebsd.h
             OptionalsReg.h
             ../linux/OptionalsReg.h
             ../linux/TimeUtils.h

--- a/xbmc/platform/linux/AppParamParserLinux.cpp
+++ b/xbmc/platform/linux/AppParamParserLinux.cpp
@@ -9,6 +9,7 @@
 #include "AppParamParserLinux.h"
 
 #include "CompileInfo.h"
+#include "utils/StringUtils.h"
 
 #include <algorithm>
 #include <array>
@@ -19,6 +20,28 @@ namespace
 {
 std::vector<std::string> availableWindowSystems = CCompileInfo::GetAvailableWindowSystems();
 std::array<std::string, 1> availableLogTargets = {"console"};
+
+constexpr const char* windowingText =
+    R"""(
+Selected window system not available: {}
+    Available window systems: {}
+)""";
+
+constexpr const char* loggingText =
+    R"""(
+Selected logging target not available: {}
+    Available log targest: {}
+)""";
+
+constexpr const char* helpText =
+    R"""(
+Linux Specific Arguments:
+  --windowing=<system>  Select which windowing method to use.
+                          Available window systems are: {}
+  --logging=<target>    Select which log target to use (log file will always be used in conjunction).
+                          Available log targets are: {}
+)""";
+
 
 } // namespace
 
@@ -39,11 +62,8 @@ void CAppParamParserLinux::ParseArg(const std::string& arg)
       m_windowing = arg.substr(12);
     else
     {
-      std::cout << "Selected window system not available: " << arg << std::endl;
-      std::cout << "    Available window systems:";
-      for (const auto& windowSystem : availableWindowSystems)
-        std::cout << " " << windowSystem;
-      std::cout << std::endl;
+      std::cout << StringUtils::Format(windowingText, arg.substr(12),
+                                       StringUtils::Join(availableWindowSystems, ", "));
       exit(0);
     }
   }
@@ -56,11 +76,8 @@ void CAppParamParserLinux::ParseArg(const std::string& arg)
     }
     else
     {
-      std::cout << "Selected logging target not available: " << arg << std::endl;
-      std::cout << "    Available log targets:";
-      for (const auto& logTarget : availableLogTargets)
-        std::cout << " " << logTarget;
-      std::cout << std::endl;
+      std::cout << StringUtils::Format(loggingText, arg.substr(10),
+                                       StringUtils::Join(availableLogTargets, ", "));
       exit(0);
     }
   }
@@ -70,18 +87,6 @@ void CAppParamParserLinux::DisplayHelp()
 {
   CAppParamParser::DisplayHelp();
 
-  printf("\n");
-  printf("Linux Specific Arguments:\n");
-
-  printf("  --windowing=<system>\tSelect which windowing method to use.\n");
-  printf("  \t\t\t\tAvailable window systems are:");
-  for (const auto& windowSystem : availableWindowSystems)
-    printf(" %s", windowSystem.c_str());
-  printf("\n");
-  printf("  --logging=<target>\tSelect which log target to use (log file will always be used in "
-         "conjunction).\n");
-  printf("  \t\t\t\tAvailable log targets are:");
-  for (const auto& logTarget : availableLogTargets)
-    printf(" %s", logTarget.c_str());
-  printf("\n");
+  std::cout << StringUtils::Format(helpText, StringUtils::Join(availableWindowSystems, ", "),
+                                   StringUtils::Join(availableLogTargets, ", "));
 }

--- a/xbmc/platform/linux/AppParamParserLinux.cpp
+++ b/xbmc/platform/linux/AppParamParserLinux.cpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AppParamParserLinux.h"
+
+#include "CompileInfo.h"
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+std::vector<std::string> availableWindowSystems = CCompileInfo::GetAvailableWindowSystems();
+std::array<std::string, 1> availableLogTargets = {"console"};
+
+} // namespace
+
+CAppParamParserLinux::CAppParamParserLinux() : CAppParamParser()
+{
+}
+
+CAppParamParserLinux::~CAppParamParserLinux() = default;
+
+void CAppParamParserLinux::ParseArg(const std::string& arg)
+{
+  CAppParamParser::ParseArg(arg);
+
+  if (arg.substr(0, 12) == "--windowing=")
+  {
+    if (std::find(availableWindowSystems.begin(), availableWindowSystems.end(), arg.substr(12)) !=
+        availableWindowSystems.end())
+      m_windowing = arg.substr(12);
+    else
+    {
+      std::cout << "Selected window system not available: " << arg << std::endl;
+      std::cout << "    Available window systems:";
+      for (const auto& windowSystem : availableWindowSystems)
+        std::cout << " " << windowSystem;
+      std::cout << std::endl;
+      exit(0);
+    }
+  }
+  else if (arg.substr(0, 10) == "--logging=")
+  {
+    if (std::find(availableLogTargets.begin(), availableLogTargets.end(), arg.substr(10)) !=
+        availableLogTargets.end())
+    {
+      m_logTarget = arg.substr(10);
+    }
+    else
+    {
+      std::cout << "Selected logging target not available: " << arg << std::endl;
+      std::cout << "    Available log targets:";
+      for (const auto& logTarget : availableLogTargets)
+        std::cout << " " << logTarget;
+      std::cout << std::endl;
+      exit(0);
+    }
+  }
+}
+
+void CAppParamParserLinux::DisplayHelp()
+{
+  CAppParamParser::DisplayHelp();
+
+  printf("\n");
+  printf("Linux Specific Arguments:\n");
+
+  printf("  --windowing=<system>\tSelect which windowing method to use.\n");
+  printf("  \t\t\t\tAvailable window systems are:");
+  for (const auto& windowSystem : availableWindowSystems)
+    printf(" %s", windowSystem.c_str());
+  printf("\n");
+  printf("  --logging=<target>\tSelect which log target to use (log file will always be used in "
+         "conjunction).\n");
+  printf("  \t\t\t\tAvailable log targets are:");
+  for (const auto& logTarget : availableLogTargets)
+    printf(" %s", logTarget.c_str());
+  printf("\n");
+}

--- a/xbmc/platform/linux/AppParamParserLinux.h
+++ b/xbmc/platform/linux/AppParamParserLinux.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AppParamParser.h"
+
+class CAppParamParserLinux : public CAppParamParser
+{
+public:
+  CAppParamParserLinux();
+  ~CAppParamParserLinux();
+
+protected:
+  void ParseArg(const std::string& arg) override;
+  void DisplayHelp() override;
+};

--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -1,11 +1,13 @@
-set(SOURCES CPUInfoLinux.cpp
+set(SOURCES AppParamParserLinux.cpp
+            CPUInfoLinux.cpp
             MemUtils.cpp
             OptionalsReg.cpp
             PlatformLinux.cpp
             SysfsPath.cpp
             TimeUtils.cpp)
 
-set(HEADERS CPUInfoLinux.h
+set(HEADERS AppParamParserLinux.h
+            CPUInfoLinux.h
             OptionalsReg.h
             PlatformLinux.h
             SysfsPath.h

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -17,6 +17,10 @@
 #include "PlatformPosix.h"
 #include "platform/xbmc.h"
 
+#if defined(TARGET_LINUX) || defined(TARGET_FREEBSD)
+#include "platform/linux/AppParamParserLinux.h"
+#endif
+
 #include <cstdio>
 #include <cstring>
 #include <errno.h>
@@ -55,7 +59,11 @@ int main(int argc, char* argv[])
 
   setlocale(LC_NUMERIC, "C");
 
+#if defined(TARGET_LINUX) || defined(TARGET_FREEBSD)
+  CAppParamParserLinux appParamParser;
+#else
   CAppParamParser appParamParser;
+#endif
   appParamParser.Parse(argv, argc);
 
   return XBMC_Run(true, appParamParser);

--- a/xbmc/platform/win10/Win10App.cpp
+++ b/xbmc/platform/win10/Win10App.cpp
@@ -83,10 +83,10 @@ void App::Run()
 
     CAppParamParser appParamParser;
     appParamParser.Parse(m_argv.data(), m_argv.size());
-    appParamParser.m_startFullScreen = fullscreen;
+    appParamParser.SetStartFullScreen(fullscreen);
 
     if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::Xbox)
-      appParamParser.m_standAlone = true;
+      appParamParser.SetStandAlone(true);
 
     // Create and run the app
     XBMC_Run(true, appParamParser);

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -47,11 +47,11 @@ void CSettingsComponent::Init(const CAppParamParser &params)
   if (m_state == State::DEINITED)
   {
     // only the InitDirectories* for the current platform should return true
-    bool inited = InitDirectoriesLinux(params.m_platformDirectories);
+    bool inited = InitDirectoriesLinux(params.HasPlatformDirectories());
     if (!inited)
-      inited = InitDirectoriesOSX(params.m_platformDirectories);
+      inited = InitDirectoriesOSX(params.HasPlatformDirectories());
     if (!inited)
-      inited = InitDirectoriesWin32(params.m_platformDirectories);
+      inited = InitDirectoriesWin32(params.HasPlatformDirectories());
 
     m_settings->Initialize();
 

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -37,7 +37,7 @@ TestBasicEnvironment::TestBasicEnvironment() = default;
 void TestBasicEnvironment::SetUp()
 {
   CAppParamParser params;
-  params.m_platformDirectories = false;
+  params.SetPlatformDirectories(false);
 
   CServiceBroker::CreateLogging();
 


### PR DESCRIPTION
This splits out the linux specific options from `CAppParamParser`. I wanted to do this to make it easier to read and extend.

I've also made some other improvements:
1) Using raw string literals for the text. This is much more readable (IMO) than the printf statements with new line and tab characters.
2) Using proper setters and getters for the private members.

This also fixes (what I think was a bug) the version string.
before:
```
$ ./kodi.bin --version
20.0-ALPHA1 (19.90.101) Git:20211104-f8d5f01074-dirty Media Center Kodi
Copyright (C) 2005-2021 Team Kodi - http://kodi.tv
```

after:
```
$ ./kodi.bin --version
Kodi Media Center 20.0-ALPHA1 (19.90.101) Git:20211120-d7727f99ee
Copyright (C) 2005-2021 Team Kodi - http://kodi.tv
```

Notice that the `Kodi Media Center`, then the version string. I'm not sure if what is contained in the `before` version is actually desired or not.


Also, the help text looks like this on Linux now:
```
$ ./kodi.bin --help
Usage: kodi [OPTION]... [FILE]...

Arguments:
  -fs                   Runs Kodi in full screen
  --standalone          Kodi runs in a stand alone environment without a window
                        manager and supporting applications. For example, that
                        enables network settings.
  -p or --portable      Kodi will look for configurations in install folder instead of ~/.kodi
  --debug               Enable debug logging
  --version             Print version information
  --test                Enable test mode. [FILE] required.
  --settings=<filename> Loads specified file after advancedsettings.xml replacing any settings specified
                        specified file must exist in special://xbmc/system/

Linux Specific Arguments:
  --windowing=<system>  Select which windowing method to use.
                          Available window systems are: x11, wayland, gbm
  --logging=<target>    Select which log target to use (log file will always be used in conjunction).
                          Available log targets are: console
```