### PR TITLE
[skin] Reworked DialogPlayerProcess to add more info

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6524,7 +6524,6 @@ msgid "Hardware:"
 msgstr ""
 
 #: xbmc/windows/GUIWindowSystemInfo.cpp
-#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#13271"
 msgid "System CPU usage:"
 msgstr ""

--- a/addons/skin.estouchy/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estouchy/language/resource.language.en_gb/strings.po
@@ -78,22 +78,32 @@ msgctxt "#31016"
 msgid "Albums"
 msgstr ""
 
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show PVR info page
 msgctxt "#31017"
-msgid "PVR info"
+msgid "PVR"
 msgstr ""
 
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show player info page
 msgctxt "#31018"
-msgid "Player process info"
+msgid "Player"
 msgstr ""
 
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show video decoder name
 msgctxt "#31019"
 msgid "Video decoder"
 msgstr ""
 
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video pixel format
 msgctxt "#31020"
 msgid "Pixel format"
 msgstr ""
 
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system memory usage
 msgctxt "#31021"
 msgid "System memory usage"
 msgstr ""
@@ -386,7 +396,81 @@ msgctxt "#31565"
 msgid "Show deleted"
 msgstr ""
 
-#empty strings from id 31566 to 31899
+#empty strings from id 31566 to 31599
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video codec name
+msgctxt "#31600"
+msgid "Video codec"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video resolution
+msgctxt "#31601"
+msgid "Video resolution"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video aspect
+msgctxt "#31602"
+msgid "Video aspect"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video bitrate
+msgctxt "#31603"
+msgid "Video bitrate"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the audio codec name
+msgctxt "#31604"
+msgid "Audio codec"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the number of audio channels
+msgctxt "#31605"
+msgid "Audio channels"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the audio bitrate
+msgctxt "#31606"
+msgid "Audio bitrate"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the screen resolution
+msgctxt "#31607"
+msgid "Screen resolution"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system rendering speed
+msgctxt "#31608"
+msgid "System rendering speed"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system CPU usage
+msgctxt "#31609"
+msgid "System CPU usage"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the media (metadata) info page
+msgctxt "#31610"
+msgid "Media"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system info page
+msgctxt "#31611"
+msgid "System"
+msgstr ""
+
+#empty strings from id 31612 to 31899
 
 msgctxt "#31900"
 msgid "First Run"

--- a/addons/skin.estouchy/xml/DialogPlayerProcessInfo.xml
+++ b/addons/skin.estouchy/xml/DialogPlayerProcessInfo.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<defaultcontrol always="true">5553</defaultcontrol>
 	<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
 	<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 	<include>16x9_xPos_Relocation</include>
-	<onunload>ClearProperty(PlayerPVRInfo,Home)</onunload>
+	<onload>SetProperty(PlayerInfoDialogFocus,5553,Home)</onload>
+	<onunload>ClearProperty(PlayerInfoDialogFocus,Home)</onunload>
 	<controls>
 		<control type="group">
 			<posy>80</posy>
@@ -20,9 +22,9 @@
 				<include>DialogCloseButtonCommons</include>
 			</control>
 			<control type="grouplist">
-				<posx>52</posx>
+				<posx>50</posx>
 				<posy>50</posy>
-				<visible>!String.IsEmpty(Window(Home).Property(PlayerPVRInfo))</visible>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5551)</visible>
 				<control type="label">
 					<width>800</width>
 					<height>30</height>
@@ -75,7 +77,7 @@
 			<control type="grouplist">
 				<posx>850</posx>
 				<posy>50</posy>
-				<visible>!String.IsEmpty(Window(Home).Property(PlayerPVRInfo))</visible>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5551)</visible>
 				<control type="label">
 					<width>400</width>
 					<height>30</height>
@@ -131,9 +133,82 @@
 				</control>
 			</control>
 			<control type="grouplist">
-				<posx>52</posx>
+				<posx>50</posx>
 				<posy>20</posy>
-				<visible>String.IsEmpty(Window(Home).Property(PlayerPVRInfo))</visible>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5552)</visible>
+				<control type="label">
+					<width>600</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoCodec,[COLOR blue]$LOCALIZE[31600]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>600</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoResolution,[COLOR blue]$LOCALIZE[31601]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>600</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoAspect,[COLOR blue]$LOCALIZE[31602]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>600</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoBitrate,[COLOR blue]$LOCALIZE[31603]:[/COLOR] , kb/s]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+			</control>
+			<control type="grouplist">
+				<posx>650</posx>
+				<posy>20</posy>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5552)</visible>
+				<control type="label">
+					<width>600</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.AudioCodec,[COLOR blue]$LOCALIZE[31604]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>600</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.AudioChannels,[COLOR blue]$LOCALIZE[31605]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>600</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.AudioBitrate,[COLOR blue]$LOCALIZE[31606]:[/COLOR] , kb/s]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+			</control>
+			<control type="grouplist">
+				<posx>50</posx>
+				<posy>20</posy>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5553)</visible>
 				<control type="label">
 					<width>1000</width>
 					<height>30</height>
@@ -178,22 +253,53 @@
 					<font>font25</font>
 					<shadowcolor>black</shadowcolor>
 				</control>
+			</control>
+			<control type="grouplist">
+				<posx>50</posx>
+				<posy>20</posy>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5554)</visible>
 				<control type="label">
 					<width>1000</width>
 					<height>30</height>
 					<aligny>bottom</aligny>
-					<label>$INFO[System.Memory(used.percent),[COLOR blue]$LOCALIZE[31021]:[/COLOR] ,       ]</label>
+					<label>$INFO[System.ScreenResolution,[COLOR blue]$LOCALIZE[31607]:[/COLOR] ]</label>
 					<font>font25</font>
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
 					<width>1000</width>
-					<height>60</height>
+					<height>30</height>
 					<aligny>bottom</aligny>
-					<label>$INFO[System.CpuUsage,[COLOR blue]$LOCALIZE[13271][/COLOR] ]</label>
+					<label>$INFO[System.FPS,[COLOR blue]$LOCALIZE[31608]:[/COLOR] , fps]</label>
 					<font>font25</font>
 					<shadowcolor>black</shadowcolor>
-					<wrapmultiline>true</wrapmultiline>
+				</control>
+				<control type="label">
+					<width>1000</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[System.Memory(used.percent),[COLOR blue]$LOCALIZE[31021]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>System.SupportsCPUUsage</visible>
+				</control>
+				<control type="label">
+					<width>1000</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[System.CpuUsage,[COLOR blue]$LOCALIZE[31609]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>System.SupportsCPUUsage</visible>
+				</control>
+				<control type="label">
+					<width>1000</width>
+					<height>30</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[System.Memory(used.percent),[COLOR blue]$LOCALIZE[31021]:[/COLOR] ]</label>
+					<font>font25</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!System.SupportsCPUUsage</visible>
 				</control>
 			</control>
 			<control type="grouplist" id="5550">
@@ -204,20 +310,34 @@
 				<align>center</align>
 				<orientation>horizontal</orientation>
 				<itemgap>10</itemgap>
-				<control type="button" id="5552">
-					<width>250</width>
-					<height>60</height>
-					<include>ButtonInfoDialogsCommonValues</include>
-					<onclick>ClearProperty(PlayerPVRInfo,Home)</onclick>
-					<label>$LOCALIZE[31018]</label>
-				</control>
 				<control type="button" id="5551">
 					<width>250</width>
 					<height>60</height>
 					<include>ButtonInfoDialogsCommonValues</include>
 					<label>$LOCALIZE[31017]</label>
-					<onclick>SetProperty(PlayerPVRInfo,true,Home)</onclick>
 					<visible>VideoPlayer.Content(livetv)</visible>
+					<onclick>SetProperty(PlayerInfoDialogFocus,5551,Home)</onclick>
+				</control>
+				<control type="button" id="5552">
+					<width>250</width>
+					<height>60</height>
+					<include>ButtonInfoDialogsCommonValues</include>
+					<label>$LOCALIZE[31610]</label>
+					<onclick>SetProperty(PlayerInfoDialogFocus,5552,Home)</onclick>
+				</control>
+				<control type="button" id="5553">
+					<width>250</width>
+					<height>60</height>
+					<include>ButtonInfoDialogsCommonValues</include>
+					<label>$LOCALIZE[31018]</label>
+					<onclick>SetProperty(PlayerInfoDialogFocus,5553,Home)</onclick>
+				</control>
+				<control type="button" id="5554">
+					<width>250</width>
+					<height>60</height>
+					<include>ButtonInfoDialogsCommonValues</include>
+					<label>$LOCALIZE[31611]</label>
+					<onclick>SetProperty(PlayerInfoDialogFocus,5554,Home)</onclick>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -181,6 +181,8 @@ msgid "Last logged in"
 msgstr ""
 
 #: /xml/SettingsSystemInfo.xml
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system memory usage
 msgctxt "#31030"
 msgid "System memory usage"
 msgstr ""
@@ -640,21 +642,25 @@ msgid "Click here to see latest changes..."
 msgstr ""
 
 #: /xml/DialogPlayerProcessInfo.xml
+#. Label to show PVR info page
 msgctxt "#31137"
-msgid "PVR info"
+msgid "PVR"
 msgstr ""
 
 #: /xml/DialogPlayerProcessInfo.xml
+#. Label to show player info page
 msgctxt "#31138"
-msgid "Player process info"
+msgid "Player"
 msgstr ""
 
 #: /xml/DialogPlayerProcessInfo.xml
+#. Label to show video decoder name
 msgctxt "#31139"
 msgid "Video decoder"
 msgstr ""
 
 #: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video pixel format
 msgctxt "#31140"
 msgid "Pixel format"
 msgstr ""
@@ -806,4 +812,78 @@ msgstr ""
 #: /xml/Variables.xml
 msgctxt "#31169"
 msgid "Artwork related settings."
+msgstr ""
+
+#empty strings from id 31170 to 31599
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video codec name
+msgctxt "#31600"
+msgid "Video codec"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video resolution
+msgctxt "#31601"
+msgid "Video resolution"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video aspect
+msgctxt "#31602"
+msgid "Video aspect"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video bitrate
+msgctxt "#31603"
+msgid "Video bitrate"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the audio codec name
+msgctxt "#31604"
+msgid "Audio codec"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the number of audio channels
+msgctxt "#31605"
+msgid "Audio channels"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the audio bitrate
+msgctxt "#31606"
+msgid "Audio bitrate"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the screen resolution
+msgctxt "#31607"
+msgid "Screen resolution"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system rendering speed
+msgctxt "#31608"
+msgid "System rendering speed"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system CPU usage
+msgctxt "#31609"
+msgid "System CPU usage"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the media (metadata) info page
+msgctxt "#31610"
+msgid "Media"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the system info page
+msgctxt "#31611"
+msgid "System"
 msgstr ""

--- a/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
+++ b/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<depth>DepthOSD</depth>
-	<defaultcontrol always="true">5550</defaultcontrol>
+	<defaultcontrol always="true">5553</defaultcontrol>
 	<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
 	<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+	<onunload>ClearProperty(PlayerInfoDialogFocus,Home)</onunload>
 	<controls>
 		<control type="group">
 			<bottom>0</bottom>
@@ -17,9 +18,9 @@
 				<texture border="40">dialogs/dialog-bg-nobo.png</texture>
 			</control>
 			<control type="grouplist">
-				<left>52</left>
+				<left>50</left>
 				<top>-204</top>
-				<visible>Control.HasFocus(5551)</visible>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5551)</visible>
 				<control type="label">
 					<width>1200</width>
 					<height>50</height>
@@ -72,7 +73,7 @@
 			<control type="grouplist">
 				<left>1250</left>
 				<top>-204</top>
-				<visible>Control.HasFocus(5551)</visible>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5551)</visible>
 				<usecontrolcoords>true</usecontrolcoords>
 				<control type="label">
 					<width>600</width>
@@ -129,9 +130,82 @@
 				</control>
 			</control>
 			<control type="grouplist">
-				<left>52</left>
+				<left>50</left>
 				<top>-204</top>
-				<visible>Control.HasFocus(5552)</visible>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5552)</visible>
+				<control type="label">
+					<width>830</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoCodec,[COLOR button_focus]$LOCALIZE[31600]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoResolution,[COLOR button_focus]$LOCALIZE[31601]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoAspect,[COLOR button_focus]$LOCALIZE[31602]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.VideoBitrate,[COLOR button_focus]$LOCALIZE[31603]:[/COLOR] , kb/s]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+			</control>
+			<control type="grouplist">
+				<left>1010</left>
+				<top>-204</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5552)</visible>
+				<control type="label">
+					<width>830</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.AudioCodec,[COLOR button_focus]$LOCALIZE[31604]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.AudioChannels,[COLOR button_focus]$LOCALIZE[31605]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+				<control type="label">
+					<width>830</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.AudioBitrate,[COLOR button_focus]$LOCALIZE[31606]:[/COLOR] , kb/s]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>Player.HasVideo</visible>
+				</control>
+			</control>
+			<control type="grouplist">
+				<left>50</left>
+				<top>-204</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5553)</visible>
 				<control type="label">
 					<width>1600</width>
 					<height>50</height>
@@ -176,11 +250,41 @@
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
 				</control>
+			</control>
+			<control type="grouplist">
+				<left>50</left>
+				<top>-204</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5554)</visible>
 				<control type="label">
 					<width>1600</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
-					<label>$INFO[System.Memory(used.percent),[COLOR button_focus]$LOCALIZE[31030]:[/COLOR] ,       ]$INFO[System.CpuUsage,[COLOR button_focus]$LOCALIZE[13271][/COLOR] ]</label>
+					<label>$INFO[System.ScreenResolution,[COLOR button_focus]$LOCALIZE[31607]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[System.FPS,[COLOR button_focus]$LOCALIZE[31608]:[/COLOR] , fps]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[System.Memory(used.percent),[COLOR button_focus]$LOCALIZE[31030]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>System.SupportsCPUUsage</visible>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[System.CpuUsage,[COLOR button_focus]$LOCALIZE[31609]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
 					<visible>System.SupportsCPUUsage</visible>
@@ -212,12 +316,28 @@
 					<textoffsetx>40</textoffsetx>
 					<label>$LOCALIZE[31137]</label>
 					<visible>VideoPlayer.Content(livetv)</visible>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,5551,Home)</onfocus>
 				</control>
 				<control type="button" id="5552">
 					<width>auto</width>
 					<height>100</height>
 					<textoffsetx>40</textoffsetx>
+					<label>$LOCALIZE[31610]</label>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,5552,Home)</onfocus>
+				</control>
+				<control type="button" id="5553">
+					<width>auto</width>
+					<height>100</height>
+					<textoffsetx>40</textoffsetx>
 					<label>$LOCALIZE[31138]</label>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,5553,Home)</onfocus>
+				</control>
+				<control type="button" id="5554">
+					<width>auto</width>
+					<height>100</height>
+					<textoffsetx>40</textoffsetx>
+					<label>$LOCALIZE[31611]</label>
+					<onfocus>SetProperty(PlayerInfoDialogFocus,5554,Home)</onfocus>
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This will add more infos to the current Player Process Info window dialog,
now there are four sections:
- PVR -> to see PVR info (unchanged)
- Media -> to see metadata infos
- Player -> (the previous `Player Process Info`) to see infos processed by the kodi player
- System -> to check system status

the name of the xml (DialogPlayerProcessInfo.xml) should be renamed (in future on other PR) appropriately to better reflect its functionality, since more information is now being provided not only for `Player Process Info`

In estuary skin, i have also made a small fix to keep the information visible on the screen even when moving the mouse pointer.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initially for the need to see in real time when the video bitrate change while watching a video with InputStreamAdaptive,
then has been discussed (#20593) to reorganise the information in the most appropriate way

This superseed PR's:
#20593
#11693

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
by using InputStreamAdaptive, see screenshots

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More useful information

## Screenshots (if appropriate):
Estouchy
![immagine](https://user-images.githubusercontent.com/3257156/145208335-bb2c65be-9ee2-4269-8b0d-990c22bcec1f.png)
Estuary
![immagine](https://user-images.githubusercontent.com/3257156/145208466-91fd59ac-49d5-437a-a9e8-b5e6cc00cee9.png)
![immagine](https://user-images.githubusercontent.com/3257156/145208500-9a394959-f439-459f-9be2-f0c073381c40.png)
![immagine](https://user-images.githubusercontent.com/3257156/145213912-85b3c3e8-b7f7-44f3-849f-6d70683d54d6.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
