### PR TITLE
[EDL] Use TrickPlay in EDL seeks

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -200,6 +200,12 @@ public:
     bool accurate = true;
     bool sync = true;
     bool restore = true;
+    /** Trick player to avoid calling SetDisplayAfterSeek
+     *  (which sets the Player.DisplayAfterSeek infolabel) 
+     *  used by the GUI layer/skins to show the player is seeking.
+     *  This is mainly used when VideoPlayer is in DVD menus,
+     *  Bluray menus or EDL skips - i.e., not user initiated seeks.
+     */
     bool trickplay = false;
   };
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2350,7 +2350,7 @@ void CVideoPlayer::CheckAutoSceneSkip()
         mode.backward = true;
         mode.accurate = true;
         mode.restore = false;
-        mode.trickplay = false;
+        mode.trickplay = true;
         mode.sync = true;
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
 
@@ -2382,7 +2382,7 @@ void CVideoPlayer::CheckAutoSceneSkip()
         mode.backward = true;
         mode.accurate = true;
         mode.restore = false;
-        mode.trickplay = false;
+        mode.trickplay = true;
         mode.sync = true;
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
       }


### PR DESCRIPTION
## Description
Currently, when VP reaches the start of an EDL edit that involves an automatic seek (for instance edl cuts or commbreaks) Kodi will show the user the top seekbar "control" (or the video OSD) for a while with the information that Kodi is seeking. Since those "cut" blocks are not user initiated (but are rather automatic) this is unintended behavior. Kodi should skip/seek to the new point without presenting any GUI elements on top of the video to avoid disturbing the user attention.
Fortunately this is already implemented in Kodi in one of the `CDVDMsgPlayerSeek` message struct members. Initially created to avoid displaying the OSD in seeks originated by DVD and Bluray menus, `trickplay` can also be reused in this context.
Added documentation to this struct member as well, as I needed some code archeology to figure out what this was all about:

```
/** Trick player to avoid calling SetDisplayAfterSeek
     *  (which sets the Player.DisplayAfterSeek infolabel) 
     *  used by the GUI layer/skins to show the player is seeking.
     *  This is mainly used when VideoPlayer is in DVD menus,
     *  Bluray menus or EDL skips - i.e., not user initiated seeks.
```

## Motivation and context
Improved user experience. Also, this has been requested in https://forum.kodi.tv/showthread.php?tid=365838

## How has this been tested?
Runtime tested

## What is the effect on users?
Users should not see the seeking information being displayed when reaching EDL skips, video seeks and continues to play as if "nothing" happened.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
