### PR TITLE
[PVR] Fix CPVRChannelGroups::(Delete|Hide)Group to respect hidden and deleted groups

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -235,6 +235,12 @@ namespace PVR
      */
     void RemoveFromAllGroups(const std::shared_ptr<CPVRChannel>& channel);
 
+    /*!
+     * @brief Obtain the first non-hidden channel group.
+     * @return The group or nullptr, if none found.
+     */
+    std::shared_ptr<CPVRChannelGroup> GetFirstNonHiddenChannelGroup() const;
+
     bool m_bRadio; /*!< true if this is a container for radio channels, false if it is for tv channels */
     std::shared_ptr<CPVRChannelGroup> m_selectedGroup; /*!< the group that's currently selected in the UI */
     std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups; /*!< the groups in this container */

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -454,7 +454,9 @@ void CGUIDialogPVRGroupManager::Update()
   if (m_selectedGroup)
   {
     /* set this group in the pvrmanager, so it becomes the selected group in other dialogs too */
-    CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(m_selectedGroup);
+    if (!m_selectedGroup->IsHidden())
+      CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(m_selectedGroup);
+
     SET_CONTROL_LABEL(CONTROL_CURRENT_GROUP_LABEL, m_selectedGroup->GroupName());
     SET_CONTROL_SELECTED(GetID(), BUTTON_HIDE_GROUP, m_selectedGroup->IsHidden());
 


### PR DESCRIPTION
Backport of #20761, not a simply cherry-pick, but same logic as for the master fix.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish when you are in the right mood for a code review...
