### PR TITLE
CCPUInfoPosix: return early if m_cpuTempCmd is empty

### DIFF
--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -243,7 +243,7 @@ float CCPUInfoFreebsd::GetCPUFrequency()
 
 bool CCPUInfoFreebsd::GetTemperature(CTemperature& temperature)
 {
-  if (CCPUInfoPosix::GetTemperature(temperature))
+  if (CheckUserTemperatureCommand(temperature))
     return true;
 
   int value;

--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -243,12 +243,16 @@ float CCPUInfoFreebsd::GetCPUFrequency()
 
 bool CCPUInfoFreebsd::GetTemperature(CTemperature& temperature)
 {
+  if (CCPUInfoPosix::GetTemperature(temperature))
+    return true;
+
   int value;
   size_t len = sizeof(value);
 
   /* Temperature is in Kelvin * 10 */
   if (sysctlbyname("dev.cpu.0.temperature", &value, &len, nullptr, 0) != 0)
-    return CCPUInfoPosix::GetTemperature(temperature);
+    return false;
+
   temperature = CTemperature::CreateFromKelvin(static_cast<double>(value) / 10.0);
   temperature.SetValid(true);
 

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -334,7 +334,7 @@ float CCPUInfoLinux::GetCPUFrequency()
 
 bool CCPUInfoLinux::GetTemperature(CTemperature& temperature)
 {
-  if (CCPUInfoPosix::GetTemperature(temperature))
+  if (CheckUserTemperatureCommand(temperature))
     return true;
 
   if (m_tempPath.empty())

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -334,8 +334,11 @@ float CCPUInfoLinux::GetCPUFrequency()
 
 bool CCPUInfoLinux::GetTemperature(CTemperature& temperature)
 {
+  if (CCPUInfoPosix::GetTemperature(temperature))
+    return true;
+
   if (m_tempPath.empty())
-    return CCPUInfoPosix::GetTemperature(temperature);
+    return false;
 
   CSysfsPath path{m_tempPath};
   double value = path.Get<double>() / 1000.0;

--- a/xbmc/platform/posix/CPUInfoPosix.cpp
+++ b/xbmc/platform/posix/CPUInfoPosix.cpp
@@ -14,24 +14,24 @@
 
 bool CCPUInfoPosix::GetTemperature(CTemperature& temperature)
 {
-  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
-
   temperature.SetValid(false);
 
-  int value{-1};
-  char scale{'c'};
+  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
 
-  if (!cmd.empty())
+  if (cmd.empty())
+    return false;
+
+  int value = {};
+  char scale = {};
+
+  auto p = popen(cmd.c_str(), "r");
+  if (p)
   {
-    auto p = popen(cmd.c_str(), "r");
-    if (p)
-    {
-      int ret = fscanf(p, "%d %c", &value, &scale);
-      pclose(p);
+    int ret = fscanf(p, "%d %c", &value, &scale);
+    pclose(p);
 
-      if (ret < 2)
-        return false;
-    }
+    if (ret < 2)
+      return false;
   }
 
   if (scale == 'C' || scale == 'c')

--- a/xbmc/platform/posix/CPUInfoPosix.cpp
+++ b/xbmc/platform/posix/CPUInfoPosix.cpp
@@ -14,9 +14,22 @@
 
 bool CCPUInfoPosix::GetTemperature(CTemperature& temperature)
 {
+  return CheckUserTemperatureCommand(temperature);
+}
+
+bool CCPUInfoPosix::CheckUserTemperatureCommand(CTemperature& temperature)
+{
   temperature.SetValid(false);
 
-  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
+  auto settingComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingComponent)
+    return false;
+
+  auto advancedSettings = settingComponent->GetAdvancedSettings();
+  if (!advancedSettings)
+    return false;
+
+  std::string cmd = advancedSettings->m_cpuTempCmd;
 
   if (cmd.empty())
     return false;

--- a/xbmc/platform/posix/CPUInfoPosix.h
+++ b/xbmc/platform/posix/CPUInfoPosix.h
@@ -18,4 +18,6 @@ public:
 protected:
   CCPUInfoPosix() = default;
   virtual ~CCPUInfoPosix() = default;
+
+  bool CheckUserTemperatureCommand(CTemperature& temperature);
 };


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20690

## Motivation and context
Fixes CPU temperature info (-1 ºC) . See: https://github.com/xbmc/xbmc/issues/20619


## What is the effect on users?
Fixes CPU temperature info (-1 ºC) when temperature info is not available.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
