### PR TITLE
[Subtitles][WebVTT] No flush with data processed like file

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.h
@@ -33,5 +33,6 @@ private:
   CDVDOverlay* m_pOverlay;
   CWebVTTISOHandler m_webvttHandler;
   bool m_isISOFormat{false};
+  bool m_allowFlush{true};
   std::vector<int> m_previousSubIds;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change the flush behaviour from default disabled to default enabled
and will be disabled only when ISAdaptive process WebVTT data "as single file",
this because in this last case ISAdaptive will send to kodi the full data in a single packet
and will be never sent again until the end of playback, therefore we want avoid that a video seek clear the stored data.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On ISAdaptive the segmented WebVTT data in HLS streams was not correctly handled,
all segments are sent to kodi demuxer before playback starts which may cause delays in the execution of the video and/or block the video for minutes if there are a lot of segments.

This will be fixed by https://github.com/xbmc/inputstream.adaptive/pull/875 that should be merged as first, and require this change to fix the flush behaviour.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See https://github.com/xbmc/inputstream.adaptive/pull/875 to get test streams

If someone want to test this i want to point out that currently DEMUX_SPECIALID_STREAMCHANGE call on kodi still badly handled and will broke the subtitles parsers at every call, therefore subtitles may be partially displayed or not displayed,
a temporary solution can be hacked/forced "disabled" the stream adaptive feature on ISA in this way: https://github.com/CastagnaIT/inputstream.adaptive/commit/4cccf510e54a6a5a83bdf425513a672908f1fccf

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Have the HLS video streams that starts immediately

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
