### PR TITLE
[tools/depends][target] bump libuuid

### DIFF
--- a/tools/depends/target/libuuid/Makefile
+++ b/tools/depends/target/libuuid/Makefile
@@ -1,13 +1,12 @@
 include ../../Makefile.include
 DEPS= ../../Makefile.include Makefile
 
-# We use uuid from e2fsprogs since this easily cross-compiles on android, while util-linux does not.
+# We use uuid from e2fsprogs for legacy. util-linux works fine on android now
 # lib name, version
 LIBNAME=libuuid
-VERSION=1.42.13
-SOURCE=e2fsprogs-1.42.13
+VERSION=1.46.5
+SOURCE=e2fsprogs-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
-
 
 LIBDYLIB=$(PLATFORM)/lib/$(LIBNAME).a
 
@@ -19,12 +18,14 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM); ./configure --prefix=$(PREFIX) --disable-fsck
+	cd $(PLATFORM); ./configure --prefix=$(PREFIX) --disable-fsck --enable-libuuid
 
 $(LIBDYLIB): $(PLATFORM)
+  # -j1 is required due to concurrency failures with dirpath.h generation
 	cd $(PLATFORM)/lib/uuid ; $(MAKE) -j1
 
 .installed-$(PLATFORM): $(LIBDYLIB)
+  # -j1 is required due to concurrency failures with dirpath.h generation
 	cd $(PLATFORM)/lib/uuid ; $(MAKE) -j1 install
 	touch $@
 


### PR DESCRIPTION
## Description
Bump libuuid to latest e2fsprogs version

## Motivation and context
Dependency bump.
util-linux libuuid now successfully builds and runs on android, so it is a viable alternative. It appears to be more regularly updated, however nothing we use utilises the extended functions in util-linux version, so for now, stick with legacy e2fsprogs version.

Apple platform looks to be using e2fsprogs according to man page, so another point for consistency for now.

## How has this been tested?
Build aarch android

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
