### PR TITLE
[tools/depends][target] cleanup ffmpeg configoptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,11 +343,10 @@ if(NOT CORE_SYSTEM_NAME STREQUAL android)
 else()
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
   add_library(${APP_NAME_LC} SHARED ${CORE_MAIN_SOURCE} "${RESOURCES}" ${OTHER_FILES})
-  if(CPU MATCHES x86_64)
-    # Statically resolve global references to shared library (ie. ffmpeg) definitions.
-    # Related to https://stackoverflow.com/questions/46307266/including-objects-to-a-shared-library-from-a-c-archive-a
-    set_target_properties(${APP_NAME_LC} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
-  endif()
+
+  # Statically resolve global references to shared library (ie. ffmpeg) definitions.
+  # Related to https://stackoverflow.com/questions/46307266/including-objects-to-a-shared-library-from-a-c-archive-a
+  set_target_properties(${APP_NAME_LC} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
 endif()
 add_dependencies(${APP_NAME_LC} ${APP_NAME_LC}-libraries export-files pack-skins)
 whole_archive(_MAIN_LIBRARIES ${FSTRCMP_LIBRARY} ${core_DEPENDS})

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -365,9 +365,8 @@ case $host in
 
     meson_system="darwin"
 
-    platform_cflags="-fheinous-gnu-extensions -no-cpp-precomp"
+    platform_cflags="-fheinous-gnu-extensions"
     platform_ldflags="-Wl,-search_paths_first"
-    platform_cxxflags="-no-cpp-precomp"
 
     case $use_platform in
       tvos)

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -62,11 +62,10 @@ elseif(CORE_SYSTEM_NAME STREQUAL android)
   endif()
   list(APPEND ffmpeg_conf --target-os=linux --extra-libs=-liconv --disable-linux-perf)
 elseif(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
-  list(APPEND ffmpeg_conf "--as=${NATIVEPREFIX}/bin/gas-preprocessor.pl -arch aarch64 -- ${CMAKE_C_COMPILER}")
-  list(APPEND ffmpeg_conf --disable-decoder=mpeg_xvmc --disable-crystalhd --enable-videotoolbox
+  list(APPEND ffmpeg_conf --disable-crystalhd --enable-videotoolbox 
                           --target-os=darwin)
 elseif(CORE_SYSTEM_NAME STREQUAL osx)
-  list(APPEND ffmpeg_conf --disable-decoder=mpeg_xvmc --disable-crystalhd --enable-videotoolbox
+  list(APPEND ffmpeg_conf --disable-crystalhd --enable-videotoolbox
                           --target-os=darwin
                           --disable-securetransport)
 endif()
@@ -113,23 +112,11 @@ externalproject_add(ffmpeg
                       --extra-version="kodi-${FFMPEG_VER}"
                       --disable-devices
                       --disable-doc
-                      --disable-ffplay
-                      --disable-ffmpeg
-                      --disable-ffprobe
+                      --disable-programs
                       --enable-gpl
                       --enable-runtime-cpudetect
                       --enable-postproc
                       --enable-pthreads
-                      --enable-muxer=spdif
-                      --enable-muxer=adts
-                      --enable-muxer=asf
-                      --enable-muxer=ipod
-                      --enable-encoder=ac3
-                      --enable-encoder=aac
-                      --enable-encoder=wmav2
-                      --enable-protocol=http
-                      --enable-encoder=png
-                      --enable-encoder=mjpeg
                       ${ffmpeg_conf}
                     BUILD_COMMAND ${MAKE_COMMAND})
 

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -2,55 +2,57 @@ include ../../Makefile.include
 include FFMPEG-VERSION
 DEPS= ../../Makefile.include FFMPEG-VERSION Makefile
 
-# set to "yes" to enable patching
-# we don't apply patches until we move to a vanilla ffmpeg tarball
-APPLY_PATCHES=no
+export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
 
 # configuration settings
 ffmpg_config = --prefix=$(PREFIX) --extra-version="kodi-$(VERSION)"
 ffmpg_config += --cc="$(CC)" --cxx="$(CXX)" --ar=$(AR) --ranlib=$(RANLIB) --strip=$(STRIP)
-ffmpg_config += --disable-devices --disable-doc
-ffmpg_config += --disable-ffplay --disable-ffmpeg
-ffmpg_config += --disable-ffprobe
+ffmpg_config += --extra-cflags="$(CFLAGS)"
+ffmpg_config += --extra-cxxflags="$(CXXFLAGS)"
+ffmpg_config += --extra-ldflags="$(LDFLAGS)"
+ffmpg_config += --pkg-config=$(NATIVEPREFIX)/bin/pkg-config
+
+ffmpg_config += --disable-doc
+ffmpg_config += --disable-devices
+ffmpg_config += --disable-programs
 ffmpg_config += --disable-sdl2
-ffmpg_config += --enable-gpl --enable-runtime-cpudetect
-ffmpg_config += --enable-postproc --enable-pthreads
-ffmpg_config += --enable-muxer=spdif --enable-muxer=adts
-ffmpg_config += --enable-muxer=asf --enable-muxer=ipod
-ffmpg_config += --enable-encoder=ac3 --enable-encoder=aac
-ffmpg_config += --enable-encoder=wmav2 --enable-protocol=http
+ffmpg_config += --enable-gpl
+ffmpg_config += --enable-postproc
+ffmpg_config += --enable-runtime-cpudetect
+ffmpg_config += --enable-pthreads
 ffmpg_config += --enable-gnutls
-ffmpg_config += --enable-encoder=png --enable-encoder=mjpeg
 ffmpg_config += --enable-libdav1d
 ffmpg_config += $(FFMPEG_CONFIGURE_OPTIONS)
 
+CONFIGARCH= --arch=$(CPU)
+
 ifeq ($(CROSS_COMPILING), yes)
-  ffmpg_config += --arch=$(CPU) --enable-cross-compile
+  ffmpg_config += --enable-cross-compile
+  ffmpg_config += --pkg-config-flags=--static
+  ffmpg_config += --enable-pic
 endif
 ifeq ($(OS), linux)
   ffmpg_config += --target-os=$(OS)
-  ffmpg_config += --enable-pic
 endif
 ifeq ($(OS), android)
   ifeq ($(findstring arm64, $(CPU)), arm64)
-    ffmpg_config += --arch=aarch64 --cpu=cortex-a53
+    ffmpg_config += --cpu=cortex-a53
+    CONFIGARCH= --arch=aarch64
   else
     ifeq ($(findstring arm, $(CPU)), arm)
       ffmpg_config += --cpu=cortex-a9
     else
       ifeq ($(CPU), x86_64)
-        ffmpg_config += --cpu=x86_64 --enable-pic
+        ffmpg_config += --cpu=$(CPU)
       else
         ffmpg_config += --cpu=i686 --disable-mmx
       endif
-      ffmpg_config += --extra-cflags='-no-integrated-as -mno-stackrealign'
+      ffmpg_config += --extra-cflags='-mno-stackrealign'
     endif
   endif
-  ffmpg_config += --target-os=linux --extra-libs=-liconv --disable-linux-perf
+  ffmpg_config += --target-os=$(OS) --extra-libs=-liconv
 endif
 ifeq ($(OS), darwin_embedded)
-  ffmpg_config += --as="$(NATIVEPREFIX)/bin/gas-preprocessor.pl -arch aarch64 -- $(CC)"
-  ffmpg_config += --x86asmexe=$(NATIVEPREFIX)/bin/nasm
   ffmpg_config += --disable-crystalhd --enable-videotoolbox
   ffmpg_config += --target-os=darwin
 endif
@@ -58,20 +60,23 @@ ifeq ($(OS), osx)
   ffmpg_config += --disable-crystalhd --enable-videotoolbox
   ffmpg_config += --target-os=darwin
   ffmpg_config += --disable-securetransport
-ifeq ($(CPU),arm64)
-  ffmpg_config += --as="$(NATIVEPREFIX)/bin/gas-preprocessor.pl -arch aarch64 -- $(CC)"
-  ffmpg_config += --x86asmexe=$(NATIVEPREFIX)/bin/nasm
-endif
 endif
 ifeq ($(findstring arm, $(CPU)), arm)
-  ffmpg_config += --enable-pic --disable-armv5te --disable-armv6t2
+  ffmpg_config += --disable-armv5te --disable-armv6t2
 endif
 ifeq ($(findstring mips, $(CPU)), mips)
   ffmpg_config += --disable-mips32r2 --disable-mipsdsp --disable-mipsdspr2
 endif
+ifeq ($(CPU),x86)
+  ffmpg_config += --x86asmexe=$(NATIVEPREFIX)/bin/nasm
+else ifeq ($(CPU),x86_64)
+  ffmpg_config += --x86asmexe=$(NATIVEPREFIX)/bin/nasm
+endif
 ifeq ($(Configuration), Release)
   ffmpg_config += --disable-debug
 endif
+
+ffmpg_config +=$(CONFIGARCH)
 
 all: .installed-$(PLATFORM)
 
@@ -81,10 +86,7 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM); sed -i".bak" -e "s%pkg_config_default=pkg-config%export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig \&\& pkg_config_default=$(NATIVEPREFIX)/bin/pkg-config%" configure
-	cd $(PLATFORM);\
-	CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" \
-	./configure $(ffmpg_config)
+	cd $(PLATFORM);	./configure $(ffmpg_config)
 
 .build-$(PLATFORM): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)


### PR DESCRIPTION
## Description
cleanup ffmpeg build options

## Motivation and context
We had a number of redundant/old options. On top of that, theres 3-4 DIFFERENT build scripts across kodi + addons. I wont touch the ppa autobuild.sh script, but ideally the cmake and the makefile should be more similar for consistency imo.

gas isnt required by ffmpeg anymore for darwin platforms
remove the sed replace and just supply via appropriate option flags
reorganise options to single line.
enable-pic for all cross-compile platforms (ie every platform that uses this)
x86asmexe is only required for x86/x86_64 targets (as the name would suggest)

## How has this been tested?
build osx x86_64/aarch64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
