### PR TITLE
[Android][Fix] System Info displays empty/incorrect CPU info values

### DIFF
--- a/xbmc/platform/android/CPUInfoAndroid.cpp
+++ b/xbmc/platform/android/CPUInfoAndroid.cpp
@@ -8,9 +8,13 @@
 
 #include "CPUInfoAndroid.h"
 
+#include "URL.h"
+#include "utils/StringUtils.h"
 #include "utils/Temperature.h"
 
 #include "platform/android/activity/AndroidFeatures.h"
+
+#include <array>
 
 std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
 {
@@ -19,6 +23,28 @@ std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
 
 CCPUInfoAndroid::CCPUInfoAndroid()
 {
+  m_posixFile = std::make_unique<CPosixFile>();
+
+  if (m_posixFile && m_posixFile->Open(CURL("/proc/cpuinfo")))
+  {
+    std::array<char, 2048> buffer = {};
+
+    if (0 < m_posixFile->Read(buffer.data(), buffer.size()))
+    {
+      for (const auto& line : StringUtils::Split(buffer.data(), '\n'))
+      {
+        if (line.find("vendor_id") != std::string::npos)
+          m_cpuVendor = line.substr(line.find(':') + 2);
+        else if (line.find("model name") != std::string::npos)
+          m_cpuModel = line.substr(line.find(':') + 2);
+        else if (line.find("BogoMIPS") != std::string::npos)
+          m_cpuBogoMips = line.substr(line.find(':') + 2);
+      }
+    }
+
+    m_posixFile->Close();
+  }
+
   m_cpuCount = CAndroidFeatures::GetCPUCount();
 
   for (int i = 0; i < m_cpuCount; i++)
@@ -30,4 +56,24 @@ CCPUInfoAndroid::CCPUInfoAndroid()
 
   if (CAndroidFeatures::HasNeon())
     m_cpuFeatures |= CPU_FEATURE_NEON;
+}
+
+float CCPUInfoAndroid::GetCPUFrequency()
+{
+  float freq = 0.f;
+
+  if (!m_posixFile)
+    return freq;
+
+  if (m_posixFile->Open(CURL("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq")))
+  {
+    std::array<char, 32> buffer = {};
+
+    if (0 < m_posixFile->Read(buffer.data(), buffer.size()))
+      freq = std::atof(buffer.data()) / 1000;
+
+    m_posixFile->Close();
+  }
+
+  return freq;
 }

--- a/xbmc/platform/android/CPUInfoAndroid.h
+++ b/xbmc/platform/android/CPUInfoAndroid.h
@@ -11,6 +11,11 @@
 #include "utils/Temperature.h"
 
 #include "platform/posix/CPUInfoPosix.h"
+#include "platform/posix/filesystem/PosixFile.h"
+
+#include <memory>
+
+using namespace XFILE;
 
 class CCPUInfoAndroid : public CCPUInfoPosix
 {
@@ -20,5 +25,8 @@ public:
 
   bool SupportsCPUUsage() const override { return false; }
   int GetUsedPercentage() override { return 0; }
-  float GetCPUFrequency() override { return 0; }
+  float GetCPUFrequency() override;
+
+private:
+  std::unique_ptr<CPosixFile> m_posixFile;
 };


### PR DESCRIPTION
## Description
Implements some basic CPU info methods for Android.

Fixes https://github.com/xbmc/xbmc/issues/20619

## Motivation and context
System Info - Hardware displays empty/incorrect CPU info values. It seems that the functionality for Android was never implemented or worked differently before.

## How has this been tested?
Runtime tested on Nvidia Shield Pro 2019 (ARM64) and Android TV (ARM)

## What is the effect on users?
Provides some basic CPU info: model name, mips, frequency. ~Corrects wrong temperature indication (-1 ºC).~ 

Also improves logs info:

**Before**
```
2021-12-08 10:13:28.812 T:12633    INFO <general>: FFmpeg version/source: 4.4-Kodi
2021-12-08 10:13:28.812 T:12633    INFO <general>: 4 CPU cores available
```

**After**
```
2021-12-08 10:16:45.296 T:13108    INFO <general>: FFmpeg version/source: 4.4-Kodi
2021-12-08 10:16:45.296 T:13108    INFO <general>: Host CPU: ARMv8 Processor rev 1 (v8l), 4 cores available
```

## Screenshots (if appropriate):

**Before**
![screenshot00000](https://user-images.githubusercontent.com/58434170/145184419-9c7dc517-e8d0-43f7-b3d9-1c7b6998af7d.png)

**After**
![screenshot00001](https://user-images.githubusercontent.com/58434170/145184461-f75457b6-7e84-476f-b48b-8ae67008e184.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
