### PR TITLE
[PVR] Fix crashes when navigating in empty Guide window.

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -899,6 +899,9 @@ void CGUIEPGGridContainer::ProgrammesScroll(int amount)
 
 void CGUIEPGGridContainer::OnUp()
 {
+  if (!HasData())
+    return CGUIControl::OnUp();
+
   if (m_orientation == VERTICAL)
   {
     CGUIAction action = GetAction(ACTION_MOVE_UP);
@@ -948,6 +951,9 @@ void CGUIEPGGridContainer::OnUp()
 
 void CGUIEPGGridContainer::OnDown()
 {
+  if (!HasData())
+    return CGUIControl::OnDown();
+
   if (m_orientation == VERTICAL)
   {
     CGUIAction action = GetAction(ACTION_MOVE_DOWN);
@@ -998,6 +1004,9 @@ void CGUIEPGGridContainer::OnDown()
 
 void CGUIEPGGridContainer::OnLeft()
 {
+  if (!HasData())
+    return CGUIControl::OnLeft();
+
   if (m_orientation == VERTICAL)
   {
     if (m_gridModel->GetGridItemStartBlock(m_channelCursor + m_channelOffset,
@@ -1047,6 +1056,9 @@ void CGUIEPGGridContainer::OnLeft()
 
 void CGUIEPGGridContainer::OnRight()
 {
+  if (!HasData())
+    return CGUIControl::OnRight();
+
   if (m_orientation == VERTICAL)
   {
     if (m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -206,7 +206,9 @@ void CGUIWindowPVRGuideBase::UpdateButtons()
   CGUIWindowPVRBase::UpdateButtons();
 
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetChannelGroup()->GroupName());
+
+  const std::shared_ptr<CPVRChannelGroup> group = GetChannelGroup();
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, group ? group->GroupName() : "");
 }
 
 bool CGUIWindowPVRGuideBase::Update(const std::string& strDirectory, bool updateFilterPath /* = true */)


### PR DESCRIPTION
This PR fixes crashes reported in the Forum that will occur under very special circumstances when navigating the PVR Guide window when it is completely empty. This can happen if user enables a PVR add-on, but does not configure it correctly (e.g. backend IP address is wrong), so the add-on cannot deliver any data.

Crashes will occur, if the user opens the Guide window in this scenario (e.g. by pressing "E" or clicking on the PVR home screen item) and then 
* presses left/right or 
* presses "M" to access the side blade and then changes sort order/direction there

Please note that the PR contains a check for up/down as well for safety, although those keys will currently not lead to a crash.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please do the code review?
 