### PR TITLE
[tools\depends] Reduce greying of developer hair

### DIFF
--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -4,15 +4,32 @@ ifneq ($(shell test -f $(NATIVEPREFIX)/share/config.site && echo 1),1)
   $(error Error: $(NATIVEPREFIX)/share/config.site  is missing. Please reconfigure depends to generate it)
 endif
 
-NATIVE= m4 gettext heimdal autoconf automake \
-        libtool pkg-config nasm cmake \
-        gas-preprocessor python3 zlib \
-        pcre swig openssl \
-        libpng libjpeg-turbo liblzo2 giflib \
-        setuptools JsonSchemaBuilder TexturePacker \
-        flatbuffers \
-        meson ninja \
-        autoconf-archive
+NATIVE= \
+  autoconf \
+  autoconf-archive \
+  automake \
+  cmake \
+  flatbuffers \
+  gas-preprocessor \
+  gettext \
+  heimdal \
+  JsonSchemaBuilder \
+  libjpeg-turbo \
+  liblzo2 giflib \
+  libpng \
+  libtool \
+  m4 \
+  meson \
+  nasm \
+  ninja \
+  openssl \
+  pcre \
+  pkg-config \
+  python3 \
+  setuptools \
+  swig \
+  TexturePacker \
+  zlib
 
 ifneq ($(NATIVE_OS),osx)
   NATIVE += libffi
@@ -38,36 +55,36 @@ all: native
 	@echo "Dependencies built successfully."
 
 # Dependency layout for parallel builds
+autoconf-archive: autoconf
 autoconf: m4
 automake: autoconf
-autoconf-archive: autoconf
 dpkg: automake gettext libtool pkg-config tar
 flatbuffers: cmake
 heimdal: libtool
-libtool: automake
+JsonSchemaBuilder: automake
 libjpeg-turbo: cmake nasm
 libpng: zlib automake
+libtool: automake
+Mako: MarkupSafe
 meson: python3 setuptools
 ninja: meson
 openssl: zlib
-swig: pcre
-tar: xz automake
+pugixml: cmake
 python3: $(EXPAT) $(LIBFFI) pkg-config zlib openssl autoconf-archive
 setuptools: python3
+swig: pcre
+tar: xz automake
+TexturePacker: automake pkg-config libpng liblzo2 giflib libjpeg-turbo
 wayland-scanner: expat pkg-config
 waylandpp-scanner: cmake pugixml
-pugixml: cmake
 
 # python installs are not thread safe when using easy_install method.
 # MarkupSafe doesn't really depend on ninja but we need to make the
 # build sequential
 MarkupSafe: ninja
-Mako: MarkupSafe
 
 #liblzo2 has stale packaged automake files that cause borked host/build detection
 liblzo2: automake
-JsonSchemaBuilder: automake
-TexturePacker: automake pkg-config libpng liblzo2 giflib libjpeg-turbo
 
 native: $(NATIVE)
 $(NATIVE):

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -5,17 +5,59 @@ ifneq ($(shell test -f $(PREFIX)/share/config.site && echo 1),1)
 endif
 
 DEPENDS = \
-	pcre expat gettext sqlite3 libgpg-error \
-	libgcrypt bzip2 libfstrcmp liblzo2 freetype2-noharfbuzz fontconfig \
-	openssl gmp nettle gnutls googletest curl nghttp2 \
-	libjpeg-turbo libpng fribidi harfbuzz libass \
-	libxml2 rapidjson libmicrohttpd mariadb libffi \
-	python3 libshairplay libfmt libspdlog \
-	libplist libcec libbluray tinyxml \
-	taglib libusb libnfs freetype2 \
-	pythonmodule-pil pythonmodule-pycryptodome pythonmodule-setuptools \
-	libxslt ffmpeg crossguid libudfread \
-	libdvdread libdvdnav libdvdcss p8-platform flatbuffers dav1d xz
+  bzip2 \
+  crossguid \
+  curl \
+  dav1d \
+  expat \
+  ffmpeg \
+  flatbuffers \
+  fontconfig \
+  freetype2 \
+  freetype2-noharfbuzz \
+  gettext \
+  gmp \
+  gnutls \
+  googletest \
+  harfbuzz \
+  libass \
+  libbluray \
+  libcec \
+  libdvdcss \
+  libdvdnav \
+  libdvdread \
+  libffi \
+  libfmt \
+  libfstrcmp \
+  libgcrypt \
+  libgpg-error \
+  libjpeg-turbo \
+  liblzo2 \
+  libmicrohttpd \
+  libnfs \
+  libplist \
+  libpng fribidi \
+  libshairplay \
+  libspdlog \
+  libudfread \
+  libusb \
+  libxml2 \
+  libxslt  \
+  mariadb \
+  nettle \
+  nghttp2 \
+  openssl \
+  p8-platform \
+  pcre \
+  python3 \
+  pythonmodule-pil \
+  pythonmodule-pycryptodome \
+  pythonmodule-setuptools \
+  rapidjson \
+  sqlite3 \
+  taglib \
+  tinyxml \
+  xz
 
 ifeq ($(ENABLE_GPLV3),yes)
   DEPENDS+=samba-gplv3 libcdio-gplv3
@@ -88,48 +130,48 @@ endif
 
 all: .installed-$(PLATFORM)
 
-gettext: $(ICONV)
-xz: gettext
-libgcrypt: libgpg-error
-fontconfig: freetype2 expat $(ICONV) $(LIBUUID)
-curl: openssl nghttp2
-harfbuzz: meson-cross-file freetype2-noharfbuzz $(ICONV)
-freetype2: harfbuzz $(ZLIB)
-libass: fontconfig fribidi harfbuzz libpng freetype2 expat $(ICONV)
-libmicrohttpd: gnutls libgcrypt libgpg-error
-python3: expat gettext libxml2 sqlite3 openssl libffi bzip2 xz
-libcdio: $(ICONV)
-libcdio-gplv3: $(ICONV)
-libplist: $(ZLIB)
-libbluray: fontconfig freetype2 $(ICONV) libxml2
-mariadb: openssl $(ICONV) $(ZLIB)
-libzip: bzip2 gnutls $(ZLIB)
-libpng: $(ZLIB)
-openssl: $(ZLIB)
-gnutls: nettle $(ZLIB)
-nettle: gmp
-pythonmodule-pycryptodome: $(PYMODULE_DEPS) python3 pythonmodule-setuptools
-pythonmodule-pil: bzip2 $(PYMODULE_DEPS) $(ZLIB) libjpeg-turbo libpng freetype2 python3 pythonmodule-setuptools
-pythonmodule-setuptools: $(PYMODULE_DEPS) python3
-libxslt: libgcrypt libxml2
-ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)
-libcec: p8-platform
 crossguid: $(LIBUUID)
+curl: openssl nghttp2
+dav1d: meson-cross-file
+dbus: expat
+ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)
+fontconfig: freetype2 expat $(ICONV) $(LIBUUID)
+freetype2: harfbuzz $(ZLIB)
+fribidi: meson-cross-file
+gettext: $(ICONV)
+gnutls: nettle $(ZLIB)
+harfbuzz: meson-cross-file freetype2-noharfbuzz $(ICONV)
+libass: fontconfig fribidi harfbuzz libpng freetype2 expat $(ICONV)
+libbluray: fontconfig freetype2 $(ICONV) libxml2
+libcdio-gplv3: $(ICONV)
+libcdio: $(ICONV)
+libcec: p8-platform
+libdrm: meson-cross-file
 libdvdnav: libdvdread
 libdvdread: libdvdcss
-wayland: expat libffi
-waylandpp: wayland $(WAYLANDPP_DEPS)
-dbus: expat
-libinput: mtdev libevdev meson-cross-file
 libevdev: libudev
+libgcrypt: libgpg-error
+libinput: mtdev libevdev meson-cross-file
+libmicrohttpd: gnutls libgcrypt libgpg-error
+libplist: $(ZLIB)
+libpng: $(ZLIB)
+libspdlog: libfmt
+libva: libdrm $(LIBVA_DEPS)
+libxslt: libgcrypt libxml2
+libzip: bzip2 gnutls $(ZLIB)
+mariadb: openssl $(ICONV) $(ZLIB)
+mesa: libdrm meson-cross-file $(MESA_DEPS)
+nettle: gmp
+openssl: $(ZLIB)
+python3: expat gettext libxml2 sqlite3 openssl libffi bzip2 xz
+pythonmodule-pil: bzip2 $(PYMODULE_DEPS) $(ZLIB) libjpeg-turbo libpng freetype2 python3 pythonmodule-setuptools
+pythonmodule-pycryptodome: $(PYMODULE_DEPS) python3 pythonmodule-setuptools
+pythonmodule-setuptools: $(PYMODULE_DEPS) python3
 samba-gplv3: gnutls
 taglib: $(ZLIB)
-dav1d: meson-cross-file
-fribidi: meson-cross-file
-libspdlog: libfmt
-libdrm: meson-cross-file
-mesa: libdrm meson-cross-file $(MESA_DEPS)
-libva: libdrm $(LIBVA_DEPS)
+wayland: expat libffi
+waylandpp: wayland $(WAYLANDPP_DEPS)
+xz: gettext
 
 .installed-$(PLATFORM): $(DEPENDS)
 	touch $@


### PR DESCRIPTION
## Description

One of the largest sources of rebase conflicts is with the two depends Makefiles, causing endless frustration for frequent rebasers. Let's alphabetize these and save us the grey hair.

## Motivation and context

And after making this change I went to rebase it, and hit this!

```
Auto-merging tools/depends/target/Makefile
Auto-merging tools/depends/native/Makefile
CONFLICT (content): Merge conflict in tools/depends/native/Makefile
error: could not apply a280e4d06b... Reduce greying of developer hair
Could not apply a280e4d06b... Reduce greying of developer hair
```

So grey hair not avoided for me.

## How has this been tested?

Tested by building depends via `make`.

## What is the effect on users?

* Happier developers

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
