### PR TITLE
[tools/depends][target] bump openssl 1.1.1m

### DIFF
--- a/tools/depends/target/openssl/001-android-getauxvalrevert.patch
+++ b/tools/depends/target/openssl/001-android-getauxvalrevert.patch
@@ -1,0 +1,61 @@
+--- a/crypto/armcap.c
++++ b/crypto/armcap.c
+@@ -68,12 +68,6 @@
+ #   include <sys/auxv.h>
+ #   define OSSL_IMPLEMENT_GETAUXVAL
+ #  endif
+-# elif defined(__ANDROID_API__)
+-/* see https://developer.android.google.cn/ndk/guides/cpu-features */
+-#  if __ANDROID_API__ >= 18
+-#   include <sys/auxv.h>
+-#   define OSSL_IMPLEMENT_GETAUXVAL
+-#  endif
+ # endif
+ # if defined(__FreeBSD__)
+ #  include <sys/param.h>
+@@ -94,15 +88,6 @@
+ # endif
+ 
+ /*
+- * Android: according to https://developer.android.com/ndk/guides/cpu-features,
+- * getauxval is supported starting with API level 18
+- */
+-#  if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ >= 18
+-#   include <sys/auxv.h>
+-#   define OSSL_IMPLEMENT_GETAUXVAL
+-#  endif
+-
+-/*
+  * ARM puts the feature bits for Crypto Extensions in AT_HWCAP2, whereas
+  * AArch64 used AT_HWCAP.
+  */
+--- a/crypto/ppccap.c
++++ b/crypto/ppccap.c
+@@ -211,12 +211,6 @@
+ # if __GLIBC_PREREQ(2, 16)
+ #  include <sys/auxv.h>
+ #  define OSSL_IMPLEMENT_GETAUXVAL
+-# elif defined(__ANDROID_API__)
+-/* see https://developer.android.google.cn/ndk/guides/cpu-features */
+-#  if __ANDROID_API__ >= 18
+-#   include <sys/auxv.h>
+-#   define OSSL_IMPLEMENT_GETAUXVAL
+-#  endif
+ # endif
+ #endif
+ 
+--- a/crypto/uid.c
++++ b/crypto/uid.c
+@@ -36,12 +36,6 @@
+ #   include <sys/auxv.h>
+ #   define OSSL_IMPLEMENT_GETAUXVAL
+ #  endif
+-# elif defined(__ANDROID_API__)
+-/* see https://developer.android.google.cn/ndk/guides/cpu-features */
+-#  if __ANDROID_API__ >= 18
+-#   include <sys/auxv.h>
+-#   define OSSL_IMPLEMENT_GETAUXVAL
+-#  endif
+ # endif
+ 
+ int OPENSSL_issetugid(void)

--- a/tools/depends/target/openssl/16-kodi.conf
+++ b/tools/depends/target/openssl/16-kodi.conf
@@ -1,0 +1,35 @@
+#### Kodi dependency build configs for Apple Platforms
+#
+# Provide our system specific configs.
+# Allows us to pass through our CFLAGS, and also adds a tvos target
+#
+my %targets = (
+    "kodi-darwin64-x86_64" => {
+        inherit_from     => [ "darwin-common", asm("x86_64_asm") ],
+        cflags           => add("\$(CFLAGS)"),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "macosx",
+    },
+    "kodi-darwin64-arm64" => {
+        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
+        cflags           => add("\$(CFLAGS)"),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "ios64",
+    },
+    "kodi-iphoneos-arm64" => {
+        inherit_from     => [ "ios-common", asm("aarch64_asm") ],
+        cflags           => add("\$(CFLAGS)"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        perlasm_scheme   => "ios64",
+    },
+    "kodi-appletvos-arm64" => {
+        inherit_from     => [ "ios-common", asm("aarch64_asm") ],
+        cflags           => add("\$(CFLAGS)"),
+        defines          => [ "HAVE_FORK=0" ],
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        perlasm_scheme   => "ios64",
+        sys_id           => "tvOS",
+    },
+);

--- a/tools/depends/target/openssl/Makefile
+++ b/tools/depends/target/openssl/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile 001-android-getauxvalrevert.patch
+DEPS= ../../Makefile.include Makefile 001-android-getauxvalrevert.patch 16-kodi.conf
 
 # lib name, version
 LIBNAME=openssl
@@ -8,25 +8,42 @@ SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
 # configuration settings
-CONFIGURE=MACHINE=$(PLATFORM) ./config no-shared zlib no-asm --prefix=$(PREFIX) --with-zlib-include=$(PREFIX)/include --with-zlib-lib=$(PREFIX)/lib
-ifeq ($(OS), android)
-  CONFIGURE=./Configure no-shared zlib --prefix=$(PREFIX) --with-zlib-include=$(PREFIX)/include --with-zlib-lib=$(PREFIX)/lib linux-generic32 -D__ANDROID_API__=$(NDK_LEVEL)
-endif
-ifeq ($(OS), darwin_embedded)
-  ifeq ($(TARGET_PLATFORM),appletvos)
-    # Need to add "no-async" to avoid "'setcontext' is unavailable: not available on tvOS" error
-    CONFIGURE=./Configure iphoneos-cross no-shared zlib no-async --prefix=$(PREFIX)
-  else
-    CONFIGURE=./Configure iphoneos-cross no-shared zlib --prefix=$(PREFIX)
+ifeq ($(OS), linux)
+  # Need to export our vars to override "default" conf data of openssl
+  TARGETOPT=--with-zlib-include=$(PREFIX)/include --with-zlib-lib=$(PREFIX)/lib
+  CONFIGURE=MACHINE=$(PLATFORM) ./config no-shared zlib no-tests no-asm $(TARGETOPT) --prefix=$(PREFIX)
+else
+  ifeq ($(OS), android)
+    TARGETOPT=--with-zlib-include=$(PREFIX)/include --with-zlib-lib=$(PREFIX)/lib -D__ANDROID_API__=$(NDK_LEVEL)
+    # openssl 1.x incorrectly uses ANDROID_NDK_HOME, when openssl 3.x.x comes in use ANDROID_NDK_ROOT
+    # see https://github.com/openssl/openssl/pull/11206
+    export ANDROID_NDK_HOME=$(NDKROOT)
+    export PATH:=$(TOOLCHAIN)/bin:$(PATH)
+    ifeq ($(MESON_CPU), aarch64)
+      OPENSSLPLATFORM=android-arm64
+    else
+      OPENSSLPLATFORM=android-$(MESON_CPU)
+    endif
   endif
-endif
-ifeq ($(OS), osx)
-  ifeq ($(BUILD_CPU), x86_64)
-    CONFIGURE=./Configure darwin64-$(CPU)-cc zlib no-asm no-shared --prefix=$(PREFIX)
-  else
-    CONFIGURE=./Configure darwin64-arm64-cc zlib no-asm no-shared --prefix=$(PREFIX)
+  ifeq ($(OS), darwin_embedded)
+    export SDKROOT CFLAGS
+    OPENSSLPLATFORM=kodi-$(TARGET_PLATFORM)-$(CPU)
+    ifeq ($(TARGET_PLATFORM),appletvos)
+      # Need to add "no-async" to avoid "'setcontext' is unavailable: not available on tvOS" error
+      TARGETOPT=no-async
+    endif
   endif
+  ifeq ($(OS), osx)
+    OPENSSLPLATFORM=kodi-darwin64-$(CPU)
+    ASMFLAG=no-asm
+  endif
+
+  CONFIGURE=./Configure $(OPENSSLPLATFORM) no-shared $(ASMFLAG) zlib no-tests $(TARGETOPT) --prefix=$(PREFIX)
 endif
+
+export CC CXX AR RANLIB
+export CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+
 LIBDYLIB=$(PLATFORM)/libssl.a
 
 all: .installed-$(PLATFORM)
@@ -40,17 +57,10 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 ifeq ($(OS),android)
 	cd $(PLATFORM); patch -p1 -i ../001-android-getauxvalrevert.patch
 endif
-	cd $(PLATFORM); AR="$(AR)" CFLAGS="$(CFLAGS)" CC="$(CC)" RANLIB=$(RANLIB) $(CONFIGURE)
-	if test "$(OS)" = "osx"; then \
-		sed -ie "s|CC= /usr/bin/gcc-4.2|CC= $(CC)|" "$(PLATFORM)/Makefile"; \
-		sed -E -ie "s|^CFLAGS=-|CFLAGS=$(CFLAGS) -|" "$(PLATFORM)/Makefile"; \
-	fi
-	# for iphoneos-cross config a sysroot argument is added
-	# however sysroot already set in Makefile.include, so remove this
+	cd $(PLATFORM); cp ../16-kodi.conf ./Configurations/
+	cd $(PLATFORM); $(CONFIGURE)
 	if test "$(OS)" = "darwin_embedded"; then \
-		sed -E -ie "s|^CFLAGS=-|CFLAGS=$(CFLAGS) -|" "$(PLATFORM)/Makefile"; \
-		sed -ie "s|-isysroot \$$(CROSS_TOP)/SDKs/\$$(CROSS_SDK) ||" "$(PLATFORM)/Makefile"; \
-		sed -ie "s|static volatile sig_atomic_t intr_signal;|static volatile intr_signal;|" "$(PLATFORM)/crypto/ui/ui_openssl.c"; \
+		sed -E -ie "s|static volatile sig_atomic_t intr_signal;|static volatile intr_signal;|" "$(PLATFORM)/crypto/ui/ui_openssl.c"; \
 	fi
 	sed -ie "s|PROGRAMS=|PROGRAMS=#|" "$(PLATFORM)/Makefile";
 

--- a/tools/depends/target/openssl/Makefile
+++ b/tools/depends/target/openssl/Makefile
@@ -1,9 +1,9 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 001-android-getauxvalrevert.patch
 
 # lib name, version
 LIBNAME=openssl
-VERSION=1.1.1k
+VERSION=1.1.1m
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
@@ -37,6 +37,9 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+ifeq ($(OS),android)
+	cd $(PLATFORM); patch -p1 -i ../001-android-getauxvalrevert.patch
+endif
 	cd $(PLATFORM); AR="$(AR)" CFLAGS="$(CFLAGS)" CC="$(CC)" RANLIB=$(RANLIB) $(CONFIGURE)
 	if test "$(OS)" = "osx"; then \
 		sed -ie "s|CC= /usr/bin/gcc-4.2|CC= $(CC)|" "$(PLATFORM)/Makefile"; \


### PR DESCRIPTION
## Description
Bump Openssl 1.1.1m

## Motivation and context
dependency bumps.

redoes #20129 but fixes the android failures that @wsnipex experienced
supersedes #20141

Through bisecting openssl, found that the following 2 commits were the root case of the android failures in wnsipex's previous bump attempt. At this stage, will look to patch those 2 commits out. My understanding is the getauxval usage is only about potential runtime detection of soc capabilities, but will fall back to pre 1.1.1l behaviour without

https://github.com/openssl/openssl/commit/b2dea4d5f22ec146373324c282fb1bcecd5a7d90
https://github.com/openssl/openssl/commit/2357e6e94a46362dbf56eecfec6ffbaa8bd76a68

Have also done a "cleanup" of the openssl config.
Apple platforms have a "kodi" config file for easy setup. Easier to run this than to patch the default configurations for our build usage

Android uses the openssl android build target, rather than the generic linux one previously used.

Removed some sed usage, and now just set/utilise env vars appropriately

## How has this been tested?
osx x86_64 build/run
aarch64 android build/run

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
