### PR TITLE
[cmake] work around target gen expression issues for xcode projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,17 @@ endif()
 set(GLOBAL_TARGET_DEPS ffmpeg dvdnav crossguid fmt Spdlog::Spdlog fstrcmp flatbuffers ${PLATFORM_GLOBAL_TARGET_DEPS})
 
 # main library (used for main binary and tests)
-add_library(lib${APP_NAME_LC} STATIC $<TARGET_OBJECTS:compileinfo>)
+if(CMAKE_GENERATOR STREQUAL Xcode)
+  add_library(compileinfo_obj OBJECT IMPORTED)
+  set_property(TARGET compileinfo_obj PROPERTY IMPORTED_OBJECTS
+    "${CMAKE_BINARY_DIR}/$(PROJECT_NAME).build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/compileinfo.build/$(OBJECT_FILE_DIR_normal:base)/$(CURRENT_ARCH)/CompileInfo.o"
+  )
+  add_library(lib${APP_NAME_LC} STATIC)
+  add_dependencies(lib${APP_NAME_LC} compileinfo)
+  target_link_libraries(lib${APP_NAME_LC} PUBLIC compileinfo_obj)
+else()
+  add_library(lib${APP_NAME_LC} STATIC $<TARGET_OBJECTS:compileinfo>)
+endif()
 add_dependencies(lib${APP_NAME_LC} ${GLOBAL_TARGET_DEPS})
 set_target_properties(lib${APP_NAME_LC} PROPERTIES PREFIX "")
 


### PR DESCRIPTION
## Description
cmake has known shortcomings regarding generator expressions and xcode projects.
https://gitlab.kitware.com/cmake/cmake/-/issues/21039

The issue that shows up for kodi is arm64 build host building an x86_64 target, The
$<TARGET_OBJECTS:compileinfo> call can not detect the target arch type at build time,
and falls back to system arch at cmake generation time.
Build failure then occurs due to attempting to link compileinfo.o into libkodi.o from an
incorrect build folder (eg $(PROJECT_NAME).build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/compileinfo.build/$(OBJECT_FILE_DIR_normal:base)/arm64/CompileInfo.o)

## Motivation and context
Building x86_64 macos target on m1 device and having to manually alter the other library flags to the correct platform became annoying enough to dig into the cause

## How has this been tested?
Generation and build on m1 mac for x86_64 target

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
