### PR TITLE
make sure we really link spdlog

### DIFF
--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -37,6 +37,10 @@ if(ENABLE_INTERNAL_SPDLOG)
     if(WIN32 OR WINDOWS_STORE)
       set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/001-windows-pdb-symbol-gen.patch")
       generate_patchcommand("${patches}")
+
+      set(EXTRA_ARGS -DSPDLOG_WCHAR_SUPPORT=ON
+                     -DSPDLOG_WCHAR_FILENAMES=ON)
+
     endif()
 
     set(SPDLOG_VERSION ${${MODULE}_VER})
@@ -49,7 +53,7 @@ if(ENABLE_INTERNAL_SPDLOG)
                    -DSPDLOG_BUILD_TESTS=OFF
                    -DSPDLOG_BUILD_BENCH=OFF
                    -DSPDLOG_FMT_EXTERNAL=ON
-                   "${EXTRA_ARGS}")
+                   ${EXTRA_ARGS})
 
     BUILD_DEP_TARGET()
 
@@ -91,32 +95,34 @@ if(SPDLOG_FOUND)
   set(SPDLOG_DEFINITIONS -DSPDLOG_FMT_EXTERNAL
                          -DSPDLOG_DEBUG_ON
                          -DSPDLOG_NO_ATOMIC_LEVELS
-                         -DSPDLOG_ENABLE_PATTERN_PADDING)
+                         -DSPDLOG_ENABLE_PATTERN_PADDING
+                         -DSPDLOG_COMPILED_LIB
+                         ${PC_SPDLOG_CFLAGS})
   if(WIN32)
     list(APPEND SPDLOG_DEFINITIONS -DSPDLOG_WCHAR_FILENAMES
                                    -DSPDLOG_WCHAR_TO_UTF8_SUPPORT)
   endif()
 
-  if(NOT TARGET Spdlog::Spdlog)
-    add_library(Spdlog::Spdlog UNKNOWN IMPORTED)
+  if(NOT TARGET spdlog::spdlog)
+    add_library(spdlog::spdlog UNKNOWN IMPORTED)
     if(SPDLOG_LIBRARY_RELEASE)
-      set_target_properties(Spdlog::Spdlog PROPERTIES
+      set_target_properties(spdlog::spdlog PROPERTIES
                                            IMPORTED_CONFIGURATIONS RELEASE
                                            IMPORTED_LOCATION "${SPDLOG_LIBRARY_RELEASE}")
     endif()
     if(SPDLOG_LIBRARY_DEBUG)
-      set_target_properties(Spdlog::Spdlog PROPERTIES
+      set_target_properties(spdlog::spdlog PROPERTIES
                                            IMPORTED_CONFIGURATIONS DEBUG
                                            IMPORTED_LOCATION "${SPDLOG_LIBRARY_DEBUG}")
     endif()
-    set_target_properties(Spdlog::Spdlog PROPERTIES
+    set_target_properties(spdlog::spdlog PROPERTIES
                                          INTERFACE_INCLUDE_DIRECTORIES "${SPDLOG_INCLUDE_DIR}"
                                          INTERFACE_COMPILE_DEFINITIONS "${SPDLOG_DEFINITIONS}")
   endif()
   if(TARGET spdlog)
-    add_dependencies(Spdlog::Spdlog spdlog)
+    add_dependencies(spdlog::spdlog spdlog)
   endif()
-  set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP Spdlog::Spdlog)
+  set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP spdlog::spdlog)
 endif()
 
 mark_as_advanced(SPDLOG_INCLUDE_DIR SPDLOG_LIBRARY)

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -12,6 +12,7 @@
 #include "AEStreamInfo.h"
 #include "utils/log.h"
 
+#include <array>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+#include <array>
 #include <mutex>
 
 #include <drm_fourcc.h>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -27,6 +27,7 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/X11/WinSystemX11.h"
 
+#include <array>
 #include <mutex>
 
 #include <dlfcn.h>

--- a/xbmc/platform/linux/test/TestSysfsPath.cpp
+++ b/xbmc/platform/linux/test/TestSysfsPath.cpp
@@ -70,7 +70,7 @@ TEST_F(TestSysfsPath, SysfsPathTestString)
 
 TEST_F(TestSysfsPath, SysfsPathTestLongString)
 {
-  std::string filepath = GetTestFilePath();
+  std::string filepath = GetTestFilePath().append("-long");
   std::ofstream m_output{filepath};
 
   std::string temp{"test with spaces"};

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -161,7 +161,7 @@ TEST_F(TestRegExpLog, DumpOvector)
 
   EXPECT_STREQ("\xEF\xBB\xBF", logstring.substr(0, 3).c_str());
 
-  EXPECT_TRUE(regex.RegComp(".*DEBUG <general>: regexp ovector=\\{\\[0,12\\],\\[0,4\\],"
+  EXPECT_TRUE(regex.RegComp(".*(debug|DEBUG) <general>: regexp ovector=\\{\\[0,12\\],\\[0,4\\],"
                             "\\[5,11\\]\\}.*"));
   EXPECT_GE(regex.RegFind(logstring), 0);
 

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -60,17 +60,17 @@ TEST_F(Testlog, Log)
 
   EXPECT_STREQ("\xEF\xBB\xBF", logstring.substr(0, 3).c_str());
 
-  EXPECT_TRUE(regex.RegComp(".*DEBUG <general>: debug log message.*"));
+  EXPECT_TRUE(regex.RegComp(".*(debug|DEBUG) <general>: debug log message.*"));
   EXPECT_GE(regex.RegFind(logstring), 0);
-  EXPECT_TRUE(regex.RegComp(".*INFO <general>: info log message.*"));
+  EXPECT_TRUE(regex.RegComp(".*(info|INFO) <general>: info log message.*"));
   EXPECT_GE(regex.RegFind(logstring), 0);
-  EXPECT_TRUE(regex.RegComp(".*WARNING <general>: warning log message.*"));
+  EXPECT_TRUE(regex.RegComp(".*(warning|WARNING) <general>: warning log message.*"));
   EXPECT_GE(regex.RegFind(logstring), 0);
-  EXPECT_TRUE(regex.RegComp(".*ERROR <general>: error log message.*"));
+  EXPECT_TRUE(regex.RegComp(".*(error|ERROR) <general>: error log message.*"));
   EXPECT_GE(regex.RegFind(logstring), 0);
-  EXPECT_TRUE(regex.RegComp(".*FATAL <general>: fatal log message.*"));
+  EXPECT_TRUE(regex.RegComp(".*(critical|CRITICAL|fatal|FATAL) <general>: fatal log message.*"));
   EXPECT_GE(regex.RegFind(logstring), 0);
-  EXPECT_TRUE(regex.RegComp(".*OFF <general>: none type log message.*"));
+  EXPECT_TRUE(regex.RegComp(".*(off|OFF) <general>: none type log message.*"));
   EXPECT_GE(regex.RegFind(logstring), 0);
 
   EXPECT_TRUE(XFILE::CFile::Delete(logfile));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Currently we use spdlog in header only mode, because the needed define to link against the lib is missing.
GCC will omit linking against the lib completely while Clang, curiously, still links against spdlog.so

Adding the define fixes GCC and seems to make no difference for Clang, both will link the lib. 


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/xbmc/xbmc/pull/17498#issuecomment-619024975

reproduced and diagnosed by @notspiff and me on slack

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

compiled on linux with GCC and Clang

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
