### PR TITLE
[Estuary] Use AlarmClock instead of input idletimer for top seekbar

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <window type="dialog" id="1109">
+	<onload>AlarmClock(seekbartimer,SetProperty(timerelapsed,1,1109),00:00:05,silent,false])</onload>
+	<onunload>CancelAlarm(seekbartimer,silent)</onunload>
+	<onunload>ClearProperty(timerelapsed,1109)</onunload>
 	<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)</visible>
 	<visible>Window.IsActive(seekbar) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)</visible>
 	<depth>DepthOSD</depth>
@@ -9,7 +12,7 @@
 		<control type="group">
 			<visible>![Player.ShowInfo | Window.IsActive(fullscreeninfo) | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(PVR.ChannelNumberInput) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)] + [!String.IsEmpty(Player.SeekNumeric) | Player.Seeking | Player.DisplayAfterSeek | Player.Forwarding | Player.Rewinding | Player.Paused]</visible>
 			<animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>
-			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="Player.Paused + System.IdleTime(5)">Conditional</animation>
+			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="Player.Paused + String.IsEqual(Window(1109).Property(timerelapsed),1)">Conditional</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -160,7 +160,7 @@ static int ActivateAndFocus(const std::vector<std::string>& params)
  */
 static int AlarmClock(const std::vector<std::string>& params)
 {
-  // format is alarmclock(name,command[,seconds,true]);
+  // format is alarmclock(name,command[,time,true,false]);
   float seconds = 0;
   if (params.size() > 2)
   {
@@ -411,7 +411,7 @@ static int ToggleDirty(const std::vector<std::string>&)
 ///     @param[in] silent                Send "true" or "silent" to silently cancel alarm (optional).
 ///   }
 ///   \table_row2_l{
-///     <b>`AlarmClock(name\,command\,time[\,silent\,loop])`</b>
+///     <b>`AlarmClock(name\,command[\,time\,silent\,loop])`</b>
 ///     ,
 ///     Pops up a dialog asking for the length of time for the alarm (unless the
 ///     parameter time is specified)\, and starts a timer. When the timer runs out\,
@@ -419,11 +419,22 @@ static int ToggleDirty(const std::vector<std::string>&)
 ///     specified\, otherwise it'll pop up an alarm notice. Add silent to hide the
 ///     alarm notification. Add loop for the alarm to execute the command each
 ///     time the specified time interval expires.
+///     @note if using any of the last optional parameters (silent or loop)\, both must
+///     be provided for any to take effect.
+///     <p>
+///     <b>Example:</b>
+///     The following example will create an alarmclock named `mytimer` which will silently
+///     fire (a single time) and set a property (timerelapsed) with value 1 in the window with
+///     id 1109 after 5 seconds have passed.
+///     ~~~~~~~~~~~~~
+///     AlarmClock(mytimer\,SetProperty(timerelapsed\,1\,1109)\,00:00:05\,silent\,false])
+///     ~~~~~~~~~~~~~
+///     <p>
 ///     @param[in] name                  name
 ///     @param[in] command               command
-///     @param[in] time                  Length in seconds (optional).
-///     @param[in] silent                Send "silent" to suppress notifications.
-///     @param[in] loop                  Send "loop" to loop the alarm.
+///     @param[in] time                  [opt] <b>(a)</b> Length in minutes or <b>(b)</b> a timestring in the format `hh:mm:ss` or `mm min`.
+///     @param[in] silent                [opt] Send "silent" to suppress notifications.
+///     @param[in] loop                  [opt] Send "loop" to loop the alarm.
 ///   }
 ///   \table_row2_l{
 ///     <b>`ActivateWindow(window[\,dir\, return])`</b>


### PR DESCRIPTION
## Description
This is a second attempt at tackling https://github.com/xbmc/xbmc/issues/20078, with an interesting discussion taking place both in https://github.com/xbmc/xbmc/pull/20807 and in the forums (https://forum.kodi.tv/showthread.php?tid=366362).
Estuary is showing different behaviour when the player play/pause action is executed from the GUI (using remotes) and from JSON-RPC Player methods.

It comes down to the usage of `System.IdleTimer` to hide the topseekbar dialog, which is (and in my opinion should be) completely linked to input. When `Player.PlayPause` is executed from JSON-RPC we are affecting the player state, not exactly providing input to the application via the input subsystem so the timer is not (and imho should not be) restarted. The current skin would work well if the `playpause` action was provided by json clients via `Input.SendAction` since it restarts the idletimer. That would require too drastic changes in any remote application (and also would affect consistency). What about other player methods?

While we could have infinite discussions about what could or could not be considered input and the inherent limitations of our JSON-RPC interface - and never reach a quorum - we can also think about the root cause of the problem from a different angle.
We can think that estuary is incorrectly making use of the input subsystem to control the visibility time of controls. In that top seekbar dialog, we want to hide the dialog if it is visible for 5 seconds which is not exactly the same as "hide the dialog if the user has not send any input to kodi in 5 seconds". We want to control the visibility based on the player state and skin timers and not on input.

So, this PR replaces the usage of `System.IdleTimer` with a purely GUI based timer implementation relying on the **AlarmClock** builtin function and window properties. When the dialog is loaded it starts a `silent` alarmclock that will execute `Window.SetProperty` after 5 seconds are elapsed. The close animation then depends on the definition of the said property. When the window is unloaded (visibility is false) it automatically cancels the timer and clears the property.
This makes sure we do not rely on the input subsystem and consistency is achieved when methods are executed from any source (since we only rely on the player state and gui elements).

Took the time to update the documentation for **AlarmClock** which was not exactly correct.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/20078 / identifying limitations on Kodi.

## How has this been tested?
Runtime tested, pausing via input and and via json/kore.

## What is the effect on users?
Consistency of behaviour on the default skin regardless of the way player is play/paused.

## Screenshots (if appropriate):
**Hitting spacebar:**
![image](https://user-images.githubusercontent.com/7375276/148642243-aab0e0c3-36ae-4630-90aa-cd830b286afd.png)

**After 5 secs:**
![Screenshot from 2022-01-08 11-21-22](https://user-images.githubusercontent.com/7375276/148642252-afa8111a-63bf-4cb3-a77e-fc48f2e288ac.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
