### PR TITLE
[Docs] Fix the table of infobools & infolabels

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5201,7 +5201,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     values include:
 ///       - <b>"Daylight"</b>
 ///       - <b>"Fluorescent"</b>
-///       - <b>"Incandescent</b>
+///       - <b>"Incandescent"</b>
 ///       - etc
 ///     @note This is the value of the EXIF LightSource tag (hex code 0x9208).
 ///     <p><hr>


### PR DESCRIPTION
## Description

This fixes the list of infolabels and infobools that got broken recently in Doxygen