### PR TITLE
[Android][Fix] System Info - Network displays malformed gateway string

### DIFF
--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -191,16 +191,16 @@ std::string CNetworkInterfaceAndroid::GetCurrentNetmask() const
 std::string CNetworkInterfaceAndroid::GetCurrentDefaultGateway() const
 {
   CJNIList<CJNIRouteInfo> ris = m_lp.getRoutes();
+
   for (int i = 0; i < ris.size(); ++i)
   {
     CJNIRouteInfo ri = ris.get(i);
     if (!ri.isDefaultRoute())
       continue;
 
-    CJNIInetAddress ia = ri.getGateway();
-    std::vector<char> adr = ia.getAddress();
-    return StringUtils::Format("{}.{}.{}.{}", adr[0], adr[1], adr[2], adr[3]);
+    return ri.getGateway().getHostAddress();
   }
+
   return "";
 }
 


### PR DESCRIPTION
## Description
Fix: System Info - Network displays malformed gateway string

## Motivation and context
Wrong string displayed because source data are type char (signed)  [-127 to 128] and numbers displayed need to be in range 0 to 255. 

Also found that `StringUtils::Format` is not necessary here because `getHostAddress()` returns IP string directly 😃

## How has this been tested?
Runtime tested Nvidia Shield 2019

## What is the effect on users?
Fixed network info displays malformed gateway string

## Screenshots (if appropriate):
**Before**
![screenshot00001](https://user-images.githubusercontent.com/58434170/145675297-8187c1cd-e0d5-4ac5-a159-abfc610bc50e.png)

**After**
![screenshot00000](https://user-images.githubusercontent.com/58434170/145675312-db75fd92-2d9b-470c-b99e-0de328fea565.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
