### PR TITLE
[cmake] add Wextra minus a few warnings

### DIFF
--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -154,7 +154,15 @@ if(NOT MSVC)
     -Wdouble-promotion
     -Wmissing-field-initializers
     -Wsign-compare
+    -Wextra
+    -Wno-cast-function-type # from -Wextra
+    -Wno-unused-parameter # from -Wextra
   )
+
+  add_options(CXX ALL_BUILDS
+    -Wno-deprecated-copy # from -Wextra
+  )
+
   add_options(ALL_LANGUAGES DEBUG
     -g
     -D_DEBUG

--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -161,6 +161,7 @@ if(NOT MSVC)
 
   add_options(CXX ALL_BUILDS
     -Wno-deprecated-copy # from -Wextra
+    -Wnon-virtual-dtor
   )
 
   add_options(ALL_LANGUAGES DEBUG

--- a/xbmc-xrandr.c
+++ b/xbmc-xrandr.c
@@ -2479,12 +2479,15 @@ int main(int argc, char** argv)
         case 2:
           pan->left = pan->top = 0;
           /* fall through */
+          __attribute__((fallthrough));
         case 4:
           pan->track_left = pan->track_top = pan->track_width = pan->track_height = 0;
           /* fall through */
+          __attribute__((fallthrough));
         case 8:
           pan->border_left = pan->border_top = pan->border_right = pan->border_bottom = 0;
           /* fall through */
+          __attribute__((fallthrough));
         case 12:
           break;
         default:

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -20,7 +20,7 @@ class CAppParamParser
 {
 public:
   CAppParamParser();
-  ~CAppParamParser();
+  virtual ~CAppParamParser();
 
   void Parse(const char* const* argv, int nArgs);
   void SetAdvancedSettings(CAdvancedSettings& advancedSettings) const;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -321,10 +321,11 @@ CFileItem::CFileItem(const CGenre& genre)
 }
 
 CFileItem::CFileItem(const CFileItem& item)
-: m_musicInfoTag(NULL),
-  m_videoInfoTag(NULL),
-  m_pictureInfoTag(NULL),
-  m_gameInfoTag(NULL)
+  : CGUIListItem(item),
+    m_musicInfoTag(NULL),
+    m_videoInfoTag(NULL),
+    m_pictureInfoTag(NULL),
+    m_gameInfoTag(NULL)
 {
   *this = item;
 }

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -39,6 +39,8 @@ using ADDON_INSTANCE_HANDLER = const void*;
 class CAddonDllInformer
 {
 public:
+  virtual ~CAddonDllInformer() = default;
+
   virtual bool IsInUse(const std::string& id) = 0;
 };
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
@@ -611,7 +611,7 @@ public:
   /// @brief Class copy constructor.
   ///
   /// @param[in] other Other class to copy on construct here
-  Joystick(const Joystick& other) { *this = other; }
+  Joystick(const Joystick& other) : Peripheral(other) { *this = other; }
 
   /// @brief Destructor.
   ///

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -860,6 +860,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             return;
           CLog::Log(LOGDEBUG,"CActiveAE - display reset event");
           displayReset = true;
+          [[fallthrough]];
         case CActiveAEControlProtocol::INIT:
           m_extError = false;
           m_extSuspended = false;

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -65,7 +65,7 @@ public:
   // unsigned int GetDTSBlocks() const { return m_dtsBlocks; }
   unsigned int GetDTSPeriod() const { return m_info.m_dtsPeriod; }
   unsigned int GetEAC3BlocksDiv() const { return m_info.m_repeat; }
-  enum CAEStreamInfo::DataType const GetDataType() const { return m_info.m_type; }
+  enum CAEStreamInfo::DataType GetDataType() const { return m_info.m_type; }
   bool IsLittleEndian() const { return m_info.m_dataIsLE; }
   unsigned int GetBufferSize() const { return m_bufferSize; }
   CAEStreamInfo& GetStreamInfo() { return m_info; }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -360,6 +360,8 @@ private:
 class IVaapiWinSystem
 {
 public:
+  virtual ~IVaapiWinSystem() = default;
+
   virtual VADisplay GetVADisplay() = 0;
   virtual void* GetEGLDisplay() { return nullptr; }
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -2311,6 +2311,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 8:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L8))
        {
@@ -2318,6 +2319,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 7:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L7))
        {
@@ -2325,6 +2327,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 6:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L6))
        {
@@ -2332,6 +2335,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 5:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L5))
        {
@@ -2339,6 +2343,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 4:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L4))
        {
@@ -2346,6 +2351,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 3:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L3))
        {
@@ -2353,6 +2359,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 2:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L2))
        {
@@ -2360,6 +2367,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     case 1:
        if (m_config.vdpau->Supports(VDP_VIDEO_MIXER_FEATURE_HIGH_QUALITY_SCALING_L1))
        {
@@ -2367,6 +2375,7 @@ void CMixer::SetHWUpscaling()
           vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
           break;
        }
+       [[fallthrough]];
     default:
        DisableHQScaling();
        return;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
@@ -487,6 +487,7 @@ cmsToneCurve* CColorManager::CreateToneCurve(CMS_TRC_TYPE gammaType,
 #undef HALFPT
     }
     // fall through to bt.1886 with calculated technical gamma
+    [[fallthrough]];
 
   case CMS_TRC_BT1886:
     {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -807,6 +807,8 @@ void CLinuxRendererGL::UpdateVideoFilter()
           return;
         }
       }
+
+      [[fallthrough]];
     }
 
   case VS_SCALINGMETHOD_LANCZOS2:

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -996,6 +996,7 @@ void MysqlDatabase::mysqlVXPrintf(
         flag_longlong = sizeof(char*)==sizeof(int64_t);
         flag_long = sizeof(char*)==sizeof(long int);
         /* Fall through into the next case */
+        [[fallthrough]];
       case etRADIX:
         if( infop->flags & FLAG_SIGNED ){
           int64_t v;

--- a/xbmc/dialogs/IGUIVolumeBarCallback.h
+++ b/xbmc/dialogs/IGUIVolumeBarCallback.h
@@ -14,7 +14,7 @@
 class IGUIVolumeBarCallback
 {
 public:
-  ~IGUIVolumeBarCallback() = default;
+  virtual ~IGUIVolumeBarCallback() = default;
 
   /*!
    * \brief Return true if the callback is active in the GUI

--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -27,6 +27,8 @@ namespace XCURL
 class DllLibCurl
 {
 public:
+  virtual ~DllLibCurl() = default;
+
   CURLcode global_init(long flags);
   void global_cleanup();
   CURL_HANDLE* easy_init();

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -509,6 +509,7 @@ bool CZipFile::DecompressGzip(const std::string& in, std::string& out)
     {
       case Z_NEED_DICT:
         err = Z_DATA_ERROR;
+        [[fallthrough]];
       case Z_DATA_ERROR:
       case Z_MEM_ERROR:
       case Z_STREAM_ERROR:

--- a/xbmc/guilib/DispResource.h
+++ b/xbmc/guilib/DispResource.h
@@ -14,6 +14,8 @@
 class IDispResource
 {
 public:
+  virtual ~IDispResource() = default;
+
   virtual void OnLostDisplay() {}
   virtual void OnResetDisplay() {}
   virtual void OnAppFocusChange(bool focus) {}
@@ -24,5 +26,7 @@ public:
 class IRenderLoop
 {
 public:
+  virtual ~IRenderLoop() = default;
+
   virtual void FrameMove() = 0;
 };

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -373,8 +373,8 @@ bool CGUIBaseContainer::OnAction(const CAction &action)
       return true;
     else if (action.GetID())
       return OnClick(action.GetID());
-    else
-      return false;
+
+    return false;
 
   case ACTION_FIRST_PAGE:
     SelectItem(0);

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -337,6 +337,7 @@ void CGUIEditControl::OnClick()
     case INPUT_TYPE_PASSWORD_MD5:
       utf8 = ""; //! @todo Ideally we'd send this to the keyboard and tell the keyboard we have this type of input
       // fallthrough
+      [[fallthrough]];
     case INPUT_TYPE_TEXT:
     default:
       textChanged = CGUIKeyboardFactory::ShowAndGetInput(utf8, m_inputHeading, true, m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5);

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -247,6 +247,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         if (!g_application.GetAppPlayer().IsPlayingAudio())
           break;
         // fall-thru is intended.
+        [[fallthrough]];
       case MUSICPLAYER_DURATION:
       case LISTITEM_DURATION:
       {

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -652,6 +652,7 @@ CTCPServer::CWebSocketClient::CWebSocketClient(CWebSocket *websocket)
 }
 
 CTCPServer::CWebSocketClient::CWebSocketClient(const CWebSocketClient& client)
+  : CTCPServer::CTCPClient(client)
 {
   *this = client;
   m_buffer.reserve(maxBufferLength);

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -984,6 +984,7 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo)
         LOGINFO,
         "Xcddb::queryCDinfo No match found in CDDB database when doing the query shown below:\n{}",
         query_buffer);
+    [[fallthrough]];
   case 403: //Database entry is corrupt
   case 409: //No handshake
   default:

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -602,6 +602,7 @@ bool CUPnPPlayer::OnAction(const CAction &action)
 
         return false; /* let normal code handle the action */
       }
+      [[fallthrough]];
     default:
       return false;
   }

--- a/xbmc/platform/android/activity/IActivityHandler.h
+++ b/xbmc/platform/android/activity/IActivityHandler.h
@@ -24,6 +24,7 @@ typedef enum
 class IActivityHandler
 {
 public:
+  virtual ~IActivityHandler() = default;
 
   virtual void onStart() {}
   virtual void onResume() {}

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
@@ -61,7 +61,7 @@ public:
   */
   bool GetServerList(CFileItemList& items);
 
-  const long long GetInstanceID() { return wsd_instance_id; }
+  long long GetInstanceID() const { return wsd_instance_id; }
 
   /*
    * Set List of WSD info request
@@ -78,7 +78,7 @@ public:
   */
   bool GetCached(const std::string& strHostName, std::string& strIpAddress);
 
-  static const bool IsInitialized() { return m_isInitialized; }
+  static bool IsInitialized() { return m_isInitialized; }
 
 private:
   CCriticalSection m_critWSD;

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -553,7 +553,7 @@ const std::string CWSDiscoveryListenerUDP::wsd_tag_find(
   return "";
 }
 
-const bool CWSDiscoveryListenerUDP::equalsAddress(const wsd_req_info& lhs, const wsd_req_info& rhs)
+bool CWSDiscoveryListenerUDP::equalsAddress(const wsd_req_info& lhs, const wsd_req_info& rhs) const
 {
   return lhs.address == rhs.address;
 }

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
@@ -94,8 +94,8 @@ private:
   void PrintWSDInfo(const WSDiscovery::wsd_req_info& info);
 
   // compare WSD entry address
-  const bool equalsAddress(const WSDiscovery::wsd_req_info& lhs,
-                           const WSDiscovery::wsd_req_info& rhs);
+  bool equalsAddress(const WSDiscovery::wsd_req_info& lhs,
+                     const WSDiscovery::wsd_req_info& rhs) const;
 
   // Socket FD for send/recv
   int fd;

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -134,6 +134,7 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
     case ACTION_JUMP_SMS9:
       bIsJumpSMS = true;
       // fallthru is intended
+      [[fallthrough]];
     case REMOTE_0:
     case REMOTE_1:
     case REMOTE_2:

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -748,6 +748,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
             return true;
         }
         // fall-thru is intended
+        [[fallthrough]];
       }
       case VIDEOPLAYER_CHANNEL_NAME:
       case LISTITEM_CHANNEL_NAME:

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -346,6 +346,7 @@ bool CGUIWindowPVRGuideBase::OnAction(const CAction& action)
         break;
       }
       // fall-thru is intended
+      [[fallthrough]];
     case REMOTE_1:
     case REMOTE_2:
     case REMOTE_3:

--- a/xbmc/utils/ContentUtils.cpp
+++ b/xbmc/utils/ContentUtils.cpp
@@ -13,7 +13,7 @@
 
 namespace
 {
-const bool HasPreferredArtType(const CFileItem& item)
+bool HasPreferredArtType(const CFileItem& item)
 {
   return item.HasVideoInfoTag() && (item.GetVideoInfoTag()->m_type == MediaTypeMovie ||
                                     item.GetVideoInfoTag()->m_type == MediaTypeTvShow ||

--- a/xbmc/utils/IArchivable.h
+++ b/xbmc/utils/IArchivable.h
@@ -14,7 +14,7 @@ class IArchivable
 {
 protected:
   /* make sure nobody deletes a pointer to this class */
-  ~IArchivable() = default;
+  virtual ~IArchivable() = default;
 
 public:
   virtual void Archive(CArchive& ar) = 0;

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -329,8 +329,8 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = music->GetOriginalDate();
       if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bMusicLibraryUseISODates)
         value = StringUtils::ISODateToLocalizedDate(value);
-      break;
     }
+    break;
   case 'd': // date and time
     if (item->m_dateTime.IsValid())
       value = item->m_dateTime.GetAsLocalizedDateTime();


### PR DESCRIPTION
This further increases our warning level by adding `-Wextra` and `-Wnon-virtual-dtor`. I also had to disable some of the warnings that are enabled by `-Wextra` because they are spammy and not really relevant (IMO).

I wanted to use `-Wextra` rather than enabling the options individually because it enables some warnings that aren't possible to enable individually (like: `(C++ only) A base class is not initialized in the copy constructor of a derived class.`).

I wanted to wait for c++17 to PR this so we can use the `[[fallthrough]]` attribute. I think some of the places this is used isn't the greatest but it highlights where we can improve the code flow.

The other warnings are somewhat trivial but it will be interesting to see what people say.

I only tested this on linux with gcc so it will be interesting to see what clang says 🙃  If it because too much of a burden I'll just close the PR. Let's see what jenkins says first though.

ref:
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
https://clang.llvm.org/docs/DiagnosticsReference.html#wextra