### PR TITLE
[Jenkins][build ffmpeg] Forces delete build folder and creates it clean

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -167,11 +167,14 @@ do_clean_get() {
 PATH_CHANGE_REV_FILENAME=".last_success_revision"
 
 #hash a dir based on the git revision and $TRIPLET
-#params paths to be hashed
+#param1 path to be hashed
 function getBuildHash ()
 {
+  local checkPath
+  checkPath="$1"
+  shift 1
   local hashStr
-  hashStr="$(git rev-list HEAD --max-count=1  -- $@)"
+  hashStr="$(git rev-list HEAD --max-count=1  -- $checkPath $@)"
   hashStr="$hashStr $@ $TRIPLET"
   echo $hashStr
 }

--- a/tools/buildsteps/windows/make-mingwlibs.bat
+++ b/tools/buildsteps/windows/make-mingwlibs.bat
@@ -5,9 +5,10 @@ PUSHD %~dp0\..\..\..
 SET WORKDIR=%CD%
 POPD
 
-REM recreates ffmpeg build dir in case it does not exist
+REM forces delete build folder and creates it clean
 SET BUILD_DIR=%WORKDIR%\project\BuildDependencies\build
-IF NOT EXIST %BUILD_DIR% mkdir %BUILD_DIR%
+IF EXIST %BUILD_DIR% rmdir /S /Q %BUILD_DIR%
+mkdir %BUILD_DIR%
 
 SET PROMPTLEVEL=prompt
 SET BUILDMODE=clean

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -18,8 +18,3 @@ SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "p
 
 ECHO running %GIT_CLEAN_CMD%
 %GIT_CLEAN_CMD%
-
-REM 'build' dir is necessary to extract ffmpeg code
-REM we prevents missing under certain circumstances (early creation)
-SET BUILD_FFMPEG=%WORKSPACE%\project\BuildDependencies\build
-IF NOT EXIST %BUILD_FFMPEG% mkdir %BUILD_FFMPEG%


### PR DESCRIPTION
## Description
Forces delete ffmpeg build folder and creates it clean

## Motivation and context
This is a follow of https://github.com/xbmc/xbmc/pull/20767

Seen in some jenkins log that some rare times `git clean -xffd`  fails because cannot delete `build` folder. Probably in use by other process/thread ?

`build` folder should not exist when this script is executed (or should be empty).

Now is deleted in case still exists...


## How has this been tested?
Tested locally


## What is the effect on users?
N/A


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
