### PR TITLE
[Fix] Allow inputstreamaddon property to still work while depreciated

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -69,18 +69,21 @@ CInputStreamAddon::~CInputStreamAddon()
 
 bool CInputStreamAddon::Supports(const AddonInfoPtr& addonInfo, const CFileItem& fileitem)
 {
-  /// @todo Error for users to show deprecation, can be removed in Kodi 20
-  CVariant oldAddonProp = fileitem.GetProperty("inputstreamaddon");
-  if (!oldAddonProp.isNull())
-  {
-    CLog::Log(LOGERROR,
-              "CInputStreamAddon::{} - 'inputstreamaddon' has been deprecated, "
-              "please use `#KODIPROP:inputstream={}` instead",
-              __func__, oldAddonProp.asString());
-  }
-
   // check if a specific inputstream addon is requested
   CVariant addon = fileitem.GetProperty(STREAM_PROPERTY_INPUTSTREAM);
+
+  /// @todo Error for users to show deprecation, below block can be removed in Kodi 20
+  if (addon.isNull())
+  {
+    addon = fileitem.GetProperty("inputstreamaddon");
+    if (!addon.isNull())
+    {
+      CLog::Log(LOGERROR,
+                "CInputStreamAddon::%s - 'inputstreamaddon' has been deprecated, "
+                "please use `#KODIPROP:inputstream=%s` instead", __func__, addon.asString());
+    }
+  }
+
   if (!addon.isNull())
     return (addon.asString() == addonInfo->ID());
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
**This needs backport to 19**

Currently in Matrix, #KODIPROP:inputstreamaddon=inputstream.adaptive will not work
Is is meant to work and just show deprecation error with removal due for Kodi 20.

The issue is just the logic in CInputStreamAddon::Supports.
Currently oldAddonProp is never used.
So False is returned.

I've also changed it to check for the "new correct" property first.
And then revert to checking the old.
Now simply removing the code block under the comment will remove the old method.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://forum.kodi.tv/showthread.php?tid=353903&page=3

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the below test.strm

```
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://cwip-shaka-proxy.appspot.com/no_auth||R{SSM}|
https://storage.googleapis.com/shaka-demo-assets/angel-one-widevine-hls/hls.m3u8
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Using inputstreamaddon property will still work in Matrix

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
