### PR TITLE
[Subtitles] Show font family name's to subtitle fonts list

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2695,6 +2695,7 @@ msgid "Date added"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/settings/SubtitlesSettings.cpp
 msgctxt "#571"
 msgid "Default"
 msgstr ""
@@ -22982,4 +22983,10 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#39179"
 msgid "The time in seconds for the video OSD to be automatically closed"
+msgstr ""
+
+#. Progress text on splash screen, to build the font cache
+#: xbmc/Application.cpp
+msgctxt "#39180"
+msgid "Building font cache in progress - please wait"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -517,26 +517,23 @@
           </constraints>
           <control type="spinner" format="integer" delayed="true"/>
         </setting>
-        <setting id="subtitles.font" type="string" label="14089" help="36185">
+        <setting id="subtitles.fontname" type="string" label="14089" help="36185">
           <level>1</level>
-          <default>arial.ttf</default>
+          <default>DEFAULT</default>
           <constraints>
-            <options>fonts</options>
+            <options>subtitlesfonts</options>
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.charset" type="string" parent="subtitles.font" label="735" help="36189">
+        <setting id="subtitles.charset" type="string" parent="subtitles.fontname" label="735" help="36189">
           <level>1</level>
           <default>DEFAULT</default>
           <constraints>
             <options>charsets</options>
           </constraints>
-          <dependencies>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
-          </dependencies>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.fontsize" type="integer" parent="subtitles.font" label="289" help="36186">
+        <setting id="subtitles.fontsize" type="integer" parent="subtitles.fontname" label="289" help="36186">
           <level>3</level>
           <default>42</default>
           <constraints>
@@ -545,11 +542,11 @@
             <maximum>74</maximum>
           </constraints>
           <dependencies>
-            <dependency type="update" setting="subtitles.font" />
+            <dependency type="update" setting="subtitles.fontname" />
           </dependencies>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.style" type="integer" parent="subtitles.font" label="736" help="36187">
+        <setting id="subtitles.style" type="integer" parent="subtitles.fontname" label="736" help="36187">
           <level>3</level>
           <default>0</default> <!-- FONT_STYLE_NORMAL -->
           <constraints>
@@ -560,62 +557,40 @@
               <option label="741">3</option> <!-- FONT_STYLE_BOLD | FONT_STYLE_ITALICS -->
             </options>
           </constraints>
-          <dependencies>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
-          </dependencies>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.colorpick" type="string" parent="subtitles.font" label="737" help="36188">
+        <setting id="subtitles.colorpick" type="string" parent="subtitles.fontname" label="737" help="36188">
           <level>3</level>
           <default>FFFFFFFF</default> <!-- White -->
-          <dependencies>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
-          </dependencies>
           <control type="colorbutton" />
         </setting>
-        <setting id="subtitles.opacity" type="integer" parent="subtitles.font" label="752" help="36295">
+        <setting id="subtitles.opacity" type="integer" parent="subtitles.fontname" label="752" help="36295">
           <level>3</level>
           <default>100</default>
-          <dependencies>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
-          </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
-        <setting id="subtitles.bordersize" type="integer" parent="subtitles.font" label="39159">
+        <setting id="subtitles.bordersize" type="integer" parent="subtitles.fontname" label="39159">
           <level>3</level>
           <default>30</default>
           <dependencies>
-            <dependency type="enable">
-              <and>
-                <condition on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font"/>
-                <condition setting="subtitles.backgroundtype" operator="!is">2</condition>
-              </and>
-            </dependency>
+            <dependency type="enable" setting="subtitles.backgroundtype" operator="!is">2</dependency>
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
-        <setting id="subtitles.bordercolorpick" type="string" parent="subtitles.font" label="39160">
+        <setting id="subtitles.bordercolorpick" type="string" parent="subtitles.fontname" label="39160">
           <level>3</level>
           <default>FF000000</default> <!-- Black -->
           <dependencies>
-            <dependency type="enable">
-              <and>
-                <condition on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font"/>
-                <condition setting="subtitles.backgroundtype" operator="!is">2</condition>
-              </and>
-            </dependency>
+            <dependency type="enable" setting="subtitles.backgroundtype" operator="!is">2</dependency>
           </dependencies>
           <control type="colorbutton" />
         </setting>
-        <setting id="subtitles.blur" type="integer" parent="subtitles.font" label="39173">
+        <setting id="subtitles.blur" type="integer" parent="subtitles.fontname" label="39173">
           <level>3</level>
           <default>0</default>
-          <dependencies>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
-          </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
-        <setting id="subtitles.backgroundtype" type="integer" parent="subtitles.font" label="39165" help="39169">
+        <setting id="subtitles.backgroundtype" type="integer" parent="subtitles.fontname" label="39165" help="39169">
           <level>3</level>
           <default>0</default>
           <constraints>
@@ -626,9 +601,6 @@
               <option label="39168">3</option> <!-- SUBTITLE_BACKGROUNDTYPE_SQUAREBOX -->
             </options>
           </constraints>
-          <dependencies>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
-          </dependencies>
           <control type="list" format="integer" />
         </setting>
         <setting id="subtitles.bgcolorpick" type="string" parent="subtitles.backgroundtype" label="745" help="36228">
@@ -641,7 +613,6 @@
                 <condition setting="subtitles.backgroundtype">3</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="colorbutton" />
         </setting>
@@ -655,7 +626,6 @@
                 <condition setting="subtitles.backgroundtype">3</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
@@ -669,7 +639,6 @@
                 <condition setting="subtitles.backgroundtype">2</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="colorbutton" />
         </setting>
@@ -683,7 +652,6 @@
                 <condition setting="subtitles.backgroundtype">2</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
@@ -697,7 +665,6 @@
                 <condition setting="subtitles.backgroundtype">2</condition>
               </or>
             </dependency>
-            <dependency type="enable" on="property" name="HasSubtitlesFontExtensions" setting="subtitles.font" />
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -678,26 +678,6 @@ void CUtil::ClearSubtitles()
   }
 }
 
-void CUtil::ClearTempFonts()
-{
-  const std::string searchPath = "special://home/media/Fonts/";
-
-  if (!CDirectory::Exists(searchPath))
-    return;
-
-  CFileItemList items;
-  CDirectory::GetDirectory(searchPath, items, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
-                           DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE | DIR_FLAG_GET_HIDDEN);
-  for (const auto &item : items)
-  {
-    if (item->m_bIsFolder)
-      continue;
-
-    if (UTILS::FONT::IsTemporaryFontFile(item->GetPath()))
-      CFile::Delete(item->GetPath());
-  }
-}
-
 int64_t CUtil::ToInt64(uint32_t high, uint32_t low)
 {
   int64_t n;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -70,6 +70,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"
+#include "utils/FontUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
@@ -685,14 +686,14 @@ void CUtil::ClearTempFonts()
     return;
 
   CFileItemList items;
-  CDirectory::GetDirectory(searchPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE | DIR_FLAG_GET_HIDDEN);
-
+  CDirectory::GetDirectory(searchPath, items, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                           DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE | DIR_FLAG_GET_HIDDEN);
   for (const auto &item : items)
   {
     if (item->m_bIsFolder)
       continue;
 
-    if (StringUtils::StartsWithNoCase(URIUtils::GetFileName(item->GetPath()), "tmp.font."))
+    if (UTILS::FONT::IsTemporaryFontFile(item->GetPath()))
       CFile::Delete(item->GetPath());
   }
 }
@@ -1021,11 +1022,6 @@ std::string CUtil::ValidatePath(const std::string &path, bool bFixDoubleSlashes 
     }
   }
   return result;
-}
-
-bool CUtil::IsSupportedFontExtension(const std::string& fileName)
-{
-  return URIUtils::HasExtension(fileName, ".ttf|.otf");
 }
 
 void CUtil::SplitExecFunction(const std::string &execString, std::string &function, std::vector<std::string> &parameters)

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -64,7 +64,6 @@ public:
   static bool GetDirectoryName(const std::string& strFileName, std::string& strDescription);
   static void GetDVDDriveIcon(const std::string& strPath, std::string& strIcon);
   static void RemoveTempFiles();
-  static void ClearTempFonts();
 
   static void ClearSubtitles();
   static void ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles );

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -25,6 +25,7 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
+#include "utils/FontUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
@@ -1764,11 +1765,16 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           }
           else
           {
-            // Note: libass only supports a single font directory to look for additional fonts
-            // (c.f. ass_set_fonts_dir). To support both user defined fonts (those placed in
-            // special://home/media/Fonts/) and fonts extracted by the demuxer, make it extract
-            // fonts to the user directory with a known, easy to identify, prefix (tmp.font.*).
-            fileName += "tmp.font." + CUtil::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
+            // Note: Libass only supports a single additional font directory,
+            // currently set for user fonts (c.f. ass_set_fonts_dir) therefore
+            // we will also use this folder to store fonts extracted by the
+            // demuxer. The extracted fonts will have a prefix in the filename
+            // for easy identification.
+            //! @todo: this font file management system on disk could be completely
+            //! removed, by sending font data to the subtitle renderer and
+            //! using libass ass_add_font to add the fonts directly in memory.
+            fileName += UTILS::FONT::TEMP_FONT_FILENAME_PREFIX +
+                        CUtil::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
             XFILE::CFile file;
             if (pStream->codecpar->extradata && file.OpenForWrite(fileName))
             {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -37,24 +37,6 @@ constexpr int ASS_BORDER_STYLE_SQUARE_BOX = 4; // Square box + outline
 
 constexpr int ASS_FONT_ENCODING_AUTO = -1;
 
-// Directory where user defined fonts are located (and where MKV fonts are
-// extracted and temporarily stored)
-constexpr const char* userFontPath = "special://home/media/Fonts/";
-// Directory where Kodi bundled fonts files are located
-constexpr const char* systemFontPath = "special://xbmc/media/Fonts/";
-
-std::string GetSystemFontPath(const std::string& filename)
-{
-  std::string fontPath = URIUtils::AddFileToFolder(systemFontPath, filename);
-  if (XFILE::CFile::Exists(fontPath))
-  {
-    return CSpecialProtocol::TranslatePath(fontPath);
-  }
-
-  CLog::LogF(LOGERROR, "Could not find application system font {}", filename);
-  return "";
-}
-
 // Convert RGB/ARGB to RGBA by also applying the opacity value
 COLOR::Color ConvColor(COLOR::Color argbColor, int opacity = 100)
 {
@@ -115,11 +97,18 @@ void CDVDSubtitlesLibass::Configure()
   // platforms (e.g. linux/windows), on some other systems like android the
   // font provider is currenlty not supported, then an user can add his
   // additionals fonts only by using the user fonts folder.
-  ass_set_fonts_dir(m_library, CSpecialProtocol::TranslatePath(userFontPath).c_str());
+  ass_set_fonts_dir(m_library,
+                    CSpecialProtocol::TranslatePath(UTILS::FONT::FONTPATH::USER).c_str());
 
-  // Load additionals application system fonts to Libass
+  // Load additional fonts into Libass memory
   CFileItemList items;
-  XFILE::CDirectory::GetDirectory(systemFontPath, items, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+  // Get fonts from system directory
+  XFILE::CDirectory::GetDirectory(UTILS::FONT::FONTPATH::SYSTEM, items,
+                                  UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                                  XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  // Get temporary fonts
+  XFILE::CDirectory::GetDirectory(UTILS::FONT::FONTPATH::TEMP, items,
+                                  UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
                                   XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
   for (const auto& item : items)
   {
@@ -152,7 +141,8 @@ void CDVDSubtitlesLibass::Configure()
                FONT::FONT_DEFAULT_FILENAME);
   }
 
-  ass_set_fonts(m_renderer, GetSystemFontPath(FONT::FONT_DEFAULT_FILENAME).c_str(),
+  ass_set_fonts(m_renderer,
+                UTILS::FONT::FONTPATH::GetSystemFontPath(FONT::FONT_DEFAULT_FILENAME).c_str(),
                 m_defaultFontFamilyName.c_str(), ASS_FONTPROVIDER_AUTODETECT, nullptr, 1);
 
   ass_set_font_scale(m_renderer, 1);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -8,13 +8,18 @@
 
 #include "DVDSubtitlesLibass.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
+#include "Util.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/SubtitlesSettings.h"
 #include "threads/SingleLock.h"
+#include "utils/FontUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -32,24 +37,21 @@ constexpr int ASS_BORDER_STYLE_SQUARE_BOX = 4; // Square box + outline
 
 constexpr int ASS_FONT_ENCODING_AUTO = -1;
 
-// Directory where user defined fonts are located (and where mkv fonts are extracted to)
+// Directory where user defined fonts are located (and where MKV fonts are
+// extracted and temporarily stored)
 constexpr const char* userFontPath = "special://home/media/Fonts/";
-// Directory where Kodi bundled fonts (default ones like Arial or Teletext) are located
+// Directory where Kodi bundled fonts files are located
 constexpr const char* systemFontPath = "special://xbmc/media/Fonts/";
 
-std::string GetDefaultFontPath(std::string& font)
+std::string GetSystemFontPath(const std::string& filename)
 {
-  constexpr std::array<const char*, 2> fontSources{userFontPath, systemFontPath};
-
-  for (const auto& path : fontSources)
+  std::string fontPath = URIUtils::AddFileToFolder(systemFontPath, filename);
+  if (XFILE::CFile::Exists(fontPath))
   {
-    auto fontPath = URIUtils::AddFileToFolder(path, font);
-    if (XFILE::CFile::Exists(fontPath))
-    {
-      return CSpecialProtocol::TranslatePath(fontPath).c_str();
-    }
+    return CSpecialProtocol::TranslatePath(fontPath);
   }
-  CLog::Log(LOGERROR, "CDVDSubtitlesLibass: Could not find font {} in font sources", font);
+
+  CLog::LogF(LOGERROR, "Could not find application system font {}", filename);
   return "";
 }
 
@@ -109,9 +111,50 @@ void CDVDSubtitlesLibass::Configure()
   ass_set_margins(m_renderer, 0, 0, 0, 0);
   ass_set_use_margins(m_renderer, 0);
 
-  // libass uses fontconfig (system lib) by default in some platforms (e.g. linux/android) or as
-  // a fallback for all platforms. It is not wrapped so translate the path before calling into libass
+  // Libass uses system font provider (like fontconfig) by default in some
+  // platforms (e.g. linux/windows), on some other systems like android the
+  // font provider is currenlty not supported, then an user can add his
+  // additionals fonts only by using the user fonts folder.
   ass_set_fonts_dir(m_library, CSpecialProtocol::TranslatePath(userFontPath).c_str());
+
+  // Load additionals application system fonts to Libass
+  CFileItemList items;
+  XFILE::CDirectory::GetDirectory(systemFontPath, items, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                                  XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  for (const auto& item : items)
+  {
+    if (item->m_bIsFolder)
+      continue;
+    const std::string filepath = item->GetPath();
+    const std::string fileName = item->GetLabel();
+    std::vector<uint8_t> buffer;
+    if (XFILE::CFile().LoadFile(filepath, buffer) <= 0)
+    {
+      CLog::LogF(LOGERROR, "Failed to load file {}", filepath);
+      continue;
+    }
+#if LIBASS_VERSION >= 0x01501000
+    ass_add_font(m_library, fileName.c_str(), reinterpret_cast<const char*>(buffer.data()),
+                 static_cast<int>(buffer.size()));
+#else
+    ass_add_font(m_library, const_cast<char*>(fileName.c_str()),
+                 reinterpret_cast<char*>(buffer.data()), static_cast<int>(buffer.size()));
+#endif
+    if (StringUtils::CompareNoCase(fileName, FONT::FONT_DEFAULT_FILENAME) == 0)
+    {
+      m_defaultFontFamilyName = FONT::GetFontFamily(buffer);
+    }
+  }
+  if (m_defaultFontFamilyName.empty())
+  {
+    CLog::LogF(LOGERROR,
+               "The application font {} is missing. The default subtitle font cannot be set.",
+               FONT::FONT_DEFAULT_FILENAME);
+  }
+
+  ass_set_fonts(m_renderer, GetSystemFontPath(FONT::FONT_DEFAULT_FILENAME).c_str(),
+                m_defaultFontFamilyName.c_str(), ASS_FONTPROVIDER_AUTODETECT, nullptr, 1);
+
   ass_set_font_scale(m_renderer, 1);
 
   // Extract font must be set before loading ASS/SSA data,
@@ -277,14 +320,13 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLE
     return;
   }
 
-  ConfigureFont((m_subtitleType == NATIVE && subStyle->assOverrideFont), subStyle->fontName);
-
   // ASS_Style is a POD struct need to be initialized with {}
   ASS_Style defaultStyle{};
   ASS_Style* style = nullptr;
 
   if (m_subtitleType == ADAPTED ||
-      (m_subtitleType == NATIVE && subStyle->assOverrideStyles != OverrideStyles::DISABLED))
+      (m_subtitleType == NATIVE &&
+       (subStyle->assOverrideStyles != OverrideStyles::DISABLED || subStyle->assOverrideFont)))
   {
     m_currentDefaultStyleId = m_defaultKodiStyleId;
 
@@ -297,6 +339,7 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLE
       style = &m_track->styles[m_currentDefaultStyleId];
     }
 
+    free(style->Name);
     style->Name = strdup("KodiDefault");
 
     // Calculate the scale (influence ASS style properties)
@@ -304,7 +347,8 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLE
     int playResY;
     if (m_subtitleType == NATIVE &&
         (subStyle->assOverrideStyles == OverrideStyles::STYLES ||
-         subStyle->assOverrideStyles == OverrideStyles::STYLES_POSITIONS))
+         subStyle->assOverrideStyles == OverrideStyles::STYLES_POSITIONS ||
+         subStyle->assOverrideFont))
     {
       // With styles overridden the PlayResY will be changed to 288
       playResY = 288;
@@ -316,104 +360,105 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLE
     }
 
     // It is mandatory set the FontName, the text is case sensitive
-    style->FontName = strdup(subStyle->fontName.c_str());
+    free(style->FontName);
+    if (subStyle->fontName == FONT_DEFAULT_FAMILYNAME)
+      style->FontName = strdup(m_defaultFontFamilyName.c_str());
+    else
+      style->FontName = strdup(subStyle->fontName.c_str());
 
-    if (m_subtitleType != NATIVE || subStyle->assOverrideStyles != OverrideStyles::POSITIONS)
+    // Configure the font properties
+    // FIXME: The font size need to be scaled to be shown in right PT size
+    style->FontSize = (subStyle->fontSize / 720) * playResY;
+    // Modifies the width/height of the font (1 = 100%)
+    style->ScaleX = 1.0;
+    style->ScaleY = 1.0;
+    // Extra space between characters causes the underlined
+    // text line to become more discontinuous (test on LibAss 15.1)
+    style->Spacing = 0;
+
+    // Set automatic paragraph direction (not VSFilter-compatible)
+    // to fix wrong RTL text direction when there are unicode chars
+    style->Encoding = ASS_FONT_ENCODING_AUTO;
+
+    bool isFontBold =
+        (subStyle->fontStyle == FontStyle::BOLD || subStyle->fontStyle == FontStyle::BOLD_ITALIC);
+    bool isFontItalic =
+        (subStyle->fontStyle == FontStyle::ITALIC || subStyle->fontStyle == FontStyle::BOLD_ITALIC);
+    style->Bold = isFontBold * -1;
+    style->Italic = isFontItalic * -1;
+
+    // Compute the font color, depending on the opacity
+    COLOR::Color subColor = ConvColor(subStyle->fontColor, subStyle->fontOpacity);
+    // Set default subtitles color
+    style->PrimaryColour = subColor;
+    // Set SecondaryColour may be used to prevent an onscreen collision
+    style->SecondaryColour = subColor;
+
+    // Configure the effects
+    double lineSpacing = 0.0;
+    if (subStyle->borderStyle == BorderStyle::OUTLINE ||
+        subStyle->borderStyle == BorderStyle::OUTLINE_NO_SHADOW)
     {
-      // Configure the font properties
-      // FIXME: The font size need to be scaled to be shown in right PT size
-      style->FontSize = (subStyle->fontSize / 720) * playResY;
-      // Modifies the width/height of the font (1 = 100%)
-      style->ScaleX = 1.0;
-      style->ScaleY = 1.0;
-      // Extra space between characters causes the underlined
-      // text line to become more discontinuous (test on LibAss 15.1)
-      style->Spacing = 0;
-
-      // Set automatic paragraph direction (not VSFilter-compatible)
-      // to fix wrong RTL text direction when there are unicode chars
-      style->Encoding = ASS_FONT_ENCODING_AUTO;
-
-      bool isFontBold =
-          (subStyle->fontStyle == FontStyle::BOLD || subStyle->fontStyle == FontStyle::BOLD_ITALIC);
-      bool isFontItalic = (subStyle->fontStyle == FontStyle::ITALIC ||
-                           subStyle->fontStyle == FontStyle::BOLD_ITALIC);
-      style->Bold = isFontBold * -1;
-      style->Italic = isFontItalic * -1;
-
-      // Compute the font color, depending on the opacity
-      COLOR::Color subColor = ConvColor(subStyle->fontColor, subStyle->fontOpacity);
-      // Set default subtitles color
-      style->PrimaryColour = subColor;
-      // Set SecondaryColour may be used to prevent an onscreen collision
-      style->SecondaryColour = subColor;
-
-      // Configure the effects
-      double lineSpacing = 0.0;
-      if (subStyle->borderStyle == BorderStyle::OUTLINE ||
-          subStyle->borderStyle == BorderStyle::OUTLINE_NO_SHADOW)
+      style->BorderStyle = ASS_BORDER_STYLE_OUTLINE;
+      style->Outline = (10.00 / 100 * subStyle->fontBorderSize) * scale;
+      style->OutlineColour = ConvColor(subStyle->fontBorderColor, subStyle->fontOpacity);
+      if (subStyle->borderStyle == BorderStyle::OUTLINE_NO_SHADOW)
       {
-        style->BorderStyle = ASS_BORDER_STYLE_OUTLINE;
-        style->Outline = (10.00 / 100 * subStyle->fontBorderSize) * scale;
-        style->OutlineColour = ConvColor(subStyle->fontBorderColor, subStyle->fontOpacity);
-        if (subStyle->borderStyle == BorderStyle::OUTLINE_NO_SHADOW)
-        {
-          style->BackColour = ConvColor(COLOR::NONE, 0); // Set the shadow color
-          style->Shadow = 0; // Set the shadow size
-        }
-        else
-        {
-          style->BackColour =
-              ConvColor(subStyle->shadowColor, subStyle->shadowOpacity); // Set the shadow color
-          style->Shadow = (10.00 / 100 * subStyle->shadowSize) * scale; // Set the shadow size
-        }
+        style->BackColour = ConvColor(COLOR::NONE, 0); // Set the shadow color
+        style->Shadow = 0; // Set the shadow size
       }
-      else if (subStyle->borderStyle == BorderStyle::BOX)
-      {
-        // This BorderStyle not support outline color/size
-        style->BorderStyle = ASS_BORDER_STYLE_BOX;
-        style->Outline = 4 * scale; // Space between the text and the box edges
-        style->OutlineColour =
-            ConvColor(subStyle->backgroundColor,
-                      subStyle->backgroundOpacity); // Set the background border color
-        style->BackColour =
-            ConvColor(subStyle->shadowColor, subStyle->shadowOpacity); // Set the box shadow color
-        style->Shadow = (10.00 / 100 * subStyle->shadowSize) * scale; // Set the box shadow size
-        // By default a box overlaps the other, then we increase a bit the line spacing
-        lineSpacing = 6.0;
-      }
-      else if (subStyle->borderStyle == BorderStyle::SQUARE_BOX)
-      {
-        // This BorderStyle not support shadow color/size
-        style->BorderStyle = ASS_BORDER_STYLE_SQUARE_BOX;
-        style->Outline = (10.00 / 100 * subStyle->fontBorderSize) * scale;
-        style->OutlineColour = ConvColor(subStyle->fontBorderColor, subStyle->fontOpacity);
-        style->BackColour = ConvColor(subStyle->backgroundColor, subStyle->backgroundOpacity);
-        style->Shadow = 4 * scale; // Space between the text and the box edges
-      }
-
-      ass_set_line_spacing(m_renderer, lineSpacing);
-
-      style->Blur = (10.00 / 100 * subStyle->blur);
-
-      double marginLR = 20;
-      if (opts.horizontalAlignment != HorizontalAlignment::DISABLED)
-      {
-        // If the subtitle text is aligned on the left or right
-        // of the screen, we set an extra left/right margin
-        marginLR += static_cast<double>(opts.frameWidth) / 10;
-      }
-
-      // Set the margins (in pixel)
-      style->MarginL = static_cast<int>(marginLR * scale);
-      style->MarginR = static_cast<int>(marginLR * scale);
-      // Vertical margin (direction depends on alignment)
-      // to be set only when the video calibration position setting is not used
-      if (opts.usePosition)
-        style->MarginV = 0;
       else
-        style->MarginV = static_cast<int>(subStyle->marginVertical * scale);
+      {
+        style->BackColour =
+            ConvColor(subStyle->shadowColor, subStyle->shadowOpacity); // Set the shadow color
+        style->Shadow = (10.00 / 100 * subStyle->shadowSize) * scale; // Set the shadow size
+      }
     }
+    else if (subStyle->borderStyle == BorderStyle::BOX)
+    {
+      // This BorderStyle not support outline color/size
+      style->BorderStyle = ASS_BORDER_STYLE_BOX;
+      style->Outline = 4 * scale; // Space between the text and the box edges
+      style->OutlineColour =
+          ConvColor(subStyle->backgroundColor,
+                    subStyle->backgroundOpacity); // Set the background border color
+      style->BackColour =
+          ConvColor(subStyle->shadowColor, subStyle->shadowOpacity); // Set the box shadow color
+      style->Shadow = (10.00 / 100 * subStyle->shadowSize) * scale; // Set the box shadow size
+      // By default a box overlaps the other, then we increase a bit the line spacing
+      lineSpacing = 6.0;
+    }
+    else if (subStyle->borderStyle == BorderStyle::SQUARE_BOX)
+    {
+      // This BorderStyle not support shadow color/size
+      style->BorderStyle = ASS_BORDER_STYLE_SQUARE_BOX;
+      style->Outline = (10.00 / 100 * subStyle->fontBorderSize) * scale;
+      style->OutlineColour = ConvColor(subStyle->fontBorderColor, subStyle->fontOpacity);
+      style->BackColour = ConvColor(subStyle->backgroundColor, subStyle->backgroundOpacity);
+      style->Shadow = 4 * scale; // Space between the text and the box edges
+    }
+
+    ass_set_line_spacing(m_renderer, lineSpacing);
+
+    style->Blur = (10.00 / 100 * subStyle->blur);
+
+    double marginLR = 20;
+    if (opts.horizontalAlignment != HorizontalAlignment::DISABLED)
+    {
+      // If the subtitle text is aligned on the left or right
+      // of the screen, we set an extra left/right margin
+      marginLR += static_cast<double>(opts.frameWidth) / 10;
+    }
+
+    // Set the margins (in pixel)
+    style->MarginL = static_cast<int>(marginLR * scale);
+    style->MarginR = static_cast<int>(marginLR * scale);
+    // Vertical margin (direction depends on alignment)
+    // to be set only when the video calibration position setting is not used
+    if (opts.usePosition)
+      style->MarginV = 0;
+    else
+      style->MarginV = static_cast<int>(subStyle->marginVertical * scale);
 
     // Set the vertical alignment
     if (subStyle->alignment == FontAlignment::TOP_LEFT ||
@@ -467,42 +512,32 @@ void CDVDSubtitlesLibass::ConfigureAssOverride(
   }
 
   // Default behaviour, disable ASS embedded styles override (if has been changed)
-  int stylesFlags = ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
-
+  int stylesFlags{ASS_OVERRIDE_DEFAULT};
   if (style)
   {
     // Manage override cases with ASS embedded styles
     if (subStyle->assOverrideStyles == OverrideStyles::STYLES)
     {
-      stylesFlags = ASS_OVERRIDE_BIT_FONT_SIZE_FIELDS | ASS_OVERRIDE_BIT_FONT_NAME |
-                    ASS_OVERRIDE_BIT_COLORS | ASS_OVERRIDE_BIT_ATTRIBUTES |
+      stylesFlags = ASS_OVERRIDE_BIT_COLORS | ASS_OVERRIDE_BIT_ATTRIBUTES |
                     ASS_OVERRIDE_BIT_BORDER | ASS_OVERRIDE_BIT_MARGINS;
     }
     else if (subStyle->assOverrideStyles == OverrideStyles::STYLES_POSITIONS)
     {
-      stylesFlags = ASS_OVERRIDE_BIT_FONT_SIZE_FIELDS | ASS_OVERRIDE_BIT_FONT_NAME |
-                    ASS_OVERRIDE_BIT_COLORS | ASS_OVERRIDE_BIT_ATTRIBUTES |
+      stylesFlags = ASS_OVERRIDE_BIT_COLORS | ASS_OVERRIDE_BIT_ATTRIBUTES |
                     ASS_OVERRIDE_BIT_BORDER | ASS_OVERRIDE_BIT_MARGINS | ASS_OVERRIDE_BIT_ALIGNMENT;
     }
     else if (subStyle->assOverrideStyles == OverrideStyles::POSITIONS)
     {
       stylesFlags = ASS_OVERRIDE_BIT_ALIGNMENT;
     }
+    if (subStyle->assOverrideFont)
+    {
+      stylesFlags |= ASS_OVERRIDE_BIT_FONT_SIZE_FIELDS | ASS_OVERRIDE_BIT_FONT_NAME;
+    }
     ass_set_selective_style_override(m_renderer, style);
   }
-  ass_set_selective_style_override_enabled(m_renderer, stylesFlags);
-}
 
-void CDVDSubtitlesLibass::ConfigureFont(bool overrideFont, std::string fontName)
-{
-  int fontProvider = ASS_FONTPROVIDER_AUTODETECT;
-  std::string fontPath = GetDefaultFontPath(fontName);
-  if ((m_subtitleType == ADAPTED || overrideFont) && !fontPath.empty())
-    fontProvider = ASS_FONTPROVIDER_NONE;
-  // Libass take in consideration of the default font specified only
-  // as last resort so when the builtin list of fallbacks fails,
-  // the be able to use our font we have to set ASS_FONTPROVIDER_NONE
-  ass_set_fonts(m_renderer, fontPath.c_str(), fontName.c_str(), fontProvider, nullptr, 1);
+  ass_set_selective_style_override_enabled(m_renderer, stylesFlags);
 }
 
 ASS_Event* CDVDSubtitlesLibass::GetEvents()

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -146,7 +146,6 @@ protected:
 private:
   void ConfigureAssOverride(const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
                             ASS_Style* style);
-  void ConfigureFont(bool overrideFont, std::string fontName);
   void ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
                   KODI::SUBTITLES::renderOpts opts);
 
@@ -162,4 +161,5 @@ private:
   // default allocated style ID for the kodi user configured subtitle style
   int m_defaultKodiStyleId{ASS_NO_ID};
   bool m_drawWithinBlackBars{false};
+  std::string m_defaultFontFamilyName;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -21,7 +21,6 @@ constexpr double VIEWPORT_HEIGHT = 1080.0;
 constexpr double VIEWPORT_WIDTH = 1920.0;
 constexpr int MARGIN_VERTICAL = 30;
 
-
 enum class HorizontalAlignment
 {
   DISABLED = 0,
@@ -69,8 +68,8 @@ enum class OverrideStyles
 
 struct style
 {
-  std::string fontName;
-  double fontSize;
+  std::string fontName; // Font family name
+  double fontSize; // Font size in PT
   FontStyle fontStyle = FontStyle::NORMAL;
   UTILS::COLOR::Color fontColor = UTILS::COLOR::WHITE;
   int fontBorderSize = 15; // In %

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -50,6 +50,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/FontUtils.h"
 #include "utils/JobManager.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StreamDetails.h"
@@ -745,7 +746,7 @@ void CVideoPlayer::OnStartup()
   m_CurrentTeletext.Clear();
   m_CurrentRadioRDS.Clear();
 
-  CUtil::ClearTempFonts();
+  UTILS::FONT::ClearTemporaryFonts();
 }
 
 bool CVideoPlayer::OpenInputStream()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -263,7 +263,7 @@ void CRenderer::CreateSubtitlesStyle()
   m_overlayStyle = std::make_shared<KODI::SUBTITLES::style>();
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
-  m_overlayStyle->fontName = settings->GetString(CSettings::SETTING_SUBTITLES_FONT);
+  m_overlayStyle->fontName = settings->GetString(CSettings::SETTING_SUBTITLES_FONTNAME);
   m_overlayStyle->fontSize = (double)settings->GetInt(CSettings::SETTING_SUBTITLES_FONTSIZE);
 
   uint32_t fontStyleMask = settings->GetInt(CSettings::SETTING_SUBTITLES_STYLE) & FONT_STYLE_MASK;

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -28,16 +28,48 @@
 #include "filesystem/File.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
+#include "utils/FontUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+
+#include <algorithm>
+#include <set>
 
 #ifdef TARGET_POSIX
 #include "filesystem/SpecialProtocol.h"
 #endif
 
 using namespace ADDON;
+
+namespace
+{
+constexpr const char* xmlUserFontCachePath = "special://home/media/Fonts/fontcache.xml";
+constexpr const char* userFontsPath = "special://home/media/Fonts/";
+
+bool LoadXMLData(const std::string& filepath, CXBMCTinyXML& xmlDoc)
+{
+  if (!XFILE::CFile::Exists(filepath))
+  {
+    CLog::LogF(LOGDEBUG, "Couldn't load '{}' the file don't exists", filepath);
+    return false;
+  }
+  if (!xmlDoc.LoadFile(filepath))
+  {
+    CLog::LogF(LOGERROR, "Couldn't load '{}'", filepath);
+    return false;
+  }
+  TiXmlElement* pRootElement = xmlDoc.RootElement();
+  if (!pRootElement || pRootElement->ValueStr() != "fonts")
+  {
+    CLog::LogF(LOGERROR, "Couldn't load '{}' XML content doesn't start with <fonts>", filepath);
+    return false;
+  }
+  return true;
+}
+} // unnamed namespace
+
 
 GUIFontManager::GUIFontManager() = default;
 
@@ -383,29 +415,18 @@ void GUIFontManager::Clear()
 void GUIFontManager::LoadFonts(const std::string& fontSet)
 {
   // Get the file to load fonts from:
-  const std::string strPath = g_SkinInfo->GetSkinPath("Font.xml", &m_skinResolution);
-  CLog::Log(LOGINFO, "GUIFontManager::{}: Loading fonts from '{}'", __func__, strPath);
+  const std::string filePath = g_SkinInfo->GetSkinPath("Font.xml", &m_skinResolution);
+  CLog::LogF(LOGINFO, "Loading fonts from '{}'", filePath);
 
   CXBMCTinyXML xmlDoc;
-  if (!xmlDoc.LoadFile(strPath))
-  {
-    CLog::Log(LOGERROR, "GUIFontManager::{}: Couldn't load '{}'", __func__, strPath);
+  if (!LoadXMLData(filePath, xmlDoc))
     return;
-  }
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
-  if (!pRootElement || pRootElement->ValueStr() != "fonts")
-  {
-    CLog::Log(LOGERROR, "GUIFontManager::{}: File {} doesn't start with <fonts>", __func__,
-              strPath);
-    return;
-  }
-
   // Resolve includes in Font.xml
   g_SkinInfo->ResolveIncludes(pRootElement);
   // take note of the first font available in case we can't load the one specified
   std::string firstFont;
-
   const TiXmlElement* pChild = pRootElement->FirstChildElement("fontset");
   while (pChild)
   {
@@ -434,8 +455,7 @@ void GUIFontManager::LoadFonts(const std::string& fontSet)
     LoadFonts(firstFont);
   }
   else
-    CLog::Log(LOGERROR, "GUIFontManager::{}: File '{}' doesn't have a valid <fontset>", __func__,
-              strPath);
+    CLog::LogF(LOGERROR, "File '{}' doesn't have a valid <fontset>", filePath);
 }
 
 void GUIFontManager::LoadFonts(const TiXmlNode* fontNode)
@@ -508,19 +528,140 @@ void GUIFontManager::SettingOptionsFontsFiller(const SettingConstPtr& setting,
   CFileItemList items;
 
   // Find font files
-  XFILE::CDirectory::GetDirectory("special://xbmc/media/Fonts/", itemsRoot, "",
-                                  XFILE::DIR_FLAG_DEFAULTS);
-  XFILE::CDirectory::GetDirectory("special://home/media/Fonts/", items, "",
-                                  XFILE::DIR_FLAG_DEFAULTS);
+  XFILE::CDirectory::GetDirectory("special://xbmc/media/Fonts/", itemsRoot,
+                                  UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                                  XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  XFILE::CDirectory::GetDirectory("special://home/media/Fonts/", items,
+                                  UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                                  XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
 
   for (auto itItem = itemsRoot.rbegin(); itItem != itemsRoot.rend(); ++itItem)
     items.AddFront(*itItem, 0);
 
   for (const auto& item : items)
   {
-    if (!item->m_bIsFolder && CUtil::IsSupportedFontExtension(item->GetLabel()))
+    if (item->m_bIsFolder)
+      continue;
+
+    list.emplace_back(item->GetLabel(), item->GetLabel());
+  }
+}
+
+void GUIFontManager::Initialize()
+{
+  CSingleLock lock(m_critSection);
+  LoadUserFonts();
+}
+
+void GUIFontManager::LoadUserFonts()
+{
+  if (!XFILE::CDirectory::Exists(userFontsPath))
+    return;
+
+  CLog::LogF(LOGDEBUG, "Updating user fonts cache...");
+  CXBMCTinyXML xmlDoc;
+  if (LoadXMLData(xmlUserFontCachePath, xmlDoc))
+  {
+    // Load in cache the fonts metadata previously stored in the XML
+    TiXmlElement* pRootElement = xmlDoc.RootElement();
+    if (pRootElement)
     {
-      list.emplace_back(item->GetLabel(), item->GetLabel());
+      const TiXmlNode* fontNode = pRootElement->FirstChild("font");
+      while (fontNode)
+      {
+        std::string filename;
+        std::string familyName;
+        XMLUtils::GetString(fontNode, "filename", filename);
+        XMLUtils::GetString(fontNode, "familyname", familyName);
+        m_userFontsCache.emplace_back(filename, familyName);
+        fontNode = fontNode->NextSibling("font");
+      }
     }
   }
+
+  bool isCacheChanged{false};
+  size_t previousCacheSize = m_userFontsCache.size();
+  CFileItemList dirItems;
+  // Get the current files list from user fonts folder
+  XFILE::CDirectory::GetDirectory(userFontsPath, dirItems, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                                  XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  dirItems.SetFastLookup(true);
+
+  // Remove files that no longer exist from cache
+  auto it = m_userFontsCache.begin();
+  while (it != m_userFontsCache.end())
+  {
+    const std::string filePath = userFontsPath + (*it).m_filename;
+    if (!dirItems.Contains(filePath))
+    {
+      it = m_userFontsCache.erase(it);
+    }
+    else
+    {
+      auto item = dirItems.Get(filePath);
+      dirItems.Remove(item.get());
+      ++it;
+    }
+  }
+  isCacheChanged = previousCacheSize != m_userFontsCache.size();
+  previousCacheSize = m_userFontsCache.size();
+
+  // Add new files in cache and generate the metadata
+  //!@todo FIXME: this "for" loop should be replaced with the more performant
+  //! parallel execution std::for_each(std::execution::par, ...
+  //! to halving loading times of fonts list, maybe with C++17 with appropriate
+  //! fix to include parallel execution or future C++20
+  for (auto& item : dirItems)
+  {
+    std::string filepath = item->GetPath();
+    if (item->m_bIsFolder || UTILS::FONT::IsTemporaryFontFile(filepath))
+      continue;
+
+    std::string familyName = UTILS::FONT::GetFontFamily(filepath);
+    if (!familyName.empty())
+    {
+      m_userFontsCache.emplace_back(item->GetLabel(), familyName);
+    }
+  }
+  isCacheChanged = isCacheChanged || previousCacheSize != m_userFontsCache.size();
+
+  // If the cache is changed save an updated XML cache file
+  if (isCacheChanged)
+  {
+    CXBMCTinyXML xmlDoc;
+    TiXmlDeclaration decl("1.0", "UTF-8", "yes");
+    xmlDoc.InsertEndChild(decl);
+    TiXmlElement xmlMainElement("fonts");
+    TiXmlNode* fontsNode = xmlDoc.InsertEndChild(xmlMainElement);
+    if (fontsNode)
+    {
+      for (auto& fontMetadata : m_userFontsCache)
+      {
+        TiXmlElement fontElement("font");
+        TiXmlNode* fontNode = fontsNode->InsertEndChild(fontElement);
+        XMLUtils::SetString(fontNode, "filename", fontMetadata.m_filename);
+        XMLUtils::SetString(fontNode, "familyname", fontMetadata.m_familyName);
+      }
+      if (!xmlDoc.SaveFile(xmlUserFontCachePath))
+        CLog::LogF(LOGERROR, "Failed to save fonts cache file '{}'", xmlUserFontCachePath);
+    }
+    else
+    {
+      CLog::LogF(LOGERROR, "Failed to create XML 'fonts' node");
+    }
+  }
+  CLog::LogF(LOGDEBUG, "Updating user fonts cache... DONE");
+}
+
+std::vector<std::string> GUIFontManager::GetUserFontsFamilyNames()
+{
+  // We ensure to have unique font family names and sorted alphabetically
+  // Duplicated family names can happens for example when a font have each style
+  // on different files
+  std::set<std::string, sortstringbyname> familyNames;
+  for (auto& fontMetadata : m_userFontsCache)
+  {
+    familyNames.insert(fontMetadata.m_familyName);
+  }
+  return std::vector<std::string>(familyNames.begin(), familyNames.end());
 }

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -25,6 +25,7 @@
 #include "profiles/ProfileManager.h"
 #include "settings/SettingAddon.h"
 #include "settings/SettingsComponent.h"
+#include "utils/FontUtils.h"
 #include "utils/StringUtils.h"
 #include "windowing/WinSystem.h"
 
@@ -134,7 +135,7 @@ bool HasSubtitlesFontExtensions(const std::string& condition,
   if (!settingStr)
     return false;
 
-  return CUtil::IsSupportedFontExtension(settingStr->GetValue());
+  return UTILS::FONT::IsSupportedFontExtension(settingStr->GetValue());
 }
 
 bool ProfileCanWriteDatabase(const std::string& condition,

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -164,7 +164,7 @@ constexpr const char* CSettings::SETTING_SUBTITLES_PARSECAPTIONS;
 constexpr const char* CSettings::SETTING_SUBTITLES_CAPTIONSALIGN;
 constexpr const char* CSettings::SETTING_SUBTITLES_ALIGN;
 constexpr const char* CSettings::SETTING_SUBTITLES_STEREOSCOPICDEPTH;
-constexpr const char* CSettings::SETTING_SUBTITLES_FONT;
+constexpr const char* CSettings::SETTING_SUBTITLES_FONTNAME;
 constexpr const char* CSettings::SETTING_SUBTITLES_FONTSIZE;
 constexpr const char* CSettings::SETTING_SUBTITLES_STYLE;
 constexpr const char* CSettings::SETTING_SUBTITLES_COLOR;
@@ -788,6 +788,8 @@ void CSettings::InitializeOptionFillers()
 #endif
   GetSettingsManager()->RegisterSettingOptionsFiller("charsets", CCharsetConverter::SettingOptionsCharsetsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "subtitlesfonts", SUBTITLES::CSubtitlesSettings::SettingOptionsSubtitleFontsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("languagenames", CLangInfo::SettingOptionsLanguageNamesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
@@ -832,6 +834,7 @@ void CSettings::UninitializeOptionFillers()
   GetSettingsManager()->UnregisterSettingOptionsFiller("charsets");
   GetSettingsManager()->UnregisterSettingOptionsFiller("fontheights");
   GetSettingsManager()->UnregisterSettingOptionsFiller("fonts");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("subtitlesfonts");
   GetSettingsManager()->UnregisterSettingOptionsFiller("languagenames");
   GetSettingsManager()->UnregisterSettingOptionsFiller("refreshchangedelays");
   GetSettingsManager()->UnregisterSettingOptionsFiller("refreshrates");

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -143,7 +143,7 @@ public:
   static constexpr auto SETTING_SUBTITLES_CAPTIONSALIGN = "subtitles.captionsalign";
   static constexpr auto SETTING_SUBTITLES_ALIGN = "subtitles.align";
   static constexpr auto SETTING_SUBTITLES_STEREOSCOPICDEPTH = "subtitles.stereoscopicdepth";
-  static constexpr auto SETTING_SUBTITLES_FONT = "subtitles.font";
+  static constexpr auto SETTING_SUBTITLES_FONTNAME = "subtitles.fontname";
   static constexpr auto SETTING_SUBTITLES_FONTSIZE = "subtitles.fontsize";
   static constexpr auto SETTING_SUBTITLES_STYLE = "subtitles.style";
   static constexpr auto SETTING_SUBTITLES_COLOR = "subtitles.colorpick";

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -8,14 +8,22 @@
 
 #include "SubtitlesSettings.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
+#include "guilib/GUIFontManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
+#include "utils/FontUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
 
 using namespace KODI;
 using namespace SUBTITLES;
-
 
 CSubtitlesSettings::CSubtitlesSettings()
 {
@@ -25,7 +33,7 @@ CSubtitlesSettings::CSubtitlesSettings()
                                       CSettings::SETTING_SUBTITLES_PARSECAPTIONS,
                                       CSettings::SETTING_SUBTITLES_ALIGN,
                                       CSettings::SETTING_SUBTITLES_STEREOSCOPICDEPTH,
-                                      CSettings::SETTING_SUBTITLES_FONT,
+                                      CSettings::SETTING_SUBTITLES_FONTNAME,
                                       CSettings::SETTING_SUBTITLES_FONTSIZE,
                                       CSettings::SETTING_SUBTITLES_STYLE,
                                       CSettings::SETTING_SUBTITLES_COLOR,
@@ -69,4 +77,27 @@ void CSubtitlesSettings::OnSettingChanged(const std::shared_ptr<const CSetting>&
 
   SetChanged();
   NotifyObservers(ObservableMessageSettingsChanged);
+}
+
+void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr& setting,
+                                                           std::vector<StringSettingOption>& list,
+                                                           std::string& current,
+                                                           void* data)
+{
+  // From application system fonts folder we add the default font only
+  std::string defaultFontPath =
+      URIUtils::AddFileToFolder("special://xbmc/media/Fonts/", UTILS::FONT::FONT_DEFAULT_FILENAME);
+  if (XFILE::CFile::Exists(defaultFontPath))
+  {
+    std::string familyName = UTILS::FONT::GetFontFamily(defaultFontPath);
+    if (!familyName.empty())
+    {
+      list.emplace_back(g_localizeStrings.Get(571) + " " + familyName, FONT_DEFAULT_FAMILYNAME);
+    }
+  }
+  // Add additionals fonts from the user fonts folder
+  for (std::string familyName : g_fontManager.GetUserFontsFamilyNames())
+  {
+    list.emplace_back(familyName, familyName);
+  }
 }

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -11,13 +11,19 @@
 #include "settings/lib/ISettingCallback.h"
 #include "utils/Observer.h"
 
+#include <memory>
+
 class CSetting;
 class CSettings;
+struct StringSettingOption;
 
 namespace KODI
 {
 namespace SUBTITLES
 {
+// This is a placeholder to keep the fontname setting valid
+// even if the default app font could be changed
+constexpr const char* FONT_DEFAULT_FAMILYNAME = "DEFAULT";
 
 class CSubtitlesSettings : public ISettingCallback, public Observable
 {
@@ -26,6 +32,11 @@ public:
 
   // Inherited from ISettingCallback
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
+
+  static void SettingOptionsSubtitleFontsFiller(const std::shared_ptr<const CSetting>& setting,
+                                                std::vector<StringSettingOption>& list,
+                                                std::string& current,
+                                                void* data);
 
 protected:
   CSubtitlesSettings();

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -670,9 +670,8 @@ bool CGUIControlListSetting::OnClick()
   if (!bAllowNewOption)
   {
     // Do not show dialog if
-    // * there are no items to be chosen or
-    // * only one value can be chosen and there are less than two items available
-    if (!optionsValid || options.Size() <= 0 || (!control->CanMultiSelect() && options.Size() <= 1))
+    // there are no items to be chosen
+    if (!optionsValid || options.Size() <= 0)
       return false;
 
     dialog->Reset();
@@ -851,10 +850,8 @@ void CGUIControlListSetting::Update(bool fromControl, bool updateDisplayOnly)
   if (!updateDisplayOnly)
   {
     // Disable the control if no items can be added and
-    // * there are no items to be chosen
-    // * only one value can be chosen and there are less than two items available
-    if (!m_pButton->IsDisabled() && !bAllowNewOption &&
-        (options.Size() <= 0 || (!control->CanMultiSelect() && options.Size() <= 1)))
+    // there are no items to be chosen
+    if (!m_pButton->IsDisabled() && !bAllowNewOption && (options.Size() <= 0))
       m_pButton->SetEnabled(false);
   }
 }

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -21,6 +21,7 @@ namespace XbmcThreads
    *   lock();
    *   try_lock();
    *   unlock();
+   *   IsLocked();
    *
    * "Exitable" specifically means that, no matter how deep the recursion
    * on the mutex/critical section, we can exit from it and then restore
@@ -49,6 +50,12 @@ namespace XbmcThreads
     inline void lock() { mutex.lock(); count++; }
     inline bool try_lock() { return mutex.try_lock() ? count++, true : false; }
     inline void unlock() { count--; mutex.unlock(); }
+
+    /*!
+     * \brief Check if have a lock owned
+     * \return True if have a lock, otherwise false
+     */
+    inline bool IsLocked() const { return count > 0; }
 
     /**
      * This implements the "exitable" behavior mentioned above.

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES ActorProtocol.cpp
             Fanart.cpp
             FileOperationJob.cpp
             FileUtils.cpp
+            FontUtils.cpp
             GroupUtils.cpp
             HTMLUtil.cpp
             HttpHeader.cpp
@@ -99,6 +100,7 @@ set(HEADERS ActorProtocol.h
             Fanart.h
             FileOperationJob.h
             FileUtils.h
+            FontUtils.h
             Geometry.h
             GlobalsHandling.h
             GroupUtils.h

--- a/xbmc/utils/FontUtils.cpp
+++ b/xbmc/utils/FontUtils.cpp
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FontUtils.h"
+
+#include "StringUtils.h"
+#include "URIUtils.h"
+#include "Util.h"
+#include "filesystem/File.h"
+#include "utils/log.h"
+
+#include <ft2build.h>
+
+#include FT_FREETYPE_H
+
+
+std::string UTILS::FONT::GetFontFamily(std::vector<uint8_t>& buffer)
+{
+  FT_Library m_library{nullptr};
+  FT_Init_FreeType(&m_library);
+  if (!m_library)
+  {
+    CLog::LogF(LOGERROR, "Unable to initialize freetype library");
+    return "";
+  }
+
+  // Load the font face
+  FT_Face face;
+  std::string familyName;
+  if (FT_New_Memory_Face(m_library, reinterpret_cast<const FT_Byte*>(buffer.data()), buffer.size(),
+                         0, &face) == 0)
+  {
+    familyName = std::string(face->family_name);
+  }
+  else
+  {
+    CLog::LogF(LOGERROR, "Failed to process font memory buffer");
+  }
+
+  FT_Done_Face(face);
+  FT_Done_FreeType(m_library);
+  return familyName;
+}
+
+std::string UTILS::FONT::GetFontFamily(const std::string& filepath)
+{
+  std::vector<uint8_t> buffer;
+  if (filepath.empty())
+    return "";
+  if (XFILE::CFile().LoadFile(filepath, buffer) <= 0)
+  {
+    CLog::LogF(LOGERROR, "Failed to load file {}", filepath);
+    return "";
+  }
+  return GetFontFamily(buffer);
+}
+
+bool UTILS::FONT::IsTemporaryFontFile(const std::string& filepath)
+{
+  return StringUtils::StartsWithNoCase(URIUtils::GetFileName(filepath),
+                                       UTILS::FONT::TEMP_FONT_FILENAME_PREFIX);
+}
+
+bool UTILS::FONT::IsSupportedFontExtension(const std::string& filepath)
+{
+  return URIUtils::HasExtension(filepath, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK);
+}

--- a/xbmc/utils/FontUtils.cpp
+++ b/xbmc/utils/FontUtils.cpp
@@ -8,16 +8,20 @@
 
 #include "FontUtils.h"
 
+#include "FileItem.h"
 #include "StringUtils.h"
 #include "URIUtils.h"
 #include "Util.h"
+#include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
 #include "utils/log.h"
 
 #include <ft2build.h>
 
 #include FT_FREETYPE_H
 
+using namespace XFILE;
 
 std::string UTILS::FONT::GetFontFamily(std::vector<uint8_t>& buffer)
 {
@@ -60,13 +64,38 @@ std::string UTILS::FONT::GetFontFamily(const std::string& filepath)
   return GetFontFamily(buffer);
 }
 
-bool UTILS::FONT::IsTemporaryFontFile(const std::string& filepath)
-{
-  return StringUtils::StartsWithNoCase(URIUtils::GetFileName(filepath),
-                                       UTILS::FONT::TEMP_FONT_FILENAME_PREFIX);
-}
-
 bool UTILS::FONT::IsSupportedFontExtension(const std::string& filepath)
 {
   return URIUtils::HasExtension(filepath, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK);
+}
+
+void UTILS::FONT::ClearTemporaryFonts()
+{
+  if (!CDirectory::Exists(UTILS::FONT::FONTPATH::TEMP))
+    return;
+
+  CFileItemList items;
+  CDirectory::GetDirectory(UTILS::FONT::FONTPATH::TEMP, items,
+                           UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                           DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE | DIR_FLAG_GET_HIDDEN);
+  for (const auto& item : items)
+  {
+    if (item->m_bIsFolder)
+      continue;
+
+    CFile::Delete(item->GetPath());
+  }
+}
+
+std::string UTILS::FONT::FONTPATH::GetSystemFontPath(const std::string& filename)
+{
+  std::string fontPath = URIUtils::AddFileToFolder(
+      CSpecialProtocol::TranslatePath(UTILS::FONT::FONTPATH::SYSTEM), filename);
+  if (XFILE::CFile::Exists(fontPath))
+  {
+    return CSpecialProtocol::TranslatePath(fontPath);
+  }
+
+  CLog::LogF(LOGERROR, "Could not find application system font {}", filename);
+  return "";
 }

--- a/xbmc/utils/FontUtils.h
+++ b/xbmc/utils/FontUtils.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+namespace UTILS
+{
+namespace FONT
+{
+constexpr const char* SUPPORTED_EXTENSIONS_MASK = ".ttf|.otf";
+
+// The default application font
+constexpr const char* FONT_DEFAULT_FILENAME = "arial.ttf";
+
+// Prefix used to store temporary font files in the user fonts folder
+constexpr const char* TEMP_FONT_FILENAME_PREFIX = "tmp.font.";
+
+/*!
+ *  \brief Get the font family name from a font file
+ *  \param buffer The font data
+ *  \return The font family name, otherwise empty if fails
+ */
+std::string GetFontFamily(std::vector<uint8_t>& buffer);
+
+/*!
+ *  \brief Get the font family name from a font file
+ *  \param filepath The path where read the font data
+ *  \return The font family name, otherwise empty if fails
+ */
+std::string GetFontFamily(const std::string& filepath);
+
+/*!
+ *  \brief Check if a file is a temporary font file. Temporary fonts are
+ *         extracted by the demuxer from MKV files and stored in the user
+ *         fonts folder.
+ *  \param filepath The font file path
+ *  \return True if it is a temporary file, otherwise false
+ */
+bool IsTemporaryFontFile(const std::string& filepath);
+
+/*!
+ *  \brief Check if a filename have a supported font extension.
+ *  \param filepath The font file path
+ *  \return True if it has a supported extension, otherwise false
+ */
+bool IsSupportedFontExtension(const std::string& filepath);
+} // namespace FONT
+} // namespace UTILS

--- a/xbmc/utils/FontUtils.h
+++ b/xbmc/utils/FontUtils.h
@@ -21,8 +21,23 @@ constexpr const char* SUPPORTED_EXTENSIONS_MASK = ".ttf|.otf";
 // The default application font
 constexpr const char* FONT_DEFAULT_FILENAME = "arial.ttf";
 
-// Prefix used to store temporary font files in the user fonts folder
-constexpr const char* TEMP_FONT_FILENAME_PREFIX = "tmp.font.";
+namespace FONTPATH
+{
+// Directory where Kodi bundled fonts files are located
+constexpr const char* SYSTEM = "special://xbmc/media/Fonts/";
+// Directory where user defined fonts are located
+constexpr const char* USER = "special://home/media/Fonts/";
+// Temporary font path (where MKV fonts are extracted and temporarily stored)
+constexpr const char* TEMP = "special://temp/fonts/";
+
+/*!
+ *  \brief Provided a font filename returns the complete path for the font in
+ *  the system font folder (if it exists) or an empty string otherwise
+ *  \param filename The font file name
+ *  \return The path for the font or an empty string if the path does not exist
+ */
+std::string GetSystemFontPath(const std::string& filename);
+}; // namespace FONTPATH
 
 /*!
  *  \brief Get the font family name from a font file
@@ -39,19 +54,17 @@ std::string GetFontFamily(std::vector<uint8_t>& buffer);
 std::string GetFontFamily(const std::string& filepath);
 
 /*!
- *  \brief Check if a file is a temporary font file. Temporary fonts are
- *         extracted by the demuxer from MKV files and stored in the user
- *         fonts folder.
- *  \param filepath The font file path
- *  \return True if it is a temporary file, otherwise false
- */
-bool IsTemporaryFontFile(const std::string& filepath);
-
-/*!
  *  \brief Check if a filename have a supported font extension.
  *  \param filepath The font file path
  *  \return True if it has a supported extension, otherwise false
  */
 bool IsSupportedFontExtension(const std::string& filepath);
+
+/*!
+ *  \brief Removes all temporary fonts, e.g.those extract from MKV containers
+ *  that are only available during playback
+ */
+void ClearTemporaryFonts();
+
 } // namespace FONT
 } // namespace UTILS

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -395,7 +395,7 @@ private:
 
 struct sortstringbyname
 {
-  bool operator()(const std::string& strItem1, const std::string& strItem2)
+  bool operator()(const std::string& strItem1, const std::string& strItem2) const
   {
     return StringUtils::CompareNoCase(strItem1, strItem2) < 0;
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change allow to show in the subtitles font setting list, the font family name instead of the font filename, as happens on every text editor.
To achieve this has been introduced a new building fonts cache which is triggered when Kodi is started. This also solves the side effect of the GUI freeze every time you try to open the subtitle Kodi settings when there are hundreds/thousands of fonts,
and ensure to fix #20861 memory leak.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initially started to fix issue #20861 for a memory leak,
i preferred to make more radical changes in order to improve the current architecture.

The memory leak was because `ass_set_fonts` was called more times,
and libass was not cleaningup the allocated memory, libass bug!?

The choice to call `ass_set_fonts` each time the style change was made for two main reasons:
- be able to set the selected font from our fonts folders (kodi system or user), this was a kind of workaround to manage fonts from more folders, thing not supported from libass (allow only one additional folder)
- was not implemented a way to get the font family name, kodi only provided the font filename
with the side effect in some cases to have the font provider disabled in libass.

Then implementing a way to retrieve the font family name,
allow to set the right font name to the libass style, avoid call `ass_set_fonts` each time (then no mem leak),
and allowing the advantage to have a font list with font family names in font settings.

To note that the default subtitle font, is now called as:
`Default DejaVu Sans`
this is a dynamic entry constructed by code, in two string parts:
"Default" + font family name, of the default kodi font file set by source code

Why the default Kodi font is not more called `Arial`?
As someone has tried to explain in this issue #19912, our current default Kodi font used in GUI and subtitles, is a real chimera,
the Arial name come from first Kodi versions (10.0 ?) but has nothing to do with Arial font, appears to be a merge of two differents fonts: DejaVu Sans + Droid Sans Fallback, no longer up-to-date.
After the future merge of GUI font rework PR, we are planning to remove this chimera Arial font

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Load more than 1000 fonts in user fonts folder
Load some SRT subtitle and look at loaded font name in libass log
Test an ASS subtitle for testing various overriding settings

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
![immagine](https://user-images.githubusercontent.com/3257156/150825950-a1706f18-5d18-4e02-bd9b-435aa391f97f.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
