### PR TITLE
CThread: cleanup and priority abstraction

### DIFF
--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -109,7 +109,7 @@ void CBackgroundInfoLoader::Load(CFileItemList& items)
 
   m_thread = new CThread(this, "BackgroundLoader");
   m_thread->Create();
-  m_thread->SetPriority(THREAD_PRIORITY_BELOW_NORMAL);
+  m_thread->SetPriority(ThreadPriority::BELOW_NORMAL);
 }
 
 void CBackgroundInfoLoader::StopAsync()

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -72,7 +72,7 @@ CAddonStatusHandler::~CAddonStatusHandler()
 
 void CAddonStatusHandler::OnStartup()
 {
-  SetPriority(GetMinPriority());
+  SetPriority(ThreadPriority::LOWEST);
 }
 
 void CAddonStatusHandler::OnExit()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -43,7 +43,7 @@ void CActiveAESink::Start()
   if (!IsRunning())
   {
     Create();
-    SetPriority(THREAD_PRIORITY_ABOVE_NORMAL);
+    SetPriority(ThreadPriority::ABOVE_NORMAL);
   }
 }
 

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -312,7 +312,7 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
 
 void CAnnouncementManager::Process()
 {
-  SetPriority(GetMinPriority());
+  SetPriority(ThreadPriority::LOWEST);
 
   while (!m_bStop)
   {

--- a/xbmc/network/UdpClient.cpp
+++ b/xbmc/network/UdpClient.cpp
@@ -73,7 +73,7 @@ void CUdpClient::Destroy()
 
 void CUdpClient::OnStartup()
 {
-  SetPriority( GetMinPriority() );
+  SetPriority(ThreadPriority::LOWEST);
 }
 
 bool CUdpClient::Broadcast(int aPort, const std::string& aMessage)

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -240,7 +240,7 @@ void CPeripheralBus::Initialise(void)
   {
     m_triggerEvent.Reset();
     Create();
-    SetPriority(-1);
+    SetPriority(ThreadPriority::BELOW_NORMAL);
   }
 }
 

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -40,7 +40,7 @@ CLirc::~CLirc()
 void CLirc::Start()
 {
   Create();
-  SetPriority(GetMinPriority());
+  SetPriority(ThreadPriority::LOWEST);
 }
 
 void CLirc::Process()

--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -136,7 +136,7 @@ bool CLibInputHandler::SetKeymap(const std::string& layout)
 void CLibInputHandler::Start()
 {
   Create();
-  SetPriority(GetMinPriority());
+  SetPriority(ThreadPriority::LOWEST);
 }
 
 void CLibInputHandler::Process()

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -176,7 +176,7 @@ void CWSDiscoveryListenerUDP::Start()
 
   // Create thread and set low priority
   Create();
-  SetPriority(GetMinPriority());
+  SetPriority(ThreadPriority::LOWEST);
   CLog::Log(LOGINFO, "CWSDiscoveryListenerUDP::Start - Started");
 }
 

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -62,7 +62,7 @@ void CIRServerSuite::Close()
 void CIRServerSuite::Initialize()
 {
   Create();
-  SetPriority(GetMinPriority());
+  SetPriority(ThreadPriority::LOWEST);
 }
 
 void CIRServerSuite::Process()

--- a/xbmc/platform/win32/powermanagement/Win32PowerSyscall.h
+++ b/xbmc/platform/win32/powermanagement/Win32PowerSyscall.h
@@ -23,7 +23,7 @@ public:
 
 protected:
   virtual void Process(void);
-  virtual void OnStartup() { SetPriority(THREAD_PRIORITY_IDLE); }
+  virtual void OnStartup() { SetPriority(ThreadPriority::LOWEST); }
 
 private:
   static bool PowerManagement(PowerState State);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -394,7 +394,7 @@ void CPVRManager::Start()
 
   /* create the pvrmanager thread, which will ensure that all data will be loaded */
   Create();
-  SetPriority(-1);
+  SetPriority(ThreadPriority::BELOW_NORMAL);
 }
 
 void CPVRManager::Stop(bool bRestart /* = false */)

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -150,7 +150,7 @@ void CPVREpgContainer::Start()
     CheckPlayingEvents();
 
     Create();
-    SetPriority(-1);
+    SetPriority(ThreadPriority::BELOW_NORMAL);
 
     m_bStarted = true;
   }
@@ -330,7 +330,7 @@ void CPVREpgContainer::Process()
   bool bUpdateEpg = true;
   bool bHasPendingUpdates = false;
 
-  SetPriority(GetMinPriority());
+  SetPriority(ThreadPriority::LOWEST);
 
   while (!m_bStop)
   {

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -114,7 +114,7 @@ void CPVRGUIInfo::Start()
 {
   ResetProperties();
   Create();
-  SetPriority(-1);
+  SetPriority(ThreadPriority::BELOW_NORMAL);
 }
 
 void CPVRGUIInfo::Stop()

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -55,7 +55,7 @@ CDetectDVDMedia::~CDetectDVDMedia() = default;
 
 void CDetectDVDMedia::OnStartup()
 {
-  // SetPriority( THREAD_PRIORITY_LOWEST );
+  // SetPriority( ThreadPriority::LOWEST );
   CLog::Log(LOGDEBUG, "Compiled with libcdio Version 0.{}", LIBCDIO_VERSION_NUM);
 }
 

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -138,12 +138,6 @@ void CThread::Create(bool bAutoDelete)
 
         pThread->Action();
 
-        // lock during termination
-        {
-          CSingleLock lock(pThread->m_CriticalSection);
-          pThread->TermHandler();
-        }
-
         if (autodelete)
         {
           CLog::Log(LOGDEBUG, "Thread {} {} terminating (autodelete)", name, id);
@@ -224,10 +218,6 @@ bool CThread::IsCurrentThread() const
 CThread* CThread::GetCurrentThread()
 {
   return currentThread;
-}
-
-void CThread::TermHandler()
-{
 }
 
 bool CThread::Join(std::chrono::milliseconds duration)

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -110,7 +110,6 @@ private:
   // -----------------------------------------------------------------------------------
   void SetThreadInfo(); // called from the spawned thread
   void TermHandler();
-  void SetSignalHandlers();
   // -----------------------------------------------------------------------------------
 
   bool m_bAutoDelete = false;

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -107,7 +107,6 @@ private:
   // These are platform specific and can be found in ./platform/[platform]/ThreadImpl.cpp
   // -----------------------------------------------------------------------------------
   void SetThreadInfo(); // called from the spawned thread
-  void TermHandler();
   // -----------------------------------------------------------------------------------
 
   bool m_bAutoDelete = false;

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -25,6 +25,21 @@
 #include <string>
 #include <thread>
 
+enum class ThreadPriority
+{
+  LOWEST,
+  BELOW_NORMAL,
+  NORMAL,
+  ABOVE_NORMAL,
+  HIGHEST,
+};
+
+struct ThreadPriorityStruct
+{
+  ThreadPriority priority;
+  int nativePriority;
+};
+
 class IRunnable;
 
 class CThread
@@ -61,12 +76,9 @@ public:
   // -----------------------------------------------------------------------------------
   // These are platform specific and can be found in ./platform/[platform]/ThreadImpl.cpp
   // -----------------------------------------------------------------------------------
-  static int GetMinPriority(void);
-  static int GetMaxPriority(void);
-  static int GetNormalPriority(void);
 
   // Get and set the thread's priority
-  bool SetPriority(const int iPriority);
+  bool SetPriority(const ThreadPriority& priority);
 
   // -----------------------------------------------------------------------------------
 

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -66,7 +66,6 @@ public:
   static int GetNormalPriority(void);
 
   // Get and set the thread's priority
-  int GetPriority(void);
   bool SetPriority(const int iPriority);
 
   // -----------------------------------------------------------------------------------

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -64,7 +64,6 @@ public:
   static int GetMinPriority(void);
   static int GetMaxPriority(void);
   static int GetNormalPriority(void);
-  static uint64_t GetCurrentThreadNativeId();
 
   // Get and set the thread's priority
   int GetPriority(void);

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -64,7 +64,6 @@ public:
   static int GetMinPriority(void);
   static int GetMaxPriority(void);
   static int GetNormalPriority(void);
-  static std::uintptr_t GetCurrentThreadNativeHandle();
   static uint64_t GetCurrentThreadNativeId();
 
   // Get and set the thread's priority

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -228,14 +228,3 @@ void term_handler(int signum)
   }
   pthread_exit(NULL);
 }
-
-void CThread::SetSignalHandlers()
-{
-  struct sigaction action;
-  action.sa_handler = term_handler;
-  sigemptyset(&action.sa_mask);
-  action.sa_flags = 0;
-  //sigaction (SIGABRT, &action, NULL);
-  //sigaction (SIGSEGV, &action, NULL);
-}
-

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -211,20 +211,3 @@ int CThread::GetPriority()
 
   return iReturn;
 }
-
-void term_handler(int signum)
-{
-  CLog::Log(
-      LOGERROR,
-      "thread 0x{:x} ({}) got signal {}. calling OnException and terminating thread abnormally.",
-      (long unsigned int)pthread_self(), (long unsigned int)pthread_self(), signum);
-  CThread* curThread = CThread::GetCurrentThread();
-  if (curThread)
-  {
-    curThread->StopThread(false);
-    curThread->OnException();
-    if (curThread->IsAutoDelete())
-      delete curThread;
-  }
-  pthread_exit(NULL);
-}

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -132,11 +132,6 @@ void CThread::SetThreadInfo()
 #endif
 }
 
-uint64_t CThread::GetCurrentThreadNativeId()
-{
-  return static_cast<uint64_t>(GetCurrentThreadPid_());
-}
-
 int CThread::GetMinPriority(void)
 {
   // one level lower than application

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -186,14 +186,3 @@ bool CThread::SetPriority(const int iPriority)
 
   return bReturn;
 }
-
-int CThread::GetPriority()
-{
-  int iReturn;
-
-  int appNice = getpriority(PRIO_PROCESS, getpid());
-  int prio = getpriority(PRIO_PROCESS, m_lwpId);
-  iReturn = appNice - prio;
-
-  return iReturn;
-}

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -132,15 +132,6 @@ void CThread::SetThreadInfo()
 #endif
 }
 
-std::uintptr_t CThread::GetCurrentThreadNativeHandle()
-{
-#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
-  return reinterpret_cast<std::uintptr_t>(pthread_self());
-#else
-  return pthread_self();
-#endif
-}
-
 uint64_t CThread::GetCurrentThreadNativeId()
 {
   return static_cast<uint64_t>(GetCurrentThreadPid_());

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -19,8 +19,37 @@
 #include <pthread_np.h>
 #endif
 
-#include <signal.h>
 #include "utils/log.h"
+
+#include <array>
+#include <signal.h>
+
+namespace
+{
+
+constexpr std::array<ThreadPriorityStruct, 5> nativeThreadPriorityMap = {{
+    {ThreadPriority::LOWEST, -1},
+    {ThreadPriority::BELOW_NORMAL, -1},
+    {ThreadPriority::NORMAL, 0},
+    {ThreadPriority::ABOVE_NORMAL, 1},
+    {ThreadPriority::HIGHEST, 1},
+}};
+
+//! @todo: c++20 has constexpr std::find_if
+int ThreadPriorityToNativePriority(const ThreadPriority& priority)
+{
+  auto it = std::find_if(nativeThreadPriorityMap.cbegin(), nativeThreadPriorityMap.cend(),
+                         [&priority](const auto& map) { return map.priority == priority; });
+
+  if (it != nativeThreadPriorityMap.cend())
+  {
+    return it->nativePriority;
+  }
+
+  throw std::runtime_error("priority not implemented");
+}
+
+} // namespace
 
 namespace XbmcThreads
 {
@@ -118,7 +147,7 @@ void CThread::SetThreadInfo()
 
 #ifdef RLIMIT_NICE
   // get user max prio
-  int userMaxPrio = GetUserMaxPriority(GetMaxPriority());
+  int userMaxPrio = GetUserMaxPriority(ThreadPriorityToNativePriority(ThreadPriority::HIGHEST));
 
   // if the user does not have an entry in limits.conf the following
   // call will fail
@@ -132,25 +161,7 @@ void CThread::SetThreadInfo()
 #endif
 }
 
-int CThread::GetMinPriority(void)
-{
-  // one level lower than application
-  return -1;
-}
-
-int CThread::GetMaxPriority(void)
-{
-  // one level higher than application
-  return 1;
-}
-
-int CThread::GetNormalPriority(void)
-{
-  // same level as application
-  return 0;
-}
-
-bool CThread::SetPriority(const int iPriority)
+bool CThread::SetPriority(const ThreadPriority& priority)
 {
   bool bReturn = false;
 
@@ -164,14 +175,14 @@ bool CThread::SetPriority(const int iPriority)
   else
   {
     // get user max prio given max prio (will take the min)
-    int userMaxPrio = GetUserMaxPriority(GetMaxPriority());
+    int userMaxPrio = GetUserMaxPriority(ThreadPriorityToNativePriority(ThreadPriority::HIGHEST));
 
     // keep priority in bounds
-    int prio = iPriority;
-    if (prio >= GetMaxPriority())
+    int prio = ThreadPriorityToNativePriority(priority);
+    if (prio >= ThreadPriorityToNativePriority(ThreadPriority::HIGHEST))
       prio = userMaxPrio; // this is already the min of GetMaxPriority and what the user can set.
-    if (prio < GetMinPriority())
-      prio = GetMinPriority();
+    if (prio < ThreadPriorityToNativePriority(ThreadPriority::LOWEST))
+      prio = ThreadPriorityToNativePriority(ThreadPriority::LOWEST);
 
     // nice level of application
     const int appNice = getpriority(PRIO_PROCESS, getpid());

--- a/xbmc/threads/platform/pthreads/ThreadImpl.h
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.h
@@ -11,15 +11,4 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-constexpr int THREAD_BASE_PRIORITY_LOWRT{15};
-constexpr int THREAD_BASE_PRIORITY_MAX{2};
-constexpr int THREAD_BASE_PRIORITY_MIN{-2};
-constexpr int THREAD_BASE_PRIORITY_IDLE{-15};
-constexpr int THREAD_PRIORITY_LOWEST{THREAD_BASE_PRIORITY_MIN};
-constexpr int THREAD_PRIORITY_BELOW_NORMAL{THREAD_PRIORITY_LOWEST + 1};
-constexpr int THREAD_PRIORITY_NORMAL{0};
-constexpr int THREAD_PRIORITY_HIGHEST{THREAD_BASE_PRIORITY_MAX};
-constexpr int THREAD_PRIORITY_ABOVE_NORMAL{THREAD_PRIORITY_HIGHEST - 1};
-
 typedef pid_t ThreadLwpId;
-

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -45,11 +45,6 @@ void CThread::SetThreadInfo()
   CWIN32Util::SetThreadLocalLocale(true); // avoid crashing with setlocale(), see https://connect.microsoft.com/VisualStudio/feedback/details/794122
 }
 
-uint64_t CThread::GetCurrentThreadNativeId()
-{
-  return static_cast<uint64_t>(::GetCurrentThreadId());
-}
-
 int CThread::GetMinPriority(void)
 {
   return(THREAD_PRIORITY_IDLE);

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -10,8 +10,37 @@
 
 #include "platform/win32/WIN32Util.h"
 
+#include <array>
+
 #include <process.h>
 #include <windows.h>
+
+namespace
+{
+
+constexpr std::array<ThreadPriorityStruct, 5> nativeThreadPriorityMap = {{
+    {ThreadPriority::LOWEST, THREAD_PRIORITY_IDLE},
+    {ThreadPriority::BELOW_NORMAL, THREAD_PRIORITY_BELOW_NORMAL},
+    {ThreadPriority::NORMAL, THREAD_PRIORITY_NORMAL},
+    {ThreadPriority::ABOVE_NORMAL, THREAD_PRIORITY_ABOVE_NORMAL},
+    {ThreadPriority::HIGHEST, THREAD_PRIORITY_HIGHEST},
+}};
+
+//! @todo: c++20 has constexpr std::find_if
+int ThreadPriorityToNativePriority(const ThreadPriority& priority)
+{
+  auto it = std::find_if(nativeThreadPriorityMap.cbegin(), nativeThreadPriorityMap.cend(),
+                         [&priority](const auto& map) { return map.priority == priority; });
+
+  if (it != nativeThreadPriorityMap.cend())
+  {
+    return it->nativePriority;
+  }
+
+  throw std::runtime_error("priority not implemented");
+}
+
+} // namespace
 
 void CThread::SetThreadInfo()
 {
@@ -45,28 +74,13 @@ void CThread::SetThreadInfo()
   CWIN32Util::SetThreadLocalLocale(true); // avoid crashing with setlocale(), see https://connect.microsoft.com/VisualStudio/feedback/details/794122
 }
 
-int CThread::GetMinPriority(void)
-{
-  return(THREAD_PRIORITY_IDLE);
-}
-
-int CThread::GetMaxPriority(void)
-{
-  return(THREAD_PRIORITY_HIGHEST);
-}
-
-int CThread::GetNormalPriority(void)
-{
-  return(THREAD_PRIORITY_NORMAL);
-}
-
-bool CThread::SetPriority(const int iPriority)
+bool CThread::SetPriority(const ThreadPriority& priority)
 {
   bool bReturn = false;
 
   CSingleLock lock(m_CriticalSection);
   if (m_thread)
-    bReturn = SetThreadPriority(m_lwpId, iPriority) == TRUE;
+    bReturn = SetThreadPriority(m_lwpId, ThreadPriorityToNativePriority(priority)) == TRUE;
 
   return bReturn;
 }

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -45,11 +45,6 @@ void CThread::SetThreadInfo()
   CWIN32Util::SetThreadLocalLocale(true); // avoid crashing with setlocale(), see https://connect.microsoft.com/VisualStudio/feedback/details/794122
 }
 
-std::uintptr_t CThread::GetCurrentThreadNativeHandle()
-{
-  return reinterpret_cast<std::uintptr_t>(::GetCurrentThread());
-}
-
 uint64_t CThread::GetCurrentThreadNativeId()
 {
   return static_cast<uint64_t>(::GetCurrentThreadId());

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -90,7 +90,3 @@ int CThread::GetPriority()
     iReturn = GetThreadPriority(m_lwpId);
   return iReturn;
 }
-
-void CThread::SetSignalHandlers()
-{
-}

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -70,13 +70,3 @@ bool CThread::SetPriority(const int iPriority)
 
   return bReturn;
 }
-
-int CThread::GetPriority()
-{
-  CSingleLock lock(m_CriticalSection);
-
-  int iReturn = THREAD_PRIORITY_NORMAL;
-  if (m_thread)
-    iReturn = GetThreadPriority(m_lwpId);
-  return iReturn;
-}

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -43,7 +43,7 @@ CJobWorker::~CJobWorker()
 
 void CJobWorker::Process()
 {
-  SetPriority( GetMinPriority() );
+  SetPriority(ThreadPriority::LOWEST);
   while (true)
   {
     // request an item from our manager (this call is blocking)

--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -76,7 +76,7 @@ bool CVideoSyncGbm::Setup(PUPDATECLOCK func)
 void CVideoSyncGbm::Run(CEvent& stopEvent)
 {
   /* This shouldn't be very busy and timing is important so increase priority */
-  CThread::GetCurrentThread()->SetPriority(CThread::GetCurrentThread()->GetPriority() + 1);
+  CThread::GetCurrentThread()->SetPriority(GetMaxPriority());
 
   if (m_fd < 0)
   {

--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -76,7 +76,7 @@ bool CVideoSyncGbm::Setup(PUPDATECLOCK func)
 void CVideoSyncGbm::Run(CEvent& stopEvent)
 {
   /* This shouldn't be very busy and timing is important so increase priority */
-  CThread::GetCurrentThread()->SetPriority(GetMaxPriority());
+  CThread::GetCurrentThread()->SetPriority(ThreadPriority::ABOVE_NORMAL);
 
   if (m_fd < 0)
   {


### PR DESCRIPTION
This is the first part of a larger cleanup for the `CThread` codebase. (see: [link](https://github.com/lrusak/xbmc/commits/threading-cleanup))

The first 7 commits remove a bunch of dead/unneeded code. Should be simple enough.

Currently the priority uses the windows defines `THREAD_PRIORITY_XXX`. This PR abstracts that away by using an enum class to define our own priority levels. These levels are then mapped to the platform thread implementation when they are used.

The platforms use a constexpr array to map the new `ThreadPriority` enum values to the native thread priority levels. `std::map` cannot be constexpr and isn't really useful for small maps. I could have also used a switch/case but would rather use a stl algorithm to search the map. If someone has a strong opinion about this just say so.

The new levels are
```
  LOWEST,
  BELOW_NORMAL,
  NORMAL,
  ABOVE_NORMAL,
  HIGHEST,
```

On windows this maps to:
```
    {ThreadPriority::LOWEST, THREAD_PRIORITY_IDLE},
    {ThreadPriority::BELOW_NORMAL, THREAD_PRIORITY_BELOW_NORMAL},
    {ThreadPriority::NORMAL, THREAD_PRIORITY_NORMAL},
    {ThreadPriority::ABOVE_NORMAL, THREAD_PRIORITY_ABOVE_NORMAL},
    {ThreadPriority::HIGHEST, THREAD_PRIORITY_HIGHEST},
```

and on posix it maps to:
```
    {ThreadPriority::LOWEST, -1},
    {ThreadPriority::BELOW_NORMAL, -1},
    {ThreadPriority::NORMAL, 0},
    {ThreadPriority::ABOVE_NORMAL, 1},
    {ThreadPriority::HIGHEST, 1},
```
This only really matters on linux where we attempt to adjust the thread niceness. We clamp this to `[-1, +1]` from the niceness that Kodi was originally launched at. This is why `ABOVE_NORMAL` and `HIGHEST` are the same (same for `LOWEST` and `BELOW_NORMAL`).


