### PR TITLE
[Fix] Attempts to fix random Jenkins errors building FFmpeg Windows libs

### DIFF
--- a/tools/buildsteps/windows/make-mingwlibs.bat
+++ b/tools/buildsteps/windows/make-mingwlibs.bat
@@ -5,6 +5,10 @@ PUSHD %~dp0\..\..\..
 SET WORKDIR=%CD%
 POPD
 
+REM recreates ffmpeg build dir in case it does not exist
+SET BUILD_DIR=%WORKDIR%\project\BuildDependencies\build
+IF NOT EXIST %BUILD_DIR% mkdir %BUILD_DIR%
+
 SET PROMPTLEVEL=prompt
 SET BUILDMODE=clean
 SET opt=mintty

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -13,5 +13,13 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
-ECHO running git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs"
-git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs"
+rem also keeps MSYS2 installation
+SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64"
+
+ECHO running %GIT_CLEAN_CMD%
+%GIT_CLEAN_CMD%
+
+REM 'build' dir is necessary to extract ffmpeg code
+REM we prevents missing under certain circumstances (early creation)
+SET BUILD_FFMPEG=%WORKSPACE%\project\BuildDependencies\build
+IF NOT EXIST %BUILD_FFMPEG% mkdir %BUILD_FFMPEG%


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20767

## Motivation and context

There have been no Jenkins glitches since https://github.com/xbmc/xbmc/pull/20767 was merged. Although because the Matrix builds keep reinstalling MSYS2 every time, it is likely that it will fail sooner or later. It will be difficult to draw conclusions because the failure may be caused by the old script in Matrix or that the new one does not solve 100% all cases.

Better to have the same Jenkins script in Matrix / master to keep things simple. In addition, the new one speeds up the compilation of all Windows variants by several minutes.


## What is the effect on users?
N/A


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
