### PR TITLE
fixed: Cache low speed condition check could report wrong rate

### DIFF
--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -399,7 +399,7 @@ int CVFSEntry::IoControl(void* ctx, XFILE::EIoControl request, void* param)
         kodiData->forward = status.forward;
         kodiData->maxrate = status.maxrate;
         kodiData->currate = status.currate;
-        kodiData->lowspeed = status.lowspeed;
+        kodiData->lowrate = status.lowrate;
       }
       return ret;
     }

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -408,7 +408,7 @@ int CVFSEntry::IoControl(void* ctx, XFILE::EIoControl request, void* param)
       if (!m_ifc.vfs->toAddon->io_control_set_cache_rate)
         return -1;
 
-      unsigned int& iParam = *static_cast<unsigned int*>(param);
+      uint32_t& iParam = *static_cast<uint32_t*>(param);
       return m_ifc.vfs->toAddon->io_control_set_cache_rate(m_ifc.vfs, ctx, iParam) ? 1 : 0;
     }
     case XFILE::EIoControl::IOCTRL_SET_RETRY:

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -1028,7 +1028,7 @@ bool Interface_Filesystem::io_control_get_cache_status(void* kodiBase,
   return false;
 }
 
-bool Interface_Filesystem::io_control_set_cache_rate(void* kodiBase, void* file, unsigned int rate)
+bool Interface_Filesystem::io_control_set_cache_rate(void* kodiBase, void* file, uint32_t rate)
 {
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -1022,7 +1022,7 @@ bool Interface_Filesystem::io_control_get_cache_status(void* kodiBase,
     status->forward = data.forward;
     status->maxrate = data.maxrate;
     status->currate = data.currate;
-    status->lowspeed = data.lowspeed;
+    status->lowrate = data.lowrate;
     return true;
   }
   return false;

--- a/xbmc/addons/interfaces/Filesystem.h
+++ b/xbmc/addons/interfaces/Filesystem.h
@@ -114,7 +114,7 @@ struct Interface_Filesystem
   static bool io_control_get_cache_status(void* kodiBase,
                                           void* file,
                                           struct VFS_CACHE_STATUS_DATA* status);
-  static bool io_control_set_cache_rate(void* kodiBase, void* file, unsigned int rate);
+  static bool io_control_set_cache_rate(void* kodiBase, void* file, uint32_t rate);
   static bool io_control_set_retry(void* kodiBase, void* file, bool retry);
   static char** get_property_values(
       void* kodiBase, void* file, int type, const char* name, int* numValues);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
@@ -240,9 +240,9 @@ public:
   /// | Name | Type | Set call | Get call
   /// |------|------|----------|----------
   /// | **Number of bytes cached** | `uint64_t` | @ref CacheStatus::SetForward "SetForward" | @ref CacheStatus::GetForward "GetForward"
-  /// | **Maximum number of bytes per second** | `unsigned int` | @ref CacheStatus::SetMaxRate "SetMaxRate" | @ref CacheStatus::GetMaxRate "GetMaxRate"
-  /// | **Average read rate from source file** | `unsigned int` | @ref CacheStatus::SetCurrentRate "SetCurrentRate" | @ref CacheStatus::GetCurrentRate "GetCurrentRate"
-  /// | **Cache low speed rate detected** | `unsigned int` | @ref CacheStatus::SetLowRate "SetLowRate" | @ref CacheStatus::GetLowRate "GetLowRate"
+  /// | **Maximum number of bytes per second** | `uint32_t` | @ref CacheStatus::SetMaxRate "SetMaxRate" | @ref CacheStatus::GetMaxRate "GetMaxRate"
+  /// | **Average read rate from source file** | `uint32_t` | @ref CacheStatus::SetCurrentRate "SetCurrentRate" | @ref CacheStatus::GetCurrentRate "GetCurrentRate"
+  /// | **Cache low speed rate detected** | `uint32_t` | @ref CacheStatus::SetLowRate "SetLowRate" | @ref CacheStatus::GetLowRate "GetLowRate"
   ///
 
   /// @addtogroup cpp_kodi_vfs_Defs_CacheStatus
@@ -256,22 +256,22 @@ public:
   uint64_t GetForward() { return m_cStructure->forward; }
 
   /// @brief Set maximum number of bytes per second cache is allowed to fill.
-  void SetMaxRate(unsigned int maxrate) { m_cStructure->maxrate = maxrate; }
+  void SetMaxRate(uint32_t maxrate) { m_cStructure->maxrate = maxrate; }
 
   /// @brief Set maximum number of bytes per second cache is allowed to fill.
-  unsigned int GetMaxRate() { return m_cStructure->maxrate; }
+  uint32_t GetMaxRate() { return m_cStructure->maxrate; }
 
   /// @brief Set number of bytes per second for average read rate from source file since last position change.
-  void SetCurrentRate(unsigned int currate) { m_cStructure->currate = currate; }
+  void SetCurrentRate(uint32_t currate) { m_cStructure->currate = currate; }
 
   /// @brief Get number of bytes per second for average read rate from source file since last position change.
-  unsigned int GetCurrentRate() { return m_cStructure->currate; }
+  uint32_t GetCurrentRate() { return m_cStructure->currate; }
 
   /// @brief Set number of bytes per second for low speed rate.
-  void SetLowRate(unsigned int lowrate) { m_cStructure->lowrate = lowrate; }
+  void SetLowRate(uint32_t lowrate) { m_cStructure->lowrate = lowrate; }
 
   /// @brief Get number of bytes per second for low speed rate.
-  unsigned int GetLowRate() { return m_cStructure->lowrate; }
+  uint32_t GetLowRate() { return m_cStructure->lowrate; }
 
   ///@}
 };
@@ -2247,7 +2247,7 @@ public:
   /// @param[in] rate Cache rate size to use
   /// @return true if successfully done, false otherwise
   ///
-  bool IoControlSetCacheRate(unsigned int rate)
+  bool IoControlSetCacheRate(uint32_t rate)
   {
     using namespace kodi::addon;
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
@@ -242,7 +242,7 @@ public:
   /// | **Number of bytes cached** | `uint64_t` | @ref CacheStatus::SetForward "SetForward" | @ref CacheStatus::GetForward "GetForward"
   /// | **Maximum number of bytes per second** | `unsigned int` | @ref CacheStatus::SetMaxRate "SetMaxRate" | @ref CacheStatus::GetMaxRate "GetMaxRate"
   /// | **Average read rate from source file** | `unsigned int` | @ref CacheStatus::SetCurrentRate "SetCurrentRate" | @ref CacheStatus::GetCurrentRate "GetCurrentRate"
-  /// | **Cache low speed condition detected** | `bool` | @ref CacheStatus::SetLowspeed "SetLowspeed" | @ref CacheStatus::GetLowspeed "GetLowspeed"
+  /// | **Cache low speed rate detected** | `unsigned int` | @ref CacheStatus::SetLowRate "SetLowRate" | @ref CacheStatus::GetLowRate "GetLowRate"
   ///
 
   /// @addtogroup cpp_kodi_vfs_Defs_CacheStatus
@@ -261,17 +261,17 @@ public:
   /// @brief Set maximum number of bytes per second cache is allowed to fill.
   unsigned int GetMaxRate() { return m_cStructure->maxrate; }
 
-  /// @brief Set average read rate from source file since last position change.
+  /// @brief Set number of bytes per second for average read rate from source file since last position change.
   void SetCurrentRate(unsigned int currate) { m_cStructure->currate = currate; }
 
-  /// @brief Get average read rate from source file since last position change.
+  /// @brief Get number of bytes per second for average read rate from source file since last position change.
   unsigned int GetCurrentRate() { return m_cStructure->currate; }
 
-  /// @brief Set cache low speed condition detected.
-  void SetLowspeed(bool lowspeed) { m_cStructure->lowspeed = lowspeed; }
+  /// @brief Set number of bytes per second for low speed rate.
+  void SetLowRate(unsigned int lowrate) { m_cStructure->lowrate = lowrate; }
 
-  /// @brief Get cache low speed condition detected.
-  bool GetLowspeed() { return m_cStructure->lowspeed; }
+  /// @brief Get number of bytes per second for low speed rate.
+  unsigned int GetLowRate() { return m_cStructure->lowrate; }
 
   ///@}
 };

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VFS.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VFS.h
@@ -641,7 +641,7 @@ public:
   /// @param[in] rate Cache rate size to use
   /// @return true if successfully done, false otherwise
   ///
-  virtual bool IoControlSetCacheRate(kodi::addon::VFSFileHandle context, unsigned int rate)
+  virtual bool IoControlSetCacheRate(kodi::addon::VFSFileHandle context, uint32_t rate)
   {
     return false;
   }
@@ -1017,7 +1017,7 @@ private:
 
   inline static bool ADDON_IoControlSetCacheRate(const struct AddonInstance_VFSEntry* instance,
                                                  VFS_FILE_HANDLE context,
-                                                 unsigned int rate)
+                                                 uint32_t rate)
   {
     return static_cast<CInstanceVFS*>(instance->toAddon->addonInstance)
         ->IoControlSetCacheRate(context, rate);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/vfs.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/vfs.h
@@ -95,7 +95,7 @@ extern "C"
                                                struct VFS_CACHE_STATUS_DATA* status);
     bool(__cdecl* io_control_set_cache_rate)(const struct AddonInstance_VFSEntry* instance,
                                              VFS_FILE_HANDLE context,
-                                             unsigned int rate);
+                                             uint32_t rate);
     bool(__cdecl* io_control_set_retry)(const struct AddonInstance_VFSEntry* instance,
                                         VFS_FILE_HANDLE context,
                                         bool retry);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -219,9 +219,9 @@ extern "C"
   struct VFS_CACHE_STATUS_DATA
   {
     uint64_t forward;
-    unsigned int maxrate;
-    unsigned int currate;
-    unsigned int lowrate;
+    uint32_t maxrate;
+    uint32_t currate;
+    uint32_t lowrate;
   };
 
   struct VFSProperty
@@ -298,7 +298,7 @@ extern "C"
     bool (*io_control_get_cache_status)(void* kodiBase,
                                         void* file,
                                         struct VFS_CACHE_STATUS_DATA* status);
-    bool (*io_control_set_cache_rate)(void* kodiBase, void* file, unsigned int rate);
+    bool (*io_control_set_cache_rate)(void* kodiBase, void* file, uint32_t rate);
     bool (*io_control_set_retry)(void* kodiBase, void* file, bool retry);
     char** (*get_property_values)(
         void* kodiBase, void* file, int type, const char* name, int* numValues);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -221,7 +221,7 @@ extern "C"
     uint64_t forward;
     unsigned int maxrate;
     unsigned int currate;
-    bool lowspeed;
+    unsigned int lowrate;
   };
 
   struct VFSProperty

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -62,8 +62,8 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.6"
-#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.0"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.7"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.7"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \
                                                       "c-api/filesystem.h" \
@@ -162,8 +162,8 @@
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_DEPENDS    "c-api/addon-instance/screensaver.h" \
                                                       "addon-instance/Screensaver.h"
 
-#define ADDON_INSTANCE_VERSION_VFS                    "3.0.0"
-#define ADDON_INSTANCE_VERSION_VFS_MIN                "3.0.0"
+#define ADDON_INSTANCE_VERSION_VFS                    "3.0.1"
+#define ADDON_INSTANCE_VERSION_VFS_MIN                "3.0.1"
 #define ADDON_INSTANCE_VERSION_VFS_XML_ID             "kodi.binary.instance.vfs"
 #define ADDON_INSTANCE_VERSION_VFS_DEPENDS            "c-api/addon-instance/vfs.h" \
                                                       "addon-instance/VFS.h"

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -163,7 +163,7 @@ public:
    *  This could be used to throttle caching rate. Should
    *  be seen as only a hint
    */
-  virtual void SetReadRate(unsigned rate) {}
+  virtual void SetReadRate(uint32_t rate) {}
 
   /*! \brief Get the cache status
    \return true when cache status was successfully obtained

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -150,10 +150,10 @@ int CDVDInputStreamFile::GetBlockSize()
     return 0;
 }
 
-void CDVDInputStreamFile::SetReadRate(unsigned rate)
+void CDVDInputStreamFile::SetReadRate(uint32_t rate)
 {
   // Increase requested rate by 10%:
-  unsigned maxrate = (unsigned) (1.1 * rate);
+  uint32_t maxrate = static_cast<uint32_t>(1.1 * rate);
 
   if(m_pFile->IoControl(IOCTRL_CACHE_SETRATE, &maxrate) >= 0)
     CLog::Log(LOGDEBUG,

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
@@ -23,7 +23,7 @@ public:
   int64_t GetLength() override;
   BitstreamStats GetBitstreamStats() const override ;
   int GetBlockSize() override;
-  void SetReadRate(unsigned rate) override;
+  void SetReadRate(uint32_t rate) override;
   bool GetCacheStatus(XFILE::SCacheStatus *status) override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp
@@ -136,7 +136,7 @@ int64_t CInputStreamMultiSource::Seek(int64_t offset, int whence)
   return -1;
 }
 
-void CInputStreamMultiSource::SetReadRate(unsigned rate)
+void CInputStreamMultiSource::SetReadRate(uint32_t rate)
 {
   for (const auto& iter : m_InputStreams)
     iter->SetReadRate(rate);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
@@ -34,7 +34,7 @@ public:
   bool Open() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  void SetReadRate(unsigned rate) override;
+  void SetReadRate(uint32_t rate) override;
 
 protected:
   IVideoPlayer* m_pPlayer;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1742,10 +1742,10 @@ bool CVideoPlayer::GetCachingTimes(double& level, double& delay, double& offset)
   if (!m_pInputStream->GetCacheStatus(&status))
     return false;
 
-  const uint64_t &cached = status.forward;
-  const unsigned &currate = status.currate;
-  const unsigned &maxrate = status.maxrate;
-  const bool &lowspeed = status.lowspeed;
+  const uint64_t& cached = status.forward;
+  const unsigned& currate = status.currate;
+  const unsigned& maxrate = status.maxrate;
+  const unsigned& lowrate = status.lowrate;
 
   int64_t length = m_pInputStream->GetLength();
   int64_t remain = length - m_pInputStream->Seek(0, SEEK_CUR);
@@ -1770,9 +1770,9 @@ bool CVideoPlayer::GetCachingTimes(double& level, double& delay, double& offset)
 
   delay = cache_left - play_left;
 
-  if (lowspeed)
+  if (lowrate > 0)
   {
-    CLog::Log(LOGDEBUG, "Readrate {} is too low with {} required", currate, maxrate);
+    CLog::Log(LOGDEBUG, "Readrate {} was too low with {} required", lowrate, maxrate);
     level = -1.0;                          /* buffer is full & our read rate is too low  */
   }
   else

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -853,7 +853,7 @@ bool CVideoPlayer::OpenDemuxStream()
   int64_t len = m_pInputStream->GetLength();
   int64_t tim = m_pDemuxer->GetStreamLength();
   if (len > 0 && tim > 0)
-    m_pInputStream->SetReadRate((unsigned int) (len * 1000 / tim));
+    m_pInputStream->SetReadRate(static_cast<uint32_t>(len * 1000 / tim));
 
   m_offset_pts = 0;
 
@@ -1743,9 +1743,9 @@ bool CVideoPlayer::GetCachingTimes(double& level, double& delay, double& offset)
     return false;
 
   const uint64_t& cached = status.forward;
-  const unsigned& currate = status.currate;
-  const unsigned& maxrate = status.maxrate;
-  const unsigned& lowrate = status.lowrate;
+  const uint32_t& currate = status.currate;
+  const uint32_t& maxrate = status.maxrate;
+  const uint32_t& lowrate = status.lowrate;
 
   int64_t length = m_pInputStream->GetLength();
   int64_t remain = length - m_pInputStream->Seek(0, SEEK_CUR);

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -180,7 +180,7 @@ int CSimpleFileCache::ReadFromCache(char *pBuffer, size_t iMaxSize)
   return readBytes;
 }
 
-int64_t CSimpleFileCache::WaitForData(unsigned int iMinAvail, unsigned int iMillis)
+int64_t CSimpleFileCache::WaitForData(uint32_t iMinAvail, uint32_t iMillis)
 {
   if( iMillis == 0 || IsEndOfInput() )
     return GetAvailableRead();
@@ -219,7 +219,7 @@ int64_t CSimpleFileCache::Seek(int64_t iFilePosition)
   }
 
   if (nDiff > 0 &&
-      WaitForData(static_cast<unsigned int>(iTarget - m_nReadPosition), 5000) == CACHE_RC_TIMEOUT)
+      WaitForData(static_cast<uint32_t>(iTarget - m_nReadPosition), 5000) == CACHE_RC_TIMEOUT)
   {
     CLog::Log(LOGDEBUG, "CSimpleFileCache::{} - <{}> Wait for position {} failed. Ended up at {}",
               __FUNCTION__, m_filename, iFilePosition, m_nWritePosition);
@@ -330,7 +330,7 @@ int CDoubleCache::ReadFromCache(char *pBuffer, size_t iMaxSize)
   return m_pCache->ReadFromCache(pBuffer, iMaxSize);
 }
 
-int64_t CDoubleCache::WaitForData(unsigned int iMinAvail, unsigned int iMillis)
+int64_t CDoubleCache::WaitForData(uint32_t iMinAvail, uint32_t iMillis)
 {
   return m_pCache->WaitForData(iMinAvail, iMillis);
 }

--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -32,7 +32,7 @@ public:
   virtual size_t GetMaxWriteSize(const size_t& iRequestSize) = 0;
   virtual int WriteToCache(const char *pBuffer, size_t iSize) = 0;
   virtual int ReadFromCache(char *pBuffer, size_t iMaxSize) = 0;
-  virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) = 0;
+  virtual int64_t WaitForData(uint32_t iMinAvail, uint32_t iMillis) = 0;
 
   virtual int64_t Seek(int64_t iFilePosition) = 0;
 
@@ -73,7 +73,7 @@ public:
   size_t GetMaxWriteSize(const size_t& iRequestSize) override;
   int WriteToCache(const char *pBuffer, size_t iSize) override;
   int ReadFromCache(char *pBuffer, size_t iMaxSize) override;
-  int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) override;
+  int64_t WaitForData(uint32_t iMinAvail, uint32_t iMillis) override;
 
   int64_t Seek(int64_t iFilePosition) override;
   bool Reset(int64_t iSourcePosition) override;
@@ -109,7 +109,7 @@ public:
   size_t GetMaxWriteSize(const size_t& iRequestSize) override;
   int WriteToCache(const char *pBuffer, size_t iSize) override;
   int ReadFromCache(char *pBuffer, size_t iMaxSize) override;
-  int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) override;
+  int64_t WaitForData(uint32_t iMinAvail, uint32_t iMillis) override;
 
   int64_t Seek(int64_t iFilePosition) override;
   bool Reset(int64_t iSourcePosition) override;

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -181,7 +181,7 @@ int CCircularCache::ReadFromCache(char *buf, size_t len)
  * Note that caller needs to make sure there's sufficient space in the forward
  * buffer for "minimum" bytes else we may block the full timeout time
  */
-int64_t CCircularCache::WaitForData(unsigned int minimum, unsigned int millis)
+int64_t CCircularCache::WaitForData(uint32_t minimum, uint32_t millis)
 {
   CSingleLock lock(m_sync);
   int64_t avail = m_end - m_cur;

--- a/xbmc/filesystem/CircularCache.h
+++ b/xbmc/filesystem/CircularCache.h
@@ -26,7 +26,7 @@ public:
     size_t GetMaxWriteSize(const size_t& iRequestSize) override;
     int WriteToCache(const char *buf, size_t len) override;
     int ReadFromCache(char *buf, size_t len) override;
-    int64_t WaitForData(unsigned int minimum, unsigned int iMillis) override;
+    int64_t WaitForData(uint32_t minimum, uint32_t iMillis) override;
 
     int64_t Seek(int64_t pos) override;
     bool Reset(int64_t pos) override;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -58,7 +58,7 @@ public:
     }
   }
 
-  unsigned Rate(int64_t pos, unsigned int time_bias = 0)
+  uint32_t Rate(int64_t pos, uint32_t time_bias = 0)
   {
     auto ts = std::chrono::steady_clock::now();
 
@@ -70,7 +70,7 @@ public:
     if (m_time == std::chrono::milliseconds(0))
       return 0;
 
-    return (unsigned)(1000 * (m_size / (m_time.count() + time_bias)));
+    return static_cast<uint32_t>(1000 * (m_size / (m_time.count() + time_bias)));
   }
 
 private:
@@ -549,7 +549,8 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     {
       CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> waiting for position {}", __FUNCTION__,
                 m_sourcePath, iTarget);
-      if(m_pCache->WaitForData((unsigned)(iTarget - m_seekPos), 10000) < iTarget - m_seekPos)
+      if (m_pCache->WaitForData(static_cast<uint32_t>(iTarget - m_seekPos), 10000) <
+          iTarget - m_seekPos)
       {
         CLog::Log(LOGWARNING, "CFileCache::{} - <{}> failed to get remaining data", __FUNCTION__,
                   m_sourcePath);
@@ -618,7 +619,7 @@ int CFileCache::IoControl(EIoControl request, void* param)
 
   if (request == IOCTRL_CACHE_SETRATE)
   {
-    m_writeRate = *(unsigned*)param;
+    m_writeRate = *static_cast<uint32_t*>(param);
     return 0;
   }
 

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -68,9 +68,9 @@ namespace XFILE
     unsigned m_chunkSize;
     unsigned m_writeRate;
     unsigned m_writeRateActual;
+    unsigned m_writeRateLowSpeed;
     int64_t m_forwardCacheSize;
     bool m_bFilling;
-    bool m_bLowSpeedDetected;
     std::atomic<int64_t> m_fileSize;
     unsigned int m_flags;
     CCriticalSection m_sync;

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -66,9 +66,9 @@ namespace XFILE
     int64_t m_readPos;
     int64_t m_writePos;
     unsigned m_chunkSize;
-    unsigned m_writeRate;
-    unsigned m_writeRateActual;
-    unsigned m_writeRateLowSpeed;
+    uint32_t m_writeRate;
+    uint32_t m_writeRateActual;
+    uint32_t m_writeRateLowSpeed;
     int64_t m_forwardCacheSize;
     bool m_bFilling;
     std::atomic<int64_t> m_fileSize;

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -49,9 +49,9 @@ struct SNativeIoControl
 struct SCacheStatus
 {
   uint64_t forward; /**< number of bytes cached forward of current position */
-  unsigned maxrate; /**< maximum allowed read(fill) rate (bytes/second) */
-  unsigned currate; /**< average read rate (bytes/second) since last position change */
-  unsigned lowrate; /**< low speed read rate (bytes/second) (if any, else 0) */
+  uint32_t maxrate; /**< maximum allowed read(fill) rate (bytes/second) */
+  uint32_t currate; /**< average read rate (bytes/second) since last position change */
+  uint32_t lowrate; /**< low speed read rate (bytes/second) (if any, else 0) */
 };
 
 typedef enum {

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -48,10 +48,10 @@ struct SNativeIoControl
 
 struct SCacheStatus
 {
-  uint64_t forward;  /**< number of bytes cached forward of current position */
-  unsigned maxrate;  /**< maximum number of bytes per second cache is allowed to fill */
-  unsigned currate;  /**< average read rate from source file since last position change */
-  bool     lowspeed; /**< cache low speed condition detected? */
+  uint64_t forward; /**< number of bytes cached forward of current position */
+  unsigned maxrate; /**< maximum allowed read(fill) rate (bytes/second) */
+  unsigned currate; /**< average read rate (bytes/second) since last position change */
+  unsigned lowrate; /**< low speed read rate (bytes/second) (if any, else 0) */
 };
 
 typedef enum {


### PR DESCRIPTION
## Description

Copy about https://github.com/xbmc/xbmc/pull/20705, needed to become asap, system ready for addon updates!

His Text:
------------------------------
Previously a boolean flag was used to "remember" whether a low speed read condition occurred in the filecache. The problem with this is that since it's a past event, reporting the current rate is wrong and may be confusing. I've resolved this may changing the boolean into an unsigned which either stores the low speed rate or is reset to 0 when none occurred.

@AlwinEsch : Since it also affects the addon vfs, I suspect "something" needs to be bumped somewhere. Please let me know what.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
