### PR TITLE
JSON/RPC Support adding new videos

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -163,6 +163,7 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
   { "VideoLibrary.Scan",                            CVideoLibrary::Scan },
   { "VideoLibrary.Export",                          CVideoLibrary::Export },
   { "VideoLibrary.Clean",                           CVideoLibrary::Clean },
+  { "VideoLibrary.AddMovie",                        CVideoLibrary::AddMovie },
 
 // Addon operations
   { "Addons.GetAddons",                             CAddonsOperations::GetAddons },

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -72,6 +72,7 @@ namespace JSONRPC
     static JSONRPC_STATUS Scan(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Export(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Clean(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
+    static JSONRPC_STATUS AddMovie(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
     static bool FillFileItem(
         const std::string& strFilename,

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -3170,6 +3170,16 @@
     ],
     "returns": "string"
   },
+  "VideoLibrary.AddMovie": {
+    "type": "method",
+    "description": "Add a new movie",
+    "transport": "Response",
+    "permission": "UpdateData",
+    "params": [
+      { "name": "filepath", "type": "string", "required": true, "minLength": 1, "description": "Path to the video file to add" }
+    ],
+    "returns": "string"
+  },
   "VideoLibrary.GetMovies": {
     "type": "method",
     "description": "Retrieve all movies",

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1245,6 +1245,7 @@ public:
   void SetMovieSet(int idMovie, int idSet);
   bool SetVideoUserRating(int dbId, int rating, const MediaType& mediaType);
   bool GetUseAllExternalAudioForVideo(const std::string& videoPath);
+  int AddNewMovie(CVideoInfoTag& details);
 
   std::string GetSetByNameLike(const std::string& nameLike) const;
 
@@ -1347,7 +1348,6 @@ public:
   std::string GetRemovableBlurayPath(std::string originalPath);
 
 protected:
-  int AddNewMovie(CVideoInfoTag& details);
   int AddNewMusicVideo(CVideoInfoTag& details);
 
   int GetMusicVideoId(const std::string& strFilenameAndPath);


### PR DESCRIPTION
## Description
This PR adds support for adding new movies to the library.

I plan to extend it to support adding TV shows, TV show series and TV show episodes as well as Music Videos, but want to get these changes for the addition of movies into shape first.

## Motivation and context
This PR extends the utility of the JSON/RPC interface by adding support for the creation of new entries in the library.

At the moment it is possible to set all details for movies (and TV shows, etc.) via JSON/RPC, but only for files that are already existing in the library. This requires a successful scan of those videos into the library.

In the case the scan does not import those files or using the scan functionality is not desired, it is not possible to add those items to the library via JSON/RPC.

## How has this been tested?

I tested it by executing the corresponding JSON/RPC function. The files were correctly inserted into the database and are accessible from the Kodi UI then. Calling VideoLibrary.SetVideoDetails afterwards does also work as expected.

## What is the effect on users?
It increases the utility of the JSON/RPC interface by offering users a way to create entries for movies (TV shows, etc.) in the library.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki (new functions in the JSON/RPC documentation in the Wiki)
- [ ] I have updated the documentation accordingly (I didn't change the wiki, as this PR is not yet integrated)
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

## Open questions:

The PR is (apart from the missing functionality to add other types of video than movies) ready. 

However I have a few questions about possible changes to the PR.

1. To be able to call `VideoDatabase::AddNewMovie` from the `VideoLibrary` I had to change the visiblity of it.
   If this is not desired, how should I handle his? Add another method in `VideoDtabase` that delegates to `VideoDatabase::AddNewMovie`? This would not provide any benefit in my opinion.

   https://github.com/hupfdule/xbmc/commit/8c265cd0fa6ec535e51912dc4ed3ca7fbd467b99#diff-1c9dd1b7b484ba7a64c670d64a855bfe5ff9e8ba31da75a3be351223a3b61815R915-R917

1. At the moment this new function only creates the entry in the library and sets the title to the filename. All remaining information has to be set afterwards by calling `VideoLibrary.SetMovieDetails`. It would be possible to allow setting all the same fields that can be modified via `VideoLibrary.SetMovieDetails` in `VideoLibrary.AddMovie` as well. This would remove the need for calling a second function by providing the ability to create the entry and fill it with data in the same call.
   Is there any guideline/convention on whether to provide this functionality?