### PR TITLE
[cmake] use -Werror for double-promotion, missing-field-initializers, and sign-compare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,10 @@ set_target_properties(compileinfo PROPERTIES FOLDER "Build Utilities")
 target_compile_options(compileinfo PRIVATE "${SYSTEM_DEFINES} ${ARCH_DEFINES}")
 add_dependencies(compileinfo fmt)
 
+if(NOT MSVC)
+  target_compile_options(compileinfo PUBLIC ${CORE_COMPILE_OPTIONS})
+endif()
+
 # RC File
 if(WIN32)
   configure_file(${CMAKE_SOURCE_DIR}/xbmc/platform/win32/XBMC_PC.rc.in

--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -149,8 +149,15 @@ endif()
 
 if(NOT MSVC)
   # these options affect all code built by cmake including external projects.
-  add_options(ALL_LANGUAGES ALL_BUILDS "-Wall" "-Wdouble-promotion" "-Wmissing-field-initializers")
-  add_options(ALL_LANGUAGES DEBUG "-g" "-D_DEBUG")
+  add_options(ALL_LANGUAGES ALL_BUILDS
+    -Wall
+    -Wdouble-promotion
+    -Wmissing-field-initializers
+  )
+  add_options(ALL_LANGUAGES DEBUG
+    -g
+    -D_DEBUG
+  )
 
   # these options affect only core code
   if(NOT CORE_COMPILE_OPTIONS)

--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -153,6 +153,7 @@ if(NOT MSVC)
     -Wall
     -Wdouble-promotion
     -Wmissing-field-initializers
+    -Wsign-compare
   )
   add_options(ALL_LANGUAGES DEBUG
     -g

--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -148,8 +148,18 @@ if(NOT DEFINED NEON OR NEON)
 endif()
 
 if(NOT MSVC)
+  # these options affect all code built by cmake including external projects.
   add_options(ALL_LANGUAGES ALL_BUILDS "-Wall" "-Wdouble-promotion" "-Wmissing-field-initializers")
   add_options(ALL_LANGUAGES DEBUG "-g" "-D_DEBUG")
+
+  # these options affect only core code
+  if(NOT CORE_COMPILE_OPTIONS)
+    set(CORE_COMPILE_OPTIONS
+      -Werror=double-promotion
+      -Werror=missing-field-initializers
+      -Werror=sign-compare
+    )
+  endif()
 endif()
 
 # set for compile info to help detect binary addons

--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -75,6 +75,10 @@ function(core_add_library name)
     add_dependencies(${name} ${GLOBAL_TARGET_DEPS})
     set(CORE_LIBRARY ${name} PARENT_SCOPE)
 
+    if(NOT MSVC)
+      target_compile_options(${name} PUBLIC ${CORE_COMPILE_OPTIONS})
+    endif()
+
     # Add precompiled headers to Kodi main libraries
     if(CORE_SYSTEM_NAME MATCHES windows)
       add_precompiled_header(${name} pch.h ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/pch.cpp PCH_TARGET kodi)
@@ -104,6 +108,11 @@ function(core_add_test_library name)
                                              FOLDER "Build Utilities/tests")
     add_dependencies(${name} ${GLOBAL_TARGET_DEPS})
     set(test_archives ${test_archives} ${name} CACHE STRING "" FORCE)
+
+    if(NOT MSVC)
+      target_compile_options(${name} PUBLIC ${CORE_COMPILE_OPTIONS})
+    endif()
+
   endif()
   foreach(src IN LISTS SOURCES SUPPORTED_SOURCES HEADERS OTHERS)
     get_filename_component(src_path "${src}" ABSOLUTE)
@@ -166,6 +175,10 @@ function(core_add_shared_library name)
     add_library(${name} STATIC ${SOURCES} ${HEADERS} ${OTHERS})
     set_target_properties(${name} PROPERTIES POSITION_INDEPENDENT_CODE 1)
     core_link_library(${name} ${OUTPUT_DIRECTORY}/lib${name})
+
+    if(NOT MSVC)
+      target_compile_options(${name} PUBLIC ${CORE_COMPILE_OPTIONS})
+    endif()
   endif()
 endfunction()
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -199,7 +199,7 @@ bool CDVDAudioCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   {
     //StereoDownmixAllowed is true if the user has selected 2.0 Audio channels in settings
     bool stereoDownmixAllowed = CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
-    unsigned int num_codecs = CJNIMediaCodecList::getCodecCount();
+    int num_codecs = CJNIMediaCodecList::getCodecCount();
     std::vector<std::string> mimeTypes;
 
     for (int i = 0; i < num_codecs; i++)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -200,7 +200,7 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
     // Only 12 audio units are packed in the buffer to avoid overflows and reduce latency.
     // Compensates for the small increased latency in CAEBitstreamPacker::PackTrueHD (IEC)
     // Android IEC packer (RAW) needs 24 audio units.
-    const int nFrames = m_deviceIsRAW ? 24 : 12;
+    const unsigned int nFrames = m_deviceIsRAW ? 24 : 12;
 
     if (m_trueHDframes == nFrames)
     {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -475,7 +475,7 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
 
   if (aspect_ratio <= 0.0)
     aspect_ratio =
-        static_cast<float>(pVideoPicture->iWidth) / static_cast<float>(pVideoPicture->iHeight);
+        static_cast<double>(pVideoPicture->iWidth) / static_cast<double>(pVideoPicture->iHeight);
 
   if (m_DAR != aspect_ratio)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
@@ -196,8 +196,7 @@ bool CColorManager::GetVideo3dLut(AVColorPrimaries srcPrimaries, int* cmsToken,
       cmsToneCurve* gammaCurve;
       m_m_curIccGammaMode = static_cast<CMS_TRC_TYPE>(settings->GetInt("videoscreen.cmsgammamode"));
       m_curIccGamma = settings->GetInt("videoscreen.cmsgamma");
-      gammaCurve =
-        CreateToneCurve(m_m_curIccGammaMode, m_curIccGamma/100.0f, m_blackPoint);
+      gammaCurve = CreateToneCurve(m_m_curIccGammaMode, m_curIccGamma / 100.0, m_blackPoint);
 
       // create source profile
       m_curIccWhitePoint = static_cast<CMS_WHITEPOINT>(settings->GetInt("videoscreen.cmswhitepoint"));
@@ -436,7 +435,9 @@ cmsHPROFILE CColorManager::LoadIccDisplayProfile(const std::string& filename)
 }
 
 
-cmsToneCurve* CColorManager::CreateToneCurve(CMS_TRC_TYPE gammaType, float gammaValue, cmsCIEXYZ blackPoint)
+cmsToneCurve* CColorManager::CreateToneCurve(CMS_TRC_TYPE gammaType,
+                                             double gammaValue,
+                                             cmsCIEXYZ blackPoint)
 {
   const int tableSize = 1024;
   cmsFloat32Number gammaTable[tableSize];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
@@ -149,7 +149,7 @@ private:
 
 
   // create a gamma curve
-  cmsToneCurve* CreateToneCurve(CMS_TRC_TYPE gammaType, float gammaValue, cmsCIEXYZ blackPoint);
+  cmsToneCurve* CreateToneCurve(CMS_TRC_TYPE gammaType, double gammaValue, cmsCIEXYZ blackPoint);
 
   // create a source profile
   cmsHPROFILE CreateSourceProfile(CMS_PRIMARIES primaries, cmsToneCurve *gamma, CMS_WHITEPOINT whitepoint);

--- a/xbmc/platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.cpp
+++ b/xbmc/platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.cpp
@@ -39,7 +39,7 @@ CMediaCodecDecoderFilterManager::CMediaCodecDecoderFilterManager()
     NULL
   };
 
-  unsigned int num_codecs = CJNIMediaCodecList::getCodecCount();
+  int num_codecs = CJNIMediaCodecList::getCodecCount();
   for (int i = 0; i < num_codecs; i++)
   {
     CJNIMediaCodecInfo codec_info = CJNIMediaCodecList::getCodecInfoAt(i);

--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -60,7 +60,7 @@ CCPUInfoFreebsd::CCPUInfoFreebsd()
   if (sysctlbyname("hw.model", cpuModel.data(), &length, nullptr, 0) == 0)
     m_cpuModel = cpuModel.data();
 
-  for (size_t i = 0; i < m_cpuCount; i++)
+  for (int i = 0; i < m_cpuCount; i++)
   {
     CoreInfo core;
     core.m_id = i;
@@ -189,7 +189,7 @@ int CCPUInfoFreebsd::GetUsedPercentage()
 
   std::vector<CpuData> cpuData;
 
-  for (size_t i = 0; i < m_cpuCount; i++)
+  for (int i = 0; i < m_cpuCount; i++)
   {
     CpuData info;
 

--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -222,7 +222,7 @@ int CCPUInfoFreebsd::GetUsedPercentage()
     auto idleTime = cpuData[core].GetIdleTime() - m_cores[core].m_idleTime;
     auto totalTime = cpuData[core].GetTotalTime() - m_cores[core].m_totalTime;
 
-    m_cores[core].m_usagePercent = activeTime * 100.0f / totalTime;
+    m_cores[core].m_usagePercent = activeTime * 100.0 / totalTime;
 
     m_cores[core].m_activeTime += activeTime;
     m_cores[core].m_idleTime += idleTime;

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -207,7 +207,7 @@ CGDirectDisplayID GetDisplayID(int screen_index)
 
   // Get the list of displays.
   CGGetActiveDisplayList(MAX_DISPLAYS, displayArray, &numDisplays);
-  if (screen_index >= 0 && screen_index < numDisplays)
+  if (screen_index >= 0 && screen_index < static_cast<int>(numDisplays))
     return(displayArray[screen_index]);
   else
     return(displayArray[0]);


### PR DESCRIPTION
We seem to continue adding warnings and continue having to fix them. Let's make these `-Werror` now to avoid adding new warnings.

I'm not sure if there is any negative repercussions at this time.

I had to disable the behaviour for a couple of the external libraries. This seems like an ok solution for now.

Note that this is only for posix platforms. I'm not sure what the windows changes would be.