### PR TITLE
[EDL] Rename EDL cuts to EDL edits

### DIFF
--- a/xbmc/cores/CMakeLists.txt
+++ b/xbmc/cores/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SOURCES DataCacheCore.cpp
             VideoSettings.cpp)
 
 set(HEADERS DataCacheCore.h
-            Cut.h
+            EdlEdit.h
             FFmpeg.h
             GameSettings.h
             IPlayer.h

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -9,7 +9,7 @@
 #include "DataCacheCore.h"
 
 #include "ServiceBroker.h"
-#include "cores/Cut.h"
+#include "cores/EdlEdit.h"
 #include "threads/SingleLock.h"
 
 #include <utility>
@@ -48,7 +48,7 @@ void CDataCacheCore::Reset()
     CSingleLock lock(m_contentSection);
 
     m_contentInfo.m_chapters.clear();
-    m_contentInfo.m_cutList.clear();
+    m_contentInfo.m_editList.clear();
   }
 }
 
@@ -246,16 +246,16 @@ int CDataCacheCore::GetAudioBitsPerSample()
   return m_playerAudioInfo.bitsPerSample;
 }
 
-void CDataCacheCore::SetCutList(const std::vector<EDL::Cut>& cutList)
+void CDataCacheCore::SetEditList(const std::vector<EDL::Edit>& editList)
 {
   CSingleLock lock(m_contentSection);
-  m_contentInfo.m_cutList = cutList;
+  m_contentInfo.m_editList = editList;
 }
 
-std::vector<EDL::Cut> CDataCacheCore::GetCutList() const
+std::vector<EDL::Edit> CDataCacheCore::GetEditList() const
 {
   CSingleLock lock(m_contentSection);
-  return m_contentInfo.m_cutList;
+  return m_contentInfo.m_editList;
 }
 
 void CDataCacheCore::SetChapters(const std::vector<std::pair<std::string, int64_t>>& chapters)

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -16,7 +16,7 @@
 
 namespace EDL
 {
-  struct Cut;
+struct Edit;
 }
 
 class CDataCacheCore
@@ -60,8 +60,8 @@ public:
   int GetAudioBitsPerSample();
 
   // content info
-  void SetCutList(const std::vector<EDL::Cut>& cutList);
-  std::vector<EDL::Cut> GetCutList() const;
+  void SetEditList(const std::vector<EDL::Edit>& editList);
+  std::vector<EDL::Edit> GetEditList() const;
   void SetChapters(const std::vector<std::pair<std::string, int64_t>>& chapters);
   std::vector<std::pair<std::string, int64_t>> GetChapters() const;
 
@@ -155,7 +155,7 @@ protected:
   mutable CCriticalSection m_contentSection;
   struct SContentInfo
   {
-    std::vector<EDL::Cut> m_cutList;
+    std::vector<EDL::Edit> m_editList;
     std::vector<std::pair<std::string, int64_t>> m_chapters; // name and position for chapters
   } m_contentInfo;
 

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -60,8 +60,19 @@ public:
   int GetAudioBitsPerSample();
 
   // content info
+
+  /*!
+   * @brief Set the EDL edit list.
+   * @param editList The vector of edits to fill.
+   */
   void SetEditList(const std::vector<EDL::Edit>& editList);
+
+  /*!
+   * @brief Get the EDL edit list.
+   * @return The EDL edits or an empty vector if no edits exist.
+   */
   std::vector<EDL::Edit> GetEditList() const;
+
   void SetChapters(const std::vector<std::pair<std::string, int64_t>>& chapters);
   std::vector<std::pair<std::string, int64_t>> GetChapters() const;
 

--- a/xbmc/cores/EdlEdit.h
+++ b/xbmc/cores/EdlEdit.h
@@ -19,11 +19,11 @@ enum class Action
   COMM_BREAK = 3
 };
 
-struct Cut
+struct Edit
 {
   int start = 0; // ms
-  int end = 0;   // ms
+  int end = 0; // ms
   Action action = Action::CUT;
 };
 
-}
+} // namespace EDL

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -155,8 +155,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
         std::vector<std::string> fieldParts = StringUtils::Split(strFields[i], '.');
         if (fieldParts.size() == 1) // No ms
         {
-          editStartEnd[i] =
-              StringUtils::TimeStringToSeconds(fieldParts[0]) * (int64_t)1000; // seconds to ms
+          editStartEnd[i] = StringUtils::TimeStringToSeconds(fieldParts[0]) *
+                            static_cast<int64_t>(1000); // seconds to ms
         }
         else if (fieldParts.size() == 2) // Has ms. Everything after the dot (.) is ms
         {
@@ -175,8 +175,9 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
           {
             fieldParts[1] = fieldParts[1].substr(0, 3);
           }
-          editStartEnd[i] = (int64_t)StringUtils::TimeStringToSeconds(fieldParts[0]) * 1000 +
-                            atoi(fieldParts[1].c_str()); // seconds to ms
+          editStartEnd[i] =
+              static_cast<int64_t>(StringUtils::TimeStringToSeconds(fieldParts[0])) * 1000 +
+              atoi(fieldParts[1].c_str()); // seconds to ms
         }
         else
         {
@@ -202,7 +203,7 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       }
       else // Plain old seconds in float format, e.g. 123.45
       {
-        editStartEnd[i] = (int64_t)(atof(strFields[i].c_str()) * 1000); // seconds to ms
+        editStartEnd[i] = static_cast<int64_t>(atof(strFields[i].c_str()) * 1000); // seconds to ms
       }
     }
 
@@ -422,8 +423,8 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
          *  Times need adjusting by 1/10,000 to get ms.
          */
         Edit edit;
-        edit.start = (int64_t)(dStart / 10000);
-        edit.end = (int64_t)(dEnd / 10000);
+        edit.start = static_cast<int64_t>(dStart / 10000);
+        edit.end = static_cast<int64_t>(dEnd / 10000);
         edit.action = Action::CUT;
         bValid = AddEdit(edit);
       }
@@ -521,8 +522,8 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
        * atof() returns 0 if there were any problems and will subsequently be rejected in AddEdit().
        */
       Edit edit;
-      edit.start = (int64_t)(atof(pStart->FirstChild()->Value()) / 10000);
-      edit.end = (int64_t)(atof(pEnd->FirstChild()->Value()) / 10000);
+      edit.start = static_cast<int64_t>((atof(pStart->FirstChild()->Value()) / 10000));
+      edit.end = static_cast<int64_t>((atof(pEnd->FirstChild()->Value()) / 10000));
       edit.action = Action::COMM_BREAK;
       bValid = AddEdit(edit);
     }
@@ -633,7 +634,7 @@ bool CEdl::AddEdit(const Edit& newEdit)
     return false;
   }
 
-  for (int i = 0; i < (int)m_vecEdits.size(); i++)
+  for (size_t i = 0; i < m_vecEdits.size(); ++i)
   {
     if (edit.start < m_vecEdits[i].start && edit.end > m_vecEdits[i].end)
     {
@@ -737,7 +738,7 @@ int CEdl::RemoveCutTime(int iSeek) const
    * total duration for display.
    */
   int iCutTime = 0;
-  for (int i = 0; i < (int)m_vecEdits.size(); i++)
+  for (size_t i = 0; i < m_vecEdits.size(); ++i)
   {
     if (m_vecEdits[i].action == Action::CUT)
     {
@@ -757,7 +758,7 @@ double CEdl::RestoreCutTime(double dClock) const
     return dClock;
 
   double dSeek = dClock;
-  for (int i = 0; i < (int)m_vecEdits.size(); i++)
+  for (size_t i = 0; i < m_vecEdits.size(); ++i)
   {
     if (m_vecEdits[i].action == Action::CUT && dSeek >= m_vecEdits[i].start)
       dSeek += static_cast<double>(m_vecEdits[i].end - m_vecEdits[i].start);
@@ -777,7 +778,7 @@ std::string CEdl::GetInfo() const
   if (HasEdits())
   {
     int cutCount = 0, muteCount = 0, commBreakCount = 0;
-    for (int i = 0; i < (int)m_vecEdits.size(); i++)
+    for (size_t i = 0; i < m_vecEdits.size(); ++i)
     {
       switch (m_vecEdits[i].action)
       {
@@ -809,7 +810,7 @@ std::string CEdl::GetInfo() const
 
 bool CEdl::InEdit(const int iSeek, Edit* pEdit)
 {
-  for (int i = 0; i < (int)m_vecEdits.size(); i++)
+  for (size_t i = 0; i < m_vecEdits.size(); ++i)
   {
     if (iSeek < m_vecEdits[i].start) // Early exit if not even up to the edit start time.
       return false;
@@ -860,7 +861,7 @@ bool CEdl::GetNearestEdit(bool bPlus, const int iSeek, Edit* pEdit) const
   else
   {
     // Searching backwards
-    for (int i = (int)m_vecEdits.size() - 1; i >= 0; i--)
+    for (size_t i = m_vecEdits.size() - 1; i >= 0; i--)
     {
       if (iSeek - 20000 >= m_vecEdits[i].start && iSeek <= m_vecEdits[i].end)
       // Inside edit. We ignore if we're closer to 20 seconds inside
@@ -953,7 +954,7 @@ void CEdl::MergeShortCommBreaks()
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   if (advancedSettings->m_bEdlMergeShortCommBreaks)
   {
-    for (int i = 0; i < static_cast<int>(m_vecEdits.size()) - 1; i++)
+    for (size_t i = 0; i < m_vecEdits.size() - 1; ++i)
     {
       if ((m_vecEdits[i].action == Action::COMM_BREAK &&
            m_vecEdits[i + 1].action == Action::COMM_BREAK) &&
@@ -1003,7 +1004,7 @@ void CEdl::MergeShortCommBreaks()
     /*
      * Remove any commercial breaks shorter than the minimum (unless at the start)
      */
-    for (int i = 0; i < static_cast<int>(m_vecEdits.size()); i++)
+    for (size_t i = 0; i < m_vecEdits.size(); ++i)
     {
       if (m_vecEdits[i].action == Action::COMM_BREAK && m_vecEdits[i].start > 0 &&
           (m_vecEdits[i].end - m_vecEdits[i].start) <
@@ -1024,7 +1025,7 @@ void CEdl::MergeShortCommBreaks()
   /*
    * Add in scene markers at the start and end of the commercial breaks.
    */
-  for (int i = 0; i < (int)m_vecEdits.size(); i++)
+  for (size_t i = 0; i < m_vecEdits.size(); ++i)
   {
     if (m_vecEdits[i].action == Action::COMM_BREAK)
     {

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -680,7 +680,7 @@ bool CEdl::AddEdit(const Edit& newEdit)
     CLog::Log(LOGDEBUG, "{} - Pushing new edit to back [{} - {}], {}", __FUNCTION__,
               MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
               static_cast<int>(edit.action));
-    m_vecEdits.push_back(edit);
+    m_vecEdits.emplace_back(edit);
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -730,6 +730,9 @@ int CEdl::GetTotalCutTime() const
 
 int CEdl::RemoveCutTime(int iSeek) const
 {
+  // FIXME - This should actually be HasCuts and not HasEdits
+  // since if the file HasEdits but not any EDL cut there's
+  // no time to remove
   if (!HasEdits())
     return iSeek;
 
@@ -755,6 +758,9 @@ int CEdl::RemoveCutTime(int iSeek) const
 
 double CEdl::RestoreCutTime(double dClock) const
 {
+  // FIXME - This should actually be HasCuts and not HasEdits
+  // since if the file HasEdits but not any EDL cut there's
+  // no time to restore
   if (!HasEdits())
     return dClock;
 

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -843,23 +843,23 @@ void CEdl::SetLastEditTime(int editTime)
   m_lastEditTime = editTime;
 }
 
-bool CEdl::GetNearestEdit(bool bPlus, const int iSeek, Edit* pEdit) const
+bool CEdl::GetNearestEdit(bool forward, int seekTime, Edit* nearestEdit) const
 {
-  if (bPlus)
+  if (forward)
   {
     // Searching forwards
     for (auto& edit : m_vecEdits)
     {
-      if (iSeek >= edit.start && iSeek <= edit.end) // Inside edit.
+      if (seekTime >= edit.start && seekTime <= edit.end) // Inside edit.
       {
-        if (pEdit)
-          *pEdit = edit;
+        if (nearestEdit)
+          *nearestEdit = edit;
         return true;
       }
-      else if (iSeek < edit.start) // before this edit
+      else if (seekTime < edit.start) // before this edit
       {
-        if (pEdit)
-          *pEdit = edit;
+        if (nearestEdit)
+          *nearestEdit = edit;
         return true;
       }
     }
@@ -870,17 +870,17 @@ bool CEdl::GetNearestEdit(bool bPlus, const int iSeek, Edit* pEdit) const
     // Searching backwards
     for (size_t i = m_vecEdits.size() - 1; i >= 0; i--)
     {
-      if (iSeek - 20000 >= m_vecEdits[i].start && iSeek <= m_vecEdits[i].end)
+      if (seekTime - 20000 >= m_vecEdits[i].start && seekTime <= m_vecEdits[i].end)
       // Inside edit. We ignore if we're closer to 20 seconds inside
       {
-        if (pEdit)
-          *pEdit = m_vecEdits[i];
+        if (nearestEdit)
+          *nearestEdit = m_vecEdits[i];
         return true;
       }
-      else if (iSeek > m_vecEdits[i].end) // after this edit
+      else if (seekTime > m_vecEdits[i].end) // after this edit
       {
-        if (pEdit)
-          *pEdit = m_vecEdits[i];
+        if (nearestEdit)
+          *nearestEdit = m_vecEdits[i];
         return true;
       }
     }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -177,7 +177,7 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
           }
           editStartEnd[i] =
               static_cast<int64_t>(StringUtils::TimeStringToSeconds(fieldParts[0])) * 1000 +
-              atoi(fieldParts[1].c_str()); // seconds to ms
+              std::atoi(fieldParts[1].c_str()); // seconds to ms
         }
         else
         {
@@ -203,7 +203,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       }
       else // Plain old seconds in float format, e.g. 123.45
       {
-        editStartEnd[i] = static_cast<int64_t>(atof(strFields[i].c_str()) * 1000); // seconds to ms
+        editStartEnd[i] =
+            static_cast<int64_t>(std::atof(strFields[i].c_str()) * 1000); // seconds to ms
       }
     }
 
@@ -522,8 +523,8 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
        * atof() returns 0 if there were any problems and will subsequently be rejected in AddEdit().
        */
       Edit edit;
-      edit.start = static_cast<int64_t>((atof(pStart->FirstChild()->Value()) / 10000));
-      edit.end = static_cast<int64_t>((atof(pEnd->FirstChild()->Value()) / 10000));
+      edit.start = static_cast<int64_t>((std::atof(pStart->FirstChild()->Value()) / 10000));
+      edit.end = static_cast<int64_t>((std::atof(pEnd->FirstChild()->Value()) / 10000));
       edit.action = Action::COMM_BREAK;
       bValid = AddEdit(edit);
     }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -10,7 +10,7 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "cores/Cut.h"
+#include "cores/EdlEdit.h"
 #include "filesystem/File.h"
 #include "pvr/PVREdl.h"
 #include "settings/AdvancedSettings.h"
@@ -37,10 +37,10 @@ CEdl::CEdl()
 
 void CEdl::Clear()
 {
-  m_vecCuts.clear();
+  m_vecEdits.clear();
   m_vecSceneMarkers.clear();
   m_iTotalCutTime = 0;
-  m_lastCutTime = -1;
+  m_lastEditTime = -1;
 }
 
 bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond)
@@ -147,7 +147,7 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
      * For each of the first two fields read, parse based on whether it is a time string
      * (HH:MM:SS.sss), frame marker (#12345), or normal seconds string (123.45).
      */
-    int64_t iCutStartEnd[2];
+    int64_t editStartEnd[2];
     for (int i = 0; i < 2; i++)
     {
       if (strFields[i].find(':') != std::string::npos) // HH:MM:SS.sss format
@@ -155,7 +155,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
         std::vector<std::string> fieldParts = StringUtils::Split(strFields[i], '.');
         if (fieldParts.size() == 1) // No ms
         {
-          iCutStartEnd[i] = StringUtils::TimeStringToSeconds(fieldParts[0]) * (int64_t)1000; // seconds to ms
+          editStartEnd[i] =
+              StringUtils::TimeStringToSeconds(fieldParts[0]) * (int64_t)1000; // seconds to ms
         }
         else if (fieldParts.size() == 2) // Has ms. Everything after the dot (.) is ms
         {
@@ -174,7 +175,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
           {
             fieldParts[1] = fieldParts[1].substr(0, 3);
           }
-          iCutStartEnd[i] = (int64_t)StringUtils::TimeStringToSeconds(fieldParts[0]) * 1000 + atoi(fieldParts[1].c_str()); // seconds to ms
+          editStartEnd[i] = (int64_t)StringUtils::TimeStringToSeconds(fieldParts[0]) * 1000 +
+                            atoi(fieldParts[1].c_str()); // seconds to ms
         }
         else
         {
@@ -186,7 +188,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       {
         if (fFramesPerSecond > 0.0f)
         {
-          iCutStartEnd[i] = static_cast<int64_t>(std::atol(strFields[i].substr(1).c_str()) / fFramesPerSecond * 1000); // frame number to ms
+          editStartEnd[i] = static_cast<int64_t>(std::atol(strFields[i].substr(1).c_str()) /
+                                                 fFramesPerSecond * 1000); // frame number to ms
         }
         else
         {
@@ -199,22 +202,22 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       }
       else // Plain old seconds in float format, e.g. 123.45
       {
-        iCutStartEnd[i] = (int64_t)(atof(strFields[i].c_str()) * 1000); // seconds to ms
+        editStartEnd[i] = (int64_t)(atof(strFields[i].c_str()) * 1000); // seconds to ms
       }
     }
 
     if (bError) // If there was an error in the for loop, ignore and continue with the next line
       continue;
 
-    Cut cut;
-    cut.start = iCutStartEnd[0];
-    cut.end = iCutStartEnd[1];
+    Edit edit;
+    edit.start = editStartEnd[0];
+    edit.end = editStartEnd[1];
 
     switch (iAction)
     {
     case 0:
-      cut.action = Action::CUT;
-      if (!AddCut(cut))
+      edit.action = Action::CUT;
+      if (!AddEdit(edit))
       {
         CLog::Log(LOGWARNING, "{} - Error adding cut from line {} in EDL file: {}", __FUNCTION__,
                   iLine, CURL::GetRedacted(edlFilename));
@@ -222,8 +225,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       }
       break;
     case 1:
-      cut.action = Action::MUTE;
-      if (!AddCut(cut))
+      edit.action = Action::MUTE;
+      if (!AddEdit(edit))
       {
         CLog::Log(LOGWARNING, "{} - Error adding mute from line {} in EDL file: {}", __FUNCTION__,
                   iLine, CURL::GetRedacted(edlFilename));
@@ -231,7 +234,7 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       }
       break;
     case 2:
-      if (!AddSceneMarker(cut.end))
+      if (!AddSceneMarker(edit.end))
       {
         CLog::Log(LOGWARNING, "{} - Error adding scene marker from line {} in EDL file: {}",
                   __FUNCTION__, iLine, CURL::GetRedacted(edlFilename));
@@ -239,8 +242,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       }
       break;
     case 3:
-      cut.action = Action::COMM_BREAK;
-      if (!AddCut(cut))
+      edit.action = Action::COMM_BREAK;
+      if (!AddEdit(edit))
       {
         CLog::Log(LOGWARNING, "{} - Error adding commercial break from line {} in EDL file: {}",
                   __FUNCTION__, iLine, CURL::GetRedacted(edlFilename));
@@ -260,15 +263,15 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
 
   edlFile.Close();
 
-  if (HasCut() || HasSceneMarker())
+  if (HasEdits() || HasSceneMarker())
   {
-    CLog::Log(LOGDEBUG, "{0} - Read {1} cuts and {2} scene markers in EDL file: {3}", __FUNCTION__,
-              m_vecCuts.size(), m_vecSceneMarkers.size(), CURL::GetRedacted(edlFilename));
+    CLog::Log(LOGDEBUG, "{0} - Read {1} edits and {2} scene markers in EDL file: {3}", __FUNCTION__,
+              m_vecEdits.size(), m_vecSceneMarkers.size(), CURL::GetRedacted(edlFilename));
     return true;
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - No cuts or scene markers found in EDL file: {}", __FUNCTION__,
+    CLog::Log(LOGDEBUG, "{} - No edits or scene markers found in EDL file: {}", __FUNCTION__,
               CURL::GetRedacted(edlFilename));
     return false;
   }
@@ -335,11 +338,11 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
     double dStartFrame, dEndFrame;
     if (sscanf(szBuffer, "%lf %lf", &dStartFrame, &dEndFrame) == 2)
     {
-      Cut cut;
-      cut.start = static_cast<int64_t>(dStartFrame / static_cast<double>(fFrameRate) * 1000.0);
-      cut.end = static_cast<int64_t>(dEndFrame / static_cast<double>(fFrameRate) * 1000.0);
-      cut.action = Action::COMM_BREAK;
-      bValid = AddCut(cut);
+      Edit edit;
+      edit.start = static_cast<int64_t>(dStartFrame / static_cast<double>(fFrameRate) * 1000.0);
+      edit.end = static_cast<int64_t>(dEndFrame / static_cast<double>(fFrameRate) * 1000.0);
+      edit.action = Action::COMM_BREAK;
+      bValid = AddEdit(edit);
     }
     else
       bValid = false;
@@ -355,10 +358,10 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
     Clear();
     return false;
   }
-  else if (HasCut())
+  else if (HasEdits())
   {
     CLog::Log(LOGDEBUG, "{0} - Read {1} commercial breaks from Comskip file: {2}", __FUNCTION__,
-              m_vecCuts.size(), CURL::GetRedacted(comskipFilename));
+              m_vecEdits.size(), CURL::GetRedacted(comskipFilename));
     return true;
   }
   else
@@ -418,11 +421,11 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
         /*
          *  Times need adjusting by 1/10,000 to get ms.
          */
-        Cut cut;
-        cut.start = (int64_t)(dStart / 10000);
-        cut.end = (int64_t)(dEnd / 10000);
-        cut.action = Action::CUT;
-        bValid = AddCut(cut);
+        Edit edit;
+        edit.start = (int64_t)(dStart / 10000);
+        edit.end = (int64_t)(dEnd / 10000);
+        edit.action = Action::CUT;
+        bValid = AddEdit(edit);
       }
       else
         bValid = false;
@@ -445,22 +448,22 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
   if (!bValid)
   {
     CLog::Log(LOGERROR,
-              "{} - Invalid VideoReDo file: {}. Error in line {}. Clearing any valid cuts or "
+              "{} - Invalid VideoReDo file: {}. Error in line {}. Clearing any valid edits or "
               "scenes found.",
               __FUNCTION__, CURL::GetRedacted(videoReDoFilename), iLine);
     Clear();
     return false;
   }
-  else if (HasCut() || HasSceneMarker())
+  else if (HasEdits() || HasSceneMarker())
   {
-    CLog::Log(LOGDEBUG, "{0} - Read {1} cuts and {2} scene markers in VideoReDo file: {3}",
-              __FUNCTION__, m_vecCuts.size(), m_vecSceneMarkers.size(),
+    CLog::Log(LOGDEBUG, "{0} - Read {1} edits and {2} scene markers in VideoReDo file: {3}",
+              __FUNCTION__, m_vecEdits.size(), m_vecSceneMarkers.size(),
               CURL::GetRedacted(videoReDoFilename));
     return true;
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - No cuts or scene markers found in VideoReDo file: {}", __FUNCTION__,
+    CLog::Log(LOGDEBUG, "{} - No edits or scene markers found in VideoReDo file: {}", __FUNCTION__,
               CURL::GetRedacted(videoReDoFilename));
     return false;
   }
@@ -515,13 +518,13 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
        * Don't use atoll even though it is more correct as it isn't natively supported by
        * Visual Studio.
        *
-       * atof() returns 0 if there were any problems and will subsequently be rejected in AddCut().
+       * atof() returns 0 if there were any problems and will subsequently be rejected in AddEdit().
        */
-      Cut cut;
-      cut.start = (int64_t)(atof(pStart->FirstChild()->Value()) / 10000);
-      cut.end = (int64_t)(atof(pEnd->FirstChild()->Value()) / 10000);
-      cut.action = Action::COMM_BREAK;
-      bValid = AddCut(cut);
+      Edit edit;
+      edit.start = (int64_t)(atof(pStart->FirstChild()->Value()) / 10000);
+      edit.end = (int64_t)(atof(pEnd->FirstChild()->Value()) / 10000);
+      edit.action = Action::COMM_BREAK;
+      bValid = AddEdit(edit);
     }
     else
       bValid = false;
@@ -536,10 +539,10 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
     Clear();
     return false;
   }
-  else if (HasCut())
+  else if (HasEdits())
   {
     CLog::Log(LOGDEBUG, "{0} - Read {1} commercial breaks from Beyond TV file: {2}", __FUNCTION__,
-              m_vecCuts.size(), CURL::GetRedacted(beyondTVFilename));
+              m_vecEdits.size(), CURL::GetRedacted(beyondTVFilename));
     return true;
   }
   else
@@ -552,95 +555,96 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
 
 bool CEdl::ReadPvr(const CFileItem &fileItem)
 {
-  const std::vector<Cut> cutlist = PVR::CPVREdl::GetCuts(fileItem);
-  for (const auto& cut : cutlist)
+  const std::vector<Edit> editlist = PVR::CPVREdl::GetEdits(fileItem);
+  for (const auto& edit : editlist)
   {
-    switch (cut.action)
+    switch (edit.action)
     {
       case Action::CUT:
       case Action::MUTE:
       case Action::COMM_BREAK:
-        if (AddCut(cut))
+        if (AddEdit(edit))
         {
           CLog::Log(LOGDEBUG, "{} - Added break [{} - {}] found in PVR item for: {}.", __FUNCTION__,
-                    MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
+                    MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
                     CURL::GetRedacted(fileItem.GetDynPath()));
         }
         else
         {
           CLog::Log(LOGERROR,
                     "{} - Invalid break [{} - {}] found in PVR item for: {}. Continuing anyway.",
-                    __FUNCTION__, MillisecondsToTimeString(cut.start),
-                    MillisecondsToTimeString(cut.end), CURL::GetRedacted(fileItem.GetDynPath()));
+                    __FUNCTION__, MillisecondsToTimeString(edit.start),
+                    MillisecondsToTimeString(edit.end), CURL::GetRedacted(fileItem.GetDynPath()));
         }
         break;
 
       case Action::SCENE:
-        if (!AddSceneMarker(cut.end))
+        if (!AddSceneMarker(edit.end))
         {
           CLog::Log(LOGWARNING, "{} - Error adding scene marker for PVR item", __FUNCTION__);
         }
         break;
 
       default:
-        CLog::Log(LOGINFO, "{} - Ignoring entry of unknown cut action: {}", __FUNCTION__,
-                  static_cast<int>(cut.action));
+        CLog::Log(LOGINFO, "{} - Ignoring entry of unknown edit action: {}", __FUNCTION__,
+                  static_cast<int>(edit.action));
         break;
     }
   }
 
-  return !cutlist.empty();
+  return !editlist.empty();
 }
 
-bool CEdl::AddCut(const Cut& newCut)
+bool CEdl::AddEdit(const Edit& newEdit)
 {
-  Cut cut = newCut;
+  Edit edit = newEdit;
 
-  if (cut.action != Action::CUT && cut.action != Action::MUTE && cut.action != Action::COMM_BREAK)
+  if (edit.action != Action::CUT && edit.action != Action::MUTE &&
+      edit.action != Action::COMM_BREAK)
   {
     CLog::Log(LOGERROR,
               "{} - Not an Action::CUT, Action::MUTE, or Action::COMM_BREAK! [{} - {}], {}",
-              __FUNCTION__, MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
-              static_cast<int>(cut.action));
+              __FUNCTION__, MillisecondsToTimeString(edit.start),
+              MillisecondsToTimeString(edit.end), static_cast<int>(edit.action));
     return false;
   }
 
-  if (cut.start < 0)
+  if (edit.start < 0)
   {
     CLog::Log(LOGERROR, "{} - Before start! [{} - {}], {}", __FUNCTION__,
-              MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
-              static_cast<int>(cut.action));
+              MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+              static_cast<int>(edit.action));
     return false;
   }
 
-  if (cut.start >= cut.end)
+  if (edit.start >= edit.end)
   {
     CLog::Log(LOGERROR, "{} - Times are around the wrong way or the same! [{} - {}], {}",
-              __FUNCTION__, MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
-              static_cast<int>(cut.action));
+              __FUNCTION__, MillisecondsToTimeString(edit.start),
+              MillisecondsToTimeString(edit.end), static_cast<int>(edit.action));
     return false;
   }
 
-  if (InCut(cut.start) || InCut(cut.end))
+  if (InEdit(edit.start) || InEdit(edit.end))
   {
-    CLog::Log(LOGERROR, "{} - Start or end is in an existing cut! [{} - {}], {}", __FUNCTION__,
-              MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
-              static_cast<int>(cut.action));
+    CLog::Log(LOGERROR, "{} - Start or end is in an existing edit! [{} - {}], {}", __FUNCTION__,
+              MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+              static_cast<int>(edit.action));
     return false;
   }
 
-  for (int i = 0; i < (int)m_vecCuts.size(); i++)
+  for (int i = 0; i < (int)m_vecEdits.size(); i++)
   {
-    if (cut.start < m_vecCuts[i].start && cut.end > m_vecCuts[i].end)
+    if (edit.start < m_vecEdits[i].start && edit.end > m_vecEdits[i].end)
     {
-      CLog::Log(LOGERROR, "{} - Cut surrounds an existing cut! [{} - {}], {}", __FUNCTION__,
-                MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
-                static_cast<int>(cut.action));
+      CLog::Log(LOGERROR, "{} - Edit surrounds an existing edit! [{} - {}], {}", __FUNCTION__,
+                MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                static_cast<int>(edit.action));
       return false;
     }
   }
 
-  if (cut.action == Action::COMM_BREAK)
+  if (edit.action == Action::COMM_BREAK)
   {
     /*
      * Detection isn't perfect near the edges of commercial breaks so automatically wait for a bit at
@@ -650,59 +654,59 @@ bool CEdl::AddCut(const Cut& newCut)
     int autowait = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iEdlCommBreakAutowait * 1000; // seconds -> ms
     int autowind = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iEdlCommBreakAutowind * 1000; // seconds -> ms
 
-    if (cut.start > 0) // Only autowait if not at the start.
+    if (edit.start > 0) // Only autowait if not at the start.
     {
-      /* get the cut length so we don't start skipping after the end */
-      int cutLength = cut.end - cut.start;
-      /* add the lesser of the cut length or the autowait to the start */
-      cut.start += autowait > cutLength ? cutLength : autowait;
+      /* get the edit length so we don't start skipping after the end */
+      int editLength = edit.end - edit.start;
+      /* add the lesser of the edit length or the autowait to the start */
+      edit.start += autowait > editLength ? editLength : autowait;
     }
-    if (cut.end > cut.start) // Only autowind if there is any cut time remaining.
+    if (edit.end > edit.start) // Only autowind if there is any edit time remaining.
     {
-      /* get the remaining cut length so we don't rewind to before the start */
-      int cutLength = cut.end - cut.start;
-      /* subtract the lesser of the cut length or the autowind from the end */
-      cut.end -= autowind > cutLength ? cutLength : autowind;
+      /* get the remaining edit length so we don't rewind to before the start */
+      int editLength = edit.end - edit.start;
+      /* subtract the lesser of the edit length or the autowind from the end */
+      edit.end -= autowind > editLength ? editLength : autowind;
     }
   }
 
   /*
-   * Insert cut in the list in the right position (ALL algorithms assume cuts are in ascending order)
+   * Insert edit in the list in the right position (ALL algorithms assume edits are in ascending order)
    */
-  if (m_vecCuts.empty() || cut.start > m_vecCuts.back().start)
+  if (m_vecEdits.empty() || edit.start > m_vecEdits.back().start)
   {
-    CLog::Log(LOGDEBUG, "{} - Pushing new cut to back [{} - {}], {}", __FUNCTION__,
-              MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
-              static_cast<int>(cut.action));
-    m_vecCuts.push_back(cut);
+    CLog::Log(LOGDEBUG, "{} - Pushing new edit to back [{} - {}], {}", __FUNCTION__,
+              MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+              static_cast<int>(edit.action));
+    m_vecEdits.push_back(edit);
   }
   else
   {
-    std::vector<Cut>::iterator pCurrentCut;
-    for (pCurrentCut = m_vecCuts.begin(); pCurrentCut != m_vecCuts.end(); ++pCurrentCut)
+    std::vector<Edit>::iterator pCurrentEdit;
+    for (pCurrentEdit = m_vecEdits.begin(); pCurrentEdit != m_vecEdits.end(); ++pCurrentEdit)
     {
-      if (cut.start < pCurrentCut->start)
+      if (edit.start < pCurrentEdit->start)
       {
-        CLog::Log(LOGDEBUG, "{} - Inserting new cut [{} - {}], {}", __FUNCTION__,
-                  MillisecondsToTimeString(cut.start), MillisecondsToTimeString(cut.end),
-                  static_cast<int>(cut.action));
-        m_vecCuts.insert(pCurrentCut, cut);
+        CLog::Log(LOGDEBUG, "{} - Inserting new edit [{} - {}], {}", __FUNCTION__,
+                  MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                  static_cast<int>(edit.action));
+        m_vecEdits.insert(pCurrentEdit, edit);
         break;
       }
     }
   }
 
-  if (cut.action == Action::CUT)
-    m_iTotalCutTime += cut.end - cut.start;
+  if (edit.action == Action::CUT)
+    m_iTotalCutTime += edit.end - edit.start;
 
   return true;
 }
 
 bool CEdl::AddSceneMarker(const int iSceneMarker)
 {
-  Cut cut;
+  Edit edit;
 
-  if (InCut(iSceneMarker, &cut) && cut.action == Action::CUT) // Only works for current cuts.
+  if (InEdit(iSceneMarker, &edit) && edit.action == Action::CUT) // Only works for current cuts.
     return false;
 
   CLog::Log(LOGDEBUG, "{} - Inserting new scene marker: {}", __FUNCTION__,
@@ -712,9 +716,9 @@ bool CEdl::AddSceneMarker(const int iSceneMarker)
   return true;
 }
 
-bool CEdl::HasCut() const
+bool CEdl::HasEdits() const
 {
-  return !m_vecCuts.empty();
+  return !m_vecEdits.empty();
 }
 
 int CEdl::GetTotalCutTime() const
@@ -724,7 +728,7 @@ int CEdl::GetTotalCutTime() const
 
 int CEdl::RemoveCutTime(int iSeek) const
 {
-  if (!HasCut())
+  if (!HasEdits())
     return iSeek;
 
   /**
@@ -733,14 +737,15 @@ int CEdl::RemoveCutTime(int iSeek) const
    * total duration for display.
    */
   int iCutTime = 0;
-  for (int i = 0; i < (int)m_vecCuts.size(); i++)
+  for (int i = 0; i < (int)m_vecEdits.size(); i++)
   {
-    if (m_vecCuts[i].action == Action::CUT)
+    if (m_vecEdits[i].action == Action::CUT)
     {
-      if (iSeek >= m_vecCuts[i].start && iSeek <= m_vecCuts[i].end) // Inside cut
-        iCutTime += iSeek - m_vecCuts[i].start - 1; // Decrease cut length by 1ms to jump over end boundary.
-      else if (iSeek >= m_vecCuts[i].start) // Cut has already been passed over.
-        iCutTime += m_vecCuts[i].end - m_vecCuts[i].start;
+      if (iSeek >= m_vecEdits[i].start && iSeek <= m_vecEdits[i].end) // Inside cut
+        iCutTime += iSeek - m_vecEdits[i].start -
+                    1; // Decrease cut length by 1ms to jump over end boundary.
+      else if (iSeek >= m_vecEdits[i].start) // Cut has already been passed over.
+        iCutTime += m_vecEdits[i].end - m_vecEdits[i].start;
     }
   }
   return iSeek - iCutTime;
@@ -748,14 +753,14 @@ int CEdl::RemoveCutTime(int iSeek) const
 
 double CEdl::RestoreCutTime(double dClock) const
 {
-  if (!HasCut())
+  if (!HasEdits())
     return dClock;
 
   double dSeek = dClock;
-  for (int i = 0; i < (int)m_vecCuts.size(); i++)
+  for (int i = 0; i < (int)m_vecEdits.size(); i++)
   {
-    if (m_vecCuts[i].action == Action::CUT && dSeek >= m_vecCuts[i].start)
-      dSeek += static_cast<double>(m_vecCuts[i].end - m_vecCuts[i].start);
+    if (m_vecEdits[i].action == Action::CUT && dSeek >= m_vecEdits[i].start)
+      dSeek += static_cast<double>(m_vecEdits[i].end - m_vecEdits[i].start);
   }
 
   return dSeek;
@@ -769,12 +774,12 @@ bool CEdl::HasSceneMarker() const
 std::string CEdl::GetInfo() const
 {
   std::string strInfo;
-  if (HasCut())
+  if (HasEdits())
   {
     int cutCount = 0, muteCount = 0, commBreakCount = 0;
-    for (int i = 0; i < (int)m_vecCuts.size(); i++)
+    for (int i = 0; i < (int)m_vecEdits.size(); i++)
     {
-      switch (m_vecCuts[i].action)
+      switch (m_vecEdits[i].action)
       {
       case Action::CUT:
         cutCount++;
@@ -802,17 +807,17 @@ std::string CEdl::GetInfo() const
   return strInfo;
 }
 
-bool CEdl::InCut(const int iSeek, Cut *pCut)
+bool CEdl::InEdit(const int iSeek, Edit* pEdit)
 {
-  for (int i = 0; i < (int)m_vecCuts.size(); i++)
+  for (int i = 0; i < (int)m_vecEdits.size(); i++)
   {
-    if (iSeek < m_vecCuts[i].start) // Early exit if not even up to the cut start time.
+    if (iSeek < m_vecEdits[i].start) // Early exit if not even up to the edit start time.
       return false;
 
-    if (iSeek >= m_vecCuts[i].start && iSeek <= m_vecCuts[i].end) // Inside cut.
+    if (iSeek >= m_vecEdits[i].start && iSeek <= m_vecEdits[i].end) // Inside edit.
     {
-      if (pCut)
-        *pCut = m_vecCuts[i];
+      if (pEdit)
+        *pEdit = m_vecEdits[i];
       return true;
     }
   }
@@ -820,33 +825,33 @@ bool CEdl::InCut(const int iSeek, Cut *pCut)
   return false;
 }
 
-int CEdl::GetLastCutTime() const
+int CEdl::GetLastEditTime() const
 {
-  return m_lastCutTime;
+  return m_lastEditTime;
 }
 
-void CEdl::SetLastCutTime(const int iCutTime)
+void CEdl::SetLastEditTime(const int editTime)
 {
-  m_lastCutTime = iCutTime;
+  m_lastEditTime = editTime;
 }
 
-bool CEdl::GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const
+bool CEdl::GetNearestEdit(bool bPlus, const int iSeek, Edit* pEdit) const
 {
   if (bPlus)
   {
     // Searching forwards
-    for (auto &cut : m_vecCuts)
+    for (auto& edit : m_vecEdits)
     {
-      if (iSeek >= cut.start && iSeek <= cut.end) // Inside cut.
+      if (iSeek >= edit.start && iSeek <= edit.end) // Inside edit.
       {
-        if (pCut)
-          *pCut = cut;
+        if (pEdit)
+          *pEdit = edit;
         return true;
       }
-      else if (iSeek < cut.start) // before this cut
+      else if (iSeek < edit.start) // before this edit
       {
-        if (pCut)
-          *pCut = cut;
+        if (pEdit)
+          *pEdit = edit;
         return true;
       }
     }
@@ -855,19 +860,19 @@ bool CEdl::GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const
   else
   {
     // Searching backwards
-    for (int i = (int)m_vecCuts.size() - 1; i >= 0; i--)
+    for (int i = (int)m_vecEdits.size() - 1; i >= 0; i--)
     {
-      if (iSeek - 20000 >= m_vecCuts[i].start && iSeek <= m_vecCuts[i].end)
-        // Inside cut. We ignore if we're closer to 20 seconds inside
+      if (iSeek - 20000 >= m_vecEdits[i].start && iSeek <= m_vecEdits[i].end)
+      // Inside edit. We ignore if we're closer to 20 seconds inside
       {
-        if (pCut)
-          *pCut = m_vecCuts[i];
+        if (pEdit)
+          *pEdit = m_vecEdits[i];
         return true;
       }
-      else if (iSeek > m_vecCuts[i].end) // after this cut
+      else if (iSeek > m_vecEdits[i].end) // after this edit
       {
-        if (pCut)
-          *pCut = m_vecCuts[i];
+        if (pEdit)
+          *pEdit = m_vecEdits[i];
         return true;
       }
     }
@@ -914,9 +919,9 @@ bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker)
    * If the scene marker is in a cut then return the end of the cut. Can't guarantee that this is
    * picked up when scene markers are added.
    */
-  Cut cut;
-  if (bFound && InCut(*iSceneMarker, &cut) && cut.action == Action::CUT)
-    *iSceneMarker = cut.end;
+  Edit edit;
+  if (bFound && InEdit(*iSceneMarker, &edit) && edit.action == Action::CUT)
+    *iSceneMarker = edit.end;
 
   return bFound;
 }
@@ -936,43 +941,45 @@ void CEdl::MergeShortCommBreaks()
    * Remove any spurious short commercial breaks at the very start so they don't interfere with
    * the algorithms below.
    */
-  if (!m_vecCuts.empty()
-  &&  m_vecCuts[0].action == Action::COMM_BREAK
-  && (m_vecCuts[0].end - m_vecCuts[0].start) < 5 * 1000) // 5 seconds
+  if (!m_vecEdits.empty() && m_vecEdits[0].action == Action::COMM_BREAK &&
+      (m_vecEdits[0].end - m_vecEdits[0].start) < 5 * 1000) // 5 seconds
   {
     CLog::Log(LOGDEBUG, "{} - Removing short commercial break at start [{} - {}]. <5 seconds",
-              __FUNCTION__, MillisecondsToTimeString(m_vecCuts[0].start),
-              MillisecondsToTimeString(m_vecCuts[0].end));
-    m_vecCuts.erase(m_vecCuts.begin());
+              __FUNCTION__, MillisecondsToTimeString(m_vecEdits[0].start),
+              MillisecondsToTimeString(m_vecEdits[0].end));
+    m_vecEdits.erase(m_vecEdits.begin());
   }
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   if (advancedSettings->m_bEdlMergeShortCommBreaks)
   {
-    for (int i = 0; i < static_cast<int>(m_vecCuts.size()) - 1; i++)
+    for (int i = 0; i < static_cast<int>(m_vecEdits.size()) - 1; i++)
     {
-      if ((m_vecCuts[i].action == Action::COMM_BREAK && m_vecCuts[i + 1].action == Action::COMM_BREAK)
-          &&  (m_vecCuts[i + 1].end - m_vecCuts[i].start < advancedSettings->m_iEdlMaxCommBreakLength * 1000) // s to ms
-          &&  (m_vecCuts[i + 1].start - m_vecCuts[i].end < advancedSettings->m_iEdlMaxCommBreakGap * 1000)) // s to ms
+      if ((m_vecEdits[i].action == Action::COMM_BREAK &&
+           m_vecEdits[i + 1].action == Action::COMM_BREAK) &&
+          (m_vecEdits[i + 1].end - m_vecEdits[i].start <
+           advancedSettings->m_iEdlMaxCommBreakLength * 1000) // s to ms
+          && (m_vecEdits[i + 1].start - m_vecEdits[i].end <
+              advancedSettings->m_iEdlMaxCommBreakGap * 1000)) // s to ms
       {
-        Cut commBreak;
+        Edit commBreak;
         commBreak.action = Action::COMM_BREAK;
-        commBreak.start = m_vecCuts[i].start;
-        commBreak.end = m_vecCuts[i + 1].end;
+        commBreak.start = m_vecEdits[i].start;
+        commBreak.end = m_vecEdits[i + 1].end;
 
         CLog::Log(
             LOGDEBUG, "{} - Consolidating commercial break [{} - {}] and [{} - {}] to: [{} - {}]",
-            __FUNCTION__, MillisecondsToTimeString(m_vecCuts[i].start),
-            MillisecondsToTimeString(m_vecCuts[i].end),
-            MillisecondsToTimeString(m_vecCuts[i + 1].start),
-            MillisecondsToTimeString(m_vecCuts[i + 1].end),
+            __FUNCTION__, MillisecondsToTimeString(m_vecEdits[i].start),
+            MillisecondsToTimeString(m_vecEdits[i].end),
+            MillisecondsToTimeString(m_vecEdits[i + 1].start),
+            MillisecondsToTimeString(m_vecEdits[i + 1].end),
             MillisecondsToTimeString(commBreak.start), MillisecondsToTimeString(commBreak.end));
 
         /*
-         * Erase old cuts and insert the new merged one.
+         * Erase old edits and insert the new merged one.
          */
-        m_vecCuts.erase(m_vecCuts.begin() + i, m_vecCuts.begin() + i + 2);
-        m_vecCuts.insert(m_vecCuts.begin() + i, commBreak);
+        m_vecEdits.erase(m_vecEdits.begin() + i, m_vecEdits.begin() + i + 2);
+        m_vecEdits.insert(m_vecEdits.begin() + i, commBreak);
 
         i--; // Reduce i to see if the next break is also within the max commercial break length.
       }
@@ -984,30 +991,30 @@ void CEdl::MergeShortCommBreaks()
      * starts within the maximum start gap. This is done outside of the consolidation to prevent
      * the maximum commercial break length being triggered.
      */
-    if (!m_vecCuts.empty()
-        &&  m_vecCuts[0].action == Action::COMM_BREAK
-        &&  m_vecCuts[0].start < advancedSettings->m_iEdlMaxStartGap * 1000)
+    if (!m_vecEdits.empty() && m_vecEdits[0].action == Action::COMM_BREAK &&
+        m_vecEdits[0].start < advancedSettings->m_iEdlMaxStartGap * 1000)
     {
       CLog::Log(LOGDEBUG, "{} - Expanding first commercial break back to start [{} - {}].",
-                __FUNCTION__, MillisecondsToTimeString(m_vecCuts[0].start),
-                MillisecondsToTimeString(m_vecCuts[0].end));
-      m_vecCuts[0].start = 0;
+                __FUNCTION__, MillisecondsToTimeString(m_vecEdits[0].start),
+                MillisecondsToTimeString(m_vecEdits[0].end));
+      m_vecEdits[0].start = 0;
     }
 
     /*
      * Remove any commercial breaks shorter than the minimum (unless at the start)
      */
-    for (int i = 0; i < static_cast<int>(m_vecCuts.size()); i++)
+    for (int i = 0; i < static_cast<int>(m_vecEdits.size()); i++)
     {
-      if (m_vecCuts[i].action == Action::COMM_BREAK
-          &&  m_vecCuts[i].start > 0
-          && (m_vecCuts[i].end - m_vecCuts[i].start) < advancedSettings->m_iEdlMinCommBreakLength * 1000)
+      if (m_vecEdits[i].action == Action::COMM_BREAK && m_vecEdits[i].start > 0 &&
+          (m_vecEdits[i].end - m_vecEdits[i].start) <
+              advancedSettings->m_iEdlMinCommBreakLength * 1000)
       {
-        CLog::Log(
-            LOGDEBUG, "{} - Removing short commercial break [{} - {}]. Minimum length: {} seconds",
-            __FUNCTION__, MillisecondsToTimeString(m_vecCuts[i].start),
-            MillisecondsToTimeString(m_vecCuts[i].end), advancedSettings->m_iEdlMinCommBreakLength);
-        m_vecCuts.erase(m_vecCuts.begin() + i);
+        CLog::Log(LOGDEBUG,
+                  "{} - Removing short commercial break [{} - {}]. Minimum length: {} seconds",
+                  __FUNCTION__, MillisecondsToTimeString(m_vecEdits[i].start),
+                  MillisecondsToTimeString(m_vecEdits[i].end),
+                  advancedSettings->m_iEdlMinCommBreakLength);
+        m_vecEdits.erase(m_vecEdits.begin() + i);
 
         i--;
       }
@@ -1017,13 +1024,13 @@ void CEdl::MergeShortCommBreaks()
   /*
    * Add in scene markers at the start and end of the commercial breaks.
    */
-  for (int i = 0; i < (int)m_vecCuts.size(); i++)
+  for (int i = 0; i < (int)m_vecEdits.size(); i++)
   {
-    if (m_vecCuts[i].action == Action::COMM_BREAK)
+    if (m_vecEdits[i].action == Action::COMM_BREAK)
     {
-      if (m_vecCuts[i].start > 0) // Don't add a scene marker at the start.
-        AddSceneMarker(m_vecCuts[i].start);
-      AddSceneMarker(m_vecCuts[i].end);
+      if (m_vecEdits[i].start > 0) // Don't add a scene marker at the start.
+        AddSceneMarker(m_vecEdits[i].start);
+      AddSceneMarker(m_vecEdits[i].end);
     }
   }
 }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -832,7 +832,7 @@ int CEdl::GetLastEditTime() const
   return m_lastEditTime;
 }
 
-void CEdl::SetLastEditTime(const int editTime)
+void CEdl::SetLastEditTime(int editTime)
 {
   m_lastEditTime = editTime;
 }

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -23,6 +23,9 @@ class CEdl
 public:
   CEdl();
 
+  // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   bool ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond);
   void Clear();
 
@@ -78,8 +81,14 @@ public:
   */
   void SetLastEditTime(int editTime);
 
+  // FIXME: remove const modifier for iClock as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
 
+  // FIXME: remove const modifier as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   static std::string MillisecondsToTimeString(const int iMilliseconds);
 
 private:
@@ -88,9 +97,21 @@ private:
   std::vector<int> m_vecSceneMarkers;
   int m_lastEditTime;
 
+  // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   bool ReadEdl(const std::string& strMovie, const float fFramesPerSecond);
+  // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   bool ReadComskip(const std::string& strMovie, const float fFramesPerSecond);
+  // FIXME: remove const modifier for strMovie as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   bool ReadVideoReDo(const std::string& strMovie);
+  // FIXME: remove const modifier for strMovie as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   bool ReadBeyondTV(const std::string& strMovie);
   bool ReadPvr(const CFileItem& fileItem);
 
@@ -100,6 +121,10 @@ private:
    * @return true if the operation succeeds, false otherwise
   */
   bool AddEdit(const EDL::Edit& newEdit);
+
+  // FIXME: remove const modifier for strMovie as it makes no sense as it means nothing
+  // for the reader of the interface, but limits the implementation
+  // to not modify the parameter on stack
   bool AddSceneMarker(const int sceneMarker);
 
   void MergeShortCommBreaks();

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -60,12 +60,12 @@ public:
 
   /*!
    * @brief Get the nearest edit provided a given seek time
-   * @param bPlus if searching should be done forward (true) or backwards (false)
-   * @param iSeek the seek time
-   * @param[in,out] pEdit a pointer to the nearest edit
+   * @param forward if searching should be done forward (true) or backwards (false)
+   * @param seekTime the seek time
+   * @param[in,out] nearestEdit a pointer to the nearest edit
    * @return true if the nearest EDL edit was found, false otherwise
   */
-  bool GetNearestEdit(bool bPlus, const int iSeek, EDL::Edit* pEdit) const;
+  bool GetNearestEdit(bool forward, int seekTime, EDL::Edit* nearestEdit) const;
 
   /*!
    * @brief Get the last processed edit time (set during playback when a given

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -76,7 +76,7 @@ public:
    * edit is surpassed)
    * @param editTime The last processed EDL edit time (ms)
   */
-  void SetLastEditTime(const int editTime);
+  void SetLastEditTime(int editTime);
 
   bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
 

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -13,7 +13,7 @@
 
 namespace EDL
 {
-  struct Cut;
+struct Edit;
 }
 
 class CFileItem;
@@ -26,20 +26,20 @@ public:
   bool ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond);
   void Clear();
 
-  bool HasCut() const;
+  bool HasEdits() const;
   bool HasSceneMarker() const;
   std::string GetInfo() const;
   int GetTotalCutTime() const;
   int RemoveCutTime(int iSeek) const;
   double RestoreCutTime(double dClock) const;
 
-  const std::vector<EDL::Cut>& GetCutList() const { return m_vecCuts; }
+  const std::vector<EDL::Edit>& GetEditList() const { return m_vecEdits; }
 
-  bool InCut(int iSeek, EDL::Cut* pCut = nullptr);
-  bool GetNearestCut(bool bPlus, const int iSeek, EDL::Cut* pCut) const;
+  bool InEdit(int iSeek, EDL::Edit* pEdit = nullptr);
+  bool GetNearestEdit(bool bPlus, const int iSeek, EDL::Edit* pEdit) const;
 
-  int GetLastCutTime() const;
-  void SetLastCutTime(const int iCutTime);
+  int GetLastEditTime() const;
+  void SetLastEditTime(const int editTime);
 
   bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
 
@@ -47,9 +47,9 @@ public:
 
 private:
   int m_iTotalCutTime; // ms
-  std::vector<EDL::Cut> m_vecCuts;
+  std::vector<EDL::Edit> m_vecEdits;
   std::vector<int> m_vecSceneMarkers;
-  int m_lastCutTime;
+  int m_lastEditTime;
 
   bool ReadEdl(const std::string& strMovie, const float fFramesPerSecond);
   bool ReadComskip(const std::string& strMovie, const float fFramesPerSecond);
@@ -57,7 +57,7 @@ private:
   bool ReadBeyondTV(const std::string& strMovie);
   bool ReadPvr(const CFileItem& fileItem);
 
-  bool AddCut(const EDL::Cut& newCut);
+  bool AddEdit(const EDL::Edit& newEdit);
   bool AddSceneMarker(const int sceneMarker);
 
   void MergeShortCommBreaks();

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -26,19 +26,56 @@ public:
   bool ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond);
   void Clear();
 
+  /*!
+   * @brief Check if there are any parsed edits in EDL for the current item
+   * @return true if EDL has edits, false otherwise
+   */
   bool HasEdits() const;
+
   bool HasSceneMarker() const;
   std::string GetInfo() const;
   int GetTotalCutTime() const;
   int RemoveCutTime(int iSeek) const;
   double RestoreCutTime(double dClock) const;
 
+  /*!
+   * @brief Get the EDL edit list.
+   * @return The EDL edits or an empty vector if no edits exist.
+  */
   const std::vector<EDL::Edit>& GetEditList() const { return m_vecEdits; }
 
+  /*!
+   * @brief Check if for the provided seek time is contained within an EDL
+   * edit and fill pEdit with the respective edit struct.
+   * @note seek time refers to the time in the original file timeline (i.e. without
+   * considering cut blocks)
+   * @param iSeek The seek time (on the original timeline)
+   * @param[in,out] pEdit The edit pointer (or nullptr if iSeek not within an edit)
+   * @return true if iSeek is within an edit, false otherwise
+  */
   bool InEdit(int iSeek, EDL::Edit* pEdit = nullptr);
+
+  /*!
+   * @brief Get the nearest edit provided a given seek time
+   * @param bPlus if searching should be done forward (true) or backwards (false)
+   * @param iSeek the seek time
+   * @param[in,out] pEdit a pointer to the nearest edit
+   * @return true if the nearest EDL edit was found, false otherwise
+  */
   bool GetNearestEdit(bool bPlus, const int iSeek, EDL::Edit* pEdit) const;
 
+  /*!
+   * @brief Get the last processed edit time (set during playback when a given
+   * edit is surpassed)
+   * @return The last processed edit time (ms) or -1 if not any
+  */
   int GetLastEditTime() const;
+
+  /*!
+   * @brief Set the last processed edit time (set during playback when a given
+   * edit is surpassed)
+   * @param editTime The last processed EDL edit time (ms)
+  */
   void SetLastEditTime(const int editTime);
 
   bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
@@ -57,6 +94,11 @@ private:
   bool ReadBeyondTV(const std::string& strMovie);
   bool ReadPvr(const CFileItem& fileItem);
 
+  /*!
+   * @brief Adds an edit to the list of EDL edits
+   * @param newEdit the edit to add
+   * @return true if the operation succeeds, false otherwise
+  */
   bool AddEdit(const EDL::Edit& newEdit);
   bool AddSceneMarker(const int sceneMarker);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1277,7 +1277,7 @@ void CVideoPlayer::Prepare()
                   __FUNCTION__, starttime);
       }
 
-      std::string strTimeString =
+      const std::string strTimeString =
           StringUtils::SecondsToTimeString(edit.end / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
     }
@@ -2354,7 +2354,7 @@ void CVideoPlayer::CheckAutoSceneSkip()
     // marker for commbrak may be inaccurate. allow user to skip into break from the back
     if (m_playSpeed >= 0 && m_Edl.GetLastEditTime() != edit.start && clock < edit.end - 1000)
     {
-      std::string strTimeString =
+      const std::string strTimeString =
           StringUtils::SecondsToTimeString((edit.end - edit.start) / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -33,8 +33,8 @@
 #include "Util.h"
 #include "VideoPlayerAudio.h"
 #include "VideoPlayerRadioRDS.h"
-#include "cores/Cut.h"
 #include "cores/DataCacheCore.h"
+#include "cores/EdlEdit.h"
 #include "cores/FFmpeg.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
@@ -720,7 +720,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
   }
 
   m_Edl.Clear();
-  CServiceBroker::GetDataCacheCore().SetCutList(m_Edl.GetCutList());
+  CServiceBroker::GetDataCacheCore().SetEditList(m_Edl.GetEditList());
 
   m_HasVideo = false;
   m_HasAudio = false;
@@ -1243,7 +1243,7 @@ void CVideoPlayer::Prepare()
    * if there was a start time specified as part of the "Start from where last stopped" (aka
    * auto-resume) feature or if there is an EDL cut or commercial break that starts at time 0.
    */
-  EDL::Cut cut;
+  EDL::Edit edit;
   int starttime = 0;
   if (m_playerOptions.starttime > 0 || m_playerOptions.startpercent > 0)
   {
@@ -1260,24 +1260,25 @@ void CVideoPlayer::Prepare()
     CLog::Log(LOGDEBUG, "{} - Start position set to last stopped position: {}", __FUNCTION__,
               starttime);
   }
-  else if (m_Edl.InCut(starttime, &cut))
+  else if (m_Edl.InEdit(starttime, &edit))
   {
-    if (cut.action == EDL::Action::CUT)
+    if (edit.action == EDL::Action::CUT)
     {
-      starttime = cut.end;
+      starttime = edit.end;
       CLog::Log(LOGDEBUG, "{} - Start position set to end of first cut: {}", __FUNCTION__,
                 starttime);
     }
-    else if (cut.action == EDL::Action::COMM_BREAK)
+    else if (edit.action == EDL::Action::COMM_BREAK)
     {
       if (m_SkipCommercials)
       {
-        starttime = cut.end;
+        starttime = edit.end;
         CLog::Log(LOGDEBUG, "{} - Start position set to end of first commercial break: {}",
                   __FUNCTION__, starttime);
       }
 
-      std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
+      std::string strTimeString =
+          StringUtils::SecondsToTimeString(edit.end / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
     }
   }
@@ -1328,7 +1329,7 @@ void CVideoPlayer::Process()
       continue;
     }
 
-    // check if in a cut or commercial break that should be automatically skipped
+    // check if in an edit (cut or commercial break) that should be automatically skipped
     CheckAutoSceneSkip();
 
     // handle messages send to this thread, like seek or demuxer reset requests
@@ -1639,10 +1640,11 @@ void CVideoPlayer::ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket)
   /*
    * If CheckSceneSkip() returns true then demux point is inside an EDL cut and the packets are dropped.
    */
-  EDL::Cut cut;
+  EDL::Edit edit;
   if (CheckSceneSkip(m_CurrentAudio))
     drop = true;
-  else if (m_Edl.InCut(DVD_TIME_TO_MSEC(m_CurrentAudio.dts + m_offset_pts), &cut) && cut.action == EDL::Action::MUTE)
+  else if (m_Edl.InEdit(DVD_TIME_TO_MSEC(m_CurrentAudio.dts + m_offset_pts), &edit) &&
+           edit.action == EDL::Action::MUTE)
   {
     drop = true;
   }
@@ -2289,7 +2291,7 @@ bool CVideoPlayer::CheckContinuity(CCurrentStream& current, DemuxPacket* pPacket
 
 bool CVideoPlayer::CheckSceneSkip(CCurrentStream& current)
 {
-  if(!m_Edl.HasCut())
+  if (!m_Edl.HasEdits())
     return false;
 
   if(current.dts == DVD_NOPTS_VALUE)
@@ -2298,13 +2300,14 @@ bool CVideoPlayer::CheckSceneSkip(CCurrentStream& current)
   if(current.inited == false)
     return false;
 
-  EDL::Cut cut;
-  return m_Edl.InCut(DVD_TIME_TO_MSEC(current.dts + m_offset_pts), &cut) && cut.action == EDL::Action::CUT;
+  EDL::Edit edit;
+  return m_Edl.InEdit(DVD_TIME_TO_MSEC(current.dts + m_offset_pts), &edit) &&
+         edit.action == EDL::Action::CUT;
 }
 
 void CVideoPlayer::CheckAutoSceneSkip()
 {
-  if (!m_Edl.HasCut())
+  if (!m_Edl.HasEdits())
     return;
 
   // Check that there is an audio and video stream.
@@ -2320,21 +2323,21 @@ void CVideoPlayer::CheckAutoSceneSkip()
 
   const int64_t clock = GetTime();
 
-  EDL::Cut cut;
-  if (!m_Edl.InCut(clock, &cut))
+  EDL::Edit edit;
+  if (!m_Edl.InEdit(clock, &edit))
     return;
 
-  if (cut.action == EDL::Action::CUT)
+  if (edit.action == EDL::Action::CUT)
   {
-    if ((m_playSpeed > 0 && clock < cut.end - 1000) ||
-        (m_playSpeed < 0 && clock < cut.start + 1000))
+    if ((m_playSpeed > 0 && clock < edit.end - 1000) ||
+        (m_playSpeed < 0 && clock < edit.start + 1000))
     {
       CLog::Log(LOGDEBUG, "{} - Clock in EDL cut [{} - {}]: {}. Automatically skipping over.",
-                __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start),
-                CEdl::MillisecondsToTimeString(cut.end), CEdl::MillisecondsToTimeString(clock));
+                __FUNCTION__, CEdl::MillisecondsToTimeString(edit.start),
+                CEdl::MillisecondsToTimeString(edit.end), CEdl::MillisecondsToTimeString(clock));
 
-      //Seeking either goes to the start or the end of the cut depending on the play direction.
-      int seek = m_playSpeed >= 0 ? cut.end : cut.start;
+      // Seeking either goes to the start or the end of the cut depending on the play direction.
+      int seek = m_playSpeed >= 0 ? edit.end : edit.start;
 
       CDVDMsgPlayerSeek::CMode mode;
       mode.time = seek;
@@ -2346,26 +2349,27 @@ void CVideoPlayer::CheckAutoSceneSkip()
       m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
     }
   }
-  else if (cut.action == EDL::Action::COMM_BREAK)
+  else if (edit.action == EDL::Action::COMM_BREAK)
   {
     // marker for commbrak may be inaccurate. allow user to skip into break from the back
-    if (m_playSpeed >= 0 && m_Edl.GetLastCutTime() != cut.start && clock < cut.end - 1000)
+    if (m_playSpeed >= 0 && m_Edl.GetLastEditTime() != edit.start && clock < edit.end - 1000)
     {
-      std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
+      std::string strTimeString =
+          StringUtils::SecondsToTimeString((edit.end - edit.start) / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
 
-      m_Edl.SetLastCutTime(cut.start);
+      m_Edl.SetLastEditTime(edit.start);
 
       if (m_SkipCommercials)
       {
         CLog::Log(LOGDEBUG,
                   "{} - Clock in commercial break [{} - {}]: {}. Automatically skipping to end of "
                   "commercial break",
-                  __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start),
-                  CEdl::MillisecondsToTimeString(cut.end), CEdl::MillisecondsToTimeString(clock));
+                  __FUNCTION__, CEdl::MillisecondsToTimeString(edit.start),
+                  CEdl::MillisecondsToTimeString(edit.end), CEdl::MillisecondsToTimeString(clock));
 
         CDVDMsgPlayerSeek::CMode mode;
-        mode.time = cut.end;
+        mode.time = edit.end;
         mode.backward = true;
         mode.accurate = true;
         mode.restore = false;
@@ -3648,7 +3652,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     if (m_CurrentVideo.hint.fpsscale > 0.0f)
       fFramesPerSecond = static_cast<float>(m_CurrentVideo.hint.fpsrate) / static_cast<float>(m_CurrentVideo.hint.fpsscale);
     m_Edl.ReadEditDecisionLists(m_item, fFramesPerSecond);
-    CServiceBroker::GetDataCacheCore().SetCutList(m_Edl.GetCutList());
+    CServiceBroker::GetDataCacheCore().SetEditList(m_Edl.GetEditList());
 
     static_cast<IDVDStreamPlayerVideo*>(player)->SetSpeed(m_streamPlayerSpeed);
     m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_STARTING;
@@ -4734,7 +4738,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     m_processInfo->SetStateRealtime(realtime);
   }
 
-  if (m_Edl.HasCut())
+  if (m_Edl.HasEdits())
   {
     state.time = (double) m_Edl.RemoveCutTime(llrint(state.time));
     state.timeMax = (double) m_Edl.RemoveCutTime(llrint(state.timeMax));

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4738,6 +4738,9 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     m_processInfo->SetStateRealtime(realtime);
   }
 
+  // FIXME - This block of code only makes sense if the item has EDL *cuts*
+  // not any of the other edit types (mute, commbreak, etc). We loop over
+  // the EDL edit list twice unnecessarily.
   if (m_Edl.HasEdits())
   {
     state.time = (double) m_Edl.RemoveCutTime(llrint(state.time));

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -14,8 +14,8 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
-#include "cores/Cut.h"
 #include "cores/DataCacheCore.h"
+#include "cores/EdlEdit.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIDialog.h"
 #include "guilib/GUIWindowManager.h"
@@ -619,7 +619,7 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
     switch (iInfo)
     {
       case PLAYER_CUTLIST:
-        ranges = GetCutList(data, duration);
+        ranges = GetEditList(data, duration);
         break;
       case PLAYER_CHAPTERS:
         ranges = GetChapters(data, duration);
@@ -640,19 +640,19 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
   return values;
 }
 
-std::vector<std::pair<float, float>> CPlayerGUIInfo::GetCutList(CDataCacheCore& data, time_t duration) const
+std::vector<std::pair<float, float>> CPlayerGUIInfo::GetEditList(CDataCacheCore& data,
+                                                                 time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
 
-  const std::vector<EDL::Cut> cuts = data.GetCutList();
-  for (const auto& cut : cuts)
+  const std::vector<EDL::Edit> edits = data.GetEditList();
+  for (const auto& edit : edits)
   {
-    if (cut.action != EDL::Action::CUT &&
-        cut.action != EDL::Action::COMM_BREAK)
+    if (edit.action != EDL::Action::CUT && edit.action != EDL::Action::COMM_BREAK)
       continue;
 
-    float cutStart = cut.start * 100.0f / duration;
-    float cutEnd = cut.end * 100.0f / duration;
+    float cutStart = edit.start * 100.0f / duration;
+    float cutEnd = edit.end * 100.0f / duration;
     ranges.emplace_back(std::make_pair(cutStart, cutEnd));
   }
   return ranges;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -66,7 +66,7 @@ private:
   std::string GetSeekTime(TIME_FORMAT format) const;
 
   std::string GetContentRanges(int iInfo) const;
-  std::vector<std::pair<float, float>> GetCutList(CDataCacheCore& data, time_t duration) const;
+  std::vector<std::pair<float, float>> GetEditList(CDataCacheCore& data, time_t duration) const;
   std::vector<std::pair<float, float>> GetChapters(CDataCacheCore& data, time_t duration) const;
 };
 

--- a/xbmc/pvr/PVREdl.cpp
+++ b/xbmc/pvr/PVREdl.cpp
@@ -10,7 +10,7 @@
 
 #include "FileItem.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_edl.h"
-#include "cores/Cut.h"
+#include "cores/EdlEdit.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "utils/log.h"
@@ -18,7 +18,7 @@
 namespace PVR
 {
 
-std::vector<EDL::Cut> CPVREdl::GetCuts(const CFileItem& item)
+std::vector<EDL::Edit> CPVREdl::GetEdits(const CFileItem& item)
 {
   std::vector<PVR_EDL_ENTRY> edl;
 
@@ -34,35 +34,35 @@ std::vector<EDL::Cut> CPVREdl::GetCuts(const CFileItem& item)
     edl = item.GetEPGInfoTag()->GetEdl();
   }
 
-  std::vector<EDL::Cut> cutlist;
+  std::vector<EDL::Edit> editlist;
   for (const auto& entry : edl)
   {
-    EDL::Cut cut;
-    cut.start = entry.start;
-    cut.end = entry.end;
+    EDL::Edit edit;
+    edit.start = entry.start;
+    edit.end = entry.end;
 
     switch (entry.type)
     {
     case PVR_EDL_TYPE_CUT:
-      cut.action = EDL::Action::CUT;
+      edit.action = EDL::Action::CUT;
       break;
     case PVR_EDL_TYPE_MUTE:
-      cut.action = EDL::Action::MUTE;
+      edit.action = EDL::Action::MUTE;
       break;
     case PVR_EDL_TYPE_SCENE:
-      cut.action = EDL::Action::SCENE;
+      edit.action = EDL::Action::SCENE;
       break;
     case PVR_EDL_TYPE_COMBREAK:
-      cut.action = EDL::Action::COMM_BREAK;
+      edit.action = EDL::Action::COMM_BREAK;
       break;
     default:
       CLog::LogF(LOGWARNING, "Ignoring entry of unknown EDL type: {}", entry.type);
       continue;
     }
 
-    cutlist.emplace_back(cut);
+    editlist.emplace_back(edit);
   }
-  return cutlist;
+  return editlist;
 }
 
 } // namespace PVR

--- a/xbmc/pvr/PVREdl.h
+++ b/xbmc/pvr/PVREdl.h
@@ -14,7 +14,7 @@ class CFileItem;
 
 namespace EDL
 {
-struct Cut;
+struct Edit;
 }
 
 namespace PVR
@@ -24,11 +24,11 @@ class CPVREdl
 {
 public:
   /*!
-   * @brief Get the cuts for the given item.
+   * @brief Get the EDL edits for the given item.
    * @param item The item.
-   * @return The EDL cuts or enpty vector if no cuts exist.
+   * @return The EDL edits or an empty vector if no edits exist.
    */
-  static std::vector<EDL::Cut> GetCuts(const CFileItem& item);
+  static std::vector<EDL::Edit> GetEdits(const CFileItem& item);
 };
 
 } // namespace PVR


### PR DESCRIPTION
## Description
I plan to extend EDL to support new custom types (e.g. for Netflix-like intro/outro skip buttons on the GUI). In order to make sense of the code base I've been slowly testing actual EDL edit types (mute, cut, commbreak, etc). Unfortunately some of them (namely edl cuts) are completely broken. Others like EDL mute have recently been fixed.

Before actually trying to add new stuff - let's first fix the edl actions that do not work. While attempting to fix EDL cuts and studying the codebase I found it extremely confusing that we reuse the word cut pretty much everywhere in EDL -  when cut is actually just one of the types (the action) of supported EDL's. For instance, the `EDL::Cut` struct is reused to store any type of EDL edit (the `EDL::Cut::Action` actually being the action). Methods such has `HasCut()`, `InCut()`, etc actually refer to EDL edits in a generic way and not just those of type `CUT`.

Hence, this PR renames `EDL::Cut` to `EDL::Edit` (and companion methods and comments) to avoid confusion. While at it and for the changed codelines:

- Added doxygen docs to the renamed methods
- Replaced c-style casts
- Added a couple of FIXMEs on places that needs future improvement.

The actual fix for EDL cuts will come after this one, this PR does not change any behaviour.
