### PR TITLE
[PVR] Rework component startup / shutdown

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10697,11 +10697,7 @@ msgctxt "#19238"
 msgid "Loading recordings from clients"
 msgstr ""
 
-#. label 'starting background tasks' for progress dialog text
-#: xbmc/pvr/PVRManager.cpp
-msgctxt "#19239"
-msgid "Starting background threads"
-msgstr ""
+#empty string with id 19239
 
 #. label for pvr settings client priorities control and client priorities dialog heading.
 #: system/settings/settings.xml

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -390,7 +390,7 @@ bool CDatabase::ExecuteQuery(const std::string &strQuery)
   return bReturn;
 }
 
-bool CDatabase::ResultQuery(const std::string &strQuery)
+bool CDatabase::ResultQuery(const std::string& strQuery) const
 {
   bool bReturn = false;
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -178,7 +178,7 @@ public:
    * @param strQuery The query to execute.
    * @return True if the query was executed successfully, false otherwise.
    */
-  bool ResultQuery(const std::string &strQuery);
+  bool ResultQuery(const std::string& strQuery) const;
 
   /*!
    * @brief Start a multiple execution queue. Any ExecuteQuery() function

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -22,7 +22,6 @@
 #include "network/NetworkServices.h"
 #include "platform/xbmc.h"
 #include "powermanagement/PowerManager.h"
-#include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -426,7 +426,7 @@ bool CPVRDatabase::Delete(const CPVRProvider& provider)
 }
 
 bool CPVRDatabase::Get(CPVRProviders& results,
-                       const std::vector<std::shared_ptr<CPVRClient>>& clients)
+                       const std::vector<std::shared_ptr<CPVRClient>>& clients) const
 {
   bool bReturn = false;
 
@@ -477,7 +477,7 @@ bool CPVRDatabase::Get(CPVRProviders& results,
 
 int CPVRDatabase::Get(bool bRadio,
                       const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                      std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results)
+                      std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results) const
 {
   int iReturn = 0;
 
@@ -621,7 +621,7 @@ bool CPVRDatabase::Delete(const CPVRChannelGroup& group)
   return RemoveChannelsFromGroup(group) && DeleteValues("channelgroups", filter);
 }
 
-int CPVRDatabase::Get(CPVRChannelGroups& results)
+int CPVRDatabase::Get(CPVRChannelGroups& results) const
 {
   int iLoaded = 0;
   CSingleLock lock(m_critSection);
@@ -666,7 +666,7 @@ int CPVRDatabase::Get(CPVRChannelGroups& results)
 }
 
 std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRDatabase::Get(
-    const CPVRChannelGroup& group, const std::vector<std::shared_ptr<CPVRClient>>& clients)
+    const CPVRChannelGroup& group, const std::vector<std::shared_ptr<CPVRClient>>& clients) const
 {
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> results;
 
@@ -997,7 +997,7 @@ bool CPVRDatabase::UpdateLastOpened(const CPVRChannelGroup& group)
 /********** Timer methods **********/
 
 std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRDatabase::GetTimers(
-    CPVRTimers& timers, const std::vector<std::shared_ptr<CPVRClient>>& clients)
+    CPVRTimers& timers, const std::vector<std::shared_ptr<CPVRClient>>& clients) const
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> result;
 

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -91,6 +91,25 @@ namespace
     ")";
 
   // clang-format on
+
+  std::string GetClientIdsSQL(const std::vector<std::shared_ptr<CPVRClient>>& clients)
+  {
+    if (clients.empty())
+      return {};
+
+    std::string clientIds = "(";
+    for (auto it = clients.cbegin(); it != clients.cend(); ++it)
+    {
+      if (it != clients.cbegin())
+        clientIds += " OR ";
+
+      clientIds += "iClientId = ";
+      clientIds += std::to_string((*it)->GetID());
+    }
+    clientIds += ")";
+    return clientIds;
+  }
+
 } // unnamed namespace
 
 bool CPVRDatabase::Open()
@@ -406,12 +425,18 @@ bool CPVRDatabase::Delete(const CPVRProvider& provider)
   return DeleteValues("providers", filter);
 }
 
-bool CPVRDatabase::Get(CPVRProviders& results)
+bool CPVRDatabase::Get(CPVRProviders& results,
+                       const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   bool bReturn = false;
-  CSingleLock lock(m_critSection);
 
-  const std::string strQuery = PrepareSQL("SELECT * from providers");
+  std::string strQuery = "SELECT * from providers ";
+  const std::string clientIds = GetClientIdsSQL(clients);
+  if (!clientIds.empty())
+    strQuery += "WHERE " + clientIds;
+
+  CSingleLock lock(m_critSection);
+  strQuery = PrepareSQL(strQuery);
   if (ResultQuery(strQuery))
   {
     try
@@ -451,12 +476,18 @@ bool CPVRDatabase::Get(CPVRProviders& results)
 /********** Channel methods **********/
 
 int CPVRDatabase::Get(bool bRadio,
+                      const std::vector<std::shared_ptr<CPVRClient>>& clients,
                       std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results)
 {
   int iReturn = 0;
-  const std::string strQuery = PrepareSQL("SELECT * from channels WHERE bIsRadio = %u", bRadio);
+
+  std::string strQuery = "SELECT * from channels WHERE bIsRadio = %u ";
+  const std::string clientIds = GetClientIdsSQL(clients);
+  if (!clientIds.empty())
+    strQuery += "AND " + clientIds;
 
   CSingleLock lock(m_critSection);
+  strQuery = PrepareSQL(strQuery, bRadio);
   if (ResultQuery(strQuery))
   {
     try
@@ -635,7 +666,7 @@ int CPVRDatabase::Get(CPVRChannelGroups& results)
 }
 
 std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRDatabase::Get(
-    const CPVRChannelGroup& group)
+    const CPVRChannelGroup& group, const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> results;
 
@@ -646,22 +677,24 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRDatabase::Get(
     return results;
   }
 
-  const std::string strQuery =
-      PrepareSQL("SELECT map_channelgroups_channels.idChannel, "
-                 "map_channelgroups_channels.iChannelNumber, "
-                 "map_channelgroups_channels.iSubChannelNumber, "
-                 "map_channelgroups_channels.iOrder, "
-                 "map_channelgroups_channels.iClientChannelNumber, "
-                 "map_channelgroups_channels.iClientSubChannelNumber, "
-                 "channels.iClientId, channels.iUniqueId, channels.bIsRadio "
-                 "FROM map_channelgroups_channels "
-                 "LEFT JOIN channels ON channels.idChannel = map_channelgroups_channels.idChannel "
-                 "WHERE map_channelgroups_channels.idGroup = %i ORDER BY "
-                 "map_channelgroups_channels.iChannelNumber",
-                 group.GroupID());
+  std::string strQuery =
+      "SELECT map_channelgroups_channels.idChannel, "
+      "map_channelgroups_channels.iChannelNumber, "
+      "map_channelgroups_channels.iSubChannelNumber, "
+      "map_channelgroups_channels.iOrder, "
+      "map_channelgroups_channels.iClientChannelNumber, "
+      "map_channelgroups_channels.iClientSubChannelNumber, "
+      "channels.iClientId, channels.iUniqueId, channels.bIsRadio "
+      "FROM map_channelgroups_channels "
+      "LEFT JOIN channels ON channels.idChannel = map_channelgroups_channels.idChannel "
+      "WHERE map_channelgroups_channels.idGroup = %i ";
+  const std::string clientIds = GetClientIdsSQL(clients);
+  if (!clientIds.empty())
+    strQuery += "AND " + clientIds;
+  strQuery += " ORDER BY map_channelgroups_channels.iChannelNumber";
 
   CSingleLock lock(m_critSection);
-
+  strQuery = PrepareSQL(strQuery, group.GroupID());
   if (ResultQuery(strQuery))
   {
     try
@@ -963,12 +996,18 @@ bool CPVRDatabase::UpdateLastOpened(const CPVRChannelGroup& group)
 
 /********** Timer methods **********/
 
-std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRDatabase::GetTimers(CPVRTimers& timers)
+std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRDatabase::GetTimers(
+    CPVRTimers& timers, const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> result;
 
+  std::string strQuery = "SELECT * FROM timers ";
+  const std::string clientIds = GetClientIdsSQL(clients);
+  if (!clientIds.empty())
+    strQuery += "WHERE " + clientIds;
+
   CSingleLock lock(m_critSection);
-  const std::string strQuery = PrepareSQL("SELECT * FROM timers");
+  strQuery = PrepareSQL(strQuery);
   if (ResultQuery(strQuery))
   {
     try

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -120,7 +120,7 @@ namespace PVR
      */
     int Get(bool bRadio,
             const std::vector<std::shared_ptr<CPVRClient>>& clients,
-            std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results);
+            std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results) const;
 
     /*!
      * @brief Add or update a channel entry in the database
@@ -181,7 +181,7 @@ namespace PVR
      * @param clients The PVR clients the providers should be loaded for. Leave empty for all clients.
      * @return The amount of providers that were added.
      */
-    bool Get(CPVRProviders& results, const std::vector<std::shared_ptr<CPVRClient>>& clients);
+    bool Get(CPVRProviders& results, const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
     //@}
 
@@ -206,7 +206,7 @@ namespace PVR
      * @param results The container to store the results in.
      * @return The number of groups loaded.
      */
-    int Get(CPVRChannelGroups& results);
+    int Get(CPVRChannelGroups& results) const;
 
     /*!
      * @brief Get the members of a channel group.
@@ -215,7 +215,8 @@ namespace PVR
      * @return The group members.
      */
     std::vector<std::shared_ptr<CPVRChannelGroupMember>> Get(
-        const CPVRChannelGroup& group, const std::vector<std::shared_ptr<CPVRClient>>& clients);
+        const CPVRChannelGroup& group,
+        const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
     /*!
      * @brief Add or update a channel group entry in the database.
@@ -240,7 +241,7 @@ namespace PVR
      * @return The timers.
      */
     std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetTimers(
-        CPVRTimers& timers, const std::vector<std::shared_ptr<CPVRClient>>& clients);
+        CPVRTimers& timers, const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
     /*!
      * @brief Add or update a timer entry in the database
@@ -308,6 +309,6 @@ namespace PVR
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup& group);
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
   };
 }

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -114,10 +114,13 @@ namespace PVR
     /*!
      * @brief Get channels from the database.
      * @param bRadio Whether to fetch radio or TV channels.
+     * @param clients The PVR clients the channels should be loaded for. Leave empty for all clients.
      * @param results The container for the channels.
      * @return The number of channels loaded.
      */
-    int Get(bool bRadio, std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results);
+    int Get(bool bRadio,
+            const std::vector<std::shared_ptr<CPVRClient>>& clients,
+            std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& results);
 
     /*!
      * @brief Add or update a channel entry in the database
@@ -175,9 +178,10 @@ namespace PVR
     /*!
      * @brief Get the list of providers from the database
      * @param results The providers to store the results in.
+     * @param clients The PVR clients the providers should be loaded for. Leave empty for all clients.
      * @return The amount of providers that were added.
      */
-    bool Get(CPVRProviders& results);
+    bool Get(CPVRProviders& results, const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     //@}
 
@@ -207,9 +211,11 @@ namespace PVR
     /*!
      * @brief Get the members of a channel group.
      * @param group The group to get the members for.
+     * @param clients The PVR clients the group members should be loaded for. Leave empty for all clients.
      * @return The group members.
      */
-    std::vector<std::shared_ptr<CPVRChannelGroupMember>> Get(const CPVRChannelGroup& group);
+    std::vector<std::shared_ptr<CPVRChannelGroupMember>> Get(
+        const CPVRChannelGroup& group, const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @brief Add or update a channel group entry in the database.
@@ -230,9 +236,11 @@ namespace PVR
     /*!
      * @brief Get the timers.
      * @param timers The container for the timers.
+     * @param clients The PVR clients the timers should be loaded for. Leave empty for all clients.
      * @return The timers.
      */
-    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetTimers(CPVRTimers& timers);
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetTimers(
+        CPVRTimers& timers, const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @brief Add or update a timer entry in the database

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -415,23 +415,7 @@ void CPVRManager::Stop(bool bRestart /* = false */)
   CLog::Log(LOGINFO, "PVR Manager: Stopping");
   SetState(ManagerStateStopping);
 
-  m_addons->Stop();
-  m_pendingUpdates->Stop();
-  m_timers->Stop();
-  m_epgContainer.Stop();
-  m_guiInfo->Stop();
-
   StopThread();
-
-  SetState(ManagerStateInterrupted);
-
-  UnloadComponents();
-  m_database->Close();
-
-  ResetProperties();
-
-  CLog::Log(LOGINFO, "PVR Manager: Stopped");
-  SetState(ManagerStateStopped);
 }
 
 void CPVRManager::Unload()
@@ -504,26 +488,23 @@ void CPVRManager::Process()
   m_addons->Continue();
   m_database->Open();
 
-  /* load the pvr data from the db and clients if it's not already loaded */
-  XbmcThreads::EndTime<> progressTimeout(30s); // 30 secs
-  CPVRGUIProgressHandler* progressHandler = new CPVRGUIProgressHandler(g_localizeStrings.Get(19235)); // PVR manager is starting up
-  while (!LoadComponents(progressHandler) && IsInitialising())
+  if (!IsInitialising())
   {
-    CLog::Log(LOGWARNING, "PVR Manager failed to load data, retrying");
-    CThread::Sleep(1000ms);
-
-    if (progressHandler && progressTimeout.IsTimePast())
-    {
-      progressHandler->DestroyProgress();
-      progressHandler = nullptr; // no delete, instance is deleting itself
-    }
+    CLog::Log(LOGINFO, "PVR Manager: Start aborted");
+    return;
   }
 
-  if (progressHandler)
+  UnloadComponents();
+
+  if (!IsInitialising())
   {
-    progressHandler->DestroyProgress();
-    progressHandler = nullptr; // no delete, instance is deleting itself
+    CLog::Log(LOGINFO, "PVR Manager: Start aborted");
+    return;
   }
+
+  // Wait for at least one client to come up and load/update data
+  std::vector<std::shared_ptr<CPVRClient>> knownClients;
+  UpdateComponents(knownClients, ManagerStateStarting);
 
   if (!IsInitialising())
   {
@@ -545,19 +526,27 @@ void CPVRManager::Process()
   SetState(ManagerStateStarted);
   CLog::Log(LOGINFO, "PVR Manager: Started");
 
-  /* main loop */
-  CLog::LogFC(LOGDEBUG, LOGPVR, "PVR Manager entering main loop");
-
   bool bRestart(false);
   XbmcThreads::EndTime<> cachedImagesCleanupTimeout(30s); // first timeout after 30 secs
 
   while (IsStarted() && m_addons->HasCreatedClients() && !bRestart)
   {
+    // In case any new client connected, load from db and fetch data update from new client(s)
+    UpdateComponents(knownClients, ManagerStateStarted);
+
     if (cachedImagesCleanupTimeout.IsTimePast())
     {
-      // start a job to erase stale texture db entries and image files
-      TriggerCleanupCachedImages();
-      cachedImagesCleanupTimeout.Set(12h); // following timeouts after 12 hours
+      // We don't know for sure what to delete if there are not (yet) connected clients
+      if (m_addons->HasIgnoredClients())
+      {
+        cachedImagesCleanupTimeout.Set(10s); // try again in 10 secs
+      }
+      else
+      {
+        // start a job to erase stale texture db entries and image files
+        TriggerCleanupCachedImages();
+        cachedImagesCleanupTimeout.Set(12h); // following timeouts after 12 hours
+      }
     }
 
     /* first startup */
@@ -593,7 +582,21 @@ void CPVRManager::Process()
       m_pendingUpdates->WaitForJobs(1000);
   }
 
-  CLog::LogFC(LOGDEBUG, LOGPVR, "PVR Manager leaving main loop");
+  m_addons->Stop();
+  m_pendingUpdates->Stop();
+  m_timers->Stop();
+  m_epgContainer.Stop();
+  m_guiInfo->Stop();
+
+  SetState(ManagerStateInterrupted);
+
+  UnloadComponents();
+  m_database->Close();
+
+  ResetProperties();
+
+  CLog::Log(LOGINFO, "PVR Manager: Stopped");
+  SetState(ManagerStateStopped);
 }
 
 bool CPVRManager::SetWakeupCommand()
@@ -659,47 +662,127 @@ void CPVRManager::OnWake()
   TriggerTimersUpdate();
 }
 
-bool CPVRManager::LoadComponents(CPVRGUIProgressHandler* progressHandler)
+void CPVRManager::UpdateComponents(std::vector<std::shared_ptr<CPVRClient>>& knownClients,
+                                   ManagerState stateToCheck)
 {
-  /* load at least one client */
-  while (IsInitialising() && m_addons && !m_addons->HasCreatedClients())
-    CThread::Sleep(50ms);
+  XbmcThreads::EndTime<> progressTimeout(30s);
+  CPVRGUIProgressHandler* progressHandler =
+      new CPVRGUIProgressHandler(g_localizeStrings.Get(19235)); // PVR manager is starting up
 
-  if (!IsInitialising() || !m_addons->HasCreatedClients())
-    return false;
+  // Wait for at least one client to come up and load/update data
+  while (!UpdateComponents(knownClients, stateToCheck, progressHandler) &&
+         m_addons->HasCreatedClients() && (stateToCheck == GetState()))
+  {
+    CThread::Sleep(1000ms);
 
-  CLog::LogFC(LOGDEBUG, LOGPVR, "PVR Manager found active clients. Continuing startup");
+    if (progressHandler && progressTimeout.IsTimePast())
+    {
+      progressHandler->DestroyProgress();
+      progressHandler = nullptr; // no delete, instance is deleting itself
+    }
+  }
 
-  /* load all channels and groups */
   if (progressHandler)
-    progressHandler->UpdateProgress(g_localizeStrings.Get(19236), 0); // Loading channels from clients
+  {
+    progressHandler->DestroyProgress();
+    progressHandler = nullptr; // no delete, instance is deleting itself
+  }
+}
 
-  if (!m_providers->Load() || !IsInitialising())
-    return false;
+bool CPVRManager::UpdateComponents(std::vector<std::shared_ptr<CPVRClient>>& knownClients,
+                                   ManagerState stateToCheck,
+                                   CPVRGUIProgressHandler* progressHandler)
+{
+  // find clients which disappeared since last check and remove them from known clients
+  for (auto it = knownClients.begin(); it != knownClients.end();)
+  {
+    if ((*it)->IgnoreClient())
+    {
+      it = knownClients.erase(it);
+      CLog::LogFC(LOGDEBUG, LOGPVR,
+                  "PVR client '{}' disconnected. Erasing from list of known clients.", (*it)->ID());
+    }
+    else
+      ++it;
+  }
 
-  if (!m_channelGroups->Load() || !IsInitialising())
+  // find clients which appeared since last check and update them
+  CPVRClientMap clientMap;
+  m_addons->GetCreatedClients(clientMap);
+  if (clientMap.empty())
+  {
+    CLog::LogFC(LOGDEBUG, LOGPVR, "All created PVR clients gone!");
     return false;
+  }
+
+  std::vector<std::shared_ptr<CPVRClient>> newClients;
+  for (const auto& entry : clientMap)
+  {
+    // skip not (yet) connected clients
+    if (entry.second->IgnoreClient())
+    {
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Skipping not (yet) connected PVR client '{}'",
+                  entry.second->ID());
+      continue;
+    }
+
+    if (knownClients.empty() || std::find_if(knownClients.cbegin(), knownClients.cend(),
+                                             [&entry](const std::shared_ptr<CPVRClient>& client) {
+                                               return entry.first == client->GetID();
+                                             }) == knownClients.cend())
+    {
+      knownClients.emplace_back(entry.second);
+      newClients.emplace_back(entry.second);
+
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Adding new PVR client '{}' to list of known clients",
+                  entry.second->ID());
+    }
+  }
+
+  if (newClients.empty())
+    return !knownClients.empty();
+
+  // Load all channels and groups
+  if (progressHandler)
+    progressHandler->UpdateProgress(g_localizeStrings.Get(19236), 0); // Loading channels and groups
+
+  if (!m_providers->Update(newClients) || (stateToCheck != GetState()))
+  {
+    CLog::LogF(LOGERROR, "Failed to load PVR providers.");
+    knownClients.clear(); // start over
+    return false;
+  }
+
+  if (!m_channelGroups->Update(newClients) || (stateToCheck != GetState()))
+  {
+    CLog::LogF(LOGERROR, "Failed to load PVR channels / groups.");
+    knownClients.clear(); // start over
+    return false;
+  }
 
   PublishEvent(PVREvent::ChannelGroupsLoaded);
 
-  /* get timers from the backends */
+  // Load all timers
   if (progressHandler)
-    progressHandler->UpdateProgress(g_localizeStrings.Get(19237), 50); // Loading timers from clients
+    progressHandler->UpdateProgress(g_localizeStrings.Get(19237), 50); // Loading timers
 
-  m_timers->Load();
-
-  /* get recordings from the backend */
-  if (progressHandler)
-    progressHandler->UpdateProgress(g_localizeStrings.Get(19238), 75); // Loading recordings from clients
-
-  m_recordings->Load();
-
-  if (!IsInitialising())
+  if (!m_timers->Update(newClients) || (stateToCheck != GetState()))
+  {
+    CLog::LogF(LOGERROR, "Failed to load PVR timers.");
+    knownClients.clear(); // start over
     return false;
+  }
 
-  /* start the other pvr related update threads */
+  // Load all recordings
   if (progressHandler)
-    progressHandler->UpdateProgress(g_localizeStrings.Get(19239), 85); // Starting background threads
+    progressHandler->UpdateProgress(g_localizeStrings.Get(19238), 75); // Loading recordings
+
+  if (!m_recordings->Update(newClients) || (stateToCheck != GetState()))
+  {
+    CLog::LogF(LOGERROR, "Failed to load PVR recordings.");
+    knownClients.clear(); // start over
+    return false;
+  }
 
   return true;
 }
@@ -812,13 +895,6 @@ void CPVRManager::TriggerEpgsCreate()
   });
 }
 
-void CPVRManager::TriggerRecordingsUpdate()
-{
-  m_pendingUpdates->Append("pvr-update-recordings", [this]() {
-    return Recordings()->Update();
-  });
-}
-
 void CPVRManager::TriggerRecordingsSizeInProgressUpdate()
 {
   m_pendingUpdates->Append("pvr-update-recordings-size", [this]() {
@@ -826,32 +902,80 @@ void CPVRManager::TriggerRecordingsSizeInProgressUpdate()
   });
 }
 
+void CPVRManager::TriggerRecordingsUpdate(int clientId)
+{
+  m_pendingUpdates->Append("pvr-update-recordings-" + std::to_string(clientId), [this, clientId]() {
+    const std::shared_ptr<CPVRClient> client = GetClient(clientId);
+    if (client)
+      Recordings()->UpdateFromClients({client});
+  });
+}
+
+void CPVRManager::TriggerRecordingsUpdate()
+{
+  m_pendingUpdates->Append("pvr-update-recordings",
+                           [this]() { Recordings()->UpdateFromClients({}); });
+}
+
+void CPVRManager::TriggerTimersUpdate(int clientId)
+{
+  m_pendingUpdates->Append("pvr-update-timers-" + std::to_string(clientId), [this, clientId]() {
+    const std::shared_ptr<CPVRClient> client = GetClient(clientId);
+    if (client)
+      Timers()->UpdateFromClients({client});
+  });
+}
+
 void CPVRManager::TriggerTimersUpdate()
 {
-  m_pendingUpdates->Append("pvr-update-timers", [this]() {
-    return Timers()->Update();
+  m_pendingUpdates->Append("pvr-update-timers", [this]() { Timers()->UpdateFromClients({}); });
+}
+
+void CPVRManager::TriggerProvidersUpdate(int clientId)
+{
+  m_pendingUpdates->Append("pvr-update-channel-providers-" + std::to_string(clientId),
+                           [this, clientId]() {
+                             const std::shared_ptr<CPVRClient> client = GetClient(clientId);
+                             if (client)
+                               Providers()->UpdateFromClients({client});
+                           });
+}
+
+void CPVRManager::TriggerProvidersUpdate()
+{
+  m_pendingUpdates->Append("pvr-update-channel-providers",
+                           [this]() { Providers()->UpdateFromClients({}); });
+}
+
+void CPVRManager::TriggerChannelsUpdate(int clientId)
+{
+  m_pendingUpdates->Append("pvr-update-channels-" + std::to_string(clientId), [this, clientId]() {
+    const std::shared_ptr<CPVRClient> client = GetClient(clientId);
+    if (client)
+      ChannelGroups()->UpdateFromClients({client}, true);
   });
 }
 
 void CPVRManager::TriggerChannelsUpdate()
 {
-  m_pendingUpdates->Append("pvr-update-channels", [this]() {
-    return ChannelGroups()->Update(true);
-  });
+  m_pendingUpdates->Append("pvr-update-channels",
+                           [this]() { ChannelGroups()->UpdateFromClients({}, true); });
 }
 
-void CPVRManager::TriggerProvidersUpdate()
+void CPVRManager::TriggerChannelGroupsUpdate(int clientId)
 {
-  m_pendingUpdates->Append("pvr-update-channel-providers", [this]() {
-    return Providers()->Update();
-  });
+  m_pendingUpdates->Append("pvr-update-channelgroups-" + std::to_string(clientId),
+                           [this, clientId]() {
+                             const std::shared_ptr<CPVRClient> client = GetClient(clientId);
+                             if (client)
+                               ChannelGroups()->UpdateFromClients({client}, false);
+                           });
 }
 
 void CPVRManager::TriggerChannelGroupsUpdate()
 {
-  m_pendingUpdates->Append("pvr-update-channelgroups", [this]() {
-    return ChannelGroups()->Update(false);
-  });
+  m_pendingUpdates->Append("pvr-update-channelgroups",
+                           [this]() { ChannelGroups()->UpdateFromClients({}, false); });
 }
 
 void CPVRManager::TriggerSearchMissingChannelIcons()
@@ -895,10 +1019,6 @@ void CPVRManager::ConnectionStateChange(CPVRClient* client,
 {
   CJobManager::GetInstance().Submit([this, client, connectString, state, message] {
     Clients()->ConnectionStateChange(client, connectString, state, message);
-
-    if (state == PVR_CONNECTION_STATE_CONNECTED)
-      Start(); // start over
-
     return true;
   });
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -390,7 +390,7 @@ void CPVRManager::Start()
     return;
 
   CLog::Log(LOGINFO, "PVR Manager: Starting");
-  SetState(ManagerStateStarting);
+  SetState(ManagerState::STATE_STARTING);
 
   /* create the pvrmanager thread, which will ensure that all data will be loaded */
   Create();
@@ -413,7 +413,7 @@ void CPVRManager::Stop(bool bRestart /* = false */)
   }
 
   CLog::Log(LOGINFO, "PVR Manager: Stopping");
-  SetState(ManagerStateStopping);
+  SetState(ManagerState::STATE_SSTOPPING);
 
   StopThread();
 }
@@ -453,22 +453,22 @@ void CPVRManager::SetState(CPVRManager::ManagerState state)
   PVREvent event;
   switch (state)
   {
-    case ManagerStateError:
+    case ManagerState::STATE_ERROR:
       event = PVREvent::ManagerError;
       break;
-    case ManagerStateStopped:
+    case ManagerState::STATE_STOPPED:
       event = PVREvent::ManagerStopped;
       break;
-    case ManagerStateStarting:
+    case ManagerState::STATE_STARTING:
       event = PVREvent::ManagerStarting;
       break;
-    case ManagerStateStopping:
+    case ManagerState::STATE_SSTOPPING:
       event = PVREvent::ManagerStopped;
       break;
-    case ManagerStateInterrupted:
+    case ManagerState::STATE_INTERRUPTED:
       event = PVREvent::ManagerInterrupted;
       break;
-    case ManagerStateStarted:
+    case ManagerState::STATE_STARTED:
       event = PVREvent::ManagerStarted;
       break;
     default:
@@ -504,7 +504,7 @@ void CPVRManager::Process()
 
   // Wait for at least one client to come up and load/update data
   std::vector<std::shared_ptr<CPVRClient>> knownClients;
-  UpdateComponents(knownClients, ManagerStateStarting);
+  UpdateComponents(knownClients, ManagerState::STATE_STARTING);
 
   if (!IsInitialising())
   {
@@ -523,7 +523,7 @@ void CPVRManager::Process()
   m_timers->Start();
   m_pendingUpdates->Start();
 
-  SetState(ManagerStateStarted);
+  SetState(ManagerState::STATE_STARTED);
   CLog::Log(LOGINFO, "PVR Manager: Started");
 
   bool bRestart(false);
@@ -532,7 +532,7 @@ void CPVRManager::Process()
   while (IsStarted() && m_addons->HasCreatedClients() && !bRestart)
   {
     // In case any new client connected, load from db and fetch data update from new client(s)
-    UpdateComponents(knownClients, ManagerStateStarted);
+    UpdateComponents(knownClients, ManagerState::STATE_STARTED);
 
     if (cachedImagesCleanupTimeout.IsTimePast())
     {
@@ -588,7 +588,7 @@ void CPVRManager::Process()
   m_epgContainer.Stop();
   m_guiInfo->Stop();
 
-  SetState(ManagerStateInterrupted);
+  SetState(ManagerState::STATE_INTERRUPTED);
 
   UnloadComponents();
   m_database->Close();
@@ -596,7 +596,7 @@ void CPVRManager::Process()
   ResetProperties();
 
   CLog::Log(LOGINFO, "PVR Manager: Stopped");
-  SetState(ManagerStateStopped);
+  SetState(ManagerState::STATE_STOPPED);
 }
 
 bool CPVRManager::SetWakeupCommand()

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -211,39 +211,10 @@ namespace PVR
     std::shared_ptr<CPVRDatabase> GetTVDatabase() const;
 
     /*!
-     * @return True while the PVRManager is initialising.
-     */
-    inline bool IsInitialising() const
-    {
-      return GetState() == ManagerStateStarting;
-    }
-
-    /*!
      * @brief Check whether the PVRManager has fully started.
      * @return True if started, false otherwise.
      */
-    inline bool IsStarted() const
-    {
-      return GetState() == ManagerStateStarted;
-    }
-
-    /*!
-     * @brief Check whether the PVRManager is stopping
-     * @return True while the PVRManager is stopping.
-     */
-    inline bool IsStopping() const
-    {
-      return GetState() == ManagerStateStopping;
-    }
-
-    /*!
-     * @brief Check whether the PVRManager has been stopped.
-     * @return True if stopped, false otherwise.
-     */
-    inline bool IsStopped() const
-    {
-      return GetState() == ManagerStateStopped;
-    }
+    bool IsStarted() const { return GetState() == ManagerState::STATE_STARTED; }
 
     /*!
      * @brief Check whether EPG tags for channels have been created.
@@ -391,15 +362,26 @@ namespace PVR
      */
     bool SetWakeupCommand();
 
-    enum ManagerState
+    enum class ManagerState
     {
-      ManagerStateError = 0,
-      ManagerStateStopped,
-      ManagerStateStarting,
-      ManagerStateStopping,
-      ManagerStateInterrupted,
-      ManagerStateStarted
+      STATE_ERROR = 0,
+      STATE_STOPPED,
+      STATE_STARTING,
+      STATE_SSTOPPING,
+      STATE_INTERRUPTED,
+      STATE_STARTED
     };
+
+    /*!
+     * @return True while the PVRManager is initialising.
+     */
+    bool IsInitialising() const { return GetState() == ManagerState::STATE_STARTING; }
+
+    /*!
+     * @brief Check whether the PVRManager has been stopped.
+     * @return True if stopped, false otherwise.
+     */
+    bool IsStopped() const { return GetState() == ManagerState::STATE_STOPPED; }
 
     /*!
      * @brief Get the current state of the PVR manager.
@@ -475,7 +457,7 @@ namespace PVR
     bool m_bEpgsCreated = false; /*!< true if epg data for channels has been created */
 
     mutable CCriticalSection m_managerStateMutex;
-    ManagerState m_managerState = ManagerStateStopped;
+    ManagerState m_managerState = ManagerState::STATE_STOPPED;
     std::unique_ptr<CStopWatch> m_parentalTimer;
 
     CCriticalSection m_startStopMutex; // mutex for protecting pvr manager's start/restart/stop sequence */

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -276,7 +276,9 @@ namespace PVR
 
     /*!
      * @brief Let the background thread update the recordings list.
+     * @param clientId The id of the PVR client to update.
      */
+    void TriggerRecordingsUpdate(int clientId);
     void TriggerRecordingsUpdate();
 
     /*!
@@ -286,22 +288,30 @@ namespace PVR
 
     /*!
      * @brief Let the background thread update the timer list.
+     * @param clientId The id of the PVR client to update.
      */
+    void TriggerTimersUpdate(int clientId);
     void TriggerTimersUpdate();
 
     /*!
      * @brief Let the background thread update the channel list.
+     * @param clientId The id of the PVR client to update.
      */
+    void TriggerChannelsUpdate(int clientId);
     void TriggerChannelsUpdate();
 
     /*!
      * @brief Let the background thread update the provider list.
+     * @param clientId The id of the PVR client to update.
      */
+    void TriggerProvidersUpdate(int clientId);
     void TriggerProvidersUpdate();
 
     /*!
      * @brief Let the background thread update the channel groups list.
+     * @param clientId The id of the PVR client to update.
      */
+    void TriggerChannelGroupsUpdate(int clientId);
     void TriggerChannelGroupsUpdate();
 
     /*!
@@ -381,33 +391,6 @@ namespace PVR
      */
     bool SetWakeupCommand();
 
-    /*!
-     * @brief Load at least one client and load all other PVR data (channelgroups, timers, recordings) after loading the client.
-     * @param progressHandler The progress handler to use for showing the different load stages.
-     * @return If at least one client and all pvr data was loaded, false otherwise.
-     */
-    bool LoadComponents(CPVRGUIProgressHandler* progressHandler);
-
-    /*!
-     * @brief Unload all PVR data (recordings, timers, channelgroups).
-     */
-    void UnloadComponents();
-
-    /*!
-     * @brief Reset all properties.
-     */
-    void ResetProperties();
-
-    /*!
-     * @brief Destroy PVRManager's objects.
-     */
-    void Clear();
-
-    /*!
-     * @brief Continue playback on the last played channel.
-     */
-    void TriggerPlayChannelOnStartup();
-
     enum ManagerState
     {
       ManagerStateError = 0,
@@ -429,6 +412,45 @@ namespace PVR
      * @param state the new state.
      */
     void SetState(ManagerState state);
+
+    /*!
+     * @brief Wait until at least one client is up. Update all data from database and the given PVR clients.
+     * @param knownClients [inout] List of last known active clients.
+     * @param stateToCheck Required state of the PVR manager while this method gets called.
+     */
+    void UpdateComponents(std::vector<std::shared_ptr<CPVRClient>>& knownClients,
+                          ManagerState stateToCheck);
+
+    /*!
+     * @brief Update all data from database and the given PVR clients.
+     * @param knownClients [inout] List of last known active clients.
+     * @param stateToCheck Required state of the PVR manager while this method gets called.
+     * @param progressHandler The progress handler to use for showing the different stages.
+     * @return True if at least one client is known and successfully loaded, false otherwise.
+     */
+    bool UpdateComponents(std::vector<std::shared_ptr<CPVRClient>>& knownClients,
+                          ManagerState stateToCheck,
+                          CPVRGUIProgressHandler* progressHandler);
+
+    /*!
+     * @brief Unload all PVR data (recordings, timers, channelgroups).
+     */
+    void UnloadComponents();
+
+    /*!
+     * @brief Reset all properties.
+     */
+    void ResetProperties();
+
+    /*!
+     * @brief Destroy PVRManager's objects.
+     */
+    void Clear();
+
+    /*!
+     * @brief Continue playback on the last played channel.
+     */
+    void TriggerPlayChannelOnStartup();
 
     bool IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel, bool bGenerallyLocked) const;
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -158,10 +158,23 @@ namespace PVR
     int GetFirstCreatedClientID();
 
     /*!
+     * @brief Check whether there are any created, but not (yet) connected clients.
+     * @return True if at least one client is ignored.
+     */
+    bool HasIgnoredClients() const;
+
+    /*!
      * @brief Get the number of enabled clients.
      * @return The amount of enabled clients.
      */
     int EnabledClientAmount() const;
+
+    /*!
+     * @brief Check whether a given client ID points to an enabled client.
+     * @param clientId The client ID.
+     * @return True if the the client ID represents an enabled client, false otherwise.
+     */
+    bool IsEnabledClient(int clientId) const;
 
     /*!
      * @brief Get a list of the enabled client infos.
@@ -186,12 +199,15 @@ namespace PVR
     //@{
 
     /*!
-     * @brief Get all timers from all created clients
+     * @brief Get all timers from the given clients
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @param timers Store the timers in this container.
      * @param failedClients in case of errors will contain the ids of the clients for which the timers could not be obtained.
      * @return true on success for all clients, false in case of error for at least one client.
      */
-    bool GetTimers(CPVRTimersContainer* timers, std::vector<int>& failedClients);
+    bool GetTimers(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                   CPVRTimersContainer* timers,
+                   std::vector<int>& failedClients);
 
     /*!
      * @brief Get all supported timer types.
@@ -206,13 +222,15 @@ namespace PVR
     //@{
 
     /*!
-     * @brief Get all recordings from clients
+     * @brief Get all recordings from the given clients
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @param recordings Store the recordings in this container.
      * @param deleted If true, return deleted recordings, return not deleted recordings otherwise.
      * @param failedClients in case of errors will contain the ids of the clients for which the recordings could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
      */
-    PVR_ERROR GetRecordings(CPVRRecordings* recordings,
+    PVR_ERROR GetRecordings(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                            CPVRRecordings* recordings,
                             bool deleted,
                             std::vector<int>& failedClients);
 
@@ -263,40 +281,50 @@ namespace PVR
     //@{
 
     /*!
-     * @brief Get all channels from backends.
+     * @brief Get all channels from the given clients.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @param bRadio Whether to fetch radio or TV channels.
      * @param channels The container to store the channels.
      * @param failedClients in case of errors will contain the ids of the clients for which the channels could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the channels were fetched successfully, last error otherwise.
      */
-    PVR_ERROR GetChannels(bool bRadio,
+    PVR_ERROR GetChannels(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                          bool bRadio,
                           std::vector<std::shared_ptr<CPVRChannel>>& channels,
                           std::vector<int>& failedClients);
 
     /*!
      * @brief Get all providers from backends.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @param group The container to store the providers in.
      * @param failedClients in case of errors will contain the ids of the clients for which the providers could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the providers were fetched successfully, last error otherwise.
      */
-    PVR_ERROR GetProviders(CPVRProvidersContainer* providers, std::vector<int>& failedClients);
+    PVR_ERROR GetProviders(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                           CPVRProvidersContainer* providers,
+                           std::vector<int>& failedClients);
 
     /*!
-     * @brief Get all channel groups from backends.
+     * @brief Get all channel groups from the given clients.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @param groups Store the channel groups in this container.
      * @param failedClients in case of errors will contain the ids of the clients for which the channel groups could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the channel groups were fetched successfully, last error otherwise.
      */
-    PVR_ERROR GetChannelGroups(CPVRChannelGroups* groups, std::vector<int>& failedClients);
+    PVR_ERROR GetChannelGroups(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                               CPVRChannelGroups* groups,
+                               std::vector<int>& failedClients);
 
     /*!
-     * @brief Get all group members of a channel group.
+     * @brief Get all group members of a channel group from the given clients.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @param group The group to get the member for.
      * @param groupMembers The container for the group members.
      * @param failedClients in case of errors will contain the ids of the clients for which the channel group members could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the channel group members were fetched successfully, last error otherwise.
      */
     PVR_ERROR GetChannelGroupMembers(
+        const std::vector<std::shared_ptr<CPVRClient>>& clients,
         CPVRChannelGroup* group,
         std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
         std::vector<int>& failedClients);
@@ -405,9 +433,23 @@ namespace PVR
      * @param clientsNotReady Store the the ids of the not (yet) ready clients in this list.
      * @return PVR_ERROR_NO_ERROR in case all clients are ready, PVR_ERROR_SERVER_ERROR otherwise.
      */
-    PVR_ERROR GetCreatedClients(CPVRClientMap& clientsReady, std::vector<int>& clientsNotReady) const;
+    PVR_ERROR GetCallableClients(CPVRClientMap& clientsReady,
+                                 std::vector<int>& clientsNotReady) const;
 
     typedef std::function<PVR_ERROR(const std::shared_ptr<CPVRClient>&)> PVRClientFunction;
+
+    /*!
+     * @brief Wraps calls to the given clients in order to do common pre and post function invocation actions.
+     * @param strFunctionName The function name, for logging purposes.
+     * @param clients The clients to wrap.
+     * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a std::shared_ptr<CPVRClient> as parameter.
+     * @param failedClients Contains a list of the ids of clients for that the call failed, if any.
+     * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
+     */
+    PVR_ERROR ForClients(const char* strFunctionName,
+                         const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                         const PVRClientFunction& function,
+                         std::vector<int>& failedClients) const;
 
     /*!
      * @brief Wraps calls to all created clients in order to do common pre and post function invocation actions.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -32,6 +32,7 @@ namespace PVR
 
   class CPVRChannel;
   class CPVRChannelGroupMember;
+  class CPVRClient;
   class CPVREpgInfoTag;
 
   enum EpgDateType
@@ -82,11 +83,14 @@ namespace PVR
     CEventStream<PVREvent>& Events() { return m_events; }
 
     /*!
-     * @brief Load the channels from the database, update and sync data from clients.
+     * @brief Load the channels from the database.
      * @param channels All available channels.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
      * @return True when loaded successfully, false otherwise.
      */
-    virtual bool Load(const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels);
+    virtual bool LoadFromDatabase(
+        const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels,
+        const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @brief Clear all data.
@@ -99,10 +103,11 @@ namespace PVR
     size_t Size() const;
 
     /*!
-     * @brief Refresh the channel list from the clients, sync with local data.
+     * @brief Update data with channel group members from the given clients, sync with local data.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @return True on success, false otherwise.
      */
-    virtual bool Update();
+    virtual bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @brief Get the path of this group.
@@ -514,9 +519,10 @@ namespace PVR
   private:
     /*!
      * @brief Load the channel group members stored in the database.
+     * @param clients The PVR clients to load data for. Leave empty for all clients.
      * @return The amount of channel group members that were added.
      */
-    int LoadFromDb();
+    int LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @brief Delete channel group members from database.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -44,10 +44,11 @@ CPVRChannelGroupInternal::~CPVRChannelGroupInternal()
   Unload();
 }
 
-bool CPVRChannelGroupInternal::Load(
-    const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels)
+bool CPVRChannelGroupInternal::LoadFromDatabase(
+    const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels,
+    const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
-  if (CPVRChannelGroup::Load(channels))
+  if (CPVRChannelGroup::LoadFromDatabase(channels, clients))
   {
     for (const auto& groupMember : m_members)
     {
@@ -102,11 +103,13 @@ void CPVRChannelGroupInternal::UpdateChannelPaths()
   }
 }
 
-bool CPVRChannelGroupInternal::Update()
+bool CPVRChannelGroupInternal::UpdateFromClients(
+    const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
-  // get the channels from the backends
+  // get the channels from the given clients
   std::vector<std::shared_ptr<CPVRChannel>> channels;
-  CServiceBroker::GetPVRManager().Clients()->GetChannels(IsRadio(), channels, m_failedClients);
+  CServiceBroker::GetPVRManager().Clients()->GetChannels(clients, IsRadio(), channels,
+                                                         m_failedClients);
 
   // create group members for the channels
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -82,17 +82,21 @@ namespace PVR
         const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) override;
 
     /*!
-     * @brief Refresh the channel list from the clients, sync with local data.
+     * @brief Update data with 'all channels' group members from the given clients, sync with local data.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @return True on success, false otherwise.
      */
-    bool Update() override;
+    bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) override;
 
     /*!
-     * @brief Load the channels from the database, update and sync data from clients.
+     * @brief Load the channels from the database.
      * @param channels All available channels.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
      * @return True when loaded successfully, false otherwise.
      */
-    bool Load(const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels) override;
+    bool LoadFromDatabase(
+        const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels,
+        const std::vector<std::shared_ptr<CPVRClient>>& clients) override;
 
     /*!
      * @brief Clear all data.

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -19,6 +19,7 @@
 namespace PVR
 {
   class CPVRChannel;
+  class CPVRClient;
 
   /** A container class for channel groups */
 
@@ -33,15 +34,16 @@ namespace PVR
     virtual ~CPVRChannelGroups();
 
     /*!
-     * @brief Remove all channels from this group.
+     * @brief Remove all groups from this container.
      */
-    void Clear();
+    void Unload();
 
     /*!
-     * @brief Load this container's contents from the database or PVR clients.
-     * @return True if it was loaded successfully, false if not.
+     * @brief Load all channel groups and all channels from PVR database.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+     * @return True on success, false otherwise.
      */
-    bool Load();
+    bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @brief Create a channel group matching the given type.
@@ -199,11 +201,13 @@ namespace PVR
     bool IsRadio() const { return m_bRadio; }
 
     /*!
-     * @brief Update the contents of the groups in this container.
+     * @brief Update data with groups and channels from the given clients, sync with local data.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
      * @param bChannelsOnly Set to true to only update channels, not the groups themselves.
-     * @return True if the update was successful, false otherwise.
+     * @return True on success, false otherwise.
      */
-    bool Update(bool bChannelsOnly = false);
+    bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                           bool bChannelsOnly = false);
 
     /*!
      * @brief Update the channel numbers across the channel groups from the all channels group
@@ -218,7 +222,6 @@ namespace PVR
     int CleanupCachedImages();
 
   private:
-    bool LoadFromDb();
     void SortGroups();
 
     /*!

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -11,6 +11,7 @@
 #include "threads/CriticalSection.h"
 
 #include <memory>
+#include <vector>
 
 namespace PVR
 {
@@ -18,6 +19,7 @@ namespace PVR
   class CPVRChannelGroup;
   class CPVRChannelGroupMember;
   class CPVRChannelGroups;
+  class CPVRClient;
   class CPVREpgInfoTag;
 
   class CPVRChannelGroupsContainer
@@ -34,28 +36,25 @@ namespace PVR
     virtual ~CPVRChannelGroupsContainer();
 
     /*!
-     * @brief Load all channel groups and all channels in those channel groups.
-     * @return True if all groups were loaded, false otherwise.
+     * @brief Update all channel groups and all channels from PVR database and from given clients.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+     * @return True on success, false otherwise.
      */
-    bool Load();
+    bool Update(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
-     * @brief Checks whether groups were already loaded.
-     * @return True if groups were successfully loaded, false otherwise.
+     * @brief Update data with groups and channels from the given clients, sync with local data.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+     * @param bChannelsOnly Set to true to only update channels, not the groups themselves.
+     * @return True on success, false otherwise.
      */
-    bool Loaded() const;
+    bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                           bool bChannelsOnly = false);
 
     /*!
      * @brief Unload and destruct all channel groups and all channels in them.
      */
     void Unload();
-
-    /*!
-     * @brief Update the contents of all the groups in this container.
-     * @param bChannelsOnly Set to true to only update channels, not the groups themselves.
-     * @return True if the update was successful, false otherwise.
-     */
-    bool Update(bool bChannelsOnly = false);
 
     /*!
      * @brief Get the TV channel groups.
@@ -161,10 +160,16 @@ namespace PVR
     CPVRChannelGroupsContainer& operator=(const CPVRChannelGroupsContainer&) = delete;
     CPVRChannelGroupsContainer(const CPVRChannelGroupsContainer&) = delete;
 
+    /*!
+     * @brief Load all channel groups and all channels from PVR database.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+     * @return True on success, false otherwise.
+     */
+    bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
+
     CPVRChannelGroups* m_groupsRadio; /*!< all radio channel groups */
     CPVRChannelGroups* m_groupsTV; /*!< all TV channel groups */
     CCriticalSection m_critSection;
     bool m_bIsUpdating = false;
-    bool m_bLoaded = false;
   };
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -706,7 +706,7 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
               CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio);
           if (groups)
           {
-            groups->Update();
+            groups->UpdateFromClients({});
             Update();
           }
         }
@@ -754,10 +754,10 @@ void CGUIDialogPVRChannelManager::Update()
   std::shared_ptr<CPVRChannelGroup> channels = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
 
   // No channels available, nothing to do.
-  if(!channels)
+  if (!channels)
     return;
 
-  channels->Update();
+  channels->UpdateFromClients({});
 
   const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers = channels->GetMembers();
   std::shared_ptr<CFileItem> channelFile;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -236,7 +236,7 @@ void CPVREpgContainer::Notify(const PVREvent& event)
   m_events.Publish(event);
 }
 
-void CPVREpgContainer::LoadFromDB()
+void CPVREpgContainer::LoadFromDatabase()
 {
   CSingleLock lock(m_critSection);
 
@@ -564,7 +564,7 @@ std::shared_ptr<CPVREpg> CPVREpgContainer::CreateChannelEpg(int iEpgId, const st
   std::shared_ptr<CPVREpg> epg;
 
   WaitForUpdateFinish();
-  LoadFromDB();
+  LoadFromDatabase();
 
   if (iEpgId > 0)
     epg = GetById(iEpgId);
@@ -736,7 +736,8 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
 
   CPVRGUIProgressHandler* progressHandler = nullptr;
   if (bShowProgress && !bOnlyPending)
-    progressHandler = new CPVRGUIProgressHandler(g_localizeStrings.Get(19004)); // Importing guide from clients
+    progressHandler =
+        new CPVRGUIProgressHandler(g_localizeStrings.Get(19004)); // Loading programme guide
 
   /* load or update all EPG tables */
   unsigned int iCounter = 0;

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -312,7 +312,7 @@ namespace PVR
     /*!
      * @brief Load all tables from the database
      */
-    void LoadFromDB();
+    void LoadFromDatabase();
 
     /*!
      * @brief Insert data from database

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -200,8 +200,7 @@ bool CPVRGUIDirectory::GetDirectory(CFileItemList& results) const
   }
   else if (StringUtils::StartsWith(fileName, "channels"))
   {
-    if (CServiceBroker::GetPVRManager().ChannelGroups() &&
-        CServiceBroker::GetPVRManager().ChannelGroups()->Loaded())
+    if (CServiceBroker::GetPVRManager().IsStarted())
     {
       return GetChannelsDirectory(results);
     }

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -333,7 +333,7 @@ void CPVRGUIActionListener::OnSettingAction(const std::shared_ptr<const CSetting
       if (dialog)
       {
         dialog->Open();
-        CServiceBroker::GetPVRManager().ChannelGroups()->Update();
+        CServiceBroker::GetPVRManager().ChannelGroups()->UpdateFromClients({});
       }
     }
   }

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
@@ -22,77 +22,82 @@ using namespace std::chrono_literals;
 
 namespace PVR
 {
-  CPVRGUIProgressHandler::CPVRGUIProgressHandler(const std::string& strTitle)
-  : CThread("PVRGUIProgressHandler"),
-    m_strTitle(strTitle),
-    m_fProgress(0.0f),
-    m_bChanged(false)
+
+CPVRGUIProgressHandler::CPVRGUIProgressHandler(const std::string& strTitle)
+  : CThread("PVRGUIProgressHandler"), m_strTitle(strTitle)
+{
+}
+
+void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fProgress)
+{
+  CSingleLock lock(m_critSection);
+  m_bChanged = true;
+  m_strText = strText;
+  m_fProgress = fProgress;
+
+  if (!m_bCreated)
   {
+    m_bCreated = true;
     Create(true /* bAutoDelete */);
   }
+}
 
-  void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fProgress)
+void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, int iCurrent, int iMax)
+{
+  float fPercentage = (iCurrent * 100.0f) / iMax;
+  if (!std::isnan(fPercentage))
+    fPercentage = std::min(100.0f, fPercentage);
+
+  UpdateProgress(strText, fPercentage);
+}
+
+void CPVRGUIProgressHandler::DestroyProgress()
+{
+  CSingleLock lock(m_critSection);
+  m_bStop = true;
+  m_bChanged = false;
+}
+
+void CPVRGUIProgressHandler::Process()
+{
+  CGUIDialogExtendedProgressBar* progressBar =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(
+          WINDOW_DIALOG_EXT_PROGRESS);
+  if (m_bStop || !progressBar)
+    return;
+
+  CGUIDialogProgressBarHandle* progressHandle = progressBar->GetHandle(m_strTitle);
+  if (!progressHandle)
+    return;
+
+  while (!m_bStop)
   {
-    CSingleLock lock(m_critSection);
-    m_bChanged = true;
-    m_strText = strText;
-    m_fProgress = fProgress;
-  }
+    float fProgress = 0.0;
+    std::string strText;
+    bool bUpdate = false;
 
-  void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, int iCurrent, int iMax)
-  {
-    float fPercentage = (iCurrent * 100.0f) / iMax;
-    if (!std::isnan(fPercentage))
-      fPercentage = std::min(100.0f, fPercentage);
-
-    UpdateProgress(strText, fPercentage);
-  }
-
-  void CPVRGUIProgressHandler::DestroyProgress()
-  {
-    CSingleLock lock(m_critSection);
-    m_bStop = true;
-    m_bChanged = false;
-  }
-
-  void CPVRGUIProgressHandler::Process()
-  {
-    CGUIDialogExtendedProgressBar* progressBar = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
-    if (m_bStop || !progressBar)
-      return;
-
-    CGUIDialogProgressBarHandle* progressHandle = progressBar->GetHandle(m_strTitle);
-    if (!progressHandle)
-      return;
-
-    while (!m_bStop)
     {
-      float fProgress = 0.0;
-      std::string strText;
-      bool bUpdate = false;
-
+      CSingleLock lock(m_critSection);
+      if (m_bChanged)
       {
-        CSingleLock lock(m_critSection);
-        if (m_bChanged)
-        {
-          m_bChanged = false;
-          fProgress = m_fProgress;
-          strText = m_strText;
-          bUpdate = true;
-        }
+        m_bChanged = false;
+        fProgress = m_fProgress;
+        strText = m_strText;
+        bUpdate = true;
       }
-
-      if (bUpdate)
-      {
-        progressHandle->SetPercentage(fProgress);
-        progressHandle->SetText(strText);
-      }
-
-      // Intentionally ignore some changes that come in too fast. Humans cannot read as fast as Mr. Data ;-)
-      CThread::Sleep(100ms);
     }
 
-    progressHandle->MarkFinished();
+    if (bUpdate)
+    {
+      progressHandle->SetPercentage(fProgress);
+      progressHandle->SetText(strText);
+    }
+
+    // Intentionally ignore some changes that come in too fast. Humans cannot read as fast as Mr. Data ;-)
+    CThread::Sleep(100ms);
   }
+
+  progressHandle->MarkFinished();
+}
 
 } // namespace PVR

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.h
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.h
@@ -55,8 +55,9 @@ namespace PVR
     CCriticalSection m_critSection;
     const std::string m_strTitle;
     std::string m_strText;
-    float m_fProgress;
-    bool m_bChanged;
+    float m_fProgress{0.0f};
+    bool m_bChanged{false};
+    bool m_bCreated{false};
   };
 
 } // namespace PVR

--- a/xbmc/pvr/providers/PVRProviders.h
+++ b/xbmc/pvr/providers/PVRProviders.h
@@ -15,6 +15,7 @@
 
 namespace PVR
 {
+class CPVRClient;
 class CPVRProvider;
 
 enum class ProviderUpdateMode;
@@ -64,10 +65,11 @@ public:
   ~CPVRProviders() = default;
 
   /**
-     * @brief (re)load the providers from the clients.
-     * @return True if loaded successfully, false otherwise.
+   * @brief Update all providers from PVR database and from given clients.
+   * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+   * @return True on success, false otherwise.
      */
-  bool Load();
+  bool Update(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
   /**
      * @brief unload all providers.
@@ -75,15 +77,18 @@ public:
   void Unload();
 
   /**
-     * @brief refresh the providers list from the clients.
+   * @brief Update data with providers from the given clients, sync with local data.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @return True on success, false otherwise.
      */
-  bool Update();
+  bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
   /**
-     * @brief load the local providers from database.
-     * @return True if loaded successfully, false otherwise.
+   * @brief Load all local providers from PVR database.
+   * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+   * @return True on success, false otherwise.
      */
-  bool LoadFromDatabase();
+  bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
   /*!
      * @brief Check if the entry exists in the container, if it does update it otherwise add it

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -32,10 +32,11 @@ namespace PVR
     virtual ~CPVRRecordings();
 
     /*!
-     * @brief (re)load the recordings from the clients.
-     * @return the number of recordings loaded.
+     * @brief Update all recordings from the given PVR clients.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+     * @return True on success, false otherwise.
      */
-    int Load();
+    bool Update(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @brief unload all recordings.
@@ -43,16 +44,18 @@ namespace PVR
     void Unload();
 
     /*!
+     * @brief Update data with recordings from the given clients, sync with local data.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+     * @return True on success, false otherwise.
+     */
+    bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
+
+    /*!
      * @brief client has delivered a new/updated recording.
      * @param tag The recording
      * @param client The client the recording belongs to.
      */
     void UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag, const CPVRClient& client);
-
-    /*!
-     * @brief refresh the recordings list from the clients.
-     */
-    void Update();
 
     /*!
      * @brief refresh the size of any in progress recordings from the clients.
@@ -112,8 +115,6 @@ namespace PVR
     bool m_bDeletedRadioRecordings = false;
     unsigned int m_iTVRecordings = 0;
     unsigned int m_iRadioRecordings = 0;
-
-    void UpdateFromClients();
 
     /*!
      * @brief Get/Open the video database.

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -23,6 +23,7 @@ namespace PVR
   enum class PVREvent;
 
   class CPVRChannel;
+  class CPVRClient;
   class CPVREpgInfoTag;
   class CPVRTimerInfoTag;
   class CPVRTimersPath;
@@ -68,37 +69,34 @@ namespace PVR
     CPVRTimers();
     ~CPVRTimers() override = default;
 
-    /**
+    /*!
      * @brief start the timer update thread.
      */
     void Start();
 
-    /**
+    /*!
      * @brief stop the timer update thread.
      */
     void Stop();
 
-    /**
-     * @brief (re)load the timers from the clients.
-     * @return True if loaded successfully, false otherwise.
+    /*!
+     * @brief Update all timers from PVR database and from given clients.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+     * @return True on success, false otherwise.
      */
-    bool Load();
+    bool Update(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
-    /**
+    /*!
      * @brief unload all timers.
      */
     void Unload();
 
-    /**
-     * @brief refresh the timer list from the clients.
+    /*!
+     * @brief Update data with recordings from the given clients, sync with local data.
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+     * @return True on success, false otherwise.
      */
-    bool Update();
-
-    /**
-     * @brief load the local timers from database.
-     * @return True if loaded successfully, false otherwise.
-     */
-    bool LoadFromDatabase();
+    bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     /*!
      * @param bIgnoreReminders include or ignore reminders
@@ -268,6 +266,13 @@ namespace PVR
 
   private:
     void Process() override;
+
+    /*!
+     * @brief Load all timers from PVR database.
+     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+     * @return True on success, false otherwise.
+     */
+    bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
     void RemoveEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag);
     bool UpdateEntries(const CPVRTimersContainer& timers, const std::vector<int>& failedClients);


### PR DESCRIPTION
This fixes and improves a couple of things related to PVR startup / shutdown. Sorry, I was not able to split this up in separate commits as code changes evolved over time, in many iterations.

1) Fixes a startup race which happens with multiple PVR add-ons enabled, and at least one of the add-ons supports "async connect". 

If the add-on supporting async-connect notifices "connected" somewhere in the middle of pvr manager loading components, it could happen that PVR ended up with inconsistent data. Loading sequence is GetChannelGroups, GetChannels, for every group GetChannelGroupMembers. If for example, call to GetChannelGroups fails, call to GetChannels also fails because add-on supporting async-connect is not yet connected, then the add-ons gets connected, call to first and subsequent GetChannelGroupMembers will succeed, leading evtually to deletion of all channel data in the PVR data base. => Log entries ala "Removed stale channel...)

The race gets fixed by determining the ready-to-use add-ons and passing those add-ons to the respective methods which are changed to load data from the database for the given clients only and to update date from the given clients only. PVR manager main loop now periodically checks for newly connected clients and in case to load data for those new clients only.

2) Due to the beforementioned code changes, PVR restart no longer needs to get restarted when an add-on signals "connected".

3) Data update jobs are now only scheduled for the add-on requesting to update data only, not for all available PVR clients.

4) Some logging improvements

I runtime-tested the changes very carefully on macOS and Android - no regressions found.

@phunkyfish when you find some time for a code review...

