### PR TITLE
[backport] Windows: update wget and remove --quiet from wget command 

### DIFF
--- a/project/BuildDependencies/bin/wget.exe.sha256
+++ b/project/BuildDependencies/bin/wget.exe.sha256
@@ -1,0 +1,1 @@
+bc8a2eabcb5598b66ea8c4a385a8135887a5688d9ad5dd33d2d3d6716c9332e7  project/BuildDependencies/bin/wget.exe

--- a/project/BuildDependencies/bin/wget.exe.url
+++ b/project/BuildDependencies/bin/wget.exe.url
@@ -1,0 +1,1 @@
+https://eternallybored.org/misc/wget/1.21.1/64/wget.exe

--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -64,7 +64,7 @@ IF EXIST %1 (
 ) ELSE (
   CALL :setSubStageName Downloading %1...
   SET DOWNLOAD_URL=%KODI_MIRROR%/build-deps/win32/%1
-  %WGET% --quiet --tries=5 --retry-connrefused --waitretry=2 --show-progress "!DOWNLOAD_URL!" 2>&1
+  %WGET% --tries=5 --retry-connrefused --waitretry=2 --show-progress "!DOWNLOAD_URL!" 2>&1
   REM Apparently there's a quirk in cmd so this means if error level => 1
   IF ERRORLEVEL 1 (
     ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST%


### PR DESCRIPTION
## Description

Fix binary addons build on Windows. Currently does by all addons on Matrix Jenkins fails with Windows builds.

---------------------------------------------

**Backport about https://github.com/xbmc/xbmc/pull/19588 with text:**

It seems to be non stop problems with windows builds these days so this is my attempt to solve them.

I've updated wget to the only version I could find (no idea if this source is trustworthy or not wink).

I've also removed the --quiet switch so we can actually see what happened if a download failed.

I've tested running the download-dependencies.bat on the Azure builder a few times with success.

@phunkyfish can you see if this solves the download issues you were having when doing windows builds?

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
