### PR TITLE
[cmake] set TARBALL_DIR for overriding tarball download location

### DIFF
--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -23,7 +23,7 @@ if(ENABLE_INTERNAL_CROSSGUID)
   set(CROSSGUID_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
   externalproject_add(crossguid
                       URL ${CROSSGUID_URL}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/crossguid
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}

--- a/cmake/modules/FindDav1d.cmake
+++ b/cmake/modules/FindDav1d.cmake
@@ -47,7 +47,7 @@ if(ENABLE_INTERNAL_DAV1D)
   externalproject_add(dav1d
                       URL ${DAV1D_URL}
                       DOWNLOAD_NAME ${ARCHIVE}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/dav1d
                       CONFIGURE_COMMAND meson
                                         --buildtype=release

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -251,7 +251,7 @@ if(NOT FFMPEG_FOUND)
   externalproject_add(ffmpeg
                       URL ${FFMPEG_URL}
                       DOWNLOAD_NAME ${ARCHIVE}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/ffmpeg
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/cmake/modules/FindFlatBuffers.cmake
+++ b/cmake/modules/FindFlatBuffers.cmake
@@ -31,7 +31,7 @@ if(ENABLE_INTERNAL_FLATBUFFERS)
 
   externalproject_add(flatbuffers
                       URL ${FLATBUFFERS_URL}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/flatbuffers
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_BUILD_TYPE=Release

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -37,7 +37,7 @@ if(ENABLE_INTERNAL_FMT)
   set(FMT_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
   externalproject_add(fmt
                       URL ${FMT_URL}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/fmt
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}

--- a/cmake/modules/FindFstrcmp.cmake
+++ b/cmake/modules/FindFstrcmp.cmake
@@ -32,7 +32,7 @@ if(ENABLE_INTERNAL_FSTRCMP)
   set(FSTRCMP_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
   externalproject_add(fstrcmp
                       URL ${FSTRCMP_URL}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/fstrcmp
                       PATCH_COMMAND autoreconf -vif
                       CONFIGURE_COMMAND ./configure --prefix ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}

--- a/cmake/modules/FindGtest.cmake
+++ b/cmake/modules/FindGtest.cmake
@@ -38,7 +38,7 @@ if(ENABLE_INTERNAL_GTEST)
 
   externalproject_add(gtest
                       URL ${GTEST_URL}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/gtest
                       INSTALL_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                       CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DBUILD_GMOCK=OFF -DINSTALL_GTEST=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DCMAKE_INSTALL_LIBDIR=lib

--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -111,7 +111,7 @@ else()
       set(DVDCSS_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdcss.a)
       ExternalProject_Add(dvdcss URL ${LIBDVDCSS_URL}
                                   DOWNLOAD_NAME libdvdcss-${libdvdcss_VER}.tar.gz
-                                  DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                                  DOWNLOAD_DIR ${TARBALL_DIR}
                                   PREFIX ${CORE_BUILD_DIR}/libdvd
                                   CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
                                                     --target=${HOST_ARCH}
@@ -135,7 +135,7 @@ else()
     else()
       ExternalProject_Add(dvdcss
         URL ${LIBDVDCSS_URL}
-        DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/downloads
+        DOWNLOAD_DIR ${TARBALL_DIR}
         DOWNLOAD_NAME libdvdcss-${libdvdcss_VER}.tar.gz
         CMAKE_ARGS
           ${LIBDVD_ADDITIONAL_ARGS}
@@ -154,7 +154,7 @@ else()
     set(DVDREAD_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.a)
     ExternalProject_Add(dvdread URL ${LIBDVDREAD_URL}
                                 DOWNLOAD_NAME libdvdread-${libdvdread_VER}.tar.gz
-                                DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                                DOWNLOAD_DIR ${TARBALL_DIR}
                                 PREFIX ${CORE_BUILD_DIR}/libdvd
                                 CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
                                                   --target=${HOST_ARCH}
@@ -177,7 +177,7 @@ else()
   else()
     ExternalProject_Add(dvdread
       URL ${LIBDVDREAD_URL}
-      DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/downloads
+      DOWNLOAD_DIR ${TARBALL_DIR}
       DOWNLOAD_NAME libdvdread-${libdvdread_VER}.tar.gz
       CMAKE_ARGS
         ${LIBDVD_ADDITIONAL_ARGS}
@@ -199,7 +199,7 @@ else()
     set(DVDNAV_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdnav.a)
     ExternalProject_Add(dvdnav URL ${LIBDVDNAV_URL}
                                 DOWNLOAD_NAME libdvdnav-${libdvdnav_VER}.tar.gz
-                                DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                                DOWNLOAD_DIR ${TARBALL_DIR}
                                 PREFIX ${CORE_BUILD_DIR}/libdvd
                                 CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
                                                   --target=${HOST_ARCH}
@@ -226,7 +226,7 @@ else()
     set(DVDNAV_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdnav.lib)
     ExternalProject_Add(dvdnav
       URL ${LIBDVDNAV_URL}
-      DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/downloads
+      DOWNLOAD_DIR ${TARBALL_DIR}
       DOWNLOAD_NAME libdvdnav-${libdvdnav_VER}.tar.gz
       CMAKE_ARGS
         ${LIBDVD_ADDITIONAL_ARGS}

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -33,7 +33,7 @@ if(ENABLE_INTERNAL_RapidJSON)
   set(RapidJSON_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
   externalproject_add(rapidjson
                       URL ${RapidJSON_URL}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/rapidjson
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -40,7 +40,7 @@ if(ENABLE_INTERNAL_SPDLOG)
 
   externalproject_add(spdlog
                       URL ${SPDLOG_URL}
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/spdlog
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}

--- a/cmake/modules/FindUdfread.cmake
+++ b/cmake/modules/FindUdfread.cmake
@@ -47,7 +47,7 @@ if(ENABLE_INTERNAL_UDFREAD)
   externalproject_add(udfread
                       URL ${UDFREAD_URL}
                       DOWNLOAD_NAME libudfread-${UDFREAD_VER}.tar.gz
-                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      DOWNLOAD_DIR ${TARBALL_DIR}
                       PREFIX ${CORE_BUILD_DIR}/libudfread
                       CONFIGURE_COMMAND autoreconf -vif &&
                                         ./configure

--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -74,6 +74,11 @@ if(NOT EXISTS ${CMAKE_SOURCE_DIR}/cmake/scripts/${CORE_SYSTEM_NAME}/ArchSetup.cm
 endif()
 include(${CMAKE_SOURCE_DIR}/cmake/scripts/${CORE_SYSTEM_NAME}/ArchSetup.cmake)
 
+# No TARBALL_DIR given, or no arch specific default set
+if(NOT TARBALL_DIR)
+  set(TARBALL_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download)
+endif()
+
 message(STATUS "Core system type: ${CORE_SYSTEM_NAME}")
 message(STATUS "Platform: ${CORE_PLATFORM_NAME}")
 message(STATUS "CPU: ${CPU}, ARCH: ${ARCH}")

--- a/cmake/scripts/darwin_embedded/ArchSetup.cmake
+++ b/cmake/scripts/darwin_embedded/ArchSetup.cmake
@@ -47,6 +47,10 @@ set(CMAKE_XCODE_ATTRIBUTE_INLINES_ARE_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_COPY_PHASE_STRIP OFF)
 
+if(NOT TARBALL_DIR)
+  set(TARBALL_DIR "/Users/Shared/xbmc-depends/xbmc-tarballs")
+endif()
+
 include(cmake/scripts/darwin/Macros.cmake)
 enable_arc()
 

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -23,6 +23,10 @@ else()
   endif()
 endif()
 
+if(NOT TARBALL_DIR)
+  set(TARBALL_DIR "/Users/Shared/xbmc-depends/xbmc-tarballs")
+endif()
+
 set(CMAKE_OSX_ARCHITECTURES ${CPU})
 
 # Additional SYSTEM_DEFINES

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -38,6 +38,10 @@ list(APPEND CMAKE_LIBRARY_PATH ${MINGW_LIBS_DIR}/bin)
 # dependencies
 list(PREPEND CMAKE_PREFIX_PATH ${DEPENDENCIES_DIR})
 
+if(NOT TARBALL_DIR)
+  set(TARBALL_DIR "${CMAKE_SOURCE_DIR}/project/BuildDependencies/downloads")
+endif()
+
 # -------- Compiler options ---------
 
 add_options(CXX ALL_BUILDS "/wd\"4996\"")

--- a/cmake/scripts/windowsstore/ArchSetup.cmake
+++ b/cmake/scripts/windowsstore/ArchSetup.cmake
@@ -54,6 +54,9 @@ list(APPEND CMAKE_LIBRARY_PATH ${MINGW_LIBS_DIR}/bin)
 # dependencies
 list(PREPEND CMAKE_PREFIX_PATH ${DEPENDENCIES_DIR})
 
+if(NOT TARBALL_DIR)
+  set(TARBALL_DIR "${CMAKE_SOURCE_DIR}/project/BuildDependencies/downloads")
+endif()
 
 # -------- Compiler options ---------
 


### PR DESCRIPTION
## Description
TARBALL_DIR is set in common Archsetup after the load of platform archsetup.
This allows platforms to potentially set a default if not provided, otherwise fallback
to a default

## Motivation and context
Some minor quality of life things. tools/depends configure for apple platforms has a specific fallback location for tarballs (/Users/Shared/xbmc-depends/xbmc-tarballs). This allows "internal" dependency builds to use this fallback, or allow complete override by user if desired. Non apple platforms fall through to the existing ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download location if no TARBALL_DIR is specified.
Other platforms can set defaults relevant to them if so required in platform ArchSetup.cmake.

## How has this been tested?
Generate/build internal dependency in cmake project, check download location

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
