### PR TITLE
Android fixups/minors

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -55,6 +55,7 @@
             android:configChanges="orientation|keyboard|keyboardHidden|navigation|touchscreen|screenLayout|screenSize|colorMode"
             android:finishOnTaskLaunch="true"
             android:launchMode="singleInstance"
+            android:exported="true"
             android:screenOrientation="sensorLandscape"
             android:theme="@style/AppTheme">
             <intent-filter>
@@ -100,6 +101,7 @@
             android:finishOnTaskLaunch="true"
             android:label="@string/app_name"
             android:launchMode="singleInstance"
+            android:exported="true"
             android:screenOrientation="sensorLandscape"
             android:theme="@style/AppTheme">
 
@@ -109,7 +111,8 @@
                 android:value="@APP_NAME_LC@" />
         </activity>
 
-        <receiver android:name=".XBMCBroadcastReceiver">
+        <receiver android:name=".XBMCBroadcastReceiver"
+                  android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.DREAMING_STOPPED" />
                 <action android:name="android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED" />
@@ -132,7 +135,8 @@
             android:authorities="@APP_PACKAGE@.ytdl"
             android:exported="true" />
 
-        <activity android:name=".XBMCSearchableActivity" >
+        <activity android:name=".XBMCSearchableActivity" 
+                  android:exported="true">
              <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
 

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -469,13 +469,19 @@ XBMC_SETUP_ARCH_DEFINES()
 
 case $build in
   *darwin*)
-    # MacOS 11 requires explicit isysroot for autoconf link tests
-    # However we do not want to pollute LDFLAGS once lib link tests are complete
-    LDFLAGS="$platform_includes"
-    AC_CHECK_LIB([z], [main], has_zlib=1, AC_MSG_WARN("No zlib support in toolchain. Will build libz."); has_zlib=0)
+    if test "$platform_os" != "android"; then
+      # MacOS 11 requires explicit isysroot for autoconf link tests
+      # However we do not want to pollute LDFLAGS once lib link tests are complete
+      LDFLAGS="$platform_includes"
+      AC_CHECK_LIB([z], [main], has_zlib=1, AC_MSG_WARN("No zlib support in toolchain. Will build libz."); has_zlib=0)
+    fi
 esac
 
-AC_SEARCH_LIBS([iconv_open],iconv, link_iconv=$ac_cv_search_iconv_open, link_iconv=-liconv; AC_MSG_WARN("No iconv support in toolchain. Will build libiconv."); need_libiconv=1)
+if test "$platform_os" == "android"; then
+  need_libiconv=1
+else
+  AC_SEARCH_LIBS([iconv_open],iconv, link_iconv=$ac_cv_search_iconv_open, link_iconv=-liconv; AC_MSG_WARN("No iconv support in toolchain. Will build libiconv."); need_libiconv=1)
+fi
 
 case $build in
   *darwin*)

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -24,7 +24,7 @@ else
 endif
 
 ifeq ($(OS),darwin_embedded)
-  EXCLUDED_DEPENDS = libcec libusb
+  EXCLUDED_DEPENDS = libcec libusb googletest
   ifeq ($(TARGET_PLATFORM),appletvos)
     DEPENDS += boblight
     EXCLUDED_DEPENDS += libshairplay libplist
@@ -43,7 +43,7 @@ ifeq ($(OS),osx)
 endif
 
 ifeq ($(OS),android)
-  EXCLUDED_DEPENDS = libcec libusb
+  EXCLUDED_DEPENDS = libcec libusb googletest
   DEPENDS += dummy-libxbmc libuuid libandroidjni libzip
   PYMODULE_DEPS = dummy-libxbmc
   LIBUUID = libuuid

--- a/tools/depends/target/libnfs/Makefile
+++ b/tools/depends/target/libnfs/Makefile
@@ -9,7 +9,7 @@ COMMITDATE=2020-06-09
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 
 # configuration settings
-CONFIGURE=./configure --prefix=$(PREFIX) --disable-shared --disable-utils --disable-examples
+CONFIGURE=./configure --prefix=$(PREFIX) --disable-shared --disable-utils --disable-examples --disable-werror
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(LIBNAME).a
 


### PR DESCRIPTION
## Description
Some minor fixes for use when building against current SDK/NDK (eg 31/23 right now)

## Motivation and context
Updating android build instructions for a macos host. In addition, get any android host to be able to build against latest SDK/NDK's

## How has this been tested?
Build and runtime tested aarch64 android built on Apple Silicon based host. Requires a few additional patches. WIP branch can be seen at https://github.com/fuzzard/xbmc/commits/macosarm_android

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
