### PR TITLE
[GuiDialogSimpleMenu][Fix] Save streamdetails for blurays

### DIFF
--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -130,6 +130,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
     {
       std::string original_path = item.GetDynPath();
       item.SetDynPath(item_new->GetDynPath());
+      item.SetProperty("get_stream_details_from_player", true);
       item.SetProperty("original_listitem_url", original_path);
       return true;
     }


### PR DESCRIPTION
## Description
A regression introduced in https://github.com/xbmc/xbmc/pull/20551 which leads to VP not to save the streamdetails for library Bluray isos after the stream selection in the simple menu. This makes sure VP updates the item m_streamdetails of the original item when playback is stopped.

Reported by @lharms in https://github.com/xbmc/xbmc/pull/20551#issuecomment-977331104

## Motivation and context
Fix regression

## How has this been tested?
Manually tested

## What is the effect on users?
Stream details should be saved again after playback

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

