### PR TITLE
[EDL] Also show EDL mutes on the ranges control/Player.EditList

### DIFF
--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -664,12 +664,9 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetEditList(const CDataCach
   const std::vector<EDL::Edit> edits = data.GetEditList();
   for (const auto& edit : edits)
   {
-    if (edit.action != EDL::Action::CUT && edit.action != EDL::Action::COMM_BREAK)
-      continue;
-
-    float cutStart = edit.start * 100.0f / duration;
-    float cutEnd = edit.end * 100.0f / duration;
-    ranges.emplace_back(std::make_pair(cutStart, cutEnd));
+    float editStart = edit.start * 100.0f / duration;
+    float editEnd = edit.end * 100.0f / duration;
+    ranges.emplace_back(std::make_pair(editStart, editEnd));
   }
   return ranges;
 }


### PR DESCRIPTION
## Description
Currently the `Player.Editlist` infolabel (and old `Player.Cutlist`) does not include EDL mute sections. I don't really know why this has been done but IMHO they should be displayed just like any other edit. E.g. if a user plays some file with EDL mutes and he's not aware of the EDL file, he might not figure out why the audio is not playing in specific sections. With this, at least some red marks are shown on those regions.

EDL file with 2 mute sections:
```
00:00:23.897 00:00:27.500 1
00:00:32.427 00:00:37.862 1
```

**Master:**
![image](https://user-images.githubusercontent.com/7375276/149939246-017481dc-ad84-4a20-85f3-1ad7a120cd49.png)


**PR:**
![image](https://user-images.githubusercontent.com/7375276/149939010-8d3b3550-a465-4ba5-a7b4-157f8f6a401f.png)

