### PR TITLE
[AEsinkAUDIOTRACK] Fix TrueHD buffer size/frame duration IEC and RAW

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -922,8 +922,7 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
   unsigned int maxFrames;
   int retry = 0;
   unsigned int written = 0;
-  std::unique_ptr<uint8_t[]> mergebuffer;
-  uint8_t* p_mergebuffer = NULL;
+  uint8_t* p_mergeBuffer = nullptr;
   AEDelayStatus status;
 
   if (m_requestedFormat.m_dataFormat == AE_FMT_RAW)
@@ -990,25 +989,28 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
           break;
       }
     }
-    else
+    else // Android IEC packer (RAW)
     {
       if (m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD && frames == 61440)
       {
-        unsigned int size = 0;
-        mergebuffer.reset(new uint8_t[MAX_IEC61937_PACKET]);
-        p_mergebuffer = mergebuffer.get();
+        if (m_mergeBuffer.empty())
+          m_mergeBuffer.resize(MAX_IEC61937_PACKET);
 
-        for (int i = 0, offset = 0; i < 12; i++)
+        p_mergeBuffer = m_mergeBuffer.data();
+        unsigned int size = 0;
+
+        for (int i = 0, of = 0; i < 24; i++)
         {
           // calculates length of each audio unit using raw data of stream
-          uint16_t len = ((*(buffer[0] + offset) & 0x0F) << 8 | *(buffer[0] + offset + 1)) << 1;
+          const uint16_t len = ((*(buffer[0] + of) & 0x0F) << 8 | *(buffer[0] + of + 1)) << 1;
 
-          memcpy(&(mergebuffer.get())[size], buffer[0] + offset, len);
+          memcpy(m_mergeBuffer.data() + of, buffer[0] + of, len);
           size += len;
-          offset += len;
+          of += len;
         }
-        buffer = &p_mergebuffer;
-        totalFrames = size / m_sinkFormat.m_frameSize;
+
+        buffer = &p_mergeBuffer;
+        totalFrames = size / m_sinkFormat.m_frameSize; // m_frameSize = 1
         frames = totalFrames;
       }
       if (samples->pkt->pause_burst_ms > 0)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -134,6 +134,8 @@ protected:
     SKIP_SWAP,
   } m_swapState;
 
+  std::vector<uint8_t> m_mergeBuffer;
+
   std::string m_deviceFriendlyName;
   std::string m_device;
   std::vector<AE::AESinkInfo> m_sinkInfoList;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -756,6 +756,9 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   uint8_t *out_buf = buffer;
   int size = frames * m_format.m_frameSize;
 
+  // TrueHD IEC has 12 audio units (half packet and half duration) on CDVDAudioCodecPassthrough
+  double ratio = (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD) ? 2.0 : 1.0;
+
   // write as many frames of audio as we can fit into our internal buffer.
   int written = 0;
   int loop_written = 0;
@@ -819,7 +822,12 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
         }
       }
       else
-        m_duration_written += ((double) loop_written / m_format.m_frameSize) / m_format.m_sampleRate;
+      {
+        double duration =
+            (static_cast<double>(loop_written) / m_format.m_frameSize) / m_format.m_sampleRate;
+        duration /= ratio;
+        m_duration_written += duration;
+      }
 
       // just try again to care for fragmentation
       if (written < size)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -52,5 +52,5 @@ private:
   std::vector<uint8_t> m_trueHDBuffer;
   unsigned int m_trueHDoffset = 0;
   unsigned int m_trueHDframes = 0;
+  bool m_deviceIsRAW{false};
 };
-

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -71,6 +71,7 @@ public:
   void SetAudioBitsPerSample(int bitsPerSample);
   int GetAudioBitsPerSample();
   virtual bool AllowDTSHDDecode();
+  virtual bool WantsRawPassthrough() { return false; }
 
   // render info
   void SetRenderClockSync(bool enabled);

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
@@ -8,6 +8,10 @@
 
 #include "ProcessInfoAndroid.h"
 
+#include "ServiceBroker.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+
 using namespace VIDEOPLAYER;
 
 CProcessInfo* CProcessInfoAndroid::Create()
@@ -23,4 +27,15 @@ void CProcessInfoAndroid::Register()
 EINTERLACEMETHOD CProcessInfoAndroid::GetFallbackDeintMethod()
 {
   return EINTERLACEMETHOD::VS_INTERLACEMETHOD_DEINTERLACE_HALF;
+}
+
+bool CProcessInfoAndroid::WantsRawPassthrough()
+{
+  const std::string device = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+      CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE);
+
+  if (std::string::npos != device.find("(RAW)"))
+    return true;
+
+  return false;
 }

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
@@ -13,14 +13,15 @@
 
 namespace VIDEOPLAYER
 {
-  class CProcessInfoAndroid : public CProcessInfo
-  {
-  public:
-    CProcessInfoAndroid() = default;
-    static CProcessInfo* Create();
-    static void Register();
-    EINTERLACEMETHOD GetFallbackDeintMethod() override;
 
-  //protected:
-  };
-}
+class CProcessInfoAndroid : public CProcessInfo
+{
+public:
+  CProcessInfoAndroid() = default;
+  static CProcessInfo* Create();
+  static void Register();
+  EINTERLACEMETHOD GetFallbackDeintMethod() override;
+  bool WantsRawPassthrough() override;
+};
+
+} // namespace VIDEOPLAYER


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20550


## What is the effect on users?
- Fixes no audio output using Android IEC packer (RAW) with TrueHD.
- Fixes micro-stuttering using Kodi IEC packer with TrueHD.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
