### PR TITLE
CWinSystemWayland: try to keep fullscreen states (windowing and advanced settings) synchronized

### DIFF
--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -408,7 +408,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
     return;
   }
 
-  if (res >= RES_DESKTOP)
+  if (CDisplaySettings::GetInstance().GetResolutionInfo(res).bFullScreen)
   {
     CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen = true;
     m_bFullScreenRoot = true;

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -343,7 +343,7 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
 
   // Update resolution with real size as it could have changed due to configure()
   UpdateDesktopResolution(res, res.strOutput, m_bufferSize.Width(), m_bufferSize.Height(), res.fRefreshRate, 0);
-  res.bFullScreen = fullScreen;
+  res.bFullScreen = m_bFullScreen;
 
   // Now start processing events
   //
@@ -787,7 +787,7 @@ void CWinSystemWayland::OnConfigure(std::uint32_t serial, CSizeInt size, IShellS
     CLog::LogF(LOGDEBUG, "Initial configure serial {}: size {}x{} state {}", serial, size.Width(),
                size.Height(), IShellSurface::StateToString(state));
     m_shellSurfaceState = state;
-    if (!size.IsZero())
+    if (!size.IsZero() || state.test(IShellSurface::STATE_FULLSCREEN))
     {
       UpdateSizeVariables(size, m_scale, m_shellSurfaceState, true);
     }
@@ -1015,6 +1015,7 @@ CWinSystemWayland::SizeUpdateInformation CWinSystemWayland::UpdateSizeVariables(
   m_surfaceSize = sizes.surfaceSize;
   m_bufferSize = sizes.bufferSize;
   m_configuredSize = sizes.configuredSize;
+  m_bFullScreen = state.test(IShellSurface::STATE_FULLSCREEN);
 
   SizeUpdateInformation changes{m_surfaceSize != oldSurfaceSize, m_bufferSize != oldBufferSize, m_configuredSize != oldConfiguredSize, m_scale != oldBufferScale};
 


### PR DESCRIPTION
## Description
CWinSystemWayland: keep initializing until first non-zero configure

the very first configure event doesn't necessarily include a size nor acknowledged our fullscreen request.
Keep handling configure events synchronously until we get an event that has either.

## Motivation and context

We have to do this because otherwise events are queued, and queued
events are only processed when a frame has been committed -- but if
nothing is configured yet we'll never get that commit event either,
thus never process the precious configure event that does have useful
information we need to act on.

## How has this been tested?
Ran on linux/sway. Will also test with Gnome in a bit.

## What is the effect on users?
Fixes #20629 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed


I'll check how to run tests after trying to run on gnome, but if the window opens properly there should be no further impact.