### PR TITLE
[PVR] Fix: EPGs must be created when loading channels from database.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -221,12 +221,6 @@ bool CPVRChannelGroupInternal::IsGroupMember(const std::shared_ptr<CPVRChannel>&
   return !channel->IsHidden();
 }
 
-void CPVRChannelGroupInternal::CreateChannelEpg(const std::shared_ptr<CPVRChannel>& channel)
-{
-  if (channel)
-    channel->CreateEPG();
-}
-
 bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)
 {
   if (!CServiceBroker::GetPVRManager().EpgContainer().IsStarted())
@@ -235,7 +229,7 @@ bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)
   {
     CSingleLock lock(m_critSection);
     for (auto& groupMemberPair : m_members)
-      CreateChannelEpg(groupMemberPair.second->Channel());
+      groupMemberPair.second->Channel()->CreateEPG();
   }
 
   return Persist();

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -49,6 +49,18 @@ bool CPVRChannelGroupInternal::Load(
 {
   if (CPVRChannelGroup::Load(channels))
   {
+    for (const auto& groupMember : m_members)
+    {
+      const std::shared_ptr<CPVRChannel> channel = groupMember.second->Channel();
+
+      // create the EPG for the channel
+      if (channel->CreateEPG())
+      {
+        CLog::LogFC(LOGDEBUG, LOGPVR, "Created EPG for {} channel '{}'", IsRadio() ? "radio" : "TV",
+                    channel->ChannelName());
+      }
+    }
+
     UpdateChannelPaths();
     CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRChannelGroupInternal::OnPVRManagerEvent);
     return true;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -104,8 +104,6 @@ namespace PVR
      */
     void UpdateChannelPaths();
 
-    void CreateChannelEpg(const std::shared_ptr<CPVRChannel>& channel);
-
     size_t m_iHiddenChannels; /*!< the amount of hidden channels in this container */
 
   private:


### PR DESCRIPTION
Currently, EPGs are created on first successful channels update from PVR client. If this first update fails (for example, because network is down), EPGsare loaded from datbase, but are not properly associated with the respective channel instance. This PR fixes this issue by creating the channel EPGs directly after loading channels from database, which is done before updating data from PVR clients.

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish whenever you find some time for a review.