### PR TITLE
[Docs] Remove codedocs.xyz integration

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -1,9 +1,0 @@
-# CodeDocs.xyz Configuration File
-
-DOXYFILE = docs/doxygen/Doxyfile.doxy 
-
-PROJECT_LOGO = docs/doxygen/Thumbnail-symbol-whitebg-small.jpg
-
-INPUT= xbmc \
-       docs/CODE_GUIDELINES.md \
-       docs/doxygen


### PR DESCRIPTION
## Description
Codedocs uses a pretty old version of doxygen, generated docs are broken for a while.
Documentation artifacts are now generated with github actions and published to github pages.
DNS entries in cloudflare were already adjusted to point to the new locations so...let's drop codedocs as a means to avoid confusion.

Docs: https://docs.kodi.tv
Addon Docs: http://dev-kit.kodi.tv
