### PR TITLE
SysfsPath: add multi line support

### DIFF
--- a/xbmc/platform/linux/SysfsPath.cpp
+++ b/xbmc/platform/linux/SysfsPath.cpp
@@ -23,9 +23,7 @@ std::string CSysfsPath::Get()
 {
   std::ifstream file(m_path);
 
-  std::string value;
-
-  std::getline(file, value);
+  std::string value(std::istreambuf_iterator<char>(file), {});
 
   if (file.bad())
   {
@@ -33,5 +31,5 @@ std::string CSysfsPath::Get()
     throw std::runtime_error("error reading from " + m_path);
   }
 
-  return value;
+  return StringUtils::Trim(value);
 }

--- a/xbmc/platform/linux/SysfsPath.cpp
+++ b/xbmc/platform/linux/SysfsPath.cpp
@@ -10,12 +10,8 @@
 
 bool CSysfsPath::Exists()
 {
-  std::ifstream file(m_path);
-
-  if (!file.is_open())
-    return false;
-
-  return true;
+  struct stat buffer;
+  return (stat(m_path.c_str(), &buffer) == 0);
 }
 
 template<>

--- a/xbmc/platform/linux/SysfsPath.h
+++ b/xbmc/platform/linux/SysfsPath.h
@@ -13,6 +13,7 @@
 
 #include <fstream>
 #include <string>
+#include <sys/stat.h>
 
 class CSysfsPath
 {

--- a/xbmc/platform/linux/SysfsPath.h
+++ b/xbmc/platform/linux/SysfsPath.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <fstream>

--- a/xbmc/platform/linux/test/TestSysfsPath.cpp
+++ b/xbmc/platform/linux/test/TestSysfsPath.cpp
@@ -84,6 +84,22 @@ TEST_F(TestSysfsPath, SysfsPathTestLongString)
   std::remove(filepath.c_str());
 }
 
+TEST_F(TestSysfsPath, SysfsPathTestMultiLine)
+{
+  std::string filepath = GetTestFilePath();
+  std::ofstream m_output{filepath};
+
+  std::string temp{"line1\nline2\nline3"};
+  m_output << temp;
+  m_output.close();
+
+  CSysfsPath path(filepath);
+  ASSERT_TRUE(path.Exists());
+  EXPECT_EQ(path.Get<std::string>(), "line1\nline2\nline3");
+
+  std::remove(filepath.c_str());
+}
+
 TEST_F(TestSysfsPath, SysfsPathTestPathDoesNotExist)
 {
   CSysfsPath otherPath{"/thispathdoesnotexist"};


### PR DESCRIPTION
Get all chars of the sysfs file.

## Description
Right now `SysfsPath.Get` only support single line when request a string from `sysfs`.
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
Be able to get whole sysfs file content.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Result by `getline`:
```text
2021-11-27 07:50:34.889 T:4961     INFO <general>: aml_probe_resolutions: Get by 'getline' from '/sys/class/amhdmitx/amhdmitx0/disp_cap': 480i60hz
```

Result by `istreambuf_iterator`:
```text
2021-11-27 07:50:34.889 T:4961     INFO <general>: aml_probe_resolutions: Get by 'istreambuf_iterator' from '/sys/class/amhdmitx/amhdmitx0/disp_cap': 480i60hz
                                                   576i50hz
                                                   480p60hz
                                                   576p50hz
                                                   720p60hz
                                                   1080i60hz
                                                   1080p60hz*
                                                   720p50hz
                                                   1080i50hz
                                                   1080p50hz
```

No other difference could be recorded on tests on Linux platform.
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
It may include filtered chars by `getline` like new line `"\n"` on the end.
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
