### PR TITLE
[android] Fix: misdetection of CPU feature NEON on ARM64 platforms

### DIFF
--- a/xbmc/platform/android/activity/AndroidFeatures.cpp
+++ b/xbmc/platform/android/activity/AndroidFeatures.cpp
@@ -15,8 +15,13 @@
 
 bool CAndroidFeatures::HasNeon()
 {
+  // All ARMv8-based devices support Neon - https://developer.android.com/ndk/guides/cpu-arm-neon
+  if (android_getCpuFamily() == ANDROID_CPU_FAMILY_ARM64)
+    return true;
+
   if (android_getCpuFamily() == ANDROID_CPU_FAMILY_ARM)
     return ((android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON) != 0);
+
   return false;
 }
 


### PR DESCRIPTION
## Description
Fix: misdetection of CPU feature NEON on ARM64 platforms

## Motivation and context
Currently on platforms like Shield Pro 2019 / ARM64 (ARMv8) is reported NEON disabled:

`INFO <general>: ARM Features: Neon disabled`

And this is not true: "All ARMv8-based devices support Neon."  
https://developer.android.com/ndk/guides/cpu-arm-neon

I don't think this has any impact on performance because all major external libraries (openSSL, ffmpeg, libSMB, libCURL, etc.) often use their own methods to detect CPU capabilities at runtime/compilation time.

Anyway, since this detection exists in Kodi code, it should return a correct result.

## How has this been tested?
Runtime tested Nvidia Shield Pro 2019

## What is the effect on users?
Proper detection of CPU NEON capabilities on ARM64 platforms and fix wrong logs "Neon disabled" indication.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
