### PR TITLE
Various CLog fixes after PR20718 merge

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -747,9 +747,9 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
   else if (format.m_dataFormat == AE_FMT_RAW) //No sense in trying other formats for passthrough.
     return false;
 
-  CLog::LogF(LOGDEBUG, LOGAUDIO,
-             "IsFormatSupported failed ({}) - trying to find a compatible format",
-             WASAPIErrToStr(hr));
+  CLog::LogFC(LOGDEBUG, LOGAUDIO,
+              "IsFormatSupported failed ({}) - trying to find a compatible format",
+              WASAPIErrToStr(hr));
 
   requestedChannels = wfxex.Format.nChannels;
   desired_map = CAESinkFactoryWin::SpeakerMaskFromAEChannels(format.m_channelLayout);

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.cpp
@@ -45,7 +45,7 @@ const char *WASAPIErrToStr(HRESULT err)
     ERRTOSTR(E_OUTOFMEMORY);
   default: break;
   }
-  return NULL;
+  return "Undefined";
 }
 
   void CAESinkFactoryWin::AEChannelsFromSpeakerMask(CAEChannelInfo& channelLayout, DWORD speakers)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -135,9 +135,9 @@ bool CProcessorHD::InitProcessor()
   }
 
   CLog::LogF(LOGDEBUG, "video processor has {} rate conversion.", m_vcaps.RateConversionCapsCount);
-  CLog::LogF(LOGDEBUG, "video processor has %#x feature caps.", m_vcaps.FeatureCaps);
-  CLog::LogF(LOGDEBUG, "video processor has %#x device caps.", m_vcaps.DeviceCaps);
-  CLog::LogF(LOGDEBUG, "video processor has %#x input format caps.", m_vcaps.InputFormatCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} feature caps.", m_vcaps.FeatureCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} device caps.", m_vcaps.DeviceCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} input format caps.", m_vcaps.InputFormatCaps);
   CLog::LogF(LOGDEBUG, "video processor has {} max input streams.", m_vcaps.MaxInputStreams);
   CLog::LogF(LOGDEBUG, "video processor has {} max stream states.", m_vcaps.MaxStreamStates);
   if (m_vcaps.FeatureCaps & D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_METADATA_HDR10)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1165,11 +1165,11 @@ void CRenderManager::PrepareNextRender()
     m_dvdClock.SetVsyncAdjust(0);
   }
 
-  CLog::LogF(LOGDEBUG, LOGAVTIMING,
-             "frameOnScreen: {:f} renderPts: {:f} nextFramePts: {:f} -> diff: {:f}  render: {} "
-             "forceNext: {}",
-             frameOnScreen, renderPts, nextFramePts, (renderPts - nextFramePts),
-             renderPts >= nextFramePts, m_forceNext);
+  CLog::LogFC(LOGDEBUG, LOGAVTIMING,
+              "frameOnScreen: {:f} renderPts: {:f} nextFramePts: {:f} -> diff: {:f}  render: {} "
+              "forceNext: {}",
+              frameOnScreen, renderPts, nextFramePts, (renderPts - nextFramePts),
+              renderPts >= nextFramePts, m_forceNext);
 
   bool combined = false;
   if (m_presentsourcePast >= 0)

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -272,7 +272,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
     s.erase(len - 1, 1);
   }
 
-  CLog::LogF(LOGDEBUG, LOGSAMBA, "Using authentication url {}", CURL::GetRedacted(s));
+  CLog::LogFC(LOGDEBUG, LOGSAMBA, "Using authentication url {}", CURL::GetRedacted(s));
 
   { CSingleLock lock(smb);
     if (!smb.IsSmbValid())

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -112,10 +112,9 @@ public:
     Log(level, format, std::forward<Args>(args)...);
   }
 
-#define LogF(level, format, ...) \
-  Log((level), ("{}: " DEF_TO_STR_VALUE(format)), __FUNCTION__, ##__VA_ARGS__)
+#define LogF(level, format, ...) Log((level), ("{}: " format), __FUNCTION__, ##__VA_ARGS__)
 #define LogFC(level, component, format, ...) \
-  Log((level), (component), ("{}: " DEF_TO_STR_VALUE(format)), __FUNCTION__, ##__VA_ARGS__)
+  Log((level), (component), ("{}: " format), __FUNCTION__, ##__VA_ARGS__)
 
 private:
   static CLog& GetInstance();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9397,7 +9397,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       // Otherwise there is a mismatch between the path contents and the hash in the
       // database, leading to potentially missed items on re-scan (if deleted files are
       // later re-added to a source)
-      CLog::LogF(LOGDEBUG, LOGDATABASE, "Cleaning path hashes");
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning path hashes");
       m_pDS->query("SELECT DISTINCT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile IN " + filesToDelete);
       int pathHashCount = m_pDS->num_rows();
       while (!m_pDS->eof())
@@ -9405,7 +9405,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
         InvalidatePathHash(m_pDS->fv("strPath").get_asString());
         m_pDS->next();
       }
-      CLog::LogF(LOGDEBUG, LOGDATABASE, "Cleaned {} path hashes", pathHashCount);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaned {} path hashes", pathHashCount);
 
       CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning files table", __FUNCTION__);
       sql = "DELETE FROM files WHERE idFile IN " + filesToDelete;


### PR DESCRIPTION
## Description
Various `CLog` fixes after PR20718 merge.

## Motivation and context
It seems that https://github.com/xbmc/xbmc/pull/20718 has woken up several latent bugs (at least on Windows):

Strange things in logs:

`2022-01-03 11:59:42.434 T:376 DEBUG <general>: CAESinkWASAPI::InitializeExclusive: (1 << (5 + 6))`

`2022-01-03 12:00:13.522 T:8844    DEBUG <general>: CRenderManager:repareNextRender: (1 << (5 + 13))`

Some have not been easy to locate because the root of the problem has nothing to do with the code that has been changed in PR20718.

`DEBUG <general>: DXVA::CProcessorHD::InitProcessor: "video processor has %#x device caps."`

Others cause severe bug's because vital thread is aborted due string null pointer exception:

`DEBUG <general>: Thread Terminating with Exception: string pointer is null`

Quotation marks appear in some sentences (not all):

`INFO <general>: DXVA::CDecoder::Open: "Total video memory available is 4142 MB (dedicated = 128 MB, shared = 4014 MB)"`

See: https://forum.kodi.tv/showthread.php?tid=366301

## How has this been tested?
Runtime tested Windows x64

## What is the effect on users?
Fix a lot of broken things.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
