### PR TITLE
[PVR] CPVRChannelgroupMember::SetPriority: Do not mark dirty as value…

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -68,7 +68,7 @@ void CPVRChannelGroupMember::SetGroupID(int iGroupID)
   if (m_iGroupID != iGroupID)
   {
     m_iGroupID = iGroupID;
-    m_bChanged = true;
+    m_bNeedsSave = true;
   }
 }
 
@@ -86,7 +86,7 @@ void CPVRChannelGroupMember::SetChannelNumber(const CPVRChannelNumber& channelNu
   if (m_channelNumber != channelNumber)
   {
     m_channelNumber = channelNumber;
-    m_bChanged = true;
+    m_bNeedsSave = true;
   }
 }
 
@@ -95,7 +95,7 @@ void CPVRChannelGroupMember::SetClientChannelNumber(const CPVRChannelNumber& cli
   if (m_clientChannelNumber != clientChannelNumber)
   {
     m_clientChannelNumber = clientChannelNumber;
-    m_bChanged = true;
+    m_bNeedsSave = true;
   }
 }
 
@@ -104,7 +104,7 @@ void CPVRChannelGroupMember::SetClientPriority(int iClientPriority)
   if (m_iClientPriority != iClientPriority)
   {
     m_iClientPriority = iClientPriority;
-    m_bChanged = true;
+    // Note: do not set m_bNeedsSave here as priority is not stored in database
   }
 }
 
@@ -113,7 +113,7 @@ void CPVRChannelGroupMember::SetOrder(int iOrder)
   if (m_iOrder != iOrder)
   {
     m_iOrder = iOrder;
-    m_bChanged = true;
+    m_bNeedsSave = true;
   }
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -25,7 +25,7 @@ class CPVRChannelGroupMember : public ISerializable, public ISortable
   friend class CPVRDatabase;
 
 public:
-  CPVRChannelGroupMember() : m_bChanged(false) {}
+  CPVRChannelGroupMember() : m_bNeedsSave(false) {}
 
   CPVRChannelGroupMember(int iGroupID,
                          const std::string& groupName,
@@ -60,8 +60,8 @@ public:
   int Order() const { return m_iOrder; }
   void SetOrder(int iOrder);
 
-  bool NeedsSave() const { return m_bChanged; }
-  void SetSaved() { m_bChanged = false; }
+  bool NeedsSave() const { return m_bNeedsSave; }
+  void SetSaved() { m_bNeedsSave = false; }
 
   int ClientID() const { return m_iClientID; }
 
@@ -91,7 +91,7 @@ private:
   int m_iClientPriority = 0;
   int m_iOrder = 0; // The value denoting the order of this member in the group
 
-  bool m_bChanged = true;
+  bool m_bNeedsSave = true;
 };
 
 } // namespace PVR


### PR DESCRIPTION
… is not stored in the database. Rename respective member to reflect its actual purpose.

Fixes unneeed databse writes on Kodi startup and channel/groups updates.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish code change should be pretty self-explaining. `NeedsSave()` is called from the PVRDatabase code persisting channel groups and its members.