### PR TITLE
[cmake] Fix android link failure fstrcmp ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,7 @@ else()
   endif()
 endif()
 add_dependencies(${APP_NAME_LC} ${APP_NAME_LC}-libraries export-files pack-skins)
-whole_archive(_MAIN_LIBRARIES ${core_DEPENDS})
+whole_archive(_MAIN_LIBRARIES ${FSTRCMP_LIBRARY} ${core_DEPENDS})
 target_link_libraries(${APP_NAME_LC} ${_MAIN_LIBRARIES} lib${APP_NAME_LC} ${DEPLIBS})
 unset(_MAIN_LIBRARIES)
 


### PR DESCRIPTION
## Description
Building android kodi on macos host runs across linker failure for libkodi target.
Avoid by adding explicit fstrcmp lib prior to core_DEPENDS in whole_archive macro

```
ld: error: undefined symbol: fstrcmp
>>> referenced by StringUtils.cpp:1716 (/Users/brent/Dev/android/xbmc/utils/StringUtils.cpp:1716)
>>>               StringUtils.cpp.o:(StringUtils::CompareFuzzy(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&)) in archive build/utils/utils.a
>>> referenced by Scraper.cpp:991 (/Users/brent/Dev/android/xbmc/addons/Scraper.cpp:991)
>>>               Scraper.cpp.o:(ADDON::CScraper::FindMovie(XFILE::CCurlFile&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, int, bool)) in archive build/addons/addons.a
>>> referenced by Util.cpp:1418 (/Users/brent/Dev/android/xbmc/Util.cpp:1418)
>>>               Util.cpp.o:(CUtil::AlbumRelevance(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&)) in archive build/xbmc/xbmc.a
>>> referenced 1 more times
>>> did you mean: strcmp
>>> defined in: /Library/Android/sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/darwin-x86_64/bin/../sysroot/usr/lib/aarch64-linux-android/31/libc.so
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libkodi.so] Error 1
make[1]: *** [CMakeFiles/kodi.dir/all] Error 2
```

## Motivation and context
Macos build host throws this error when linking the app so when using latest sdk/ndk (31/23). Ran tests on a linux vm with same versions, and it didnt have issues.

After discussion in slack, was suggested we just apply this for all as wont have any effect on other platforms with an additional link option earlier in the linker flags.

## How has this been tested?
Build macos host - aarch64 android target
build linux (ubuntu 20.04) host - aarch64 android target

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
