### PR TITLE
Support choosing a network interface via advanced settings

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -65,7 +65,7 @@ sudo apt install autoconf build-essential curl default-jdk gawk git gperf lib32s
 **[back to top](#table-of-contents)**
 
 ## 3. Prerequisites
-Building Kodi for Android requires Android NDK revision 20b. For the SDK just use the latest available.
+Building Kodi for Android requires Android NDK revision 21e. For the SDK just use the latest available.
 Kodi CI/CD platforms currently use r21e for build testing and releases, so we recommend using r21e for the most tested build experience
 
 * **[Android SDK](https://developer.android.com/studio/index.html)** (Look for `Get just the command line tools`)

--- a/xbmc/addons/interfaces/Network.cpp
+++ b/xbmc/addons/interfaces/Network.cpp
@@ -68,7 +68,7 @@ char* Interface_Network::get_ip_address(void* kodiBase)
   }
 
   std::string titleIP;
-  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
   if (iface)
     titleIP = iface->GetCurrentIPAddress();
   else

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -347,7 +347,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case NETWORK_IP_ADDRESS:
     {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
       if (iface)
       {
         value = iface->GetCurrentIPAddress();
@@ -357,7 +357,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     }
     case NETWORK_SUBNET_MASK:
     {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
       if (iface)
       {
         value = iface->GetCurrentNetmask();
@@ -367,7 +367,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     }
     case NETWORK_GATEWAY_ADDRESS:
     {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
       if (iface)
       {
         value = iface->GetCurrentDefaultGateway();
@@ -406,7 +406,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     {
       std::string linkStatus = g_localizeStrings.Get(151);
       linkStatus += " ";
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
       if (iface && iface->IsConnected())
         linkStatus += g_localizeStrings.Get(15207);
       else

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -228,7 +228,7 @@ namespace XBMCAddon
       XBMC_TRACE;
       char cTitleIP[32];
       sprintf(cTitleIP, "127.0.0.1");
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
       if (iface)
         return iface->GetCurrentIPAddress();
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -1158,7 +1158,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
   {
     CLog::Log(LOGDEBUG, "AIRPLAY: got request {}", uri);
     responseBody = StringUtils::Format(
-        SERVER_INFO, CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetMacAddress());
+        SERVER_INFO, CServiceBroker::GetNetwork().GetDefaultInterface()->GetMacAddress());
     responseHeader = "Content-Type: text/x-apple-plist+xml\r\n";
   }
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -569,7 +569,7 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
 {
   bool success = false;
   std::string pw = password;
-  CNetworkInterface *net = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  CNetworkInterface* net = CServiceBroker::GetNetwork().GetDefaultInterface();
   StopServer(true);
 
   if (net)
@@ -713,7 +713,7 @@ bool CAirTunesServer::Initialize(const std::string &password)
 
     raop_set_log_callback(m_pRaop, shairplay_log, NULL);
 
-    CNetworkInterface* net = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+    CNetworkInterface* net = CServiceBroker::GetNetwork().GetDefaultInterface();
 
     if (net)
     {

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -20,6 +20,8 @@ class CNetworkInterface
 public:
    virtual ~CNetworkInterface() = default;
 
+   virtual const std::string& GetName(void) const = 0;
+
    virtual bool IsEnabled(void) const = 0;
    virtual bool IsConnected(void) const = 0;
 
@@ -59,9 +61,10 @@ public:
 
   // Return the list of interfaces
   virtual std::vector<CNetworkInterface*>& GetInterfaceList(void) = 0;
+  CNetworkInterface* GetInterfaceByName(const std::string& name);
 
   // Return the first interface which is active
-  virtual CNetworkInterface* GetFirstConnectedInterface(void);
+  virtual CNetworkInterface* GetDefaultInterface(void);
 
   // Return true if there is a interface for the same network as address
   bool HasInterfaceForIP(unsigned long address);

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -771,7 +771,7 @@ bool CNetworkServices::StartAirPlayServer()
 
 #ifdef HAS_ZEROCONF
   std::vector<std::pair<std::string, std::string> > txt;
-  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
   txt.emplace_back("deviceid", iface != nullptr ? iface->GetMacAddress() : "FF:FF:FF:FF:FF:F2");
   txt.emplace_back("model", "Xbmc,1");
   txt.emplace_back("srcvers", AIRPLAY_SERVER_VERSION_STR);

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -497,8 +497,9 @@ CUPnP::CUPnP() :
     m_UPnP = new PLT_UPnP();
 
     // keep main IP around
-    if (CServiceBroker::GetNetwork().GetFirstConnectedInterface()) {
-        m_IP = CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetCurrentIPAddress().c_str();
+    if (CServiceBroker::GetNetwork().GetDefaultInterface())
+    {
+      m_IP = CServiceBroker::GetNetwork().GetDefaultInterface()->GetCurrentIPAddress().c_str();
     }
     NPT_List<NPT_IpAddress> list;
     if (NPT_SUCCEEDED(PLT_UPnPMessageHelper::GetIPAddresses(list)) && list.GetItemCount()) {

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -424,8 +424,9 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
         thumb = CTextureUtils::GetWrappedImageURL(thumb);
 
         NPT_String ip;
-        if (CServiceBroker::GetNetwork().GetFirstConnectedInterface()) {
-            ip = CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetCurrentIPAddress().c_str();
+        if (CServiceBroker::GetNetwork().GetDefaultInterface())
+        {
+          ip = CServiceBroker::GetNetwork().GetDefaultInterface()->GetCurrentIPAddress().c_str();
         }
         // build url, use the internal device http server to serv the image
         NPT_HttpUrlQuery query;

--- a/xbmc/platform/android/network/NetworkAndroid.h
+++ b/xbmc/platform/android/network/NetworkAndroid.h
@@ -29,6 +29,7 @@ public:
 
   // CNetworkInterface interface
 public:
+  virtual const std::string& GetName() const override;
   bool IsEnabled() const override;
   bool IsConnected() const override;
   std::string GetMacAddress() const override;
@@ -60,7 +61,7 @@ public:
 public:
   bool GetHostName(std::string& hostname) override;
   std::vector<CNetworkInterface*>& GetInterfaceList() override;
-  CNetworkInterface* GetFirstConnectedInterface() override;
+  CNetworkInterface* GetDefaultInterface() override;
   std::vector<std::string> GetNameServers() override;
 
   // Ping remote host

--- a/xbmc/platform/darwin/ios-common/network/NetworkIOS.h
+++ b/xbmc/platform/darwin/ios-common/network/NetworkIOS.h
@@ -33,7 +33,7 @@ public:
   std::string GetCurrentNetmask() const override;
   std::string GetCurrentDefaultGateway() const override;
 
-  std::string GetInterfaceName() const;
+  std::string& GetName() const;
 
 private:
   std::string m_interfaceName;
@@ -48,7 +48,7 @@ public:
 
   // Return the list of interfaces
   std::vector<CNetworkInterface*>& GetInterfaceList() override;
-  CNetworkInterface* GetFirstConnectedInterface() override;
+  CNetworkInterface* GetDefaultInterface() override;
 
   // Ping remote host
   bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) override;

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
@@ -31,6 +31,11 @@ CNetworkInterfaceOsx::CNetworkInterfaceOsx(CNetworkPosix* network,
 {
 }
 
+const std::string& CNetworkInterfaceOsx::GetName(void) const
+{
+  return m_interfaceName;
+}
+
 std::string CNetworkInterfaceOsx::GetCurrentDefaultGateway() const
 {
   std::string result;

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.h
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.h
@@ -21,6 +21,8 @@ public:
                        char interfaceMacAddrRaw[6]);
   ~CNetworkInterfaceOsx() override = default;
 
+  const std::string& GetName(void) const override;
+
   std::string GetCurrentDefaultGateway() const override;
   bool GetHostMacAddress(unsigned long host, std::string& mac) const override;
 };

--- a/xbmc/platform/freebsd/network/NetworkFreebsd.cpp
+++ b/xbmc/platform/freebsd/network/NetworkFreebsd.cpp
@@ -34,6 +34,11 @@ CNetworkInterfaceFreebsd::CNetworkInterfaceFreebsd(CNetworkPosix* network,
 {
 }
 
+const std::string& CNetworkInterfaceFreebsd::GetName(void) const
+{
+  return m_interfaceName;
+}
+
 std::string CNetworkInterfaceFreebsd::GetCurrentDefaultGateway() const
 {
   std::string result;

--- a/xbmc/platform/freebsd/network/NetworkFreebsd.h
+++ b/xbmc/platform/freebsd/network/NetworkFreebsd.h
@@ -21,6 +21,8 @@ public:
                            char interfaceMacAddrRaw[6]);
   ~CNetworkInterfaceFreebsd() override = default;
 
+  const std::string& GetName(void) const override;
+
   std::string GetCurrentDefaultGateway() const override;
   bool GetHostMacAddress(unsigned long host, std::string& mac) const override;
 };

--- a/xbmc/platform/linux/network/NetworkLinux.cpp
+++ b/xbmc/platform/linux/network/NetworkLinux.cpp
@@ -27,6 +27,11 @@ CNetworkInterfaceLinux::CNetworkInterfaceLinux(CNetworkPosix* network,
 {
 }
 
+const std::string& CNetworkInterfaceLinux::GetName(void) const
+{
+  return m_interfaceName;
+}
+
 std::string CNetworkInterfaceLinux::GetCurrentDefaultGateway() const
 {
   std::string result;

--- a/xbmc/platform/linux/network/NetworkLinux.h
+++ b/xbmc/platform/linux/network/NetworkLinux.h
@@ -21,6 +21,8 @@ public:
                          char interfaceMacAddrRaw[6]);
   ~CNetworkInterfaceLinux() override = default;
 
+  const std::string& GetName(void) const override;
+
   std::string GetCurrentDefaultGateway() const override;
   bool GetHostMacAddress(unsigned long host, std::string& mac) const override;
 };

--- a/xbmc/platform/posix/network/NetworkPosix.h
+++ b/xbmc/platform/posix/network/NetworkPosix.h
@@ -23,6 +23,8 @@ public:
                          char interfaceMacAddrRaw[6]);
   virtual ~CNetworkInterfacePosix() override = default;
 
+  const std::string& GetName(void) const override;
+
   bool IsEnabled() const override;
   bool IsConnected() const override;
   std::string GetCurrentIPAddress() const override;
@@ -46,7 +48,7 @@ public:
   virtual ~CNetworkPosix() override;
 
   std::vector<CNetworkInterface*>& GetInterfaceList() override;
-  CNetworkInterface* GetFirstConnectedInterface() override;
+  CNetworkInterface* GetDefaultInterface() override;
 
   int GetSocket() { return m_sock; }
 

--- a/xbmc/platform/win10/network/NetworkWin10.h
+++ b/xbmc/platform/win10/network/NetworkWin10.h
@@ -23,8 +23,12 @@ class CNetworkWin10;
 class CNetworkInterfaceWin10 : public CNetworkInterface
 {
 public:
-  CNetworkInterfaceWin10(const PIP_ADAPTER_ADDRESSES adapter);
+  CNetworkInterfaceWin10(CNetworkWin10* network,
+                         const PIP_ADAPTER_ADDRESSES adapter,
+                         ::IUnknown* winRTadapter);
   ~CNetworkInterfaceWin10(void);
+
+  virtual const std::string& GetName(void) const;
 
   virtual bool IsEnabled(void) const;
   virtual bool IsConnected(void) const;
@@ -39,7 +43,12 @@ public:
   virtual std::string GetCurrentDefaultGateway(void) const;
 
 private:
+  CNetworkWin10* m_network;
+
+  std::string m_adaptername;
   PIP_ADAPTER_ADDRESSES m_adapterAddr;
+  winrt::Windows::Networking::Connectivity::NetworkAdapter m_winRT = nullptr;
+  mutable winrt::Windows::Networking::Connectivity::ConnectionProfile m_profile = nullptr;
 };
 
 
@@ -50,7 +59,7 @@ public:
     virtual ~CNetworkWin10(void);
 
     std::vector<CNetworkInterface*>& GetInterfaceList(void) override;
-    CNetworkInterface* GetFirstConnectedInterface() override;
+    CNetworkInterface* GetDefaultInterface() override;
     std::vector<std::string> GetNameServers(void) override;
 
     bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) override;
@@ -68,3 +77,4 @@ private:
     PIP_ADAPTER_ADDRESSES m_adapterAddresses;
 };
 
+using CNetwork = CNetworkWin10;

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -9,9 +9,11 @@
 #include "NetworkWin32.h"
 
 #include "threads/SingleLock.h"
+#include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include "platform/win32/CharsetConverter.h"
 #include "platform/win32/WIN32Util.h"
 
 #include <errno.h>
@@ -25,13 +27,22 @@
 
 #pragma comment(lib, "Ntdll.lib")
 
+using namespace KODI::PLATFORM::WINDOWS;
+
 CNetworkInterfaceWin32::CNetworkInterfaceWin32(const IP_ADAPTER_ADDRESSES& adapter)
+  : m_adaptername(adapter.AdapterName)
 {
   m_adapter = adapter;
+  g_charsetConverter.unknownToUTF8(m_adaptername);
 }
 
 CNetworkInterfaceWin32::~CNetworkInterfaceWin32(void)
 {
+}
+
+const std::string& CNetworkInterfaceWin32::GetName(void) const
+{
+  return m_adaptername;
 }
 
 bool CNetworkInterfaceWin32::IsEnabled() const

--- a/xbmc/platform/win32/network/NetworkWin32.h
+++ b/xbmc/platform/win32/network/NetworkWin32.h
@@ -23,24 +23,28 @@ class CNetworkWin32;
 class CNetworkInterfaceWin32 : public CNetworkInterface
 {
 public:
-   CNetworkInterfaceWin32(const IP_ADAPTER_ADDRESSES& adapter);
-   ~CNetworkInterfaceWin32(void) override;
+  CNetworkInterfaceWin32(CNetworkWin32* network, const IP_ADAPTER_ADDRESSES& adapter);
+  ~CNetworkInterfaceWin32(void) override;
 
-   bool IsEnabled(void) const override;
-   bool IsConnected(void) const override;
+  const std::string& GetName(void) const override;
 
-   std::string GetMacAddress(void) const override;
-   void GetMacAddressRaw(char rawMac[6]) const override;
+  bool IsEnabled(void) const override;
+  bool IsConnected(void) const override;
 
-   bool GetHostMacAddress(unsigned long host, std::string& mac) const override;
-   bool GetHostMacAddress(struct sockaddr* host, std::string& mac) const;
+  std::string GetMacAddress(void) const override;
+  void GetMacAddressRaw(char rawMac[6]) const override;
 
-   std::string GetCurrentIPAddress() const override;
-   std::string GetCurrentNetmask() const override;
-   std::string GetCurrentDefaultGateway(void) const override;
+  bool GetHostMacAddress(unsigned long host, std::string& mac) const override;
+  bool GetHostMacAddress(struct sockaddr* host, std::string& mac) const;
+
+  std::string GetCurrentIPAddress() const override;
+  std::string GetCurrentNetmask() const override;
+  std::string GetCurrentDefaultGateway(void) const override;
 
 private:
    IP_ADAPTER_ADDRESSES m_adapter;
+   CNetworkWin32* m_network;
+   std::string m_adaptername;
 };
 
 class CNetworkWin32 : public CNetworkBase
@@ -72,3 +76,4 @@ private:
    CCriticalSection m_critSection;
 };
 
+using CNetwork = CNetworkWin32;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -342,6 +342,8 @@ void CAdvancedSettings::Initialize()
                                   //with ipv6.
   m_curlDisableHTTP2 = false;
 
+  m_defaultNetworkInterfaceName = "";
+
 #if defined(TARGET_WINDOWS_DESKTOP)
   m_minimizeToTray = false;
 #endif
@@ -838,6 +840,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "curllowspeedtime", m_curllowspeedtime, 1, 1000);
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetInt(pElement, "curlkeepaliveinterval", m_curlKeepAliveInterval, 0, 300);
+    XMLUtils::GetString(pElement, "defaultInterfaceName", m_defaultNetworkInterfaceName);
     XMLUtils::GetBoolean(pElement, "disableipv6", m_curlDisableIPV6);
     XMLUtils::GetBoolean(pElement, "disablehttp2", m_curlDisableHTTP2);
     XMLUtils::GetString(pElement, "catrustfile", m_caTrustFile);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -289,6 +289,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_curlDisableIPV6;
     bool m_curlDisableHTTP2;
 
+    std::string m_defaultNetworkInterfaceName;
+
     std::string m_caTrustFile;
 
     bool m_minimizeToTray; /* win32 only */

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -299,7 +299,7 @@ CSysData::INTERNET_STATE CSysInfoJob::GetInternetState()
 
 std::string CSysInfoJob::GetMACAddress()
 {
-  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetDefaultInterface();
   if (iface)
     return iface->GetMacAddress();
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -712,7 +712,7 @@ bool URIUtils::IsHostOnLAN(const std::string& host, bool offLineCheck)
         return true;
     }
     // check if we are on the local subnet
-    if (!CServiceBroker::GetNetwork().GetFirstConnectedInterface())
+    if (!CServiceBroker::GetNetwork().GetDefaultInterface())
       return false;
 
     if (CServiceBroker::GetNetwork().HasInterfaceForIP(address))


### PR DESCRIPTION
## Description
Support choosing a network interface via advanced settings XML

## Motivation and context
Workaround UPnP discovery and similar issues caused by detecting the wrong network interface.  See [issue 14743](https://github.com/xbmc/xbmc/issues/14743) for more info.

## How has this been tested?
I'm unable to reproduce [issue 14743](https://github.com/xbmc/xbmc/issues/14743) but using Fire TV Stick 4K the network interface is auto-detected the same as before and override via `advancedsettings.xml` is possible as confirmed by DEBUG logging.  Also added logging to `UPnP.cpp` after `m_IP` is set the last time which isn't included in PR.

## What is the effect on users?
Support for new advanced setting and workaround for known issue.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
