### PR TITLE
FindDav1d.cmake: fix internal david build download / parse DAV1D-VERSION file

### DIFF
--- a/cmake/modules/FindDav1d.cmake
+++ b/cmake/modules/FindDav1d.cmake
@@ -24,19 +24,26 @@ set(DAV1D_VERSION ${PC_DAV1D_VERSION})
 if(ENABLE_INTERNAL_DAV1D)
   include(ExternalProject)
 
-  # Extract version
-  file(STRINGS ${CMAKE_SOURCE_DIR}/tools/depends/target/dav1d/DAV1D-VERSION VER)
+  # Parse DAV1D-VERSION
+  set(DAV1D_FILE "${CMAKE_SOURCE_DIR}/tools/depends/target/dav1d/DAV1D-VERSION")
 
-  string(REGEX MATCH "VERSION=[^ ]*$.*" DAV1D_VER "${VER}")
-  list(GET DAV1D_VER 0 DAV1D_VER)
-  string(SUBSTRING "${DAV1D_VER}" 8 -1 DAV1D_VER)
+  file(STRINGS ${DAV1D_FILE} DAV1D_LNAME REGEX "^[ \t]*LIBNAME=")
+  file(STRINGS ${DAV1D_FILE} DAV1D_VER REGEX "^[ \t]*VERSION=")
+  file(STRINGS ${DAV1D_FILE} DAV1D_ARCHIVE REGEX "^[ \t]*ARCHIVE=")
+
+  string(REGEX REPLACE ".*LIBNAME=([^ \t]*).*" "\\1" DAV1D_LNAME "${DAV1D_LNAME}")
+  string(REGEX REPLACE ".*VERSION=([^ \t]*).*" "\\1" DAV1D_VER "${DAV1D_VER}")
+  string(REGEX REPLACE ".*ARCHIVE=([^ \t]*).*" "\\1" DAV1D_ARCHIVE "${DAV1D_ARCHIVE}")
+
+  string(REGEX REPLACE "\\$\\(LIBNAME\\)" "${DAV1D_LNAME}" DAV1D_ARCHIVE "${DAV1D_ARCHIVE}")
+  string(REGEX REPLACE "\\$\\(VERSION\\)" "${DAV1D_VER}" DAV1D_ARCHIVE "${DAV1D_ARCHIVE}")
 
   # allow user to override the download URL with a local tarball
   # needed for offline build envs
   if(DAV1D_URL)
     get_filename_component(DAV1D_URL "${DAV1D_URL}" ABSOLUTE)
   else()
-    set(DAV1D_URL http://mirrors.kodi.tv/build-deps/sources/dav1d-${DAV1D_VER}.tar.gz)
+    set(DAV1D_URL http://mirrors.kodi.tv/build-deps/sources/${DAV1D_ARCHIVE})
   endif()
 
   if(VERBOSE)
@@ -49,7 +56,7 @@ if(ENABLE_INTERNAL_DAV1D)
 
   externalproject_add(dav1d
                       URL ${DAV1D_URL}
-                      DOWNLOAD_NAME dav1d-${DAV1D_VER}.tar.gz
+                      DOWNLOAD_NAME ${DAV1D_ARCHIVE}
                       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
                       PREFIX ${CORE_BUILD_DIR}/dav1d
                       CONFIGURE_COMMAND meson


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix archive extension in cmake downloader when building internal dav1d

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With #20585 archive extension was changed but .tar.gz is still hard coded in dav1d cmake downloader.

Now using DAV1D-VERSION file to create archive name.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local Linux build.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
