### PR TITLE
fix english keyboard layout - semicolon

### DIFF
--- a/system/keyboardlayouts/english.xml
+++ b/system/keyboardlayouts/english.xml
@@ -8,7 +8,7 @@ Default font lacks support for all characters
     <keyboard>
       <row>1234567890-=`</row>
       <row>qwertyuiop[]\</row>
-      <row>asdfghjkl:'</row>
+      <row>asdfghjkl;'</row>
       <row>zxcvbnm,./</row>
     </keyboard>
     <keyboard modifiers="shift">
@@ -34,7 +34,7 @@ Default font lacks support for all characters
     <keyboard>
       <row>1234567890-=`</row>
       <row>azertyuiop[]\</row>
-      <row>qsdfghjklm:'</row>
+      <row>qsdfghjklm;'</row>
       <row>wxcvbn,./</row>
     </keyboard>
     <keyboard modifiers="shift">
@@ -60,7 +60,7 @@ Default font lacks support for all characters
     <keyboard>
       <row>1234567890-=`</row>
       <row>abcdefghij[]\</row>
-      <row>klmnopqrst:'</row>
+      <row>klmnopqrst;'</row>
       <row>uvwxyz,./</row>
     </keyboard>
     <keyboard modifiers="shift">


### PR DESCRIPTION
## Description
the semicolon `;` was missing from the english osd keyboard, so users were unable to enter that character.
it got lost during my keyboard shuffle in https://github.com/xbmc/xbmc/pull/15687, so let's fix that.

@scott967 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
