### PR TITLE
[db] fix sorting of movies by year from json-rpc call

### DIFF
--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -479,7 +479,8 @@ bool DatabaseUtils::GetDatabaseResults(const MediaType &mediaType, const FieldLi
                   resultSet.record_header[fieldIndex].name);
 
       if (value.first == FieldYear &&
-         (mediaType == MediaTypeTvShow || mediaType == MediaTypeEpisode))
+          (mediaType == MediaTypeTvShow || mediaType == MediaTypeEpisode ||
+           mediaType == MediaTypeMovie))
       {
         CDateTime dateTime;
         dateTime.SetFromDBDate(value.second.asString());


### PR DESCRIPTION
## Description
the sortLabel for movies is not populated correctly after the data was retrieved from the database.

the premiered date in the database is stored formatted like `yyyy-mm-dd` which results in a wrong cast in SortUtils:
https://github.com/xbmc/xbmc/blob/30f7803d80be535479c755303bf1a8443d8e8dcb/xbmc/utils/SortUtils.cpp#L234

result is `0` due to the fallback in CVariant

## Motivation and context
ref. https://forum.kodi.tv/showthread.php?tid=366329

## How has this been tested?
execute request 
```
{"jsonrpc":"2.0","method":"VideoLibrary.GetMovies","id":1,
       "params":{"filter":{"setid":37},"properties":["year"],
       "sort":{"order":"ascending","method":"year","ignorearticle":false}}}
```
sortlabels before this pr:
```
"0 Angel Has Fallen"
"0 London Has Fallen"
"0 Olympus Has Fallen - Die Welt in Gefahr"
```
after:
```
"2019 Angel Has Fallen"
"2016 London Has Fallen"
"2013 Olympus Has Fallen - Die Welt in Gefahr"
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
