### PR TITLE
[tools/depends][target] update meson-cross-file due to deprecation warnings

### DIFF
--- a/tools/depends/target/meson-cross-setup.sh
+++ b/tools/depends/target/meson-cross-setup.sh
@@ -15,13 +15,16 @@ cpu = '$CPU'
 endian = 'little'
 
 [properties]
+pkg_config_libdir = '$PREFIX/lib/pkgconfig'
+
+[built-in options]
 $($NATIVEPREFIX/bin/python3 -c "print('c_args = {}'.format([x for x in '$CFLAGS'.split() if x not in ['-g', '-gdwarf-2']]))")
 $($NATIVEPREFIX/bin/python3 -c "print('c_link_args = {}'.format([x for x in '$LDFLAGS'.split()]))")
 $($NATIVEPREFIX/bin/python3 -c "print('cpp_args = {}'.format([x for x in '$CXXFLAGS'.split() if x not in ['-g', '-gdwarf-2']]))")
 $($NATIVEPREFIX/bin/python3 -c "print('cpp_link_args = {}'.format([x for x in '$LDFLAGS'.split()]))")
-
-[paths]
+default_library = 'static'
 prefix = '$PREFIX'
 libdir = 'lib'
 bindir = 'bin'
+includedir = 'include'
 EOF


### PR DESCRIPTION
## Description
Update meson cross file to remove following deprecation warnings

DEPRECATION: The [paths] section is deprecated, use the [built-in options] section instead.
DEPRECATION: c_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: c_link_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: cpp_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: cpp_link_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.

This change brings a requirement of meson 0.56.0 to build kodi as per

https://mesonbuild.com/Machine-files.html#meson-builtin-options

## Motivation and context
Deprecation warnings for tools/depend builds using current native built meson version.
As this as a quick change, figured id PR it. If people dont want the hard dependency on meson 0.56.0, can just close, let me know.

## How has this been tested?
Built fribidi using meson for osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
