### PR TITLE
CCPUInfoPosix: return early if m_cpuTempCmd is empty

### DIFF
--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -245,7 +245,7 @@ float CCPUInfoFreebsd::GetCPUFrequency()
 
 bool CCPUInfoFreebsd::GetTemperature(CTemperature& temperature)
 {
-  if (CCPUInfoPosix::GetTemperature(temperature))
+  if (CheckUserTemperatureCommand(temperature))
     return true;
 
   int value;

--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -245,12 +245,16 @@ float CCPUInfoFreebsd::GetCPUFrequency()
 
 bool CCPUInfoFreebsd::GetTemperature(CTemperature& temperature)
 {
+  if (CCPUInfoPosix::GetTemperature(temperature))
+    return true;
+
   int value;
   size_t len = sizeof(value);
 
   /* Temperature is in Kelvin * 10 */
   if (sysctlbyname("dev.cpu.0.temperature", &value, &len, nullptr, 0) != 0)
-    return CCPUInfoPosix::GetTemperature(temperature);
+    return false;
+
   temperature = CTemperature::CreateFromKelvin(static_cast<double>(value) / 10.0);
   temperature.SetValid(true);
 

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -359,8 +359,11 @@ float CCPUInfoLinux::GetCPUFrequency()
 
 bool CCPUInfoLinux::GetTemperature(CTemperature& temperature)
 {
+  if (CCPUInfoPosix::GetTemperature(temperature))
+    return true;
+
   if (m_tempPath.empty())
-    return CCPUInfoPosix::GetTemperature(temperature);
+    return false;
 
   CSysfsPath path{m_tempPath};
   double value = path.Get<double>() / 1000.0;

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -359,7 +359,7 @@ float CCPUInfoLinux::GetCPUFrequency()
 
 bool CCPUInfoLinux::GetTemperature(CTemperature& temperature)
 {
-  if (CCPUInfoPosix::GetTemperature(temperature))
+  if (CheckUserTemperatureCommand(temperature))
     return true;
 
   if (m_tempPath.empty())

--- a/xbmc/platform/posix/CPUInfoPosix.cpp
+++ b/xbmc/platform/posix/CPUInfoPosix.cpp
@@ -14,24 +14,24 @@
 
 bool CCPUInfoPosix::GetTemperature(CTemperature& temperature)
 {
-  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
-
   temperature.SetValid(false);
 
-  int value{-1};
-  char scale{'c'};
+  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
 
-  if (!cmd.empty())
+  if (cmd.empty())
+    return false;
+
+  int value = {};
+  char scale = {};
+
+  auto p = popen(cmd.c_str(), "r");
+  if (p)
   {
-    auto p = popen(cmd.c_str(), "r");
-    if (p)
-    {
-      int ret = fscanf(p, "%d %c", &value, &scale);
-      pclose(p);
+    int ret = fscanf(p, "%d %c", &value, &scale);
+    pclose(p);
 
-      if (ret < 2)
-        return false;
-    }
+    if (ret < 2)
+      return false;
   }
 
   if (scale == 'C' || scale == 'c')

--- a/xbmc/platform/posix/CPUInfoPosix.cpp
+++ b/xbmc/platform/posix/CPUInfoPosix.cpp
@@ -14,9 +14,22 @@
 
 bool CCPUInfoPosix::GetTemperature(CTemperature& temperature)
 {
+  return CheckUserTemperatureCommand(temperature);
+}
+
+bool CCPUInfoPosix::CheckUserTemperatureCommand(CTemperature& temperature)
+{
   temperature.SetValid(false);
 
-  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
+  auto settingComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingComponent)
+    return false;
+
+  auto advancedSettings = settingComponent->GetAdvancedSettings();
+  if (!advancedSettings)
+    return false;
+
+  std::string cmd = advancedSettings->m_cpuTempCmd;
 
   if (cmd.empty())
     return false;

--- a/xbmc/platform/posix/CPUInfoPosix.h
+++ b/xbmc/platform/posix/CPUInfoPosix.h
@@ -18,4 +18,6 @@ public:
 protected:
   CCPUInfoPosix() = default;
   virtual ~CCPUInfoPosix() = default;
+
+  bool CheckUserTemperatureCommand(CTemperature& temperature);
 };


### PR DESCRIPTION
This fixes showing `-1` for the cpu temp if no `m_cpuTempCmd` is provided and no cpu temp is available for a given platform.

I've also added two commits that allow overriding the built in cpu temp commands for linux and freebsd. This allows a user to provide a command via `m_cpuTempCmd` which will take precedence over the built in command.

As always. Link for whitespace changes disabled [here](https://github.com/xbmc/xbmc/pull/20690/files?w=1)