### PR TITLE
[PVR] Guide window: Fix 'smart select' prompt for items that cannot be recorded.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3706,9 +3706,10 @@ msgctxt "#825"
 msgid "Recording: {0:s}"
 msgstr ""
 
-#. Label for a context menu entry to add a reminder timer
+#. Label for buttons to add a PVR reminder timer
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: xbmc/pvr/PVRContextMenus.cpp
+#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
 msgctxt "#826"
 msgid "Set reminder"
 msgstr ""
@@ -11302,7 +11303,13 @@ msgctxt "#19343"
 msgid "[saved]"
 msgstr ""
 
-#empty strings from id 19344 to 19498
+#. text for yes no dialog shown when user selects a future programme in the guide window and default select action is 'smart select'
+#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+msgctxt "#19344"
+msgid "Do you want to set a reminder for the selected programme or to switch to the current programme?"
+msgstr ""
+
+#empty strings from id 19345 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -22,6 +22,7 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "pvr/PVRItem.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
@@ -466,11 +467,22 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                         CServiceBroker::GetPVRManager().GUIActions()->EditTimer(pItem);
                       else
                       {
-                        HELPERS::DialogResponse ret
-                          = HELPERS::ShowYesNoDialogText(CVariant{19096}, // "Smart select"
-                                                          CVariant{19302}, // "Do you want to record the selected programme or to switch to the current programme?"
-                                                          CVariant{264}, // No => "Record"
-                                                          CVariant{19165}); // Yes => "Switch"
+                        bool bCanRecord = true;
+                        const std::shared_ptr<CPVRChannel> channel = CPVRItem(pItem).GetChannel();
+                        if (channel)
+                          bCanRecord = channel->CanRecord();
+
+                        const int iTextID =
+                            bCanRecord
+                                ? 19302 // "Do you want to record the selected programme or to switch to the current programme?"
+                                : 19344; // "Do you want to set a reminder for the selected programme or to switch to the current programme?"
+                        const int iNoButtonID = bCanRecord ? 264 // No => "Record"
+                                                           : 826; // "Set reminder"
+
+                        HELPERS::DialogResponse ret =
+                            HELPERS::ShowYesNoDialogText(CVariant{19096}, // "Smart select"
+                                                         CVariant{iTextID}, CVariant{iNoButtonID},
+                                                         CVariant{19165}); // Yes => "Switch"
                         if (ret == HELPERS::DialogResponse::NO)
                           CServiceBroker::GetPVRManager().GUIActions()->AddTimer(pItem, false);
                         else if (ret == HELPERS::DialogResponse::YES)


### PR DESCRIPTION
A small glitch, a dialog box using the wrong wording. If a channel does not support recording, user should not be prompted whether the programme should be recorded, right?

If selected channel supports recording:

![screenshot00005](https://user-images.githubusercontent.com/3226626/145436068-6684a796-3417-4686-a636-7fbd5ea82c84.png)

If selected channel does not allow recordings:

![screenshot00004](https://user-images.githubusercontent.com/3226626/145436085-3d7dbe8f-843a-4971-ae95-873d50e84654.png)

Runtime-tested on macOS and Android, latest master.

@phunkyfish mind looking at the code change?

