### PR TITLE
Fix typo in xbmc/utils/Mime.cpp

### DIFF
--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -323,7 +323,7 @@ const std::map<std::string, std::string> CMime::m_mimetypes = {
      {"psd", "application/octet-stream"},
      {"pvu", "paleovu/x-pv"},
      {"pwz", "application/vnd.ms-powerpoint"},
-     {"py", "text/x-script.phyton"},
+     {"py", "text/x-script.python"},
      {"pyc", "application/x-bytecode.python"},
      {"qcp", "audio/vnd.qcelp"},
      {"qd3", "x-world/x-3dmf"},


### PR DESCRIPTION
## Description
The mime type seems to have a typo within it. This commit fixes that.

## Motivation and context
Uniformity

## How has this been tested?
n/a

## What is the effect on users?
n/a

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
