### PR TITLE
[GUI][EDL][Skins] Add Player.SceneMarkers and Player.HasSceneMarkers

### DIFF
--- a/addons/skin.estouchy/xml/IncludesPlayerControls.xml
+++ b/addons/skin.estouchy/xml/IncludesPlayerControls.xml
@@ -110,6 +110,15 @@
 					<righttexture>red.png</righttexture>
 				</control>
 				<control type="ranges">
+					<description>SceneMarkers</description>
+					<posx>0</posx>
+					<posy>50</posy>
+					<width>552</width>
+					<height>8</height>
+					<info>Player.SceneMarkers</info>
+					<righttexture>white.png</righttexture>
+				</control>
+				<control type="ranges">
 					<description>Chapters</description>
 					<posx>0</posx>
 					<posy>50</posy>

--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -151,6 +151,15 @@
 				<height>4</height>
 				<texturebg border="3" colordiffuse="00FFFFFF">colors/white50.png</texturebg>
 				<righttexture>colors/white.png</righttexture>
+				<info>Player.SceneMarkers</info>
+			</control>
+			<control type="ranges">
+				<left>0</left>
+				<top>67</top>
+				<width>100%</width>
+				<height>4</height>
+				<texturebg border="3" colordiffuse="00FFFFFF">colors/white50.png</texturebg>
+				<righttexture>colors/white.png</righttexture>
 				<info>Player.Chapters</info>
 			</control>
 		</control>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -265,6 +265,15 @@
 				<height>4</height>
 				<texturebg border="3" colordiffuse="00FFFFFF">colors/white50.png</texturebg>
 				<righttexture>colors/white.png</righttexture>
+				<info>Player.SceneMarkers</info>
+			</control>
+			<control type="ranges">
+				<left>0</left>
+				<top>82</top>
+				<width>100%</width>
+				<height>4</height>
+				<texturebg border="3" colordiffuse="00FFFFFF">colors/white50.png</texturebg>
+				<righttexture>colors/white.png</righttexture>
 				<info>Player.Chapters</info>
 			</control>
 		</control>

--- a/addons/skin.estuary/xml/VideoOSD.xml
+++ b/addons/skin.estuary/xml/VideoOSD.xml
@@ -51,7 +51,7 @@
 							<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 						</include>
 						<onclick>PlayerControl(Previous)</onclick>
-						<visible>Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | [Player.SeekEnabled + VideoPlayer.Content(livetv)]</visible>
+						<visible>Player.HasSceneMarkers | Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | [Player.SeekEnabled + VideoPlayer.Content(livetv)]</visible>
 					</control>
 					<control type="radiobutton" id="601">
 						<include content="OSDButton">
@@ -106,7 +106,7 @@
 							<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 						</include>
 						<onclick>PlayerControl(Next)</onclick>
-						<visible>Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | PVR.IsTimeShift</visible>
+						<visible>Player.HasSceneMarkers | Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | PVR.IsTimeShift</visible>
 					</control>
 					<control type="radiobutton" id="608">
 						<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/record-white.png</textureradioonfocus>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -752,6 +752,23 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     @skinning_v20 **[New Infolabel]** \link Player_Cuts `Player.Cuts`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.SceneMarkers`</b>,
+///                  \anchor Player_SceneMarkers
+///                  _string_,
+///     @return The EDL scene markers of the currently playing item as csv in the format start1\,end1\,start2\,end2\,...
+///     Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token.
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link Player_SceneMarkers `Player.SceneMarkers`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.HasSceneMarkers`</b>,
+///                  \anchor Player_HasSceneMarkers
+///                  _boolean_,
+///     @return **True** if the item being played has scene markers\, **False** otherwise
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link Player_HasSceneMarkers `Player.HasSceneMarkers`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`Player.Chapters`</b>,
 ///                  \anchor Player_Chapters
 ///                  _string_,
@@ -815,6 +832,8 @@ const infomap player_labels[] = {{"hasmedia", PLAYER_HAS_MEDIA},
                                  {"cutlist", PLAYER_CUTLIST},
                                  {"editlist", PLAYER_EDITLIST},
                                  {"cuts", PLAYER_CUTS},
+                                 {"scenemarkers", PLAYER_SCENE_MARKERS},
+                                 {"hasscenemarkers", PLAYER_HAS_SCENE_MARKERS},
                                  {"chapters", PLAYER_CHAPTERS}};
 
 /// \page modules__infolabels_boolean_conditions

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -269,6 +269,18 @@ const std::vector<int64_t>& CDataCacheCore::GetCuts() const
   return m_contentInfo.GetCuts();
 }
 
+void CDataCacheCore::SetSceneMarkers(const std::vector<int64_t>& sceneMarkers)
+{
+  CSingleLock lock(m_contentSection);
+  m_contentInfo.SetSceneMarkers(sceneMarkers);
+}
+
+const std::vector<int64_t>& CDataCacheCore::GetSceneMarkers() const
+{
+  CSingleLock lock(m_contentSection);
+  return m_contentInfo.GetSceneMarkers();
+}
+
 void CDataCacheCore::SetChapters(const std::vector<std::pair<std::string, int64_t>>& chapters)
 {
   CSingleLock lock(m_contentSection);

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -82,6 +82,18 @@ public:
    */
   const std::vector<int64_t>& GetCuts() const;
 
+  /*!
+   * @brief Set the list of scene markers in cache.
+   * @return The list of scene markers or an empty list if no scene markers exist
+   */
+  void SetSceneMarkers(const std::vector<int64_t>& sceneMarkers);
+
+  /*!
+   * @brief Get the list of scene markers markers from cache.
+   * @return The list of scene markers or an empty vector if no scene exist.
+   */
+  const std::vector<int64_t>& GetSceneMarkers() const;
+
   void SetChapters(const std::vector<std::pair<std::string, int64_t>>& chapters);
 
   /*!
@@ -206,6 +218,21 @@ protected:
     const std::vector<int64_t>& GetCuts() const { return m_cuts; }
 
     /*!
+      * @brief Save the list of scene markers in cache.
+      * @param sceneMarkers the list of scene markers to store in cache
+      */
+    void SetSceneMarkers(const std::vector<int64_t>& sceneMarkers)
+    {
+      m_sceneMarkers = sceneMarkers;
+    }
+
+    /*!
+      * @brief Get the list of scene markers in cache.
+      * @return the list of scene markers in cache
+      */
+    const std::vector<int64_t>& GetSceneMarkers() const { return m_sceneMarkers; }
+
+    /*!
       * @brief Save the chapter list in cache.
       * @param chapters the list of chapters to store in cache
       */
@@ -228,6 +255,7 @@ protected:
       m_editList.clear();
       m_chapters.clear();
       m_cuts.clear();
+      m_sceneMarkers.clear();
     }
 
   private:
@@ -237,6 +265,8 @@ protected:
     std::vector<std::pair<std::string, int64_t>> m_chapters;
     /*!< position for EDL cuts */
     std::vector<int64_t> m_cuts;
+    /*!< position for EDL scene markers */
+    std::vector<int64_t> m_sceneMarkers;
   } m_contentInfo;
 
   CCriticalSection m_renderSection;

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -777,6 +777,16 @@ const std::vector<int64_t> CEdl::GetCutMarkers() const
   return cutList;
 }
 
+const std::vector<int64_t> CEdl::GetSceneMarkers() const
+{
+  std::vector<int64_t> sceneMarkers;
+  for (const int& scene : m_vecSceneMarkers)
+  {
+    sceneMarkers.emplace_back(GetTimeWithoutCuts(scene));
+  }
+  return sceneMarkers;
+}
+
 int CEdl::GetTimeWithoutCuts(int seek) const
 {
   if (!HasCuts())

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -93,6 +93,15 @@ public:
   const std::vector<int64_t> GetCutMarkers() const;
 
   /*!
+   * @brief Get the list of EDL scene markers.
+   * @return The list of EDL scene markers or an empty vector if no EDL scene exist.
+   * The returned values are accurate with respect to cut durations. I.e. if the file
+   * has multiple cuts, the positions of scene markers are automatically corrected by
+   * substracting the surpassed cut durations until the scene marker point.
+  */
+  const std::vector<int64_t> GetSceneMarkers() const;
+
+  /*!
    * @brief Check if for the provided seek time is contained within an EDL
    * edit and fill pEdit with the respective edit struct.
    * @note seek time refers to the time in the original file timeline (i.e. without

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -722,6 +722,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
   m_Edl.Clear();
   CServiceBroker::GetDataCacheCore().SetEditList(m_Edl.GetEditList());
   CServiceBroker::GetDataCacheCore().SetCuts(m_Edl.GetCutMarkers());
+  CServiceBroker::GetDataCacheCore().SetSceneMarkers(m_Edl.GetSceneMarkers());
 
   m_HasVideo = false;
   m_HasAudio = false;
@@ -3699,6 +3700,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     m_Edl.ReadEditDecisionLists(m_item, fFramesPerSecond);
     CServiceBroker::GetDataCacheCore().SetEditList(m_Edl.GetEditList());
     CServiceBroker::GetDataCacheCore().SetCuts(m_Edl.GetCutMarkers());
+    CServiceBroker::GetDataCacheCore().SetSceneMarkers(m_Edl.GetSceneMarkers());
 
     static_cast<IDVDStreamPlayerVideo*>(player)->SetSpeed(m_streamPlayerSpeed);
     m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_STARTING;

--- a/xbmc/guilib/GUIRangesControl.dox
+++ b/xbmc/guilib/GUIRangesControl.dox
@@ -39,7 +39,7 @@ important, as xml tags are case-sensitive.
 | lefttexture   | The texture used in the left hand side of the range
 | midtexture    | The texture used for the mid section of the range
 | righttexture  | The texture used in the right hand side of the range
-| info          | Specifies the information the range control holds. It expects an infolabel that returns a string in CSV format: e.g. `"start1,end1,start2,end2,..."`. Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token. Examples of currently supported infolabels are \link Player_Editlist `Player.Editlist`\endlink, \link Player_Cutlist `Player.Cutlist`\endlink (@deprecated), \link Player_Cuts `Player.Cuts`\endlink and \link Player_Chapters `Player.Chapters`\endlink.
+| info          | Specifies the information the range control holds. It expects an infolabel that returns a string in CSV format: e.g. `"start1,end1,start2,end2,..."`. Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token. Examples of currently supported infolabels are \link Player_Editlist `Player.Editlist`\endlink, \link Player_Cutlist `Player.Cutlist`\endlink (@deprecated), \link Player_Cuts `Player.Cuts`\endlink, \link Player_SceneMarkers `Player.Cutlist`\endlink and \link Player_Chapters `Player.Chapters`\endlink.
 
 \section Ranges_Control_sect3 Revision History
 

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -75,6 +75,8 @@
 #define PLAYER_CHAPTERS              68
 #define PLAYER_EDITLIST 69
 #define PLAYER_CUTS 70
+#define PLAYER_SCENE_MARKERS 71
+#define PLAYER_HAS_SCENE_MARKERS 72
 // Keep player infolabels that work with offset and position together
 #define PLAYER_PATH                  81
 #define PLAYER_FILEPATH              82

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -304,6 +304,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       return true;
     case PLAYER_EDITLIST:
     case PLAYER_CUTS:
+    case PLAYER_SCENE_MARKERS:
     case PLAYER_CUTLIST:
     case PLAYER_CHAPTERS:
       value = GetContentRanges(info.m_info);
@@ -526,6 +527,9 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case PLAYER_FRAMEADVANCE:
       value = CServiceBroker::GetDataCacheCore().IsFrameAdvance();
       return true;
+    case PLAYER_HAS_SCENE_MARKERS:
+      value = !CServiceBroker::GetDataCacheCore().GetSceneMarkers().empty();
+      return true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // PLAYLIST_*
@@ -627,6 +631,9 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
       case PLAYER_CUTS:
         ranges = GetCuts(data, duration);
         break;
+      case PLAYER_SCENE_MARKERS:
+        ranges = GetSceneMarkers(data, duration);
+        break;
       case PLAYER_CHAPTERS:
         ranges = GetChapters(data, duration);
         break;
@@ -674,6 +681,24 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetCuts(CDataCacheCore& dat
   for (const auto& cut : cuts)
   {
     float marker = cut * 100.0f / duration;
+    if (marker != 0)
+      ranges.emplace_back(std::make_pair(lastMarker, marker));
+
+    lastMarker = marker;
+  }
+  return ranges;
+}
+
+std::vector<std::pair<float, float>> CPlayerGUIInfo::GetSceneMarkers(CDataCacheCore& data,
+                                                                     time_t duration) const
+{
+  std::vector<std::pair<float, float>> ranges;
+
+  const std::vector<int64_t> scenes = data.GetSceneMarkers();
+  float lastMarker = 0.0f;
+  for (const auto& scene : scenes)
+  {
+    float marker = scene * 100.0f / duration;
     if (marker != 0)
       ranges.emplace_back(std::make_pair(lastMarker, marker));
 

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -68,6 +68,7 @@ private:
   std::string GetContentRanges(int iInfo) const;
   std::vector<std::pair<float, float>> GetEditList(CDataCacheCore& data, time_t duration) const;
   std::vector<std::pair<float, float>> GetCuts(CDataCacheCore& data, time_t duration) const;
+  std::vector<std::pair<float, float>> GetSceneMarkers(CDataCacheCore& data, time_t duration) const;
   std::vector<std::pair<float, float>> GetChapters(CDataCacheCore& data, time_t duration) const;
 };
 


### PR DESCRIPTION
## Description
This PR adds the missing edit types (Scene Markers) to the INFO interface so that skins can take advantage of them - by introducing two new infolabels/bools -> `Player.SceneMarkers` and `Player.HasSceneMarkers`. They behave similar to chapters.
Regarding Estuary, the previous and next buttons where not available if the file had scenemarkers which could be considered wrong. `PlayerControl(Next)` already jumps to the next mark (scene or chapter) if scenemarkers exist.

## Motivation and context
Complete EDL and GUI info.

## How has this been tested?
Runtime tested

## What is the effect on users?
If using estuary, small marks like chapters will be available on the interface/seekbar. Furthermore, next and previous will also be available allowing the user to jump between scenemarkers.

## Screenshots (if appropriate):
**Previous estuary**
![image](https://user-images.githubusercontent.com/7375276/148215307-40c67e7b-e764-4307-ade2-1fab0990e238.png)

**Now Estouchy:**
~(looks like Player.EditList is not implemented, will take a look in another PR)~ (done in https://github.com/xbmc/xbmc/pull/20802)
![image](https://user-images.githubusercontent.com/7375276/148214531-60e357e0-cfff-47f5-a6d4-58a6c02e66ee.png)

**Now Estuary:**
![image](https://user-images.githubusercontent.com/7375276/148214216-bc1a0c0a-7e7e-411b-b695-f3af03de97ac.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
