### PR TITLE
[pvr] only use provider icon as fallback for recording if no addon supplied icon is available

### DIFF
--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -30,6 +30,7 @@
 #include "pvr/epg/EpgSearchFilter.h"
 #include "pvr/guilib/PVRGUIActions.h"
 #include "pvr/providers/PVRProvider.h"
+#include "pvr/providers/PVRProviders.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
@@ -478,7 +479,11 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         break;
       }
       case LISTITEM_ICON:
-        if (!recording->Channel())
+        if (recording->ClientIconPath().empty() && recording->ClientThumbnailPath().empty() &&
+            // Only use a fallback if there is more than a single provider available
+            // Note: an add-on itself is a provider, hence we don't use > 0
+            CServiceBroker::GetPVRManager().Providers()->GetNumProviders() > 1 &&
+            !recording->Channel())
         {
           auto provider = recording->GetProvider();
           if (!provider->GetIconPath().empty())

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -84,6 +84,11 @@ std::vector<std::shared_ptr<CPVRProvider>> CPVRProvidersContainer::GetProvidersL
   return m_providers;
 }
 
+std::size_t CPVRProvidersContainer::GetNumProviders() const
+{
+  CSingleLock lock(m_critSection);
+  return m_providers.size();
+}
 
 bool CPVRProviders::Load()
 {

--- a/xbmc/pvr/providers/PVRProviders.h
+++ b/xbmc/pvr/providers/PVRProviders.h
@@ -43,6 +43,12 @@ public:
      */
   std::vector<std::shared_ptr<CPVRProvider>> GetProvidersList() const;
 
+  /*!
+     * Get the number of providers in this container
+     * @return The total number of providers
+     */
+  std::size_t GetNumProviders() const;
+
 protected:
   void InsertEntry(const std::shared_ptr<CPVRProvider>& newProvider, ProviderUpdateMode updateMode);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Only use the provider icon as fallback for a PVR recording if no add-on supplied icon is available.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If an add-on supplies an icon for a recording it should always be used before the fallback.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On OSX Monterrey with pvr.vuplus.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
