### PR TITLE
Propagate Endtime std::chrono changes out

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2610,7 +2610,8 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPl
   }
   else if (item.IsPlayList() || item.IsInternetStream())
   {
-    CGUIDialogCache* dlgCache = new CGUIDialogCache(5000, g_localizeStrings.Get(10214), item.GetLabel());
+    CGUIDialogCache* dlgCache =
+        new CGUIDialogCache(5s, g_localizeStrings.Get(10214), item.GetLabel());
 
     //is or could be a playlist
     std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(item));

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2391,8 +2391,10 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
     }
   }
 
-  int timeout = (stream->m_syncState != CAESyncInfo::AESyncState::SYNC_INSYNC) ? 100 : stream->GetErrorInterval();
-  bool newerror = stream->m_syncError.Get(error, std::chrono::milliseconds(timeout));
+  std::chrono::milliseconds timeout = (stream->m_syncState != CAESyncInfo::AESyncState::SYNC_INSYNC)
+                                          ? 100ms
+                                          : stream->GetErrorInterval();
+  bool newerror = stream->m_syncError.Get(error, timeout);
 
   if (newerror && fabs(error) > threshold && stream->m_syncState == CAESyncInfo::AESyncState::SYNC_INSYNC)
   {
@@ -2548,7 +2550,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
     stream->m_processingBuffers->SetRR(1.0, m_settings.atempoThreshold);
   }
 
-  stream->m_syncError.SetErrorInterval(std::chrono::milliseconds(stream->GetErrorInterval()));
+  stream->m_syncError.SetErrorInterval(stream->GetErrorInterval());
 
   return ret;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -141,7 +141,7 @@ protected:
   void InitRemapper();
   void RemapBuffer();
   double CalcResampleRatio(double error);
-  int GetErrorInterval();
+  std::chrono::milliseconds GetErrorInterval();
 
 public:
   unsigned int GetSpace() override;
@@ -210,7 +210,7 @@ protected:
   IAEResample *m_remapper;
   double m_lastPts;
   double m_lastPtsJump;
-  std::atomic_int m_errorInterval;
+  std::chrono::milliseconds m_errorInterval{1000};
 
   // only accessed by engine
   CActiveAEBufferPool *m_inputBuffers;

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -108,12 +108,12 @@ class CDVDMsgGeneralSynchronizePriv;
 class CDVDMsgGeneralSynchronize : public CDVDMsg
 {
 public:
-  CDVDMsgGeneralSynchronize(unsigned int timeout, unsigned int sources);
- ~CDVDMsgGeneralSynchronize() override;
+  CDVDMsgGeneralSynchronize(std::chrono::milliseconds timeout, unsigned int sources);
+  ~CDVDMsgGeneralSynchronize() override;
 
   // waits until all threads waiting, released the object
   // if abort is set somehow
-  bool Wait(unsigned int ms, unsigned int source);
+  bool Wait(std::chrono::milliseconds ms, unsigned int source);
   void Wait(std::atomic<bool>& abort, unsigned int source);
 
 private:

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -15,6 +15,8 @@
 
 #include <math.h>
 
+using namespace std::chrono_literals;
+
 CDVDMessageQueue::CDVDMessageQueue(const std::string &owner) : m_hEvent(true), m_owner(owner)
 {
   m_iDataSize     = 0;
@@ -296,7 +298,7 @@ void CDVDMessageQueue::WaitUntilEmpty()
   }
 
   CLog::Log(LOGINFO, "CDVDMessageQueue({})::WaitUntilEmpty", m_owner);
-  auto msg = std::make_shared<CDVDMsgGeneralSynchronize>(40000, SYNCSOURCE_ANY);
+  auto msg = std::make_shared<CDVDMsgGeneralSynchronize>(40s, SYNCSOURCE_ANY);
   Put(msg);
   msg->Wait(m_bAbortRequest, 0);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2425,7 +2425,7 @@ void CVideoPlayer::SynchronizeDemuxer()
   if(!m_messenger.IsInited())
     return;
 
-  auto message = std::make_shared<CDVDMsgGeneralSynchronize>(500, SYNCSOURCE_PLAYER);
+  auto message = std::make_shared<CDVDMsgGeneralSynchronize>(500ms, SYNCSOURCE_PLAYER);
   m_messenger.Put(message);
   message->Wait(m_bStop, 0);
 }
@@ -2981,7 +2981,7 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
     {
-      if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100, SYNCSOURCE_PLAYER))
+      if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100ms, SYNCSOURCE_PLAYER))
         CLog::Log(LOGDEBUG, "CVideoPlayer - CDVDMsg::GENERAL_SYNCHRONIZE");
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_AVCHANGE))
@@ -3883,8 +3883,7 @@ void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
       m_playSpeed == DVD_PLAYSPEED_PAUSE)
   {
     // make sure players are properly flushed, should put them in stalled state
-    auto msg =
-        std::make_shared<CDVDMsgGeneralSynchronize>(1000, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);
+    auto msg = std::make_shared<CDVDMsgGeneralSynchronize>(1s, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);
     m_VideoPlayerAudio->SendMessage(msg, 1);
     m_VideoPlayerVideo->SendMessage(msg, 1);
     msg->Wait(m_bStop, 0);

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -286,7 +286,7 @@ void CVideoPlayerAudio::Process()
     // handle messages
     if (pMsg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
     {
-      if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100, SYNCSOURCE_AUDIO))
+      if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100ms, SYNCSOURCE_AUDIO))
         CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::GENERAL_SYNCHRONIZE");
       else
         m_messageQueue.Put(pMsg, 1); // push back as prio message, to process other prio messages

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -904,13 +904,13 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
     return OUTPUT_DROPPED;
   }
 
-  int timeToDisplay = DVD_TIME_TO_MSEC(pPicture->pts - iPlayingClock);
+  auto timeToDisplay = std::chrono::milliseconds(DVD_TIME_TO_MSEC(pPicture->pts - iPlayingClock));
 
   // make sure waiting time is not negative
-  int maxWaitTime = std::min(std::max(timeToDisplay + 500, 50), 500);
+  std::chrono::milliseconds maxWaitTime = std::min(std::max(timeToDisplay + 500ms, 50ms), 500ms);
   // don't wait when going ff
   if (m_speed > DVD_PLAYSPEED_NORMAL)
-    maxWaitTime = std::max(timeToDisplay, 0);
+    maxWaitTime = std::max(timeToDisplay, 0ms);
   int buffer = m_renderManager.WaitForBuffer(m_bAbortOutput, maxWaitTime);
   if (buffer < 0)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -399,7 +399,7 @@ void CVideoPlayerVideo::Process()
 
     if (pMsg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
     {
-      if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100, SYNCSOURCE_VIDEO))
+      if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100ms, SYNCSOURCE_VIDEO))
       {
         CLog::Log(LOGDEBUG, "CVideoPlayerVideo - CDVDMsg::GENERAL_SYNCHRONIZE");
       }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -260,9 +260,9 @@ void CRenderManager::ShowVideo(bool enable)
     DiscardBuffer();
 }
 
-void CRenderManager::FrameWait(int ms)
+void CRenderManager::FrameWait(std::chrono::milliseconds duration)
 {
-  XbmcThreads::EndTime<> timeout{std::chrono::milliseconds(ms)};
+  XbmcThreads::EndTime<> timeout{duration};
   CSingleLock lock(m_presentlock);
   while(m_presentstep == PRESENT_IDLE && !timeout.IsTimePast())
     m_presentevent.wait(lock, timeout.GetTimeLeft());
@@ -297,7 +297,7 @@ void CRenderManager::FrameMove()
         return;
 
       firstFrame = true;
-      FrameWait(50);
+      FrameWait(50ms);
     }
 
     CheckEnableClockSync();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1069,7 +1069,8 @@ bool CRenderManager::Supports(ESCALINGMETHOD method)
     return false;
 }
 
-int CRenderManager::WaitForBuffer(volatile std::atomic_bool&bStop, int timeout)
+int CRenderManager::WaitForBuffer(volatile std::atomic_bool& bStop,
+                                  std::chrono::milliseconds timeout)
 {
   CSingleLock lock(m_presentlock);
 
@@ -1097,10 +1098,10 @@ int CRenderManager::WaitForBuffer(volatile std::atomic_bool&bStop, int timeout)
     return 0;
   }
 
-  XbmcThreads::EndTime<> endtime{std::chrono::milliseconds(timeout)};
+  XbmcThreads::EndTime<> endtime{timeout};
   while(m_free.empty())
   {
-    m_presentevent.wait(lock, std::min(50ms, std::chrono::milliseconds(timeout)));
+    m_presentevent.wait(lock, std::min(50ms, timeout));
     if (endtime.IsTimePast() || bStop)
     {
       return -1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -61,7 +61,7 @@ public:
   void GetVideoRect(CRect &source, CRect &dest, CRect &view);
   float GetAspectRatio();
   void FrameMove();
-  void FrameWait(int ms);
+  void FrameWait(std::chrono::milliseconds duration);
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);
   bool IsVideoLayer();
   RESOLUTION GetResolution();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -97,7 +97,8 @@ public:
    * in case no buffer is available. Player may call this in a loop and decides
    * by itself when it wants to drop a frame.
    */
-  int WaitForBuffer(volatile std::atomic_bool& bStop, int timeout = 100);
+  int WaitForBuffer(volatile std::atomic_bool& bStop,
+                    std::chrono::milliseconds timeout = std::chrono::milliseconds(100));
 
   /**
    * Can be called by player for lateness detection. This is done best by

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -23,9 +23,10 @@
 using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
-CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const std::string& strHeader, const std::string& strMsg) : CThread("GUIDialogCache"),
-  m_strHeader(strHeader),
-  m_strLinePrev(strMsg)
+CGUIDialogCache::CGUIDialogCache(std::chrono::milliseconds delay,
+                                 const std::string& strHeader,
+                                 const std::string& strMsg)
+  : CThread("GUIDialogCache"), m_strHeader(strHeader), m_strLinePrev(strMsg)
 {
   bSentCancel = false;
 
@@ -36,12 +37,12 @@ CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const std::string& strHeader, co
 
   /* if progress dialog is already running, take it over */
   if( m_pDlg->IsDialogRunning() )
-    dwDelay = 0;
+    delay = 0ms;
 
-  if(dwDelay == 0)
+  if (delay == 0ms)
     OpenDialog();
   else
-    m_endtime.Set(std::chrono::milliseconds(static_cast<unsigned int>(dwDelay)));
+    m_endtime.Set(delay);
 
   Create(true);
 }

--- a/xbmc/dialogs/GUIDialogCache.h
+++ b/xbmc/dialogs/GUIDialogCache.h
@@ -19,7 +19,9 @@ class CGUIDialogProgress;
 class CGUIDialogCache : public CThread, public XFILE::IFileCallback
 {
 public:
-  CGUIDialogCache(DWORD dwDelay = 0, const std::string& strHeader="", const std::string& strMsg="");
+  CGUIDialogCache(std::chrono::milliseconds delay = std::chrono::milliseconds(100),
+                  const std::string& strHeader = "",
+                  const std::string& strMsg = "");
   ~CGUIDialogCache() override;
   void SetHeader(const std::string& strHeader);
   void SetHeader(int nHeader);

--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -32,7 +32,7 @@ public:
   virtual size_t GetMaxWriteSize(const size_t& iRequestSize) = 0;
   virtual int WriteToCache(const char *pBuffer, size_t iSize) = 0;
   virtual int ReadFromCache(char *pBuffer, size_t iMaxSize) = 0;
-  virtual int64_t WaitForData(uint32_t iMinAvail, uint32_t iMillis) = 0;
+  virtual int64_t WaitForData(uint32_t iMinAvail, std::chrono::milliseconds timeout) = 0;
 
   virtual int64_t Seek(int64_t iFilePosition) = 0;
 
@@ -73,7 +73,7 @@ public:
   size_t GetMaxWriteSize(const size_t& iRequestSize) override;
   int WriteToCache(const char *pBuffer, size_t iSize) override;
   int ReadFromCache(char *pBuffer, size_t iMaxSize) override;
-  int64_t WaitForData(uint32_t iMinAvail, uint32_t iMillis) override;
+  int64_t WaitForData(uint32_t iMinAvail, std::chrono::milliseconds timeout) override;
 
   int64_t Seek(int64_t iFilePosition) override;
   bool Reset(int64_t iSourcePosition) override;
@@ -109,7 +109,7 @@ public:
   size_t GetMaxWriteSize(const size_t& iRequestSize) override;
   int WriteToCache(const char *pBuffer, size_t iSize) override;
   int ReadFromCache(char *pBuffer, size_t iMaxSize) override;
-  int64_t WaitForData(uint32_t iMinAvail, uint32_t iMillis) override;
+  int64_t WaitForData(uint32_t iMinAvail, std::chrono::milliseconds timeout) override;
 
   int64_t Seek(int64_t iFilePosition) override;
   bool Reset(int64_t iSourcePosition) override;

--- a/xbmc/filesystem/CircularCache.h
+++ b/xbmc/filesystem/CircularCache.h
@@ -26,7 +26,7 @@ public:
     size_t GetMaxWriteSize(const size_t& iRequestSize) override;
     int WriteToCache(const char *buf, size_t len) override;
     int ReadFromCache(char *buf, size_t len) override;
-    int64_t WaitForData(uint32_t minimum, uint32_t iMillis) override;
+    int64_t WaitForData(uint32_t minimum, std::chrono::milliseconds timeout) override;
 
     int64_t Seek(int64_t pos) override;
     bool Reset(int64_t pos) override;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -334,7 +334,7 @@ void CFileCache::Process()
     if (iRead <= 0)
     {
       // Check for actual EOF and retry as long as we still have data in our cache
-      if (m_writePos < m_fileSize && m_pCache->WaitForData(0, 0) > 0)
+      if (m_writePos < m_fileSize && m_pCache->WaitForData(0, 0ms) > 0)
       {
         CLog::Log(LOGWARNING, "CFileCache::{} - <{}> source read returned {}! Will retry",
                   __FUNCTION__, m_sourcePath, iRead);
@@ -424,7 +424,7 @@ void CFileCache::Process()
     */
     if (m_bFilling && m_forwardCacheSize != 0)
     {
-      const int64_t forward = m_pCache->WaitForData(0, 0);
+      const int64_t forward = m_pCache->WaitForData(0, 0ms);
       if (forward + m_chunkSize >= m_forwardCacheSize)
       {
         if (m_writeRateActual < m_writeRate)
@@ -484,7 +484,7 @@ retry:
   if (iRc == CACHE_RC_WOULD_BLOCK)
   {
     // just wait for some data to show up
-    iRc = m_pCache->WaitForData(1, 10000);
+    iRc = m_pCache->WaitForData(1, 10s);
     if (iRc > 0)
       goto retry;
   }
@@ -549,7 +549,7 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     {
       CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> waiting for position {}", __FUNCTION__,
                 m_sourcePath, iTarget);
-      if (m_pCache->WaitForData(static_cast<uint32_t>(iTarget - m_seekPos), 10000) <
+      if (m_pCache->WaitForData(static_cast<uint32_t>(iTarget - m_seekPos), 10s) <
           iTarget - m_seekPos)
       {
         CLog::Log(LOGWARNING, "CFileCache::{} - <{}> failed to get remaining data", __FUNCTION__,
@@ -609,7 +609,7 @@ int CFileCache::IoControl(EIoControl request, void* param)
   if (request == IOCTRL_CACHE_STATUS)
   {
     SCacheStatus* status = (SCacheStatus*)param;
-    status->forward = m_pCache->WaitForData(0, 0);
+    status->forward = m_pCache->WaitForData(0, 0ms);
     status->maxrate = m_writeRate;
     status->currate = m_writeRateActual;
     status->lowrate = m_writeRateLowSpeed;

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -269,12 +269,12 @@ bool CWinEventsX11::HasStructureChanged()
   return ret;
 }
 
-void CWinEventsX11::SetXRRFailSafeTimer(int millis)
+void CWinEventsX11::SetXRRFailSafeTimer(std::chrono::milliseconds duration)
 {
   if (!m_display)
     return;
 
-  m_xrrFailSafeTimer.Set(std::chrono::milliseconds(millis));
+  m_xrrFailSafeTimer.Set(duration);
   m_xrrEventPending = true;
 }
 

--- a/xbmc/windowing/X11/WinEventsX11.h
+++ b/xbmc/windowing/X11/WinEventsX11.h
@@ -34,7 +34,7 @@ public:
   void Quit();
   bool HasStructureChanged();
   void PendingResize(int width, int height);
-  void SetXRRFailSafeTimer(int millis);
+  void SetXRRFailSafeTimer(std::chrono::milliseconds duration);
 
 protected:
   XBMCKey LookupXbmcKeySym(KeySym keysym);

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -631,7 +631,7 @@ void CWinSystemX11::OnLostDevice()
       (*i)->OnLostDisplay();
   }
 
-  m_winEventsX11->SetXRRFailSafeTimer(3000);
+  m_winEventsX11->SetXRRFailSafeTimer(3s);
 }
 
 void CWinSystemX11::Register(IDispResource *resource)


### PR DESCRIPTION
This is the first follow up to #20732.

This pushes out the use of `std::chrono` to avoid casting when not needed. It also improves the readability (IMO).

The changes are quite straightforward and shouldn't cause any behaviour changes.