### PR TITLE
CAppParamParser: fix mistake in SetLogLevel

### DIFF
--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -27,7 +27,7 @@ public:
 
   const CFileItemList& GetPlaylist() const;
 
-  void SetLogLevel(int logLevel) { m_logTarget = logLevel; }
+  void SetLogLevel(int logLevel) { m_logLevel = logLevel; }
   void SetStartFullScreen(bool startFullScreen) { m_startFullScreen = startFullScreen; }
   void SetPlatformDirectories(bool platformDirectories)
   {


### PR DESCRIPTION
I'm not even sure why it compiles. Oh well :)

fixes a problem introduced in 1bb35acda39230f59e12d47f510aafa6112c8204