### PR TITLE
ApplicationMessenger: fix ProcessMessage() map::at() out_of_range exception

### DIFF
--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -11,6 +11,7 @@
 #include "guilib/GUIMessage.h"
 #include "messaging/IMessageTarget.h"
 #include "threads/SingleLock.h"
+#include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
 #include <memory>
@@ -242,12 +243,14 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
   CSingleLock lock(m_critSection);
   int mask = pMsg->dwMessage & TMSG_MASK_MESSAGE;
 
-  auto target = m_mapTargets.at(mask);
-  if (target != nullptr)
+  const auto it = m_mapTargets.find(mask);
+  if (it != m_mapTargets.end())
   {
     CSingleExit exit(m_critSection);
-    target->OnApplicationMessage(pMsg);
+    it->second->OnApplicationMessage(pMsg);
   }
+  else
+    CLog::LogF(LOGERROR, "receiver {} is not defined", mask);
 }
 
 void CApplicationMessenger::ProcessWindowMessages()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Catch possible out_of_range exception in CApplicationMessenger::ProcessMessage()

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After updating openssl from 1.1.1 to 3.0.1 in LibreELEC there have been reports in the [forum](https://forum.libreelec.tv/thread/25014-libreelec-rpi4-arm-11-0-nightly-20211221-9284c92-crashes-falls-to-safemode/) of Kodi crashing because binary addons dependencies are missing, e.g. with vfs.libarchive or vfs.sftp.

Sample crash log is https://pastebin.com/embed_iframe/u9cTnBqz

Surprisingly Kodi does not crash in LoadDLL() but in ProcessMessage() with an out_of_range exception.

~Catch this possible exception in map::at()~ Use map::find() to avoid the exception when message receiver is not (yet) defined.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reproduced and successful tested in Linux desktop build.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No crash when loading binary addon is failing.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
