### PR TITLE
CLog: cleanups and newline fix

### DIFF
--- a/xbmc/addons/Webinterface.cpp
+++ b/xbmc/addons/Webinterface.cpp
@@ -26,7 +26,9 @@ CWebinterface::CWebinterface(const AddonInfoPtr& addonInfo)
   if (StringUtils::EqualsNoCase(webinterfaceType, "wsgi"))
     m_type = WebinterfaceTypeWsgi;
   else if (!webinterfaceType.empty() && !StringUtils::EqualsNoCase(webinterfaceType, "static") && !StringUtils::EqualsNoCase(webinterfaceType, "html"))
-    CLog::Log(LOGWARNING, "CWebinterface::{}: Addon \"{}\" has specified an unsupported type \"{}\"", ID(), webinterfaceType);
+    CLog::Log(LOGWARNING,
+              "CWebinterface::{}: Addon \"{}\" has specified an unsupported type \"{}\"", __func__,
+              ID(), webinterfaceType);
 
   // determine the entry point of the webinterface
   std::string entry = Type(ADDON_WEB_INTERFACE)->GetValue("@entry").asString();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -79,7 +79,7 @@ CAESinkXAudio::CAESinkXAudio() :
   HRESULT hr = XAudio2Create(m_xAudio2.ReleaseAndGetAddressOf(), 0);
   if (FAILED(hr))
   {
-    CLog::LogFunction(LOGERROR, __FUNCTION__, "XAudio initialization failed.");
+    CLog::LogF(LOGERROR, "XAudio initialization failed.");
   }
 #ifdef  _DEBUG
   else

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -455,8 +455,8 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
 
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::LogFunction(LOGWARNING, "CVaapi2Texture::Map",
-                      "vaExportSurfaceHandle failed - Error: {} ({})", vaErrorStr(status), status);
+    CLog::Log(LOGWARNING, "CVaapi2Texture::Map: vaExportSurfaceHandle failed - Error: {} ({})",
+              vaErrorStr(status), status);
     return false;
   }
 
@@ -472,8 +472,8 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
   status = vaSyncSurface(pic->vadsp, pic->procPic.videoSurface);
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::LogFunction(LOGERROR, "CVaapi2Texture::Map", "vaSyncSurface - Error: {} ({})",
-                      vaErrorStr(status), status);
+    CLog::Log(LOGERROR, "CVaapi2Texture::Map: vaSyncSurface - Error: {} ({})", vaErrorStr(status),
+              status);
     return false;
   }
 
@@ -485,8 +485,9 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
     auto const& layer = surface.layers[layerNo];
     if (layer.num_planes != 1)
     {
-      CLog::LogFunction(LOGDEBUG, "CVaapi2Texture::Map",
-                        "DRM-exported layer has {} planes - only 1 supported", layer.num_planes);
+      CLog::Log(LOGDEBUG,
+                "CVaapi2Texture::Map: DRM-exported layer has {} planes - only 1 supported",
+                layer.num_planes);
       return false;
     }
     auto const& object = surface.objects[layer.object_index[plane]];
@@ -517,8 +518,9 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
         }
         break;
       default:
-        CLog::LogFunction(LOGDEBUG, "CVaapi2Texture::Map",
-                          "DRM-exported surface {} layers - only 2 supported", surface.num_layers);
+        CLog::Log(LOGDEBUG,
+                  "CVaapi2Texture::Map: DRM-exported surface {} layers - only 2 supported",
+                  surface.num_layers);
         return false;
     }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -370,7 +370,7 @@ void CRendererBase::OnCMSConfigChanged(AVColorPrimaries srcPrimaries)
       success = COutputShader::CreateLUTView(lutSize, lutData, false, m_pLUTView.ReleaseAndGetAddressOf());
     }
     else
-      CLog::LogFunction(LOGERROR, "CRendererBase::OnCMSConfigChanged", "unable to loading the 3dlut data.");
+      CLog::Log(LOGERROR, "CRendererBase::OnCMSConfigChanged: unable to loading the 3dlut data.");
 
     KODI::MEMORY::AlignedFree(lutData);
     if (!success)

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -247,7 +247,7 @@ void CAxisFeature::ProcessMotions(void)
   const bool bWasActivated = (m_state != 0.0f);
 
   if (!bActivated && bWasActivated)
-    CLog::Log(LOGDEBUG, "Feature [ {} ] on {} deactivated", m_name);
+    CLog::Log(LOGDEBUG, "Feature [ {} ] on {} deactivated", m_name, m_handler->ControllerID());
   else if (bActivated && !bWasActivated)
   {
     CLog::Log(LOGDEBUG, "Feature [ {} ] on {} activated {}", m_name, m_handler->ControllerID(),

--- a/xbmc/platform/win10/input/RemoteControlXbox.cpp
+++ b/xbmc/platform/win10/input/RemoteControlXbox.cpp
@@ -202,7 +202,7 @@ int32_t CRemoteControlXbox::TranslateVirtualKey(VirtualKey vk)
   case VirtualKey::GamepadMenu:
     return XINPUT_IR_REMOTE_MENU;
   default:
-    CLog::LogFunction(LOGDEBUG, __FUNCTION__, "unknown vrtual key {}", static_cast<int>(vk));
+    CLog::LogF(LOGDEBUG, "unknown vrtual key {}", static_cast<int>(vk));
     return 0;
   }
 }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1440,8 +1440,8 @@ PVR_ERROR CPVRClient::DoAddonCall(const char* strFunctionName,
 
   // Log error, if any.
   if (error != PVR_ERROR_NO_ERROR && error != PVR_ERROR_NOT_IMPLEMENTED)
-    CLog::LogFunction(LOGERROR, strFunctionName, "Add-on '{}' returned an error: {}",
-                      GetFriendlyName(), ToString(error));
+    CLog::Log(LOGERROR, "{}: Add-on '{}' returned an error: {}", strFunctionName, GetFriendlyName(),
+              ToString(error));
 
   return error;
 }
@@ -1714,14 +1714,14 @@ void CPVRClient::HandleAddonCallback(const char* strFunctionName,
   CPVRClient* client = static_cast<CPVRClient*>(kodiInstance);
   if (!client)
   {
-    CLog::LogFunction(LOGERROR, strFunctionName, "No instance pointer given!");
+    CLog::Log(LOGERROR, "{}: No instance pointer given!", strFunctionName);
     return;
   }
 
   if (!bForceCall && client->m_bBlockAddonCalls && client->m_iAddonCalls == 0)
   {
-    CLog::LogFunction(LOGWARNING, strFunctionName, LOGPVR, "Ignoring callback from PVR client '{}'",
-                      client->GetFriendlyName());
+    CLog::Log(LOGWARNING, LOGPVR, "{}: Ignoring callback from PVR client '{}'", strFunctionName,
+              client->GetFriendlyName());
     return;
   }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -808,8 +808,8 @@ PVR_ERROR CPVRClients::ForCreatedClients(const char* strFunctionName,
 
     if (currentError != PVR_ERROR_NO_ERROR && currentError != PVR_ERROR_NOT_IMPLEMENTED)
     {
-      CLog::LogFunction(LOGERROR, strFunctionName, "PVR client '{}' returned an error: {}",
-                        clientEntry.second->GetFriendlyName(), CPVRClient::ToString(currentError));
+      CLog::Log(LOGERROR, "{}: PVR client '{}' returned an error: {}", strFunctionName,
+                clientEntry.second->GetFriendlyName(), CPVRClient::ToString(currentError));
       lastError = currentError;
       failedClients.emplace_back(clientEntry.first);
     }

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -102,7 +102,7 @@ bool CScreenshotSurfaceWindows::Capture()
       pImdContext->Unmap(pCopyTexture.Get(), 0);
     }
     else
-      CLog::LogFunction(LOGERROR, __FUNCTION__, "MAP_READ failed.");
+      CLog::LogF(LOGERROR, "MAP_READ failed.");
   }
 
   return m_buffer != nullptr;

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -309,9 +309,8 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     return true;
   }
 
-  CLog::Log(LOGERROR, "CEGLImage::{} - modifier ({:#x}) not supported for format ({})",
-            __FUNCTION__, DRMHELPERS::ModifierToString(modifier),
-            DRMHELPERS::FourCCToString(format));
+  CLog::Log(LOGERROR, "CEGLImage::{} - modifier ({}) not supported for format ({})", __FUNCTION__,
+            DRMHELPERS::ModifierToString(modifier), DRMHELPERS::FourCCToString(format));
 
   return false;
 }

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -75,13 +75,16 @@ public:
   Logger GetLogger(const std::string& loggerName);
 
   template<typename... Args>
-  static inline void Log(int level, const char* format, Args&&... args)
+  static inline void Log(int level, const std::string_view& format, Args&&... args)
   {
     Log(MapLogLevel(level), format, std::forward<Args>(args)...);
   }
 
   template<typename... Args>
-  static inline void Log(int level, uint32_t component, const char* format, Args&&... args)
+  static inline void Log(int level,
+                         uint32_t component,
+                         const std::string_view& format,
+                         Args&&... args)
   {
     if (!GetInstance().CanLogComponent(component))
       return;
@@ -90,7 +93,9 @@ public:
   }
 
   template<typename... Args>
-  static inline void Log(spdlog::level::level_enum level, const char* format, Args&&... args)
+  static inline void Log(spdlog::level::level_enum level,
+                         const std::string_view& format,
+                         Args&&... args)
   {
     GetInstance().FormatAndLogInternal(level, format, std::forward<Args>(args)...);
   }
@@ -98,7 +103,7 @@ public:
   template<typename... Args>
   static inline void Log(spdlog::level::level_enum level,
                          uint32_t component,
-                         const char* format,
+                         const std::string_view& format,
                          Args&&... args)
   {
     if (!GetInstance().CanLogComponent(component))
@@ -119,13 +124,15 @@ private:
 
   template<typename... Args>
   inline void FormatAndLogInternal(spdlog::level::level_enum level,
-                                   std::string format,
+                                   const std::string_view& format,
                                    Args&&... args)
   {
-    // fixup newline alignment, number of spaces should equal prefix length
-    StringUtils::Replace(format, "\n", "\n                                                   ");
+    auto message = fmt::format(format, std::forward<Args>(args)...);
 
-    m_defaultLogger->log(level, format, std::forward<Args>(args)...);
+    // fixup newline alignment, number of spaces should equal prefix length
+    StringUtils::Replace(message, "\n", "\n                                                   ");
+
+    m_defaultLogger->log(level, message);
   }
 
   Logger CreateLogger(const std::string& loggerName);

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -107,70 +107,15 @@ public:
     Log(level, format, std::forward<Args>(args)...);
   }
 
-  template<typename... Args>
-  static inline void LogFunction(int level,
-                                 const char* functionName,
-                                 const char* format,
-                                 Args&&... args)
-  {
-    LogFunction(MapLogLevel(level), functionName, format, std::forward<Args>(args)...);
-  }
-
-  template<typename... Args>
-  static inline void LogFunction(
-      int level, const char* functionName, uint32_t component, const char* format, Args&&... args)
-  {
-    if (!GetInstance().CanLogComponent(component))
-      return;
-
-    LogFunction(level, functionName, format, std::forward<Args>(args)...);
-  }
-
-  template<typename... Args>
-  static inline void LogFunction(spdlog::level::level_enum level,
-                                 const char* functionName,
-                                 const char* format,
-                                 Args&&... args)
-  {
-    if (functionName == nullptr || strlen(functionName) == 0)
-      GetInstance().FormatAndLogInternal(level, format, std::forward<Args>(args)...);
-    else
-      GetInstance().FormatAndLogFunctionInternal(level, functionName, format,
-                                                 std::forward<Args>(args)...);
-  }
-
-  template<typename... Args>
-  static inline void LogFunction(spdlog::level::level_enum level,
-                                 const char* functionName,
-                                 uint32_t component,
-                                 const char* format,
-                                 Args&&... args)
-  {
-    if (!GetInstance().CanLogComponent(component))
-      return;
-
-    LogFunction(level, functionName, format, std::forward<Args>(args)...);
-  }
-
-#define LogF(level, format, ...) LogFunction((level), __FUNCTION__, (format), ##__VA_ARGS__)
+#define LogF(level, format, ...) \
+  Log((level), ("{}: " DEF_TO_STR_VALUE(format)), __FUNCTION__, ##__VA_ARGS__)
 #define LogFC(level, component, format, ...) \
-  LogFunction((level), __FUNCTION__, (component), (format), ##__VA_ARGS__)
+  Log((level), (component), ("{}: " DEF_TO_STR_VALUE(format)), __FUNCTION__, ##__VA_ARGS__)
 
 private:
   static CLog& GetInstance();
 
   static spdlog::level::level_enum MapLogLevel(int level);
-
-  template<typename... Args>
-  static inline void FormatAndLogFunctionInternal(spdlog::level::level_enum level,
-                                                  const char* functionName,
-                                                  const char* format,
-                                                  Args&&... args)
-  {
-    GetInstance().FormatAndLogInternal(level,
-                                       StringUtils::Format("{0:s}: {1:s}", functionName, format),
-                                       std::forward<Args>(args)...);
-  }
 
   template<typename... Args>
   inline void FormatAndLogInternal(spdlog::level::level_enum level,

--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
@@ -133,7 +133,7 @@ bool CDRMLegacy::SetActive(bool active)
 {
   if (!m_connector->SetProperty("DPMS", active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF))
   {
-    CLog::Log(LOGDEBUG, "CDRMLegacy::{} - failed to set DPMS property");
+    CLog::Log(LOGDEBUG, "CDRMLegacy::{} - failed to set DPMS property", __FUNCTION__);
     return false;
   }
 

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -356,7 +356,7 @@ bool CWinSystemWin10::ChangeResolution(const RESOLUTION_INFO& res, bool forceCha
     return changed;
   }
 
-  CLog::LogFunction(LOGDEBUG, __FUNCTION__, "Not supported.");
+  CLog::LogF(LOGDEBUG, "Not supported.");
   return false;
 }
 


### PR DESCRIPTION
This cleans up some more of the logging methods.

I was playing around with getting c++20 working and it seems that with this PR and c++20 we can have compile time format checks for the logging which is cool. Unfortunately there isn't a good way to add that with c++17. The changes here work and IMO improve the interface. Doing this I found a few broken log calls (either missing a parameter or had the wrong formatter). There may be more but I only tested on linux/gl.

I'm getting rid of `CLog::LogFunction` method and opting for some macros instead to allow the calls to `LogF` and `LogFC` to then call to `Log`.

The idea here is that all logging format specifiers should be `constexpr` so in the future we can have compile time checks.

This also moves the logging formatting back to fmt from spdlog. With this we can easily add back the newline replacement again.

In the future we should also do a blanket change from `__FUNCTION__` to `__func__`

See here for some context: https://stackoverflow.com/questions/68675303/how-to-create-a-function-that-forwards-its-arguments-to-fmtformat-keeping-the