### PR TITLE
ffmpeg: Set audio channel count on AVFrame

### DIFF
--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -259,6 +259,7 @@ int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_siz
   frame->nb_samples = m_CodecCtx->frame_size;
   frame->format = m_CodecCtx->sample_fmt;
   frame->channel_layout = m_CodecCtx->channel_layout;
+  frame->channels = m_CodecCtx->channels;
 
   avcodec_fill_audio_frame(frame, m_CodecCtx->channels, m_CodecCtx->sample_fmt,
                     in, in_size, 0);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

As part of the [update to ffmpeg 4.4](https://github.com/xbmc/xbmc/pull/19558) the implementation of `avcodec_encode_audio2()` was changed to a compatibility wrapper around `avcodec_send_frame()`/`avcodec_receive_packet()` (See ffmpeg source [v4.4](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/release/4.4:/libavcodec/encode.c#l500) and [v4.3](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/release/4.3:/libavcodec/encode.c#l113)). This now seems to require the channel count to be set according to the channel layout.

<details>
<summary>A little more in-depth explanation of the problem:</summary>

Encoding failed due to the comparison [right here](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/release/4.4:/libavutil/frame.c#l783) as `src` (the frame we passed in) still has `channels`=0 while `dst` (a frame created with the exact same parameters as `src`) had it's channel count set according to the channel layout [right here](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/release/4.4:/libavutil/frame.c#l289). Both functions are called from [`av_frame_ref()`](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/release/4.4:/libavutil/frame.c#l443).
</details>

I suspect that the same issue occurs in [EncoderFFmpeg](https://github.com/lrusak/xbmc/blob/master/xbmc/cdrip/EncoderFFmpeg.cpp#L310) (the only other usage `avcodec_encode_audio2()`) as neither `m_ResampledFrame` or `m_BufferFrame` ever have `channels` set but I don't know enough about the codebase to verify the behaviour or test the fix.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #20398 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested AC3 transcoding on my NVIDIA Shield with various different files. I don't really know what else could be impacted but in any case it would probably be nice to get some people from #20398 to test on different platforms.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
