### PR TITLE
[Backport] Fix use-after-free for list within a list

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -18,6 +18,7 @@
 #include "utils/Stopwatch.h"
 
 #include <list>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -34,7 +35,7 @@ class CGUIBaseContainer : public IGUIContainer
 {
 public:
   CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
-  CGUIBaseContainer(const CGUIBaseContainer &);
+  explicit CGUIBaseContainer(const CGUIBaseContainer& other);
   ~CGUIBaseContainer(void) override;
 
   bool OnAction(const CAction &action) override;
@@ -75,7 +76,7 @@ public:
   /*! \brief Set the list provider for this container (for python).
    \param provider the list provider to use for this container.
    */
-  void SetListProvider(IListProvider *provider);
+  void SetListProvider(std::unique_ptr<IListProvider> provider);
 
   /*! \brief Set the offset of the first item in the container from the container's position
    Useful for lists/panels where the focused item may be larger than the non-focused items and thus
@@ -147,8 +148,8 @@ protected:
   std::list<CGUIListItemLayout> m_layouts;
   std::list<CGUIListItemLayout> m_focusedLayouts;
 
-  CGUIListItemLayout *m_layout;
-  CGUIListItemLayout *m_focusedLayout;
+  CGUIListItemLayout* m_layout{nullptr};
+  CGUIListItemLayout* m_focusedLayout{nullptr};
   bool m_layoutCondition = false;
   bool m_focusedLayoutCondition = false;
 
@@ -158,7 +159,7 @@ protected:
 
   CScroller m_scroller;
 
-  IListProvider *m_listProvider;
+  std::unique_ptr<IListProvider> m_listProvider;
 
   bool m_wasReset;  // true if we've received a Reset message until we've rendered once.  Allows
                     // us to make sure we don't tell the infomanager that we've been moving when

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1104,7 +1104,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     break;
   case CGUIControl::GUICONTROL_LABEL:
     {
-      const GUIINFO::CGUIInfoLabel &content = (infoLabels.size()) ? infoLabels[0] : GUIINFO::CGUIInfoLabel("");
+      static const GUIINFO::CGUIInfoLabel empty;
+      const GUIINFO::CGUIInfoLabel& content = !infoLabels.empty() ? infoLabels[0] : empty;
       if (insideContainer)
       { // inside lists we use CGUIListLabel
         control = new CGUIListLabel(parentID, id, posX, posY, width, height, labelInfo, content, scrollValue);

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -26,7 +26,7 @@ class CGUIControlGroup : public CGUIControlLookup
 public:
   CGUIControlGroup();
   CGUIControlGroup(int parentID, int controlID, float posX, float posY, float width, float height);
-  CGUIControlGroup(const CGUIControlGroup &from);
+  explicit CGUIControlGroup(const CGUIControlGroup& from);
   ~CGUIControlGroup(void) override;
   CGUIControlGroup *Clone() const override { return new CGUIControlGroup(*this); };
 

--- a/xbmc/guilib/GUIControlLookup.cpp
+++ b/xbmc/guilib/GUIControlLookup.cpp
@@ -8,6 +8,10 @@
 
 #include "GUIControlLookup.h"
 
+CGUIControlLookup::CGUIControlLookup(const CGUIControlLookup& from) : CGUIControl(from)
+{
+}
+
 CGUIControl *CGUIControlLookup::GetControl(int iControl, std::vector<CGUIControl*> *idCollector)
 {
   if (idCollector)

--- a/xbmc/guilib/GUIControlLookup.h
+++ b/xbmc/guilib/GUIControlLookup.h
@@ -16,8 +16,7 @@ public:
   CGUIControlLookup() = default;
   CGUIControlLookup(int parentID, int controlID, float posX, float posY, float width, float height)
     : CGUIControl(parentID, controlID, posX, posY, width, height) {}
-  CGUIControlLookup(const CGUIControlLookup &from)
-    : CGUIControl(from) {}
+  explicit CGUIControlLookup(const CGUIControlLookup& from);
   ~CGUIControlLookup(void) override = default;
 
   CGUIControl *GetControl(int id, std::vector<CGUIControl*> *idCollector = nullptr) override;

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -20,6 +20,10 @@ CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, fl
   m_type = VIEW_TYPE_LIST;
 }
 
+CGUIListContainer::CGUIListContainer(const CGUIListContainer& other) : CGUIBaseContainer(other)
+{
+}
+
 CGUIListContainer::~CGUIListContainer(void) = default;
 
 bool CGUIListContainer::OnAction(const CAction &action)

--- a/xbmc/guilib/GUIListContainer.h
+++ b/xbmc/guilib/GUIListContainer.h
@@ -26,12 +26,13 @@ class CGUIListContainer : public CGUIBaseContainer
 {
 public:
   CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
-//#ifdef GUILIB_PYTHON_COMPATIBILITY
+  explicit CGUIListContainer(const CGUIListContainer& other);
+  //#ifdef GUILIB_PYTHON_COMPATIBILITY
   CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height,
                          const CLabelInfo& labelInfo, const CLabelInfo& labelInfo2,
                          const CTextureInfo& textureButton, const CTextureInfo& textureButtonFocus,
                          float textureHeight, float itemWidth, float itemHeight, float spaceBetweenItems);
-//#endif
+  //#endif
   ~CGUIListContainer(void) override;
   CGUIListContainer *Clone() const override { return new CGUIListContainer(*this); };
 

--- a/xbmc/guilib/GUIListGroup.h
+++ b/xbmc/guilib/GUIListGroup.h
@@ -23,7 +23,7 @@ class CGUIListGroup final : public CGUIControlGroup
 {
 public:
   CGUIListGroup(int parentID, int controlID, float posX, float posY, float width, float height);
-  CGUIListGroup(const CGUIListGroup &right);
+  explicit CGUIListGroup(const CGUIListGroup& right);
   ~CGUIListGroup(void) override;
   CGUIListGroup *Clone() const override { return new CGUIListGroup(*this); };
 

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -48,7 +48,7 @@ public:
   /// @}
 
   CGUIListItem(void);
-  CGUIListItem(const CGUIListItem& item);
+  explicit CGUIListItem(const CGUIListItem& item);
   explicit CGUIListItem(const std::string& strLabel);
   virtual ~CGUIListItem(void);
   virtual CGUIListItem *Clone() const { return new CGUIListItem(*this); };

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -27,14 +27,20 @@ CGUIListItemLayout::CGUIListItemLayout()
   m_group.SetPushUpdates(true);
 }
 
-CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout &from, CGUIControl *control)
-: m_group(from.m_group), m_isPlaying(from.m_isPlaying)
+CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from)
+  : CGUIListItemLayout(from, nullptr)
 {
-  m_width = from.m_width;
-  m_height = from.m_height;
-  m_focused = from.m_focused;
-  m_condition = from.m_condition;
-  m_invalidated = true;
+}
+
+CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from, CGUIControl* control)
+  : m_group(from.m_group),
+    m_width(from.m_width),
+    m_height(from.m_height),
+    m_focused(from.m_focused),
+    m_invalidated(from.m_invalidated),
+    m_condition(from.m_condition),
+    m_isPlaying(from.m_isPlaying)
+{
   m_group.SetParentControl(control);
 }
 

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -42,6 +42,10 @@ CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from, CGUIContr
     m_isPlaying(from.m_isPlaying)
 {
   m_group.SetParentControl(control);
+
+  // m_group was just created, cloned controls with resources must be allocated
+  // before use
+  m_group.AllocResources();
 }
 
 bool CGUIListItemLayout::IsAnimating(ANIMATION_TYPE animType)

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -50,7 +50,6 @@ public:
   bool CheckCondition();
 protected:
   void LoadControl(TiXmlElement *child, CGUIControlGroup *group);
-  void Update(CFileItem *item);
 
   CGUIListGroup m_group;
 

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -20,7 +20,8 @@ class CGUIListItemLayout final
 {
 public:
   CGUIListItemLayout();
-  CGUIListItemLayout(const CGUIListItemLayout &from, CGUIControl *control);
+  explicit CGUIListItemLayout(const CGUIListItemLayout& from);
+  explicit CGUIListItemLayout(const CGUIListItemLayout& from, CGUIControl* control);
   void LoadLayout(TiXmlElement *layout, int context, bool focused, float maxWidth, float maxHeight);
   void Process(CGUIListItem *item, int parentID, unsigned int currentTime, CDirtyRegionList &dirtyregions);
   void Render(CGUIListItem *item, int parentID);

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -64,6 +64,15 @@ CGUIStaticItem::CGUIStaticItem(const CFileItem &item)
   m_visState = false;
 }
 
+CGUIStaticItem::CGUIStaticItem(const CGUIStaticItem& other)
+  : CFileItem(other),
+    m_info(other.m_info),
+    m_visCondition(other.m_visCondition),
+    m_visState(other.m_visState),
+    m_clickActions(other.m_clickActions)
+{
+}
+
 void CGUIStaticItem::UpdateProperties(int contextWindow)
 {
   for (const auto& i : m_info)

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -51,6 +51,7 @@ public:
    */
   CGUIStaticItem(const TiXmlElement *element, int contextWindow);
   explicit CGUIStaticItem(const CFileItem &item); // for python
+  explicit CGUIStaticItem(const CGUIStaticItem& other);
   ~CGUIStaticItem() override = default;
   CGUIListItem *Clone() const override { return new CGUIStaticItem(*this); };
 

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -1406,8 +1406,8 @@ namespace XBMCAddon
       }
 
       // set static list
-      IListProvider *provider = new CStaticListProvider(items);
-      static_cast<CGUIBaseContainer*>(pGUIControl)->SetListProvider(provider);
+      std::unique_ptr<IListProvider> provider = std::make_unique<CStaticListProvider>(items);
+      static_cast<CGUIBaseContainer*>(pGUIControl)->SetListProvider(std::move(provider));
     }
 
     // ============================================================

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -181,9 +181,31 @@ CDirectoryProvider::CDirectoryProvider(const TiXmlElement *element, int parentID
   }
 }
 
+CDirectoryProvider::CDirectoryProvider(const CDirectoryProvider& other)
+  : IListProvider(other.m_parentID),
+    m_updateState(INVALIDATED),
+    m_isAnnounced(false),
+    m_jobID(0),
+    m_url(other.m_url),
+    m_target(other.m_target),
+    m_sortMethod(other.m_sortMethod),
+    m_sortOrder(other.m_sortOrder),
+    m_limit(other.m_limit),
+    m_currentUrl(other.m_currentUrl),
+    m_currentTarget(other.m_currentTarget),
+    m_currentSort(other.m_currentSort),
+    m_currentLimit(other.m_currentLimit)
+{
+}
+
 CDirectoryProvider::~CDirectoryProvider()
 {
   Reset();
+}
+
+std::unique_ptr<IListProvider> CDirectoryProvider::Clone()
+{
+  return std::make_unique<CDirectoryProvider>(*this);
 }
 
 bool CDirectoryProvider::Update(bool forceRefresh)

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -51,8 +51,11 @@ public:
   } UpdateState;
 
   CDirectoryProvider(const TiXmlElement *element, int parentID);
+  explicit CDirectoryProvider(const CDirectoryProvider& other);
   ~CDirectoryProvider() override;
 
+  // Implementation of IListProvider
+  std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
   void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                 const std::string& sender,

--- a/xbmc/listproviders/IListProvider.cpp
+++ b/xbmc/listproviders/IListProvider.cpp
@@ -13,28 +13,28 @@
 #include "StaticProvider.h"
 #include "utils/XBMCTinyXML.h"
 
-IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
+std::unique_ptr<IListProvider> IListProvider::Create(const TiXmlNode* node, int parentID)
 {
   const TiXmlNode *root = node->FirstChild("content");
   if (root)
   {
     const TiXmlNode *next = root->NextSibling("content");
     if (next)
-      return new CMultiProvider(root, parentID);
+      return std::make_unique<CMultiProvider>(root, parentID);
 
     return CreateSingle(root, parentID);
   }
-  return NULL;
+  return std::unique_ptr<IListProvider>{};
 }
 
-IListProvider *IListProvider::CreateSingle(const TiXmlNode *content, int parentID)
+std::unique_ptr<IListProvider> IListProvider::CreateSingle(const TiXmlNode* content, int parentID)
 {
   const TiXmlElement *item = content->FirstChildElement("item");
   if (item)
-    return new CStaticListProvider(content->ToElement(), parentID);
+    return std::make_unique<CStaticListProvider>(content->ToElement(), parentID);
 
   if (!content->NoChildren())
-    return new CDirectoryProvider(content->ToElement(), parentID);
+    return std::make_unique<CDirectoryProvider>(content->ToElement(), parentID);
 
-  return NULL;
+  return std::unique_ptr<IListProvider>{};
 }

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -23,21 +23,26 @@ class IListProvider
 {
 public:
   explicit IListProvider(int parentID) : m_parentID(parentID) {}
+  explicit IListProvider(const IListProvider& other) = default;
   virtual ~IListProvider() = default;
 
   /*! \brief Factory to create list providers.
    \param parent a parent TiXmlNode for the container.
    \param parentID id of parent window for context.
-   \return the list provider, NULL if none.
+   \return the list provider, empty pointer if none.
    */
-  static IListProvider *Create(const TiXmlNode *parent, int parentID);
+  static std::unique_ptr<IListProvider> Create(const TiXmlNode* parent, int parentID);
 
   /*! \brief Factory to create list providers.  Cannot create a multi-provider.
    \param content the TiXmlNode for the content to create.
    \param parentID id of parent window for context.
-   \return the list provider, NULL if none.
+   \return the list provider, empty pointer if none.
    */
-  static IListProvider *CreateSingle(const TiXmlNode *content, int parentID);
+  static std::unique_ptr<IListProvider> CreateSingle(const TiXmlNode* content, int parentID);
+
+  /*! \brief Create an instance of the derived class. Allows for polymorphic copies.
+   */
+  virtual std::unique_ptr<IListProvider> Clone() = 0;
 
   /*! \brief Update the list content
    \return true if the content has changed, false otherwise.

--- a/xbmc/listproviders/MultiProvider.h
+++ b/xbmc/listproviders/MultiProvider.h
@@ -14,7 +14,7 @@
 #include <map>
 #include <vector>
 
-typedef std::shared_ptr<IListProvider> IListProviderPtr;
+typedef std::unique_ptr<IListProvider> IListProviderPtr;
 
 /*!
  \ingroup listproviders
@@ -24,7 +24,10 @@ class CMultiProvider : public IListProvider
 {
 public:
   CMultiProvider(const TiXmlNode *first, int parentID);
+  explicit CMultiProvider(const CMultiProvider& other);
 
+  // Implementation of IListProvider
+  std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
   void Fetch(std::vector<CGUIListItemPtr> &items) override;
   bool IsUpdating() const override;
@@ -37,6 +40,6 @@ protected:
   typedef size_t item_key_type;
   static item_key_type GetItemKey(CGUIListItemPtr const &item);
   std::vector<IListProviderPtr> m_providers;
-  std::map<item_key_type, IListProviderPtr> m_itemMap;
+  std::map<item_key_type, IListProvider*> m_itemMap;
   CCriticalSection m_section; // protects m_itemMap
 };

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -47,7 +47,32 @@ CStaticListProvider::CStaticListProvider(const std::vector<CGUIStaticItemPtr> &i
 {
 }
 
+CStaticListProvider::CStaticListProvider(const CStaticListProvider& other)
+  : IListProvider(other.m_parentID),
+    m_defaultItem(other.m_defaultItem),
+    m_defaultAlways(other.m_defaultAlways),
+    m_updateTime(other.m_updateTime)
+{
+  for (const auto& item : other.m_items)
+  {
+    std::shared_ptr<CGUIListItem> control(item->Clone());
+    if (!control)
+      continue;
+
+    std::shared_ptr<CGUIStaticItem> newItem = std::dynamic_pointer_cast<CGUIStaticItem>(control);
+    if (!newItem)
+      continue;
+
+    m_items.emplace_back(std::move(newItem));
+  }
+}
+
 CStaticListProvider::~CStaticListProvider() = default;
+
+std::unique_ptr<IListProvider> CStaticListProvider::Clone()
+{
+  return std::make_unique<CStaticListProvider>(*this);
+}
 
 bool CStaticListProvider::Update(bool forceRefresh)
 {

--- a/xbmc/listproviders/StaticProvider.h
+++ b/xbmc/listproviders/StaticProvider.h
@@ -18,8 +18,11 @@ class CStaticListProvider : public IListProvider
 public:
   CStaticListProvider(const TiXmlElement *element, int parentID);
   explicit CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items); // for python
+  explicit CStaticListProvider(const CStaticListProvider& other);
   ~CStaticListProvider() override;
 
+  // Implementation of IListProvider
+  std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
   void Fetch(std::vector<CGUIListItemPtr> &items) override;
   bool OnClick(const CGUIListItemPtr &item) override;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -367,7 +367,7 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPt
   {
     if (!item->GetFocusedLayout())
     {
-      item->SetFocusedLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*focusedlayout)));
+      item->SetFocusedLayout(std::make_unique<CGUIListItemLayout>(*focusedlayout, this));
     }
 
     if (resize != -1.0f)
@@ -399,7 +399,7 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPt
   {
     if (!item->GetLayout())
     {
-      item->SetLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*normallayout)));
+      item->SetLayout(std::make_unique<CGUIListItemLayout>(*normallayout, this));
     }
 
     if (resize != -1.0f)


### PR DESCRIPTION
## Description

Backport of #20852

## How has this been tested?

Link to test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-19.3-20220126

## What is the effect on users?

* Fixed skinning crash when scrolling with a list inside a list

## Screenshots (if appropriate):

See #20852

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
