### PR TITLE
[Subtitles][WebVTT] Fix for X-TIMESTAMP-MAP and position setting parsing

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -177,6 +177,9 @@ void TranslateEscapeChars(std::string& text)
   }
 }
 
+constexpr int MICROS_PER_SECOND = 1000000;
+constexpr int MPEG_TIMESCALE = 90000;
+
 } // unnamed namespace
 
 bool CWebVTTHandler::Initialize()
@@ -253,14 +256,44 @@ void CWebVTTHandler::DecodeLine(std::string line, std::vector<subtitleData>* sub
     }
     else if (StringUtils::StartsWith(line, "X-TIMESTAMP-MAP")) // HLS streaming spec
     {
-      // Get the MPEGTS timestamp offset value, to sync the subtitles with video
-      CRegExp reg;
-      if (reg.RegComp("MPEGTS:(\\d+)") && reg.RegFind(line) >= 0)
+      // Get the HLS timestamp values to sync the subtitles with video
+      CRegExp regLocal;
+      CRegExp regMpegTs;
+
+      if (regLocal.RegComp("LOCAL:((?:(\\d{1,}):)?(\\d{2}):(\\d{2}\\.\\d{3}))") &&
+          regMpegTs.RegComp("MPEGTS:(\\d+)"))
       {
-        m_mpegTsOffset = std::stoull(reg.GetMatch(1));
+        if ((regLocal.RegFind(line) >= 0 && regLocal.GetSubCount() == 4) &&
+            regMpegTs.RegFind(line) >= 0)
+        {
+          int locHrs = 0;
+          int locMins;
+          double locSecs;
+          if (!regLocal.GetMatch(1).empty())
+            locHrs = std::stoi(regLocal.GetMatch(1).c_str());
+          locMins = std::stoi(regLocal.GetMatch(2).c_str());
+          locSecs = std::atof(regLocal.GetMatch(3).c_str());
+          m_hlsTimestampLocalUs =
+              (static_cast<double>(locHrs * 3600 + locMins * 60) + locSecs) * DVD_TIME_BASE;
+          // Converts a 90 kHz clock timestamp to a timestamp in microseconds
+          m_hlsTimestampMpegTsUs =
+              std::stod(regMpegTs.GetMatch(1)) * MICROS_PER_SECOND / MPEG_TIMESCALE;
+        }
+        else
+        {
+          m_hlsTimestampLocalUs = 0;
+          m_hlsTimestampMpegTsUs = 0;
+          CLog::Log(LOGERROR,
+                    "{} - Failed to get X-TIMESTAMP-MAP values, subtitles could be out of sync",
+                    __FUNCTION__);
+        }
       }
       else
-        CLog::Log(LOGERROR, "{} - Wrong MPEGTS timestamp string or regex has failed", __FUNCTION__);
+      {
+        CLog::Log(LOGERROR,
+                  "{} - Failed to compile X-TIMESTAMP-MAP regexes, subtitles could be out of sync",
+                  __FUNCTION__);
+      }
     }
     else if (IsCueLine(line))
     {
@@ -523,11 +556,11 @@ void CWebVTTHandler::GetCueData(std::string& cueText)
     eSeconds = std::atof(m_cueTimeRegex.GetMatch(6).c_str());
 
     m_subtitleData.startTime =
-        (static_cast<double>(sHours * 3600 + sMinutes * 60) + sSeconds + m_mpegTsOffset) *
-        DVD_TIME_BASE;
+        (static_cast<double>(sHours * 3600 + sMinutes * 60) + sSeconds) * DVD_TIME_BASE +
+        m_hlsTimestampMpegTsUs - m_hlsTimestampLocalUs;
     m_subtitleData.stopTime =
-        (static_cast<double>(eHours * 3600 + eMinutes * 60) + eSeconds + m_mpegTsOffset) *
-        DVD_TIME_BASE;
+        (static_cast<double>(eHours * 3600 + eMinutes * 60) + eSeconds) * DVD_TIME_BASE +
+        m_hlsTimestampMpegTsUs - m_hlsTimestampLocalUs;
     cueSettings =
         cueText.substr(m_cueTimeRegex.GetFindLen(), cueText.length() - m_cueTimeRegex.GetFindLen());
     StringUtils::Trim(cueSettings);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -45,7 +45,7 @@ constexpr char cueTimePattern[] =
 
 // Regex patterns for cue properties
 const std::map<std::string, std::string> cuePropsPatterns = {
-    {"position", "position\\:(\\d+\\.\\d+|auto)%"},
+    {"position", "position\\:(\\d+|\\d+\\.\\d+|auto)%"},
     {"positionAlign", "position\\:\\d+\\.\\d+%,([a-z]+)"},
     {"size", "size\\:((\\d+\\.)?\\d+%?)"},
     {"line", "line\\:(\\d+%|\\d+\\.\\d+%|-?\\d+|auto)(,|\\s|$)"},

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -13,7 +13,6 @@
 #include "utils/RegExp.h"
 
 #include <map>
-#include <stdint.h>
 #include <stdio.h>
 #include <string>
 #include <utility>
@@ -174,7 +173,8 @@ private:
   bool m_overrideStyle{false};
   bool m_overridePositions{false};
   WebvttSection m_currentSection{WebvttSection::UNDEFINED};
-  uint64_t m_mpegTsOffset = 0;
+  double m_hlsTimestampMpegTsUs{0};
+  double m_hlsTimestampLocalUs{0};
   CRegExp m_cueTimeRegex;
   std::map<std::string, CRegExp> m_cuePropsMapRegex;
   CGUIColorManager m_colorManager;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The X-TIMESTAMP-MAP was added to startTime/stopTime without calculate the right value, which caused a high subs time delay.
I got some hints for implementation from here:
https://sdks.support.brightcove.com/features/synchronizing-webvtt-captions.html
https://github.com/google/ExoPlayer/blob/release-v2/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/WebvttExtractor.java

The fix for parsing of the value "position" consist in to add the support to numbers that does not have a decimal point

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An user has reported the problem with a HLS stream:
https://github.com/xbmc/inputstream.adaptive/issues/870

The same webvtt stream also highlighted a secondary problem where the parsing of "position" setting was not working

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have provided a Windows build for the test, the user has reported that works as expected:
https://github.com/xbmc/inputstream.adaptive/issues/870#issuecomment-1007741836

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Show subtitles in sync with video and with the right position

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
