### PR TITLE
[Webserver][libmicrohttpd] Update deprecated error status for libmicr…

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -597,7 +597,9 @@ bool CWebServer::ProcessPostData(const HTTPRequest& request,
     if (!postDataHandled)
     {
       m_logger->error("failed to handle HTTP POST data for {}", request.pathUrl);
-#if (MHD_VERSION >= 0x00095213)
+#if (MHD_VERSION >= 0x00097400)
+      connectionHandler->errorStatus = MHD_HTTP_CONTENT_TOO_LARGE;
+#elif (MHD_VERSION >= 0x00095213)
       connectionHandler->errorStatus = MHD_HTTP_PAYLOAD_TOO_LARGE;
 #else
       connectionHandler->errorStatus = MHD_HTTP_REQUEST_ENTITY_TOO_LARGE;


### PR DESCRIPTION
…ohttpd > 0.9.74

## Description
Found while investigating other issue, there's a compiler error when building with libmicrohttp > 0.9.74.
`MHD_HTTP_PAYLOAD_TOO_LARGE` is deprecated and has been replaced by `MHD_HTTP_CONTENT_TOO_LARGE`