### PR TITLE
CLog: optimize logs performance, avoids formatting if line is not being logged

### DIFF
--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -147,8 +147,8 @@ void CPasswordManager::Load()
     CXBMCTinyXML doc;
     if (!doc.LoadFile(passwordsFile))
     {
-      CLog::Log(LOGERROR, "{} - Unable to load: {}, Line {}\n{}", __FUNCTION__, passwordsFile,
-                doc.ErrorRow(), doc.ErrorDesc());
+      CLog::LogMultiline(LOGERROR, "{} - Unable to load: {}, Line {}\n{}", __FUNCTION__,
+                         passwordsFile, doc.ErrorRow(), doc.ErrorDesc());
       return;
     }
     const TiXmlElement *root = doc.RootElement();

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -88,9 +88,9 @@ bool CAddon::LoadSettings(bool bForce, bool loadUserSettings /* = true */)
   {
     if (CFile::Exists(addonSettingsDefinitionFile))
     {
-      CLog::Log(LOGERROR, "CAddon[{}]: unable to load: {}, Line {}\n{}", ID(),
-                addonSettingsDefinitionFile, addonSettingsDefinitionDoc.ErrorRow(),
-                addonSettingsDefinitionDoc.ErrorDesc());
+      CLog::LogMultiline(LOGERROR, "CAddon[{}]: unable to load: {}, Line {}\n{}", ID(),
+                         addonSettingsDefinitionFile, addonSettingsDefinitionDoc.ErrorRow(),
+                         addonSettingsDefinitionDoc.ErrorDesc());
     }
 
     return false;

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -58,11 +58,9 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const std::string& addonPath, bool plat
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(URIUtils::AddFileToFolder(addonRealPath, "addon.xml")))
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: Unable to load '{}', Line {}\n{}",
-                                               __FUNCTION__,
-                                               URIUtils::AddFileToFolder(addonRealPath, "addon.xml"),
-                                               xmlDoc.ErrorRow(),
-                                               xmlDoc.ErrorDesc());
+    CLog::LogMultiline(LOGERROR, "CAddonInfoBuilder::{}: Unable to load '{}', Line {}\n{}",
+                       __FUNCTION__, URIUtils::AddFileToFolder(addonRealPath, "addon.xml"),
+                       xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
     return nullptr;
   }
 

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -265,8 +265,8 @@ bool CApplicationSkinHandling::LoadCustomWindows()
           CXBMCTinyXML xmlDoc;
           if (!xmlDoc.LoadFile(item->GetPath()))
           {
-            CLog::Log(LOGERROR, "Unable to load custom window XML {}. Line {}\n{}", item->GetPath(),
-                      xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+            CLog::LogMultiline(LOGERROR, "Unable to load custom window XML {}. Line {}\n{}",
+                               item->GetPath(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
             continue;
           }
 

--- a/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
+++ b/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
@@ -206,7 +206,7 @@ public:
       }
     }
     bufferContents[m_iSize*m_planes] = '\0';
-    CLog::Log(LOGDEBUG, "AERingBuffer::Dump()\n{}", bufferContents);
+    CLog::LogMultiline(LOGDEBUG, "AERingBuffer::Dump()\n{}", bufferContents);
     KODI::MEMORY::AlignedFree(bufferContents);
   }
 

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
@@ -96,8 +96,8 @@ void CVideoBufferDMA::SetDimensions(int width,
       planeStr.append(fmt::format("\nplane[{}]: stride={}\toffset={}", plane, strides[plane],
                                   planeOffsets[plane]));
 
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
-              __FUNCTION__, m_id, DRMHELPERS::FourCCToString(m_fourcc), planeStr);
+    CLog::LogMultiline(LOGDEBUG, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
+                       __FUNCTION__, m_id, DRMHELPERS::FourCCToString(m_fourcc), planeStr);
   }
 }
 
@@ -141,8 +141,8 @@ void CVideoBufferDMA::Export(AVFrame* frame, uint32_t width, uint32_t height)
       planeStr.append(fmt::format("\nplane[{}]: stride={}\toffset={}", plane, m_strides[plane],
                                   m_offsets[plane]));
 
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
-              __FUNCTION__, m_id, DRMHELPERS::FourCCToString(m_fourcc), planeStr);
+    CLog::LogMultiline(LOGDEBUG, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
+                       __FUNCTION__, m_id, DRMHELPERS::FourCCToString(m_fourcc), planeStr);
   }
 
   for (uint32_t i = 0; i < AV_NUM_DATA_POINTERS; i++)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -363,7 +363,8 @@ bool CDVDAudioCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
     if (xbmc_jnienv()->ExceptionCheck())
     {
       std::string err = CJNIBase::ExceptionToString();
-      CLog::Log(LOGERROR, "CDVDAudioCodecAndroidMediaCodec::AddData ExceptionCheck \n {}", err);
+      CLog::LogMultiline(LOGERROR, "CDVDAudioCodecAndroidMediaCodec::AddData ExceptionCheck \n {}",
+                         err);
     }
     else if (index >= 0)
     {
@@ -630,9 +631,9 @@ int CDVDAudioCodecAndroidMediaCodec::GetData(uint8_t** dst)
   if (xbmc_jnienv()->ExceptionCheck())
   {
     std::string err = CJNIBase::ExceptionToString();
-    CLog::Log(LOGERROR,
-              "CDVDAudioCodecAndroidMediaCodec::GetData ExceptionCheck; dequeueOutputBuffer \n {}",
-              err);
+    CLog::LogMultiline(
+        LOGERROR,
+        "CDVDAudioCodecAndroidMediaCodec::GetData ExceptionCheck; dequeueOutputBuffer \n {}", err);
     xbmc_jnienv()->ExceptionDescribe();
     xbmc_jnienv()->ExceptionClear();
     return 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1237,7 +1237,8 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const std::string& filters, bool scale)
     char* graphDump = avfilter_graph_dump(m_pFilterGraph, nullptr);
     if (graphDump)
     {
-      CLog::Log(LOGDEBUG, "CDVDVideoCodecFFmpeg::FilterOpen - Final filter graph:\n{}", graphDump);
+      CLog::LogMultiline(LOGDEBUG, "CDVDVideoCodecFFmpeg::FilterOpen - Final filter graph:\n{}",
+                         graphDump);
       av_freep(&graphDump);
     }
   }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -103,7 +103,8 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
     defines += m_glslOutput->GetDefines();
   }
 
-  CLog::Log(LOGDEBUG, "GL: ConvolutionFilterShader: using {} defines:\n{}", shadername, defines);
+  CLog::LogMultiline(LOGDEBUG, "GL: ConvolutionFilterShader: using {} defines:\n{}", shadername,
+                     defines);
   PixelShader()->LoadSource(shadername, defines);
   PixelShader()->AppendSource("gl_output.glsl");
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
@@ -111,7 +111,8 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method)
     m_internalformat = GL_RGBA;
   }
 
-  CLog::Log(LOGDEBUG, "GL: ConvolutionFilterShader: using {} defines:\n{}", shadername, defines);
+  CLog::LogMultiline(LOGDEBUG, "GL: ConvolutionFilterShader: using {} defines:\n{}", shadername,
+                     defines);
   PixelShader()->LoadSource(shadername, defines);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -104,7 +104,7 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect,
 
   VertexShader()->LoadSource("gl_yuv2rgb_vertex.glsl", m_defines);
 
-  CLog::Log(LOGDEBUG, "GL: BaseYUV2RGBGLSLShader: defines:\n{}", m_defines);
+  CLog::LogMultiline(LOGDEBUG, "GL: BaseYUV2RGBGLSLShader: defines:\n{}", m_defines);
 
   m_convMatrix.SetDestinationColorPrimaries(dstPrimaries).SetSourceColorPrimaries(srcPrimaries);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -68,7 +68,7 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
 
   VertexShader()->LoadSource("gles_yuv2rgb.vert", m_defines);
 
-  CLog::Log(LOGDEBUG, "GLES: BaseYUV2RGBGLSLShader: defines:\n{}", m_defines);
+  CLog::LogMultiline(LOGDEBUG, "GLES: BaseYUV2RGBGLSLShader: defines:\n{}", m_defines);
 
   m_convMatrix.SetSourceColorPrimaries(srcPrimaries).SetDestinationColorPrimaries(dstPrimaries);
 }

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1111,8 +1111,8 @@ bool CCurlFile::Open(const CURL& url)
       ReadString(&error[0], 4095);
     }
 
-    CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Failed with code {}:\n{}", __FUNCTION__,
-              redactPath, m_httpresponse, error);
+    CLog::LogMultiline(LOGERROR, "CCurlFile::{} - <{}> Failed with code {}:\n{}", __FUNCTION__,
+                       redactPath, m_httpresponse, error);
 
     return false;
   }

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -242,7 +242,8 @@ bool CGUIAudioManager::Load()
   //  Load the config file
   if (!xmlDoc.LoadFile(strSoundsXml))
   {
-    CLog::Log(LOGINFO, "{}, Line {}\n{}", strSoundsXml, xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+    CLog::LogMultiline(LOGINFO, "{}, Line {}\n{}", strSoundsXml, xmlDoc.ErrorRow(),
+                       xmlDoc.ErrorDesc());
     return false;
   }
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -131,8 +131,8 @@ bool CGUIWindow::LoadXML(const std::string &strPath, const std::string &strLower
     StringUtils::ToLower(strPathLower);
     if (!xmlDoc.LoadFile(strPath) && !xmlDoc.LoadFile(strPathLower) && !xmlDoc.LoadFile(strLowerPath))
     {
-      CLog::Log(LOGERROR, "Unable to load window XML: {}. Line {}\n{}", strPath, xmlDoc.ErrorRow(),
-                xmlDoc.ErrorDesc());
+      CLog::LogMultiline(LOGERROR, "Unable to load window XML: {}. Line {}\n{}", strPath,
+                         xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
       SetID(WINDOW_INVALID);
       return false;
     }

--- a/xbmc/guilib/Shader.cpp
+++ b/xbmc/guilib/Shader.cpp
@@ -281,7 +281,8 @@ bool CGLSLShaderProgram::CompileAndLink()
   if (!m_pVP->Compile())
   {
     CLog::Log(LOGERROR, "GL: Error compiling vertex shader: {}", m_pVP->GetName());
-    CLog::Log(LOGDEBUG, "GL: vertex shader source:\n{}", m_pVP->GetSourceWithLineNumbers());
+    CLog::LogMultiline(LOGDEBUG, "GL: vertex shader source:\n{}",
+                       m_pVP->GetSourceWithLineNumbers());
     return false;
   }
 
@@ -290,7 +291,8 @@ bool CGLSLShaderProgram::CompileAndLink()
   {
     m_pVP->Free();
     CLog::Log(LOGERROR, "GL: Error compiling fragment shader: {}", m_pFP->GetName());
-    CLog::Log(LOGDEBUG, "GL: fragment shader source:\n{}", m_pFP->GetSourceWithLineNumbers());
+    CLog::LogMultiline(LOGDEBUG, "GL: fragment shader source:\n{}",
+                       m_pFP->GetSourceWithLineNumbers());
     return false;
   }
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -130,8 +130,8 @@ bool CButtonTranslator::LoadKeymap(const std::string& keymapPath)
   CLog::Log(LOGINFO, "Loading {}", keymapPath);
   if (!xmlDoc.LoadFile(keymapPath))
   {
-    CLog::Log(LOGERROR, "Error loading keymap: {}, Line {}\n{}", keymapPath, xmlDoc.ErrorRow(),
-              xmlDoc.ErrorDesc());
+    CLog::LogMultiline(LOGERROR, "Error loading keymap: {}, Line {}\n{}", keymapPath,
+                       xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
     return false;
   }
 

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -62,7 +62,8 @@ bool CIRTranslator::LoadIRMap(const std::string& irMapPath)
   CLog::Log(LOGINFO, "Loading {}", irMapPath);
   if (!xmlDoc.LoadFile(irMapPath))
   {
-    CLog::Log(LOGERROR, "{}, Line {}\n{}", irMapPath, xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+    CLog::LogMultiline(LOGERROR, "{}, Line {}\n{}", irMapPath, xmlDoc.ErrorRow(),
+                       xmlDoc.ErrorDesc());
     return false;
   }
 

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -980,7 +980,7 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo)
     return false; //This is actually good. The calling method will handle this
 
   case 202: //No match found
-    CLog::Log(
+    CLog::LogMultiline(
         LOGINFO,
         "Xcddb::queryCDinfo No match found in CDDB database when doing the query shown below:\n{}",
         query_buffer);

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -732,9 +732,9 @@ public:
   else
     dispatch_sync(dispatch_get_main_queue(), getInsets);
 
-  CLog::Log(LOGDEBUG, "insets: {}\nwindow: {}\nscreen: {}",
-            NSStringFromUIEdgeInsets(insets).UTF8String, m_window.description.UTF8String,
-            m_glView.currentScreen.description.UTF8String);
+  CLog::LogMultiline(LOGDEBUG, "insets: {}\nwindow: {}\nscreen: {}",
+                     NSStringFromUIEdgeInsets(insets).UTF8String, m_window.description.UTF8String,
+                     m_glView.currentScreen.description.UTF8String);
   if (UIEdgeInsetsEqualToEdgeInsets(insets, UIEdgeInsetsZero))
     return;
 

--- a/xbmc/platform/linux/network/zeroconf/ZeroconfBrowserAvahi.cpp
+++ b/xbmc/platform/linux/network/zeroconf/ZeroconfBrowserAvahi.cpp
@@ -159,9 +159,9 @@ bool CZeroconfBrowserAvahi::doResolveService ( CZeroconfBrowser::ZeroconfService
       it->first.GetName().c_str(), it->first.GetType().c_str(), it->first.GetDomain().c_str(),
                                        AVAHI_PROTO_UNSPEC, AvahiLookupFlags ( 0 ), resolveCallback, this ) )
     {
-      CLog::Log(LOGERROR,
-                "CZeroconfBrowserAvahi::doResolveService Failed to resolve service '{}': {}\n",
-                it->first.GetName(), avahi_strerror(avahi_client_errno(mp_client)));
+      CLog::LogMultiline(
+          LOGERROR, "CZeroconfBrowserAvahi::doResolveService Failed to resolve service '{}': {}\n",
+          it->first.GetName(), avahi_strerror(avahi_client_errno(mp_client)));
       return false;
     }
   } // end of this block releases lock of eventloop
@@ -230,13 +230,14 @@ void CZeroconfBrowserAvahi::browseCallback (
   switch ( event )
   {
     case AVAHI_BROWSER_FAILURE:
-      CLog::Log(LOGERROR, "CZeroconfBrowserAvahi::browseCallback error: {}\n",
-                avahi_strerror(avahi_client_errno(avahi_service_browser_get_client(browser))));
+      CLog::LogMultiline(
+          LOGERROR, "CZeroconfBrowserAvahi::browseCallback error: {}\n",
+          avahi_strerror(avahi_client_errno(avahi_service_browser_get_client(browser))));
       //! @todo implement
       return;
     case AVAHI_BROWSER_NEW:
       {
-        CLog::Log(
+        CLog::LogMultiline(
             LOGDEBUG,
             "CZeroconfBrowserAvahi::browseCallback NEW: service '{}' of type '{}' in domain '{}'\n",
             name, type, domain);
@@ -256,10 +257,11 @@ void CZeroconfBrowserAvahi::browseCallback (
         //remove the service
         ZeroconfService service(name, type, domain);
         p_instance->m_discovered_services.erase ( service );
-        CLog::Log(LOGDEBUG,
-                  "CZeroconfBrowserAvahi::browseCallback REMOVE: service '{}' of type '{}' in "
-                  "domain '{}'\n",
-                  name, type, domain);
+        CLog::LogMultiline(
+            LOGDEBUG,
+            "CZeroconfBrowserAvahi::browseCallback REMOVE: service '{}' of type '{}' in "
+            "domain '{}'\n",
+            name, type, domain);
         //if this browser already sent the all for now message, we need to update the gui now
         if( p_instance->m_all_for_now_browsers.find(browser) != p_instance->m_all_for_now_browsers.end() )
           update_gui = true;
@@ -324,19 +326,21 @@ void CZeroconfBrowserAvahi::resolveCallback(
   switch ( event )
   {
     case AVAHI_RESOLVER_FAILURE:
-      CLog::Log(LOGERROR,
-                "CZeroconfBrowserAvahi::resolveCallback Failed to resolve service '{}' of type "
-                "'{}' in domain '{}': {}\n",
-                name, type, domain,
-                avahi_strerror(avahi_client_errno(avahi_service_resolver_get_client(r))));
+      CLog::LogMultiline(
+          LOGERROR,
+          "CZeroconfBrowserAvahi::resolveCallback Failed to resolve service '{}' of type "
+          "'{}' in domain '{}': {}\n",
+          name, type, domain,
+          avahi_strerror(avahi_client_errno(avahi_service_resolver_get_client(r))));
       break;
     case AVAHI_RESOLVER_FOUND:
     {
       char a[AVAHI_ADDRESS_STR_MAX];
-      CLog::Log(LOGDEBUG,
-                "CZeroconfBrowserAvahi::resolveCallback resolved service '{}' of type '{}' in "
-                "domain '{}':\n",
-                name, type, domain);
+      CLog::LogMultiline(
+          LOGDEBUG,
+          "CZeroconfBrowserAvahi::resolveCallback resolved service '{}' of type '{}' in "
+          "domain '{}':\n",
+          name, type, domain);
 
       avahi_address_snprint ( a, sizeof ( a ), address );
       p_instance->m_resolving_service.SetIP(a);

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -561,15 +561,18 @@ bool CWSDiscoveryListenerUDP::equalsAddress(const wsd_req_info& lhs, const wsd_r
 
 void CWSDiscoveryListenerUDP::PrintWSDInfo(const wsd_req_info& info)
 {
-  CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
-            "CWSDiscoveryUtils::printstruct - message contents\n"
-            "\tAction: {}\n"
-            "\tMsgID: {}\n"
-            "\tAddress: {}\n"
-            "\tTypes: {}\n"
-            "\tXAddrs: {}\n"
-            "\tComputer: {}\n",
-            info.action, info.msgid, info.address, info.types, info.xaddrs, info.computer);
+  if (!CServiceBroker::GetLogging().CanLogComponent(LOGWSDISCOVERY))
+    return;
+
+  CLog::LogMultiline(LOGDEBUG,
+                     "CWSDiscoveryUtils::printstruct - message contents\n"
+                     "\tAction: {}\n"
+                     "\tMsgID: {}\n"
+                     "\tAddress: {}\n"
+                     "\tTypes: {}\n"
+                     "\tXAddrs: {}\n"
+                     "\tComputer: {}\n",
+                     info.action, info.msgid, info.address, info.types, info.xaddrs, info.computer);
 }
 
 void CWSDiscoveryListenerUDP::UnicastGet(wsd_req_info& info)

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -155,10 +155,10 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchComplete(LPCWSTR tag)
   for (const auto& ip : GetServersIPs())
     list.append('\n' + FromW(ip));
 
-  CLog::Log(LOGDEBUG,
-            "[WS-Discovery]: The initial servers search has completed successfully with {} "
-            "server(s) found:{}",
-            m_serversIPs.size(), list);
+  CLog::LogMultiline(LOGDEBUG,
+                     "[WS-Discovery]: The initial servers search has completed successfully with "
+                     "{} server(s) found:{}",
+                     m_serversIPs.size(), list);
 
   return S_OK;
 }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -179,8 +179,8 @@ bool CProfileManager::Load()
     }
     else
     {
-      CLog::Log(LOGERROR, "CProfileManager: error loading {}, Line {}\n{}", file,
-                profilesDoc.ErrorRow(), profilesDoc.ErrorDesc());
+      CLog::LogMultiline(LOGERROR, "CProfileManager: error loading {}, Line {}\n{}", file,
+                         profilesDoc.ErrorRow(), profilesDoc.ErrorDesc());
       ret = false;
     }
   }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -491,8 +491,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   if (!advancedXML.LoadFile(file))
   {
-    CLog::Log(LOGERROR, "Error loading {}, Line {}\n{}", file, advancedXML.ErrorRow(),
-              advancedXML.ErrorDesc());
+    CLog::LogMultiline(LOGERROR, "Error loading {}, Line {}\n{}", file, advancedXML.ErrorRow(),
+                       advancedXML.ErrorDesc());
     return;
   }
 
@@ -560,8 +560,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   advancedXMLCopy.Accept(&printer);
   // redact User/pass in URLs
   std::regex redactRe("(\\w+://)\\S+:\\S+@");
-  CLog::Log(LOGINFO, "Contents of {} are...\n{}", file,
-            std::regex_replace(printer.CStr(), redactRe, "$1USERNAME:PASSWORD@"));
+  CLog::LogMultiline(LOGINFO, "Contents of {} are...\n{}", file,
+                     std::regex_replace(printer.CStr(), redactRe, "$1USERNAME:PASSWORD@"));
 
   TiXmlElement *pElement = pRootElement->FirstChildElement("audio");
   if (pElement)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -626,8 +626,9 @@ bool CSettings::Initialize(const std::string &file)
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(file.c_str()))
   {
-    CLog::Log(LOGERROR, "CSettings: error loading settings definition from {}, Line {}\n{}", file,
-              xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+    CLog::LogMultiline(LOGERROR,
+                       "CSettings: error loading settings definition from {}, Line {}\n{}", file,
+                       xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
     return false;
   }
 

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -181,7 +181,7 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
       eglString.append(StringUtils::Format("{}: {}\n", keyStr, valueStr));
     }
 
-    CLog::Log(LOGDEBUG, "CEGLImage::{} - attributes:\n{}", __FUNCTION__, eglString);
+    CLog::LogMultiline(LOGDEBUG, "CEGLImage::{} - attributes:\n{}", __FUNCTION__, eglString);
   }
 
   if (!m_image)
@@ -235,7 +235,7 @@ bool CEGLImage::SupportsFormat(uint32_t format)
     for (const auto& supportedFormat : formats)
       formatStr.append("\n" + DRMHELPERS::FourCCToString(supportedFormat));
 
-    CLog::Log(LOGDEBUG, "CEGLImage::{} - supported formats:{}", __FUNCTION__, formatStr);
+    CLog::LogMultiline(LOGDEBUG, "CEGLImage::{} - supported formats:{}", __FUNCTION__, formatStr);
   }
 
   if (foundFormat != formats.end())
@@ -299,7 +299,8 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     for (const auto& supportedModifier : modifiers)
       modifierStr.append("\n" + DRMHELPERS::ModifierToString(supportedModifier));
 
-    CLog::Log(LOGDEBUG, "CEGLImage::{} - supported modifiers:{}", __FUNCTION__, modifierStr);
+    CLog::LogMultiline(LOGDEBUG, "CEGLImage::{} - supported modifiers:{}", __FUNCTION__,
+                       modifierStr);
   }
 
   if (foundModifier != modifiers.end())

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -115,7 +115,8 @@ void EglErrorCallback(EGLenum error,
     typeStr = eglType->second;
   }
 
-  CLog::Log(LOGDEBUG, "EGL Debugging:\nError: {}\nCommand: {}\nType: {}\nMessage: {}", errorStr, command, typeStr, message);
+  CLog::LogMultiline(LOGDEBUG, "EGL Debugging:\nError: {}\nCommand: {}\nType: {}\nMessage: {}",
+                     errorStr, command, typeStr, message);
 }
 
 std::set<std::string> CEGLUtils::GetClientExtensions()

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -99,17 +99,20 @@ void KODI::UTILS::GL::GlErrorCallback(GLenum source, GLenum type, GLuint id, GLe
     severityStr = glSeverity->second;
   }
 
-  CLog::Log(LOGDEBUG, "OpenGL(ES) Debugging:\nSource: {}\nType: {}\nSeverity: {}\nID: {}\nMessage: {}", sourceStr, typeStr, severityStr, id, message);
+  CLog::LogMultiline(
+      LOGDEBUG, "OpenGL(ES) Debugging:\nSource: {}\nType: {}\nSeverity: {}\nID: {}\nMessage: {}",
+      sourceStr, typeStr, severityStr, id, message);
 }
 
 static void PrintMatrix(const GLfloat* matrix, const std::string& matrixName)
 {
-  CLog::Log(LOGDEBUG, "{}:\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}",
-                      matrixName,
-                      matrix[0], matrix[1], matrix[2], matrix[3],
-                      matrix[4], matrix[5], matrix[6], matrix[7],
-                      matrix[8], matrix[9], matrix[10], matrix[11],
-                      matrix[12], matrix[13], matrix[14], matrix[15]);
+  CLog::LogMultiline(LOGDEBUG,
+                     "{}:\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> "
+                     "10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} "
+                     "{:> 10.3f} {:> 10.3f} {:> 10.3f}",
+                     matrixName, matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5],
+                     matrix[6], matrix[7], matrix[8], matrix[9], matrix[10], matrix[11], matrix[12],
+                     matrix[13], matrix[14], matrix[15]);
 }
 
 void _VerifyGLState(const char* szfile, const char* szfunction, int lineno)

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -106,8 +106,8 @@ bool CRssManager::Load()
   CXBMCTinyXML rssDoc;
   if (!rssDoc.LoadFile(rssXML))
   {
-    CLog::Log(LOGERROR, "CRssManager: error loading {}, Line {}\n{}", rssXML, rssDoc.ErrorRow(),
-              rssDoc.ErrorDesc());
+    CLog::LogMultiline(LOGERROR, "CRssManager: error loading {}, Line {}\n{}", rssXML,
+                       rssDoc.ErrorRow(), rssDoc.ErrorDesc());
     return false;
   }
 

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -175,8 +175,8 @@ void CLog::SetLogLevel(int level)
     return;
 
   spdlog::set_level(spdLevel);
-  FormatAndLogInternal(spdlog::level::info, "Log level changed to \"{}\"",
-                       spdlog::level::to_string_view(spdLevel));
+  LogInternal(spdlog::level::info, "Log level changed to \"{}\"",
+              spdlog::level::to_string_view(spdLevel));
 }
 
 bool CLog::IsLogLevelLogged(int loglevel)

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -94,11 +94,17 @@ public:
   }
 
   template<typename... Args>
+  static inline void LogMultiline(int level, const std::string_view& format, Args&&... args)
+  {
+    GetInstance().FormatAndLogInternal(MapLogLevel(level), format, std::forward<Args>(args)...);
+  }
+
+  template<typename... Args>
   static inline void Log(spdlog::level::level_enum level,
                          const std::string_view& format,
                          Args&&... args)
   {
-    GetInstance().FormatAndLogInternal(level, format, std::forward<Args>(args)...);
+    GetInstance().LogInternal(level, format, std::forward<Args>(args)...);
   }
 
   template<typename... Args>
@@ -121,6 +127,14 @@ private:
   static CLog& GetInstance();
 
   static spdlog::level::level_enum MapLogLevel(int level);
+
+  template<typename... Args>
+  inline void LogInternal(spdlog::level::level_enum level,
+                          const std::string_view& format,
+                          Args&&... args)
+  {
+    m_defaultLogger->log(level, format, std::forward<Args>(args)...);
+  }
 
   template<typename... Args>
   inline void FormatAndLogInternal(spdlog::level::level_enum level,

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -421,6 +421,6 @@ void CResolutionUtils::PrintWhitelist()
       modeStr.append("\n" + info.strMode);
     }
 
-    CLog::Log(LOGDEBUG, "[WHITELIST] whitelisted modes:{}", modeStr);
+    CLog::LogMultiline(LOGDEBUG, "[WHITELIST] whitelisted modes:{}", modeStr);
   }
 }

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -335,7 +335,7 @@ void CDRMAtomic::CDRMAtomicRequest::LogAtomicRequest(
                      "\tValue: " + std::to_string(property.second));
   }
 
-  CLog::Log(logLevel, "{}", message);
+  CLog::LogMultiline(logLevel, "{}", message);
 }
 
 void CDRMAtomic::CDRMAtomicRequest::DrmModeAtomicReqDeleter::operator()(drmModeAtomicReqPtr p) const

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -310,7 +310,7 @@ void CDRMUtils::PrintDrmDeviceInfo(drmDevicePtr device)
     message.append("\n    unhandled bus type");
   // clang-format on
 
-  CLog::Log(LOGDEBUG, "{}", message);
+  CLog::LogMultiline(LOGDEBUG, "{}", message);
 }
 
 bool CDRMUtils::OpenDrm(bool needConnector)


### PR DESCRIPTION
## Description
CLog: optimize logs performance, avoids string formatting and search/replace if line is not being logged

## Motivation and context
Currently all log lines (even if are not logged due log level is lower that current log level) are processed by:

https://github.com/xbmc/xbmc/blob/1d0dc77d43b4730f3b8708a84d931ce3c161d2d0/xbmc/utils/log.h#L129-L132

I want to get rid of this because, even if the performance impact is minimal, it is useless work.

The logs (like everything else) must be optimized to the maximum. With even more reason, the logs because if they have a minimal influence on performance, it is possible that some issues vary or stop being reproduced when the logs are enabled/disabled.

`StringUtils::Replace` only is used in case of multi-line logs. Those are very specific cases and it does not make sense to include that overhead in everything.

I have basically separated the multi-line log function into a new method `LogMultiline` and standard `Log`, `LogF`, `LogFC` are now performance optimized but without multi-line support.

I have opened this PR to know the opinion of others and see if doing this is viable/possible.

I also need ideas/feedback to know in which places we are using multi-line and therefore the new function should be replaced to not break anything.

Further analysis reveals that `\n` is not used anywhere else (quite safely). Then no other changes need to be made and it could be applied as is.

~So far I have Only~ replaced it in ~3~ 43 places:

AdvancedSettings:
```c++
  printer.SetLineBreak("\n");
  printer.SetIndent("  ");
  advancedXMLCopy.Accept(&printer);
  // redact User/pass in URLs
  std::regex redactRe("(\\w+://)\\S+:\\S+@");
  CLog::LogMultiline(LOGINFO, "Contents of {} are...\n{}", file,
            std::regex_replace(printer.CStr(), redactRe, "$1USERNAME:PASSWORD@"));
```

WS-Discovery:
```c++
  std::string list;

  for (const auto& ip : GetServersIPs())
    list.append('\n' + FromW(ip));

  CLog::LogMultiline(LOGDEBUG,
                     "[WS-Discovery]: The initial servers search has completed successfully with "
                     "{} server(s) found:{}",
                     m_serversIPs.size(), list);
```

WHITELIST:
```c++
  if (!indexList.empty())
  {
    for (const auto& mode : indexList)
    {
      auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
      const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
      modeStr.append('\n' + info.strMode);
    }

    CLog::LogMultiline(LOGDEBUG, "[WHITELIST] whitelisted modes:{}", modeStr);
  }
```

## How has this been tested?
Windows x64

## What is the effect on users?
Saves some CPU cycles 😄


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
