### PR TITLE
Updated online curl check link

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1026,7 +1026,7 @@ bool CCurlFile::Download(const std::string& strURL, const std::string& strFileNa
 // Detect whether we are "online" or not! Very simple and dirty!
 bool CCurlFile::IsInternet()
 {
-  CURL url("http://www.msftncsi.com/ncsi.txt");
+  CURL url("http://www.msftconnecttest.com/connecttest.txt");
   bool found = Exists(url);
   if (!found)
   {


### PR DESCRIPTION
## Description
An old link needed to be updated.
Related to DNS request to check if we are online.

previous: http://www.msftncsi.com/ncsi.txt
new: http://www.msftconnecttest.com/connecttest.txt

Closes https://github.com/xbmc/xbmc/issues/16129

## Motivation and context
It had to be done eventually.
From: Microsoft Connect Test failed #16129 

## How has this been tested?

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
