### PR TITLE
[EDL][FIX] Fix EDL cut actions

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -39,7 +39,7 @@ void CEdl::Clear()
 {
   m_vecEdits.clear();
   m_vecSceneMarkers.clear();
-  m_iTotalCutTime = 0;
+  m_totalCutTime = 0;
   m_lastEditTime = -1;
 }
 
@@ -699,7 +699,7 @@ bool CEdl::AddEdit(const Edit& newEdit)
   }
 
   if (edit.action == Action::CUT)
-    m_iTotalCutTime += edit.end - edit.start;
+    m_totalCutTime += edit.end - edit.start;
 
   return true;
 }
@@ -723,17 +723,19 @@ bool CEdl::HasEdits() const
   return !m_vecEdits.empty();
 }
 
+bool CEdl::HasCuts() const
+{
+  return m_totalCutTime > 0;
+}
+
 int CEdl::GetTotalCutTime() const
 {
-  return m_iTotalCutTime; // ms
+  return m_totalCutTime; // ms
 }
 
 int CEdl::RemoveCutTime(int iSeek) const
 {
-  // FIXME - This should actually be HasCuts and not HasEdits
-  // since if the file HasEdits but not any EDL cut there's
-  // no time to remove
-  if (!HasEdits())
+  if (!HasCuts())
     return iSeek;
 
   /**
@@ -758,10 +760,7 @@ int CEdl::RemoveCutTime(int iSeek) const
 
 double CEdl::RestoreCutTime(double dClock) const
 {
-  // FIXME - This should actually be HasCuts and not HasEdits
-  // since if the file HasEdits but not any EDL cut there's
-  // no time to restore
-  if (!HasEdits())
+  if (!HasCuts())
     return dClock;
 
   double dSeek = dClock;

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -738,11 +738,6 @@ int CEdl::RemoveCutTime(int iSeek) const
   if (!HasCuts())
     return iSeek;
 
-  /**
-   * @todo Consider an optimization of using the (now unused) total cut time if the seek time
-   * requested is later than the end of the last recorded cut. For example, when calculating the
-   * total duration for display.
-   */
   int iCutTime = 0;
   for (size_t i = 0; i < m_vecEdits.size(); ++i)
   {

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -35,6 +35,12 @@ public:
    */
   bool HasEdits() const;
 
+  /*!
+   * @brief Check if the edit list has EDL cuts (edits with action CUT)
+   * @return true if EDL has cuts, false otherwise
+   */
+  bool HasCuts() const;
+
   bool HasSceneMarker() const;
   int GetTotalCutTime() const;
   int RemoveCutTime(int iSeek) const;
@@ -82,7 +88,8 @@ public:
   static std::string MillisecondsToTimeString(const int iMilliseconds);
 
 private:
-  int m_iTotalCutTime; // ms
+  // total cut time (edl cuts) in ms
+  int m_totalCutTime;
   std::vector<EDL::Edit> m_vecEdits;
   std::vector<int> m_vecSceneMarkers;
   int m_lastEditTime;

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -42,9 +42,34 @@ public:
   bool HasCuts() const;
 
   bool HasSceneMarker() const;
+
+  /*!
+   * @brief Get the total cut time removed from the original item
+   * because of EDL cuts
+   * @return the total cut time
+  */
   int GetTotalCutTime() const;
-  int RemoveCutTime(int iSeek) const;
-  double RestoreCutTime(double dClock) const;
+
+  /*!
+   * @brief Providing a given seek time, return the actual time without
+   * considering cut ranges removed from the file
+   * @note VideoPlayer always displays/returns the playback time considering
+   * cut blocks are not part of the playable file
+   * @param seek the desired seek time
+   * @return the seek time without considering EDL cut blocks
+  */
+  int GetTimeWithoutCuts(int seek) const;
+
+  /*!
+   * @brief Provided a given seek time, return the time after correction with
+   * the addition of the already surpassed EDL cut ranges
+   * @note VideoPlayer uses it to restore the correct time after seek since cut blocks
+   * are not part of the playable file
+   * @param seek the desired seek time
+   * @return the seek time after applying the cut blocks already surpassed by the
+   * provided seek time
+  */
+  double GetTimeAfterRestoringCuts(double seek) const;
 
   /*!
    * @brief Get the EDL edit list.
@@ -76,6 +101,11 @@ public:
    * @param editTime The last processed EDL edit time (ms)
   */
   void SetLastEditTime(int editTime);
+
+  /*!
+   * @brief Reset the last recorded edit time (-1)
+  */
+  void ResetLastEditTime();
 
   // FIXME: remove const modifier for iClock as it makes no sense as it means nothing
   // for the reader of the interface, but limits the implementation

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1251,11 +1251,12 @@ void CVideoPlayer::Prepare()
     {
       int playerStartTime = static_cast<int>((static_cast<double>(
           m_pDemuxer->GetStreamLength() * (m_playerOptions.startpercent / 100.0))));
-      starttime = m_Edl.RestoreCutTime(playerStartTime);
+      starttime = m_Edl.GetTimeAfterRestoringCuts(playerStartTime);
     }
     else
     {
-      starttime = m_Edl.RestoreCutTime(static_cast<int>(m_playerOptions.starttime * 1000)); // s to ms
+      starttime = m_Edl.GetTimeAfterRestoringCuts(
+          static_cast<int>(m_playerOptions.starttime * 1000)); // s to ms
     }
     CLog::Log(LOGDEBUG, "{} - Start position set to last stopped position: {}", __FUNCTION__,
               starttime);
@@ -2323,14 +2324,18 @@ void CVideoPlayer::CheckAutoSceneSkip()
 
   const int64_t clock = GetTime();
 
+  const double correctClock = m_Edl.GetTimeAfterRestoringCuts(clock);
   EDL::Edit edit;
-  if (!m_Edl.InEdit(clock, &edit))
+  if (!m_Edl.InEdit(correctClock, &edit))
+  {
+    m_Edl.ResetLastEditTime();
     return;
+  }
 
   if (edit.action == EDL::Action::CUT)
   {
-    if ((m_playSpeed > 0 && clock < edit.end - 1000) ||
-        (m_playSpeed < 0 && clock < edit.start + 1000))
+    if ((m_playSpeed > 0 && correctClock < (edit.start + 1000)) ||
+        (m_playSpeed < 0 && correctClock < (edit.end - 1000)))
     {
       CLog::Log(LOGDEBUG, "{} - Clock in EDL cut [{} - {}]: {}. Automatically skipping over.",
                 __FUNCTION__, CEdl::MillisecondsToTimeString(edit.start),
@@ -2338,15 +2343,19 @@ void CVideoPlayer::CheckAutoSceneSkip()
 
       // Seeking either goes to the start or the end of the cut depending on the play direction.
       int seek = m_playSpeed >= 0 ? edit.end : edit.start;
+      if (m_Edl.GetLastEditTime() != seek)
+      {
+        CDVDMsgPlayerSeek::CMode mode;
+        mode.time = seek;
+        mode.backward = true;
+        mode.accurate = true;
+        mode.restore = false;
+        mode.trickplay = false;
+        mode.sync = true;
+        m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
 
-      CDVDMsgPlayerSeek::CMode mode;
-      mode.time = seek;
-      mode.backward = true;
-      mode.accurate = true;
-      mode.restore = true;
-      mode.trickplay = false;
-      mode.sync = true;
-      m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
+        m_Edl.SetLastEditTime(seek);
+      }
     }
   }
   else if (edit.action == EDL::Action::COMM_BREAK)
@@ -2585,7 +2594,7 @@ void CVideoPlayer::HandleMessages()
       if (msg.GetRelative())
         time = (m_clock.GetClock() + m_State.time_offset) / 1000l + time;
 
-      time = msg.GetRestore() ? m_Edl.RestoreCutTime(time) : time;
+      time = msg.GetRestore() ? m_Edl.GetTimeAfterRestoringCuts(time) : time;
 
       // if input stream doesn't support ISeekTime, convert back to pts
       //! @todo
@@ -2870,6 +2879,7 @@ void CVideoPlayer::HandleMessages()
         mode.accurate = true;
         mode.trickplay = true;
         mode.sync = true;
+        mode.restore = false;
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
       }
 
@@ -3314,6 +3324,16 @@ void CVideoPlayer::SeekTime(int64_t iTime)
 bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
 {
   int64_t abstime = GetTime() + iTime;
+
+  // if the file has EDL cuts we can't rely on m_clock for relative seeks
+  // EDL cuts remove time from the original file, hence we might seek to
+  // positions too far from the current m_clock position. Seek to absolute
+  // time instead
+  if (m_Edl.HasCuts())
+  {
+    SeekTime(abstime);
+    return true;
+  }
 
   CDVDMsgPlayerSeek::CMode mode;
   mode.time = (int)iTime;
@@ -4740,8 +4760,8 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   if (m_Edl.HasCuts())
   {
-    state.time = static_cast<double>(m_Edl.RemoveCutTime(std::lround(state.time)));
-    state.timeMax = std::lround(state.timeMax - static_cast<double>(m_Edl.GetTotalCutTime()));
+    state.time = static_cast<double>(m_Edl.GetTimeWithoutCuts(state.time));
+    state.timeMax = state.timeMax - static_cast<double>(m_Edl.GetTotalCutTime());
   }
 
   if (m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4740,8 +4740,8 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   if (m_Edl.HasCuts())
   {
-    state.time = (double) m_Edl.RemoveCutTime(llrint(state.time));
-    state.timeMax = (double) m_Edl.RemoveCutTime(llrint(state.timeMax));
+    state.time = static_cast<double>(m_Edl.RemoveCutTime(std::lround(state.time)));
+    state.timeMax = std::lround(state.timeMax - static_cast<double>(m_Edl.GetTotalCutTime()));
   }
 
   if (m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4738,10 +4738,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     m_processInfo->SetStateRealtime(realtime);
   }
 
-  // FIXME - This block of code only makes sense if the item has EDL *cuts*
-  // not any of the other edit types (mute, commbreak, etc). We loop over
-  // the EDL edit list twice unnecessarily.
-  if (m_Edl.HasEdits())
+  if (m_Edl.HasCuts())
   {
     state.time = (double) m_Edl.RemoveCutTime(llrint(state.time));
     state.timeMax = (double) m_Edl.RemoveCutTime(llrint(state.timeMax));


### PR DESCRIPTION
## Description
Currently EDL cut actions are broken - when reaching EDL cut start times, Kodi seeks to incorrect positions on the timeline (e.g. in the provided example Kodi seeks to 10 minutes playback, shows 10 minutes on the seek bar but the position on the actual file is far greater than 10 min).

In simple terms, EDL cuts remove playback time from the actual file. So, for instance, if you have a media item with 1 hour duration and a 30 minute EDL cut, the displayed total time should be 30 minutes (as if the cut was not part of the original item) and Kodi should be able to remove and restore the playback position as you play the file. In the provided example, at 10 seconds kodi should jump to 10 minutes of the original file but still display 11 seconds of playback on the next second.
This is what is supposed to happen with this PR. Plus a few improvements (todos and fixmes)/code cleanup were also applied.

There are a couple of issues (not introduced with this PR) that would be nice to get fixed in the near future:

- Edl cuts are displayed in the `Player.Cutlist` (ranges control in estuary), which is wrong. The ranges should not include cuts as the video timeline is no longer the original one. I will address this in the future by deprecating `Player.CutList` infolabel and introducing new infolabels. Hopefully `Player.CutList` can be safely removed in v21.

~- If you fast forward the playback with really high fast forward ratios (e.g. 8x or 16x) and then resume playback by hitting play - video will freeze. This is an extremely edge use case that I doubt anyone will use. Regardless, it's possible and it would be nice to get it working. Unfortunately, I feel @FernetMenta is the only one which can help here. The same happens when fast-forwarding backwards. Your help, as always is greatly appreciated. There's something missing after resuming from high fast forward ratios that I'm not able to figure out.~ (Fixed in https://github.com/xbmc/xbmc/pull/20744)

@a1rwulf since you were the one reporting the original "issue", it would be nice if you could spare some time testing and functionally validating this.

## Motivation and context
Fix EDL cuts

## How has this been tested?
Mainly with the following EDL file which contains two cuts and a commbreak:

```
10    600     0
610   720     0
730   749     3
```

Kodi should skip (590 seconds) at 10s and continue playback (11 secs playback) as if the first cut was not part of the original file. Should skip again at 20s playback. Total play duration should be equal to the file duration minus the time dedicated to EDL cuts.

## What is the effect on users?
EDL cuts should work again and skip to the appropriate future positions on the playback timeline.

