### PR TITLE
WASAPI: code modernization and error fix

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -52,26 +52,7 @@ inline void SafeRelease(T **ppT)
 
 using namespace Microsoft::WRL;
 
-CAESinkWASAPI::CAESinkWASAPI() :
-  m_needDataEvent(0),
-  m_pDevice(nullptr),
-  m_pAudioClient(nullptr),
-  m_pRenderClient(nullptr),
-  m_pAudioClock(nullptr),
-  m_encodedChannels(0),
-  m_encodedSampleRate(0),
-  sinkReqFormat(AE_FMT_INVALID),
-  sinkRetFormat(AE_FMT_INVALID),
-  m_running(false),
-  m_initialized(false),
-  m_isSuspended(false),
-  m_isDirty(false),
-  m_uiBufferLen(0),
-  m_avgTimeWaiting(50),
-  m_sinkLatency(0.0),
-  m_sinkFrames(0),
-  m_clockFreq(0),
-  m_bufferPtr(0)
+CAESinkWASAPI::CAESinkWASAPI()
 {
   m_channelLayout.Reset();
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -918,7 +918,7 @@ initialize:
     CLog::Log(LOGDEBUG, "  Enc. Channels   : {}", wfxex_iec61937.dwEncodedChannelCount);
     CLog::Log(LOGDEBUG, "  Enc. Samples/Sec: {}", wfxex_iec61937.dwEncodedSamplesPerSec);
     CLog::Log(LOGDEBUG, "  Channel Mask    : {}", wfxex.dwChannelMask);
-    CLog::Log(LOGDEBUG, "  Periodicty      : {:I64}", audioSinkBufferDurationMsec);
+    CLog::Log(LOGDEBUG, "  Periodicty      : {}", audioSinkBufferDurationMsec);
     return false;
   }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -71,7 +71,6 @@ CAESinkWASAPI::CAESinkWASAPI() :
   m_sinkLatency(0.0),
   m_sinkFrames(0),
   m_clockFreq(0),
-  m_pBuffer(nullptr),
   m_bufferPtr(0)
 {
   m_channelLayout.Reset();
@@ -182,8 +181,7 @@ bool CAESinkWASAPI::Initialize(AEAudioFormat &format, std::string &device)
   // if the device is opened exclusive and event driven, provided samples must match buffersize
   // ActiveAE tries to align provided samples with buffer size but cannot guarantee (e.g. transcoding)
   // this can be avoided by dropping the event mode which has not much benefit; SoftAE polls anyway
-  delete [] m_pBuffer;
-  m_pBuffer = new uint8_t[format.m_frames * format.m_frameSize];
+  m_buffer.resize(format.m_frames * format.m_frameSize);
   m_bufferPtr = 0;
 
   return true;
@@ -229,7 +227,6 @@ void CAESinkWASAPI::Deinitialize()
 
   m_initialized = false;
 
-  delete [] m_pBuffer;
   m_bufferPtr = 0;
 }
 
@@ -291,7 +288,8 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t **data, unsigned int frames, unsi
   uint8_t *buffer = data[0]+offset*m_format.m_frameSize;
   if (m_bufferPtr != 0 || frames != m_format.m_frames)
   {
-    memcpy(m_pBuffer+m_bufferPtr*m_format.m_frameSize, buffer, FramesToCopy*m_format.m_frameSize);
+    memcpy(m_buffer.data() + m_bufferPtr * m_format.m_frameSize, buffer,
+           FramesToCopy * m_format.m_frameSize);
     m_bufferPtr += FramesToCopy;
     if (m_bufferPtr != m_format.m_frames)
       return frames;
@@ -370,17 +368,21 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t **data, unsigned int frames, unsi
   hr = m_pRenderClient->GetBuffer(NumFramesRequested, &buf);
   if (FAILED(hr))
   {
-    #ifdef _DEBUG
+#ifdef _DEBUG
     CLog::LogF(LOGERROR, "GetBuffer failed due to {}", WASAPIErrToStr(hr));
 #endif
     return INT_MAX;
   }
-  memcpy(buf, m_bufferPtr == 0 ? buffer : m_pBuffer, NumFramesRequested * m_format.m_frameSize); //fill buffer
+
+  // fill buffer
+  memcpy(buf, m_bufferPtr == 0 ? buffer : m_buffer.data(),
+         NumFramesRequested * m_format.m_frameSize);
   m_bufferPtr = 0;
+
   hr = m_pRenderClient->ReleaseBuffer(NumFramesRequested, flags); //pass back to audio driver
   if (FAILED(hr))
   {
-    #ifdef _DEBUG
+#ifdef _DEBUG
     CLog::LogF(LOGDEBUG, "ReleaseBuffer failed due to {}.", WASAPIErrToStr(hr));
 #endif
     return INT_MAX;
@@ -390,7 +392,8 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t **data, unsigned int frames, unsi
   if (FramesToCopy != frames)
   {
     m_bufferPtr = frames-FramesToCopy;
-    memcpy(m_pBuffer, buffer+FramesToCopy*m_format.m_frameSize, m_bufferPtr*m_format.m_frameSize);
+    memcpy(m_buffer.data(), buffer + FramesToCopy * m_format.m_frameSize,
+           m_bufferPtr * m_format.m_frameSize);
   }
 
   return frames;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -13,6 +13,7 @@
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 
 #include <stdint.h>
+#include <vector>
 
 #include <Audioclient.h>
 #include <mmdeviceapi.h>
@@ -68,6 +69,6 @@ private:
     uint64_t            m_sinkFrames;
     uint64_t            m_clockFreq;
 
-    uint8_t            *m_pBuffer;
+    std::vector<uint8_t> m_buffer;
     int                 m_bufferPtr;
 };

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -43,32 +43,34 @@ private:
     static void BuildWaveFormatExtensibleIEC61397(AEAudioFormat &format, WAVEFORMATEXTENSIBLE_IEC61937 &wfxex);
     bool IsUSBDevice();
 
-    HANDLE m_needDataEvent;
-    IAEWASAPIDevice* m_pDevice;
+    HANDLE m_needDataEvent{0};
+    IAEWASAPIDevice* m_pDevice{nullptr};
     Microsoft::WRL::ComPtr<IAudioClient> m_pAudioClient;
     Microsoft::WRL::ComPtr<IAudioRenderClient> m_pRenderClient;
     Microsoft::WRL::ComPtr<IAudioClock> m_pAudioClock;
 
-    AEAudioFormat       m_format;
-    unsigned int        m_encodedChannels;
-    unsigned int        m_encodedSampleRate;
-    CAEChannelInfo      m_channelLayout;
-    std::string         m_device;
+    AEAudioFormat m_format{};
+    unsigned int m_encodedChannels{0};
+    unsigned int m_encodedSampleRate{0};
+    CAEChannelInfo m_channelLayout;
+    std::string m_device;
 
-    enum AEDataFormat   sinkReqFormat;
-    enum AEDataFormat   sinkRetFormat;
+    enum AEDataFormat sinkReqFormat = AE_FMT_INVALID;
+    enum AEDataFormat sinkRetFormat = AE_FMT_INVALID;
 
-    bool                m_running;
-    bool                m_initialized;
-    bool                m_isSuspended;    /* sink is in a suspended state - release audio device */
-    bool                m_isDirty;        /* sink output failed - needs re-init or new device */
+    bool m_running{false};
+    bool m_initialized{false};
+    bool m_isSuspended{false}; // sink is in a suspended state - release audio device
+    bool m_isDirty{false}; // sink output failed - needs re-init or new device
 
-    unsigned int        m_uiBufferLen;    /* wasapi endpoint buffer size, in frames */
-    double              m_avgTimeWaiting; /* time between next buffer of data from SoftAE and driver call for data */
-    double              m_sinkLatency;    /* time in seconds of total duration of the two WASAPI buffers */
-    uint64_t            m_sinkFrames;
-    uint64_t            m_clockFreq;
+    // time between next buffer of data from SoftAE and driver call for data
+    double m_avgTimeWaiting{50.0};
+    double m_sinkLatency{0.0}; // time in seconds of total duration of the two WASAPI buffers
+
+    unsigned int m_uiBufferLen{0}; // wasapi endpoint buffer size, in frames
+    uint64_t m_sinkFrames{0};
+    uint64_t m_clockFreq{0};
 
     std::vector<uint8_t> m_buffer;
-    int                 m_bufferPtr;
+    int m_bufferPtr{0};
 };


### PR DESCRIPTION
## Description
WASAPI: code modernization and error fix.

## Motivation and context
Some users experiments random issues related to WASAPI audio fails to initialize. Is also related to the fact that during video mode switch (Setting: Display adjust refresh rate at Start/Stop) generates display lost event due HDMI mode change in whole chain.

See: https://forum.kodi.tv/showthread.php?tid=361253

This PR attempts to fix this.

## How has this been tested?
Although that I am not experiment this issue in Intel NUC8i3BEK I managed to simulate/force somehow and I'm pretty sure this will work fine 😃 

## What is the effect on users?
Attempts to fix "sporadically no sound and video freezes".

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
