### PR TITLE
[VideoPlayer] Set demuxer speed to normal on flush

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3857,7 +3857,8 @@ void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
   UpdatePlayState(0);
 
   m_demuxerSpeed = DVD_PLAYSPEED_NORMAL;
-
+  if (m_pDemuxer)
+    m_pDemuxer->SetSpeed(DVD_PLAYSPEED_NORMAL);
 }
 
 // since we call ffmpeg functions to decode, this is being called in the same thread as ::Process() is


### PR DESCRIPTION
Co-Authored-By: FernetMenta <fernetmenta@online.de>

## Description
Found while working/checking EDL behaviour and explained (and solved) by FernetMenta in https://github.com/xbmc/xbmc/pull/20698#issuecomment-1001596010
Description of the bug can be found on https://github.com/xbmc/xbmc/pull/20698#issuecomment-1000369975

Might fix https://github.com/xbmc/xbmc/issues/19436
Will ask for testing to confirm

