### PR TITLE
[tools/depends][target] bump libbluray libudfread

### DIFF
--- a/tools/depends/target/libbluray/001-darwinembed_DiskArbitration-revert.patch
+++ b/tools/depends/target/libbluray/001-darwinembed_DiskArbitration-revert.patch
@@ -1,0 +1,88 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -46,7 +46,6 @@
+     ;;
+   *darwin*)
+     SYS=darwin
+-    EXTRA_LIBS="${EXTRA_LIBS} -framework CoreFoundation -framework DiskArbitration"
+     ;;
+   netbsd*)
+     SYS=netbsd
+--- a/src/file/mount_darwin.c
++++ b/src/file/mount_darwin.c
+@@ -29,53 +29,36 @@
+ 
+ #define _DARWIN_C_SOURCE
+ #include <sys/stat.h>
++#include <sys/param.h>
++#include <sys/ucred.h>
++#include <sys/mount.h>
+ 
+-#include <DiskArbitration/DADisk.h>
+-
+-static char *bsdname_get_mountpoint(const char *device_path)
++char *mount_get_mountpoint(const char *device_path)
+ {
+-    char *result = NULL;
++    struct stat st;
++    if (stat (device_path, &st) ) {
++        return str_dup(device_path);
++    }
+ 
+-    DASessionRef session = DASessionCreate(kCFAllocatorDefault);
+-    if (session) {
+-        DADiskRef disk = DADiskCreateFromBSDName(kCFAllocatorDefault, session, device_path);
+-        if (disk) {
+-            CFDictionaryRef desc = DADiskCopyDescription(disk);
+-            if (desc) {
+-                // Get Volume path as CFURL
+-                CFURLRef url = CFDictionaryGetValue(desc, kDADiskDescriptionVolumePathKey);
+-                if (url) {
+-                    // Copy Volume path as C char array
+-                    char tmp_path[PATH_MAX];
+-                    if (CFURLGetFileSystemRepresentation(url, true, (UInt8*)tmp_path, sizeof(tmp_path))) {
+-                        result = str_dup(tmp_path);
+-                    }
+-                }
+-                CFRelease(desc);
+-            }
+-            CFRelease(disk);
+-        }
+-        CFRelease(session);
++    /* If it's a directory, all is good */
++    if (S_ISDIR(st.st_mode)) {
++        return str_dup(device_path);
+     }
+ 
+-    return result;
+-}
++    struct statfs mbuf[128];
++    int fs_count;
+ 
++    if ( (fs_count = getfsstat (NULL, 0, MNT_NOWAIT)) != -1 ) {
+ 
+-char *mount_get_mountpoint(const char *device_path)
+-{
+-    struct stat st;
+-    if (stat(device_path, &st) == 0) {
+-        // If it's a directory, all is good
+-        if (S_ISDIR(st.st_mode)) {
+-            return str_dup(device_path);
+-        }
+-    }
++        getfsstat (mbuf, fs_count * sizeof(mbuf[0]), MNT_NOWAIT);
+ 
+-    char *mountpoint = bsdname_get_mountpoint(device_path);
+-    if (mountpoint) {
+-        return mountpoint;
++        for ( int i = 0; i < fs_count; ++i) {
++            if (!strcmp (mbuf[i].f_mntfromname, device_path)) {
++                return str_dup (mbuf[i].f_mntonname);
++            }
++        }
+     }
+ 
+-    return str_dup(device_path);
++    return str_dup (device_path);
+ }
++

--- a/tools/depends/target/libbluray/Makefile
+++ b/tools/depends/target/libbluray/Makefile
@@ -1,9 +1,9 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile tvos.patch
+DEPS= ../../Makefile.include Makefile 001-darwinembed_DiskArbitration-revert.patch tvos.patch
 
 # lib name, version
 LIBNAME=libbluray
-VERSION=1.1.2
+VERSION=1.3.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 
@@ -22,10 +22,11 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	# libbluray has borked Makefile.am with respect to CFLAGS, remove the offending line
-	sed -i -e "s|CFLAGS=|#CFLAGS=|" $(PLATFORM)/Makefile.am
 	cd $(PLATFORM); ./bootstrap
 	cd $(PLATFORM); $(CONFIGURE)
+ifeq ($(OS),darwin_embedded)
+	cd $(PLATFORM); patch -p1 -i ../001-darwinembed_DiskArbitration-revert.patch
+endif
 ifeq ($(TARGET_PLATFORM),appletvos)
 	cd $(PLATFORM); patch -p1 -i ../tvos.patch
 endif

--- a/tools/depends/target/libudfread/LIBUDFREAD-VERSION
+++ b/tools/depends/target/libudfread/LIBUDFREAD-VERSION
@@ -1,3 +1,3 @@
 LIBNAME=libudfread
-VERSION=1.1.0
+VERSION=1.1.2
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz


### PR DESCRIPTION
## Description
Dependency bumps. no change in core code to use the mouse events introduced in 1.2 or the change in separate keyevents in same version.
libbluray added a change to use external libudfread in 1.2.1, however it looks for the pkg-config name libudfread. Our current version of libudfread used a different pkg-config name (udfread) that was changed in libudfread 1.1.1, hence the bump of both packages in this PR

## Motivation and context
Dependency bumps.
ping @da-anda . Not sure if you want to try and revive your work for the windows depends. Maybe rope paxxi into bumping to 1.3.0 if he has time.

## How has this been tested?
Build aarch64 android, macos m1

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
