### PR TITLE
fix build error sign-compare after #20665

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -651,7 +651,7 @@ std::vector<CGUIFontTTF::Glyph> CGUIFontTTF::GetHarfBuzzShapedGlyphs(const vecTe
   }
 
   // HB_SCRIPT_COMMON or HB_SCRIPT_INHERITED should be replaced with previous script
-  for (int i = 0; i < static_cast<int>(scripts.size()); ++i)
+  for (size_t i = 0; i < scripts.size(); ++i)
   {
     if (scripts[i] == HB_SCRIPT_COMMON || scripts[i] == HB_SCRIPT_INHERITED)
     {
@@ -663,7 +663,7 @@ std::vector<CGUIFontTTF::Glyph> CGUIFontTTF::GetHarfBuzzShapedGlyphs(const vecTe
     }
     else
     {
-      for (unsigned int j = lastSetIndex + 1; j < i; j++)
+      for (size_t j = lastSetIndex + 1; j < i; ++j)
         scripts[j] = scripts[i];
       lastScript = scripts[i];
       lastScriptIndex = i;


### PR DESCRIPTION
## Description
fix build error after https://github.com/xbmc/xbmc/pull/20665

## Motivation and context
```
GUIFontTTF.cpp: In member function 'std::vector<CGUIFontTTF::Glyph> CGUIFontTTF::GetHarfBuzzShapedGlyphs(const vecText&)':
GUIFontTTF.cpp:666:49: error: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Werror=sign-compare]
  666 |       for (unsigned int j = lastSetIndex + 1; j < i; j++)
      |                                               ~~^~~
cc1plus: some warnings being treated as errors
```

## How has this been tested?
built on linux

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
