### PR TITLE
[Linux][udisks] Always mount optical media by default

### DIFF
--- a/xbmc/platform/linux/storage/UDisks2Provider.cpp
+++ b/xbmc/platform/linux/storage/UDisks2Provider.cpp
@@ -435,10 +435,15 @@ void CUDisks2Provider::FilesystemAdded(Filesystem *fs, bool isNew)
     m_filesystems[fs->GetObject()] = fs;
   }
 
-  if (fs->IsReady() && !fs->IsMounted() &&
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_handleMounting)
+  if (fs->IsReady() && !fs->IsMounted())
   {
-    fs->Mount();
+    // optical drives should be always mounted by default unless explicitly disabled by the user
+    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_handleMounting ||
+        (fs->IsOptical() &&
+         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_autoMountOpticalMedia))
+    {
+      fs->Mount();
+    }
   }
 }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -909,6 +909,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   XMLUtils::GetInt(pRootElement,     "airplayport", m_airPlayPort);
 
   XMLUtils::GetBoolean(pRootElement, "handlemounting", m_handleMounting);
+  XMLUtils::GetBoolean(pRootElement, "automountopticalmedia", m_autoMountOpticalMedia);
 
 #if defined(TARGET_WINDOWS_DESKTOP)
   XMLUtils::GetBoolean(pRootElement, "minimizetotray", m_minimizeToTray);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -191,7 +191,16 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_airTunesPort;
     int m_airPlayPort;
 
+    /*! \brief Only used in linux for the udisks and udisks2 providers
+    * defines if kodi should automount media drives
+    * @note if kodi is running standalone (--standalone option) it will
+    * be set to tue
+    */
     bool m_handleMounting;
+    /*! \brief Only used in linux for the udisks and udisks2 providers
+    * defines if kodi should automount optical discs
+    */
+    bool m_autoMountOpticalMedia{true};
 
     bool m_fullScreenOnMovieStart;
     std::string m_cachePath;


### PR DESCRIPTION
## Description
Currently the experience for optical discs (e.g. physical DVDs) is far from optimal on Linux. By default, once you insert a physical disc on your drive the default skin will show you have a DISC with options to play or eject:

![image](https://user-images.githubusercontent.com/7375276/149007966-0aa93faf-c4b0-47c2-85b3-36140149b3d1.png)

However, to be able to play the disc **you have to mount it manually on your desktop environment**. This is only true is Kodi is not running standalone (e.g. without providing the `--standalone` arg or running kodi-standalone.sh). If running standalone, the [handlemounting](https://kodi.wiki/view/Advancedsettings.xml#handlemounting) advanced setting will be set to `true` automatically and any discs will be automounted by kodi (all of them, including DVDs/BRs). While I understand the reason for this distinction so distros like Libreleec that run kodi standalone can handle generic disc mounting (while modern DEs automatically mount media for us) I think that by default Kodi should have an exception for optical discs. DEs like gnome, for example, do not automount DVDs by default without further settings/configs by the user.

IMHO if kodi, as a GUI application, shows in the UI that a disc is available for playback, it should be able to play it. It should handle the mounting of the optical disk on behalf of the user. This behaviour should be default... and at most... advanced users could disable it via an advancedsetting (not the opposite). 

That's what this PR does, by default Kodi (udisks and udisks2 storage providers) mounts optical media unless "automountopticalmedia" advanced setting is set to false. "handleautomounting" bypasses this setting since it mounts ALL discs (optical or not).

## Motivation and context
Improve UX, make it simpler for users to watch their media without having to dive into the code or read 1500 wikis and forum posts :). For example the handlemounting advanced setting was not even documented anywhere.