### PR TITLE
[Subtitles] fix li.setSubtitles() regression

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -1053,7 +1053,8 @@ namespace XBMCAddon
     void ListItem::addSubtitlesRaw(const std::vector<std::string>& subtitles)
     {
       for (size_t i = 0; i < subtitles.size(); ++i)
-        addPropertyRaw(StringUtils::Format("subtitle:{}", i), subtitles[i]);
+        // subtitle:{} index starts from 1
+        addPropertyRaw(StringUtils::Format("subtitle:{}", i + 1), subtitles[i]);
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
A refactor commit here: https://github.com/xbmc/xbmc/commit/a0e2eb98ff3a142314bdd47fca9c5ffe8a5f6d98
changed the behaviour of setSubtitles to start from index of 0 for the "subtitle:{index}" property instead of 1.

Matrix starts at 1:
https://github.com/xbmc/xbmc/blob/Matrix/xbmc/interfaces/legacy/ListItem.cpp#L788

and VideoPlayer starts checking from 1:
https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L789

Currently the below  will not work on 20
li.setSubtitles(["D:\\Back to the Future Part III (1990).eng.srt'"])
and below will only pickup the 2nd sub.
li.setSubtitles([None,"D:\\Back to the Future Part III (1990).eng.srt'"])

No backport required as the change is in Nexus only

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes setSubtitles not working / skipping the 1st subtitle

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
fixes setSubtitles

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
