### PR TITLE
[addons] check sha256 not md5 for local packages

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -371,9 +371,14 @@ void CGUIDialogAddonInfo::OnSelectVersion()
           std::string path(items[i]->GetPath());
           if (database.GetPackageHash(processAddonId, items[i]->GetPath(), hash))
           {
-            std::string md5 = CUtil::GetFileDigest(path, KODI::UTILITY::CDigest::Type::MD5);
-            if (StringUtils::EqualsNoCase(md5, hash))
-              versions.emplace_back(AddonVersion(versionString), LOCAL_CACHE);
+            std::string sha256 = CUtil::GetFileDigest(path, KODI::UTILITY::CDigest::Type::SHA256);
+
+            // don't offer locally cached packages that result in an invalid version.
+            // usually this happens when the package filename gets malformed on the fs
+            // e.g. downloading "http://localhost/a+b.zip" ends up in "a b.zip"
+            const AddonVersion version(versionString);
+            if (StringUtils::EqualsNoCase(sha256, hash) && !version.empty())
+              versions.emplace_back(version, LOCAL_CACHE);
           }
         }
       }


### PR DESCRIPTION
## Description
this partly fixes the issue, that the `Versions` button in GUIDialogAddonInfo never offers locally cached packages for installation.

## Screenshots (if appropriate)

**Studio Icons - White**

![Screenshot_20220121_194039](https://user-images.githubusercontent.com/58829855/150674929-85d0883a-ef3d-4ea1-8a6b-175815d4e518.png)

**The Movie Database Python**

problem the version here is `1.6.1+matrix.1` which ends up as `...python-1.6.1 matrix.1.zip` on the filesystem.
thus version `0.0.0` of this package - since it's calculated wrong and not installable at all - is filtered out by this PR.

![Screenshot_20220123_103053](https://user-images.githubusercontent.com/58829855/150675000-3589cd16-8f76-49e2-b026-7cdd3c05a958.png)

i'm not sure if the fix for the root issue "wrong filename" should be included in this pr, what do you think @yol ?

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
