### PR TITLE
string resources: insert missing "Jazz" subgenre

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11570,16 +11570,22 @@ msgstr ""
 #. label for "music/ballet/dance" epg subgenre value
 #: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19584"
-msgid "Musical / Opera"
+msgid "Jazz"
 msgstr ""
 
 #. label for "music/ballet/dance" epg subgenre value
 #: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19585"
+msgid "Musical / Opera"
+msgstr ""
+
+#. label for "music/ballet/dance" epg subgenre value
+#: xbmc/pvr/epg/Epg.cpp
+msgctxt "#19586"
 msgid "Ballet"
 msgstr ""
 
-#empty strings from id 19586 to 19595
+#empty strings from id 19587 to 19595
 
 #. label for "arts/culture" epg genre value
 #: xbmc/pvr/epg/Epg.cpp


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Currently, the MUSICBALLETDANCE_JAZZ subgenre (0x4) is incorrectly displayed as "Musical / Opera", and the MUSICBALLETDANCE_MUSICAL_OPERA subgenre (0x5) is incorrectly displayed as "Ballet" . The change fixes this incorrect behaviour.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I discovered the discrepancy between EPG database and Kodi display with Kodi Matrix on Android, when using the Tvheadend PVR addon, connected to a Tvheadend server (current master). Then I started digging in the code, and found the missing entry in strings.po.

For reference, the **correct** subgenre sequence is defined in xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h:
    EPG_EVENT_CONTENTSUBMASK_MUSICBALLETDANCE_GENERAL = 0x0,
    EPG_EVENT_CONTENTSUBMASK_MUSICBALLETDANCE_ROCKPOP = 0x1,
    EPG_EVENT_CONTENTSUBMASK_MUSICBALLETDANCE_SERIOUSMUSIC_CLASSICALMUSIC = 0x2,
    EPG_EVENT_CONTENTSUBMASK_MUSICBALLETDANCE_FOLK_TRADITIONAL_MUSIC = 0x3,
    EPG_EVENT_CONTENTSUBMASK_MUSICBALLETDANCE_JAZZ = 0x4,
    EPG_EVENT_CONTENTSUBMASK_MUSICBALLETDANCE_MUSICAL_OPERA = 0x5,
    EPG_EVENT_CONTENTSUBMASK_MUSICBALLETDANCE_BALLET = 0x6,

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Honestly, the investment in a complete Kodi build/test environment is too big, just to test this rather trivial fix.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users should now see the right subgenre, according to ETSI EN 300 468, Table 28.

## Screenshots (if appropriate):
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
