### PR TITLE
[warnings] fix Visual Studio 2019 warnings

### DIFF
--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -105,8 +105,8 @@ namespace XBMCAddon
             catch (XbmcCommons::Exception& e) { e.LogThrowMessage(); }
             catch (...)
             {
-              CLog::Log(LOGERROR, "Unknown exception while executing callback 0x{:x}",
-                        (long)(p->cb.get()));
+              CLog::Log(LOGERROR, "Unknown exception while executing callback {:#x}",
+                        reinterpret_cast<int64_t>(p->cb.get()));
             }
           }
         }

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -144,13 +144,13 @@ bool CPVRProviders::Update()
   for (const auto& clientInfo : clientProviderInfos)
   {
     auto addonProvider = std::make_shared<CPVRProvider>(
-        clientInfo["clientid"].asInteger(), clientInfo["name"].asString(),
+        clientInfo["clientid"].asInteger32(), clientInfo["name"].asString(),
         clientInfo["icon"].asString(), clientInfo["thumb"].asString());
 
     newAddonProviderList.CheckAndAddEntry(addonProvider, ProviderUpdateMode::BY_CLIENT);
 
     if (!clientInfo["enabled"].asBoolean())
-      disabledClients.emplace_back(clientInfo["clientid"].asInteger());
+      disabledClients.emplace_back(clientInfo["clientid"].asInteger32());
   }
   UpdateDefaultEntries(newAddonProviderList);
 


### PR DESCRIPTION
## Description
fix Visual Studio 2019 warnings

## Motivation and context
```
Build started...
1>------ Build started: Project: xbmc, Configuration: Debug x64 ------
1>PVRProviders.cpp
1>T:\KODI\kodi\xbmc\pvr\providers\PVRProviders.cpp(380,8): warning C4834: discarding return value of function with 'nodiscard' attribute
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xmemory(714,47): warning C4244: 'initializing': conversion from '_Ty' to '_Objty', possible loss of data
1>        with
1>        [
1>            _Ty=int64_t
1>        ]
1>        and
1>        [
1>            _Objty=int
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\vector(721): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,__int64>(_Alloc &,_Objty *const ,__int64 &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<int>,
1>            _Ty=int,
1>            _Objty=int
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\vector(726): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,__int64>(_Alloc &,_Objty *const ,__int64 &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<int>,
1>            _Ty=int,
1>            _Objty=int
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\vector(739): message : see reference to function template instantiation 'void std::vector<int,std::allocator<int>>::_Emplace_back_with_unused_capacity<_Ty>(_Ty &&)' being compiled
1>        with
1>        [
1>            _Ty=int64_t
1>        ]
1>T:\KODI\kodi\xbmc\pvr\providers\PVRProviders.cpp(153): message : see reference to function template instantiation 'void std::vector<int,std::allocator<int>>::emplace_back<int64_t>(int64_t &&)' being compiled
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xutility(158,77): warning C4244: 'argument': conversion from '_Ty' to 'int', possible loss of data
1>        with
1>        [
1>            _Ty=int64_t
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\memory(2021): message : see reference to function template instantiation 'void std::_Construct_in_place<_Ty,__int64,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(_Ty &,__int64 &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&) noexcept(false)' being compiled
1>        with
1>        [
1>            _Ty=PVR::CPVRProvider
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\memory(2747): message : see reference to function template instantiation 'std::_Ref_count_obj2<_Ty>::_Ref_count_obj2<__int64,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(__int64 &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled
1>        with
1>        [
1>            _Ty=PVR::CPVRProvider
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\memory(2748): message : see reference to function template instantiation 'std::_Ref_count_obj2<_Ty>::_Ref_count_obj2<__int64,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(__int64 &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled
1>        with
1>        [
1>            _Ty=PVR::CPVRProvider
1>        ]
1>T:\KODI\kodi\xbmc\pvr\providers\PVRProviders.cpp(148): message : see reference to function template instantiation 'std::shared_ptr<PVR::CPVRProvider> std::make_shared<PVR::CPVRProvider,int64_t,std::string,std::string,std::string>(int64_t &&,std::string &&,std::string &&,std::string &&)' being compiled
1>Done building project "libkodi.vcxproj".
```

```
1>CallbackHandler.cpp
1>T:\KODI\kodi\xbmc\interfaces\legacy\CallbackHandler.cpp(109,44): warning C4311: 'type cast': pointer truncation from 'T *' to 'long'
1>        with
1>        [
1>            T=XBMCAddon::Callback
1>        ]
```