### PR TITLE
[guilib] Fix Font style bits were not being applied in SetStyledText

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIEditControl.h"
 
+#include "GUIFont.h"
 #include "GUIKeyboardFactory.h"
 #include "GUIUserMessages.h"
 #include "GUIWindowManager.h"
@@ -553,9 +554,12 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   unsigned int startSelection = m_cursorPos + m_editOffset;
   unsigned int endSelection   = m_cursorPos + m_editOffset + m_editLength;
 
+  CGUIFont* font = m_label2.GetLabelInfo().font;
+  uint32_t style = (font ? font->GetStyle() : (FONT_STYLE_NORMAL & FONT_STYLE_MASK)) << 24;
+
   for (unsigned int i = 0; i < text.size(); i++)
   {
-    unsigned int ch = text[i];
+    uint32_t ch = text[i] | style;
     if (m_editLength > 0 && startSelection <= i && i < endSelection)
       ch |= (2 << 16); // highlight the letters we're playing with
     else if (!m_edit.empty() && (i < startHighlight || i >= endHighlight))
@@ -564,7 +568,7 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   }
 
   // show the cursor
-  unsigned int ch = L'|';
+  uint32_t ch = L'|' | style;
   if ((++m_cursorBlink % 64) > 32)
     ch |= (3 << 16);
   styled.insert(styled.begin() + m_cursorPos, ch);

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -8,6 +8,7 @@
 
 #include "GUILabelControl.h"
 
+#include "GUIFont.h"
 #include "GUIMessage.h"
 #include "utils/CharsetConverter.h"
 #include "utils/ColorUtils.h"
@@ -82,9 +83,13 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
       select = 0xFFFF0000;
     colors.push_back(select);
     colors.push_back(0xFF000000);
+
+    CGUIFont* font = m_label.GetLabelInfo().font;
+    uint32_t style = (font ? font->GetStyle() : (FONT_STYLE_NORMAL & FONT_STYLE_MASK)) << 24;
+
     for (unsigned int i = 0; i < utf16.size(); i++)
     {
-      unsigned int ch = utf16[i];
+      uint32_t ch = utf16[i] | style;
       if ((m_startSelection < m_endSelection) && (m_startSelection <= i && i < m_endSelection))
         ch |= (2 << 16);
       else if ((m_startHighlight < m_endHighlight) && (i < m_startHighlight || i >= m_endHighlight))
@@ -93,7 +98,7 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
     }
     if (m_bShowCursor && m_iCursorPos >= 0 && (unsigned int)m_iCursorPos <= utf16.size())
     {
-      unsigned int ch = L'|';
+      uint32_t ch = L'|' | style;
       if ((++m_dwCounter % 50) <= 25)
         ch |= (3 << 16);
       text.insert(text.begin() + m_iCursorPos, ch);


### PR DESCRIPTION
## Description
Fix for #17977 'Long text in input dialog does not scroll correctly'
Font style bits were not being applied in SetStyledText
leading to incorrect width being returned by CGUITextLayout::GetTextWidth(const std::wstring&).

Description of problem described here: https://github.com/xbmc/xbmc/issues/17977

## Motivation and context
Fixes a usability issue with entering long text into a dialog box.

## How has this been tested?
Locally tested on Matrix and Master branch. Confirmed the issue is resolved with no side effects.

## What is the effect on users?
Will allow users to see all end of their text in the dialog box regardless of selected font.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
