### PR TITLE
Port dialog: Fix controller selection

### DIFF
--- a/xbmc/games/controllers/windows/GUIPortList.cpp
+++ b/xbmc/games/controllers/windows/GUIPortList.cpp
@@ -144,7 +144,9 @@ void CGUIPortList::OnSelect()
 
 void CGUIPortList::ResetPorts()
 {
+  // Update the game client
   m_gameClient->Input().ResetPorts();
+  m_gameClient->Input().SavePorts();
 
   // Refresh the GUI
   using namespace MESSAGING;

--- a/xbmc/games/controllers/windows/GUIPortList.cpp
+++ b/xbmc/games/controllers/windows/GUIPortList.cpp
@@ -263,9 +263,9 @@ void CGUIPortList::OnControllerSelected(const CPortNode& port, const ControllerP
   const bool bConnected = static_cast<bool>(controller);
 
   // Update the game client
-  const bool bSuccess =
-      bConnected ? m_gameClient->Input().DisconnectController(port.GetAddress())
-                 : m_gameClient->Input().ConnectController(port.GetAddress(), controller);
+  const bool bSuccess = bConnected
+                            ? m_gameClient->Input().ConnectController(port.GetAddress(), controller)
+                            : m_gameClient->Input().DisconnectController(port.GetAddress());
 
   if (bSuccess)
   {

--- a/xbmc/games/controllers/windows/GUIPortWindow.h
+++ b/xbmc/games/controllers/windows/GUIPortWindow.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "addons/RepositoryUpdater.h"
 #include "games/GameTypes.h"
 #include "guilib/GUIDialog.h"
 


### PR DESCRIPTION
## Description

Somehow, merging https://github.com/xbmc/xbmc/pull/20505, logic got inverted and broke controller selection. Selecting any controller would disable the port, and it wasn't possible to re-enable. I traced the bug to a logic condition that was inverted. No idea how this happened or how it defeated testing.

## Motivation and context

Fixes bug left over in https://github.com/xbmc/xbmc/pull/20505

## How has this been tested?

Tested by selecting controllers. Multitaps properly expand for additional controllers:

![Screenshot from 2022-01-07 14-47-56](https://user-images.githubusercontent.com/531482/148620734-5cdc4ed8-503b-40b5-b89e-7dcc0f8302f2.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
