### PR TITLE
[profiles] honor lock state of media sources (fixup)

### DIFF
--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -34,7 +34,6 @@
 #include "utils/log.h"
 #include "view/ViewStateSettings.h"
 
-#include <type_traits>
 #include <utility>
 
 using namespace KODI::MESSAGING;
@@ -94,9 +93,7 @@ bool CGUIPassword::IsItemUnlocked(T pItem,
 
         // a mediasource has been unlocked successfully
         // => refresh favourites due to possible visibility changes
-        // only if this template is instantiated for a CMediaSource item
-        if (std::is_same<T, CMediaSource*>::value)
-          CServiceBroker::GetFavouritesService().RefreshFavourites();
+        CServiceBroker::GetFavouritesService().RefreshFavourites();
         break;
       }
     case 1:


### PR DESCRIPTION
## Description
follow up to https://github.com/xbmc/xbmc/pull/20708

## Motivation and context
i recently found that `RefreshFavourites` needs to be called from any template specialization of `CGUIPassword::IsItemUnlocked()`...

refresh doesn't happen, e.g. from Home screen `Videos` -> `Files` -> `"open your locked source"`

will cherry-pick this to the backport pr (https://github.com/xbmc/xbmc/pull/20762)

@phunkyfish mind taking a look?

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

