### PR TITLE
Fix two disabled unit tests in TestWebServer.cpp

### DIFF
--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -593,41 +593,39 @@ TEST_F(TestWebServer, CanGetCachedFileWithOlderIfModifiedSince)
   CheckRangesTestFileResponse(curl);
 }
 
-/** @todo Fix these two tests, they keep failing and
- *  we want to enable the test suite on PR
- */
-//TEST_F(TestWebServer, CanGetCachedFileWithExactIfModifiedSince)
-//{
-//  // get the last modified date of the file
-//  CDateTime lastModified;
-//  ASSERT_TRUE(GetLastModifiedOfTestFile(TEST_FILES_RANGES, lastModified));
-//
-//  // get the file with the exact If-Modified-Since value
-//  std::string result;
-//  CCurlFile curl;
-//  curl.SetRequestHeader(MHD_HTTP_HEADER_RANGE, "");
-//  curl.SetRequestHeader(MHD_HTTP_HEADER_IF_MODIFIED_SINCE, lastModified.GetAsRFC1123DateTime());
-//  ASSERT_TRUE(curl.Get(GetUrlOfTestFile(TEST_FILES_RANGES), result));
-//  ASSERT_TRUE(result.empty());
-//  CheckRangesTestFileResponse(curl, MHD_HTTP_NOT_MODIFIED, true);
-//}
-//
-//TEST_F(TestWebServer, CanGetCachedFileWithNewerIfModifiedSince)
-//{
-//  // get the last modified date of the file
-//  CDateTime lastModified;
-//  ASSERT_TRUE(GetLastModifiedOfTestFile(TEST_FILES_RANGES, lastModified));
-//  CDateTime lastModifiedNewer = lastModified + CDateTimeSpan(1, 0, 0, 0);
-//
-//  // get the file with a newer If-Modified-Since value
-//  std::string result;
-//  CCurlFile curl;
-//  curl.SetRequestHeader(MHD_HTTP_HEADER_RANGE, "");
-//  curl.SetRequestHeader(MHD_HTTP_HEADER_IF_MODIFIED_SINCE, lastModifiedNewer.GetAsRFC1123DateTime());
-//  ASSERT_TRUE(curl.Get(GetUrlOfTestFile(TEST_FILES_RANGES), result));
-//  ASSERT_TRUE(result.empty());
-//  CheckRangesTestFileResponse(curl, MHD_HTTP_NOT_MODIFIED, true);
-//}
+TEST_F(TestWebServer, CanGetCachedFileWithExactIfModifiedSince)
+{
+  // get the last modified date of the file
+  CDateTime lastModified;
+  ASSERT_TRUE(GetLastModifiedOfTestFile(TEST_FILES_RANGES, lastModified));
+
+  // get the file with the exact If-Modified-Since value
+  std::string result;
+  CCurlFile curl;
+  curl.SetRequestHeader(MHD_HTTP_HEADER_RANGE, "");
+  curl.SetRequestHeader(MHD_HTTP_HEADER_IF_MODIFIED_SINCE, lastModified.GetAsRFC1123DateTime());
+  ASSERT_TRUE(curl.Get(GetUrlOfTestFile(TEST_FILES_RANGES), result));
+  ASSERT_TRUE(result.empty());
+  CheckRangesTestFileResponse(curl, MHD_HTTP_NOT_MODIFIED, true);
+}
+
+TEST_F(TestWebServer, CanGetCachedFileWithNewerIfModifiedSince)
+{
+  // get the last modified date of the file
+  CDateTime lastModified;
+  ASSERT_TRUE(GetLastModifiedOfTestFile(TEST_FILES_RANGES, lastModified));
+  CDateTime lastModifiedNewer = lastModified + CDateTimeSpan(1, 0, 0, 0);
+
+  // get the file with a newer If-Modified-Since value
+  std::string result;
+  CCurlFile curl;
+  curl.SetRequestHeader(MHD_HTTP_HEADER_RANGE, "");
+  curl.SetRequestHeader(MHD_HTTP_HEADER_IF_MODIFIED_SINCE,
+                        lastModifiedNewer.GetAsRFC1123DateTime());
+  ASSERT_TRUE(curl.Get(GetUrlOfTestFile(TEST_FILES_RANGES), result));
+  ASSERT_TRUE(result.empty());
+  CheckRangesTestFileResponse(curl, MHD_HTTP_NOT_MODIFIED, true);
+}
 
 TEST_F(TestWebServer, CanGetCachedFileWithNewerIfModifiedSinceForcingNoCache)
 {

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -181,9 +181,7 @@ protected:
     // Content-Type must be "text/html"
     EXPECT_STREQ("text/plain", httpHeader.GetMimeType().c_str());
     // check Content-Length
-    if (empty)
-      EXPECT_STREQ("0", httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
-    else
+    if (!empty)
       EXPECT_STREQ("20", httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
     // Accept-Ranges must be "bytes"
     EXPECT_STREQ("bytes", httpHeader.GetValue(MHD_HTTP_HEADER_ACCEPT_RANGES).c_str());


### PR DESCRIPTION
## Description
This fixes two unit tests in `TestWebServer.cpp` which were disabled a while ago because they kept failing. I investigated the issue and both unit tests result in HTTP responses with no content (because the cache response is still valid). In such cases `CWebServer` doesn't return a `Content-Length` header because the HTTP 304 "Not Modified" status already implies that there is no content. But the unit tests expected `Content-Length: 0` as a header.

## How has this been tested?
Manually on my development machine.

## What is the effect on users?
No effect on the end user because it only affects unit tests.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] All new and existing tests passed
