### PR TITLE
[Subtitles] Fix wrong aspect ratio / scaling with ffmpeg subs

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -33,8 +33,6 @@
 #include "OverlayRendererDX.h"
 #endif
 
-#include <algorithm>
-
 using namespace OVERLAY;
 
 COverlay::COverlay()
@@ -46,8 +44,6 @@ COverlay::COverlay()
   m_type = TYPE_NONE;
   m_align = ALIGN_SCREEN;
   m_pos = POSITION_RELATIVE;
-  m_source_width = 0.0f;
-  m_source_height = 0.0f;
 }
 
 COverlay::~COverlay() = default;
@@ -163,65 +159,48 @@ void CRenderer::Render(int idx)
 void CRenderer::Render(COverlay* o)
 {
   SRenderState state;
-  state.x       = o->m_x;
-  state.y       = o->m_y;
-  state.width   = o->m_width;
-  state.height  = o->m_height;
+  state.x = o->m_x;
+  state.y = o->m_y;
+  state.width = o->m_width;
+  state.height = o->m_height;
 
-  COverlay::EPosition pos   = o->m_pos;
-  COverlay::EAlign    align = o->m_align;
+  COverlay::EPosition pos = o->m_pos;
+  COverlay::EAlign align = o->m_align;
 
   if (pos == COverlay::POSITION_RELATIVE)
   {
     float scale_x = 1.0;
     float scale_y = 1.0;
-    float scale_w = 1.0;
-    float scale_h = 1.0;
 
     if (align == COverlay::ALIGN_SCREEN || align == COverlay::ALIGN_SUBTITLE)
     {
       scale_x = m_rv.Width();
       scale_y = m_rv.Height();
-      scale_w = scale_x;
-      scale_h = scale_y;
     }
     else if (align == COverlay::ALIGN_VIDEO)
     {
       scale_x = m_rs.Width();
       scale_y = m_rs.Height();
-      scale_w = scale_x;
-      scale_h = scale_y;
-    }
-    else if (align == COverlay::ALIGN_SCREEN_AR)
-    {
-      // Align to screen by keeping aspect ratio to fit into the screen area
-      float source_width = o->m_source_width > 0 ? o->m_source_width : m_rs.Width();
-      float source_height = o->m_source_height > 0 ? o->m_source_height : m_rs.Height();
-      float ratio = std::min<float>(m_rv.Width() / source_width, m_rv.Height() / source_height);
-      scale_x = m_rv.Width();
-      scale_y = m_rv.Height();
-      scale_w = ratio;
-      scale_h = ratio;
     }
 
     state.x *= scale_x;
     state.y *= scale_y;
-    state.width *= scale_w;
-    state.height *= scale_h;
+    state.width *= scale_x;
+    state.height *= scale_y;
 
     pos = COverlay::POSITION_ABSOLUTE;
   }
 
   if (pos == COverlay::POSITION_ABSOLUTE)
   {
-    if (align == COverlay::ALIGN_SCREEN || align == COverlay::ALIGN_SCREEN_AR ||
-        align == COverlay::ALIGN_SUBTITLE)
+    if (align == COverlay::ALIGN_SCREEN || align == COverlay::ALIGN_SUBTITLE)
     {
-      if(align == COverlay::ALIGN_SUBTITLE)
+      if (align == COverlay::ALIGN_SUBTITLE)
       {
-        RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
+        RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
+            CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
         state.x += m_rv.x1 + m_rv.Width() * 0.5f;
-        state.y += m_rv.y1  + (res.iSubtitles - res.Overscan.top);
+        state.y += m_rv.y1 + (res.iSubtitles - res.Overscan.top);
       }
       else
       {
@@ -234,13 +213,13 @@ void CRenderer::Render(COverlay* o)
       float scale_x = m_rd.Width() / m_rs.Width();
       float scale_y = m_rd.Height() / m_rs.Height();
 
-      state.x      *= scale_x;
-      state.y      *= scale_y;
-      state.width  *= scale_x;
+      state.x *= scale_x;
+      state.y *= scale_y;
+      state.width *= scale_x;
       state.height *= scale_y;
 
-      state.x      += m_rd.x1;
-      state.y      += m_rd.y1;
+      state.x += m_rd.x1;
+      state.y += m_rd.y1;
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -76,7 +76,6 @@ namespace OVERLAY {
     enum EAlign
     {
       ALIGN_SCREEN,
-      ALIGN_SCREEN_AR,
       ALIGN_VIDEO,
       ALIGN_SUBTITLE
     } m_align;
@@ -92,8 +91,6 @@ namespace OVERLAY {
     float m_y;
     float m_width;
     float m_height;
-    float m_source_width; // Video source width resolution used to calculate aspect ratio
-    float m_source_height; // Video source height resolution used to calculate aspect ratio
   };
 
   class CRenderer : public Observer

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -225,26 +225,24 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
 
   if(o->source_width && o->source_height)
   {
-    float center_x = (float)(0.5f * o->width + o->x) / o->source_width;
-    float center_y = (float)(0.5f * o->height + o->y) / o->source_height;
+    float center_x = (0.5f * o->width + o->x) / o->source_width;
+    float center_y = (0.5f * o->height + o->y) / o->source_height;
 
-    m_align = ALIGN_SCREEN_AR;
+    m_align = ALIGN_VIDEO;
     m_pos = POSITION_RELATIVE;
     m_x = center_x;
     m_y = center_y;
-    m_width = static_cast<float>(o->width);
-    m_height = static_cast<float>(o->height);
-    m_source_width = static_cast<float>(o->source_width);
-    m_source_height = static_cast<float>(o->source_height);
+    m_width = static_cast<float>(o->width) / o->source_width;
+    m_height = static_cast<float>(o->height) / o->source_height;
   }
   else
   {
     m_align  = ALIGN_VIDEO;
     m_pos    = POSITION_ABSOLUTE;
-    m_x      = (float)o->x;
-    m_y      = (float)o->y;
-    m_width  = (float)o->width;
-    m_height = (float)o->height;
+    m_x = static_cast<float>(o->x);
+    m_y = static_cast<float>(o->y);
+    m_width = static_cast<float>(o->width);
+    m_height = static_cast<float>(o->height);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -202,23 +202,21 @@ COverlayTextureGL::COverlayTextureGL(CDVDOverlayImage* o)
     float center_x = (0.5f * o->width  + o->x) / o->source_width;
     float center_y = (0.5f * o->height + o->y) / o->source_height;
 
-    m_align = ALIGN_SCREEN_AR;
+    m_align = ALIGN_VIDEO;
     m_pos = POSITION_RELATIVE;
     m_x = center_x;
     m_y = center_y;
-    m_width = static_cast<float>(o->width);
-    m_height = static_cast<float>(o->height);
-    m_source_width = static_cast<float>(o->source_width);
-    m_source_height = static_cast<float>(o->source_height);
+    m_width = static_cast<float>(o->width) / o->source_width;
+    m_height = static_cast<float>(o->height) / o->source_height;
   }
   else
   {
     m_align  = ALIGN_VIDEO;
     m_pos    = POSITION_ABSOLUTE;
-    m_x      = (float)o->x;
-    m_y      = (float)o->y;
-    m_width  = (float)o->width;
-    m_height = (float)o->height;
+    m_x = static_cast<float>(o->x);
+    m_y = static_cast<float>(o->y);
+    m_width = static_cast<float>(o->width);
+    m_height = static_cast<float>(o->height);
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This fix wrong aspect ratio and scaling and relative position with ffmpeg subtitles like PGS / TS sub format, a regression introduced with #20204

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With PR #20204 i have add a calculation to keep the aspect ratio with image subs format to avoid stretching subs e.g. when the screen has wide resolutions but this led to some regressions like wrong image position due to different scale between x/y positions and height/width image scale reported by #20729 and maybe #20544

An example of wrong text position (from Issue #14866)
Text off video (before):
![immagine](https://user-images.githubusercontent.com/3257156/148082816-334618d4-8353-4977-b7d7-268732631fa0.png)
Text on video (now, like other player VLC/MPV):
![immagine](https://user-images.githubusercontent.com/3257156/148082828-b283ab29-be19-4966-b63b-cc98d4582542.png)

This is another side effect that can happens when you align to screen frame size instead of the video size, when you resize the window or you use wide resulution the text go off video:
![immagine](https://user-images.githubusercontent.com/3257156/148080781-efac9fe0-37d4-446d-b3a7-e0183c1bfb85.png)

compared to other players (like VLC/MPV) Kodi has always handled scaling/positioning by using window frame size instead to use the actual "video" size, and this confused me.

i didn't understand the initial reason for this choice, which i think was made seems about 8 years ago...
if someone has more info about this please let me know, but i think we can change it and see if there are special cases that can cause problems,
then if we scale the subtitles by aligning to the video size `ALIGN_VIDEO` instead of screen frame size `ALIGN_SCREEN` solve the problems

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested some MKV/PGS and TS files and compared to VLC now seem result the same output see screenshots below

This should solve also the BlueRay menu #20544 but i cannot test it, can someone test and report?

And is appreciated if some other tests with other files to be sure

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
Before:
![immagine](https://user-images.githubusercontent.com/3257156/148084081-736e9efb-4fb4-4838-886d-8c0fe4603d9b.png)
After:
![immagine](https://user-images.githubusercontent.com/3257156/148084263-852ac65d-113c-4c5a-8c66-c6ac0123796e.png)
VLC:
![immagine](https://user-images.githubusercontent.com/3257156/148084448-99b8b1d3-7519-456a-a446-105c3dd4e2cf.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
