### PR TITLE
[Fix] Attempts to fix random jenkins errors building FFmpeg Windows libs

### DIFF
--- a/tools/buildsteps/windows/make-mingwlibs.bat
+++ b/tools/buildsteps/windows/make-mingwlibs.bat
@@ -5,6 +5,10 @@ PUSHD %~dp0\..\..\..
 SET WORKDIR=%CD%
 POPD
 
+REM recreates ffmpeg build dir in case it does not exist
+SET BUILD_DIR=%WORKDIR%\project\BuildDependencies\build
+IF NOT EXIST %BUILD_DIR% mkdir %BUILD_DIR%
+
 SET PROMPTLEVEL=prompt
 SET BUILDMODE=clean
 SET opt=mintty

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -13,5 +13,13 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
-ECHO running git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs"
-git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs"
+rem also keeps MSYS2 installation
+SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64"
+
+ECHO running %GIT_CLEAN_CMD%
+%GIT_CLEAN_CMD%
+
+REM 'build' dir is necessary to extract ffmpeg code
+REM we prevents missing under certain circumstances (early creation)
+SET BUILD_FFMPEG=%WORKSPACE%\project\BuildDependencies\build
+IF NOT EXIST %BUILD_FFMPEG% mkdir %BUILD_FFMPEG%


### PR DESCRIPTION
## Description
Attempts to fix random jenkins errors building FFmpeg Windows libs:

1) Prevents `build` folder missing under certain circumstances. This causes ffmpeg code extraction error.
2) MSYS2 installation is preserved during cleanup between jenkins builds. Anyway if `msys64` folder is missing will be recreated (re-installed).
3) ~Forces FFmpeg libraries re-build in every jenkins build. This is only meant to be temporary until we see that it works fine.~

## Motivation and context
Jenkins build of FFmpeg Windows libs fails random but not when is executed locally with updated MSYS2 .

## How has this been tested?
Tested locally simulating Jenkins build steps.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
