### PR TITLE
[DXVA2] Use true shared decoder surfaces with NVIDIA / AMD recent drivers

### DIFF
--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -20,6 +20,14 @@
 #define BONJOUR_BROWSER_EVENT     ( WM_USER + 0x110 )
 #define TRAY_ICON_NOTIFY          ( WM_USER + 0x120 )
 
+struct VideoDriverInfo
+{
+  int majorVersion;
+  int minorVersion;
+  bool valid;
+  std::string version;
+};
+
 class CURL; // forward declaration
 
 class CWIN32Util
@@ -74,4 +82,6 @@ public:
   static HDR_STATUS GetWindowsHDRStatus();
 
   static void PlatformSyslog();
+
+  static VideoDriverInfo GetVideoDriverInfo(const UINT vendorId, const std::wstring& driverDesc);
 };

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -22,6 +22,7 @@
 
 struct RESOLUTION_INFO;
 struct DEBUG_INFO_RENDER;
+struct VideoDriverInfo;
 
 namespace DX
 {
@@ -112,6 +113,7 @@ namespace DX
     void SetWindowPos(winrt::Windows::Foundation::Rect rect);
 #endif // TARGET_WINDOWS_STORE
     bool IsNV12SharedTexturesSupported() const { return m_NV12SharedTexturesSupport; }
+    bool IsDXVA2SharedDecoderSurfaces() const { return m_DXVA2SharedDecoderSurfaces; }
 
     // Gets debug info from swapchain
     DEBUG_INFO_RENDER GetDebugInfo() const;
@@ -136,6 +138,8 @@ namespace DX
     void HandleOutputChange(const std::function<bool(DXGI_OUTPUT_DESC)>& cmpFunc);
     bool CreateFactory();
     void CheckNV12SharedTexturesSupport();
+    VideoDriverInfo GetVideoDriverVersion();
+    void CheckDXVA2SharedDecoderSurfaces();
 
     HWND m_window{ nullptr };
 #if defined(TARGET_WINDOWS_STORE)
@@ -178,5 +182,6 @@ namespace DX
     bool m_IsHDROutput;
     bool m_IsTransferPQ;
     bool m_NV12SharedTexturesSupport{false};
+    bool m_DXVA2SharedDecoderSurfaces{false};
   };
 }

--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -16,6 +16,13 @@
 #include <d3d11_4.h>
 #include <ppltasks.h> // For create_task
 
+enum PCI_Vendors
+{
+  PCIV_AMD = 0x1002,
+  PCIV_NVIDIA = 0x10DE,
+  PCIV_Intel = 0x8086,
+};
+
 namespace DX
 {
 #define RATIONAL_TO_FLOAT(rational) ((rational.Denominator != 0) ? \
@@ -92,6 +99,25 @@ namespace DX
     uint32_t fl_minor = (featureLevel & 0x0F00u) >> 8;
 
     return StringUtils::Format("D3D_FEATURE_LEVEL_{}_{}", fl_major, fl_minor);
+  }
+
+  inline std::string GetGFXProviderName(UINT vendorId)
+  {
+    std::string name;
+    switch (vendorId)
+    {
+      case PCIV_AMD:
+        name = "AMD";
+        break;
+      case PCIV_Intel:
+        name = "Intel";
+        break;
+      case PCIV_NVIDIA:
+        name = "NVIDIA";
+        break;
+    }
+
+    return name;
   }
 
   template <typename T> struct SizeGen

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -17,13 +17,6 @@
 
 #include <wrl/client.h>
 
-enum PCI_Vendors
-{
-  PCIV_ATI    = 0x1002,
-  PCIV_nVidia = 0x10DE,
-  PCIV_Intel  = 0x8086
-};
-
 class ID3DResource;
 class CGUIShaderDX;
 enum AVPixelFormat;


### PR DESCRIPTION
## Description
DXVA2: Use true shared decoder surfaces with NVIDIA / AMD recent drivers. This code path was already supported for Intel.

## Motivation and context
Recent NVIDIA drivers supports use directly video decoder textures on render device without use copy texture. This improvers greatly performance and reduces video memory usage. Also eliminates some side effects (green screen glitches) that are produced in some corner cases: skip chapters, playback Blu-Ray UHD menus / DVD menus, some MPEG2 content, PVR recordings.

Intel currently uses this code path already. Most of the code in this PR is for detecting the video driver version and enabling the optimized path (no texture copying) also for Nvidia and AMD where supported.

I have found that Nvidia started to support this form driver 465.xx. Tested with "465.89-desktop-win10-64bit-international-dch-whql.exe."  

## How has this been tested?
Runtime tested Windows 10 x64 on NVIDIA RTX 2060 SUPER

Also some forum users (https://forum.kodi.tv/showthread.php?tid=366670) have tested on:

- Windows 11, Nvidia GTX 1050
- Windows 10, Nvidia GTX 1060
- Windows 10, AMD Radeon RX 6600 XT

Testing on AMD is pending. It is expected that some user here or in the forum can test and report feedback for AMD. 

Otherwise, the code for AMD can be removed from the PR before merge and it would be valid only for NVIDIA.

## What is the effect on users?
Improves DXVA2 video decoding performance and reduces video memory usage (almost cut in half). 


## Screenshots (if appropriate):

This is playing 4K HDR video source on SDR display  (PC monitor):

**Before**
![Captura de pantalla 2022-01-24 103746](https://user-images.githubusercontent.com/58434170/151144011-2b580ba5-e80c-455c-bb2d-35ff31fd8777.png)

**After**
![Captura de pantalla 2022-01-24 104049](https://user-images.githubusercontent.com/58434170/151144051-75aac4e2-5de0-45c3-bba9-4be377c13e71.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
