### PR TITLE
[PVR] Fix PVR Channel Manager to internally work with plain URLs, notimage URLs.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -771,7 +771,7 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty("ActiveChannel", !channel->IsHidden());
     channelFile->SetProperty("Name", channel->ChannelName());
     channelFile->SetProperty("UseEPG", channel->EPGEnabled());
-    channelFile->SetProperty("Icon", channel->IconPath());
+    channelFile->SetProperty("Icon", channel->ClientIconPath());
     channelFile->SetProperty("EPGSource", 0);
     channelFile->SetProperty("ParentalLocked", channel->IsLocked());
     channelFile->SetProperty("Number", member->ChannelNumber().FormattedChannelNumber());


### PR DESCRIPTION
Smal logic glitch - fixes log spam "Not allowed to call this method with an image URL" while closing channel manager.

Runtime-tested on macOS and Android latest master.

@phunkyfish this one is a no-brainer