### PR TITLE
[Skin][Estouchy] Implement missing Player.Editlist

### DIFF
--- a/addons/skin.estouchy/xml/IncludesPlayerControls.xml
+++ b/addons/skin.estouchy/xml/IncludesPlayerControls.xml
@@ -101,6 +101,18 @@
 					<texturebg colordiffuse="002C2C2C">white.png</texturebg>
 				</control>
 				<control type="ranges">
+					<description>EdlEdits</description>
+					<posx>0</posx>
+					<posy>46</posy>
+					<width>552</width>
+					<height>10</height>
+					<info>Player.Editlist</info>
+					<texturebg border="3" colordiffuse="00FFFFFF">white.png</texturebg>
+					<lefttexture>white.png</lefttexture>
+					<midtexture colordiffuse="FFFF0000">white.png</midtexture>
+					<righttexture>white.png</righttexture>
+				</control>
+				<control type="ranges">
 					<description>Cuts</description>
 					<posx>0</posx>
 					<posy>50</posy>


### PR DESCRIPTION
## Description
Estouchy was missing the `Player.Editlist` (previous `Player.Cutlist`) on the seekbar:

**PR:**
![image](https://user-images.githubusercontent.com/7375276/148236443-b214e4df-f1a1-4150-873b-0140871fd02e.png)

**Master:**
![image](https://user-images.githubusercontent.com/7375276/148236754-61223ccb-151b-4a07-a00b-5a3e54e4b5a4.png)
