### PR TITLE
[PVR] Fix CPVRChannelGroupInternal::AppendToGroup return value.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -168,14 +168,12 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroupInternal::
 
 bool CPVRChannelGroupInternal::AppendToGroup(const std::shared_ptr<CPVRChannel>& channel)
 {
-  bool bReturn = false;
-
   if (IsGroupMember(channel))
-    return bReturn;
+    return false;
 
   const std::shared_ptr<CPVRChannelGroupMember> groupMember = GetByUniqueID(channel->StorageId());
   if (!groupMember)
-    return bReturn;
+    return false;
 
   channel->SetHidden(false);
 
@@ -188,7 +186,7 @@ bool CPVRChannelGroupInternal::AppendToGroup(const std::shared_ptr<CPVRChannel>&
   groupMember->SetChannelNumber(CPVRChannelNumber(iChannelNumber, 0));
 
   SortAndRenumber();
-  return bReturn;
+  return true;
 }
 
 bool CPVRChannelGroupInternal::RemoveFromGroup(const std::shared_ptr<CPVRChannel>& channel)


### PR DESCRIPTION
Fallout from #19862. Prevented update of channel lists in PVR Channelgroup Manager after unhiding a channel from the 'All channels' group.

Runtime-tested on macOS, alets kodi master

@phunkyfish  if/when you find some time for the review.