### PR TITLE
GLUtils: add helper method GetChannelFromARGB to replace macros

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
@@ -87,10 +87,10 @@ void CRPRendererDMA::Render(uint8_t alpha)
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
 
   // Setup color values
-  colour[0] = static_cast<GLubyte>(GET_R(color));
-  colour[1] = static_cast<GLubyte>(GET_G(color));
-  colour[2] = static_cast<GLubyte>(GET_B(color));
-  colour[3] = static_cast<GLubyte>(GET_A(color));
+  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
 
   for (unsigned int i = 0; i < 4; i++)
   {

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -21,6 +21,8 @@ using namespace DirectX;
 #endif
 
 #if defined(HAS_GL) || defined(HAS_GLES)
+#include "utils/GLUtils.h"
+
 #include "system_gl.h"
 #endif
 
@@ -196,10 +198,10 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
   glEnableVertexAttribArray(tex0Loc);
 
   // Setup Colour values
-  colour[0] = static_cast<GLubyte>(GET_R(color));
-  colour[1] = static_cast<GLubyte>(GET_G(color));
-  colour[2] = static_cast<GLubyte>(GET_B(color));
-  colour[3] = static_cast<GLubyte>(GET_A(color));
+  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
 
   if (m_context.UseLimitedColor())
   {
@@ -252,10 +254,10 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
   glEnableVertexAttribArray(tex0Loc);
 
   // Setup color values
-  col[0] = static_cast<GLubyte>(GET_R(color));
-  col[1] = static_cast<GLubyte>(GET_G(color));
-  col[2] = static_cast<GLubyte>(GET_B(color));
-  col[3] = static_cast<GLubyte>(GET_A(color));
+  col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
 
   for (unsigned int i = 0; i < 4; i++)
   {

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -11,6 +11,7 @@
 #include "cores/RetroPlayer/buffers/RenderBufferOpenGL.h"
 #include "cores/RetroPlayer/buffers/RenderBufferPoolOpenGL.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
+#include "utils/GLUtils.h"
 #include "utils/log.h"
 
 #include <cstddef>
@@ -296,10 +297,10 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
 
   // Setup color values
-  colour[0] = static_cast<GLubyte>(GET_R(color));
-  colour[1] = static_cast<GLubyte>(GET_G(color));
-  colour[2] = static_cast<GLubyte>(GET_B(color));
-  colour[3] = static_cast<GLubyte>(GET_A(color));
+  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
 
   for (unsigned int i = 0; i < 4; i++)
   {

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -270,10 +270,10 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
 
   // Setup color values
-  colour[0] = static_cast<GLubyte>(GET_R(color));
-  colour[1] = static_cast<GLubyte>(GET_G(color));
-  colour[2] = static_cast<GLubyte>(GET_B(color));
-  colour[3] = static_cast<GLubyte>(GET_A(color));
+  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
 
   for (unsigned int i = 0; i < 4; i++)
   {

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -31,6 +31,8 @@
 #include <ft2build.h>
 #include <harfbuzz/hb-ft.h>
 #if defined(HAS_GL) || defined(HAS_GLES)
+#include "utils/GLUtils.h"
+
 #include "system_gl.h"
 #endif
 
@@ -1048,10 +1050,10 @@ void CGUIFontTTF::RenderCharacter(float posX,
   m_color = color;
 
 #if !defined(HAS_DX)
-  unsigned char r = GET_R(color)
-              , g = GET_G(color)
-              , b = GET_B(color)
-              , a = GET_A(color);
+  uint8_t r = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color);
+  uint8_t g = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color);
+  uint8_t b = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
+  uint8_t a = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 #endif
 
   for(int i = 0; i < 4; i++)

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -51,10 +51,10 @@ void CGUITextureGL::Begin(UTILS::COLOR::Color color)
   texture->BindToUnit(0);
 
   // Setup Colors
-  m_col[0] = (GLubyte)GET_R(color);
-  m_col[1] = (GLubyte)GET_G(color);
-  m_col[2] = (GLubyte)GET_B(color);
-  m_col[3] = (GLubyte)GET_A(color);
+  m_col[0] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color);
+  m_col[1] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color);
+  m_col[2] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
+  m_col[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
   bool hasAlpha = m_texture.m_textures[m_currentFrame]->HasAlpha() || m_col[3] < 255;
 
@@ -288,10 +288,10 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
   GLint uniColLoc = renderSystem->ShaderGetUniCol();
 
   // Setup Colors
-  col[0] = (GLubyte)GET_R(color);
-  col[1] = (GLubyte)GET_G(color);
-  col[2] = (GLubyte)GET_B(color);
-  col[3] = (GLubyte)GET_A(color);
+  col[0] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color);
+  col[1] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color);
+  col[2] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
+  col[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
   glUniform4f(uniColLoc, col[0] / 255.0f, col[1] / 255.0f, col[2] / 255.0f, col[3] / 255.0f);
 

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -52,10 +52,10 @@ void CGUITextureGLES::Begin(UTILS::COLOR::Color color)
   texture->BindToUnit(0);
 
   // Setup Colors
-  m_col[0] = (GLubyte)GET_R(color);
-  m_col[1] = (GLubyte)GET_G(color);
-  m_col[2] = (GLubyte)GET_B(color);
-  m_col[3] = (GLubyte)GET_A(color);
+  m_col[0] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color);
+  m_col[1] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color);
+  m_col[2] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
+  m_col[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
   if (CServiceBroker::GetWinSystem()->UseLimitedColor())
   {
@@ -271,10 +271,10 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
     glEnableVertexAttribArray(tex0Loc);
 
   // Setup Colors
-  col[0] = (GLubyte)GET_R(color);
-  col[1] = (GLubyte)GET_G(color);
-  col[2] = (GLubyte)GET_B(color);
-  col[3] = (GLubyte)GET_A(color);
+  col[0] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color);
+  col[1] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color);
+  col[2] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
+  col[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
   glUniform4f(uniColLoc, col[0] / 255.0f, col[1] / 255.0f, col[2] / 255.0f, col[3] / 255.0f);
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -15,6 +15,7 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "windowing/WinSystem.h"
+
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif
@@ -22,8 +23,10 @@
 
 #if defined(HAS_GL)
 #include "rendering/gl/RenderSystemGL.h"
+#include "utils/GLUtils.h"
 #elif defined(HAS_GLES)
 #include "rendering/gles/RenderSystemGLES.h"
+#include "utils/GLUtils.h"
 #elif defined(TARGET_WINDOWS)
 #include "guilib/TextureDX.h"
 #include "rendering/dx/DeviceResources.h"
@@ -911,10 +914,10 @@ void CSlideShowPic::Render(float* x, float* y, CTexture* pTexture, UTILS::COLOR:
   glEnableVertexAttribArray(tex0Loc);
 
   // Setup Colour values
-  colour[0] = (GLubyte)GET_R(color);
-  colour[1] = (GLubyte)GET_G(color);
-  colour[2] = (GLubyte)GET_B(color);
-  colour[3] = (GLubyte)GET_A(color);
+  colour[0] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color);
+  colour[1] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color);
+  colour[2] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
+  colour[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
   glUniform4f(uniColLoc,(colour[0] / 255.0f), (colour[1] / 255.0f),
                         (colour[2] / 255.0f), (colour[3] / 255.0f));
@@ -975,10 +978,10 @@ void CSlideShowPic::Render(float* x, float* y, CTexture* pTexture, UTILS::COLOR:
   glEnableVertexAttribArray(tex0Loc);
 
   // Setup Colour values
-  col[0] = (GLubyte)GET_R(color);
-  col[1] = (GLubyte)GET_G(color);
-  col[2] = (GLubyte)GET_B(color);
-  col[3] = (GLubyte)GET_A(color);
+  col[0] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color);
+  col[1] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color);
+  col[2] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
+  col[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
   if (CServiceBroker::GetWinSystem()->UseLimitedColor())
   {

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -242,10 +242,10 @@ bool CRenderSystemGL::ClearBuffers(UTILS::COLOR::Color color)
   if(m_stereoMode == RENDER_STEREO_MODE_INTERLACED && m_stereoView == RENDER_STEREO_VIEW_RIGHT)
     return true;
 
-  float r = GET_R(color) / 255.0f;
-  float g = GET_G(color) / 255.0f;
-  float b = GET_B(color) / 255.0f;
-  float a = GET_A(color) / 255.0f;
+  float r = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color) / 255.0f;
+  float g = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color) / 255.0f;
+  float b = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color) / 255.0f;
+  float a = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color) / 255.0f;
 
   glClearColor(r, g, b, a);
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -187,10 +187,10 @@ bool CRenderSystemGLES::ClearBuffers(UTILS::COLOR::Color color)
   if (!m_bRenderCreated)
     return false;
 
-  float r = GET_R(color) / 255.0f;
-  float g = GET_G(color) / 255.0f;
-  float b = GET_B(color) / 255.0f;
-  float a = GET_A(color) / 255.0f;
+  float r = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::R, color) / 255.0f;
+  float g = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::G, color) / 255.0f;
+  float b = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color) / 255.0f;
+  float a = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color) / 255.0f;
 
   glClearColor(r, g, b, a);
 

--- a/xbmc/system_gl.h
+++ b/xbmc/system_gl.h
@@ -35,9 +35,3 @@
 #include <GLES3/gl3.h>
 #endif
 #endif
-
-// Useful pixel colour manipulation macros
-#define GET_A(color) ((color >> 24) & 0xFF)
-#define GET_R(color) ((color >> 16) & 0xFF)
-#define GET_G(color) ((color >> 8) & 0xFF)
-#define GET_B(color) ((color >> 0) & 0xFF)

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -17,6 +17,7 @@
 #include "utils/StringUtils.h"
 
 #include <map>
+#include <stdexcept>
 #include <utility>
 
 namespace
@@ -258,4 +259,22 @@ int KODI::UTILS::GL::glFormatElementByteCount(GLenum format)
     CLog::Log(LOGERROR, "glFormatElementByteCount - Unknown format {}", format);
     return 1;
   }
+}
+
+uint8_t KODI::UTILS::GL::GetChannelFromARGB(const KODI::UTILS::GL::ColorChannel colorChannel,
+                                            const uint32_t argb)
+{
+  switch (colorChannel)
+  {
+    case KODI::UTILS::GL::ColorChannel::A:
+      return (argb >> 24) & 0xFF;
+    case KODI::UTILS::GL::ColorChannel::R:
+      return (argb >> 16) & 0xFF;
+    case KODI::UTILS::GL::ColorChannel::G:
+      return (argb >> 8) & 0xFF;
+    case KODI::UTILS::GL::ColorChannel::B:
+      return (argb >> 0) & 0xFF;
+    default:
+      throw std::runtime_error("KODI::UTILS::GL::GetChannelFromARGB: ColorChannel not handled");
+  };
 }

--- a/xbmc/utils/GLUtils.h
+++ b/xbmc/utils/GLUtils.h
@@ -27,10 +27,19 @@ namespace UTILS
 {
 namespace GL
 {
-
 void GlErrorCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 
 int glFormatElementByteCount(GLenum format);
+
+enum class ColorChannel
+{
+  A,
+  R,
+  G,
+  B,
+};
+
+uint8_t GetChannelFromARGB(const ColorChannel colorChannel, const uint32_t argb);
 }
 }
 }


### PR DESCRIPTION
This removes the `GET_X` macros defined in the `system_gl.h` header file.

This new method combines the logic from the four macros. I figured `GLUtils` was the best place for this as it's used only in GL/ES code (as opposed to putting it in `ColorUtils`).

It's a bit verbose with all the namespaces but I'm ok with that.

