### PR TITLE
[tools/depends] configure fix for dav1d compile failure android x86-64 target

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -302,11 +302,17 @@ case $host in
         fi
         meson_cpu="aarch64"
       ;;
-      i*86*-linux-android*|x86_64*-linux-android*)
+      i*86*-linux-android*)
         if test "x$use_cpu" = "xauto"; then
           use_cpu=$host_cpu
         fi
         meson_cpu="x86"
+      ;;
+      x86_64*-linux-android*)
+        if test "x$use_cpu" = "xauto"; then
+          use_cpu=$host_cpu
+        fi
+        meson_cpu="x86_64"
       ;;
       *)
         AC_MSG_ERROR(unsupported host ($use_host))


### PR DESCRIPTION
## Description
dav1d compiles incorrectly with meson_cpu set to x86 for actual x86-64 target. This causes ffmpeg to be unable to locate libdav1d
This fixes depend build for x86-64 android target, however we dont CI this platform.
Actual build state of core app is unknown.

Not sure if its even worth bothering if we dont CI, thoughts?

## Motivation and context
User on forum trying to build x86-64 android for some car

See forum thread for various logs https://forum.kodi.tv/showthread.php?tid=365681

## How has this been tested?
Dependency build only. no idea about state of actual app build for this platform.

## What is the effect on users?
Able to build android x86-64 dependencies

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
