### PR TITLE
[GUIDialogSimpleMenu] Fix infotag not showing for library bluray isos

### DIFF
--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -126,8 +126,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
     if (item_new->m_bIsFolder == false)
     {
       std::string original_path = item.GetDynPath();
-      item.Reset();
-      item = *item_new;
+      item.SetDynPath(item_new->GetDynPath());
       item.SetProperty("original_listitem_url", original_path);
       return true;
     }


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20551 for Matrix 19.4
