### PR TITLE
[audio][TrueHD] Fix detection of stream discontinuities

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -129,7 +129,7 @@ void CAEBitstreamPacker::Reset()
 void CAEBitstreamPacker::PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size)
 {
   /* create the buffer if it doesn't already exist */
-  if (m_trueHD[0].size() == 0)
+  if (m_trueHD[0].empty())
   {
     m_trueHD[0].resize(MAT_FRAME_SIZE);
     m_trueHD[1].resize(MAT_FRAME_SIZE);
@@ -185,8 +185,8 @@ void CAEBitstreamPacker::PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size
     /* padding needed before this frame */
     paddingRem = deltaBytes - m_thd.prevFrameSize;
 
-    /* sanity check */
-    if (paddingRem < 0 || paddingRem >= MAT_FRAME_SIZE / 2)
+    // detects stream discontinuities
+    if (paddingRem < 0 || paddingRem >= MAT_FRAME_SIZE * 2)
     {
       m_thd = {}; // recovering after seek
       return;


### PR DESCRIPTION
## Description
[TrueHD] Fix detection of stream discontinuities.

Fixes TrueHD dropouts on very specific streams (Zootopia).

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/20339. Previous PR has fixed 99.9% of TrueHD dropouts however some very specific streams still have small dropouts. Only know example until now is Zootopia.

See: https://forum.kodi.tv/showthread.php?tid=365494 and https://forum.kodi.tv/showthread.php?tid=347674&pid=3068604#pid3068604 and https://forum.kodi.tv/showthread.php?tid=327153&pid=3071790#pid3071790

Since the TrueHD packing in MAT frames specification is not fully known (what is known is based on reverse engineering, etc.) there are some values that are taken arbitrarily (following a logic) and simply go as valid because they work "almost" always good. Until a stream is found that exceeds the known parameters and it is necessary to tweak them...

Apart from this, the changes are not at all risky or dangerous since the changed code is only executed when there is a jump in the stream (seek) or if a stream is corrupt. In these cases it will continue to work as before because the discontinuities would be much bigger. In other words, only the threshold is increased to consider that the stream is corrupt or there has been a jump.
 
## How has this been tested?
Runtime tested on:
- Windows 10 + Nvidia RTX 2060 + Denon X1600H
- Windows 11 + Intel NUC8i3BEK + Denon X1600H
- Nvidia Shield Pro 2019 + Denon X1600H
- OSMC on AMLogic s905x. (https://github.com/xbmc/xbmc/pull/20595#issuecomment-980430867)
- https://forum.kodi.tv/showthread.php?tid=365494&pid=3073042#pid3073042
- https://forum.kodi.tv/showthread.php?tid=365127&pid=3073358#pid3073358

## What is the effect on users?
Fixes TrueHD dropouts on Zootopia and probably on other streams too.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
