### PR TITLE
CUtil: remove usage of ARRAY_SIZE macro

### DIFF
--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -17,8 +17,6 @@
 #include <string.h>
 #include <vector>
 
-#define ARRAY_SIZE(X)         (sizeof(X)/sizeof((X)[0]))
-
 // A list of filesystem types for LegalPath/FileName
 #define LEGAL_NONE            0
 #define LEGAL_WIN32_COMPAT    1

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -146,6 +146,9 @@ static pa_encoding AEFormatToPulseEncoding(AEDataFormat format)
   }
 }
 
+namespace
+{
+
 // clang-format off
 constexpr std::array<AEDataFormat, 6> defaultDataFormats = {
   AE_FMT_U8,
@@ -173,6 +176,8 @@ constexpr std::array<unsigned int, 14> defaultSampleRates = {
   384000
 };
 // clang-format on
+
+} // namespace
 
 /* Static callback functions */
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -9,11 +9,12 @@
 
 #include "Application.h"
 #include "ServiceBroker.h"
-#include "Util.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
+
+#include <array>
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -145,7 +146,8 @@ static pa_encoding AEFormatToPulseEncoding(AEDataFormat format)
   }
 }
 
-static AEDataFormat defaultDataFormats[] = {
+// clang-format off
+constexpr std::array<AEDataFormat, 6> defaultDataFormats = {
   AE_FMT_U8,
   AE_FMT_S16NE,
   AE_FMT_S24NE3,
@@ -154,7 +156,7 @@ static AEDataFormat defaultDataFormats[] = {
   AE_FMT_FLOAT
 };
 
-static unsigned int defaultSampleRates[] = {
+constexpr std::array<unsigned int, 14> defaultSampleRates = {
   5512,
   8000,
   11025,
@@ -170,6 +172,7 @@ static unsigned int defaultSampleRates[] = {
   192000,
   384000
 };
+// clang-format on
 
 /* Static callback functions */
 
@@ -482,9 +485,10 @@ static void SinkInfoRequestCallback(pa_context *c, const pa_sink_info *i, int eo
     defaultDevice.m_deviceName = std::string("Default");
     defaultDevice.m_displayName = std::string("Default");
     defaultDevice.m_displayNameExtra = std::string("Default Output Device (PULSEAUDIO)");
-    defaultDevice.m_dataFormats.insert(defaultDevice.m_dataFormats.end(), defaultDataFormats, defaultDataFormats + ARRAY_SIZE(defaultDataFormats));
+    defaultDevice.m_dataFormats.insert(defaultDevice.m_dataFormats.end(),
+                                       defaultDataFormats.begin(), defaultDataFormats.end());
     defaultDevice.m_channels = CAEChannelInfo(AE_CH_LAYOUT_2_0);
-    defaultDevice.m_sampleRates.assign(defaultSampleRates, defaultSampleRates + ARRAY_SIZE(defaultSampleRates));
+    defaultDevice.m_sampleRates.assign(defaultSampleRates.begin(), defaultSampleRates.end());
     defaultDevice.m_deviceType = AE_DEVTYPE_PCM;
     defaultDevice.m_wantsIECPassthrough = true;
     sinkStruct->list->push_back(defaultDevice);
@@ -507,7 +511,7 @@ static void SinkInfoRequestCallback(pa_context *c, const pa_sink_info *i, int eo
     if(device.m_channels.Count() == 0)
       valid = false;
 
-    device.m_sampleRates.assign(defaultSampleRates, defaultSampleRates + ARRAY_SIZE(defaultSampleRates));
+    device.m_sampleRates.assign(defaultSampleRates.begin(), defaultSampleRates.end());
 
     for (unsigned int j = 0; j < i->n_formats; j++)
     {
@@ -529,7 +533,8 @@ static void SinkInfoRequestCallback(pa_context *c, const pa_sink_info *i, int eo
           device_type = AE_DEVTYPE_IEC958;
           break;
         case PA_ENCODING_PCM:
-          device.m_dataFormats.insert(device.m_dataFormats.end(), defaultDataFormats, defaultDataFormats + ARRAY_SIZE(defaultDataFormats));
+          device.m_dataFormats.insert(device.m_dataFormats.end(), defaultDataFormats.begin(),
+                                      defaultDataFormats.end());
           break;
         default:
           break;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
@@ -8,9 +8,10 @@
 
 #include "DVDCodecUtils.h"
 
-#include "Util.h"
 #include "cores/FFmpeg.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+
+#include <array>
 
 extern "C" {
 #include <libswscale/swscale.h>
@@ -35,13 +36,22 @@ bool CDVDCodecUtils::IsVP3CompatibleWidth(int width)
 double CDVDCodecUtils::NormalizeFrameduration(double frameduration, bool *match)
 {
   //if the duration is within 20 microseconds of a common duration, use that
-  const double durations[] = {DVD_TIME_BASE * 1.001 / 24.0, DVD_TIME_BASE / 24.0, DVD_TIME_BASE / 25.0,
-                              DVD_TIME_BASE * 1.001 / 30.0, DVD_TIME_BASE / 30.0, DVD_TIME_BASE / 50.0,
-                              DVD_TIME_BASE * 1.001 / 60.0, DVD_TIME_BASE / 60.0};
+  // clang-format off
+  constexpr std::array<double, 8> durations = {
+    DVD_TIME_BASE * 1.001 / 24.0,
+    DVD_TIME_BASE / 24.0,
+    DVD_TIME_BASE / 25.0,
+    DVD_TIME_BASE * 1.001 / 30.0,
+    DVD_TIME_BASE / 30.0,
+    DVD_TIME_BASE / 50.0,
+    DVD_TIME_BASE * 1.001 / 60.0,
+    DVD_TIME_BASE / 60.0
+  };
+  // clang-format on
 
   double lowestdiff = DVD_TIME_BASE;
   int    selected   = -1;
-  for (size_t i = 0; i < ARRAY_SIZE(durations); i++)
+  for (size_t i = 0; i < durations.size(); i++)
   {
     double diff = fabs(frameduration - durations[i]);
     if (diff < DVD_MSEC_TO_TIME(0.02) && diff < lowestdiff)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -722,7 +722,7 @@ void CYUV2RGBShader::SetShaderParameters(CRenderBuffer* videoBuffer)
   for (unsigned i = 0, max_i = videoBuffer->GetViewCount(); i < max_i; i++)
     ppSRView[i] = reinterpret_cast<ID3D11ShaderResourceView*>(videoBuffer->GetView(i));
   m_effect.SetResources("g_Texture", ppSRView, videoBuffer->GetViewCount());
-  m_effect.SetFloatArray("g_StepXY", m_texSteps, ARRAY_SIZE(m_texSteps));
+  m_effect.SetFloatArray("g_StepXY", m_texSteps.data(), m_texSteps.size());
 
   Matrix4 yuvMat = m_convMatrix.GetYuvMat();
   m_effect.SetMatrix("g_ColorMatrix", yuvMat.ToRaw());
@@ -871,9 +871,9 @@ void CConvolutionShader1Pass::Render(CD3DTexture& sourceTexture, CD3DTexture& ta
   const unsigned int sourceHeight = sourceTexture.GetHeight();
 
   PrepareParameters(sourceWidth, sourceHeight, sourceRect, destRect);
-  float texSteps[] = {1.0f / static_cast<float>(sourceWidth),
-                      1.0f / static_cast<float>(sourceHeight)};
-  SetShaderParameters(sourceTexture, &texSteps[0], ARRAY_SIZE(texSteps), useLimitRange);
+  std::array<float, 2> texSteps = {1.0f / static_cast<float>(sourceWidth),
+                                   1.0f / static_cast<float>(sourceHeight)};
+  SetShaderParameters(sourceTexture, texSteps.data(), texSteps.size(), useLimitRange);
   Execute({ &target }, 4);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -13,8 +13,10 @@
 #include "guilib/D3DResource.h"
 #include "utils/Geometry.h"
 
-#include <DirectXMath.h>
+#include <array>
 #include <vector>
+
+#include <DirectXMath.h>
 #include <wrl/client.h>
 
 extern "C" {
@@ -140,7 +142,7 @@ private:
   CRect m_sourceRect = {};
   CPoint m_dest[4] = {};
   AVPixelFormat m_format = AV_PIX_FMT_NONE;
-  float m_texSteps[2] = {};
+  std::array<float, 2> m_texSteps = {};
   std::shared_ptr<COutputShader> m_pOutShader = nullptr;
   CConvertMatrix m_convMatrix;
   bool m_colorConversion{false};

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -859,7 +859,6 @@ void MysqlDatabase::mysqlVXPrintf(
   etByte flag_rtz;           /* True if trailing zeros should be removed */
   etByte flag_exp;           /* True to force display of the exponent */
   int nsd;                   /* Number of significant digits returned */
-  size_t idx2;
 
   length = 0;
   bufpt = 0;
@@ -942,20 +941,28 @@ void MysqlDatabase::mysqlVXPrintf(
       flag_long = flag_longlong = 0;
     }
     /* Fetch the info entry for the field */
-    infop = &fmtinfo[0];
+    infop = fmtinfo.data();
     xtype = etINVALID;
-    for (idx2 = 0; idx2 < fmtinfo.size(); idx2++)
+
+    for (const auto& info : fmtinfo)
     {
-      if( c==fmtinfo[idx2].fmttype ){
-        infop = &fmtinfo[idx2];
-        if( useExtended || (infop->flags & FLAG_INTERN)==0 ){
-          xtype = infop->type;
-        }else{
-          return;
-        }
-        break;
+      if (c != info.fmttype)
+        continue;
+
+      infop = &info;
+
+      if (useExtended || (infop->flags & FLAG_INTERN) == 0)
+      {
+        xtype = infop->type;
       }
+      else
+      {
+        return;
+      }
+
+      break;
     }
+
     zExtra = 0;
 
     /* Limit the precision to prevent overflowing buf[] during conversion */

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -15,6 +15,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <set>
 #include <string>
@@ -616,7 +617,7 @@ std::string MysqlDatabase::vprepare(const char *format, va_list args)
     pos += 6;
   }
 
-  // Replace some dataypes in CAST statements: 
+  // Replace some dataypes in CAST statements:
   // before: CAST(iFoo AS TEXT), CAST(foo AS INTEGER)
   // after:  CAST(iFoo AS CHAR), CAST(foo AS SIGNED INTEGER)
   pos = strResult.find("CAST(");
@@ -717,28 +718,30 @@ struct StrAccum {
 */
 static const char aDigits[] = "0123456789ABCDEF0123456789abcdef";
 static const char aPrefix[] = "-x0\000X0";
-static const et_info fmtinfo[] = {
-  {  'd', 10, 1, etRADIX,      0,  0 },
-  {  's',  0, 4, etSTRING,     0,  0 },
-  {  'g',  0, 1, etGENERIC,    30, 0 },
-  {  'z',  0, 4, etDYNSTRING,  0,  0 },
-  {  'q',  0, 4, etSQLESCAPE,  0,  0 },
-  {  'Q',  0, 4, etSQLESCAPE2, 0,  0 },
-  {  'w',  0, 4, etSQLESCAPE3, 0,  0 },
-  {  'c',  0, 0, etCHARX,      0,  0 },
-  {  'o',  8, 0, etRADIX,      0,  2 },
-  {  'u', 10, 0, etRADIX,      0,  0 },
-  {  'x', 16, 0, etRADIX,      16, 1 },
-  {  'X', 16, 0, etRADIX,      0,  4 },
-  {  'f',  0, 1, etFLOAT,      0,  0 },
-  {  'e',  0, 1, etEXP,        30, 0 },
-  {  'E',  0, 1, etEXP,        14, 0 },
-  {  'G',  0, 1, etGENERIC,    14, 0 },
-  {  'i', 10, 1, etRADIX,      0,  0 },
-  {  'n',  0, 0, etSIZE,       0,  0 },
-  {  '%',  0, 0, etPERCENT,    0,  0 },
-  {  'p', 16, 0, etPOINTER,    0,  1 },
-};
+// clang-format off
+constexpr std::array<et_info, 20> fmtinfo = {{
+  {'d', 10, 1, etRADIX, 0, 0},
+  {'s', 0, 4, etSTRING, 0, 0},
+  {'g', 0, 1, etGENERIC, 30, 0},
+  {'z', 0, 4, etDYNSTRING, 0, 0},
+  {'q', 0, 4, etSQLESCAPE, 0, 0},
+  {'Q', 0, 4, etSQLESCAPE2, 0, 0},
+  {'w', 0, 4, etSQLESCAPE3, 0, 0},
+  {'c', 0, 0, etCHARX, 0, 0},
+  {'o', 8, 0, etRADIX, 0, 2},
+  {'u', 10, 0, etRADIX, 0, 0},
+  {'x', 16, 0, etRADIX, 16, 1},
+  {'X', 16, 0, etRADIX, 0, 4},
+  {'f', 0, 1, etFLOAT, 0, 0},
+  {'e', 0, 1, etEXP, 30, 0},
+  {'E', 0, 1, etEXP, 14, 0},
+  {'G', 0, 1, etGENERIC, 14, 0},
+  {'i', 10, 1, etRADIX, 0, 0},
+  {'n', 0, 0, etSIZE, 0, 0},
+  {'%', 0, 0, etPERCENT, 0, 0},
+  {'p', 16, 0, etPOINTER, 0, 1},
+}};
+// clang-format on
 
 /*
 ** "*val" is a double such that 0.1 <= *val < 10.0
@@ -941,7 +944,8 @@ void MysqlDatabase::mysqlVXPrintf(
     /* Fetch the info entry for the field */
     infop = &fmtinfo[0];
     xtype = etINVALID;
-    for(idx2=0; idx2<ARRAY_SIZE(fmtinfo); idx2++){
+    for (idx2 = 0; idx2 < fmtinfo.size(); idx2++)
+    {
       if( c==fmtinfo[idx2].fmttype ){
         infop = &fmtinfo[idx2];
         if( useExtended || (infop->flags & FLAG_INTERN)==0 ){

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -314,9 +314,9 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
         bool bl_ok = true;
 
         // What mount points are rejected
-        for (size_t i = 0; i < mountBL.size(); ++i)
+        for (const auto& mount : mountBL)
         {
-          if (StringUtils::StartsWithNoCase(mountStr, mountBL[i]))
+          if (StringUtils::StartsWithNoCase(mountStr, mount))
           {
             bl_ok = false;
             break;
@@ -327,9 +327,9 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
         {
           // What filesystems are accepted
           bool fsok = false;
-          for (size_t i = 0; i < typeWL.size(); ++i)
+          for (const auto& type : typeWL)
           {
-            if (StringUtils::StartsWithNoCase(fsStr, typeWL[i]))
+            if (StringUtils::StartsWithNoCase(fsStr, type))
             {
               fsok = true;
               break;
@@ -337,9 +337,9 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
           }
           // What devices are accepted
           bool devok = false;
-          for (size_t i = 0; i < deviceWL.size(); ++i)
+          for (const auto& device : deviceWL)
           {
-            if (StringUtils::StartsWithNoCase(deviceStr, deviceWL[i]))
+            if (StringUtils::StartsWithNoCase(deviceStr, device))
             {
               devok = true;
               break;
@@ -348,9 +348,9 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
 
           // What mount points are accepted
           bool mountok = false;
-          for (size_t i = 0; i < mountWL.size(); ++i)
+          for (const auto& mount : mountWL)
           {
-            if (StringUtils::StartsWithNoCase(mountStr, mountWL[i]))
+            if (StringUtils::StartsWithNoCase(mountStr, mount))
             {
               mountok = true;
               break;

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -19,6 +19,7 @@
 
 #include "platform/android/activity/XBMCApp.h"
 
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -29,9 +30,27 @@
 #include <androidjni/StorageManager.h>
 #include <androidjni/StorageVolume.h>
 
-static const char * typeWL[] = { "vfat", "exfat", "sdcardfs", "fuse", "ntfs", "fat32", "ext3", "ext4", "esdfs", "cifs" };
-static const char * mountWL[] = { "/mnt", "/Removable", "/storage" };
-static const char * mountBL[] = {
+// clang-format off
+constexpr std::array<const char*, 10> typeWL = {
+  "vfat",
+  "exfat",
+  "sdcardfs",
+  "fuse",
+  "ntfs",
+  "fat32",
+  "ext3",
+  "ext4",
+  "esdfs",
+  "cifs"
+};
+
+constexpr std::array<const char*, 3> mountWL = {
+  "/mnt",
+  "/Removable",
+  "/storage"
+};
+
+constexpr std::array<const char*, 9> mountBL = {
   "/mnt/secure",
   "/mnt/shell",
   "/mnt/asec",
@@ -42,12 +61,14 @@ static const char * mountBL[] = {
   "/storage/emulated",
   "/mnt/runtime"
 };
-static const char * deviceWL[] = {
+
+constexpr std::array<const char*, 4> deviceWL = {
   "/dev/block/vold",
   "/dev/fuse",
   "/mnt/media_rw",
   "//" // SMB
 };
+// clang-format on
 
 IStorageProvider* IStorageProvider::CreateInstance()
 {
@@ -293,7 +314,7 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
         bool bl_ok = true;
 
         // What mount points are rejected
-        for (unsigned int i=0; i < ARRAY_SIZE(mountBL); ++i)
+        for (size_t i = 0; i < mountBL.size(); ++i)
         {
           if (StringUtils::StartsWithNoCase(mountStr, mountBL[i]))
           {
@@ -306,7 +327,7 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
         {
           // What filesystems are accepted
           bool fsok = false;
-          for (unsigned int i=0; i < ARRAY_SIZE(typeWL); ++i)
+          for (size_t i = 0; i < typeWL.size(); ++i)
           {
             if (StringUtils::StartsWithNoCase(fsStr, typeWL[i]))
             {
@@ -316,7 +337,7 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
           }
           // What devices are accepted
           bool devok = false;
-          for (unsigned int i=0; i < ARRAY_SIZE(deviceWL); ++i)
+          for (size_t i = 0; i < deviceWL.size(); ++i)
           {
             if (StringUtils::StartsWithNoCase(deviceStr, deviceWL[i]))
             {
@@ -327,7 +348,7 @@ std::set<std::string> CAndroidStorageProvider::GetRemovableDrivesLinux()
 
           // What mount points are accepted
           bool mountok = false;
-          for (unsigned int i=0; i < ARRAY_SIZE(mountWL); ++i)
+          for (size_t i = 0; i < mountWL.size(); ++i)
           {
             if (StringUtils::StartsWithNoCase(mountStr, mountWL[i]))
             {

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -30,6 +30,9 @@
 #include <androidjni/StorageManager.h>
 #include <androidjni/StorageVolume.h>
 
+namespace
+{
+
 // clang-format off
 constexpr std::array<const char*, 10> typeWL = {
   "vfat",
@@ -69,6 +72,8 @@ constexpr std::array<const char*, 4> deviceWL = {
   "//" // SMB
 };
 // clang-format on
+
+} // namespace
 
 IStorageProvider* IStorageProvider::CreateInstance()
 {

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1521,10 +1521,10 @@ void StringUtils::RemoveCRLF(std::string& strLine)
 std::string StringUtils::SizeToString(int64_t size)
 {
   std::string strLabel;
-  const char prefixes[] = {' ', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'};
+  constexpr std::array<char, 9> prefixes = {' ', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'};
   unsigned int i = 0;
   double s = (double)size;
-  while (i < ARRAY_SIZE(prefixes) && s >= 1000.0)
+  while (i < prefixes.size() && s >= 1000.0)
   {
     s /= 1024.0;
     i++;
@@ -1532,7 +1532,7 @@ std::string StringUtils::SizeToString(int64_t size)
 
   if (!i)
     strLabel = StringUtils::Format("{:.2f} B", s);
-  else if (i == ARRAY_SIZE(prefixes))
+  else if (i == prefixes.size())
   {
     if (s >= 1000.0)
       strLabel = StringUtils::Format(">999.99 {}B", prefixes[i - 1]);

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -41,6 +41,8 @@
 #include "WinKeyMap.h"
 #include "WinEventsWin32.h"
 
+#include <array>
+
 using namespace KODI::MESSAGING;
 
 HWND g_hWnd = nullptr;
@@ -165,7 +167,7 @@ static XBMC_keysym *TranslateKey(WPARAM vkey, UINT scancode, XBMC_keysym *keysym
 
   if (pressed && XBMC_TranslateUNICODE)
   {
-    uint16_t  wchars[2];
+    std::array<uint16_t, 2> wchars;
 
     /* Numlock isn't taken into account in ToUnicode,
     * so we handle it as a special case here */
@@ -173,7 +175,8 @@ static XBMC_keysym *TranslateKey(WPARAM vkey, UINT scancode, XBMC_keysym *keysym
     {
       keysym->unicode = static_cast<uint16_t>(vkey - VK_NUMPAD0 + '0');
     }
-    else if (ToUnicode(static_cast<UINT>(vkey), scancode, keystate, reinterpret_cast<LPWSTR>(wchars), ARRAY_SIZE(wchars), 0) > 0)
+    else if (ToUnicode(static_cast<UINT>(vkey), scancode, keystate,
+                       reinterpret_cast<LPWSTR>(wchars.data()), wchars.size(), 0) > 0)
     {
       keysym->unicode = wchars[0];
     }

--- a/xbmc/windowing/windows/WinKeyMap.h
+++ b/xbmc/windowing/windows/WinKeyMap.h
@@ -17,162 +17,162 @@
 
 namespace KODI
 {
-  namespace WINDOWING
-  {
-    namespace WINDOWS
-    {
-      static XBMCKey VK_keymap[XBMCK_LAST];
+namespace WINDOWING
+{
+namespace WINDOWS
+{
+static XBMCKey VK_keymap[XBMCK_LAST];
 
-      static void DIB_InitOSKeymap()
-      {
-        /* Map the VK keysyms */
-        for (int i = 0; i < ARRAY_SIZE(VK_keymap); ++i)
-          VK_keymap[i] = XBMCK_UNKNOWN;
+static void DIB_InitOSKeymap()
+{
+  /* Map the VK keysyms */
+  for (int i = 0; i < ARRAY_SIZE(VK_keymap); ++i)
+    VK_keymap[i] = XBMCK_UNKNOWN;
 
-        VK_keymap[VK_BACK] = XBMCK_BACKSPACE;
-        VK_keymap[VK_TAB] = XBMCK_TAB;
-        VK_keymap[VK_CLEAR] = XBMCK_CLEAR;
-        VK_keymap[VK_RETURN] = XBMCK_RETURN;
-        VK_keymap[VK_PAUSE] = XBMCK_PAUSE;
-        VK_keymap[VK_ESCAPE] = XBMCK_ESCAPE;
-        VK_keymap[VK_SPACE] = XBMCK_SPACE;
-        VK_keymap[VK_APOSTROPHE] = XBMCK_QUOTE;
-        VK_keymap[VK_COMMA] = XBMCK_COMMA;
-        VK_keymap[VK_MINUS] = XBMCK_MINUS;
-        VK_keymap[VK_PERIOD] = XBMCK_PERIOD;
-        VK_keymap[VK_SLASH] = XBMCK_SLASH;
-        VK_keymap[VK_0] = XBMCK_0;
-        VK_keymap[VK_1] = XBMCK_1;
-        VK_keymap[VK_2] = XBMCK_2;
-        VK_keymap[VK_3] = XBMCK_3;
-        VK_keymap[VK_4] = XBMCK_4;
-        VK_keymap[VK_5] = XBMCK_5;
-        VK_keymap[VK_6] = XBMCK_6;
-        VK_keymap[VK_7] = XBMCK_7;
-        VK_keymap[VK_8] = XBMCK_8;
-        VK_keymap[VK_9] = XBMCK_9;
-        VK_keymap[VK_SEMICOLON] = XBMCK_SEMICOLON;
-        VK_keymap[VK_EQUALS] = XBMCK_EQUALS;
-        VK_keymap[VK_LBRACKET] = XBMCK_LEFTBRACKET;
-        VK_keymap[VK_BACKSLASH] = XBMCK_BACKSLASH;
-        VK_keymap[VK_OEM_102] = XBMCK_BACKSLASH;
-        VK_keymap[VK_RBRACKET] = XBMCK_RIGHTBRACKET;
-        VK_keymap[VK_GRAVE] = XBMCK_BACKQUOTE;
-        VK_keymap[VK_BACKTICK] = XBMCK_BACKQUOTE;
-        VK_keymap[VK_A] = XBMCK_a;
-        VK_keymap[VK_B] = XBMCK_b;
-        VK_keymap[VK_C] = XBMCK_c;
-        VK_keymap[VK_D] = XBMCK_d;
-        VK_keymap[VK_E] = XBMCK_e;
-        VK_keymap[VK_F] = XBMCK_f;
-        VK_keymap[VK_G] = XBMCK_g;
-        VK_keymap[VK_H] = XBMCK_h;
-        VK_keymap[VK_I] = XBMCK_i;
-        VK_keymap[VK_J] = XBMCK_j;
-        VK_keymap[VK_K] = XBMCK_k;
-        VK_keymap[VK_L] = XBMCK_l;
-        VK_keymap[VK_M] = XBMCK_m;
-        VK_keymap[VK_N] = XBMCK_n;
-        VK_keymap[VK_O] = XBMCK_o;
-        VK_keymap[VK_P] = XBMCK_p;
-        VK_keymap[VK_Q] = XBMCK_q;
-        VK_keymap[VK_R] = XBMCK_r;
-        VK_keymap[VK_S] = XBMCK_s;
-        VK_keymap[VK_T] = XBMCK_t;
-        VK_keymap[VK_U] = XBMCK_u;
-        VK_keymap[VK_V] = XBMCK_v;
-        VK_keymap[VK_W] = XBMCK_w;
-        VK_keymap[VK_X] = XBMCK_x;
-        VK_keymap[VK_Y] = XBMCK_y;
-        VK_keymap[VK_Z] = XBMCK_z;
-        VK_keymap[VK_DELETE] = XBMCK_DELETE;
+  VK_keymap[VK_BACK] = XBMCK_BACKSPACE;
+  VK_keymap[VK_TAB] = XBMCK_TAB;
+  VK_keymap[VK_CLEAR] = XBMCK_CLEAR;
+  VK_keymap[VK_RETURN] = XBMCK_RETURN;
+  VK_keymap[VK_PAUSE] = XBMCK_PAUSE;
+  VK_keymap[VK_ESCAPE] = XBMCK_ESCAPE;
+  VK_keymap[VK_SPACE] = XBMCK_SPACE;
+  VK_keymap[VK_APOSTROPHE] = XBMCK_QUOTE;
+  VK_keymap[VK_COMMA] = XBMCK_COMMA;
+  VK_keymap[VK_MINUS] = XBMCK_MINUS;
+  VK_keymap[VK_PERIOD] = XBMCK_PERIOD;
+  VK_keymap[VK_SLASH] = XBMCK_SLASH;
+  VK_keymap[VK_0] = XBMCK_0;
+  VK_keymap[VK_1] = XBMCK_1;
+  VK_keymap[VK_2] = XBMCK_2;
+  VK_keymap[VK_3] = XBMCK_3;
+  VK_keymap[VK_4] = XBMCK_4;
+  VK_keymap[VK_5] = XBMCK_5;
+  VK_keymap[VK_6] = XBMCK_6;
+  VK_keymap[VK_7] = XBMCK_7;
+  VK_keymap[VK_8] = XBMCK_8;
+  VK_keymap[VK_9] = XBMCK_9;
+  VK_keymap[VK_SEMICOLON] = XBMCK_SEMICOLON;
+  VK_keymap[VK_EQUALS] = XBMCK_EQUALS;
+  VK_keymap[VK_LBRACKET] = XBMCK_LEFTBRACKET;
+  VK_keymap[VK_BACKSLASH] = XBMCK_BACKSLASH;
+  VK_keymap[VK_OEM_102] = XBMCK_BACKSLASH;
+  VK_keymap[VK_RBRACKET] = XBMCK_RIGHTBRACKET;
+  VK_keymap[VK_GRAVE] = XBMCK_BACKQUOTE;
+  VK_keymap[VK_BACKTICK] = XBMCK_BACKQUOTE;
+  VK_keymap[VK_A] = XBMCK_a;
+  VK_keymap[VK_B] = XBMCK_b;
+  VK_keymap[VK_C] = XBMCK_c;
+  VK_keymap[VK_D] = XBMCK_d;
+  VK_keymap[VK_E] = XBMCK_e;
+  VK_keymap[VK_F] = XBMCK_f;
+  VK_keymap[VK_G] = XBMCK_g;
+  VK_keymap[VK_H] = XBMCK_h;
+  VK_keymap[VK_I] = XBMCK_i;
+  VK_keymap[VK_J] = XBMCK_j;
+  VK_keymap[VK_K] = XBMCK_k;
+  VK_keymap[VK_L] = XBMCK_l;
+  VK_keymap[VK_M] = XBMCK_m;
+  VK_keymap[VK_N] = XBMCK_n;
+  VK_keymap[VK_O] = XBMCK_o;
+  VK_keymap[VK_P] = XBMCK_p;
+  VK_keymap[VK_Q] = XBMCK_q;
+  VK_keymap[VK_R] = XBMCK_r;
+  VK_keymap[VK_S] = XBMCK_s;
+  VK_keymap[VK_T] = XBMCK_t;
+  VK_keymap[VK_U] = XBMCK_u;
+  VK_keymap[VK_V] = XBMCK_v;
+  VK_keymap[VK_W] = XBMCK_w;
+  VK_keymap[VK_X] = XBMCK_x;
+  VK_keymap[VK_Y] = XBMCK_y;
+  VK_keymap[VK_Z] = XBMCK_z;
+  VK_keymap[VK_DELETE] = XBMCK_DELETE;
 
-        VK_keymap[VK_NUMPAD0] = XBMCK_KP0;
-        VK_keymap[VK_NUMPAD1] = XBMCK_KP1;
-        VK_keymap[VK_NUMPAD2] = XBMCK_KP2;
-        VK_keymap[VK_NUMPAD3] = XBMCK_KP3;
-        VK_keymap[VK_NUMPAD4] = XBMCK_KP4;
-        VK_keymap[VK_NUMPAD5] = XBMCK_KP5;
-        VK_keymap[VK_NUMPAD6] = XBMCK_KP6;
-        VK_keymap[VK_NUMPAD7] = XBMCK_KP7;
-        VK_keymap[VK_NUMPAD8] = XBMCK_KP8;
-        VK_keymap[VK_NUMPAD9] = XBMCK_KP9;
-        VK_keymap[VK_DECIMAL] = XBMCK_KP_PERIOD;
-        VK_keymap[VK_DIVIDE] = XBMCK_KP_DIVIDE;
-        VK_keymap[VK_MULTIPLY] = XBMCK_KP_MULTIPLY;
-        VK_keymap[VK_SUBTRACT] = XBMCK_KP_MINUS;
-        VK_keymap[VK_ADD] = XBMCK_KP_PLUS;
+  VK_keymap[VK_NUMPAD0] = XBMCK_KP0;
+  VK_keymap[VK_NUMPAD1] = XBMCK_KP1;
+  VK_keymap[VK_NUMPAD2] = XBMCK_KP2;
+  VK_keymap[VK_NUMPAD3] = XBMCK_KP3;
+  VK_keymap[VK_NUMPAD4] = XBMCK_KP4;
+  VK_keymap[VK_NUMPAD5] = XBMCK_KP5;
+  VK_keymap[VK_NUMPAD6] = XBMCK_KP6;
+  VK_keymap[VK_NUMPAD7] = XBMCK_KP7;
+  VK_keymap[VK_NUMPAD8] = XBMCK_KP8;
+  VK_keymap[VK_NUMPAD9] = XBMCK_KP9;
+  VK_keymap[VK_DECIMAL] = XBMCK_KP_PERIOD;
+  VK_keymap[VK_DIVIDE] = XBMCK_KP_DIVIDE;
+  VK_keymap[VK_MULTIPLY] = XBMCK_KP_MULTIPLY;
+  VK_keymap[VK_SUBTRACT] = XBMCK_KP_MINUS;
+  VK_keymap[VK_ADD] = XBMCK_KP_PLUS;
 
-        VK_keymap[VK_UP] = XBMCK_UP;
-        VK_keymap[VK_DOWN] = XBMCK_DOWN;
-        VK_keymap[VK_RIGHT] = XBMCK_RIGHT;
-        VK_keymap[VK_LEFT] = XBMCK_LEFT;
-        VK_keymap[VK_INSERT] = XBMCK_INSERT;
-        VK_keymap[VK_HOME] = XBMCK_HOME;
-        VK_keymap[VK_END] = XBMCK_END;
-        VK_keymap[VK_PRIOR] = XBMCK_PAGEUP;
-        VK_keymap[VK_NEXT] = XBMCK_PAGEDOWN;
+  VK_keymap[VK_UP] = XBMCK_UP;
+  VK_keymap[VK_DOWN] = XBMCK_DOWN;
+  VK_keymap[VK_RIGHT] = XBMCK_RIGHT;
+  VK_keymap[VK_LEFT] = XBMCK_LEFT;
+  VK_keymap[VK_INSERT] = XBMCK_INSERT;
+  VK_keymap[VK_HOME] = XBMCK_HOME;
+  VK_keymap[VK_END] = XBMCK_END;
+  VK_keymap[VK_PRIOR] = XBMCK_PAGEUP;
+  VK_keymap[VK_NEXT] = XBMCK_PAGEDOWN;
 
-        VK_keymap[VK_F1] = XBMCK_F1;
-        VK_keymap[VK_F2] = XBMCK_F2;
-        VK_keymap[VK_F3] = XBMCK_F3;
-        VK_keymap[VK_F4] = XBMCK_F4;
-        VK_keymap[VK_F5] = XBMCK_F5;
-        VK_keymap[VK_F6] = XBMCK_F6;
-        VK_keymap[VK_F7] = XBMCK_F7;
-        VK_keymap[VK_F8] = XBMCK_F8;
-        VK_keymap[VK_F9] = XBMCK_F9;
-        VK_keymap[VK_F10] = XBMCK_F10;
-        VK_keymap[VK_F11] = XBMCK_F11;
-        VK_keymap[VK_F12] = XBMCK_F12;
-        VK_keymap[VK_F13] = XBMCK_F13;
-        VK_keymap[VK_F14] = XBMCK_F14;
-        VK_keymap[VK_F15] = XBMCK_F15;
+  VK_keymap[VK_F1] = XBMCK_F1;
+  VK_keymap[VK_F2] = XBMCK_F2;
+  VK_keymap[VK_F3] = XBMCK_F3;
+  VK_keymap[VK_F4] = XBMCK_F4;
+  VK_keymap[VK_F5] = XBMCK_F5;
+  VK_keymap[VK_F6] = XBMCK_F6;
+  VK_keymap[VK_F7] = XBMCK_F7;
+  VK_keymap[VK_F8] = XBMCK_F8;
+  VK_keymap[VK_F9] = XBMCK_F9;
+  VK_keymap[VK_F10] = XBMCK_F10;
+  VK_keymap[VK_F11] = XBMCK_F11;
+  VK_keymap[VK_F12] = XBMCK_F12;
+  VK_keymap[VK_F13] = XBMCK_F13;
+  VK_keymap[VK_F14] = XBMCK_F14;
+  VK_keymap[VK_F15] = XBMCK_F15;
 
-        VK_keymap[VK_NUMLOCK] = XBMCK_NUMLOCK;
-        VK_keymap[VK_CAPITAL] = XBMCK_CAPSLOCK;
-        VK_keymap[VK_SCROLL] = XBMCK_SCROLLOCK;
-        VK_keymap[VK_RSHIFT] = XBMCK_RSHIFT;
-        VK_keymap[VK_LSHIFT] = XBMCK_LSHIFT;
-        VK_keymap[VK_RCONTROL] = XBMCK_RCTRL;
-        VK_keymap[VK_LCONTROL] = XBMCK_LCTRL;
-        VK_keymap[VK_RMENU] = XBMCK_RALT;
-        VK_keymap[VK_LMENU] = XBMCK_LALT;
-        VK_keymap[VK_RWIN] = XBMCK_RSUPER;
-        VK_keymap[VK_LWIN] = XBMCK_LSUPER;
+  VK_keymap[VK_NUMLOCK] = XBMCK_NUMLOCK;
+  VK_keymap[VK_CAPITAL] = XBMCK_CAPSLOCK;
+  VK_keymap[VK_SCROLL] = XBMCK_SCROLLOCK;
+  VK_keymap[VK_RSHIFT] = XBMCK_RSHIFT;
+  VK_keymap[VK_LSHIFT] = XBMCK_LSHIFT;
+  VK_keymap[VK_RCONTROL] = XBMCK_RCTRL;
+  VK_keymap[VK_LCONTROL] = XBMCK_LCTRL;
+  VK_keymap[VK_RMENU] = XBMCK_RALT;
+  VK_keymap[VK_LMENU] = XBMCK_LALT;
+  VK_keymap[VK_RWIN] = XBMCK_RSUPER;
+  VK_keymap[VK_LWIN] = XBMCK_LSUPER;
 
-        VK_keymap[VK_HELP] = XBMCK_HELP;
+  VK_keymap[VK_HELP] = XBMCK_HELP;
 #ifdef VK_PRINT
-        VK_keymap[VK_PRINT] = XBMCK_PRINT;
+  VK_keymap[VK_PRINT] = XBMCK_PRINT;
 #endif
-        VK_keymap[VK_SNAPSHOT] = XBMCK_PRINT;
-        VK_keymap[VK_CANCEL] = XBMCK_BREAK;
-        VK_keymap[VK_APPS] = XBMCK_MENU;
+  VK_keymap[VK_SNAPSHOT] = XBMCK_PRINT;
+  VK_keymap[VK_CANCEL] = XBMCK_BREAK;
+  VK_keymap[VK_APPS] = XBMCK_MENU;
 
-        // Only include the multimedia keys if they have been enabled in the
-        // advanced settings
-        if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_enableMultimediaKeys)
-        {
-          VK_keymap[VK_BROWSER_BACK] = XBMCK_BROWSER_BACK;
-          VK_keymap[VK_BROWSER_FORWARD] = XBMCK_BROWSER_FORWARD;
-          VK_keymap[VK_BROWSER_REFRESH] = XBMCK_BROWSER_REFRESH;
-          VK_keymap[VK_BROWSER_STOP] = XBMCK_BROWSER_STOP;
-          VK_keymap[VK_BROWSER_SEARCH] = XBMCK_BROWSER_SEARCH;
-          VK_keymap[VK_BROWSER_FAVORITES] = XBMCK_BROWSER_FAVORITES;
-          VK_keymap[VK_BROWSER_HOME] = XBMCK_BROWSER_HOME;
-          VK_keymap[VK_VOLUME_MUTE] = XBMCK_VOLUME_MUTE;
-          VK_keymap[VK_VOLUME_DOWN] = XBMCK_VOLUME_DOWN;
-          VK_keymap[VK_VOLUME_UP] = XBMCK_VOLUME_UP;
-          VK_keymap[VK_MEDIA_NEXT_TRACK] = XBMCK_MEDIA_NEXT_TRACK;
-          VK_keymap[VK_MEDIA_PREV_TRACK] = XBMCK_MEDIA_PREV_TRACK;
-          VK_keymap[VK_MEDIA_STOP] = XBMCK_MEDIA_STOP;
-          VK_keymap[VK_MEDIA_PLAY_PAUSE] = XBMCK_MEDIA_PLAY_PAUSE;
-          VK_keymap[VK_LAUNCH_MAIL] = XBMCK_LAUNCH_MAIL;
-          VK_keymap[VK_LAUNCH_MEDIA_SELECT] = XBMCK_LAUNCH_MEDIA_SELECT;
-          VK_keymap[VK_LAUNCH_APP1] = XBMCK_LAUNCH_APP1;
-          VK_keymap[VK_LAUNCH_APP2] = XBMCK_LAUNCH_APP2;
-        }
-      }
-    }
+  // Only include the multimedia keys if they have been enabled in the
+  // advanced settings
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_enableMultimediaKeys)
+  {
+    VK_keymap[VK_BROWSER_BACK] = XBMCK_BROWSER_BACK;
+    VK_keymap[VK_BROWSER_FORWARD] = XBMCK_BROWSER_FORWARD;
+    VK_keymap[VK_BROWSER_REFRESH] = XBMCK_BROWSER_REFRESH;
+    VK_keymap[VK_BROWSER_STOP] = XBMCK_BROWSER_STOP;
+    VK_keymap[VK_BROWSER_SEARCH] = XBMCK_BROWSER_SEARCH;
+    VK_keymap[VK_BROWSER_FAVORITES] = XBMCK_BROWSER_FAVORITES;
+    VK_keymap[VK_BROWSER_HOME] = XBMCK_BROWSER_HOME;
+    VK_keymap[VK_VOLUME_MUTE] = XBMCK_VOLUME_MUTE;
+    VK_keymap[VK_VOLUME_DOWN] = XBMCK_VOLUME_DOWN;
+    VK_keymap[VK_VOLUME_UP] = XBMCK_VOLUME_UP;
+    VK_keymap[VK_MEDIA_NEXT_TRACK] = XBMCK_MEDIA_NEXT_TRACK;
+    VK_keymap[VK_MEDIA_PREV_TRACK] = XBMCK_MEDIA_PREV_TRACK;
+    VK_keymap[VK_MEDIA_STOP] = XBMCK_MEDIA_STOP;
+    VK_keymap[VK_MEDIA_PLAY_PAUSE] = XBMCK_MEDIA_PLAY_PAUSE;
+    VK_keymap[VK_LAUNCH_MAIL] = XBMCK_LAUNCH_MAIL;
+    VK_keymap[VK_LAUNCH_MEDIA_SELECT] = XBMCK_LAUNCH_MEDIA_SELECT;
+    VK_keymap[VK_LAUNCH_APP1] = XBMCK_LAUNCH_APP1;
+    VK_keymap[VK_LAUNCH_APP2] = XBMCK_LAUNCH_APP2;
   }
 }
+} // namespace WINDOWS
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/windows/WinKeyMap.h
+++ b/xbmc/windowing/windows/WinKeyMap.h
@@ -15,19 +15,21 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 
+#include <array>
+
 namespace KODI
 {
 namespace WINDOWING
 {
 namespace WINDOWS
 {
-static XBMCKey VK_keymap[XBMCK_LAST];
+
+static std::array<XBMCKey, XBMCK_LAST> VK_keymap;
 
 static void DIB_InitOSKeymap()
 {
   /* Map the VK keysyms */
-  for (int i = 0; i < ARRAY_SIZE(VK_keymap); ++i)
-    VK_keymap[i] = XBMCK_UNKNOWN;
+  VK_keymap.fill(XBMCK_UNKNOWN);
 
   VK_keymap[VK_BACK] = XBMCK_BACKSPACE;
   VK_keymap[VK_TAB] = XBMCK_TAB;
@@ -173,6 +175,7 @@ static void DIB_InitOSKeymap()
     VK_keymap[VK_LAUNCH_APP2] = XBMCK_LAUNCH_APP2;
   }
 }
+
 } // namespace WINDOWS
 } // namespace WINDOWING
 } // namespace KODI


### PR DESCRIPTION
Replaces many raw arrays with std::array. This allows us to remove the ARRAY_SIZE macro.

Clang format had a go at some of the changes.
It's best viewed with whitespace changes disabled. You can view that here: [link](https://github.com/xbmc/xbmc/pull/20664/files?w=1)