### PR TITLE
[PVR] Fix Recordings 'Episode' sort label.

### DIFF
--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -54,8 +54,8 @@ CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int win
     // "Size" : Filename, Size | Foldername, Size
     AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));
   }
-  // "Episode" : Series title/Season num/episode num/episode title, DateTime | Foldername, empty
-  AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%Z - %H. %T", "%d", "%L", ""));
+  // "Episode" : Filename, DateTime | Foldername, empty
+  AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%L", "%d", "%L", ""));
 
   SetSortMethod(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()
                 ->m_PVRDefaultSortOrder);


### PR DESCRIPTION
Followup to #20790, which introduced new sort method "by episodes" for recordings. Accidentally the sort label string was chosen unfortunate as redundant information displayed in the recordings window was the consequence.

This PR removes this redundancy by fixing the sort label for the new sort method.

Before:

<img width="882" alt="Screenshot 2022-01-05 at 19 53 43" src="https://user-images.githubusercontent.com/3226626/148301083-1240dbc2-6cdf-4030-8d4c-d955c4e21a72.png">

After:

<img width="880" alt="Screenshot 2022-01-05 at 20 00 14" src="https://user-images.githubusercontent.com/3226626/148301075-50cb7055-0360-4ddf-9998-35d8aafa4ac9.png">

Runtime-tesed on macOS, latest Kodi master.

@phunkyfish when you find time for a review...
