### PR TITLE
ffmpeg: build with lto when -DUSE_LTO=ON

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -72,6 +72,11 @@ macro(buildFFMPEG)
                    -DOS=${OS}
                    -DCMAKE_AR=${CMAKE_AR})
   endif()
+
+  if(USE_LTO)
+    list(APPEND FFMPEG_OPTIONS -DUSE_LTO=ON)
+  endif()
+
   set(LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
   list(APPEND LINKER_FLAGS ${SYSTEM_LDFLAGS})
 

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -115,6 +115,10 @@ if(CPU MATCHES x86 OR CPU MATCHES x86_64)
   list(APPEND ffmpeg_conf --x86asmexe=${NASM_EXECUTABLE})
 endif()
 
+if(USE_LTO)
+   list(APPEND ffmpeg_conf --enable-lto)
+endif()
+
 if(ENABLE_DAV1D)
   list(APPEND ffmpeg_conf --enable-libdav1d)
   set(pkgconf_path "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}")


### PR DESCRIPTION
## Description
I do not believe the internal ffmpeg build uses LTO if the user calls for it via `-DUSE_LTO=ON`.  This commit passes `--enable-lto` to ffmpeg's configure script if CMAKE has `CMAKE_INTERPROCEDURAL_OPTIMIZATION` set which `-DUSE_LTO=ON` does.

The original author of this, loqs, points this out [here](https://bugs.archlinux.org/task/69333#comment196255).

## Motivation and context
Building with `-DUSE_LTO=ON` should also build with lto for ffmpeg.

## How has this been tested?
Build tested on x86_64.  Behaves as expected.
Run tested on x86_64.  Behaves as expected.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed