### PR TITLE
buildsteps: fix build failures by using jenkins env variables

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -16,6 +16,14 @@ BINARY_ADDONS_ROOT=tools/depends/target
 BINARY_ADDONS="binary-addons"
 DEPLOYED_BINARY_ADDONS="-e /addons"
 
+# Jenkins env variables
+JENKINS_BUILD_TIMESTAMP=${BUILD_TIMESTAMP:-"unknown"}
+JENKINS_BUILD_COMMIT=$(echo ${GIT_COMMIT:-"unknown"} | cut -c1-8)
+JENKINS_BUILD_REVISION=${Revision:-"unknown"}
+JENKINS_BUILD_ID=${BUILD_ID:-"unknown"}
+
+JENKINS_BUILD_STRING="${JENKINS_BUILD_TIMESTAMP}-${JENKINS_BUILD_COMMIT}-${JENKINS_BUILD_REVISION}-${JENKINS_BUILD_ID}"
+
 #set platform defaults
 #$XBMC_PLATFORM_DIR matches the platform subdirs!
 case $XBMC_PLATFORM_DIR in
@@ -169,54 +177,7 @@ function tagFailedBuild ()
   echo "$(getBuildHash $pathToTag)" > $pathToTag/$FAILED_BUILD_FILENAME
 }
 
-function getBranchName ()
-{
-  local branchName
-  branchName=`git symbolic-ref HEAD 2>/dev/null || echo detached`
-
-  if [ "$branchName" != "detached" ] # if we are not detached
-  then
-    #we are attached - use the branchname then
-    if echo $branchName | grep /pr/ 2>&1 > /dev/null
-    then
-      #if this is a pull request branch - fetch the pr number and prefix with "PR"
-      #refs/heads/number/head
-      echo PR$(echo $branchName | awk '{gsub(".*/pr/","");print $1}' | awk '{gsub("/","-");print $1}')
-    else
-      #if we are on a normal branch - fetch branchname
-      #refs/heads/branchname
-      echo $branchName | awk '{gsub("^([^/]*/){2}","");print $1}' | awk '{gsub("/","-");print $1}'
-    fi
-  else
-    #if we are in detached head state
-    #get all branches pointing at HEAD which are from current GITHUB_REPO
-    #prefer non-pullrequest branches
-    branches=`(git branch -r --points-at HEAD 2> /dev/null || git branch -r --contains HEAD) | grep $GITHUB_REPO/`
-    if echo "$branches" | grep -v $GITHUB_REPO/pr/ 2>&1 > /dev/null
-    then
-      echo "$branches" | sed "/$GITHUB_REPO\/pr\//d" | head -n1 | awk '{gsub("^([^/]*/)","");print $1}' | awk '{gsub("/","-");print $1}'
-    else
-      echo PR$(echo "$branches" | head -n1 | awk '{gsub(".*/pr/","");print $1}' | awk '{gsub("/","-");print $1}')
-    fi
-  fi
-}
-
 function getBuildRevDateStr ()
 {
-  local revStr
-  #fetch date-rev
-  revStr=`git --no-pager show -s --abbrev=8 --date=short --pretty=format:"%cd %h" | awk '{gsub("-", ""); print $1"-"$2}' 2>/dev/null`
-  if [ "$?" == "0" ]
-  then
-    #fetch the first branch containing head
-    revStr=$revStr"-"$(getBranchName)
-    if [ "$?" == "0" ]
-    then
-      echo $revStr
-    else
-      echo "Unknown"
-    fi
-  else
-    echo "Unknown"
-  fi
+  echo "${JENKINS_BUILD_STRING}"
 }


### PR DESCRIPTION
This is my attempt to fix the build failures we have been having. It seems that sometimes the branch name cannot be retrieved and thus the build fails. If we just use env variables provided by jenkins it should never fail.

For example this is the output when a build fails
```
10:53:47 +++ getBuildRevDateStr
10:53:47 +++ local revStr
10:53:47 ++++ git --no-pager show -s --abbrev=8 --date=short '--pretty=format:%cd %h'
10:53:47 ++++ awk '{gsub("-", ""); print $1"-"$2}'
10:53:47 +++ revStr=20211217-b1485526
10:53:47 +++ '[' 0 == 0 ']'
10:53:47 ++++ getBranchName
10:53:47 ++++ local branchName
10:53:47 +++++ git symbolic-ref HEAD
10:53:47 +++++ echo detached
10:53:47 ++++ branchName=detached
10:53:47 ++++ '[' detached '!=' detached ']'
10:53:47 +++++ git branch -r --points-at HEAD
10:53:47 +++++ grep xbmc/
10:53:47 ++++ branches=
10:53:47 +++ revStr=20211217-b1485526-
10:53:47 ++ UPLOAD_FILENAME=kodi--arm64-v8a
10:53:47 Build step 'Execute shell' marked build as failure
```

With this new method a new string will be used that consists of
```
${JENKINS_BUILD_TIMESTAMP}-${JENKINS_BUILD_COMMIT}-${JENKINS_BUILD_REVISION}
```
Which parses out similar to what we had before:
```
20211217-b1485526-PR20702
20211217-b1485526-master
20211217-b1485526-matrix
```
The difference being we don't use the source branch name for PR builds. We just use the build revision which works out to be the PR number. I think this is a fine substitute.


I do think that we should switch from the commit hash to the jenkins build id as it always increments even on a rebuild. This would look like:
```
20211217-20764-PR20702
20211217-20765-master
20211217-20766-matrix
```

It would be interesting to get everyones thoughts about this.
