### PR TITLE
[audio] Filters audio devices from audio devices lists according capabilities reported by sinks

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -751,6 +751,15 @@ void CActiveAESink::EnumerateOutputDevices(AEDeviceList &devices, bool passthrou
       if (passthrough && devInfo.m_deviceType == AE_DEVTYPE_PCM)
         continue;
 
+      // filters devices that should not be shown in the list
+      // of AUDIO DEVICES or AUDIO PASSTHROUGH DEVICES
+      // according to the capabilities informed by each sink
+      if (devInfo.m_onlyPassthrough && !passthrough)
+        continue;
+
+      if (devInfo.m_onlyPCM && passthrough)
+        continue;
+
       std::string device = sinkInfo.m_sinkName + ":" + devInfo.m_deviceName;
 
       std::stringstream ss;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -992,6 +992,10 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   UpdateAvailablePassthroughCapabilities(isRaw);
   m_info_raw = m_info;
 
+  // no need to display two PCM sinks - as they are the same
+  if (!list.empty())
+    m_info_raw.m_onlyPassthrough = true;
+
   list.push_back(m_info_raw);
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -12,6 +12,7 @@
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/StringUtils.h"
+#include "utils/SystemInfo.h"
 #include "utils/TimeUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
@@ -404,6 +405,8 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
   WAVEFORMATEXTENSIBLE wfxex = {};
   HRESULT              hr;
 
+  const bool onlyPT = (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Xbox);
+
   for(RendererDetail& details : CAESinkFactoryWin::GetRendererDetails())
   {
     deviceInfo.m_channels.Reset();
@@ -638,18 +641,20 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     /* Store the device info */
     deviceInfo.m_wantsIECPassthrough = true;
+    deviceInfo.m_onlyPassthrough = onlyPT;
 
     if (!deviceInfo.m_streamTypes.empty())
       deviceInfo.m_dataFormats.push_back(AE_FMT_RAW);
 
     deviceInfoList.push_back(deviceInfo);
 
-    if(details.bDefault)
+    if (details.bDefault)
     {
       deviceInfo.m_deviceName = std::string("default");
       deviceInfo.m_displayName = std::string("default");
       deviceInfo.m_displayNameExtra = std::string("");
       deviceInfo.m_wantsIECPassthrough = true;
+      deviceInfo.m_onlyPassthrough = onlyPT;
       deviceInfoList.push_back(deviceInfo);
     }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -577,6 +577,7 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     /* Store the device info */
     deviceInfo.m_wantsIECPassthrough = true;
+    deviceInfo.m_onlyPCM = true;
 
     if (!deviceInfo.m_streamTypes.empty())
       deviceInfo.m_dataFormats.push_back(AE_FMT_RAW);
@@ -589,6 +590,7 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
       deviceInfo.m_displayName = std::string("default");
       deviceInfo.m_displayNameExtra = std::string("");
       deviceInfo.m_wantsIECPassthrough = true;
+      deviceInfo.m_onlyPCM = true;
       deviceInfoList.push_back(deviceInfo);
     }
   }

--- a/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.h
@@ -42,6 +42,9 @@ public:
 
   bool m_wantsIECPassthrough;           /* if sink supports passthrough encapsulation is done when set to true */
 
+  bool m_onlyPassthrough{false}; // sink only only should be used for passthrough (audio PT device)
+  bool m_onlyPCM{false}; // sink only should be used for PCM (audio device)
+
   operator std::string();
   static std::string DeviceTypeToString(enum AEDeviceType deviceType);
 };


### PR DESCRIPTION
## Description
Filters audio devices from audio devices lists according capabilities reported by sinks

## Motivation and context
Users expects all audio devices listed can be selected and used and this is not always the case:

- DirectSound cannot be used for passthrough on Windows (only supports AC3).
- WASAPI cannot be used for PCM on Xbox.
- XAudio cannot be used for passthrough on Xbox.

The situation is now even worse with the addition of WASAPI passthrough support to the Xbox. This device does not work when it is selected for "no passthrough". And what is worse: the problem is not solved until Kodi is closed and reopened completely with what some users may think audio is totally broken.

We want to avoid that when v19.4 is released for Xbox, some users will complain and want rollback to v19.3 because "audio is broken".

NOTE:
For existent/unmodified sinks new flags defaults to false and nothing changes

## How has this been tested?
Runtime tested Windows x64 and Xbox. 

Tested DirectSound, Xaudio and WASAPI sinks. WASAPI tested both Windows x64 and Xbox.

Tested on Android with modification suggested by fritsch (https://github.com/xbmc/xbmc/pull/20856#issuecomment-1013742064)

## What is the effect on users?
Avoids wrong audio device can be selected (audio device not suitable for the intended functionality).


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
