### PR TITLE
[Estouchy] use panel layout for Favourites

### DIFF
--- a/addons/skin.estouchy/xml/DialogFavourites.xml
+++ b/addons/skin.estouchy/xml/DialogFavourites.xml
@@ -4,7 +4,7 @@
 	<include>16x9_xPos_Relocation</include>
 	<include>Window_OpenClose_Animation_Zoom</include>
 	<coordinates>
-		<posx>280</posx>
+		<posx>80</posx>
 		<posy>90</posy>
 	</coordinates>
 	<controls>
@@ -12,14 +12,14 @@
 		<control type="image">
 			<posx>0</posx>
 			<posy>0</posy>
-			<width>720</width>
+			<width>1120</width>
 			<height>60</height>
 			<texture border="5">dialog_header.png</texture>
 		</control>
 		<control type="image">
 			<posx>0</posx>
 			<posy>60</posy>
-			<width>720</width>
+			<width>1120</width>
 			<height>720</height>
 			<texture>dialog_back.png</texture>
 		</control>
@@ -28,25 +28,25 @@
 			<posx>20</posx>
 			<posy>0</posy>
 			<include>WindowTitleCommons</include>
-			<width>600</width>
+			<width>1000</width>
 			<label>$LOCALIZE[1036]</label>
 		</control>
 		<control type="group">
-			<posx>650</posx>
+			<posx>1050</posx>
 			<posy>0</posy>
 			<include>DialogCloseButtonCommons</include>
 		</control>
 		<control type="image">
 			<posx>0</posx>
 			<posy>60</posy>
-			<width>670</width>
+			<width>1070</width>
 			<height>720</height>
 			<texture colordiffuse="40000000">panel.png</texture>
 		</control>
-		<control type="list" id="450">
-			<posx>0</posx>
+		<control type="panel" id="450">
+			<posx>1</posx>
 			<posy>60</posy>
-			<width>670</width>
+			<width>1068</width>
 			<height>720</height>
 			<onup>450</onup>
 			<onleft>450</onleft>
@@ -54,58 +54,79 @@
 			<ondown>450</ondown>
 			<pagecontrol>60</pagecontrol>
 			<scrolltime>200</scrolltime>
-			<itemlayout width="670" height="80">
-				<control type="label">
-					<posx>20</posx>
-					<posy>0</posy>
-					<width>570</width>
-					<height>80</height>
+			<itemlayout width="267" height="360">
+				<control type="image">
+					<posx>10</posx>
+					<posy>10</posy>
+					<width>247</width>
+					<height>340</height>
+					<texture colordiffuse="50000000">black.png</texture>
+				</control>
+				<control type="image">
+					<posx>10</posx>
+					<posy>10</posy>
+					<width>247</width>
+					<height>277</height>
+					<aspectratio align="center">keep</aspectratio>
+					<texture>$INFO[ListItem.Icon]</texture>
+				</control>
+				<control type="image">
+					<posx>10</posx>
+					<posy>287</posy>
+					<width>247</width>
+					<height>63</height>
+					<texture colordiffuse="50000000">black.png</texture>
+				</control>
+				<control type="textbox">
+					<posx>10</posx>
+					<posy>287</posy>
+					<width>247</width>
+					<height>63</height>
 					<font>font20</font>
-					<align>left</align>
+					<align>center</align>
 					<aligny>center</aligny>
 					<selectedcolor>selected</selectedcolor>
 					<label>$INFO[ListItem.Label]</label>
-				</control>
-				<control type="image">
-					<posx>595</posx>
-					<posy>5</posy>
-					<width>70</width>
-					<height>70</height>
-					<aspectratio align="right">keep</aspectratio>
-					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 			</itemlayout>
-			<focusedlayout width="670" height="80">
+			<focusedlayout width="267" height="360">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
-					<width>670</width>
-					<height>80</height>
+					<posx>10</posx>
+					<posy>10</posy>
+					<width>247</width>
+					<height>340</height>
 					<texture>list_focus.png</texture>
 				</control>
-				<control type="label">
-					<posx>20</posx>
-					<posy>0</posy>
-					<width>570</width>
-					<height>80</height>
+				<control type="image">
+					<posx>10</posx>
+					<posy>10</posy>
+					<width>247</width>
+					<height>277</height>
+					<aspectratio align="center">keep</aspectratio>
+					<texture>$INFO[ListItem.Icon]</texture>
+				</control>
+				<control type="image">
+					<posx>10</posx>
+					<posy>287</posy>
+					<width>247</width>
+					<height>63</height>
+					<texture colordiffuse="50000000">black.png</texture>
+				</control>
+				<control type="textbox">
+					<posx>10</posx>
+					<posy>287</posy>
+					<width>247</width>
+					<height>63</height>
 					<font>font20</font>
-					<align>left</align>
+					<align>center</align>
 					<aligny>center</aligny>
 					<selectedcolor>selected</selectedcolor>
 					<label>$INFO[ListItem.Label]</label>
-				</control>
-				<control type="image">
-					<posx>595</posx>
-					<posy>5</posy>
-					<width>70</width>
-					<height>70</height>
-					<aspectratio align="right">keep</aspectratio>
-					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 			</focusedlayout>
 		</control>
 		<control type="scrollbar" id="60">
-			<posx>682</posx>
+			<posx>1082</posx>
 			<posy>90</posy>
 			<width>26</width>
 			<height>660</height>


### PR DESCRIPTION
## Description
change the layout in the favourites dialog from a List to a Panel.
the current list layout is a bit too small to work properly on smaller screens.

## Motivation and context
this was requesrted on the forum.


## What is the effect on users?
it will be easier for users to select a favourite on a touchscreen as the items are much larger now.

## Screenshots (if appropriate):

before:

![before](https://user-images.githubusercontent.com/687265/147287764-18528c8e-c337-4780-8f98-a46aebb2df8f.jpg)


after:

![after](https://user-images.githubusercontent.com/687265/147287772-483070b1-a0da-4144-aabb-f9e1c38c8f66.jpg)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
