### PR TITLE
[profiles] allow path 'plugin://...' as mediasource

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1158,16 +1158,15 @@ int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES
   if (StringUtils::StartsWith(strPath, "special://skin/"))
     return 1;
 
+  // do not return early if URL protocol is "plugin"
+  // since video- and/or audio-plugins can be configured as mediasource
+
   // stack://
   if (checkURL.IsProtocol("stack"))
     strPath.erase(0, 8); // remove the stack protocol
 
   if (checkURL.IsProtocol("shout"))
     strPath = checkURL.GetHostName();
-
-  // a plugin path should not be configured in any mediasource
-  if (checkURL.IsProtocol("plugin"))
-    return -1;
 
   if (checkURL.IsProtocol("multipath"))
     strPath = CMultiPathDirectory::GetFirstPath(strPath);


### PR DESCRIPTION
## Description
in order to fix unintended side-effects of an enabled master-lock in combination with video plugins `CUtil::GetMatchingSource()` was forced to return `-1` (not found). ref. https://github.com/xbmc/xbmc/pull/20195

it turns out that having a mediasource set to a plugin path e.g. `<path pathversion="1">plugin://plugin.video.zdf_de_lite</path>` is a valid usecase. i did some testing on this here https://github.com/xbmc/xbmc/issues/20143#issuecomment-929892387

certain add-ons may use this setting and `GetMatchingSource()` has to resolve them correctly. this issue popped up recently with the PlexKodiConnect add-on. _note this change does not reintroduce the original issue._

@enen92 can you give a hint what could probably go wrong with `metadata.local` ?

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
