### PR TITLE
[PVR] CGUIWindowPVRBase: Reset channel group path after channel group init…

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -459,7 +459,9 @@ bool CGUIWindowPVRBase::InitChannelGroup()
       CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(group);
     else
       CLog::LogF(LOGERROR, "Found no {} channel group with path '{}'!", m_bRadio ? "radio" : "TV",
-                 m_vecItems->GetPath());
+                 m_channelGroupPath);
+
+    m_channelGroupPath.clear();
   }
 
   if (group)


### PR DESCRIPTION
…, otherwise wrong group could be opened on next window init.

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish whenever you find some time for a review.