### PR TITLE
Adds GUI hint for skins to skip border infill

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -342,7 +342,11 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
   if (!pNode) return false;
   const char *border = pNode->Attribute("border");
   if (border)
+  {
     GetRectFromString(border, image.border);
+    const char* borderinfill = pNode->Attribute("infill");
+    image.m_infill = (!borderinfill || !StringUtils::EqualsNoCase(borderinfill, "false"));
+  }
   image.orientation = 0;
   const char *flipX = pNode->Attribute("flipx");
   if (flipX && StringUtils::CompareNoCase(flipX, "true") == 0)

--- a/xbmc/guilib/GUIImage.dox
+++ b/xbmc/guilib/GUIImage.dox
@@ -72,6 +72,19 @@ important, as `xml` tags are case-sensitive.
 | fadetime      | This specifies a crossfade time that will be used whenever the underlying <b>`<texture>`</b> filename changes. The previous image will be held until the new image is ready, and then they will be crossfaded. This is particularly useful for a large thumbnail image showing the focused item in a list, or for fanart or other large backdrops.
 | background    | For images inside a container, you can specify background="true" to load the textures in a background worker thread. [See here for additional information about background loading](http://kodi.wiki/view/Background_Image_Loader).
 
+For the tags "texture" and "bordertexture", the following attributes are available.
+
+| Attribute     | Description                                                   |
+|--------------:|:--------------------------------------------------------------|
+| border        | Used to specify a region of the texture to be considered a border that should not be scaled when the texture is scaled to fit a control's dimensions. The portion in the border region will remain unscaled. Particularly useful to achieve rounded corners that do not change size when a control is resized. Note that zoom animations and GUI rescaling will still affect the border region - it is just the scaling of the texture to the control size which is unaffected. Using border="5" will give a 5 pixel border all around the texture. You can specify each of the border amounts on each edge individually using border="left,top,right,bottom".
+| infill        | Available if the "border" attribute is used. Hint for the GUI drawing routine if the center portion or just the outer frame should be drawn. Useful if the texture center is fully transparent. Accepts boolean values "true" (default) and "false".
+| flipx         | Specifies that the texture should be flipped in the horizontal direction, useful for reflections.
+| flipy         | Specifies that the texture should be flipped in the vertical direction, useful for reflections. 
+| background    | Used on the <b>`<imagepath>`</b> tag. When set to "true", this forces the image to be loaded via the large texture manager (except for textures located in Textures.xbt).
+| diffuse       | Specifies a diffuse texture which is "modulated" or multiplied with the texture in order to give specific effects, such as making the image gain transparency, or tint it in various ways. As it's applied per-pixel many effects are possible, the most popular being by a transparent reflection which slowly gets more and more opaque. This is achieved using a WHITE image where the transparency increases as you move down the texture.
+| colordiffuse  | This specifies the color to be used for the texture basis. It's is specified in hexadecimal notation using the AARRGGBB format. If you define <b>`<texture colordiffuse="FFFFAAFF">texture.png</texture>`</b> (magenta), the image will be given a magenta tint when rendered. You can also specify this as a name from the colour theme, or you can also use $VAR and $INFO for dynamic values.
+
+@skinning_v20 <b>infill</b> New texture attribute added.
 
 --------------------------------------------------------------------------------
 \section Image_Control_sect4 See also

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -224,7 +224,9 @@ void CGUITexture::Render()
   // middle segment (u1,0,u2,v3)
   if (m_info.border.y1)
     Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1, m_vertex.x2 - m_info.border.x2, m_vertex.y1 + m_info.border.y1, u1, 0, u2, v1, u3, v3);
-  Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1 + m_info.border.y1, m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, u1, v1, u2, v2, u3, v3);
+  if (m_info.m_infill)
+    Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1 + m_info.border.y1,
+           m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, u1, v1, u2, v2, u3, v3);
   if (m_info.border.y2)
     Render(m_vertex.x1 + m_info.border.x1, m_vertex.y2 - m_info.border.y2, m_vertex.x2 - m_info.border.x2, m_vertex.y2, u1, v2, u2, v3, u3, v3);
   // right segment

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -56,6 +56,8 @@ public:
   CTextureInfo& operator=(const CTextureInfo& right) = default;
   bool       useLarge;
   CRect      border;          // scaled  - unneeded if we get rid of scale on load
+  bool m_infill{
+      true}; // if false, the main body of a texture is not drawn. useful for borders with no inner filling
   int        orientation;     // orientation of the texture (0 - 7 == EXIForientation - 1)
   std::string diffuse;         // diffuse overlay texture
   KODI::GUILIB::GUIINFO::CGUIInfoColor diffuseColor; // diffuse color


### PR DESCRIPTION
## Description
The PR adds a new skin attribute for textures with borders. If the "border" attribute is used and "infill" is set to "false", only the frame of this texture is drawn.

## Motivation and context
Especially Estuary makes great use of shadow borders. Unfortunately not just the border region, but the whole element will be drawn, resulting in unnecessary overdraw of purely transparent triangles.

Giving the skin the choice to skip rendering the unnecessary surface enables performance gains without altering the resulting image.

## How has this been tested?
I've tested it on a RX570 with a modified Estuary skin. Renderdoc showed a improvement in render time of about 15% on the "Add-on" view of the main screen, which matches the estimated reduction of overdraw.

## What is the effect on users?
Faster GUI performance or reduced energy consumption in some cases.

## Screenshots (if appropriate):
Mesh with normal infill:
![image](https://user-images.githubusercontent.com/30039775/147791508-d53e9e3b-2982-4443-a598-072932e1037f.png)

Mesh with infill set to false:
![image(1)](https://user-images.githubusercontent.com/30039775/147791568-b93ac1c7-b51d-4a23-8a1d-1235d347e073.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
