### PR TITLE
[pvr] fix logic that deletes pvr-providers

### DIFF
--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -377,11 +377,13 @@ void CPVRProviders::RemoveEntry(const std::shared_ptr<CPVRProvider>& provider)
 {
   CSingleLock lock(m_critSection);
 
-  std::remove_if(m_providers.begin(), m_providers.end(),
-                 [&provider](const std::shared_ptr<CPVRProvider>& providerToRemove) {
-                   return provider->GetClientId() == providerToRemove->GetClientId() &&
-                          provider->GetUniqueId() == providerToRemove->GetUniqueId();
-                 });
+  m_providers.erase(
+      std::remove_if(m_providers.begin(), m_providers.end(),
+                     [&provider](const std::shared_ptr<CPVRProvider>& providerToRemove) {
+                       return provider->GetClientId() == providerToRemove->GetClientId() &&
+                              provider->GetUniqueId() == providerToRemove->GetUniqueId();
+                     }),
+      m_providers.end());
 }
 
 int CPVRProviders::CleanupCachedImages()


### PR DESCRIPTION
missing `std::vector::erase()`
found by Sanity Check

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
