### PR TITLE
[Python] Fix sys.path VFS path bug

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -290,8 +290,8 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
     // swap in my thread m_threadState
     PyThreadState_Swap(m_threadState);
 
-  // set current directory and python's path.
-  PySys_SetArgv(argc, &argv[0]);
+  // initialize python's sys.argv
+  PySys_SetArgvEx(argc, &argv[0], 0);
 
   CLog::Log(LOGDEBUG, "CPythonInvoker({}, {}): entering source directory {}", GetId(), m_sourceFile,
             scriptDir);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
fixes: https://github.com/xbmc/xbmc/issues/20623

huge thanks to @lrusak who hunted this down.

Currently https://docs.python.org/3.9/c-api/init.html#c.PySys_SetArgv is used to set Pythons sys.argv
which basically calls https://docs.python.org/3.9/c-api/init.html#c.PySys_SetArgvEx with updatepath set to 1.

updatepath set to 1 is what causes the issue of sys.path growing each time an addon re-using the language invoker is called.

When updatepath is non-zero - Python will prepend the scripts (sys.argv[0]) own path to the sys.path on every call.
This leads to two issues

1. sys.path grows by 1 everytime an add-on re-using the language invoker is called.
  only happens when using reuselanguageinvoker
2. a non-real path is added to sys.path eg. C:\\Users\\Matt\\AppData\\Roaming\\Kodi\\19\\plugin:\\plugin.video.tester,
     this is because our sys.argv[0] is the plugin:// virtual path.
     This happens regardless of reuselanguageinvoker

By using PySys_SetArgvEx  directly, we can pass in the updatepath parameter of 0 which stops this behaviour and python will no longer touch the sys.path set by kodi.

There is even a note on PySys_SetArgvEx saying updatepath should be 0 for apps embedding Python:
https://docs.python.org/3.9/c-api/init.html#c.PySys_SetArgvEx

Backport candidate for 19?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes: https://github.com/xbmc/xbmc/issues/20623

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
windows
confirmed sys.path now remains correct and the same as the path logged by kodi over multiple calls to add-on using reuse language invoker. Also confirmed all other add-ons work fine.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
could stop potential memory issues.
maybe slight performance improvement from less sys.paths to search for modules.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
