### PR TITLE
[fix][EDL] Fix regression when jumping back into commercial breaks

### DIFF
--- a/xbmc/cores/EdlEdit.h
+++ b/xbmc/cores/EdlEdit.h
@@ -11,6 +11,8 @@
 namespace EDL
 {
 
+constexpr int EDL_ACTION_NONE = -1;
+
 enum class Action
 {
   CUT = 0,

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -843,6 +843,16 @@ void CEdl::ResetLastEditTime()
   m_lastEditTime = -1;
 }
 
+void CEdl::SetLastEditActionType(EDL::Action action)
+{
+  m_lastEditActionType = action;
+}
+
+EDL::Action CEdl::GetLastEditActionType() const
+{
+  return m_lastEditActionType;
+}
+
 bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker)
 {
   if (!HasSceneMarker())

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -8,13 +8,10 @@
 
 #pragma once
 
+#include "cores/EdlEdit.h"
+
 #include <string>
 #include <vector>
-
-namespace EDL
-{
-struct Edit;
-}
 
 class CFileItem;
 
@@ -116,6 +113,19 @@ public:
   */
   void ResetLastEditTime();
 
+  /*!
+   * @brief Set the last processed edit action type
+   * @param action The action type (e.g. COMM_BREAK)
+  */
+  void SetLastEditActionType(EDL::Action action);
+
+  /*!
+   * @brief Get the last processed edit action type (set during playback when a given
+   * edit is surpassed)
+   * @return The last processed edit action type or -1 if not any
+  */
+  EDL::Action GetLastEditActionType() const;
+
   // FIXME: remove const modifier for iClock as it makes no sense as it means nothing
   // for the reader of the interface, but limits the implementation
   // to not modify the parameter on stack
@@ -131,7 +141,16 @@ private:
   int m_totalCutTime;
   std::vector<EDL::Edit> m_vecEdits;
   std::vector<int> m_vecSceneMarkers;
+
+  /*!
+   * @brief Last processed EDL edit time (ms)
+  */
   int m_lastEditTime;
+
+  /*!
+   * @brief Last processed EDL edit action type
+  */
+  EDL::Action m_lastEditActionType{EDL::EDL_ACTION_NONE};
 
   // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
   // for the reader of the interface, but limits the implementation


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/20698 introduced a small regression related to commercial breaks. Since most of the time the commercial detection is automated using external tools, there's no guarantee that those ranges are accurate. For this reason, Kodi only skips the commercial break automatically on the first playback "passage" allowing users to jump back into the commercial break zone if they desire to do so.
As we were resetting the lastedit time once not on an edit block, the condition of this line was leading to skipping the commercial break all the time:

https://github.com/xbmc/xbmc/blob/21d39cde6c17524e91a8a0315dd8756d7359ed77/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L2369 

This is documented on the wiki: https://kodi.wiki/view/Edit_decision_list

```
Commercial Break - each commercial break is automatically skipped once during playback. Since commercial detection is rarely 100% accurate, commercial breaks that have already been skipped can be re-entered by seeking backwards or rewinding.
```

## Motivation and context
Fix regression

## How has this been tested?
Runtime tested

## What is the effect on users?
Restore old commbreak behaviour
