### PR TITLE
MediaCodecAndroid: Reset cached decoding timestamp after flushing decoder

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1096,6 +1096,7 @@ void CDVDVideoCodecAndroidMediaCodec::Reset()
     // Invalidate our local VideoPicture bits
     m_videobuffer.pts = DVD_NOPTS_VALUE;
 
+    m_dtsShift = DVD_NOPTS_VALUE;
     m_indexInputBuffer = -1;
 
     if (m_bitstream)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
`m_dtsShift` is not altered after a flush/reset. Seeking is affected when starting a stream from a non-zero position i.e resume, and also live streams (except starting from zero). So really it seems by chance things work ok most of the time.

After seeking and flush/reset and when adding new frames, adjusting dts shift is not performed here https://github.com/xbmc/xbmc/blob/1d0dc77d43b4730f3b8708a84d931ce3c161d2d0/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp#L1018-L1019 so frames are added to the MediaCodec buffer with pts equal to the dts when playback first begins. As mentioned above, when this is zero it's not a problem but when it's not we end up with this situation once VideoPlayer tries to get playback going again after a seek:
```
DEBUG <general>: VideoPlayer::Sync - Audio - pts: 127802630.000000, cache: 301859.378815, totalcache: 760725.617409
DEBUG <general>: VideoPlayer::Sync - Video - pts: 299424124.000000, cache: 50000.000000, totalcache: 100000.000000
```
And the result the user sees is a mainly frozen picture which can update periodically but never seems to recover. Audio continues however.

It also needs to be noted that this issue isn't reproducible on all Android configurations, for example I can't reproduce it on Android emulator Pixel3 11 x86_64, I'm not yet familiar enough with how other components may tie into this or if something lucky is happening to mask the issue like dropped frames...

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves: 
https://github.com/xbmc/xbmc/issues/19713 (there's a lot of noise there but I refer to the issue as described by OP)
https://github.com/xbmc/inputstream.adaptive/issues/785

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Pixel 3/Android 11 with inputstream.adaptive and YouTube


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
