### PR TITLE
[Subtitles] Avoid passing copies of the overlay style

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -144,9 +144,11 @@ protected:
 
 
 private:
-  void ConfigureAssOverride(const KODI::SUBTITLES::style& subStyle, ASS_Style* style);
+  void ConfigureAssOverride(const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
+                            ASS_Style* style);
   void ConfigureFont(bool overrideFont, std::string fontName);
-  void ApplyStyle(KODI::SUBTITLES::style subStyle, KODI::SUBTITLES::renderOpts opts);
+  void ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
+                  KODI::SUBTITLES::renderOpts opts);
 
   ASS_Library* m_library = nullptr;
   ASS_Track* m_track = nullptr;


### PR DESCRIPTION
## Description
Found while debugging https://github.com/xbmc/xbmc/issues/20861, it seems we're always passing copies of the Kodi subtitle style when applying the overlay style propagated from the OverlayRenderer into the libass handler. Since its a shared struct between both the overlayrenderer and libasshandler, there's no need for this.
It doesn't solve (and is independent of) the mentioned issue.

This was also flagged by Jenkins already: https://jenkins.kodi.tv/view/Reports/job/LINUX-64-GL-Static-Analysis/lastBuild/clang-tidy/new/fileName.-1292882781/source.1f6078f7-b7da-454b-8c91-ea56bee2da8b/#269