### PR TITLE
[filesystem] Improve performance over high-latency network links

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -576,6 +576,11 @@ ssize_t CFile::Read(void *lpBuf, size_t uiBufSize)
   if (lpBuf == NULL && uiBufSize != 0)
     return -1;
 
+  ssize_t maxReadSize = GetMaxReadSize();
+  if (maxReadSize > 0 && uiBufSize > static_cast<size_t>(maxReadSize))
+    CLog::Log(LOGWARNING, "Trying to read {} bytes, which is more than the max read size {}",
+              uiBufSize, maxReadSize);
+
   if (uiBufSize > SSIZE_MAX)
     uiBufSize = SSIZE_MAX;
 
@@ -948,6 +953,13 @@ int CFile::GetChunkSize()
   if (m_pFile)
     return m_pFile->GetChunkSize();
   return 0;
+}
+
+ssize_t CFile::GetMaxReadSize()
+{
+  if (m_pFile)
+    return m_pFile->GetMaxReadSize();
+  return ReadSizeRequestCode::INVALID;
 }
 
 const std::string CFile::GetProperty(XFILE::FileProperty type, const std::string &name) const

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -96,6 +96,7 @@ public:
   int64_t GetLength();
   void Close();
   int GetChunkSize();
+  ssize_t GetMaxReadSize();
   const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const;
   const std::vector<std::string> GetPropertyValues(XFILE::FileProperty type, const std::string &name = "") const;
   ssize_t LoadFile(const std::string& filename, std::vector<uint8_t>& outputBuffer);

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -75,6 +75,7 @@ namespace XFILE
     unsigned int m_flags;
     CCriticalSection m_sync;
     ssize_t m_readSize;
+    ssize_t m_slowStartReadSize;
   };
 
 }

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -74,6 +74,7 @@ namespace XFILE
     std::atomic<int64_t> m_fileSize;
     unsigned int m_flags;
     CCriticalSection m_sync;
+    ssize_t m_readSize;
   };
 
 }

--- a/xbmc/filesystem/IFile.cpp
+++ b/xbmc/filesystem/IFile.cpp
@@ -78,6 +78,27 @@ bool IFile::ReadString(char *szLine, int iLineLength)
   return true;
 }
 
+ssize_t IFile::GetMaxReadSize()
+{
+  int chunkSize = GetChunkSize();
+
+  switch (chunkSize)
+  {
+    case 0:
+    case 1:
+      // Backwards compatibility:
+      // CFileCache used to handle a chunk size of 0 or 1 by
+      // a) Getting the chunk size from advanced settings
+      // b) Reading one chunk at a time (the only way it knew how!)
+      // To not change this behavior for IFile implementations,
+      // Assume the ONE_CHUNK behavior in those cases and let the IFiles
+      // that want something different override this method.
+      return ReadSizeRequestCode::ONE_CHUNK;
+    default:
+      return chunkSize;
+  }
+}
+
 CRedirectException::CRedirectException() :
   m_pNewFileImp(NULL), m_pNewUrl(NULL)
 {

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -39,6 +39,14 @@ class CURL;
 namespace XFILE
 {
 
+enum ReadSizeRequestCode
+{
+  // 0, to match the invalid return value in IFile::GetMaxReadSizeRequest
+  INVALID = 0,
+  ONE_CHUNK = -1,
+  ANY_SIZE = -2,
+};
+
 class IFile
 {
 public:
@@ -106,7 +114,23 @@ public:
    * to meet the requirement of CFile.                             *
    * It can also be used to indicate a file system is non buffered *
    * but accepts any read size, have it return the value 1         */
-  virtual int  GetChunkSize() {return 0;}
+  virtual int GetChunkSize() { return 0; }
+  /*!
+   * @brief Returns the maximum wanted read size.
+   *
+   * The chunk size does not limit the read size itself,
+   * it only specifies that the read size should be a multiple of it.
+   * This specifies the largest largest wanted read call either as a positive
+   * size or as a \ref SpecialReadSizeRequest value (which are negative or 0).
+   * ANY_SIZE: Size can be any positive integer. CFileCache will tune itself freely.
+   * ONE_CHUNK: Exactly one chunk per read call, either as returned by ::GetChunkSize() or,
+   *             if applicable, after consulting the advanced settings.
+   * 0: Invalid
+   * > 1: Use at most this size
+
+   * @return The maximum wanted size of reads. See description for special cases.
+   */
+  virtual ssize_t GetMaxReadSize();
   virtual double GetDownloadSpeed() { return 0.0; }
 
   virtual bool Delete(const CURL& url) { return false; }

--- a/xbmc/platform/posix/filesystem/SMBFile.h
+++ b/xbmc/platform/posix/filesystem/SMBFile.h
@@ -79,7 +79,7 @@ public:
   bool OpenForWrite(const CURL& url, bool bOverWrite = false) override;
   bool Delete(const CURL& url) override;
   bool Rename(const CURL& url, const CURL& urlnew) override;
-  int GetChunkSize() override { return 64*1024; }
+  int GetChunkSize() override { return 1; }
   int IoControl(EIoControl request, void* param) override;
 
 protected:

--- a/xbmc/platform/posix/filesystem/SMBFile.h
+++ b/xbmc/platform/posix/filesystem/SMBFile.h
@@ -80,6 +80,7 @@ public:
   bool Delete(const CURL& url) override;
   bool Rename(const CURL& url, const CURL& urlnew) override;
   int GetChunkSize() override { return 1; }
+  ssize_t GetMaxReadSize() override { return XFILE::ReadSizeRequestCode::ANY_SIZE; }
   int IoControl(EIoControl request, void* param) override;
 
 protected:


### PR DESCRIPTION
## Description

Rework FileCache so that it tries to read data in bigger blocks,
but as a multiple of the IFile::GetChunkSize() value. IFile documents
that GetChunkSize() should return the smallest suitable/efficient
read size, so this still follows that API, but it allows IFile
implementations more freedom to optimize.

In the case of (posix) SMB, this allows the samba library to issue
much bigger read commands which results in more data getting transferred
for every network roundtrip. The protocol supports reads of up to
8MiB, but the samba library will send multiple commands if the
read size is bigger than this. Hence, almost any read size is supported,
which means that GetChunkSize() can return 1 now without fear
of getting a bunch of 1 byte read calls.

With these changes, it is possible to stream high bitrate 1080p files
accessed over SMB across a WAN+VPN link, instead of just over a LAN.

## Motivation and context

I am not aware of an open issue, but I have not looked. I found an itch and scratched it.

## How has this been tested?

Lightly tested thus far, on x86_64 Linux, only with an SMB media source. In this case a remote SMB server accessed over a VPN. Some more testing would be good, especially for NFS shares. I'll see what/if I can manage more thorough testing unless this is simply immediately NAK'd.

## What is the effect on users?

Enhanced possibilities of consuming content also in poor(er) network conditions.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed (exept for TestWebServer.CanHeadFile which seems broken even without my changes)