### PR TITLE
XTimeUtils: make KODI::TIME::Sleep use std::chrono

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2299,7 +2299,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
       if (!m_appPlayer.IsPlayingVideo() || m_appPlayer.IsPausedPlayback())
         max_sleep = 80;
       unsigned int sleepTime = std::max(static_cast<unsigned int>(2), std::min(m_ProcessedExternalCalls >> 2, max_sleep));
-      KODI::TIME::Sleep(sleepTime);
+      KODI::TIME::Sleep(std::chrono::milliseconds(sleepTime));
       m_frameMoveGuard.lock();
       m_ProcessedExternalDecay = 5;
     }
@@ -2468,7 +2468,7 @@ void CApplication::Stop(int exitCode)
     XbmcThreads::EndTime<> timer(1000ms);
     while (m_pAppPort.use_count() > 1)
     {
-      KODI::TIME::Sleep(100);
+      KODI::TIME::Sleep(100ms);
       if (timer.IsTimePast())
       {
         CLog::Log(LOGERROR, "CApplication::Stop - CAppPort still in use, app may crash");
@@ -2581,7 +2581,7 @@ void CApplication::Stop(int exitCode)
 
   cleanup_emu_environ();
 
-  KODI::TIME::Sleep(200);
+  KODI::TIME::Sleep(200ms);
 }
 
 bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPlaylist)

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -75,7 +75,7 @@ int CXBApplicationEx::Run(const CAppParamParser &params)
       auto now = std::chrono::steady_clock::now();
       frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastFrameTime);
       if (frameTime.count() < noRenderFrameTime)
-        KODI::TIME::Sleep(noRenderFrameTime - frameTime.count());
+        KODI::TIME::Sleep(std::chrono::milliseconds(noRenderFrameTime - frameTime.count()));
     }
 
   }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -47,6 +47,8 @@ using namespace XFILE;
 using namespace ADDON;
 using namespace KODI::MESSAGING;
 
+using namespace std::chrono_literals;
+
 using KODI::MESSAGING::HELPERS::DialogResponse;
 using KODI::UTILITY::TypedDigest;
 
@@ -977,7 +979,7 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
         if (CAddonInstaller::GetInstance().HasJob(addonID))
         {
           while (CAddonInstaller::GetInstance().HasJob(addonID))
-            KODI::TIME::Sleep(50);
+            KODI::TIME::Sleep(50ms);
 
           if (!CServiceBroker::GetAddonMgr().IsAddonInstalled(addonID))
           {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -27,6 +27,8 @@
 
 #include <sys/utsname.h>
 
+using namespace std::chrono_literals;
+
 #define ALSA_OPTIONS (SND_PCM_NO_AUTO_FORMAT | SND_PCM_NO_AUTO_CHANNELS | SND_PCM_NO_AUTO_RESAMPLE)
 
 #define ALSA_MAX_CHANNELS 16
@@ -954,7 +956,7 @@ void CAESinkALSA::HandleError(const char* name, int err)
 
       /* try to resume the stream */
       while((err = snd_pcm_resume(m_pcm)) == -EAGAIN)
-        KODI::TIME::Sleep(1);
+        KODI::TIME::Sleep(1ms);
 
       /* if the hardware doesn't support resume, prepare the stream */
       if (err == -ENOSYS)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -338,7 +338,8 @@ unsigned int CAESinkDirectSound::AddPackets(uint8_t **data, unsigned int frames,
       return INT_MAX;
     else
     {
-      KODI::TIME::Sleep(total * 1000 / m_AvgBytesPerSec);
+      KODI::TIME::Sleep(
+          std::chrono::milliseconds(static_cast<int>(total * 1000 / m_AvgBytesPerSec)));
     }
   }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -966,7 +966,7 @@ void CAESinkWASAPI::Drain()
   AEDelayStatus status;
   GetDelay(status);
 
-  KODI::TIME::Sleep((DWORD)(status.GetDelay() * 500));
+  KODI::TIME::Sleep(std::chrono::milliseconds(static_cast<int>(status.GetDelay() * 500)));
 
   if (m_running)
   {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -847,7 +847,7 @@ void CAESinkXAudio::Drain()
   AEDelayStatus status;
   GetDelay(status);
 
-  KODI::TIME::Sleep(static_cast<int>(status.GetDelay() * 500));
+  KODI::TIME::Sleep(std::chrono::milliseconds(static_cast<int>(status.GetDelay() * 500)));
 
   if (m_running)
   {

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -276,7 +276,7 @@ static void to_wfinddata64i32(_finddata64i32_t *data, _wfinddata64i32_t *wdata)
 
 extern "C"
 {
-  void dll_sleep(unsigned long imSec) { KODI::TIME::Sleep(imSec); }
+  void dll_sleep(unsigned long imSec) { KODI::TIME::Sleep(std::chrono::milliseconds(imSec)); }
 
   // FIXME, XXX, !!!!!!
   void dllReleaseAll( )

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -18,6 +18,8 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
+using namespace std::chrono_literals;
+
 CAudioSinkAE::CAudioSinkAE(CDVDClock *clock) : m_pClock(clock)
 {
   m_pAudioStream = NULL;
@@ -144,7 +146,7 @@ unsigned int CAudioSinkAE::AddPackets(const DVDAudioFrame &audioframe)
     }
 
     lock.Leave();
-    KODI::TIME::Sleep(1);
+    KODI::TIME::Sleep(1ms);
     lock.Enter();
   } while (!m_bAbort);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -1026,7 +1026,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   {
     // if there is no other error, sleep for a short while
     // in order not to drain player's message queue
-    KODI::TIME::Sleep(10);
+    KODI::TIME::Sleep(10ms);
 
     return CDVDVideoCodec::VC_NOBUFFER;
   }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1259,7 +1259,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
       if (pkt)
         CDVDDemuxUtils::FreeDemuxPacket(pkt);
       else
-        KODI::TIME::Sleep(10);
+        KODI::TIME::Sleep(10ms);
       m_pkt.result = -1;
       av_packet_unref(&m_pkt.pkt);
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -39,6 +39,7 @@
 
 using namespace XFILE;
 
+using namespace std::chrono_literals;
 
 static int read_blocks(void* handle, void* buf, int lba, int num_blocks)
 {
@@ -569,7 +570,7 @@ void CDVDInputStreamBluray::ProcessEvent() {
     break;
 
   case BD_EVENT_IDLE:
-    KODI::TIME::Sleep(100);
+    KODI::TIME::Sleep(100ms);
     break;
 
   case BD_EVENT_SOUND_EFFECT:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -666,7 +666,7 @@ void CRenderManager::RemoveCaptures()
       entry.second->GetEvent().Set();
     }
     CSingleExit lockexit(m_captCritSect);
-    KODI::TIME::Sleep(10);
+    KODI::TIME::Sleep(10ms);
   }
 
   for (auto entry : m_captures)

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <string>
 
+using namespace std::chrono_literals;
+
 namespace {
 #define X(VAL) std::make_pair(VAL, #VAL)
 //!@todo Remove ifdefs when sqlite version requirement has been bumped to at least 3.26.0
@@ -197,7 +199,7 @@ int callback(void* res_ptr,int ncol, char** result,char** cols)
 
 static int busy_callback(void*, int busyCount)
 {
-  KODI::TIME::Sleep(100);
+  KODI::TIME::Sleep(100ms);
   return 1;
 }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -41,6 +41,8 @@
 using namespace XFILE;
 using namespace XCURL;
 
+using namespace std::chrono_literals;
+
 #define FITS_INT(a) (((a) <= INT_MAX) && ((a) >= INT_MIN))
 
 curl_proxytype proxyType2CUrlProxyType[] = {
@@ -1044,7 +1046,7 @@ void CCurlFile::Cancel()
 {
   m_state->m_cancelled = true;
   while (m_opened)
-    KODI::TIME::Sleep(1);
+    KODI::TIME::Sleep(1ms);
 }
 
 void CCurlFile::Reset()
@@ -1848,7 +1850,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
              * socket. Instead use Windows' Sleep() and sleep for 100ms which is the
              * minimum suggested value in the curl_multi_fdset() doc.
              */
-            KODI::TIME::Sleep(100);
+            KODI::TIME::Sleep(100ms);
             rc = 0;
 #else
             /* Portable sleep for platforms other than Windows. */

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -331,7 +331,7 @@ int CScriptInvocationManager::ExecuteSync(
     if (timeout && timeoutMs < sleepMs)
       sleepMs = timeoutMs;
 
-    KODI::TIME::Sleep(sleepMs);
+    KODI::TIME::Sleep(std::chrono::milliseconds(sleepMs));
 
     if (timeout)
       timeoutMs -= sleepMs;

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -146,7 +146,7 @@ namespace XBMCAddon
           long nextSleep = endTime.GetTimeLeft().count();
           if (nextSleep > 100)
             nextSleep = 100; // only sleep for 100 millis
-          KODI::TIME::Sleep(nextSleep);
+          KODI::TIME::Sleep(std::chrono::milliseconds(nextSleep));
         }
         if (lh != NULL)
           lh->MakePendingCalls();

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -417,7 +417,7 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
 
       lock.Leave();
       CPyThreadState pyState;
-      KODI::TIME::Sleep(100);
+      KODI::TIME::Sleep(100ms);
       pyState.Restore();
       lock.Enter();
     }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -73,6 +73,8 @@ using namespace MUSIC_INFO;
 using namespace KODI::MESSAGING;
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
+using namespace std::chrono_literals;
+
 #define CONTROL_BTNVIEWASICONS  2
 #define CONTROL_BTNSORTBY       3
 #define CONTROL_BTNSORTASC      4
@@ -942,7 +944,7 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
         m_dlgProgress->Progress();
       }
     } // if (bShowProgress)
-    KODI::TIME::Sleep(1);
+    KODI::TIME::Sleep(1ms);
   } // while (m_musicInfoLoader.IsLoading())
 
   if (bProgressVisible && m_dlgProgress)

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -478,7 +478,7 @@ void CNetworkBase::WaitForNet()
   for(int i=0; i < numMaxTries; ++i)
   {
     if (i > 0)
-      KODI::TIME::Sleep(intervalMs);
+      KODI::TIME::Sleep(std::chrono::milliseconds(intervalMs));
 
     if (IsConnected())
     {

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -50,6 +50,8 @@
 #define DEFAULT_WAIT_FOR_ONLINE_SEC_2 (40)   // same for extended wait
 #define DEFAULT_WAIT_FOR_SERVICES_SEC (5)    // wait 5 seconds after host go online to launch file sharing daemons
 
+using namespace std::chrono_literals;
+
 static CDateTime upnpInitReady;
 
 static int GetTotalSeconds(const CDateTimeSpan& ts)
@@ -126,7 +128,7 @@ static void AddMatchingUPnPServers(std::vector<UPnPServer>& list, const std::str
 {
 #ifdef HAS_UPNP
   while (CDateTime::GetCurrentDateTime() < upnpInitReady)
-    KODI::TIME::Sleep(1000);
+    KODI::TIME::Sleep(1s);
 
   PLT_SyncMediaBrowser* browser = UPNP::CUPnP::GetInstance()->m_MediaBrowser;
 
@@ -327,7 +329,7 @@ public:
         m_dialog->SetPercentage(std::max(percentage, 1)); // avoid flickering , keep minimum 1%
       }
 
-      KODI::TIME::Sleep(m_dialog ? 20 : 200);
+      KODI::TIME::Sleep(m_dialog ? 20ms : 200ms);
     }
 
     return TimedOut;
@@ -399,7 +401,7 @@ public:
 
       if (host.empty())
       {
-        KODI::TIME::Sleep(timeOutMs);
+        KODI::TIME::Sleep(std::chrono::milliseconds(timeOutMs));
 
         host = LookupUPnPHost(server.upnpUuid);
       }

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -45,6 +45,8 @@ using namespace XFILE;
 using namespace PLAYLIST;
 using namespace KODI::MESSAGING;
 
+using namespace std::chrono_literals;
+
 #define CONTROL_BTNSLIDESHOW   6
 #define CONTROL_BTNSLIDESHOW_RECURSIVE   7
 #define CONTROL_SHUFFLE      9
@@ -225,7 +227,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
         m_dlgProgress->Progress();
       }
     } // if (bShowProgress)
-    KODI::TIME::Sleep(1);
+    KODI::TIME::Sleep(1ms);
   } // while (loader.IsLoading())
 
   if (bProgressVisible && m_dlgProgress)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -252,7 +252,7 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
       // sleep until the loader finishes loading the current pic
       CLog::Log(LOGDEBUG,"Waiting for BackgroundLoader thread to close");
       while (m_pBackgroundLoader->IsLoading())
-        KODI::TIME::Sleep(10);
+        KODI::TIME::Sleep(10ms);
       // stop the thread
       CLog::Log(LOGDEBUG,"Stopping BackgroundLoader thread");
       m_pBackgroundLoader->StopThread();

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -13,9 +13,7 @@
 #include <errno.h>
 #include <time.h>
 
-#include <sched.h>
 #include <sys/times.h>
-#include <unistd.h>
 
 #if defined(TARGET_DARWIN)
 #include "threads/Atomics.h"
@@ -37,19 +35,6 @@ namespace TIME
  * divisible by 400
  */
 #define IsLeapYear(y) ((!(y % 4)) ? (((!(y % 400)) && (y % 100)) ? 1 : 0) : 0)
-
-void Sleep(uint32_t milliSeconds)
-{
-#if _POSIX_PRIORITY_SCHEDULING
-  if (milliSeconds == 0)
-  {
-    sched_yield();
-    return;
-  }
-#endif
-
-  usleep(milliSeconds * 1000);
-}
 
 uint32_t GetTimeZoneInformation(TimeZoneInformation* timeZoneInformation)
 {

--- a/xbmc/platform/win32/XTimeUtils.cpp
+++ b/xbmc/platform/win32/XTimeUtils.cpp
@@ -46,11 +46,6 @@ void KodiTimeToSystemTime(const SystemTime& st, SYSTEMTIME& sst)
 }
 } // namespace
 
-void Sleep(uint32_t milliSeconds)
-{
-  ::Sleep(milliSeconds);
-}
-
 uint32_t GetTimeZoneInformation(TimeZoneInformation* timeZoneInformation)
 {
   if (!timeZoneInformation)

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -24,6 +24,8 @@
 #include "utils/JobManager.h"
 #include "utils/XTimeUtils.h"
 
+using namespace std::chrono_literals;
+
 namespace
 {
 class CPVRChannelTimeoutJobBase : public CJob, public IJobCallback
@@ -51,7 +53,7 @@ public:
         OnTimeout();
         return true;
       }
-      KODI::TIME::Sleep(10);
+      KODI::TIME::Sleep(10ms);
     }
     return false;
   }

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -22,6 +22,8 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+using namespace std::chrono_literals;
+
 CRenderSystemGL::CRenderSystemGL() : CRenderSystemBase()
 {
 }
@@ -293,7 +295,7 @@ void CRenderSystemGL::PresentRender(bool rendered, bool videoLayer)
   PresentRenderImpl(rendered);
 
   if (!rendered)
-    KODI::TIME::Sleep(40);
+    KODI::TIME::Sleep(40ms);
 }
 
 void CRenderSystemGL::SetVSync(bool enable)

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -25,6 +25,8 @@
 #include "utils/EGLUtils.h"
 #endif
 
+using namespace std::chrono_literals;
+
 CRenderSystemGLES::CRenderSystemGLES()
  : CRenderSystemBase()
 {
@@ -229,7 +231,7 @@ void CRenderSystemGLES::PresentRender(bool rendered, bool videoLayer)
 
   // if video is rendered to a separate layer, we should not block this thread
   if (!rendered && !videoLayer)
-    KODI::TIME::Sleep(40);
+    KODI::TIME::Sleep(40ms);
 }
 
 void CRenderSystemGLES::SetVSync(bool enable)

--- a/xbmc/utils/XTimeUtils.h
+++ b/xbmc/utils/XTimeUtils.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
+#include <thread>
 
 #if !defined(TARGET_WINDOWS)
 #include "PlatformDefs.h"
@@ -62,7 +64,17 @@ struct FileTime
 void GetLocalTime(SystemTime* systemTime);
 uint32_t GetTimeZoneInformation(TimeZoneInformation* timeZoneInformation);
 
-void Sleep(uint32_t milliSeconds);
+template<typename Rep, typename Period>
+void Sleep(std::chrono::duration<Rep, Period> duration)
+{
+  if (duration == std::chrono::duration<Rep, Period>::zero())
+  {
+    std::this_thread::yield();
+    return;
+  }
+
+  std::this_thread::sleep_for(duration);
+}
 
 int FileTimeToLocalFileTime(const FileTime* fileTime, FileTime* localFileTime);
 int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime);

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -38,6 +38,8 @@
 
 using namespace ADDON;
 
+using namespace std::chrono_literals;
+
 CWeatherJob::CWeatherJob(int location)
 {
   m_location = location;
@@ -73,7 +75,7 @@ bool CWeatherJob::DoWork()
     {
       if (!CScriptInvocationManager::GetInstance().IsRunning(scriptId))
         break;
-      KODI::TIME::Sleep(100);
+      KODI::TIME::Sleep(100ms);
     }
 
     SetFromProperties();

--- a/xbmc/windowing/X11/VideoSyncGLX.cpp
+++ b/xbmc/windowing/X11/VideoSyncGLX.cpp
@@ -21,6 +21,8 @@
 
 using namespace KODI::WINDOWING::X11;
 
+using namespace std::chrono_literals;
+
 Display* CVideoSyncGLX::m_Dpy = NULL;
 
 void CVideoSyncGLX::OnLostDisplay()
@@ -216,7 +218,7 @@ void CVideoSyncGLX::Run(CEvent& stopEvent)
       }
 
       //sleep here so we don't busy spin when this constantly happens, for example when the display went to sleep
-      KODI::TIME::Sleep(1000);
+      KODI::TIME::Sleep(1s);
 
       CLog::Log(LOGDEBUG, "CVideoReferenceClock: Attaching glX context");
       ReturnV = glXMakeCurrent(m_Dpy, m_Window, m_Context);
@@ -235,7 +237,7 @@ void CVideoSyncGLX::Run(CEvent& stopEvent)
   m_lostEvent.Set();
   while(!stopEvent.Signaled() && m_displayLost && !m_displayReset)
   {
-    KODI::TIME::Sleep(10);
+    KODI::TIME::Sleep(10ms);
   }
 }
 

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -214,7 +214,7 @@ bool CXRandR::TurnOnOutput(const std::string& name)
     if (output && output->h > 0)
       return true;
 
-    KODI::TIME::Sleep(200);
+    KODI::TIME::Sleep(200ms);
   }
 
   return false;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -29,6 +29,8 @@
 
 using namespace KODI::WINDOWING::GBM;
 
+using namespace std::chrono_literals;
+
 CWinSystemGbmGLContext::CWinSystemGbmGLContext()
 : CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
 {}
@@ -136,7 +138,7 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
   }
   else
   {
-    KODI::TIME::Sleep(10);
+    KODI::TIME::Sleep(10ms);
   }
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -33,6 +33,8 @@
 
 using namespace KODI::WINDOWING::GBM;
 
+using namespace std::chrono_literals;
+
 CWinSystemGbmGLESContext::CWinSystemGbmGLESContext()
 : CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
 {}
@@ -145,7 +147,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
   }
   else
   {
-    KODI::TIME::Sleep(10);
+    KODI::TIME::Sleep(10ms);
   }
 }
 

--- a/xbmc/windowing/gbm/drm/DRMConnector.cpp
+++ b/xbmc/windowing/gbm/drm/DRMConnector.cpp
@@ -14,6 +14,8 @@
 
 using namespace KODI::WINDOWING::GBM;
 
+using namespace std::chrono_literals;
+
 namespace
 {
 
@@ -64,7 +66,7 @@ bool CDRMConnector::CheckConnector()
   {
     CLog::Log(LOGDEBUG, "CDRMConnector::{} - connector is disconnected", __FUNCTION__);
     retryCnt--;
-    KODI::TIME::Sleep(1000);
+    KODI::TIME::Sleep(1s);
 
     m_connector.reset(drmModeGetConnector(m_fd, m_connector->connector_id));
   }

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -17,6 +17,8 @@
 
 #include "platform/win32/WIN32Util.h"
 
+using namespace std::chrono_literals;
+
 void CWinSystemWin10DX::Register()
 {
   KODI::WINDOWING::CWindowSystemFactory::RegisterWindowSystem(CreateWinSystem);
@@ -47,7 +49,7 @@ void CWinSystemWin10DX::PresentRenderImpl(bool rendered)
   }
 
   if (!rendered)
-    KODI::TIME::Sleep(40);
+    KODI::TIME::Sleep(40ms);
 }
 
 bool CWinSystemWin10DX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -17,6 +17,8 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+using namespace std::chrono_literals;
+
 void CVideoSyncD3D::OnLostDisplay()
 {
   if (!m_displayLost)
@@ -102,7 +104,7 @@ void CVideoSyncD3D::Run(CEvent& stopEvent)
   m_lostEvent.Set();
   while (!stopEvent.Signaled() && m_displayLost && !m_displayReset)
   {
-    KODI::TIME::Sleep(10);
+    KODI::TIME::Sleep(10ms);
   }
 }
 

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -41,6 +41,8 @@
 
 using KODI::PLATFORM::WINDOWS::FromW;
 
+using namespace std::chrono_literals;
+
 // User Mode Driver hooks definitions
 void APIENTRY HookCreateResource(D3D10DDI_HDEVICE hDevice, const D3D10DDIARG_CREATERESOURCE* pResource, D3D10DDI_HRESOURCE hResource, D3D10DDI_HRTRESOURCE hRtResource);
 HRESULT APIENTRY HookCreateDevice(D3D10DDI_HADAPTER hAdapter, D3D10DDIARG_CREATEDEVICE* pCreateData);
@@ -80,7 +82,7 @@ void CWinSystemWin32DX::PresentRenderImpl(bool rendered)
   }
 
   if (!rendered)
-    KODI::TIME::Sleep(40);
+    KODI::TIME::Sleep(40ms);
 }
 
 bool CWinSystemWin32DX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)


### PR DESCRIPTION
This makes `KODI::TIME::Sleep` use `std::chrono`.

This allows specifying the sleep duration in different units (s, ms, us, ns, etc).

This may change the windows behaviour as previously the `sched_yield` call was posix only. I've moved this to use the `std::this_thread::yield()` [method](https://en.cppreference.com/w/cpp/thread/yield).

Threads are yielded when the sleep duration is 0. Currently I don't believe this is used anywhere (at least not directly).

Future PR's will continue to push the `std::chrono` interface out to remove some of the casting that is required in this PR.