### PR TITLE
EndTime: make public interface use std::chrono

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -216,6 +216,8 @@ using namespace std::chrono_literals;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
+using namespace std::chrono_literals;
+
 #define MAX_FFWD_SPEED 5
 
 CApplication::CApplication(void)
@@ -2327,7 +2329,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiSmartRedraw && m_guiRefreshTimer.IsTimePast())
     {
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(GUI_MSG_REFRESH_TIMER, 0, 0);
-      m_guiRefreshTimer.Set(500);
+      m_guiRefreshTimer.Set(500ms);
     }
 
     if (!m_bStop)
@@ -2463,7 +2465,7 @@ void CApplication::Stop(int exitCode)
   {
     // close inbound port
     CServiceBroker::UnregisterAppPort();
-    XbmcThreads::EndTime timer(1000);
+    XbmcThreads::EndTime<> timer(1000ms);
     while (m_pAppPort.use_count() > 1)
     {
       KODI::TIME::Sleep(100);

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -369,7 +369,7 @@ protected:
   CStopWatch m_navigationTimer;
   CStopWatch m_slowTimer;
   CStopWatch m_shutdownTimer;
-  XbmcThreads::EndTime m_guiRefreshTimer;
+  XbmcThreads::EndTime<> m_guiRefreshTimer;
 
   bool m_bInhibitIdleShutdown = false;
   bool m_bInhibitScreenSaver = false;

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -19,6 +19,8 @@
 #include "guilib/GUIWindowManager.h"
 #include "settings/MediaSettings.h"
 
+using namespace std::chrono_literals;
+
 std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal() const
 {
   CSingleLock lock(m_playerLock);
@@ -437,7 +439,7 @@ int CApplicationPlayer::GetAudioStream()
   if (player)
   {
     m_iAudioStream = player->GetAudioStream();
-    m_audioStreamUpdate.Set(1000);
+    m_audioStreamUpdate.Set(1000ms);
     return m_iAudioStream;
   }
   else
@@ -453,7 +455,7 @@ int CApplicationPlayer::GetSubtitle()
   if (player)
   {
     m_iSubtitleStream = player->GetSubtitle();
-    m_subtitleStreamUpdate.Set(1000);
+    m_subtitleStreamUpdate.Set(1000ms);
     return m_iSubtitleStream;
   }
   else
@@ -630,7 +632,7 @@ int CApplicationPlayer::GetVideoStream()
   if (player)
   {
     m_iVideoStream = player->GetVideoStream();
-    m_videoStreamUpdate.Set(1000);
+    m_videoStreamUpdate.Set(1000ms);
     return m_iVideoStream;
   }
   else
@@ -653,7 +655,7 @@ void CApplicationPlayer::SetAudioStream(int iStream)
   {
     player->SetAudioStream(iStream);
     m_iAudioStream = iStream;
-    m_audioStreamUpdate.Set(1000);
+    m_audioStreamUpdate.Set(1000ms);
   }
 }
 
@@ -671,7 +673,7 @@ void CApplicationPlayer::SetSubtitle(int iStream)
   {
     player->SetSubtitle(iStream);
     m_iSubtitleStream = iStream;
-    m_subtitleStreamUpdate.Set(1000);
+    m_subtitleStreamUpdate.Set(1000ms);
   }
 }
 
@@ -705,7 +707,7 @@ void CApplicationPlayer::SetVideoStream(int iStream)
   {
     player->SetVideoStream(iStream);
     m_iVideoStream = iStream;
-    m_videoStreamUpdate.Set(1000);
+    m_videoStreamUpdate.Set(1000ms);
   }
 }
 

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -167,11 +167,11 @@ private:
   CSeekHandler m_seekHandler;
 
   // cache player state
-  XbmcThreads::EndTime m_audioStreamUpdate;
+  XbmcThreads::EndTime<> m_audioStreamUpdate;
   int m_iAudioStream;
-  XbmcThreads::EndTime m_videoStreamUpdate;
+  XbmcThreads::EndTime<> m_videoStreamUpdate;
   int m_iVideoStream;
-  XbmcThreads::EndTime m_subtitleStreamUpdate;
+  XbmcThreads::EndTime<> m_subtitleStreamUpdate;
   int m_iSubtitleStream;
 
   struct SNextItem

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -975,7 +975,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
               }
             }
             else
-              m_extTimeout = m_extDrainTimer.MillisLeft();
+              m_extTimeout = m_extDrainTimer.GetTimeLeft();
           }
           else
             m_extTimeout = 5000ms;
@@ -1109,7 +1109,7 @@ void CActiveAE::Process()
     // wait for message
     else if (m_outMsgEvent.Wait(m_extTimeout))
     {
-      m_extTimeout = timer.MillisLeft();
+      m_extTimeout = timer.GetTimeLeft();
       continue;
     }
     // time out

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -26,6 +26,8 @@ using namespace ActiveAE;
 #include "windowing/WinSystem.h"
 #include "utils/log.h"
 
+using namespace std::chrono_literals;
+
 #define MAX_CACHE_LEVEL 0.4   // total cache time of stream in seconds
 #define MAX_WATER_LEVEL 0.2   // buffered time after stream stages in seconds
 #define MAX_BUFFER_TIME 0.1   // max time of a buffer in seconds
@@ -352,7 +354,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_muted = *(bool*)msg->data;
           return;
         case CActiveAEControlProtocol::KEEPCONFIG:
-          m_extKeepConfig = *(unsigned int*)msg->data;
+          m_extKeepConfig = std::chrono::milliseconds(*reinterpret_cast<unsigned int*>(msg->data));
           return;
         case CActiveAEControlProtocol::DISPLAYRESET:
           return;
@@ -476,12 +478,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!m_extError)
           {
             m_state = AE_TOP_CONFIGURED_PLAY;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
           }
           else
           {
             m_state = AE_TOP_ERROR;
-            m_extTimeout = 500;
+            m_extTimeout = 500ms;
           }
           return;
         default:
@@ -513,12 +515,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!m_extError)
           {
             m_state = AE_TOP_CONFIGURED_IDLE;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
           }
           else
           {
             m_state = AE_TOP_ERROR;
-            m_extTimeout = 500;
+            m_extTimeout = 500ms;
           }
           return;
 
@@ -537,12 +539,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           // drain
           if (RunStages())
           {
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
             return;
           }
           if (!m_sinkBuffers->m_inputSamples.empty() || !m_sinkBuffers->m_outputSamples.empty())
           {
-            m_extTimeout = 100;
+            m_extTimeout = 100ms;
             return;
           }
           if (NeedReconfigureSink())
@@ -553,12 +555,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!m_extError)
           {
             m_state = AE_TOP_CONFIGURED_PLAY;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
           }
           else
           {
             m_state = AE_TOP_ERROR;
-            m_extTimeout = 500;
+            m_extTimeout = 500ms;
           }
           m_extDeferData = false;
           return;
@@ -588,7 +590,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!NeedReconfigureBuffers() && !NeedReconfigureSink())
             return;
           m_state = AE_TOP_RECONFIGURING;
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           // don't accept any data until we are reconfigured
           m_extDeferData = true;
           return;
@@ -634,12 +636,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!m_extError)
           {
             m_state = AE_TOP_CONFIGURED_PLAY;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
           }
           else
           {
             m_state = AE_TOP_ERROR;
-            m_extTimeout = 500;
+            m_extTimeout = 500ms;
           }
           return;
         case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
@@ -656,12 +658,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             if (!m_extError)
             {
               m_state = AE_TOP_CONFIGURED_PLAY;
-              m_extTimeout = 0;
+              m_extTimeout = 0ms;
             }
             else
             {
               m_state = AE_TOP_ERROR;
-              m_extTimeout = 500;
+              m_extTimeout = 500ms;
             }
           }
           return;
@@ -683,13 +685,13 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           stream->m_paused = false;
           streaming = true;
           m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::STREAMING, &streaming, sizeof(bool));
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         case CActiveAEControlProtocol::FLUSHSTREAM:
           stream = *(CActiveAEStream**)msg->data;
           SFlushStream(stream);
           msg->Reply(CActiveAEControlProtocol::ACC);
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         case CActiveAEControlProtocol::STREAMAMP:
           MsgStreamParameter *par;
@@ -751,7 +753,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
 
             SoundState st = {sound, 0};
             m_sounds_playing.push_back(st);
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
             m_state = AE_TOP_CONFIGURED_PLAY;
           }
           return;
@@ -768,12 +770,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             if (!m_extError)
             {
               m_state = AE_TOP_CONFIGURED_PLAY;
-              m_extTimeout = 0;
+              m_extTimeout = 0ms;
             }
             else
             {
               m_state = AE_TOP_ERROR;
-              m_extTimeout = 500;
+              m_extTimeout = 500ms;
             }
           }
           else
@@ -791,7 +793,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             msgData->buffer->Return();
           else
             msgData->stream->m_processingBuffers->m_inputSamples.push_back(msgData->buffer);
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           m_state = AE_TOP_CONFIGURED_PLAY;
           return;
         case CActiveAEDataProtocol::FREESTREAM:
@@ -801,27 +803,29 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           msg->Reply(CActiveAEDataProtocol::ACC);
           if (m_streams.empty())
           {
-            if (m_extKeepConfig)
+            if (m_extKeepConfig > 0ms)
               m_extDrainTimer.Set(m_extKeepConfig);
             else
             {
               AEDelayStatus status;
               m_stats.GetDelay(status);
               if (msgStreamFree->finish)
-                m_extDrainTimer.Set(status.GetDelay() * 1000);
+                m_extDrainTimer.Set(
+                    std::chrono::milliseconds(static_cast<int>(status.GetDelay() * 1000)));
               else
-                m_extDrainTimer.Set(status.GetDelay() * 1000 + 1000);
+                m_extDrainTimer.Set(
+                    std::chrono::milliseconds(static_cast<int>(status.GetDelay() * 1000)) + 1s);
             }
             m_extDrain = true;
           }
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           m_state = AE_TOP_CONFIGURED_PLAY;
           return;
         case CActiveAEDataProtocol::DRAINSTREAM:
           stream = *(CActiveAEStream**)msg->data;
           stream->m_drain = true;
           stream->m_processingBuffers->SetDrain(true);
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           m_state = AE_TOP_CONFIGURED_PLAY;
           msg->Reply(CActiveAEDataProtocol::ACC);
           return;
@@ -840,7 +844,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           {
             (*buffer)->Return();
           }
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           m_state = AE_TOP_CONFIGURED_PLAY;
           return;
         default:
@@ -877,12 +881,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!m_extError)
           {
             m_state = AE_TOP_CONFIGURED_PLAY;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
           }
           else
           {
             m_state = AE_TOP_ERROR;
-            m_extTimeout = 500;
+            m_extTimeout = 500ms;
           }
           m_stats.SetSuspended(false);
           m_extDeferData = false;
@@ -915,7 +919,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
         switch (signal)
         {
         case CActiveAEControlProtocol::TIMEOUT:
-          m_extTimeout = 1000;
+          m_extTimeout = 1000ms;
           return;
         default:
           break;
@@ -934,14 +938,14 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           stream->m_paused = false;
           stream->m_syncState = CAESyncInfo::AESyncState::SYNC_START;
           m_state = AE_TOP_CONFIGURED_PLAY;
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         case CActiveAEControlProtocol::FLUSHSTREAM:
           stream = *(CActiveAEStream**)msg->data;
           SFlushStream(stream);
           msg->Reply(CActiveAEControlProtocol::ACC);
           m_state = AE_TOP_CONFIGURED_PLAY;
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         default:
           break;
@@ -962,19 +966,19 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
               if (!m_extError)
               {
                 m_state = AE_TOP_CONFIGURED_PLAY;
-                m_extTimeout = 0;
+                m_extTimeout = 0ms;
               }
               else
               {
                 m_state = AE_TOP_ERROR;
-                m_extTimeout = 500;
+                m_extTimeout = 500ms;
               }
             }
             else
               m_extTimeout = m_extDrainTimer.MillisLeft();
           }
           else
-            m_extTimeout = 5000;
+            m_extTimeout = 5000ms;
           return;
         default:
           break;
@@ -991,21 +995,21 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (m_extError)
           {
             m_state = AE_TOP_ERROR;
-            m_extTimeout = 100;
+            m_extTimeout = 100ms;
             return;
           }
           if (RunStages())
           {
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
             return;
           }
           if (!m_extDrain && HasWork())
           {
             ClearDiscardedBuffers();
-            m_extTimeout = 100;
+            m_extTimeout = 100ms;
             return;
           }
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           m_state = AE_TOP_CONFIGURED_IDLE;
           return;
         default:
@@ -1026,14 +1030,14 @@ void CActiveAE::Process()
   Message *msg = NULL;
   Protocol *port = NULL;
   bool gotMsg;
-  XbmcThreads::EndTime timer;
+  XbmcThreads::EndTime<> timer;
 
   m_state = AE_TOP_WAIT_PRECOND;
-  m_extTimeout = 1000;
+  m_extTimeout = 1000ms;
   m_bStateMachineSelfTrigger = false;
   m_extDrain = false;
   m_extDeferData = false;
-  m_extKeepConfig = 0;
+  m_extKeepConfig = 0ms;
 
   // start sink
   m_sink.Start();
@@ -1103,7 +1107,7 @@ void CActiveAE::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.Wait(std::chrono::milliseconds(m_extTimeout)))
+    else if (m_outMsgEvent.Wait(m_extTimeout))
     {
       m_extTimeout = timer.MillisLeft();
       continue;
@@ -1168,7 +1172,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
 
   m_sinkRequestFormat = inputFormat;
   ApplySettingsToFormat(m_sinkRequestFormat, m_settings, (int*)&m_mode);
-  m_extKeepConfig = 0;
+  m_extKeepConfig = 0ms;
 
   std::string device = (m_sinkRequestFormat.m_dataFormat == AE_FMT_RAW) ? m_settings.passthroughdevice : m_settings.device;
   std::string driver;
@@ -1701,7 +1705,8 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
 
       if (m_settings.config == AE_CONFIG_FIXED || (settings.stereoupmix && format.m_channelLayout.Count() <= 2))
         format.m_channelLayout = stdLayout;
-      else if (m_extKeepConfig && (settings.config == AE_CONFIG_AUTO) && (oldMode != MODE_RAW))
+      else if ((m_extKeepConfig > 0ms) && (settings.config == AE_CONFIG_AUTO) &&
+               (oldMode != MODE_RAW))
         format.m_channelLayout = m_internalFormat.m_channelLayout;
       else
       {
@@ -2367,7 +2372,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
   if (stream->m_syncState == CAESyncInfo::AESyncState::SYNC_START)
   {
     stream->m_syncState = CAESyncInfo::AESyncState::SYNC_MUTE;
-    stream->m_syncError.Flush(100);
+    stream->m_syncError.Flush(100ms);
     stream->m_processingBuffers->SetRR(1.0, m_settings.atempoThreshold);
     stream->m_resampleIntegral = 0;
     CLog::Log(LOGDEBUG,"ActiveAE - start sync of audio stream");
@@ -2387,7 +2392,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
   }
 
   int timeout = (stream->m_syncState != CAESyncInfo::AESyncState::SYNC_INSYNC) ? 100 : stream->GetErrorInterval();
-  bool newerror = stream->m_syncError.Get(error, timeout);
+  bool newerror = stream->m_syncError.Get(error, std::chrono::milliseconds(timeout));
 
   if (newerror && fabs(error) > threshold && stream->m_syncState == CAESyncInfo::AESyncState::SYNC_INSYNC)
   {
@@ -2509,7 +2514,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
       if (stream->m_lastSyncError > threshold * 2)
       {
         stream->m_syncState = CAESyncInfo::AESyncState::SYNC_MUTE;
-        stream->m_syncError.Flush(100);
+        stream->m_syncError.Flush(100ms);
         CLog::Log(LOGDEBUG, "ActiveAE::SyncStream - average error {:f}, last average error: {:f}",
                   error, stream->m_lastSyncError);
         stream->m_lastSyncError = error;
@@ -2517,7 +2522,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
       else
       {
         stream->m_syncState = CAESyncInfo::AESyncState::SYNC_INSYNC;
-        stream->m_syncError.Flush(1000);
+        stream->m_syncError.Flush(1000ms);
         stream->m_resampleIntegral = 0;
         stream->m_processingBuffers->SetRR(1.0, m_settings.atempoThreshold);
         CLog::Log(LOGDEBUG, "ActiveAE::SyncStream - average error {:f} below threshold of {:f}",
@@ -2543,7 +2548,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
     stream->m_processingBuffers->SetRR(1.0, m_settings.atempoThreshold);
   }
 
-  stream->m_syncError.SetErrorInterval(stream->GetErrorInterval());
+  stream->m_syncError.SetErrorInterval(std::chrono::milliseconds(stream->GetErrorInterval()));
 
   return ret;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -336,11 +336,11 @@ protected:
   CActiveAEDataProtocol m_dataPort;
   int m_state;
   bool m_bStateMachineSelfTrigger;
-  int m_extTimeout;
+  std::chrono::milliseconds m_extTimeout;
   bool m_extError;
   bool m_extDrain;
-  XbmcThreads::EndTime m_extDrainTimer;
-  unsigned int m_extKeepConfig;
+  XbmcThreads::EndTime<> m_extDrainTimer;
+  std::chrono::milliseconds m_extKeepConfig;
   bool m_extDeferData;
   std::queue<time_t> m_extLastDeviceChange;
   bool m_extSuspended = false;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -662,7 +662,7 @@ void CActiveAESink::Process()
     // wait for message
     else if (m_outMsgEvent.Wait(m_extTimeout))
     {
-      m_extTimeout = timer.MillisLeft();
+      m_extTimeout = timer.GetTimeLeft();
       continue;
     }
     // time out

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -122,13 +122,13 @@ protected:
   CEvent *m_inMsgEvent;
   int m_state;
   bool m_bStateMachineSelfTrigger;
-  int m_extTimeout;
-  int m_silenceTimeOut;
+  std::chrono::milliseconds m_extTimeout;
+  std::chrono::milliseconds m_silenceTimeOut;
   bool m_extError;
-  unsigned int m_extSilenceTimeout;
+  std::chrono::milliseconds m_extSilenceTimeout;
   bool m_extAppFocused;
   bool m_extStreaming;
-  XbmcThreads::EndTime m_extSilenceTimer;
+  XbmcThreads::EndTime<> m_extSilenceTimer;
 
   CSampleBuffer m_sampleOfSilence;
   enum

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -429,7 +429,7 @@ void CActiveAEStream::Drain(bool wait)
   if (wait)
     Resume();
 
-  XbmcThreads::EndTime timer(2000);
+  XbmcThreads::EndTime<> timer(2000ms);
   while (!timer.IsTimePast())
   {
     if (m_streamPort->ReceiveInMessage(&msg))
@@ -452,7 +452,7 @@ void CActiveAEStream::Drain(bool wait)
     else if (!wait)
       return;
 
-    m_inMsgEvent.Wait(std::chrono::milliseconds(timer.MillisLeft()));
+    m_inMsgEvent.Wait(timer.MillisLeft());
   }
   CLog::Log(LOGERROR, "CActiveAEStream::Drain - timeout out");
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -452,7 +452,7 @@ void CActiveAEStream::Drain(bool wait)
     else if (!wait)
       return;
 
-    m_inMsgEvent.Wait(timer.MillisLeft());
+    m_inMsgEvent.Wait(timer.GetTimeLeft());
   }
   CLog::Log(LOGERROR, "CActiveAEStream::Drain - timeout out");
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -68,7 +68,7 @@ public:
 
   double GetLastError(unsigned int &time)
   {
-    time = m_timer.GetStartTime().count();
+    time = m_timer.GetStartTime().time_since_epoch().count();
     return m_lastError;
   }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -35,7 +35,7 @@ public:
     m_count++;
   }
 
-  void Flush(int interval = 100)
+  void Flush(std::chrono::milliseconds interval = std::chrono::milliseconds(100))
   {
     m_buffer = 0.0;
     m_lastError = 0.0;
@@ -43,14 +43,14 @@ public:
     m_timer.Set(interval);
   }
 
-  void SetErrorInterval(int interval = 100)
+  void SetErrorInterval(std::chrono::milliseconds interval = std::chrono::milliseconds(100))
   {
     m_buffer = 0.0;
     m_count = 0;
     m_timer.Set(interval);
   }
 
-  bool Get(double& error, int interval = 100)
+  bool Get(double& error, std::chrono::milliseconds interval = std::chrono::milliseconds(100))
   {
     if(m_timer.IsTimePast())
     {
@@ -68,7 +68,7 @@ public:
 
   double GetLastError(unsigned int &time)
   {
-    time = m_timer.GetStartTime();
+    time = m_timer.GetStartTime().count();
     return m_lastError;
   }
 
@@ -88,7 +88,7 @@ protected:
   double m_buffer;
   double m_lastError;
   int m_count;
-  XbmcThreads::EndTime m_timer;
+  XbmcThreads::EndTime<> m_timer;
 };
 
 class CActiveAEStreamBuffers

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -30,6 +30,8 @@
 
 using namespace jni;
 
+using namespace std::chrono_literals;
+
 // those are empirical values while the HD buffer
 // is the max TrueHD package
 const unsigned int MAX_RAW_AUDIO_BUFFER_HD = 61440;
@@ -643,16 +645,16 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
     if (!m_at_jni->getTimestamp(m_timestamp))
     {
       CLog::Log(LOGDEBUG, "Could not acquire timestamp");
-      m_stampTimer.Set(100);
+      m_stampTimer.Set(100ms);
     }
     else
     {
       // check if frameposition is valid and nano timer less than 50 ms outdated
       if (m_timestamp.get_framePosition() > 0 &&
           (CurrentHostCounter() - m_timestamp.get_nanoTime()) < 50 * 1000 * 1000)
-        m_stampTimer.Set(1000);
+        m_stampTimer.Set(1000ms);
       else
-        m_stampTimer.Set(100);
+        m_stampTimer.Set(100ms);
     }
   }
   // check if last value was received less than 2 seconds ago

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -91,7 +91,7 @@ private:
   double m_delay = 0.0;
   double m_hw_delay = 0.0;
   CJNIAudioTimestamp m_timestamp;
-  XbmcThreads::EndTime m_stampTimer;
+  XbmcThreads::EndTime<> m_stampTimer;
 
   std::vector<float> m_floatbuf;
   std::vector<int16_t> m_shortbuf;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -77,7 +77,5 @@ private:
   pa_context *m_Context;
   pa_threaded_mainloop *m_MainLoop;
 
-  XbmcThreads::EndTime m_extTimer;
-
   static std::unique_ptr<CDriverMonitor> m_pMonitor;
 };

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -865,7 +865,7 @@ bool CCoreAudioDevice::SetBufferSize(UInt32 size)
   return (ret == noErr);
 }
 
-XbmcThreads::EndTime CCoreAudioDevice::m_callbackSuppressTimer;
+XbmcThreads::EndTime<> CCoreAudioDevice::m_callbackSuppressTimer;
 AudioObjectPropertyListenerProc CCoreAudioDevice::m_defaultOutputDeviceChangedCB = NULL;
 
 

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -66,7 +66,10 @@ public:
   static void   RegisterDeviceChangedCB(bool bRegister, AudioObjectPropertyListenerProc callback,  void *ref);
   static void   RegisterDefaultOutputDeviceChangedCB(bool bRegister, AudioObjectPropertyListenerProc callback, void *ref);
   // suppresses the default output device changed callback for given time in ms
-  static void   SuppressDefaultOutputDeviceCB(unsigned int suppressTimeMs){ m_callbackSuppressTimer.Set(suppressTimeMs); }
+  static void SuppressDefaultOutputDeviceCB(unsigned int suppressTimeMs)
+  {
+    m_callbackSuppressTimer.Set(std::chrono::milliseconds(suppressTimeMs));
+  }
 
   bool          AddIOProc(AudioDeviceIOProc ioProc, void* pCallbackData);
   bool          RemoveIOProc();
@@ -83,7 +86,7 @@ protected:
   unsigned int m_OutputBufferIndex = 0;
   unsigned int m_BufferSizeRestore = 0;
 
-  static XbmcThreads::EndTime m_callbackSuppressTimer;
+  static XbmcThreads::EndTime<> m_callbackSuppressTimer;
   static AudioObjectPropertyListenerProc m_defaultOutputDeviceChangedCB;
   static OSStatus defaultOutputDeviceChanged(AudioObjectID                       inObjectID,
                                              UInt32                              inNumberAddresses,

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -294,7 +294,7 @@ void CExternalPlayer::Process()
   /* don't block external player's access to audio device  */
   CServiceBroker::GetActiveAE()->Suspend();
   // wait for AE has completed suspended
-  XbmcThreads::EndTime timer(2000);
+  XbmcThreads::EndTime<> timer(2000ms);
   while (!timer.IsTimePast() && !CServiceBroker::GetActiveAE()->IsSuspended())
   {
     CThread::Sleep(50ms);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -51,6 +51,7 @@ extern "C" {
 #include <libavutil/opt.h>
 }
 
+using namespace std::chrono_literals;
 
 struct StereoModeConversionMap
 {
@@ -265,7 +266,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
   m_pFormatContext->interrupt_callback = int_cb;
 
   // try to abort after 30 seconds
-  m_timeout.Set(30000);
+  m_timeout.Set(30s);
 
   if (m_pInput->IsStreamType(DVDSTREAM_TYPE_FFMPEG))
   {
@@ -1022,7 +1023,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
       m_pkt.pkt.data = NULL;
 
       // timeout reads after 100ms
-      m_timeout.Set(20000);
+      m_timeout.Set(20s);
       m_pkt.result = av_read_frame(m_pFormatContext, &m_pkt.pkt);
       m_timeout.SetInfinite();
     }
@@ -1250,7 +1251,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
 
   if (m_checkTransportStream)
   {
-    XbmcThreads::EndTime timer(1000);
+    XbmcThreads::EndTime<> timer(1000ms);
 
     while (!IsTransportStreamReady())
     {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -157,7 +157,7 @@ protected:
   unsigned int m_initialProgramNumber;
   int m_seekStream;
 
-  XbmcThreads::EndTime  m_timeout;
+  XbmcThreads::EndTime<> m_timeout;
 
   // Due to limitations of ffmpeg, we only can detect a program change
   // with a packet. This struct saves the packet for the next read and

--- a/xbmc/cores/VideoPlayer/DVDMessage.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessage.cpp
@@ -21,15 +21,13 @@ class CDVDMsgGeneralSynchronizePriv
 {
 public:
   CDVDMsgGeneralSynchronizePriv(unsigned int timeout, unsigned int sources)
-    : sources(sources)
-    , reached(0)
-    , timeout(timeout)
+    : sources(sources), reached(0), timeout(std::chrono::milliseconds(timeout))
   {}
   unsigned int sources;
   unsigned int reached;
   CCriticalSection section;
   XbmcThreads::ConditionVariable condition;
-  XbmcThreads::EndTime timeout;
+  XbmcThreads::EndTime<> timeout;
 };
 
 /**
@@ -52,7 +50,7 @@ bool CDVDMsgGeneralSynchronize::Wait(unsigned int milliseconds, unsigned int sou
 {
   CSingleLock lock(m_p->section);
 
-  XbmcThreads::EndTime timeout(milliseconds);
+  XbmcThreads::EndTime<> timeout{std::chrono::milliseconds(milliseconds)};
 
   m_p->reached |= (source & m_p->sources);
   if ((m_p->sources & SYNCSOURCE_ANY) && source)
@@ -62,7 +60,7 @@ bool CDVDMsgGeneralSynchronize::Wait(unsigned int milliseconds, unsigned int sou
 
   while (m_p->reached != m_p->sources)
   {
-    milliseconds = std::min(m_p->timeout.MillisLeft(), timeout.MillisLeft());
+    milliseconds = std::min(m_p->timeout.MillisLeft().count(), timeout.MillisLeft().count());
     if (m_p->condition.wait(lock, std::chrono::milliseconds(milliseconds)))
       continue;
 

--- a/xbmc/cores/VideoPlayer/DVDMessage.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessage.cpp
@@ -60,7 +60,7 @@ bool CDVDMsgGeneralSynchronize::Wait(unsigned int milliseconds, unsigned int sou
 
   while (m_p->reached != m_p->sources)
   {
-    milliseconds = std::min(m_p->timeout.MillisLeft().count(), timeout.MillisLeft().count());
+    milliseconds = std::min(m_p->timeout.GetTimeLeft().count(), timeout.GetTimeLeft().count());
     if (m_p->condition.wait(lock, std::chrono::milliseconds(milliseconds)))
       continue;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2020,7 +2020,7 @@ void CVideoPlayer::HandlePlaySpeed()
       SetCaching(CACHESTATE_DONE);
       UpdatePlayState(0);
 
-      m_syncTimer.Set(3000);
+      m_syncTimer.Set(3000ms);
 
       if (!m_State.streamsReady)
       {
@@ -3028,7 +3028,7 @@ void CVideoPlayer::SetCaching(ECacheState state)
     m_VideoPlayerVideo->SetSpeed(DVD_PLAYSPEED_PAUSE);
     m_streamPlayerSpeed = DVD_PLAYSPEED_PAUSE;
 
-    m_cachingTimer.Set(5000);
+    m_cachingTimer.Set(5000ms);
   }
 
   if (state == CACHESTATE_PLAY ||

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -451,7 +451,7 @@ protected:
   bool m_bCloseRequest;
 
   ECacheState  m_caching;
-  XbmcThreads::EndTime m_cachingTimer;
+  XbmcThreads::EndTime<> m_cachingTimer;
 
   std::unique_ptr<CProcessInfo> m_processInfo;
 
@@ -534,7 +534,7 @@ protected:
 
   SPlayerState m_State;
   mutable CCriticalSection m_StateSection;
-  XbmcThreads::EndTime m_syncTimer;
+  XbmcThreads::EndTime<> m_syncTimer;
 
   CEdl m_Edl;
   bool m_SkipCommercials;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -307,7 +307,7 @@ void CVideoPlayerAudio::Process()
       if (m_speed != DVD_PLAYSPEED_PAUSE)
         m_audioSink.Resume();
       m_syncState = IDVDStreamPlayer::SYNC_INSYNC;
-      m_syncTimer.Set(3000);
+      m_syncTimer.Set(3000ms);
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
@@ -506,7 +506,7 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
 
     m_audioSink.SetDynamicRangeCompression(
         static_cast<long>(m_processInfo.GetVideoSettings().m_VolumeAmplification * 100));
-    
+
     SetSyncType(audioframe.passthrough);
 
     // downmix

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -91,7 +91,7 @@ protected:
   bool m_stalled;
   bool m_paused;
   IDVDStreamPlayer::ESyncState m_syncState;
-  XbmcThreads::EndTime m_syncTimer;
+  XbmcThreads::EndTime<> m_syncTimer;
 
   int m_synctype;
   int m_prevsynctype;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -123,7 +123,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
         m_forceNext = false;
         return false;
       }
-      m_presentevent.wait(lock, endtime.MillisLeft());
+      m_presentevent.wait(lock, endtime.GetTimeLeft());
     }
     m_forceNext = false;
   }
@@ -265,7 +265,7 @@ void CRenderManager::FrameWait(int ms)
   XbmcThreads::EndTime<> timeout{std::chrono::milliseconds(ms)};
   CSingleLock lock(m_presentlock);
   while(m_presentstep == PRESENT_IDLE && !timeout.IsTimePast())
-    m_presentevent.wait(lock, timeout.MillisLeft());
+    m_presentevent.wait(lock, timeout.GetTimeLeft());
 }
 
 bool CRenderManager::IsPresenting()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -144,7 +144,7 @@ protected:
   bool m_renderedOverlay = false;
   bool m_renderDebug = false;
   bool m_renderDebugVideo = false;
-  XbmcThreads::EndTime m_debugTimer;
+  XbmcThreads::EndTime<> m_debugTimer;
   std::atomic_bool m_showVideo = {false};
 
   enum EPRESENTSTEP
@@ -206,7 +206,7 @@ protected:
   int m_lateframes = -1;
   double m_presentpts = 0.0;
   EPRESENTSTEP m_presentstep = PRESENT_IDLE;
-  XbmcThreads::EndTime m_presentTimer;
+  XbmcThreads::EndTime<> m_presentTimer;
   bool m_forceNext = false;
   int m_presentsource = 0;
   int m_presentsourcePast = -1;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -125,7 +125,7 @@ void PAPlayer::SoftStop(bool wait/* = false */, bool close/* = true */)
   if(wait)
   {
     // fail safe timer, do not wait longer than 1000ms
-    XbmcThreads::EndTime timer(1000);
+    XbmcThreads::EndTime<> timer(1000ms);
 
     /* wait for them to fade out */
     lock.Leave();

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -41,7 +41,7 @@ CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const std::string& strHeader, co
   if(dwDelay == 0)
     OpenDialog();
   else
-    m_endtime.Set((unsigned int)dwDelay);
+    m_endtime.Set(std::chrono::milliseconds(static_cast<unsigned int>(dwDelay)));
 
   Create(true);
 }

--- a/xbmc/dialogs/GUIDialogCache.h
+++ b/xbmc/dialogs/GUIDialogCache.h
@@ -37,7 +37,7 @@ protected:
 
   void OpenDialog();
 
-  XbmcThreads::EndTime m_endtime;
+  XbmcThreads::EndTime<> m_endtime;
   CGUIDialogProgress* m_pDlg;
   std::string m_strHeader;
   std::string m_strLinePrev;

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -185,14 +185,14 @@ int64_t CSimpleFileCache::WaitForData(uint32_t iMinAvail, uint32_t iMillis)
   if( iMillis == 0 || IsEndOfInput() )
     return GetAvailableRead();
 
-  XbmcThreads::EndTime endTime(iMillis);
+  XbmcThreads::EndTime<> endTime{std::chrono::milliseconds(iMillis)};
   while (!IsEndOfInput())
   {
     int64_t iAvail = GetAvailableRead();
     if (iAvail >= iMinAvail)
       return iAvail;
 
-    if (!m_hDataAvailEvent->Wait(std::chrono::milliseconds(endTime.MillisLeft())))
+    if (!m_hDataAvailEvent->Wait(endTime.MillisLeft()))
       return CACHE_RC_TIMEOUT;
   }
   return GetAvailableRead();

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -192,7 +192,7 @@ int64_t CSimpleFileCache::WaitForData(uint32_t iMinAvail, uint32_t iMillis)
     if (iAvail >= iMinAvail)
       return iAvail;
 
-    if (!m_hDataAvailEvent->Wait(endTime.MillisLeft()))
+    if (!m_hDataAvailEvent->Wait(endTime.GetTimeLeft()))
       return CACHE_RC_TIMEOUT;
   }
   return GetAvailableRead();

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -192,7 +192,7 @@ int64_t CCircularCache::WaitForData(uint32_t minimum, uint32_t millis)
   if(minimum > m_size - m_size_back)
     minimum = m_size - m_size_back;
 
-  XbmcThreads::EndTime endtime(millis);
+  XbmcThreads::EndTime<> endtime{std::chrono::milliseconds(millis)};
   while (!IsEndOfInput() && avail < minimum && !endtime.IsTimePast() )
   {
     lock.Leave();

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1830,7 +1830,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
         if (CURLM_OK != g_curlInterface.multi_timeout(m_multiHandle, &timeout) || timeout == -1 || timeout < 200)
           timeout = 200;
 
-        XbmcThreads::EndTime endTime(timeout);
+        XbmcThreads::EndTime<> endTime{std::chrono::milliseconds(timeout)};
         int rc;
 
         do
@@ -1858,7 +1858,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
           }
           else
           {
-            unsigned int time_left = endTime.MillisLeft();
+            unsigned int time_left = endTime.MillisLeft().count();
             struct timeval wait = { (int)time_left / 1000, ((int)time_left % 1000) * 1000 };
             rc = select(maxfd + 1, &fdread, &fdwrite, &fdexcep, &wait);
           }

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1858,7 +1858,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
           }
           else
           {
-            unsigned int time_left = endTime.MillisLeft().count();
+            unsigned int time_left = endTime.GetTimeLeft().count();
             struct timeval wait = { (int)time_left / 1000, ((int)time_left % 1000) * 1000 };
             rc = select(maxfd + 1, &fdread, &fdwrite, &fdexcep, &wait);
           }

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -24,6 +24,8 @@
 
 using namespace XFILE;
 
+using namespace std::chrono_literals;
+
 //
 // multipath://{path1}/{path2}/{path3}/.../{path-N}
 //
@@ -43,7 +45,7 @@ bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if (!GetPaths(url, vecPaths))
     return false;
 
-  XbmcThreads::EndTime progressTime(3000); // 3 seconds before showing progress bar
+  XbmcThreads::EndTime<> progressTime(3000ms); // 3 seconds before showing progress bar
   CGUIDialogProgress* dlgProgress = NULL;
 
   unsigned int iFailures = 0;

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -189,7 +189,7 @@ void CGUIListItemLayout::LoadLayout(TiXmlElement *layout, int context, bool focu
   unsigned int infoupdatemillis = 0;
   layout->QueryUnsignedAttribute("infoupdate", &infoupdatemillis);
   if (infoupdatemillis > 0)
-    m_infoUpdateMillis = infoupdatemillis;
+    m_infoUpdateMillis = std::chrono::milliseconds(infoupdatemillis);
 
   m_infoUpdateTimeout.Set(m_infoUpdateMillis);
   m_isPlaying.Parse("listitem.isplaying", context);

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -62,7 +62,8 @@ protected:
 
   INFO::InfoPtr m_condition;
   KODI::GUILIB::GUIINFO::CGUIInfoBool m_isPlaying;
-  unsigned int m_infoUpdateMillis = std::numeric_limits<unsigned int>::max();
-  XbmcThreads::EndTime m_infoUpdateTimeout;
+  std::chrono::milliseconds m_infoUpdateMillis =
+      std::chrono::milliseconds(std::numeric_limits<std::chrono::milliseconds::rep>::max());
+  XbmcThreads::EndTime<> m_infoUpdateTimeout;
 };
 

--- a/xbmc/interfaces/generic/ScriptRunner.cpp
+++ b/xbmc/interfaces/generic/ScriptRunner.cpp
@@ -155,7 +155,7 @@ bool CScriptRunner::WaitOnScriptResult(int scriptId,
       ;
 
     // give the script 30 seconds to exit before we attempt to stop it
-    XbmcThreads::EndTime timer(30000);
+    XbmcThreads::EndTime<> timer(30s);
     while (!timer.IsTimePast() && CScriptInvocationManager::GetInstance().IsRunning(scriptId) &&
            !m_scriptDone.Wait(20ms))
       ;

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -136,14 +136,14 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
 
-      XbmcThreads::EndTime endTime(timemillis);
+      XbmcThreads::EndTime<> endTime{std::chrono::milliseconds(timemillis)};
       while (!endTime.IsTimePast())
       {
         LanguageHook* lh = NULL;
         {
           DelayedCallGuard dcguard;
           lh = dcguard.getLanguageHook(); // borrow this
-          long nextSleep = endTime.MillisLeft();
+          long nextSleep = endTime.MillisLeft().count();
           if (nextSleep > 100)
             nextSleep = 100; // only sleep for 100 millis
           KODI::TIME::Sleep(nextSleep);

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -143,7 +143,7 @@ namespace XBMCAddon
         {
           DelayedCallGuard dcguard;
           lh = dcguard.getLanguageHook(); // borrow this
-          long nextSleep = endTime.MillisLeft().count();
+          long nextSleep = endTime.GetTimeLeft().count();
           if (nextSleep > 100)
             nextSleep = 100; // only sleep for 100 millis
           KODI::TIME::Sleep(nextSleep);

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -49,7 +49,7 @@ namespace XBMCAddon
       {
         {
           DelayedCallGuard dg(languageHook);
-          auto timeout = std::min(endTime.MillisLeft(), 100ms);
+          auto timeout = std::min(endTime.GetTimeLeft(), 100ms);
           if (abortEvent.Wait(timeout))
             return true;
         }

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -13,6 +13,8 @@
 #include <algorithm>
 #include <math.h>
 
+using namespace std::chrono_literals;
+
 namespace XBMCAddon
 {
   namespace xbmc
@@ -38,7 +40,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       int timeoutMS = ceil(timeout * 1000);
-      XbmcThreads::EndTime endTime(timeoutMS);
+      XbmcThreads::EndTime<> endTime{std::chrono::milliseconds(timeoutMS)};
 
       if (timeoutMS <= 0)
         endTime.SetInfinite();
@@ -47,8 +49,8 @@ namespace XBMCAddon
       {
         {
           DelayedCallGuard dg(languageHook);
-          unsigned int t = std::min(endTime.MillisLeft(), 100u);
-          if (abortEvent.Wait(std::chrono::milliseconds(t)))
+          auto timeout = std::min(endTime.MillisLeft(), 100ms);
+          if (abortEvent.Wait(timeout))
             return true;
         }
         if (languageHook)

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -56,7 +56,7 @@ extern "C" FILE* fopen_utf8(const char* _Filename, const char* _Mode);
 #define PY_PATH_SEP DELIM
 
 // Time before ill-behaved scripts are terminated
-#define PYTHON_SCRIPT_TIMEOUT 5000 // ms
+#define PYTHON_SCRIPT_TIMEOUT 5000ms // ms
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
@@ -495,14 +495,15 @@ bool CPythonInvoker::stop(bool abort)
       //Release the lock while waiting for threads to finish
       lock.Leave();
 
-    XbmcThreads::EndTime timeout(PYTHON_SCRIPT_TIMEOUT);
+    XbmcThreads::EndTime<> timeout(PYTHON_SCRIPT_TIMEOUT);
     while (!m_stoppedEvent.Wait(15ms))
     {
       if (timeout.IsTimePast())
       {
         CLog::Log(LOGERROR,
                   "CPythonInvoker({}, {}): script didn't stop in {} seconds - let's kill it",
-                  GetId(), m_sourceFile, PYTHON_SCRIPT_TIMEOUT / 1000);
+                  GetId(), m_sourceFile,
+                  std::chrono::duration_cast<std::chrono::seconds>(PYTHON_SCRIPT_TIMEOUT).count());
         break;
       }
 
@@ -522,7 +523,7 @@ bool CPythonInvoker::stop(bool abort)
     // Useful for add-on performance metrics
     if (!timeout.IsTimePast())
       CLog::Log(LOGDEBUG, "CPythonInvoker({}, {}): script termination took {}ms", GetId(),
-                m_sourceFile, PYTHON_SCRIPT_TIMEOUT - timeout.MillisLeft());
+                m_sourceFile, (PYTHON_SCRIPT_TIMEOUT - timeout.MillisLeft()).count());
 
     // Since we released the m_critical it's possible that the state is cleaned up
     // so we need to recheck for m_threadState == NULL

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -523,7 +523,7 @@ bool CPythonInvoker::stop(bool abort)
     // Useful for add-on performance metrics
     if (!timeout.IsTimePast())
       CLog::Log(LOGDEBUG, "CPythonInvoker({}, {}): script termination took {}ms", GetId(),
-                m_sourceFile, (PYTHON_SCRIPT_TIMEOUT - timeout.MillisLeft()).count());
+                m_sourceFile, (PYTHON_SCRIPT_TIMEOUT - timeout.GetTimeLeft()).count());
 
     // Since we released the m_critical it's possible that the state is cleaned up
     // so we need to recheck for m_threadState == NULL

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -331,11 +331,11 @@ CAirPlayServer::~CAirPlayServer()
 void handleZeroconfAnnouncement()
 {
 #if defined(HAS_ZEROCONF)
-  static XbmcThreads::EndTime timeout(10000);
+  static XbmcThreads::EndTime<> timeout(10s);
   if(timeout.IsTimePast())
   {
     CZeroconf::GetInstance()->ForceReAnnounceService("servers.airplay");
-    timeout.Set(10000);
+    timeout.Set(10s);
   }
 #endif
 }

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -295,7 +295,7 @@ public:
 
   wait_result ShowAndWait (const WaitCondition& waitObj, unsigned timeOutSec, const std::string& line1)
   {
-    unsigned timeOutMs = timeOutSec * 1000;
+    auto timeOutMs = std::chrono::milliseconds(timeOutSec * 1000);
 
     if (m_dialog)
     {
@@ -304,7 +304,7 @@ public:
       m_dialog->SetPercentage(1); // avoid flickering by starting at 1% ..
     }
 
-    XbmcThreads::EndTime end_time (timeOutMs);
+    XbmcThreads::EndTime<> end_time(timeOutMs);
 
     while (!end_time.IsTimePast())
     {
@@ -321,9 +321,9 @@ public:
 
         m_dialog->Progress();
 
-        unsigned ms_passed = timeOutMs - end_time.MillisLeft();
+        auto ms_passed = timeOutMs - end_time.MillisLeft();
 
-        int percentage = (ms_passed * 100) / timeOutMs;
+        int percentage = (ms_passed.count() * 100) / timeOutMs.count();
         m_dialog->SetPercentage(std::max(percentage, 1)); // avoid flickering , keep minimum 1%
       }
 
@@ -349,12 +349,12 @@ public:
     bool online = CServiceBroker::GetNetwork().HasInterfaceForIP(address);
 
     if (!online) // setup endtime so we dont return true until network is consistently connected
-      m_end.Set (m_settle_time_ms);
+      m_end.Set(std::chrono::milliseconds(m_settle_time_ms));
 
     return online && m_end.IsTimePast();
   }
 private:
-  mutable XbmcThreads::EndTime m_end;
+  mutable XbmcThreads::EndTime<> m_end;
   unsigned m_settle_time_ms;
   const std::string m_host;
 };

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -321,7 +321,7 @@ public:
 
         m_dialog->Progress();
 
-        auto ms_passed = timeOutMs - end_time.MillisLeft();
+        auto ms_passed = timeOutMs - end_time.GetTimeLeft();
 
         int percentage = (ms_passed.count() * 100) / timeOutMs.count();
         m_dialog->SetPercentage(std::max(percentage, 1)); // avoid flickering , keep minimum 1%

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -189,7 +189,9 @@ CUPnPPlayer::~CUPnPPlayer()
   delete m_delegate;
 }
 
-static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime& timeout, CGUIDialogBusy*& dialog)
+static NPT_Result WaitOnEvent(CEvent& event,
+                              XbmcThreads::EndTime<>& timeout,
+                              CGUIDialogBusy*& dialog)
 {
   if (event.Wait(0ms))
     return NPT_SUCCESS;
@@ -200,7 +202,10 @@ static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime& timeout, CGUI
   return NPT_SUCCESS;
 }
 
-int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout)
+int CUPnPPlayer::PlayFile(const CFileItem& file,
+                          const CPlayerOptions& options,
+                          CGUIDialogBusy*& dialog,
+                          XbmcThreads::EndTime<>& timeout)
 {
   CFileItem item(file);
   NPT_Reference<CThumbLoader> thumb_loader;
@@ -347,7 +352,7 @@ failed:
 bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
 {
   CGUIDialogBusy* dialog = NULL;
-  XbmcThreads::EndTime timeout(10000);
+  XbmcThreads::EndTime<> timeout(10s);
 
   /* if no path we want to attach to a already playing player */
   if(file.GetPath() == "")
@@ -382,7 +387,7 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   if(dialog)
     dialog->Close();
 
-  m_updateTimer.Set(0);
+  m_updateTimer.Set(0ms);
 
   return true;
 failed:
@@ -618,7 +623,7 @@ void CUPnPPlayer::FrameMove()
   if (m_updateTimer.IsTimePast())
   {
     CDataCacheCore::GetInstance().SetPlayTimes(0, GetTime(), 0, GetTotalTime());
-    m_updateTimer.Set(500);
+    m_updateTimer.Set(500ms);
   }
 }
 

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -19,9 +19,6 @@
 class PLT_MediaController;
 class CGUIDialogBusy;
 
-namespace XbmcThreads { class EndTime; }
-
-
 namespace UPNP
 {
 
@@ -60,7 +57,10 @@ public:
 
   void FrameMove() override;
 
-  int PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout);
+  int PlayFile(const CFileItem& file,
+               const CPlayerOptions& options,
+               CGUIDialogBusy*& dialog,
+               XbmcThreads::EndTime<>& timeout);
 
 private:
   bool IsPaused() const;
@@ -74,7 +74,7 @@ private:
   std::string m_current_meta;
   bool m_started;
   bool m_stopremote;
-  XbmcThreads::EndTime m_updateTimer;
+  XbmcThreads::EndTime<> m_updateTimer;
 
   Logger m_logger;
 };

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -505,7 +505,7 @@ void CPVRManager::Process()
   m_database->Open();
 
   /* load the pvr data from the db and clients if it's not already loaded */
-  XbmcThreads::EndTime progressTimeout(30000); // 30 secs
+  XbmcThreads::EndTime<> progressTimeout(30s); // 30 secs
   CPVRGUIProgressHandler* progressHandler = new CPVRGUIProgressHandler(g_localizeStrings.Get(19235)); // PVR manager is starting up
   while (!LoadComponents(progressHandler) && IsInitialising())
   {
@@ -549,7 +549,7 @@ void CPVRManager::Process()
   CLog::LogFC(LOGDEBUG, LOGPVR, "PVR Manager entering main loop");
 
   bool bRestart(false);
-  XbmcThreads::EndTime cachedImagesCleanupTimeout(30000); // first timeout after 30 secs
+  XbmcThreads::EndTime<> cachedImagesCleanupTimeout(30s); // first timeout after 30 secs
 
   while (IsStarted() && m_addons->HasCreatedClients() && !bRestart)
   {
@@ -557,7 +557,7 @@ void CPVRManager::Process()
     {
       // start a job to erase stale texture db entries and image files
       TriggerCleanupCachedImages();
-      cachedImagesCleanupTimeout.Set(12 * 60 * 60 * 1000); // following timeouts after 12 hours
+      cachedImagesCleanupTimeout.Set(12h); // following timeouts after 12 hours
     }
 
     /* first startup */

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -34,7 +34,9 @@
 using namespace PVR;
 using namespace KODI::MESSAGING;
 
-#define MAX_INVALIDATION_FREQUENCY 2000 // limit to one invalidation per X milliseconds
+using namespace std::chrono_literals;
+
+#define MAX_INVALIDATION_FREQUENCY 2000ms // limit to one invalidation per X milliseconds
 
 CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD()
 : CGUIDialogPVRItemsViewBase(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml")

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -55,7 +55,7 @@ namespace PVR
 
     std::shared_ptr<CPVRChannelGroup> m_group;
     std::map<int, std::string> m_groupSelectedItemPaths;
-    XbmcThreads::EndTime m_refreshTimeout;
+    XbmcThreads::EndTime<> m_refreshTimeout;
   };
 }
 

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -286,7 +286,7 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
     // Note: We must lock the db the whole time, otherwise races may occur.
     database->Lock();
 
-    XbmcThreads::EndTime processTimeslice(iMaxTimeslice);
+    XbmcThreads::EndTime<> processTimeslice{std::chrono::milliseconds(iMaxTimeslice)};
     for (const auto& epg : changedEpgs)
     {
       if (!processTimeslice.IsTimePast())
@@ -376,7 +376,8 @@ void CPVREpgContainer::Process()
     if (!m_bStop && !m_bSuspended && CServiceBroker::GetPVRManager().EpgsCreated())
     {
       unsigned int iProcessed = 0;
-      XbmcThreads::EndTime processTimeslice(1000); // max 1 sec per cycle, regardless of how many events are in the queue
+      XbmcThreads::EndTime<> processTimeslice(
+          1000ms); // max 1 sec per cycle, regardless of how many events are in the queue
 
       while (!InterruptUpdate())
       {

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -33,7 +33,7 @@ public:
   CPVRChannelTimeoutJobBase(PVR::CPVRGUIChannelNavigator& channelNavigator, int iTimeout)
   : m_channelNavigator(channelNavigator)
   {
-    m_delayTimer.Set(iTimeout);
+    m_delayTimer.Set(std::chrono::milliseconds(iTimeout));
   }
 
   ~CPVRChannelTimeoutJobBase() override = default;
@@ -60,7 +60,7 @@ protected:
   PVR::CPVRGUIChannelNavigator& m_channelNavigator;
 
 private:
-  XbmcThreads::EndTime m_delayTimer;
+  XbmcThreads::EndTime<> m_delayTimer;
 };
 
 class CPVRChannelEntryTimeoutJob : public CPVRChannelTimeoutJobBase

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -138,9 +138,9 @@ void CPVRGUIInfo::Notify(const PVREvent& event)
 
 void CPVRGUIInfo::Process()
 {
-  int toggleIntervalMs =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRInfoToggleInterval;
-  XbmcThreads::EndTime cacheTimer(toggleIntervalMs);
+  auto toggleIntervalMs = std::chrono::milliseconds(
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRInfoToggleInterval);
+  XbmcThreads::EndTime<> cacheTimer(toggleIntervalMs);
 
   /* updated on request */
   CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRGUIInfo::Notify);

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -34,6 +34,8 @@
 
 using namespace PVR;
 
+using namespace std::chrono_literals;
+
 CPVRRecordingUid::CPVRRecordingUid(int iClientId, const std::string& strRecordingId) :
   m_iClientId(iClientId),
   m_strRecordingId(strRecordingId)
@@ -313,7 +315,7 @@ CBookmark CPVRRecording::GetResumePoint() const
       m_resumePointRefetchTimeout.IsTimePast())
   {
     // @todo: root cause should be fixed. details: https://github.com/xbmc/xbmc/pull/14961
-    m_resumePointRefetchTimeout.Set(10000); // update resume point from backend at most every 10 secs
+    m_resumePointRefetchTimeout.Set(10s); // update resume point from backend at most every 10 secs
 
     int pos = -1;
     client->GetRecordingLastPlayedPosition(*this, pos);
@@ -336,7 +338,7 @@ bool CPVRRecording::UpdateRecordingSize()
       m_recordingSizeRefetchTimeout.IsTimePast())
   {
     // @todo: root cause should be fixed. details: https://github.com/xbmc/xbmc/pull/14961
-    m_recordingSizeRefetchTimeout.Set(10000); // update size from backend at most every 10 secs
+    m_recordingSizeRefetchTimeout.Set(10s); // update size from backend at most every 10 secs
 
     int64_t sizeInBytes = -1;
     client->GetRecordingSize(*this, sizeInBytes);

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -489,9 +489,9 @@ namespace PVR
     bool m_bRadio; /*!< radio or tv recording */
     int m_iGenreType = 0; /*!< genre type */
     int m_iGenreSubType = 0; /*!< genre subtype */
-    mutable XbmcThreads::EndTime m_resumePointRefetchTimeout;
+    mutable XbmcThreads::EndTime<> m_resumePointRefetchTimeout;
     unsigned int m_iFlags = 0; /*!< the flags applicable to this recording */
-    mutable XbmcThreads::EndTime m_recordingSizeRefetchTimeout;
+    mutable XbmcThreads::EndTime<> m_recordingSizeRefetchTimeout;
     int64_t m_sizeInBytes = 0; /*!< the size of the recording in bytes */
     bool m_bDirty = false;
     std::string m_strProviderName; /*!< name of the provider this recording is from */

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -38,7 +38,9 @@
 #include <utility>
 #include <vector>
 
-#define MAX_INVALIDATION_FREQUENCY 2000 // limit to one invalidation per X milliseconds
+using namespace std::chrono_literals;
+
+#define MAX_INVALIDATION_FREQUENCY 2000ms // limit to one invalidation per X milliseconds
 
 using namespace PVR;
 using namespace KODI::MESSAGING;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -134,7 +134,7 @@ namespace PVR
 
     std::unique_ptr<CGUIPVRChannelGroupsSelector> m_channelGroupsSelector;
     std::shared_ptr<CPVRChannelGroup> m_channelGroup;
-    XbmcThreads::EndTime m_refreshTimeout;
+    XbmcThreads::EndTime<> m_refreshTimeout;
     CGUIDialogProgressBarHandle* m_progressHandle; /*!< progress dialog that is displayed while the pvr manager is loading */
   };
 }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -282,8 +282,8 @@ void CRenderSystemDX::PresentRender(bool rendered, bool videoLayer)
   // time for decoder that may require the context
   {
     CSingleLock lock(m_decoderSection);
-    XbmcThreads::EndTime timer;
-    timer.Set(5);
+    XbmcThreads::EndTime<> timer;
+    timer.Set(5ms);
     while (!m_decodingTimer.IsTimePast() && !timer.IsTimePast())
     {
       m_decodingEvent.wait(lock, 1ms);
@@ -296,7 +296,7 @@ void CRenderSystemDX::PresentRender(bool rendered, bool videoLayer)
 void CRenderSystemDX::RequestDecodingTime()
 {
   CSingleLock lock(m_decoderSection);
-  m_decodingTimer.Set(3);
+  m_decodingTimer.Set(3ms);
 }
 
 void CRenderSystemDX::ReleaseDecodingTime()

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -105,7 +105,7 @@ protected:
   // stereo interlaced/checkerboard intermediate target
   CD3DTexture m_rightEyeTex;
 
-  XbmcThreads::EndTime m_decodingTimer;
+  XbmcThreads::EndTime<> m_decodingTimer;
   XbmcThreads::ConditionVariable m_decodingEvent;
 
   std::shared_ptr<DX::DeviceResources> m_deviceResources;

--- a/xbmc/test/MtTestUtils.h
+++ b/xbmc/test/MtTestUtils.h
@@ -26,7 +26,7 @@ constexpr unsigned int defaultTimeout{20000};
  */
 template<typename L> inline bool poll(unsigned int timeoutMillis, L lambda)
 {
-  XbmcThreads::EndTime endTime(timeoutMillis);
+  XbmcThreads::EndTime<> endTime{std::chrono::milliseconds(timeoutMillis)};
   bool lastValue = false;
   while (!endTime.IsTimePast() && (lastValue = lambda()) == false)
     std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/xbmc/threads/SystemClock.cpp
+++ b/xbmc/threads/SystemClock.cpp
@@ -15,69 +15,6 @@
 namespace XbmcThreads
 {
 
-EndTime::EndTime()
-  : m_startTime(std::chrono::steady_clock::now()), m_totalWaitTime(std::chrono::milliseconds(0))
-{
-}
-
-EndTime::EndTime(unsigned int millisecondsIntoTheFuture)
-  : m_startTime(std::chrono::steady_clock::now()),
-    m_totalWaitTime(static_cast<std::chrono::milliseconds>(millisecondsIntoTheFuture))
-{
-}
-
-void EndTime::Set(unsigned int millisecondsIntoTheFuture)
-{
-  m_startTime = std::chrono::steady_clock::now();
-  m_totalWaitTime = static_cast<std::chrono::milliseconds>(millisecondsIntoTheFuture);
-}
-
-bool EndTime::IsTimePast() const
-{
-  if (m_totalWaitTime == InfiniteValue)
-    return false;
-
-  if (m_totalWaitTime == std::chrono::milliseconds(0))
-    return true;
-
-  return ((std::chrono::steady_clock::now() - m_startTime) >= m_totalWaitTime);
-}
-
-unsigned int EndTime::MillisLeft() const
-{
-  if (m_totalWaitTime == InfiniteValue)
-  {
-    //! @todo: this is a hack for now
-    return std::numeric_limits<unsigned int>::max();
-  }
-
-  if (m_totalWaitTime == std::chrono::milliseconds(0))
-    return 0;
-
-  std::chrono::milliseconds timeWaitedAlready =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                            m_startTime);
-
-  if (timeWaitedAlready >= m_totalWaitTime)
-    return 0;
-
-  return static_cast<unsigned int>(
-      std::chrono::duration_cast<std::chrono::milliseconds>(m_totalWaitTime - timeWaitedAlready)
-          .count());
-}
-
-unsigned int EndTime::GetInitialTimeoutValue() const
-{
-  return static_cast<unsigned int>(m_totalWaitTime.count());
-}
-
-unsigned int EndTime::GetStartTime() const
-{
-  return static_cast<unsigned int>(
-      std::chrono::duration_cast<std::chrono::milliseconds>(m_startTime.time_since_epoch())
-          .count());
-}
-
 unsigned int SystemClockMillis()
 {
   return static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -97,7 +97,7 @@ public:
 
   T GetInitialTimeoutValue() const { return m_totalWaitTime; }
 
-  T GetStartTime() const { return m_startTime.time_since_epoch(); }
+  std::chrono::steady_clock::time_point GetStartTime() const { return m_startTime; }
 
 private:
   std::chrono::steady_clock::time_point m_startTime;

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -74,7 +74,7 @@ public:
     return ((now - m_startTime) >= m_totalWaitTime);
   }
 
-  T MillisLeft() const
+  T GetTimeLeft() const
   {
     if (m_totalWaitTime == m_infinity)
       return m_infinity;

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -14,7 +14,7 @@
 
 namespace XbmcThreads
 {
-  /**
+/**
    * This function returns the system clock's number of milliseconds but with
    *  an arbitrary reference point. It handles the wrapping of any underlying
    *  system clock by setting a starting point at the first call. It should
@@ -23,40 +23,87 @@ namespace XbmcThreads
    * Of course, on windows it just calls timeGetTime, so you're on your own.
    */
 
-  unsigned int SystemClockMillis();
+unsigned int SystemClockMillis();
 
-  /**
+/**
    * DO NOT compare the results from SystemClockMillis() to an expected end time
    *  that was calculated by adding a number of milliseconds to some start time.
    *  The reason is because the SystemClockMillis could wrap. Instead use this
    *  class which uses differences (which are safe across a wrap).
    */
-  class EndTime
+
+template<typename>
+struct is_chrono_duration : std::false_type
+{
+};
+
+template<typename Rep, typename Period>
+struct is_chrono_duration<std::chrono::duration<Rep, Period>> : std::true_type
+{
+};
+
+template<typename T = std::chrono::milliseconds, bool = is_chrono_duration<T>::value>
+class EndTime;
+
+template<typename T>
+class EndTime<T, true>
+{
+public:
+  explicit EndTime(const T duration)
+    : m_startTime(std::chrono::steady_clock::now()), m_totalWaitTime(duration)
   {
-  public:
-    EndTime();
-    explicit EndTime(unsigned int millisecondsIntoTheFuture);
-    EndTime(const EndTime& right) = delete;
-    ~EndTime() = default;
+  }
 
-    void Set(unsigned int millisecondsIntoTheFuture);
+  EndTime() = default;
+  EndTime(const EndTime& right) = delete;
+  ~EndTime() = default;
 
-    bool IsTimePast() const;
+  void Set(const T duration)
+  {
+    m_startTime = std::chrono::steady_clock::now();
+    m_totalWaitTime = duration;
+  }
 
-    unsigned int MillisLeft() const;
+  bool IsTimePast() const
+  {
+    if (m_totalWaitTime == m_infinity)
+      return false;
 
-    void SetExpired() { m_totalWaitTime = std::chrono::milliseconds(0); }
-    void SetInfinite() { m_totalWaitTime = InfiniteValue; }
-    bool IsInfinite() const { return (m_totalWaitTime == InfiniteValue); }
+    const auto now = std::chrono::steady_clock::now();
 
-    unsigned int GetInitialTimeoutValue() const;
-    unsigned int GetStartTime() const;
+    return ((now - m_startTime) >= m_totalWaitTime);
+  }
 
-  private:
-    std::chrono::steady_clock::time_point m_startTime;
-    std::chrono::milliseconds m_totalWaitTime;
+  T MillisLeft() const
+  {
+    if (m_totalWaitTime == m_infinity)
+      return m_infinity;
 
-    const std::chrono::milliseconds InfiniteValue =
-        std::chrono::milliseconds(std::numeric_limits<std::chrono::milliseconds::rep>::max());
-  };
-}
+    const auto now = std::chrono::steady_clock::now();
+
+    const auto left = ((m_startTime + m_totalWaitTime) - now);
+
+    if (left < T::zero())
+      return T::zero();
+
+    return std::chrono::duration_cast<T>(left);
+  }
+
+  void SetExpired() { m_totalWaitTime = T::zero(); }
+
+  void SetInfinite() { m_totalWaitTime = m_infinity; }
+
+  bool IsInfinite() const { return (m_totalWaitTime == m_infinity); }
+
+  T GetInitialTimeoutValue() const { return m_totalWaitTime; }
+
+  T GetStartTime() const { return m_startTime.time_since_epoch(); }
+
+private:
+  std::chrono::steady_clock::time_point m_startTime;
+  T m_totalWaitTime = T::zero();
+
+  const T m_infinity = T::max();
+};
+
+} // namespace XbmcThreads

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -21,12 +21,12 @@ void CommonTests(XbmcThreads::EndTime<>& endTime)
   EXPECT_LT(0ms, endTime.GetStartTime());
 
   EXPECT_FALSE(endTime.IsTimePast());
-  EXPECT_LT(0ms, endTime.MillisLeft());
+  EXPECT_LT(0ms, endTime.GetTimeLeft());
 
   std::this_thread::sleep_for(100ms);
 
   EXPECT_TRUE(endTime.IsTimePast());
-  EXPECT_EQ(0ms, endTime.MillisLeft());
+  EXPECT_EQ(0ms, endTime.GetTimeLeft());
 
   endTime.SetInfinite();
   EXPECT_EQ(std::chrono::milliseconds::max(), endTime.GetInitialTimeoutValue());

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -18,7 +18,7 @@ namespace
 void CommonTests(XbmcThreads::EndTime<>& endTime)
 {
   EXPECT_EQ(100ms, endTime.GetInitialTimeoutValue());
-  EXPECT_LT(0ms, endTime.GetStartTime());
+  EXPECT_LT(0ms, endTime.GetStartTime().time_since_epoch());
 
   EXPECT_FALSE(endTime.IsTimePast());
   EXPECT_LT(0ms, endTime.GetTimeLeft());

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -15,23 +15,24 @@ using namespace std::chrono_literals;
 namespace
 {
 
-void CommonTests(XbmcThreads::EndTime<>& endTime)
+template<typename T = std::chrono::milliseconds>
+void CommonTests(XbmcThreads::EndTime<T>& endTime)
 {
   EXPECT_EQ(100ms, endTime.GetInitialTimeoutValue());
-  EXPECT_LT(0ms, endTime.GetStartTime().time_since_epoch());
+  EXPECT_LT(T::zero(), endTime.GetStartTime().time_since_epoch());
 
   EXPECT_FALSE(endTime.IsTimePast());
-  EXPECT_LT(0ms, endTime.GetTimeLeft());
+  EXPECT_LT(T::zero(), endTime.GetTimeLeft());
 
   std::this_thread::sleep_for(100ms);
 
   EXPECT_TRUE(endTime.IsTimePast());
-  EXPECT_EQ(0ms, endTime.GetTimeLeft());
+  EXPECT_EQ(T::zero(), endTime.GetTimeLeft());
 
   endTime.SetInfinite();
-  EXPECT_EQ(std::chrono::milliseconds::max(), endTime.GetInitialTimeoutValue());
+  EXPECT_EQ(T::max(), endTime.GetInitialTimeoutValue());
   endTime.SetExpired();
-  EXPECT_EQ(0ms, endTime.GetInitialTimeoutValue());
+  EXPECT_EQ(T::zero(), endTime.GetInitialTimeoutValue());
 }
 
 } // namespace
@@ -47,6 +48,13 @@ TEST(TestEndTime, DefaultConstructor)
 TEST(TestEndTime, ExplicitConstructor)
 {
   XbmcThreads::EndTime<> endTime(100ms);
+
+  CommonTests(endTime);
+}
+
+TEST(TestEndTime, DoubleMicroSeconds)
+{
+  XbmcThreads::EndTime<std::chrono::duration<double, std::micro>> endTime(100ms);
 
   CommonTests(endTime);
 }

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -10,41 +10,43 @@
 
 #include <gtest/gtest.h>
 
+using namespace std::chrono_literals;
+
 namespace
 {
 
-void CommonTests(XbmcThreads::EndTime& endTime)
+void CommonTests(XbmcThreads::EndTime<>& endTime)
 {
-  EXPECT_EQ(static_cast<unsigned int>(100), endTime.GetInitialTimeoutValue());
-  EXPECT_LT(static_cast<unsigned int>(0), endTime.GetStartTime());
+  EXPECT_EQ(100ms, endTime.GetInitialTimeoutValue());
+  EXPECT_LT(0ms, endTime.GetStartTime());
 
   EXPECT_FALSE(endTime.IsTimePast());
-  EXPECT_LT(static_cast<unsigned int>(0), endTime.MillisLeft());
+  EXPECT_LT(0ms, endTime.MillisLeft());
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(100ms);
 
   EXPECT_TRUE(endTime.IsTimePast());
-  EXPECT_EQ(static_cast<unsigned int>(0), endTime.MillisLeft());
+  EXPECT_EQ(0ms, endTime.MillisLeft());
 
   endTime.SetInfinite();
-  EXPECT_EQ(std::numeric_limits<unsigned int>::max(), endTime.GetInitialTimeoutValue());
+  EXPECT_EQ(std::chrono::milliseconds::max(), endTime.GetInitialTimeoutValue());
   endTime.SetExpired();
-  EXPECT_EQ(static_cast<unsigned int>(0), endTime.GetInitialTimeoutValue());
+  EXPECT_EQ(0ms, endTime.GetInitialTimeoutValue());
 }
 
 } // namespace
 
 TEST(TestEndTime, DefaultConstructor)
 {
-  XbmcThreads::EndTime endTime;
-  endTime.Set(static_cast<unsigned int>(100));
+  XbmcThreads::EndTime<> endTime;
+  endTime.Set(100ms);
 
   CommonTests(endTime);
 }
 
 TEST(TestEndTime, ExplicitConstructor)
 {
-  XbmcThreads::EndTime endTime(static_cast<unsigned int>(100));
+  XbmcThreads::EndTime<> endTime(100ms);
 
   CommonTests(endTime);
 }

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -11,6 +11,7 @@
 #include "threads/SystemClock.h"
 #include "utils/Temperature.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -71,7 +72,7 @@ public:
   const unsigned int CPUID_80000001_EDX_3DNOW = (1 << 31);
 
   // In milliseconds
-  const int MINIMUM_TIME_BETWEEN_READS{500};
+  const std::chrono::milliseconds MINIMUM_TIME_BETWEEN_READS{500};
 
   static std::shared_ptr<CCPUInfo> GetCPUInfo();
 
@@ -99,7 +100,7 @@ protected:
   virtual ~CCPUInfo() = default;
 
   int m_lastUsedPercentage;
-  XbmcThreads::EndTime m_nextUsedReadTime;
+  XbmcThreads::EndTime<> m_nextUsedReadTime;
   std::string m_cpuVendor;
   std::string m_cpuModel;
   std::string m_cpuBogoMips;

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -139,7 +139,7 @@ void CRssReader::Process()
     }
     else
     {
-      XbmcThreads::EndTime timeout(15000);
+      XbmcThreads::EndTime<> timeout(15s);
       while (!m_bStop && nRetries > 0)
       {
         if (timeout.IsTimePast())

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -274,7 +274,7 @@ void CWinEventsX11::SetXRRFailSafeTimer(int millis)
   if (!m_display)
     return;
 
-  m_xrrFailSafeTimer.Set(millis);
+  m_xrrFailSafeTimer.Set(std::chrono::milliseconds(millis));
   m_xrrEventPending = true;
 }
 

--- a/xbmc/windowing/X11/WinEventsX11.h
+++ b/xbmc/windowing/X11/WinEventsX11.h
@@ -50,7 +50,7 @@ protected:
   int m_keymodState;
   bool m_structureChanged;
   int m_RREventBase;
-  XbmcThreads::EndTime m_xrrFailSafeTimer;
+  XbmcThreads::EndTime<> m_xrrFailSafeTimer;
   bool m_xrrEventPending;
   CWinSystemX11& m_winSystem;
 };

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -36,6 +36,8 @@
 using namespace KODI::MESSAGING;
 using namespace KODI::WINDOWING::X11;
 
+using namespace std::chrono_literals;
+
 #define EGL_NO_CONFIG (EGLConfig)0
 
 CWinSystemX11::CWinSystemX11() : CWinSystemBase()
@@ -277,11 +279,14 @@ bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
         OnLostDevice();
         m_bIsInternalXrr = true;
         g_xrandr.SetMode(out, mode);
-        int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange");
-        if (delay > 0)
+        auto delay =
+            std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                          "videoscreen.delayrefreshchange") *
+                                      100);
+        if (delay > 0ms)
         {
           m_delayDispReset = true;
-          m_dispResetTimer.Set(delay * 100);
+          m_dispResetTimer.Set(delay);
         }
         return true;
       }

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -95,7 +95,7 @@ protected:
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*>  m_resources;
   bool m_delayDispReset;
-  XbmcThreads::EndTime m_dispResetTimer;
+  XbmcThreads::EndTime<> m_dispResetTimer;
   std::string m_currentOutput;
   std::string m_userOutput;
   bool m_windowDirty;

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -26,6 +26,8 @@
 #include <sys/wait.h>
 #endif
 
+using namespace std::chrono_literals;
+
 CXRandR::CXRandR(bool query)
 {
   m_bInit = false;
@@ -202,7 +204,7 @@ bool CXRandR::TurnOnOutput(const std::string& name)
   if (!SetMode(*output, mode))
     return false;
 
-  XbmcThreads::EndTime timeout(5000);
+  XbmcThreads::EndTime<> timeout(5s);
   while (!timeout.IsTimePast())
   {
     if (!Query(true))

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -28,6 +28,8 @@
 
 using namespace KODI::WINDOWING::GBM;
 
+using namespace std::chrono_literals;
+
 CWinSystemGbm::CWinSystemGbm() :
   m_DRM(nullptr),
   m_GBM(new CGBMUtils),
@@ -170,9 +172,12 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   auto result = m_DRM->SetVideoMode(res, bo);
 
-  int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange");
-  if (delay > 0)
-    m_dispResetTimer.Set(delay * 100);
+  auto delay =
+      std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                    "videoscreen.delayrefreshchange") *
+                                100);
+  if (delay > 0ms)
+    m_dispResetTimer.Set(delay);
 
   return result;
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -81,7 +81,7 @@ protected:
   std::vector<IDispResource*>  m_resources;
 
   bool m_dispReset = false;
-  XbmcThreads::EndTime m_dispResetTimer;
+  XbmcThreads::EndTime<> m_dispResetTimer;
   std::unique_ptr<CLibInputHandler> m_libinput;
 };
 

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.h
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.h
@@ -106,6 +106,6 @@ protected:
   std::vector<IDispResource*>  m_resources;
   CTimer                       m_lostDeviceTimer;
   bool                         m_delayDispReset;
-  XbmcThreads::EndTime         m_dispResetTimer;
+  XbmcThreads::EndTime<> m_dispResetTimer;
   int m_updateGLContext = 0;
 };

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -1780,11 +1780,14 @@ void CWinSystemOSX::AnnounceOnLostDevice()
 void CWinSystemOSX::HandleOnResetDevice()
 {
 
-  int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange");
-  if (delay > 0)
+  auto delay =
+      std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                    "videoscreen.delayrefreshchange") *
+                                100);
+  if (delay > 0ms)
   {
     m_delayDispReset = true;
-    m_dispResetTimer.Set(delay * 100);
+    m_dispResetTimer.Set(delay);
   }
   else
   {

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -43,6 +43,8 @@ using namespace winrt::Windows::Graphics::Display::Core;
 using namespace winrt::Windows::UI::Core;
 using namespace winrt::Windows::UI::ViewManagement;
 
+using namespace std::chrono_literals;
+
 CWinSystemWin10::CWinSystemWin10()
   : CWinSystemBase()
   , m_ValidWindowedPosition(false)
@@ -581,11 +583,14 @@ void CWinSystemWin10::OnDisplayReset()
 
 void CWinSystemWin10::OnDisplayBack()
 {
-  int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange");
-  if (delay > 0)
+  auto delay =
+      std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                    "videoscreen.delayrefreshchange") *
+                                100);
+  if (delay > 0ms)
   {
     m_delayDispReset = true;
-    m_dispResetTimer.Set(delay * 100);
+    m_dispResetTimer.Set(delay);
   }
   OnDisplayReset();
 }

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -137,7 +137,7 @@ protected:
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;
   bool m_delayDispReset;
-  XbmcThreads::EndTime m_dispResetTimer;
+  XbmcThreads::EndTime<> m_dispResetTimer;
 
   WINDOW_STATE m_state;                       // the state of the window
   WINDOW_FULLSCREEN_STATE m_fullscreenState;  // the state of the window when in fullscreen

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -39,6 +39,8 @@
 
 #include <tpcshrd.h>
 
+using namespace std::chrono_literals;
+
 CWinSystemWin32::CWinSystemWin32()
   : CWinSystemBase()
   , PtrGetGestureInfo(nullptr)
@@ -214,14 +216,14 @@ bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, 
   // Show the window
   ShowWindow( m_hWnd, SW_SHOWDEFAULT );
   UpdateWindow( m_hWnd );
-  
+
   // Configure the tray icon.
   m_trayIcon.cbSize = sizeof(m_trayIcon);
   m_trayIcon.hWnd = m_hWnd;
   m_trayIcon.hIcon = m_hIcon;
   wcsncpy(m_trayIcon.szTip, nameW.c_str(), sizeof(m_trayIcon.szTip) / sizeof(WCHAR));
   m_trayIcon.uCallbackMessage = TRAY_ICON_NOTIFY;
-  m_trayIcon.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;  
+  m_trayIcon.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
 
   return true;
 }
@@ -1085,11 +1087,14 @@ void CWinSystemWin32::OnDisplayReset()
 
 void CWinSystemWin32::OnDisplayBack()
 {
-  int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange");
-  if (delay > 0)
+  auto delay =
+      std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                    "videoscreen.delayrefreshchange") *
+                                100);
+  if (delay > 0ms)
   {
     m_delayDispReset = true;
-    m_dispResetTimer.Set(delay * 100);
+    m_dispResetTimer.Set(delay);
   }
   OnDisplayReset();
 }

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -180,7 +180,7 @@ protected:
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;
   bool m_delayDispReset;
-  XbmcThreads::EndTime m_dispResetTimer;
+  XbmcThreads::EndTime<> m_dispResetTimer;
 
   WINDOW_STATE m_state;                       // the state of the window
   WINDOW_FULLSCREEN_STATE m_fullscreenState;  // the state of the window when in fullscreen


### PR DESCRIPTION
This is a follow up to #18783 that I made a year ago. This pushes the `std::chrono` usage into the public interface.

IMO this help make the code a lot more readable when the values are assigned units.

I decided to template the entire `EndTime` class, not so much for the duration but for the underlying type. With these changes you can make your timer use `double` or `float` easily. The default template uses `std::chrono::milliseconds` which can be seen by the update from `EndTime` -> `EndTime<>`. When declaring your type you could use something like `EndTime<std::chrono::duration<double, std::nano>>` to have a double, nanosecond value.

When calling `GetTimeLeft` it returns the templated duration (ie. `std::chrono::milliseconds` by default)

One thing to note that you will see in the diff is that an `EndTime` declaration may use `std::chrono::milliseconds` but when calling `Set()` I use a different unit (ie. seconds, or hours). This is perfectly valid usage as it will implicitly cast to the type. You can cast down in units (s -> ms) but not up in units (ms -> s) as the value may truncate (ie 1234ms -> 1s).
ref: https://en.cppreference.com/w/cpp/chrono/duration

I've also included a commit to use a static start time for a couple methods.

I've also renamed `MillisLeft()` to `GetTimeLeft()` for obvious reasons.

I've done more work to further expand `std::chrono` into some of the changes in this PR instead of casting to `std::chrono::milliseconds` but I didn't include it in this PR as it's already quite large and will be in follow up PR's