### PR TITLE
[skin][estuary] Fix visibility condition on topbaroverlay

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -9,7 +9,7 @@
 		<control type="group">
 			<visible>![Player.ShowInfo | Window.IsActive(fullscreeninfo) | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(PVR.ChannelNumberInput) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)] + [!String.IsEmpty(Player.SeekNumeric) | Player.Seeking | Player.DisplayAfterSeek | Player.Forwarding | Player.Rewinding | Player.Paused]</visible>
 			<animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>
-			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="Player.Paused + System.IdleTime(5)">Conditional</animation>
+			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="System.IdleTime(5) + !Player.Paused">Conditional</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>


### PR DESCRIPTION
## Description
OSD redesign in Matrix introduced a new top bar overlay which is automatically closed once the user gives some input to kodi as a result of some action (e.g. seek). However this has introduced some sort of regression for the pause state.
If the user executes play/pause via the GUI (by hitting the button) the overlay will stay displayed on top of video (since the idle timer is restarted). However if the user does the same action via JSON using for example:

```
http://localhost:8152/jsonrpc?request={"jsonrpc":"2.0","method":"Player.PlayPause","params":{"playerid":1},"id":8}
```
Sometimes the overlay is not show or ir autohides too quickly. This happens because those methods don't reset the idle timer (which is correct as they are not input methods). Since this seems to be something wanted by remote developers (and users) and we have differences of behaviour for the same action, lets keep it open for Player.Paused.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/20078

## How has this been tested?
Runtime tested

## What is the effect on users?
Paused state will be shown either if paused from the GUI or from JSON, estuary keeps it open if `Player.Paused` is true

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7375276/148523967-6b6eb42a-754b-4050-afbf-3f6cb3747f27.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
