### PR TITLE
[Android] Fix system memory usage info

### DIFF
--- a/xbmc/platform/android/MemUtils.cpp
+++ b/xbmc/platform/android/MemUtils.cpp
@@ -35,13 +35,14 @@ void GetMemoryStatus(MemoryStatus* buffer)
   if (!buffer)
     return;
 
-  long availMem, totalMem;
+  long availMem = 0;
+  long totalMem = 0;
 
   if (CXBMCApp::get()->GetMemoryInfo(availMem, totalMem))
   {
     *buffer = {};
-    buffer->totalPhys = totalMem;
-    buffer->availPhys = availMem;
+    buffer->totalPhys = static_cast<unsigned long>(totalMem);
+    buffer->availPhys = static_cast<unsigned long>(availMem);
   }
 }
 


### PR DESCRIPTION
## Description
Fix system memory usage info

## Motivation and context
I have come across this while trying other things on android TV...

## How has this been tested?
Runtime tested Android TV (Sony AG9)

## What is the effect on users?
Fix wrong big numbers displayed on "System memory usage info" and 100% usage on Player Info

## Screenshots (if appropriate):

**Before:**
![screenshot00000](https://user-images.githubusercontent.com/58434170/143244478-8f91d47d-e2cf-499f-ae5e-dd6a10297666.png)

**After:**
![screenshot00001](https://user-images.githubusercontent.com/58434170/143244511-7f13fc6e-0f5c-4458-bfeb-8d194919bad7.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
