### PR TITLE
[PVR] Fix client friendly name - connection string is optional.

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -456,7 +456,9 @@ bool CPVRClient::GetAddonProperties()
     return false;
 
   /* display name = backend name:connection string */
-  strFriendlyName = StringUtils::Format("{}:{}", strBackendName, strConnectionString);
+  strFriendlyName = strlen(strConnectionString) == 0 // connection string is optional
+                        ? strBackendName
+                        : StringUtils::Format("{}:{}", strBackendName, strConnectionString);
 
   /* backend version number */
   retVal = DoAddonCall(


### PR DESCRIPTION
Just I minor UI glitch I came cross while using a PVR client not setting the connection string.
 
Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish when you find time for a review.