### PR TITLE
[List inception] Fix use-after-free for list within a list

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -48,22 +48,65 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, fl
   m_cacheItems = preloadItems;
   m_scrollItemsPerFrame = 0.0f;
   m_type = VIEW_TYPE_NONE;
-  m_listProvider = NULL;
   m_autoScrollMoveTime = 0;
   m_autoScrollDelayTime = 0;
   m_autoScrollIsReversed = false;
   m_lastRenderTime = 0;
 }
 
-CGUIBaseContainer::CGUIBaseContainer(const CGUIBaseContainer &) = default;
+CGUIBaseContainer::CGUIBaseContainer(const CGUIBaseContainer& other)
+  : IGUIContainer(other),
+    m_renderOffset(other.m_renderOffset),
+    m_analogScrollCount(other.m_analogScrollCount),
+    m_lastHoldTime(other.m_lastHoldTime),
+    m_orientation(other.m_orientation),
+    m_itemsPerPage(other.m_itemsPerPage),
+    m_pageControl(other.m_pageControl),
+    m_layoutCondition(other.m_layoutCondition),
+    m_focusedLayoutCondition(other.m_focusedLayoutCondition),
+    m_scroller(other.m_scroller),
+    m_listProvider(other.m_listProvider ? other.m_listProvider->Clone() : nullptr),
+    m_wasReset(other.m_wasReset),
+    m_letterOffsets(other.m_letterOffsets),
+    m_autoScrollCondition(other.m_autoScrollCondition),
+    m_autoScrollMoveTime(other.m_autoScrollMoveTime),
+    m_autoScrollDelayTime(other.m_autoScrollDelayTime),
+    m_autoScrollIsReversed(other.m_autoScrollIsReversed),
+    m_lastRenderTime(other.m_lastRenderTime),
+    m_cursor(other.m_cursor),
+    m_offset(other.m_offset),
+    m_cacheItems(other.m_cacheItems),
+    m_scrollTimer(other.m_scrollTimer),
+    m_lastScrollStartTimer(other.m_lastScrollStartTimer),
+    m_pageChangeTimer(other.m_pageChangeTimer),
+    m_clickActions(other.m_clickActions),
+    m_focusActions(other.m_focusActions),
+    m_unfocusActions(other.m_unfocusActions),
+    m_matchTimer(other.m_matchTimer),
+    m_match(other.m_match),
+    m_scrollItemsPerFrame(other.m_scrollItemsPerFrame),
+    m_gestureActive(other.m_gestureActive),
+    m_waitForScrollEnd(other.m_waitForScrollEnd),
+    m_lastScrollValue(other.m_lastScrollValue)
+{
+  // Initialize CGUIControl
+  m_bInvalidated = true;
+
+  for (const auto& item : other.m_items)
+    m_items.emplace_back(std::make_shared<CGUIListItem>(*item));
+
+  for (const auto& layout : other.m_layouts)
+    m_layouts.emplace_back(layout, this);
+
+  for (const auto& focusedLayout : other.m_focusedLayouts)
+    m_focusedLayouts.emplace_back(focusedLayout, this);
+}
 
 CGUIBaseContainer::~CGUIBaseContainer(void)
 {
   // release the container from items
   for (const auto& item : m_items)
     item->FreeMemory();
-
-  delete m_listProvider;
 }
 
 void CGUIBaseContainer::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
@@ -165,7 +208,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
   {
     if (!item->GetFocusedLayout())
     {
-      item->SetFocusedLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*m_focusedLayout, this)));
+      item->SetFocusedLayout(std::make_unique<CGUIListItemLayout>(*m_focusedLayout, this));
     }
     if (item->GetFocusedLayout())
     {
@@ -191,8 +234,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
       item->GetFocusedLayout()->SetFocusedItem(0);  // focus is not set
     if (!item->GetLayout())
     {
-      CGUIListItemLayoutPtr layout(new CGUIListItemLayout(*m_layout));
-      layout->SetParentControl(this);
+      CGUIListItemLayoutPtr layout = std::make_unique<CGUIListItemLayout>(*m_layout, this);
       item->SetLayout(std::move(layout));
     }
     if (item->GetFocusedLayout())
@@ -1213,16 +1255,14 @@ void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)
 
 void CGUIBaseContainer::LoadListProvider(TiXmlElement *content, int defaultItem, bool defaultAlways)
 {
-  delete m_listProvider;
   m_listProvider = IListProvider::Create(content, GetParentID());
   if (m_listProvider)
     m_listProvider->SetDefaultItem(defaultItem, defaultAlways);
 }
 
-void CGUIBaseContainer::SetListProvider(IListProvider *provider)
+void CGUIBaseContainer::SetListProvider(std::unique_ptr<IListProvider> provider)
 {
-  delete m_listProvider;
-  m_listProvider = provider;
+  m_listProvider = std::move(provider);
   UpdateListProvider(true);
 }
 

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -18,6 +18,7 @@
 #include "utils/Stopwatch.h"
 
 #include <list>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -34,7 +35,7 @@ class CGUIBaseContainer : public IGUIContainer
 {
 public:
   CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
-  CGUIBaseContainer(const CGUIBaseContainer &);
+  explicit CGUIBaseContainer(const CGUIBaseContainer& other);
   ~CGUIBaseContainer(void) override;
 
   bool OnAction(const CAction &action) override;
@@ -75,7 +76,7 @@ public:
   /*! \brief Set the list provider for this container (for python).
    \param provider the list provider to use for this container.
    */
-  void SetListProvider(IListProvider *provider);
+  void SetListProvider(std::unique_ptr<IListProvider> provider);
 
   /*! \brief Set the offset of the first item in the container from the container's position
    Useful for lists/panels where the focused item may be larger than the non-focused items and thus
@@ -147,8 +148,8 @@ protected:
   std::list<CGUIListItemLayout> m_layouts;
   std::list<CGUIListItemLayout> m_focusedLayouts;
 
-  CGUIListItemLayout *m_layout;
-  CGUIListItemLayout *m_focusedLayout;
+  CGUIListItemLayout* m_layout{nullptr};
+  CGUIListItemLayout* m_focusedLayout{nullptr};
   bool m_layoutCondition = false;
   bool m_focusedLayoutCondition = false;
 
@@ -158,7 +159,7 @@ protected:
 
   CScroller m_scroller;
 
-  IListProvider *m_listProvider;
+  std::unique_ptr<IListProvider> m_listProvider;
 
   bool m_wasReset;  // true if we've received a Reset message until we've rendered once.  Allows
                     // us to make sure we don't tell the infomanager that we've been moving when

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1129,7 +1129,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     break;
   case CGUIControl::GUICONTROL_LABEL:
     {
-      const GUIINFO::CGUIInfoLabel &content = (infoLabels.size()) ? infoLabels[0] : GUIINFO::CGUIInfoLabel("");
+      static const GUIINFO::CGUIInfoLabel empty;
+      const GUIINFO::CGUIInfoLabel& content = !infoLabels.empty() ? infoLabels[0] : empty;
       if (insideContainer)
       { // inside lists we use CGUIListLabel
         control = new CGUIListLabel(parentID, id, posX, posY, width, height, labelInfo, content, scrollValue);

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -26,7 +26,7 @@ class CGUIControlGroup : public CGUIControlLookup
 public:
   CGUIControlGroup();
   CGUIControlGroup(int parentID, int controlID, float posX, float posY, float width, float height);
-  CGUIControlGroup(const CGUIControlGroup &from);
+  explicit CGUIControlGroup(const CGUIControlGroup& from);
   ~CGUIControlGroup(void) override;
   CGUIControlGroup* Clone() const override { return new CGUIControlGroup(*this); }
 

--- a/xbmc/guilib/GUIControlLookup.cpp
+++ b/xbmc/guilib/GUIControlLookup.cpp
@@ -8,6 +8,10 @@
 
 #include "GUIControlLookup.h"
 
+CGUIControlLookup::CGUIControlLookup(const CGUIControlLookup& from) : CGUIControl(from)
+{
+}
+
 CGUIControl *CGUIControlLookup::GetControl(int iControl, std::vector<CGUIControl*> *idCollector)
 {
   if (idCollector)

--- a/xbmc/guilib/GUIControlLookup.h
+++ b/xbmc/guilib/GUIControlLookup.h
@@ -16,8 +16,7 @@ public:
   CGUIControlLookup() = default;
   CGUIControlLookup(int parentID, int controlID, float posX, float posY, float width, float height)
     : CGUIControl(parentID, controlID, posX, posY, width, height) {}
-  CGUIControlLookup(const CGUIControlLookup &from)
-    : CGUIControl(from) {}
+  explicit CGUIControlLookup(const CGUIControlLookup& from);
   ~CGUIControlLookup(void) override = default;
 
   CGUIControl *GetControl(int id, std::vector<CGUIControl*> *idCollector = nullptr) override;

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -20,6 +20,10 @@ CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, fl
   m_type = VIEW_TYPE_LIST;
 }
 
+CGUIListContainer::CGUIListContainer(const CGUIListContainer& other) : CGUIBaseContainer(other)
+{
+}
+
 CGUIListContainer::~CGUIListContainer(void) = default;
 
 bool CGUIListContainer::OnAction(const CAction &action)

--- a/xbmc/guilib/GUIListContainer.h
+++ b/xbmc/guilib/GUIListContainer.h
@@ -26,12 +26,13 @@ class CGUIListContainer : public CGUIBaseContainer
 {
 public:
   CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
-//#ifdef GUILIB_PYTHON_COMPATIBILITY
+  explicit CGUIListContainer(const CGUIListContainer& other);
+  //#ifdef GUILIB_PYTHON_COMPATIBILITY
   CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height,
                          const CLabelInfo& labelInfo, const CLabelInfo& labelInfo2,
                          const CTextureInfo& textureButton, const CTextureInfo& textureButtonFocus,
                          float textureHeight, float itemWidth, float itemHeight, float spaceBetweenItems);
-//#endif
+  //#endif
   ~CGUIListContainer(void) override;
   CGUIListContainer* Clone() const override { return new CGUIListContainer(*this); }
 

--- a/xbmc/guilib/GUIListGroup.h
+++ b/xbmc/guilib/GUIListGroup.h
@@ -23,7 +23,7 @@ class CGUIListGroup final : public CGUIControlGroup
 {
 public:
   CGUIListGroup(int parentID, int controlID, float posX, float posY, float width, float height);
-  CGUIListGroup(const CGUIListGroup &right);
+  explicit CGUIListGroup(const CGUIListGroup& right);
   ~CGUIListGroup(void) override;
   CGUIListGroup* Clone() const override { return new CGUIListGroup(*this); }
 

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -48,7 +48,7 @@ public:
   /// @}
 
   CGUIListItem(void);
-  CGUIListItem(const CGUIListItem& item);
+  explicit CGUIListItem(const CGUIListItem& item);
   explicit CGUIListItem(const std::string& strLabel);
   virtual ~CGUIListItem(void);
   virtual CGUIListItem* Clone() const { return new CGUIListItem(*this); }

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -44,6 +44,10 @@ CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from, CGUIContr
 {
   m_group.SetParentControl(control);
   m_infoUpdateTimeout.Set(m_infoUpdateMillis);
+
+  // m_group was just created, cloned controls with resources must be allocated
+  // before use
+  m_group.AllocResources();
 }
 
 bool CGUIListItemLayout::IsAnimating(ANIMATION_TYPE animType)

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -28,6 +28,11 @@ CGUIListItemLayout::CGUIListItemLayout()
 }
 
 CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from)
+  : CGUIListItemLayout(from, nullptr)
+{
+}
+
+CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from, CGUIControl* control)
   : m_group(from.m_group),
     m_width(from.m_width),
     m_height(from.m_height),
@@ -37,20 +42,8 @@ CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from)
     m_isPlaying(from.m_isPlaying),
     m_infoUpdateMillis(from.m_infoUpdateMillis)
 {
-  m_infoUpdateTimeout.Set(m_infoUpdateMillis);
-}
-
-CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout &from, CGUIControl *control)
-: m_group(from.m_group), m_isPlaying(from.m_isPlaying)
-{
-  m_width = from.m_width;
-  m_height = from.m_height;
-  m_focused = from.m_focused;
-  m_condition = from.m_condition;
-  m_infoUpdateMillis = from.m_infoUpdateMillis;
-  m_infoUpdateTimeout.Set(m_infoUpdateMillis);
-  m_invalidated = true;
   m_group.SetParentControl(control);
+  m_infoUpdateTimeout.Set(m_infoUpdateMillis);
 }
 
 bool CGUIListItemLayout::IsAnimating(ANIMATION_TYPE animType)

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -21,8 +21,8 @@ class CGUIListItemLayout final
 {
 public:
   CGUIListItemLayout();
-  CGUIListItemLayout(const CGUIListItemLayout& from);
-  CGUIListItemLayout(const CGUIListItemLayout &from, CGUIControl *control);
+  explicit CGUIListItemLayout(const CGUIListItemLayout& from);
+  explicit CGUIListItemLayout(const CGUIListItemLayout& from, CGUIControl* control);
   void LoadLayout(TiXmlElement *layout, int context, bool focused, float maxWidth, float maxHeight);
   void Process(CGUIListItem *item, int parentID, unsigned int currentTime, CDirtyRegionList &dirtyregions);
   void Render(CGUIListItem *item, int parentID);

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -51,7 +51,6 @@ public:
   bool CheckCondition();
 protected:
   void LoadControl(TiXmlElement *child, CGUIControlGroup *group);
-  void Update(CFileItem *item);
 
   CGUIListGroup m_group;
 

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -64,6 +64,15 @@ CGUIStaticItem::CGUIStaticItem(const CFileItem &item)
   m_visState = false;
 }
 
+CGUIStaticItem::CGUIStaticItem(const CGUIStaticItem& other)
+  : CFileItem(other),
+    m_info(other.m_info),
+    m_visCondition(other.m_visCondition),
+    m_visState(other.m_visState),
+    m_clickActions(other.m_clickActions)
+{
+}
+
 void CGUIStaticItem::UpdateProperties(int contextWindow)
 {
   for (const auto& i : m_info)

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -51,6 +51,7 @@ public:
    */
   CGUIStaticItem(const TiXmlElement *element, int contextWindow);
   explicit CGUIStaticItem(const CFileItem &item); // for python
+  explicit CGUIStaticItem(const CGUIStaticItem& other);
   ~CGUIStaticItem() override = default;
   CGUIListItem* Clone() const override { return new CGUIStaticItem(*this); }
 

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -1406,8 +1406,8 @@ namespace XBMCAddon
       }
 
       // set static list
-      IListProvider *provider = new CStaticListProvider(items);
-      static_cast<CGUIBaseContainer*>(pGUIControl)->SetListProvider(provider);
+      std::unique_ptr<IListProvider> provider = std::make_unique<CStaticListProvider>(items);
+      static_cast<CGUIBaseContainer*>(pGUIControl)->SetListProvider(std::move(provider));
     }
 
     // ============================================================

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -180,9 +180,31 @@ CDirectoryProvider::CDirectoryProvider(const TiXmlElement *element, int parentID
   }
 }
 
+CDirectoryProvider::CDirectoryProvider(const CDirectoryProvider& other)
+  : IListProvider(other.m_parentID),
+    m_updateState(INVALIDATED),
+    m_isAnnounced(false),
+    m_jobID(0),
+    m_url(other.m_url),
+    m_target(other.m_target),
+    m_sortMethod(other.m_sortMethod),
+    m_sortOrder(other.m_sortOrder),
+    m_limit(other.m_limit),
+    m_currentUrl(other.m_currentUrl),
+    m_currentTarget(other.m_currentTarget),
+    m_currentSort(other.m_currentSort),
+    m_currentLimit(other.m_currentLimit)
+{
+}
+
 CDirectoryProvider::~CDirectoryProvider()
 {
   Reset();
+}
+
+std::unique_ptr<IListProvider> CDirectoryProvider::Clone()
+{
+  return std::make_unique<CDirectoryProvider>(*this);
 }
 
 bool CDirectoryProvider::Update(bool forceRefresh)

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -51,8 +51,11 @@ public:
   } UpdateState;
 
   CDirectoryProvider(const TiXmlElement *element, int parentID);
+  explicit CDirectoryProvider(const CDirectoryProvider& other);
   ~CDirectoryProvider() override;
 
+  // Implementation of IListProvider
+  std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
   void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                 const std::string& sender,

--- a/xbmc/listproviders/IListProvider.cpp
+++ b/xbmc/listproviders/IListProvider.cpp
@@ -13,28 +13,28 @@
 #include "StaticProvider.h"
 #include "utils/XBMCTinyXML.h"
 
-IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
+std::unique_ptr<IListProvider> IListProvider::Create(const TiXmlNode* node, int parentID)
 {
   const TiXmlNode *root = node->FirstChild("content");
   if (root)
   {
     const TiXmlNode *next = root->NextSibling("content");
     if (next)
-      return new CMultiProvider(root, parentID);
+      return std::make_unique<CMultiProvider>(root, parentID);
 
     return CreateSingle(root, parentID);
   }
-  return NULL;
+  return std::unique_ptr<IListProvider>{};
 }
 
-IListProvider *IListProvider::CreateSingle(const TiXmlNode *content, int parentID)
+std::unique_ptr<IListProvider> IListProvider::CreateSingle(const TiXmlNode* content, int parentID)
 {
   const TiXmlElement *item = content->FirstChildElement("item");
   if (item)
-    return new CStaticListProvider(content->ToElement(), parentID);
+    return std::make_unique<CStaticListProvider>(content->ToElement(), parentID);
 
   if (!content->NoChildren())
-    return new CDirectoryProvider(content->ToElement(), parentID);
+    return std::make_unique<CDirectoryProvider>(content->ToElement(), parentID);
 
-  return NULL;
+  return std::unique_ptr<IListProvider>{};
 }

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -23,21 +23,26 @@ class IListProvider
 {
 public:
   explicit IListProvider(int parentID) : m_parentID(parentID) {}
+  explicit IListProvider(const IListProvider& other) = default;
   virtual ~IListProvider() = default;
 
   /*! \brief Factory to create list providers.
    \param parent a parent TiXmlNode for the container.
    \param parentID id of parent window for context.
-   \return the list provider, NULL if none.
+   \return the list provider, empty pointer if none.
    */
-  static IListProvider *Create(const TiXmlNode *parent, int parentID);
+  static std::unique_ptr<IListProvider> Create(const TiXmlNode* parent, int parentID);
 
   /*! \brief Factory to create list providers.  Cannot create a multi-provider.
    \param content the TiXmlNode for the content to create.
    \param parentID id of parent window for context.
-   \return the list provider, NULL if none.
+   \return the list provider, empty pointer if none.
    */
-  static IListProvider *CreateSingle(const TiXmlNode *content, int parentID);
+  static std::unique_ptr<IListProvider> CreateSingle(const TiXmlNode* content, int parentID);
+
+  /*! \brief Create an instance of the derived class. Allows for polymorphic copies.
+   */
+  virtual std::unique_ptr<IListProvider> Clone() = 0;
 
   /*! \brief Update the list content
    \return true if the content has changed, false otherwise.

--- a/xbmc/listproviders/MultiProvider.h
+++ b/xbmc/listproviders/MultiProvider.h
@@ -14,7 +14,7 @@
 #include <map>
 #include <vector>
 
-typedef std::shared_ptr<IListProvider> IListProviderPtr;
+typedef std::unique_ptr<IListProvider> IListProviderPtr;
 
 /*!
  \ingroup listproviders
@@ -24,7 +24,10 @@ class CMultiProvider : public IListProvider
 {
 public:
   CMultiProvider(const TiXmlNode *first, int parentID);
+  explicit CMultiProvider(const CMultiProvider& other);
 
+  // Implementation of IListProvider
+  std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
   void Fetch(std::vector<CGUIListItemPtr> &items) override;
   bool IsUpdating() const override;
@@ -37,6 +40,6 @@ protected:
   typedef size_t item_key_type;
   static item_key_type GetItemKey(CGUIListItemPtr const &item);
   std::vector<IListProviderPtr> m_providers;
-  std::map<item_key_type, IListProviderPtr> m_itemMap;
+  std::map<item_key_type, IListProvider*> m_itemMap;
   CCriticalSection m_section; // protects m_itemMap
 };

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -47,7 +47,32 @@ CStaticListProvider::CStaticListProvider(const std::vector<CGUIStaticItemPtr> &i
 {
 }
 
+CStaticListProvider::CStaticListProvider(const CStaticListProvider& other)
+  : IListProvider(other.m_parentID),
+    m_defaultItem(other.m_defaultItem),
+    m_defaultAlways(other.m_defaultAlways),
+    m_updateTime(other.m_updateTime)
+{
+  for (const auto& item : other.m_items)
+  {
+    std::shared_ptr<CGUIListItem> control(item->Clone());
+    if (!control)
+      continue;
+
+    std::shared_ptr<CGUIStaticItem> newItem = std::dynamic_pointer_cast<CGUIStaticItem>(control);
+    if (!newItem)
+      continue;
+
+    m_items.emplace_back(std::move(newItem));
+  }
+}
+
 CStaticListProvider::~CStaticListProvider() = default;
+
+std::unique_ptr<IListProvider> CStaticListProvider::Clone()
+{
+  return std::make_unique<CStaticListProvider>(*this);
+}
 
 bool CStaticListProvider::Update(bool forceRefresh)
 {

--- a/xbmc/listproviders/StaticProvider.h
+++ b/xbmc/listproviders/StaticProvider.h
@@ -18,8 +18,11 @@ class CStaticListProvider : public IListProvider
 public:
   CStaticListProvider(const TiXmlElement *element, int parentID);
   explicit CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items); // for python
+  explicit CStaticListProvider(const CStaticListProvider& other);
   ~CStaticListProvider() override;
 
+  // Implementation of IListProvider
+  std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
   void Fetch(std::vector<CGUIListItemPtr> &items) override;
   bool OnClick(const CGUIListItemPtr &item) override;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -370,7 +370,7 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPt
   {
     if (!item->GetFocusedLayout())
     {
-      item->SetFocusedLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*focusedlayout)));
+      item->SetFocusedLayout(std::make_unique<CGUIListItemLayout>(*focusedlayout, this));
     }
 
     if (resize != -1.0f)
@@ -402,7 +402,7 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPt
   {
     if (!item->GetLayout())
     {
-      item->SetLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*normallayout)));
+      item->SetLayout(std::make_unique<CGUIListItemLayout>(*normallayout, this));
     }
 
     if (resize != -1.0f)


### PR DESCRIPTION
## Description

This PR contains two fixes that allow for lists-within-lists.

The first is a use-after-free segfault. Kodi can show a list within a list, but when a list item scrolls off the screen, Kodi will free the memory, invalidating all the other list items, causing the use-after-free.

The solution is to thoroughly implement clone functions and copy constructors for all related classes. Also I changed to `std::unique_ptr` to verify memory soundness at compile time.

The second fix is for unallocated resources when a list item is cloned. Skin resources are allocated at window load, but cloning creates controls after window load. Throughout core this is handled by manually allocating resources. The fix does that, specifically in the outer-most memory copy that the control is still accessible, which is the list item layout.

## Motivation and context

I wanted to experiment with lists-within-lists for the player manager. Yes, I know I started creating player managers in 2016, but this time I have a reallly good concept mockup from @KOPRajs.

## How has this been tested?

To test, I replaced the `GameController` window with some initial skinning for the Player manager. I copied just the list-within-a-scrollable-list stuff. Here's the test window (note that paths are hard-coded):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<window>
  <defaultcontrol always="true">11</defaultcontrol>
  <include>Animation_DialogPopupOpenClose</include>
  <controls>
    <control type="group">
      <centertop>50%</centertop>
      <centerleft>50%</centerleft>
      <width>1600</width>
      <height>962</height>
      <include content="DialogBackgroundCommons">
        <param name="width" value="1600" />
        <param name="height" value="962" />
        <param name="header_label" value="$LOCALIZE[35151]" />
        <param name="header_id" value="2" />
      </include>
      <control type="group">
        <description>Content area</description>
        <top>110</top>
        <bottom>40</bottom>
        <left>40</left>
        <right>40</right>
        <control type="group">
          <description>Area of the dialog for players</description>
          <top>136</top>
          <height>576</height>
          <control type="image">
            <description>Player list background</description>
            <top>-20</top>
            <bottom>-20</bottom>
            <left>-20</left>
            <right>-20</right>
            <texture border="40">buttons/dialogbutton-nofo.png</texture>
          </control>
          <control type="list" id="11">
            <description>Player list</description>
            <ondown>5</ondown>
            <pagecontrol>12</pagecontrol>
            <scrolltime tween="sine">200</scrolltime>
            <orientation>vertical</orientation>
            <itemlayout width="1520" height="96">
              <control type="group">
                <control type="label">
                  <top>20</top>
                  <left>20</left>
                  <label>$INFO[ListItem.Label]</label>
                  <font>font37</font>
                  <shadowcolor>text_shadow</shadowcolor>
                  <align>left</align>
                </control>
                <control type="list" id="$INFO[ListItem.Property(ControlID)]">
                  <description>Player controller list</description>
                  <left>500</left>
                  <orientation>horizontal</orientation>
                  <enable>false</enable>
                  <itemlayout width="96" height="96">
                    <control type="group">
                      <control type="image">
                        <texture>$INFO[ListItem.Icon]</texture>
                      </control>
                    </control>
                  </itemlayout>
                  <focusedlayout width="96" height="96">
                    <control type="group">
                      <control type="image">
                        <texture>$INFO[ListItem.Icon]</texture>
                      </control>
                    </control>
                  </focusedlayout>
                  <content>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                  </content>
                </control>
              </control>
            </itemlayout>
            <focusedlayout width="1520" height="96">
              <control type="group">
                <control type="image">
                  <top>-20</top>
                  <bottom>-20</bottom>
                  <left>-20</left>
                  <right>-20</right>
                  <texture border="40" colordiffuse="button_focus">buttons/dialogbutton-fo.png</texture>
                  <visible>Control.HasFocus(11)</visible>
                </control>
                <control type="label">
                  <top>20</top>
                  <left>20</left>
                  <label>$INFO[ListItem.Label]</label>
                  <font>font37</font>
                  <shadowcolor>text_shadow</shadowcolor>
                  <align>left</align>
                </control>
                <control type="list" id="$INFO[ListItem.Property(ControlID)]">
                  <description>Player controller list</description>
                  <left>500</left>
                  <orientation>horizontal</orientation>
                  <enable>false</enable>
                  <itemlayout width="96" height="96">
                    <control type="group">
                      <control type="image">
                        <texture>$INFO[ListItem.Icon]</texture>
                      </control>
                    </control>
                  </itemlayout>
                  <focusedlayout width="96" height="96">
                    <control type="group">
                      <control type="image">
                        <texture>$INFO[ListItem.Icon]</texture>
                      </control>
                    </control>
                  </focusedlayout>
                  <content>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                    <item>
                      <icon>C:\Users\Garrett\Documents\kodi\addons\game.controller.default\resources\layout.png</icon>
                    </item>
                  </content>
                </control>
              </control>
            </focusedlayout>
            <content>
              <item>
                <label>Player 1</label>
              </item>
              <item>
                <label>Player 2</label>
              </item>
              <item>
                <label>Player 3</label>
              </item>
              <item>
                <label>Player 4</label>
              </item>
              <item>
                <label>Player 5</label>
              </item>
              <item>
                <label>Player 6</label>
              </item>
              <item>
                <label>Player 7</label>
              </item>
              <item>
                <label>Player 8</label>
              </item>
            </content>
          </control>
        </control>
        <control type="scrollbar" id="12">
          <description>Player list scroll bar</description>
          <top>136</top>
          <height>576</height>
          <right>-12</right>
          <width>12</width>
          <orientation>vertical</orientation>
        </control>
      </control>
    </control>
  </controls>
</window>
```

When loading the list and scrolling, we get the segfault:

![Use after free](https://user-images.githubusercontent.com/531482/149604868-c6e95895-fe19-47da-a4d6-74d27181ef9f.png)

When the first fix is applied, we no longer segfault, but the inner lists aren't loaded:

![Player configuration broken list](https://user-images.githubusercontent.com/531482/149604876-50ed3775-4a1e-4b75-8934-c2cb5657a7dd.png)

When the second fix is applied, the lists load successfully, and scrolling works flawlessly:

![Player configuration working list](https://user-images.githubusercontent.com/531482/149604889-c2def63f-5441-45f2-974d-b92471dc2983.png)

## What is the effect on users?

* Fixed skinning crash for lists within lists

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
