### PR TITLE
[profiles] honor lock state of media sources

### DIFF
--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -14,6 +14,7 @@
 #include "Util.h"
 #include "dialogs/GUIDialogGamepad.h"
 #include "dialogs/GUIDialogNumeric.h"
+#include "favourites/FavouritesService.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -28,9 +29,12 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 #include "view/ViewStateSettings.h"
 
+#include <type_traits>
 #include <utility>
 
 using namespace KODI::MESSAGING;
@@ -87,6 +91,12 @@ bool CGUIPassword::IsItemUnlocked(T pItem,
         CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount",
                                                          std::to_string(pItem->m_iBadPwdCount));
         CMediaSourceSettings::GetInstance().Save();
+
+        // a mediasource has been unlocked successfully
+        // => refresh favourites due to possible visibility changes
+        // only if this template is instantiated for a CMediaSource item
+        if (std::is_same<T, CMediaSource*>::value)
+          CServiceBroker::GetFavouritesService().RefreshFavourites();
         break;
       }
     case 1:
@@ -549,7 +559,7 @@ bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES
 }
 
 bool CGUIPassword::IsMediaPathUnlocked(const std::shared_ptr<CProfileManager>& profileManager,
-                                       const std::string& strType)
+                                       const std::string& strType) const
 {
   if (!StringUtils::StartsWithNoCase(m_strMediaSourcePath, "root") &&
       !StringUtils::StartsWithNoCase(m_strMediaSourcePath, "library://"))
@@ -566,6 +576,31 @@ bool CGUIPassword::IsMediaPathUnlocked(const std::shared_ptr<CProfileManager>& p
       }
     }
   }
+
+  return true;
+}
+
+bool CGUIPassword::IsMediaFileUnlocked(const std::string& type, const std::string& file) const
+{
+  std::vector<CMediaSource>* vecSources = CMediaSourceSettings::GetInstance().GetSources(type);
+
+  if (!vecSources)
+  {
+    CLog::Log(LOGERROR,
+              "{}: CMediaSourceSettings::GetInstance().GetSources(\"{}\") returned nullptr.",
+              __func__, type);
+    return true;
+  }
+
+  // try to find the best matching source for this file
+
+  bool isSourceName{false};
+  const std::string fileBasePath = URIUtils::GetBasePath(file);
+
+  int iIndex = CUtil::GetMatchingSource(fileBasePath, *vecSources, isSourceName);
+
+  if (iIndex > -1 && iIndex < static_cast<int>(vecSources->size()))
+    return (*vecSources)[iIndex].m_iHasLock < LOCK_STATE_LOCKED;
 
   return true;
 }

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -66,6 +66,15 @@ public:
   void RemoveSourceLocks();
   bool IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources);
 
+  /*! \brief Helper function to test if a matching mediasource is currently unlocked
+   for a given media file
+   \note this function only returns the lock state. it does not provide unlock functionality
+   \param type The type of share being accessed, e.g. "music", "video", etc.
+   \param file The file to check lock state for
+   \return If access is granted, returns \e true
+   */
+  bool IsMediaFileUnlocked(const std::string& type, const std::string& file) const;
+
   void SetMediaSourcePath(const std::string& strMediaSourcePath)
   {
     m_strMediaSourcePath = strMediaSourcePath;
@@ -84,7 +93,7 @@ private:
    \return If access is granted, returns \e true
    */
   bool IsMediaPathUnlocked(const std::shared_ptr<CProfileManager>& profileManager,
-                           const std::string& strType);
+                           const std::string& strType) const;
 
   std::string m_strMediaSourcePath;
   int VerifyPassword(LockType btnType, const std::string& strPassword, const std::string& strHeading);

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -19,6 +19,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "addons/Scraper.h"
+#include "favourites/FavouritesService.h"
 #include "filesystem/File.h"
 #include "guilib/GUIButtonControl.h"
 #include "guilib/GUIComponent.h"
@@ -450,6 +451,10 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
 
+      // lock of a mediasource has been added
+      // => refresh favourites due to possible visibility changes
+      CServiceBroker::GetFavouritesService().RefreshFavourites();
+
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
       return true;
@@ -480,6 +485,11 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockcode", "0");
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
+
+      // lock of a mediasource has been removed
+      // => refresh favourites due to possible visibility changes
+      CServiceBroker::GetFavouritesService().RefreshFavourites();
+
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
       return true;
@@ -493,6 +503,10 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       {
         // don't prompt user for mastercode when reactivating a lock
         g_passwordManager.LockSource(type, share->strName, true);
+
+        // lock of a mediasource has been reactivated
+        // => refresh favourites due to possible visibility changes
+        CServiceBroker::GetFavouritesService().RefreshFavourites();
         return true;
       }
       return false;
@@ -513,6 +527,11 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockmode", strNewLockMode);
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
+
+      // lock of a mediasource has been changed
+      // => refresh favourites due to possible visibility changes
+      CServiceBroker::GetFavouritesService().RefreshFavourites();
+
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
       return true;

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -9,11 +9,13 @@
 #include "FavouritesService.h"
 
 #include "FileItem.h"
+#include "GUIPassword.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
 #include "music/tags/MusicInfoTag.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ContentUtils.h"
@@ -23,6 +25,75 @@
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 
+namespace
+{
+bool IsMediasourceOfFavItemUnlocked(const std::shared_ptr<CFileItem>& item)
+{
+  if (!item)
+  {
+    CLog::Log(LOGERROR, "{}: No item passed (nullptr).", __func__);
+    return true;
+  }
+
+  std::string execString = CURL::Decode(item->GetPath());
+  std::string execute;
+  std::vector<std::string> params;
+
+  CUtil::SplitExecFunction(execString, execute, params);
+
+  FavAction favAction;
+  if (StringUtils::EqualsNoCase(execute, "Favourites://PlayMedia"))
+    favAction = FavAction::PLAYMEDIA;
+  else if (StringUtils::EqualsNoCase(execute, "Favourites://ShowPicture"))
+    favAction = FavAction::SHOWPICTURE;
+  else
+    return true;
+
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+  {
+    CLog::Log(LOGERROR, "{}: returned nullptr.", __func__);
+    return true;
+  }
+
+  const auto profileManager = settingsComponent->GetProfileManager();
+  if (!profileManager)
+  {
+    CLog::Log(LOGERROR, "{}: returned nullptr.", __func__);
+    return true;
+  }
+
+  bool isFolder{false};
+  CFileItem itemToCheck(params[0], isFolder);
+
+  if (favAction == FavAction::PLAYMEDIA)
+  {
+    if (itemToCheck.IsVideo())
+    {
+      if (!profileManager->GetCurrentProfile().videoLocked())
+        return g_passwordManager.IsMediaFileUnlocked("video", itemToCheck.GetPath());
+
+      return false;
+    }
+    else if (itemToCheck.IsAudio())
+    {
+      if (!profileManager->GetCurrentProfile().musicLocked())
+        return g_passwordManager.IsMediaFileUnlocked("music", itemToCheck.GetPath());
+
+      return false;
+    }
+  }
+  else if (favAction == FavAction::SHOWPICTURE && itemToCheck.IsPicture())
+  {
+    if (!profileManager->GetCurrentProfile().picturesLocked())
+      return g_passwordManager.IsMediaFileUnlocked("pictures", itemToCheck.GetPath());
+
+    return false;
+  }
+
+  return true;
+}
+} // anonymous namespace
 
 static bool LoadFromFile(const std::string& strPath, CFileItemList& items)
 {
@@ -227,5 +298,21 @@ void CFavouritesService::GetAll(CFileItemList& items) const
 {
   CSingleLock lock(m_criticalSection);
   items.Clear();
-  items.Copy(m_favourites);
+  if (g_passwordManager.IsMasterLockUnlocked(false)) // don't prompt
+  {
+    items.Copy(m_favourites, true); // copy items
+  }
+  else
+  {
+    for (const auto& fav : m_favourites)
+    {
+      if (IsMediasourceOfFavItemUnlocked(fav))
+        items.Add(fav);
+    }
+  }
+}
+
+void CFavouritesService::RefreshFavourites()
+{
+  m_events.Publish(FavouritesUpdated{});
 }

--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -15,6 +15,11 @@
 #include <string>
 #include <vector>
 
+enum class FavAction : int
+{
+  PLAYMEDIA,
+  SHOWPICTURE,
+};
 
 class CFavouritesService
 {
@@ -31,6 +36,10 @@ public:
   std::string GetExecutePath(const CFileItem &item, const std::string &contextWindow) const;
   bool AddOrRemove(const CFileItem& item, int contextWindow);
   bool Save(const CFileItemList& items);
+
+  /*! \brief Refresh favourites for directory providers, e.g. the GUI needs to be updated
+   */
+  void RefreshFavourites();
 
   struct FavouritesUpdated { };
 

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -14,6 +14,7 @@
 #include "Util.h"
 #include "addons/AddonManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "favourites/FavouritesService.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -66,12 +67,20 @@ static int MasterMode(const std::vector<std::string>& params)
   {
     g_passwordManager.bMasterUser = false;
     g_passwordManager.LockSources(true);
+
+    // master mode turned OFF => refresh favourites due to possible visibility changes
+    CServiceBroker::GetFavouritesService().RefreshFavourites();
+
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20053));
   }
-  else if (g_passwordManager.IsMasterLockUnlocked(true))
+  else if (g_passwordManager.IsMasterLockUnlocked(true)) // prompt user for code
   {
     g_passwordManager.LockSources(false);
     g_passwordManager.bMasterUser = true;
+
+    // master mode turned ON => refresh favourites due to possible visibility changes
+    CServiceBroker::GetFavouritesService().RefreshFavourites();
+
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20054));
   }
 

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -13,6 +13,7 @@
 #include "dialogs/GUIDialogGamepad.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "favourites/FavouritesService.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -75,6 +76,11 @@ bool CGUIDialogLockSettings::ShowAndGetLock(CProfile::CLock &locks, int buttonLa
     return false;
 
   locks = dialog->m_locks;
+
+  // changed lock settings for certain sections (e.g. video, audio, or pictures)
+  // => refresh favourites due to possible visibility changes
+  CServiceBroker::GetFavouritesService().RefreshFavourites();
+
   return true;
 }
 


### PR DESCRIPTION
## Description
closes https://github.com/xbmc/xbmc/issues/20687

this is the continuation of patching profiles mediasource locks. ~~the lock will now be honored if media from a restricted source is added to favourites.~~

EDIT: changed the approach:
favourite items are hidden now if the matching mediasource is restricted+locked and master mode is not active.

## How has this been tested?
runtime test on linux

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
