### PR TITLE
[GUI][Skin] Add support for onlongclick actions on button controls (and derived classes)

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -271,7 +271,13 @@ msgctxt "#31048"
 msgid "Available"
 msgstr ""
 
-#empty strings from id 31049 to 31051
+#empty string with id 31049
+
+#: /xml/Variables.xml
+#: Help text for info button on video OSD
+msgctxt "#31050"
+msgid "Press [B]info[/B] to display plot, or long press [B]info[/B] to display player info"
+msgstr ""
 
 #: /xml/Includes.xml
 msgctxt "#31052"

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -269,7 +269,7 @@
 		<value condition="Control.HasFocus(70040)">$LOCALIZE[19019]</value>
 		<value condition="Control.HasFocus(70041)">$LOCALIZE[19069]</value>
 		<value condition="Control.HasFocus(70042)">$LOCALIZE[31065]</value>
-		<value condition="Control.HasFocus(70043)">$LOCALIZE[19033]</value>
+		<value condition="Control.HasFocus(70043)">$LOCALIZE[31050]</value>
 		<value condition="Control.HasFocus(70044)">$LOCALIZE[298]</value>
 		<value condition="Control.HasFocus(70045)">$LOCALIZE[31106]</value>
 		<value condition="Control.HasFocus(70046)">$LOCALIZE[24012]</value>

--- a/addons/skin.estuary/xml/VideoOSD.xml
+++ b/addons/skin.estuary/xml/VideoOSD.xml
@@ -180,6 +180,7 @@
 							<param name="texture" value="osd/fullscreen/buttons/information.png"/>
 						</include>
 						<onclick>Info</onclick>
+						<onlongclick>PlayerProcessInfo</onlongclick>
 					</control>
 					<control type="radiobutton" id="70044">
 						<include content="OSDButton">

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -208,6 +208,11 @@ bool CGUIButtonControl::OnAction(const CAction &action)
     OnClick();
     return true;
   }
+  else if (action.GetID() == ACTION_LONGCLICK)
+  {
+    m_longClickActions.ExecuteActions(GetID(), GetParentID());
+  }
+
   return CGUIControl::OnAction(action);
 }
 

--- a/xbmc/guilib/GUIButtonControl.dox
+++ b/xbmc/guilib/GUIButtonControl.dox
@@ -72,6 +72,7 @@ important, as xml tags are case-sensitive.
 | onclick       | Specifies the action to perform when the button is pressed. Should be a built in function. [See here for more information](http://kodi.wiki/view/Built-in_functions_available_to_FTP,_Webserver,_skins,_keymap_and_to_python). You may have more than one <b>`<onclick>`</b> tag, and they'll be executed in sequence.
 | onfocus       | Specifies the action to perform when the button is focused. Should be a built in function. The action is performed after any focus animations have completed. [See here for more information](http://kodi.wiki/view/Built-in_functions_available_to_FTP,_Webserver,_skins,_keymap_and_to_python).
 | onunfocus     | Specifies the action to perform when the button loses focus. Should be a built in function.
+| onlongclick   | Specifies the action to perform when the button is long clicked. You may have more than one <b>`<onlongclick>`</b> tag, and they'll be executed in sequence.<p><hr>@skinning_v20 <b>onlongclick</b> New tag added<p>
 | wrapmultiline | Will wrap the label across multiple lines if the label exceeds the control width.
 
 

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -49,6 +49,16 @@ public:
   virtual void SetLabel(const std::string & aLabel);
   virtual void SetLabel2(const std::string & aLabel2);
   void SetClickActions(const CGUIAction& clickActions) { m_clickActions = clickActions; }
+
+  /*!
+   * @brief Set the actions to run once the item is longclicked
+   * @param longClickActions the actions to run when the item is longclicked
+   */
+  void SetLongClickActions(const CGUIAction& longClickActions)
+  {
+    m_longClickActions = longClickActions;
+  }
+
   const CGUIAction& GetClickActions() const { return m_clickActions; }
   void SetFocusActions(const CGUIAction& focusActions) { m_focusActions = focusActions; }
   void SetUnFocusActions(const CGUIAction& unfocusActions) { m_unfocusActions = unfocusActions; }
@@ -106,6 +116,10 @@ protected:
   CGUIAction m_clickActions;
   CGUIAction m_focusActions;
   CGUIAction m_unfocusActions;
+  /*!
+   * @brief actions to run once the control is long clicked
+   */
+  CGUIAction m_longClickActions;
 
   bool m_bSelected;
 };

--- a/xbmc/guilib/GUIColorButtonControl.dox
+++ b/xbmc/guilib/GUIColorButtonControl.dox
@@ -78,6 +78,7 @@ important, as xml tags are case-sensitive.
 | colorheight   | Height in Pixels of the preview color box
 | texturecolormask | Specifies the image mask which should be displayed to see the color preview. [See here for additional information about textures](http://kodi.wiki/view/Texture_Attributes).
 | texturecolordisabledmask | Specifies the image mask which should be displayed when the control is disabled. [See here for additional information about textures](http://kodi.wiki/view/Texture_Attributes).
+| onlongclick   | Specifies the action to perform when the button is long clicked. You may have more than one <b>`<onlongclick>`</b> tag, and they'll be executed in sequence.<p><hr>@skinning_v20 <b>onlongclick</b> New tag added<p>
 
 
 --------------------------------------------------------------------------------

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -721,6 +721,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   bool bHasPath = false;
   CGUIAction clickActions;
+  CGUIAction longClickActions;
   CGUIAction altclickActions;
   CGUIAction focusActions;
   CGUIAction unfocusActions;
@@ -868,6 +869,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     labelInfo.align |= XBFONT_TRUNCATED;
 
   GetActions(pControlNode, "onclick", clickActions);
+  GetActions(pControlNode, "onlongclick", longClickActions);
   GetActions(pControlNode, "ontextchange", textChangeActions);
   GetActions(pControlNode, "onfocus", focusActions);
   GetActions(pControlNode, "onunfocus", unfocusActions);
@@ -1153,6 +1155,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       GUIINFO::CGUIInfoLabel hint_text;
       GetInfoLabel(pControlNode, "hinttext", hint_text, parentID);
       static_cast<CGUIEditControl*>(control)->SetHint(hint_text);
+      static_cast<CGUIEditControl*>(control)->SetLongClickActions(longClickActions);
 
       if (bPassword)
         static_cast<CGUIEditControl*>(control)->SetInputType(CGUIEditControl::INPUT_TYPE_PASSWORD, 0);
@@ -1217,6 +1220,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       bcontrol->SetLabel2(strLabel2);
       bcontrol->SetMinWidth(minWidth);
       bcontrol->SetClickActions(clickActions);
+      bcontrol->SetLongClickActions(longClickActions);
       bcontrol->SetFocusActions(focusActions);
       bcontrol->SetUnFocusActions(unfocusActions);
     }
@@ -1234,6 +1238,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       tcontrol->SetAltLabel(altLabel);
       tcontrol->SetMinWidth(minWidth);
       tcontrol->SetClickActions(clickActions);
+      tcontrol->SetLongClickActions(longClickActions);
       tcontrol->SetAltClickActions(altclickActions);
       tcontrol->SetFocusActions(focusActions);
       tcontrol->SetUnFocusActions(unfocusActions);
@@ -1254,6 +1259,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       rcontrol->SetRadioDimensions(radioPosX, radioPosY, radioWidth, radioHeight);
       rcontrol->SetToggleSelect(toggleSelect);
       rcontrol->SetClickActions(clickActions);
+      rcontrol->SetLongClickActions(longClickActions);
       rcontrol->SetFocusActions(focusActions);
       rcontrol->SetUnFocusActions(unfocusActions);
     }
@@ -1506,6 +1512,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     rcontrol->SetClickActions(clickActions);
     rcontrol->SetFocusActions(focusActions);
     rcontrol->SetUnFocusActions(unfocusActions);
+    rcontrol->SetLongClickActions(longClickActions);
   }
   break;
   default:

--- a/xbmc/guilib/GUIEditControl.dox
+++ b/xbmc/guilib/GUIEditControl.dox
@@ -47,6 +47,7 @@ important, as `xml` tags are case-sensitive.
 | font          | Specifies the font to use from the **font.xml** file.
 | textcolor     | Specifies the color the text should be, in hex **AARRGGBB** format, or a name from the [colour theme](http://kodi.wiki/view/Colour_Themes).
 | textwidth     | Will truncate any text that's too long.
+| onlongclick   | Specifies the action to perform when the button is long clicked. You may have more than one <b>`<onlongclick>`</b> tag, and they'll be executed in sequence.<p><hr>@skinning_v20 <b>onlongclick</b> New tag added<p>
 
 
 --------------------------------------------------------------------------------

--- a/xbmc/guilib/GUIRadioButtonControl.dox
+++ b/xbmc/guilib/GUIRadioButtonControl.dox
@@ -89,6 +89,7 @@ important, as `xml` tags are case-sensitive.
 | radioheight             | Height in Pixels of the dot or radio button itself
 | onfocus                 | Specifies the action to perform when the button is focused. Should be a built in function. The action is performed after any focus animations have completed. See here for more information.
 | onunfocus               | Specifies the action to perform when the button loses focus. Should be a built in function.
+| onlongclick   | Specifies the action to perform when the button is long clicked. You may have more than one <b>`<onlongclick>`</b> tag, and they'll be executed in sequence.<p><hr>@skinning_v20 <b>onlongclick</b> New tag added<p>
 
 
 --------------------------------------------------------------------------------

--- a/xbmc/guilib/GUIToggleButtonControl.dox
+++ b/xbmc/guilib/GUIToggleButtonControl.dox
@@ -79,6 +79,8 @@ that each tag is lower case only. This is important, as xml tags are case-sensit
 | onfocus           | Specifies the action to perform when the button is focused. Should be a built in function. The action is performed after any focus animations have completed. See here for more information.
 | onunfocus         | Specifies the action to perform when the button loses focus. Should be a built in function.
 | wrapmultiline     | Allows wrapping on the label across multiple lines. Defaults to false.
+| onlongclick       | Specifies the action to perform when the button is long clicked. You may have more than one <b>`<onlongclick>`</b> tag, and they'll be executed in sequence.<p><hr>@skinning_v20 <b>onlongclick</b> New tag added<p>
+
 
 
 --------------------------------------------------------------------------------

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -438,6 +438,9 @@
 // Voice actions
 #define ACTION_VOICE_RECOGNIZE 300
 
+#define ACTION_LONGCLICK \
+  310 //!< triggered when a long click happens (e.g. in a keyboard key, touch longpress or a mouse button)
+
 // Touch actions
 #define ACTION_TOUCH_TAP 401 //!< touch actions
 #define ACTION_TOUCH_TAP_TEN 410 //!< touch actions


### PR DESCRIPTION
## Description
In https://github.com/xbmc/xbmc/pull/20646 Player process info dialog was redesigned to include more info. In https://github.com/xbmc/xbmc/pull/20646#issuecomment-993347807 the idea of having a way to access this information on the GUI without relying on shortcuts was proposed. Thinking a bit about this, and since estuary already includes an info toggle button on the video OSD, it would be nice if we could reuse the button to also trigger the `PlayerProcessInfo` dialog relying on something like a longclick (touch longpress, mouse or key longclick) and, at the same time, avoiding to clutter already existing dialogs. 

That's what this PR does, it allows to define `<onlongclick>` for button controls and derived classes (colorbutton, edit control, radio button and toggle button).

~Information button on estuary video OSD was changed to include the `CodecInfo` action `<oncontextmenu>`.
@jjd-uk maybe we can improve the help text `Information` to give some instructions to the user (similar to what you've done for frameadvance et al?)~

## Motivation and context
Improved user experience. Get a way to show the PlayerProcessInfo information without having to change xml files (in some platforms like Android, it's a bit cumbersome).

## How has this been tested?
Runtime tested

## What is the effect on users?
Users should be able to trigger the `PlayerProcessInfo` action when longpressing the `info` button on video OSD.

## Screenshots (if appropriate):

**Single click:**

![image](https://user-images.githubusercontent.com/7375276/148220065-7db8bc32-fda3-4624-99a1-103beceb0efb.png)
**Long press:**

![image](https://user-images.githubusercontent.com/7375276/148220129-e1a4b608-4eff-4bfc-b57b-b9cf4ba550a3.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
