### PR TITLE
[cmake] Findspdlog ENABLE_INTERNAL_SPDLOG min fmt lib required

### DIFF
--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -56,6 +56,9 @@ if(ENABLE_INTERNAL_SPDLOG)
 
   if(ENABLE_INTERNAL_FMT)
     add_dependencies(spdlog fmt)
+  else()
+    # spdlog 1.9.2 fails to build with fmt < 8.0.0
+    find_package(fmt 8.0.0 CONFIG REQUIRED QUIET)
   endif()
 else()
   find_package(spdlog 1.5.0 CONFIG REQUIRED QUIET)


### PR DESCRIPTION
## Description
Do a sanity check if a user uses internal spdlog with external fmt

## Motivation and context
Just a sanity check on a potential corner case. Internal spdlog uses 1.9.2, and this fails to build with fmt < 8.0.0. Do a check and bail early if fmt supplied doesnt meet the required version

@howie-f i know your setup wont fall over this now, but just an fyi from our discussion

## How has this been tested?
Cmake generation with various versions of fmt supploed

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
