### PR TITLE
[EDL][OSD] Add setting to avoid commbreak notification

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1278,9 +1278,14 @@ void CVideoPlayer::Prepare()
                   __FUNCTION__, starttime);
       }
 
-      const std::string strTimeString =
-          StringUtils::SecondsToTimeString(edit.end / 1000, TIME_FORMAT_MM_SS);
-      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+      const std::shared_ptr<CAdvancedSettings> advancedSettings =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+      if (advancedSettings && advancedSettings->m_EdlDisplayCommbreakNotifications)
+      {
+        const std::string timeString =
+            StringUtils::SecondsToTimeString(edit.end / 1000, TIME_FORMAT_MM_SS);
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), timeString);
+      }
     }
   }
 
@@ -2363,9 +2368,14 @@ void CVideoPlayer::CheckAutoSceneSkip()
     // marker for commbrak may be inaccurate. allow user to skip into break from the back
     if (m_playSpeed >= 0 && m_Edl.GetLastEditTime() != edit.start && clock < edit.end - 1000)
     {
-      const std::string strTimeString =
-          StringUtils::SecondsToTimeString((edit.end - edit.start) / 1000, TIME_FORMAT_MM_SS);
-      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+      const std::shared_ptr<CAdvancedSettings> advancedSettings =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+      if (advancedSettings && advancedSettings->m_EdlDisplayCommbreakNotifications)
+      {
+        const std::string timeString =
+            StringUtils::SecondsToTimeString((edit.end - edit.start) / 1000, TIME_FORMAT_MM_SS);
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), timeString);
+      }
 
       m_Edl.SetLastEditTime(edit.start);
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -327,6 +327,7 @@ void CAdvancedSettings::Initialize()
                                                   only if 'displayupdatepopup' is also enabled. */
 
   m_bEdlMergeShortCommBreaks = false;      // Off by default
+  m_EdlDisplayCommbreakNotifications = true; // On by default
   m_iEdlMaxCommBreakLength = 8 * 30 + 10;  // Just over 8 * 30 second commercial break.
   m_iEdlMinCommBreakLength = 3 * 30;       // 3 * 30 second commercial breaks.
   m_iEdlMaxCommBreakGap = 4 * 30;          // 4 * 30 second commercial breaks.
@@ -940,6 +941,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   if (pElement)
   {
     XMLUtils::GetBoolean(pElement, "mergeshortcommbreaks", m_bEdlMergeShortCommBreaks);
+    XMLUtils::GetBoolean(pElement, "displaycommbreaknotifications",
+                         m_EdlDisplayCommbreakNotifications);
     XMLUtils::GetInt(pElement, "maxcommbreaklength", m_iEdlMaxCommBreakLength, 0, 10 * 60); // Between 0 and 10 minutes
     XMLUtils::GetInt(pElement, "mincommbreaklength", m_iEdlMinCommBreakLength, 0, 5 * 60);  // Between 0 and 5 minutes
     XMLUtils::GetInt(pElement, "maxcommbreakgap", m_iEdlMaxCommBreakGap, 0, 5 * 60);        // Between 0 and 5 minutes.

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -275,6 +275,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     // EDL Commercial Break
     bool m_bEdlMergeShortCommBreaks;
+    /*!< @brief If GUI notifications should be shown when reaching the start of commercial breaks */
+    bool m_EdlDisplayCommbreakNotifications;
     int m_iEdlMaxCommBreakLength;   // seconds
     int m_iEdlMinCommBreakLength;   // seconds
     int m_iEdlMaxCommBreakGap;      // seconds


### PR DESCRIPTION
## Description
This PR adds an advanced setting to allow the user to avoid showing the edl commbreak notifications (they display by default)

```xml
<advancedsettings version="1.0">
        <edl>
		<displaycommbreaknotifications>false</displaycommbreaknotifications>
	</edl>
</advancedsettings>
```

## Motivation and context
Improve EDL usability

## How has this been tested?
Runtime tested

## What is the effect on users?
They may hide the notification that's shown when reaching EDL blocks.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7375276/147144158-a4e36428-e3f5-4b64-866a-7f4c79b7a473.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
