### PR TITLE
[Xbox] Enable audio passthrough

### DIFF
--- a/system/settings/win10.xml
+++ b/system/settings/win10.xml
@@ -26,7 +26,7 @@
       <group id="3">
         <setting id="audiooutput.passthroughdevice">
           <level>1</level>
-          <default>XAUDIO:default</default>
+          <default>WASAPI:default</default>
         </setting>
       </group>
     </category>

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -58,12 +58,8 @@ CWinSystemWin10::CWinSystemWin10()
 
   AE::CAESinkFactory::ClearSinks();
   CAESinkXAudio::Register();
+  CAESinkWASAPI::Register();
   CScreenshotSurfaceWindows::Register();
-
-  if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Desktop)
-  {
-    CAESinkWASAPI::Register();
-  }
 }
 
 CWinSystemWin10::~CWinSystemWin10()


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20723

## Motivation and context
It can also be considered a fix because an important feature that is currently available on the platform is missing, and even the code already implemented, but "not enabled".


## How has this been tested?
Runtime tested Xbox Series S + AVR Denon X1600H


## What is the effect on users?
Enables audio passthrough on Xbox: AC3, DTS, DD+, DTSHD-MA, TrueHD, DD+ Atmos, TrueHD Atmos.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
