### PR TITLE
[cmake] Internal depends download macro refactor

### DIFF
--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -2,18 +2,9 @@ if(ENABLE_INTERNAL_CROSSGUID)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(crossguid)
+  set(MODULE_LC crossguid)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(CROSSGUID_URL)
-    get_filename_component(CROSSGUID_URL "${CROSSGUID_URL}" ABSOLUTE)
-  else()
-    set(CROSSGUID_URL http://mirrors.kodi.tv/build-deps/sources/${CROSSGUID_ARCHIVE})
-  endif()
-  if(VERBOSE)
-    message(STATUS "CROSSGUID_URL: ${CROSSGUID_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   if(APPLE)
     set(EXTRA_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
@@ -21,11 +12,14 @@ if(ENABLE_INTERNAL_CROSSGUID)
 
   set(CROSSGUID_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libcrossguid.a)
   set(CROSSGUID_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
-  externalproject_add(crossguid
-                      URL ${CROSSGUID_URL}
-                      URL_HASH ${CROSSGUID_HASH}
+  set(CROSSGUID_VER ${${MODULE}_VER})
+
+  externalproject_add(${MODULE_LC}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
                       DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/crossguid
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
+                      PREFIX ${CORE_BUILD_DIR}/${MODULE_LC}
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                                  "${EXTRA_ARGS}"
@@ -45,7 +39,6 @@ else()
 
   include(SelectLibraryConfigurations)
   select_library_configurations(CROSSGUID)
-
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/modules/FindDav1d.cmake
+++ b/cmake/modules/FindDav1d.cmake
@@ -13,31 +13,20 @@ if(ENABLE_INTERNAL_DAV1D)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(dav1d)
-  set(DAV1D_VERSION ${DAV1D_VER})
+  set(MODULE_LC dav1d)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(DAV1D_URL)
-    get_filename_component(DAV1D_URL "${DAV1D_URL}" ABSOLUTE)
-  else()
-    set(DAV1D_URL http://mirrors.kodi.tv/build-deps/sources/${DAV1D_ARCHIVE})
-  endif()
-
-  if(VERBOSE)
-    message(STATUS "DAV1D_URL: ${DAV1D_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   set(DAV1D_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libdav1d.a)
   set(DAV1D_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
   set(DAV1D_VERSION ${DAV1D_VER})
 
-  externalproject_add(dav1d
-                      URL ${DAV1D_URL}
-                      URL_HASH ${DAV1D_HASH}
-                      DOWNLOAD_NAME ${DAV1D_ARCHIVE}
+  externalproject_add(${MODULE_LC}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
                       DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/dav1d
+                      PREFIX ${CORE_BUILD_DIR}/${MODULE_LC}
                       CONFIGURE_COMMAND meson
                                         --buildtype=release
                                         --default-library=static
@@ -52,7 +41,7 @@ if(ENABLE_INTERNAL_DAV1D)
                       INSTALL_COMMAND ninja install
                       BUILD_BYPRODUCTS ${DAV1D_LIBRARY})
 
-  set_target_properties(dav1d PROPERTIES FOLDER "External Projects")
+  set_target_properties(${MODULE_LC} PROPERTIES FOLDER "External Projects")
 else()
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_DAV1D dav1d QUIET)

--- a/cmake/modules/FindFlatBuffers.cmake
+++ b/cmake/modules/FindFlatBuffers.cmake
@@ -13,27 +13,20 @@ if(ENABLE_INTERNAL_FLATBUFFERS)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(flatbuffers)
+  set(MODULE_LC flatbuffers)
 
-  # Allow user to override the download URL with a local tarball
-  # Needed for offline build envs
-  if(FLATBUFFERS_URL)
-    get_filename_component(FLATBUFFERS_URL "${FLATBUFFERS_URL}" ABSOLUTE)
-  else()
-    set(FLATBUFFERS_URL http://mirrors.kodi.tv/build-deps/sources/${FLATBUFFERS_ARCHIVE})
-  endif()
-  if(VERBOSE)
-    message(STATUS "FLATBUFFERS_URL: ${FLATBUFFERS_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   set(FLATBUFFERS_FLATC_EXECUTABLE ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin/flatc CACHE INTERNAL "FlatBuffer compiler")
   set(FLATBUFFERS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include CACHE INTERNAL "FlatBuffer include dir")
+  set(FLATBUFFERS_VER ${${MODULE}_VER})
 
-  externalproject_add(flatbuffers
-                      URL ${FLATBUFFERS_URL}
-                      URL_HASH ${FLATBUFFERS_HASH}
+  externalproject_add(${MODULE_LC}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
                       DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/flatbuffers
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
+                      PREFIX ${CORE_BUILD_DIR}/${MODULE_LC}
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_BUILD_TYPE=Release
                                  -DFLATBUFFERS_CODE_COVERAGE=OFF
@@ -46,8 +39,8 @@ if(ENABLE_INTERNAL_FLATBUFFERS)
                                  -DFLATBUFFERS_BUILD_SHAREDLIB=OFF
                                  "${EXTRA_ARGS}"
                       BUILD_BYPRODUCTS ${FLATBUFFERS_FLATC_EXECUTABLE})
-  set_target_properties(flatbuffers PROPERTIES FOLDER "External Projects"
-                                    INTERFACE_INCLUDE_DIRECTORIES ${FLATBUFFERS_INCLUDE_DIR})
+  set_target_properties(${MODULE_LC} PROPERTIES FOLDER "External Projects"
+                                     INTERFACE_INCLUDE_DIRECTORIES ${FLATBUFFERS_INCLUDE_DIR})
 else()
   find_program(FLATBUFFERS_FLATC_EXECUTABLE NAMES flatc)
   find_path(FLATBUFFERS_INCLUDE_DIR NAMES flatbuffers/flatbuffers.h)

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -16,18 +16,9 @@ if(ENABLE_INTERNAL_FMT)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(libfmt)
+  set(MODULE_LC libfmt)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(FMT_URL)
-      get_filename_component(FMT_URL "${FMT_URL}" ABSOLUTE)
-  else()
-    set(FMT_URL http://mirrors.kodi.tv/build-deps/sources/${LIBFMT_ARCHIVE})
-  endif()
-  if(VERBOSE)
-      message(STATUS "FMT_URL: ${FMT_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   if(APPLE)
     set(EXTRA_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
@@ -35,12 +26,13 @@ if(ENABLE_INTERNAL_FMT)
 
   set(FMT_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libfmt.a)
   set(FMT_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
-  set(FMT_VERSION ${LIBFMT_VER})
+  set(FMT_VERSION ${${MODULE}_VER})
 
   externalproject_add(fmt
-                      URL ${FMT_URL}
-                      URL_HASH ${LIBFMT_HASH}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
                       DOWNLOAD_DIR ${TARBALL_DIR}
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
                       PREFIX ${CORE_BUILD_DIR}/fmt
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}

--- a/cmake/modules/FindFstrcmp.cmake
+++ b/cmake/modules/FindFstrcmp.cmake
@@ -15,25 +15,19 @@ if(ENABLE_INTERNAL_FSTRCMP)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(libfstrcmp)
+  set(MODULE_LC libfstrcmp)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(FSTRCMP_URL)
-    get_filename_component(FSTRCMP_URL "${FSTRCMP_URL}" ABSOLUTE)
-  else()
-    set(FSTRCMP_URL http://mirrors.kodi.tv/build-deps/sources/${LIBFSTRCMP_ARCHIVE})
-  endif()
-  if(VERBOSE)
-    message(STATUS "FSTRCMPURL: ${FSTRCMP_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   set(FSTRCMP_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libfstrcmp.a)
   set(FSTRCMP_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+  set(FSTRCMP_VER ${${MODULE}_VER})
+
   externalproject_add(fstrcmp
-                      URL ${FSTRCMP_URL}
-                      URL_HASH ${FSTRCMP_HASH}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
                       DOWNLOAD_DIR ${TARBALL_DIR}
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
                       PREFIX ${CORE_BUILD_DIR}/fstrcmp
                       PATCH_COMMAND autoreconf -vif
                       CONFIGURE_COMMAND ./configure --prefix ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}

--- a/cmake/modules/FindGtest.cmake
+++ b/cmake/modules/FindGtest.cmake
@@ -18,29 +18,20 @@ if(ENABLE_INTERNAL_GTEST)
 
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(googletest)
-  set(GTEST_VERSION ${GOOGLETEST_VER})
+  set(MODULE_LC googletest)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(GTEST_URL)
-    get_filename_component(GTEST_URL "${GTEST_URL}" ABSOLUTE)
-  else()
-    set(GTEST_URL http://mirrors.kodi.tv/build-deps/sources/${GTEST_ARCHIVE})
-  endif()
-
-  if(VERBOSE)
-    message(STATUS "GTEST_URL: ${GTEST_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   set(GTEST_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libgtest.a)
   set(GTEST_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+  set(GTEST_VERSION ${${MODULE}_VER})
 
   externalproject_add(gtest
-                      URL ${GTEST_URL}
-                      URL_HASH ${GTEST_HASH}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
                       DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/gtest
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
+                      PREFIX ${CORE_BUILD_DIR}/${MODULE_LC}
                       INSTALL_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                       CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DBUILD_GMOCK=OFF -DINSTALL_GTEST=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DCMAKE_INSTALL_LIBDIR=lib
                       BUILD_BYPRODUCTS ${GTEST_LIBRARY})

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -12,18 +12,9 @@ if(ENABLE_INTERNAL_RapidJSON)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(rapidjson)
+  set(MODULE_LC rapidjson)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(RapidJSON_URL)
-    get_filename_component(RapidJSON_URL "${RapidJSON_URL}" ABSOLUTE)
-  else()
-    set(RapidJSON_URL http://mirrors.kodi.tv/build-deps/sources/${RAPIDJSON_ARCHIVE})
-  endif()
-  if(VERBOSE)
-    message(STATUS "RapidJSON_URL: ${RapidJSON_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   if(APPLE)
     set(EXTRA_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
@@ -31,11 +22,14 @@ if(ENABLE_INTERNAL_RapidJSON)
 
   set(RapidJSON_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/librapidjson.a)
   set(RapidJSON_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
-  externalproject_add(rapidjson
-                      URL ${RapidJSON_URL}
-                      URL_HASH ${RAPIDJSON_HASH}
+  set(RapidJSON_VERSION ${${MODULE}_VER})
+
+  externalproject_add(${MODULE_LC}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
                       DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/rapidjson
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
+                      PREFIX ${CORE_BUILD_DIR}/${MODULE_LC}
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                                  -DRAPIDJSON_BUILD_DOC=OFF
@@ -45,34 +39,26 @@ if(ENABLE_INTERNAL_RapidJSON)
                                  "${EXTRA_ARGS}"
                       PATCH_COMMAND patch -p1 < ${CORE_SOURCE_DIR}/tools/depends/target/rapidjson/0001-remove_custom_cxx_flags.patch
                       BUILD_BYPRODUCTS ${RapidJSON_LIBRARY})
-  set_target_properties(rapidjson PROPERTIES FOLDER "External Projects")
+  set_target_properties(${MODULE_LC} PROPERTIES FOLDER "External Projects")
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(rapidjson
-                                    REQUIRED_VARS RapidJSON_LIBRARY RapidJSON_INCLUDE_DIR
-                                    VERSION_VAR RAPIDJSON_VER)
-
-  set(RapidJSON_LIBRARIES ${RapidJSON_LIBRARY})
-  set(RapidJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR})
 else()
-
-if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_RapidJSON RapidJSON>=1.0.2 QUIET)
-endif()
-
-if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
-  set(RapidJSON_VERSION 1.1.0)
-else()
-  if(PC_RapidJSON_VERSION)
-    set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
-  else()
-    find_package(RapidJSON 1.1.0 CONFIG REQUIRED QUIET)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_RapidJSON RapidJSON>=1.0.2 QUIET)
   endif()
+
+  if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
+    set(RapidJSON_VERSION 1.1.0)
+  else()
+    if(PC_RapidJSON_VERSION)
+      set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
+    else()
+      find_package(RapidJSON 1.1.0 CONFIG REQUIRED QUIET)
+    endif()
+  endif()
+
+  find_path(RapidJSON_INCLUDE_DIR NAMES rapidjson/rapidjson.h
+                                  PATHS ${PC_RapidJSON_INCLUDEDIR})
 endif()
-
-find_path(RapidJSON_INCLUDE_DIR NAMES rapidjson/rapidjson.h
-                                PATHS ${PC_RapidJSON_INCLUDEDIR})
-
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(RapidJSON
@@ -84,5 +70,3 @@ if(RAPIDJSON_FOUND)
 endif()
 
 mark_as_advanced(RapidJSON_INCLUDE_DIR)
-
-endif()

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -17,19 +17,9 @@ if(ENABLE_INTERNAL_SPDLOG)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(libspdlog)
-  set(SPDLOG_VERSION ${SPDLOG_VER})
+  set(MODULE_LC libspdlog)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(SPDLOG_URL)
-      get_filename_component(SPDLOG_URL "${SPDLOG_URL}" ABSOLUTE)
-  else()
-      set(SPDLOG_URL http://mirrors.kodi.tv/build-deps/sources/${LIBSPDLOG_ARCHIVE})
-  endif()
-  if(VERBOSE)
-      message(STATUS "SPDLOG_URL: ${SPDLOG_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   if(APPLE)
     set(EXTRA_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
@@ -37,12 +27,14 @@ if(ENABLE_INTERNAL_SPDLOG)
 
   set(SPDLOG_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libspdlog.a)
   set(SPDLOG_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+  set(SPDLOG_VERSION ${${MODULE}_VER})
 
   externalproject_add(spdlog
-                      URL ${SPDLOG_URL}
-                      URL_HASH ${SPDLOG_HASH}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
                       DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/spdlog
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
+                      PREFIX ${CORE_BUILD_DIR}/${MODULE_LC}
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}
                                  -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}

--- a/cmake/modules/FindUdfread.cmake
+++ b/cmake/modules/FindUdfread.cmake
@@ -14,30 +14,20 @@ if(ENABLE_INTERNAL_UDFREAD)
   include(ExternalProject)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  get_archive_name(libudfread)
+  set(MODULE_LC libudfread)
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(UDFREAD_URL)
-    get_filename_component(UDFREAD_URL "${UDFREAD_URL}" ABSOLUTE)
-  else()
-    set(UDFREAD_URL http://mirrors.kodi.tv/build-deps/sources/${LIBUDFREAD_ARCHIVE})
-  endif()
-
-  if(VERBOSE)
-    message(STATUS "UDFREAD_URL: ${UDFREAD_URL}")
-  endif()
+  SETUP_BUILD_VARS()
 
   set(UDFREAD_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libudfread.a)
   set(UDFREAD_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
-  set(UDFREAD_VERSION ${LIBUDFREAD_VER})
+  set(UDFREAD_VERSION ${${MODULE}_VER})
 
   externalproject_add(udfread
-                      URL ${UDFREAD_URL}
-                      URL_HASH ${LIBUDFREAD_HASH}
-                      DOWNLOAD_NAME ${LIBUDFREAD_ARCHIVE}
+                      URL ${${MODULE}_URL}
+                      URL_HASH ${${MODULE}_HASH}
+                      DOWNLOAD_NAME ${${MODULE}_ARCHIVE}
                       DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/libudfread
+                      PREFIX ${CORE_BUILD_DIR}/${MODULE_LC}
                       CONFIGURE_COMMAND autoreconf -vif &&
                                         ./configure
                                         --enable-static

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -39,6 +39,8 @@ function(get_archive_name module_name)
   set(${UPPER_MODULE_NAME}_VER ${${UPPER_MODULE_NAME}_VER} PARENT_SCOPE)
   if (${UPPER_MODULE_NAME}_BASE_URL)
     set(${UPPER_MODULE_NAME}_BASE_URL ${${UPPER_MODULE_NAME}_BASE_URL} PARENT_SCOPE)
+  else()
+    set(${UPPER_MODULE_NAME}_BASE_URL "http://mirrors.kodi.tv/build-deps/sources" PARENT_SCOPE)
   endif()
 
   if (${UPPER_MODULE_NAME}_HASH_SHA256)
@@ -48,3 +50,20 @@ function(get_archive_name module_name)
   endif()
 
 endfunction()
+
+# Macro to factor out the repetitive URL setup
+macro(SETUP_BUILD_VARS)
+  get_archive_name(${MODULE_LC})
+  string(TOUPPER ${MODULE_LC} MODULE)
+
+  # allow user to override the download URL with a local tarball
+  # needed for offline build envs
+  if(${MODULE}_URL)
+    get_filename_component(${MODULE}_URL "${${MODULE}_URL}" ABSOLUTE)
+  else()
+    set(${MODULE}_URL ${${MODULE}_BASE_URL}/${${MODULE}_ARCHIVE})
+  endif()
+  if(VERBOSE)
+    message(STATUS "${MODULE}_URL: ${${MODULE}_URL}")
+  endif()
+endmacro()


### PR DESCRIPTION
## Description
Refactor some repetitive code into a macro.
Essentially any cmake internal dependency uses the same code to set download url.

## Motivation and context
Part of my work looking at moving tools/depends to a full cmake build. One avenue was to reuse the same methods used to do an internal dependency build. To simplify this i was looking at ways we can refactor out the current code to a generic macro/function.
For those eagle eyed viewers at home, you may notice the generalisation of the externalproject_add as much as i can. The next step would be to template that out into a macro/function.
This is part of that work. Whether i continue with tools/depends via this route is TBD, but at least minimising code duplication is good imo.

Of note, the libdvd and ffmpeg modules use different base_urls due to their hosting being on github and not our mirrors. Therefore they arent changed to use the macro. In the long run, i think we should move them to our mirrors to unify everything.

A couple of packages also had duplicate find_package_handle_standard_args calls. We can set all the variables we need in our build path, so that call has been pulled out where appropriate.

@howie-f if you have time to test, i know you've been using these internal depends from time to time

## How has this been tested?
osx various internal depends paths.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
