### PR TITLE
Revert "[depends] Updates MSYS2 to 20210725"

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -121,7 +121,7 @@ do_download() {
 
     do_print_status "$LIBNAME-$VERSION" "$blue_color" "Extracting"
     mkdir $LOCALSRCDIR && cd $LOCALSRCDIR
-    tar -xaf /downloads/$ARCHIVE --strip 1
+    tar -xf /downloads/$ARCHIVE --strip 1
   fi
   # applying patches
   local patches=(/xbmc/tools/buildsteps/windows/patches/*-$LIBNAME-*.patch)


### PR DESCRIPTION
Reverts #20726

To check ffmpeg builds on Jenkins. This the most related part to them.

If from them, then strange that not visible before.

Now via my fork, as can not update the branch inside Kodi.
Thought that only master and other releases are locked about upload and not all.