### PR TITLE
[EDL] Global cleanup and documentation

### DIFF
--- a/xbmc/cores/EdlEdit.h
+++ b/xbmc/cores/EdlEdit.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include <array>
+#include <string_view>
+
 namespace EDL
 {
 
@@ -20,6 +23,9 @@ enum class Action
   SCENE = 2,
   COMM_BREAK = 3
 };
+
+constexpr std::array<std::string_view, 4> edlActionDescription{
+    {"Cut", "Mute", "Scene Marker", "Commercial Break"}};
 
 struct Edit
 {

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -910,8 +910,8 @@ void CEdl::MergeShortCommBreaks()
       (m_edits.front().end - m_edits.front().start) < 5 * 1000) // 5 seconds
   {
     CLog::LogF(LOGDEBUG, "Removing short commercial break at start [{} - {}]. <5 seconds",
-               MillisecondsToTimeString(m_edits[0].start),
-               MillisecondsToTimeString(m_edits[0].end));
+               MillisecondsToTimeString(m_edits.front().start),
+               MillisecondsToTimeString(m_edits.front().end));
     m_edits.erase(m_edits.begin());
   }
 

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -46,49 +46,44 @@ void CEdl::Clear()
   m_lastEditTime = -1;
 }
 
-bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond)
+bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, float fps)
 {
-  bool bFound = false;
+  bool found = false;
 
-  /*
-   * Only check for edit decision lists if the movie is on the local hard drive, or accessed over a
-   * network share.
-   */
-  const std::string& strMovie = fileItem.GetDynPath();
-  if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie)) &&
-      !URIUtils::IsInternetStream(strMovie))
+  // Only check for edit decision lists if the movie is on the local hard drive, or accessed over a
+  // network share.
+  const std::string& path = fileItem.GetDynPath();
+  if ((URIUtils::IsHD(path) || URIUtils::IsOnLAN(path)) && !URIUtils::IsInternetStream(path))
   {
-    CLog::Log(LOGDEBUG,
-              "{} - Checking for edit decision lists (EDL) on local drive or remote share for: {}",
-              __FUNCTION__, CURL::GetRedacted(strMovie));
+    CLog::LogF(LOGDEBUG,
+               "Checking for edit decision lists (EDL) on local drive or remote share for: {}",
+               CURL::GetRedacted(path));
 
-    /*
-     * Read any available file format until a valid EDL related file is found.
-     */
-    if (!bFound)
-      bFound = ReadVideoReDo(strMovie);
+    // Read any available file format until a valid EDL related file is found.
+    if (!found)
+      found = ReadVideoReDo(path);
 
-    if (!bFound)
-      bFound = ReadEdl(strMovie, fFramesPerSecond);
+    if (!found)
+      found = ReadEdl(path, fps);
 
-    if (!bFound)
-      bFound = ReadComskip(strMovie, fFramesPerSecond);
+    if (!found)
+      found = ReadComskip(path, fps);
 
-    if (!bFound)
-      bFound = ReadBeyondTV(strMovie);
+    if (!found)
+      found = ReadBeyondTV(path);
   }
   else
   {
-    bFound = ReadPvr(fileItem);
+    found = ReadPvr(fileItem);
   }
 
-  if (bFound)
+  if (found)
   {
     MergeShortCommBreaks();
     AddSceneMarkersAtStartAndEndOfEdits();
   }
 
-  return bFound;
+  return found;
 }
 
 bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -166,19 +166,19 @@ bool CEdl::ReadEdl(const std::string& path, float fps)
           // Have to pad or truncate the ms portion to 3 characters before converting to ms.
           if (fieldParts.at(1).length() == 1)
           {
-            fieldParts.at(1) = fieldParts[1] + "00";
+            fieldParts.at(1) = fieldParts.at(1) + "00";
           }
           else if (fieldParts.at(1).length() == 2)
           {
-            fieldParts.at(1) = fieldParts[1] + "0";
+            fieldParts.at(1) = fieldParts.at(1) + "0";
           }
           else if (fieldParts.at(1).length() > 3)
           {
-            fieldParts.at(1) = fieldParts[1].substr(0, 3);
+            fieldParts.at(1) = fieldParts.at(1).substr(0, 3);
           }
           editStartEnd.at(i) =
-              static_cast<int64_t>(StringUtils::TimeStringToSeconds(fieldParts[0])) * 1000 +
-              std::stoi(fieldParts[1]); // seconds to ms
+              static_cast<int64_t>(StringUtils::TimeStringToSeconds(fieldParts.at(0))) * 1000 +
+              std::stoi(fieldParts.at(1)); // seconds to ms
         }
         else
         {
@@ -957,24 +957,25 @@ void CEdl::MergeShortCommBreaks()
   {
     for (size_t i = 0; i < m_edits.size() - 1; ++i)
     {
-      if ((m_edits[i].action == Action::COMM_BREAK &&
-           m_edits[i + 1].action == Action::COMM_BREAK) &&
-          (m_edits[i + 1].end - m_edits[i].start <
+      if ((m_edits.at(i).action == Action::COMM_BREAK &&
+           m_edits.at(i + 1).action == Action::COMM_BREAK) &&
+          (m_edits.at(i + 1).end - m_edits.at(i).start <
            advancedSettings->m_iEdlMaxCommBreakLength * 1000) // s to ms
-          && (m_edits[i + 1].start - m_edits[i].end <
+          && (m_edits.at(i + 1).start - m_edits.at(i).end <
               advancedSettings->m_iEdlMaxCommBreakGap * 1000)) // s to ms
       {
         Edit commBreak;
         commBreak.action = Action::COMM_BREAK;
-        commBreak.start = m_edits[i].start;
-        commBreak.end = m_edits[i + 1].end;
+        commBreak.start = m_edits.at(i).start;
+        commBreak.end = m_edits.at(i + 1).end;
 
-        CLog::LogF(
-            LOGDEBUG, "Consolidating commercial break [{} - {}] and [{} - {}] to: [{} - {}]",
-            MillisecondsToTimeString(m_edits[i].start), MillisecondsToTimeString(m_edits[i].end),
-            MillisecondsToTimeString(m_edits[i + 1].start),
-            MillisecondsToTimeString(m_edits[i + 1].end), MillisecondsToTimeString(commBreak.start),
-            MillisecondsToTimeString(commBreak.end));
+        CLog::LogF(LOGDEBUG, "Consolidating commercial break [{} - {}] and [{} - {}] to: [{} - {}]",
+                   MillisecondsToTimeString(m_edits.at(i).start),
+                   MillisecondsToTimeString(m_edits.at(i).end),
+                   MillisecondsToTimeString(m_edits.at(i + 1).start),
+                   MillisecondsToTimeString(m_edits.at(i + 1).end),
+                   MillisecondsToTimeString(commBreak.start),
+                   MillisecondsToTimeString(commBreak.end));
 
         // Erase old edits and insert the new merged one.
         m_edits.erase(m_edits.begin() + i, m_edits.begin() + i + 2);
@@ -1001,13 +1002,15 @@ void CEdl::MergeShortCommBreaks()
     // Remove any commercial breaks shorter than the minimum (unless at the start)
     for (size_t i = 0; i < m_edits.size(); ++i)
     {
-      if (m_edits[i].action == Action::COMM_BREAK && m_edits[i].start > 0 &&
-          (m_edits[i].end - m_edits[i].start) < advancedSettings->m_iEdlMinCommBreakLength * 1000)
+      if (m_edits.at(i).action == Action::COMM_BREAK && m_edits.at(i).start > 0 &&
+          (m_edits.at(i).end - m_edits.at(i).start) <
+              advancedSettings->m_iEdlMinCommBreakLength * 1000)
       {
-        CLog::LogF(
-            LOGDEBUG, "Removing short commercial break [{} - {}]. Minimum length: {} seconds",
-            MillisecondsToTimeString(m_edits[i].start), MillisecondsToTimeString(m_edits[i].end),
-            advancedSettings->m_iEdlMinCommBreakLength);
+        CLog::LogF(LOGDEBUG,
+                   "Removing short commercial break [{} - {}]. Minimum length: {} seconds",
+                   MillisecondsToTimeString(m_edits.at(i).start),
+                   MillisecondsToTimeString(m_edits.at(i).end),
+                   advancedSettings->m_iEdlMinCommBreakLength);
         m_edits.erase(m_edits.begin() + i);
 
         i--;

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -921,11 +921,13 @@ bool CEdl::GetNextSceneMarker(bool forward, int clock, int* sceneMarker)
   return found;
 }
 
-std::string CEdl::MillisecondsToTimeString(const int iMilliseconds)
+std::string CEdl::MillisecondsToTimeString(int msec)
 {
-  std::string strTimeString = StringUtils::SecondsToTimeString((long)(iMilliseconds / 1000), TIME_FORMAT_HH_MM_SS); // milliseconds to seconds
-  strTimeString += StringUtils::Format(".{:03}", iMilliseconds % 1000);
-  return strTimeString;
+  // milliseconds to seconds
+  std::string timeString =
+      StringUtils::SecondsToTimeString(static_cast<long>(msec / 1000), TIME_FORMAT_HH_MM_SS);
+  timeString += StringUtils::Format(".{:03}", msec % 1000);
+  return timeString;
 }
 
 void CEdl::MergeShortCommBreaks()

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -573,29 +573,29 @@ bool CEdl::ReadPvr(const CFileItem &fileItem)
       case Action::COMM_BREAK:
         if (AddEdit(edit))
         {
-          CLog::Log(LOGDEBUG, "{} - Added break [{} - {}] found in PVR item for: {}.", __FUNCTION__,
-                    MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
-                    CURL::GetRedacted(fileItem.GetDynPath()));
+          CLog::LogF(LOGDEBUG, "Added break [{} - {}] found in PVR item for: {}.",
+                     MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                     CURL::GetRedacted(fileItem.GetDynPath()));
         }
         else
         {
-          CLog::Log(LOGERROR,
-                    "{} - Invalid break [{} - {}] found in PVR item for: {}. Continuing anyway.",
-                    __FUNCTION__, MillisecondsToTimeString(edit.start),
-                    MillisecondsToTimeString(edit.end), CURL::GetRedacted(fileItem.GetDynPath()));
+          CLog::LogF(LOGERROR,
+                     "Invalid break [{} - {}] found in PVR item for: {}. Continuing anyway.",
+                     MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                     CURL::GetRedacted(fileItem.GetDynPath()));
         }
         break;
 
       case Action::SCENE:
         if (!AddSceneMarker(edit.end))
         {
-          CLog::Log(LOGWARNING, "{} - Error adding scene marker for PVR item", __FUNCTION__);
+          CLog::LogF(LOGWARNING, "Error adding scene marker for PVR item");
         }
         break;
 
       default:
-        CLog::Log(LOGINFO, "{} - Ignoring entry of unknown edit action: {}", __FUNCTION__,
-                  static_cast<int>(edit.action));
+        CLog::LogF(LOGINFO, "Ignoring entry of unknown edit action: {}",
+                   static_cast<int>(edit.action));
         break;
     }
   }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -838,21 +838,22 @@ bool CEdl::HasSceneMarker() const
   return !m_vecSceneMarkers.empty();
 }
 
-bool CEdl::InEdit(const int iSeek, Edit* pEdit)
+bool CEdl::InEdit(int seekTime, Edit* edit)
 {
-  for (size_t i = 0; i < m_vecEdits.size(); ++i)
+  for (const EDL::Edit& editItem : m_vecEdits)
   {
-    if (iSeek < m_vecEdits[i].start) // Early exit if not even up to the edit start time.
+    // Early exit if not even up to the edit start time.
+    if (seekTime < editItem.start)
       return false;
 
-    if (iSeek >= m_vecEdits[i].start && iSeek <= m_vecEdits[i].end) // Inside edit.
+    // Inside edit.
+    if (seekTime >= editItem.start && seekTime <= editItem.end)
     {
-      if (pEdit)
-        *pEdit = m_vecEdits[i];
+      if (edit)
+        *edit = editItem;
       return true;
     }
   }
-
   return false;
 }
 

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -876,50 +876,50 @@ EDL::Action CEdl::GetLastEditActionType() const
   return m_lastEditActionType;
 }
 
-bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker)
+bool CEdl::GetNextSceneMarker(bool forward, int clock, int* sceneMarker)
 {
   if (!HasSceneMarker())
     return false;
 
-  int iSeek = GetTimeAfterRestoringCuts(iClock);
+  int seekTime = GetTimeAfterRestoringCuts(clock);
 
-  int iDiff = 10 * 60 * 60 * 1000; // 10 hours to ms.
-  bool bFound = false;
+  int diff = 10 * 60 * 60 * 1000; // 10 hours to ms.
+  bool found = false;
 
-  if (bPlus) // Find closest scene forwards
+  // Find closest scene forwards
+  if (forward)
   {
-    for (int i = 0; i < (int)m_vecSceneMarkers.size(); i++)
+    for (const int& scene : m_vecSceneMarkers)
     {
-      if ((m_vecSceneMarkers[i] > iSeek) && ((m_vecSceneMarkers[i] - iSeek) < iDiff))
+      if ((scene > seekTime) && ((scene - seekTime) < diff))
       {
-        iDiff = m_vecSceneMarkers[i] - iSeek;
-        *iSceneMarker = m_vecSceneMarkers[i];
-        bFound = true;
+        diff = scene - seekTime;
+        *sceneMarker = scene;
+        found = true;
       }
     }
   }
-  else // Find closest scene backwards
+  // Find closest scene backwards
+  else
   {
-    for (int i = 0; i < (int)m_vecSceneMarkers.size(); i++)
+    for (const int& scene : m_vecSceneMarkers)
     {
-      if ((m_vecSceneMarkers[i] < iSeek) && ((iSeek - m_vecSceneMarkers[i]) < iDiff))
+      if ((scene < seekTime) && ((seekTime - scene) < diff))
       {
-        iDiff = iSeek - m_vecSceneMarkers[i];
-        *iSceneMarker = m_vecSceneMarkers[i];
-        bFound = true;
+        diff = seekTime - scene;
+        *sceneMarker = scene;
+        found = true;
       }
     }
   }
 
-  /*
-   * If the scene marker is in a cut then return the end of the cut. Can't guarantee that this is
-   * picked up when scene markers are added.
-   */
+  // If the scene marker is in a cut then return the end of the cut. Can't guarantee that this is
+  // picked up when scene markers are added.
   Edit edit;
-  if (bFound && InEdit(*iSceneMarker, &edit) && edit.action == Action::CUT)
-    *iSceneMarker = edit.end;
+  if (found && InEdit(*sceneMarker, &edit) && edit.action == Action::CUT)
+    *sceneMarker = edit.end;
 
-  return bFound;
+  return found;
 }
 
 std::string CEdl::MillisecondsToTimeString(const int iMilliseconds)

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -701,16 +701,15 @@ bool CEdl::AddEdit(const Edit& newEdit)
   return true;
 }
 
-bool CEdl::AddSceneMarker(const int iSceneMarker)
+bool CEdl::AddSceneMarker(int sceneMarker)
 {
   Edit edit;
 
-  if (InEdit(iSceneMarker, &edit) && edit.action == Action::CUT) // Only works for current cuts.
+  if (InEdit(sceneMarker, &edit) && edit.action == Action::CUT) // Only works for current cuts.
     return false;
 
-  CLog::Log(LOGDEBUG, "{} - Inserting new scene marker: {}", __FUNCTION__,
-            MillisecondsToTimeString(iSceneMarker));
-  m_vecSceneMarkers.push_back(iSceneMarker); // Unsorted
+  CLog::LogF(LOGDEBUG, "Inserting new scene marker: {}", MillisecondsToTimeString(sceneMarker));
+  m_vecSceneMarkers.push_back(sceneMarker); // Unsorted
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -245,6 +245,9 @@ private:
   */
   bool AddSceneMarker(int sceneMarker);
 
+  /*!
+   * @brief Merge all short commbreaks, depending on EDL advanced settings
+  */
   void MergeShortCommBreaks();
 
   /*!

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -18,6 +18,9 @@ class CFileItem;
 class CEdl
 {
 public:
+  /*!
+   * @brief EDL class constructor
+  */
   CEdl();
 
   /*!

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -89,7 +89,7 @@ public:
    * @return The EDL edits or an empty vector if no edits exist. Edits are
    * provided with respect to the original media item timeline.
   */
-  const std::vector<EDL::Edit>& GetRawEditList() const { return m_vecEdits; }
+  const std::vector<EDL::Edit>& GetRawEditList() const { return m_edits; }
 
   /*!
    * @brief Get the EDL edit list.
@@ -178,16 +178,22 @@ public:
   static std::string MillisecondsToTimeString(int msec);
 
 private:
-  // total cut time (edl cuts) in ms
+  /*!
+   * @brief total cut time (EDL cuts) in ms
+  */
   int m_totalCutTime;
-  std::vector<EDL::Edit> m_vecEdits;
-  std::vector<int> m_vecSceneMarkers;
-
+  /*!
+   * @brief the list of EDL edits
+  */
+  std::vector<EDL::Edit> m_edits;
+  /*!
+   * @brief the list of EDL scene markers
+  */
+  std::vector<int> m_sceneMarkers;
   /*!
    * @brief Last processed EDL edit time (ms)
   */
   int m_lastEditTime;
-
   /*!
    * @brief Last processed EDL edit action type
   */

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -30,6 +30,9 @@ public:
    */
   bool ReadEditDecisionLists(const CFileItem& fileItem, float fps);
 
+  /*!
+   * @brief Reset the CEdl member variables (clear all entries)
+  */
   void Clear();
 
   /*!

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -183,10 +183,13 @@ private:
   */
   EDL::Action m_lastEditActionType{EDL::EDL_ACTION_NONE};
 
-  // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  bool ReadEdl(const std::string& strMovie, const float fFramesPerSecond);
+  /*!
+   * @brief Read .edl files (MPlayer format)
+   * @param path the path of the media item being played
+   * @param fps frames per second of the item being played
+   * @return true if the file is correctly parsed and edits added, false otherwise
+  */
+  bool ReadEdl(const std::string& path, float fps);
   // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
   // for the reader of the interface, but limits the implementation
   // to not modify the parameter on stack

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -106,11 +106,11 @@ public:
    * edit and fill pEdit with the respective edit struct.
    * @note seek time refers to the time in the original file timeline (i.e. without
    * considering cut blocks)
-   * @param iSeek The seek time (on the original timeline)
-   * @param[in,out] pEdit The edit pointer (or nullptr if iSeek not within an edit)
-   * @return true if iSeek is within an edit, false otherwise
+   * @param seekTime The seek time (on the original timeline)
+   * @param[in,out] edit The edit pointer (or nullptr if seekTime not within an edit)
+   * @return true if seekTime is within an edit, false otherwise
   */
-  bool InEdit(int iSeek, EDL::Edit* pEdit = nullptr);
+  bool InEdit(int seekTime, EDL::Edit* edit = nullptr);
 
   /*!
    * @brief Get the last processed edit time (set during playback when a given

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -190,10 +190,14 @@ private:
    * @return true if the file is correctly parsed and edits added, false otherwise
   */
   bool ReadEdl(const std::string& path, float fps);
-  // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  bool ReadComskip(const std::string& strMovie, const float fFramesPerSecond);
+
+  /*!
+   * @brief Read edl files (Comskip format)
+   * @param path the path of the media item being played
+   * @param fps frames per second of the item being played
+   * @return true if the file is correctly parsed and edits added, false otherwise
+  */
+  bool ReadComskip(const std::string& path, float fps);
   // FIXME: remove const modifier for strMovie as it makes no sense as it means nothing
   // for the reader of the interface, but limits the implementation
   // to not modify the parameter on stack

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -202,10 +202,13 @@ private:
   // for the reader of the interface, but limits the implementation
   // to not modify the parameter on stack
   bool ReadVideoReDo(const std::string& strMovie);
-  // FIXME: remove const modifier for strMovie as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  bool ReadBeyondTV(const std::string& strMovie);
+
+  /*!
+   * @brief Read edl files (SnapStream BeyondTV format)
+   * @param path the path of the media item being played
+   * @return true if the file is correctly parsed and edits added, false otherwise
+  */
+  bool ReadBeyondTV(const std::string& path);
 
   /*!
    * @brief Read edl edits provided by a PVR backend for a given fileitem

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -157,10 +157,16 @@ public:
   */
   EDL::Action GetLastEditActionType() const;
 
-  // FIXME: remove const modifier for iClock as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
+  /*!
+   * @brief Get the closest scenemarker by providing the given clock time and the search
+   * direction (forward vs backwards)
+   * @param forward If the search should be performed forward (true) with respect to the provided
+   * clock time or backwards (false)
+   * @param clock The clock time
+   * @param[in,out] sceneMarker The closest scene marker
+   * @return true if it could find a next scene marker, false otherwise
+  */
+  bool GetNextSceneMarker(bool forward, int clock, int* sceneMarker);
 
   // FIXME: remove const modifier as it makes no sense as it means nothing
   // for the reader of the interface, but limits the implementation

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -15,6 +15,31 @@
 
 class CFileItem;
 
+/*!
+ * @brief Edit decision lists (EDL)
+ *
+ * An edit decision list (EDL) contains information about edits that should be made to
+ * the video during playback. Edit decision list information is contained in a separate
+ * file to the video that is read by Kodi just before the video is played.
+ * Examples of use include can be to skip commercials, cut out content inappropriate for children,
+ * or skip over the half hour acid trip in <i>2001: A Space Odyssey</i>.
+ * Kodi supports the following EDL edit types:
+ * - \link CUT_Anchor Cut \endlink
+ * - \link MUTE_Anchor Mute \endlink
+ * - \link SCENE_Anchor Scene Marker \endlink
+ * - \link COMM_BREAK_Anchor Commercial Break \endlink
+ *
+ * Kodi is able to read edit decision lists from multiple file formats. The EDL file for a video
+ * must be in the same folder as the video file and is looked for based on the file extensions for
+ *  the supported formats. For example if the video file is called The Matrix.avi Kodi will look
+ *  for the following files, in order, until a valid file is found. Note the the file name may
+ *  be case-sensitive based on the operating system being used.
+ * - The Matrix.Vprj (VideoReDo)
+ * - The Matrix.edl (MPlayer)
+ * - The Matrix.txt (Comskip)
+ * - The Matrix.avi.chapters.xml (SnapStream BeyondTV)
+ * EDL edits might also be provided by the PVR backend
+*/
 class CEdl
 {
 public:

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -47,6 +47,10 @@ public:
    */
   bool HasCuts() const;
 
+  /*!
+   * @brief Check if EDL has scene markers
+   * @return true if EDL has scene markers, false otherwise
+   */
   bool HasSceneMarker() const;
 
   /*!

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -168,10 +168,11 @@ public:
   */
   bool GetNextSceneMarker(bool forward, int clock, int* sceneMarker);
 
-  // FIXME: remove const modifier as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  static std::string MillisecondsToTimeString(const int iMilliseconds);
+  /*!
+   * @brief Provided the time in msec, returns a timestring (\sa TIME_FORMAT_HH_MM_SS)
+   * return the timestring correspondent to the provided time in msec
+  */
+  static std::string MillisecondsToTimeString(int msec);
 
 private:
   // total cut time (edl cuts) in ms

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -229,6 +229,7 @@ private:
 
   /*!
    * @brief Adds an edit to the list of EDL edits
+   * @note Edits are stored in ascending order
    * @param newEdit the edit to add
    * @return true if the operation succeeds, false otherwise
   */

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -206,6 +206,12 @@ private:
   // for the reader of the interface, but limits the implementation
   // to not modify the parameter on stack
   bool ReadBeyondTV(const std::string& strMovie);
+
+  /*!
+   * @brief Read edl edits provided by a PVR backend for a given fileitem
+   * @param fileItem the item being played
+   * @return true if the file has EDL edits provided by PVR, false otherwise
+  */
   bool ReadPvr(const CFileItem& fileItem);
 
   /*!

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -20,10 +20,16 @@ class CEdl
 public:
   CEdl();
 
-  // FIXME: remove const modifier for fFramesPerSecond as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  bool ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond);
+  /*!
+   * @brief Searches and reads all possible EDL sources for a given fileItem
+   * until a matching one is found. In case it finds a match, it parses the
+   * file using the appropriate parser (e.g. ReadVideoReDo, ReadComskip, etc).
+   * @param fileItem the fileItem to look for EDL files @note Kodi will use the dynpath
+   * @param fps the frames per second of the playing file
+   * @return true if a matching EDL file was found and parsed correctly, false otherwise
+   */
+  bool ReadEditDecisionLists(const CFileItem& fileItem, float fps);
+
   void Clear();
 
   /*!

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -198,10 +198,13 @@ private:
    * @return true if the file is correctly parsed and edits added, false otherwise
   */
   bool ReadComskip(const std::string& path, float fps);
-  // FIXME: remove const modifier for strMovie as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  bool ReadVideoReDo(const std::string& strMovie);
+
+  /*!
+   * @brief Read edl files (VideoReDo format)
+   * @param path the path of the media item being played
+   * @return true if the file is correctly parsed and edits added, false otherwise
+  */
+  bool ReadVideoReDo(const std::string& path);
 
   /*!
    * @brief Read edl files (SnapStream BeyondTV format)

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -233,10 +233,12 @@ private:
   */
   bool AddEdit(const EDL::Edit& newEdit);
 
-  // FIXME: remove const modifier for strMovie as it makes no sense as it means nothing
-  // for the reader of the interface, but limits the implementation
-  // to not modify the parameter on stack
-  bool AddSceneMarker(const int sceneMarker);
+  /*!
+   * @brief Adds a scene marker to the EDL list
+   * @param sceneMarker the scene marker
+   * @return true if the operation succeeds, false otherwise
+  */
+  bool AddSceneMarker(int sceneMarker);
 
   void MergeShortCommBreaks();
 

--- a/xbmc/cores/VideoPlayer/test/edl/TestEdl.cpp
+++ b/xbmc/cores/VideoPlayer/test/edl/TestEdl.cpp
@@ -227,8 +227,8 @@ TEST_F(TestEdl, TestSnapStreamEDL)
   EXPECT_EQ(edl.GetSceneMarkers().size(), 3 * 2); // start and end of each commbreak
   // snapstream beyond tv uses ms * 10000
   // check if first commbreak (4235230000 - 5936600000) is 423.523 sec - 593.660 sec
-  EXPECT_EQ(edl.GetEditList().front().start, static_cast<int>(423.523 * 1000));
-  EXPECT_EQ(edl.GetEditList().front().end, static_cast<int>(593.660 * 1000));
+  EXPECT_EQ(edl.GetEditList().front().start, static_cast<int64_t>(423.523 * 1000));
+  EXPECT_EQ(edl.GetEditList().front().end, static_cast<int64_t>(593.660 * 1000));
 }
 
 TEST_F(TestEdl, TestComSkipVersion1EDL)
@@ -251,8 +251,8 @@ TEST_F(TestEdl, TestComSkipVersion1EDL)
   EXPECT_EQ(edl.GetCutMarkers().empty(), true);
   EXPECT_EQ(edl.GetEditList().size(), 3);
   EXPECT_EQ(edl.GetSceneMarkers().size(), 3 * 2); // start and end of each commbreak
-  EXPECT_EQ(edl.GetEditList().front().start, static_cast<int>(12693 / fps * 1000));
-  EXPECT_EQ(edl.GetEditList().front().end, static_cast<int>(17792 / fps * 1000));
+  EXPECT_EQ(edl.GetEditList().front().start, static_cast<int64_t>(12693 / fps * 1000));
+  EXPECT_EQ(edl.GetEditList().front().end, static_cast<int64_t>(17792 / fps * 1000));
 }
 
 TEST_F(TestEdl, TestComSkipVersion2EDL)
@@ -274,8 +274,8 @@ TEST_F(TestEdl, TestComSkipVersion2EDL)
   EXPECT_EQ(edl.GetCutMarkers().empty(), true);
   EXPECT_EQ(edl.GetEditList().size(), 3);
   EXPECT_EQ(edl.GetSceneMarkers().size(), 3 * 2); // start and end of each commbreak
-  EXPECT_EQ(edl.GetEditList().front().start, static_cast<int>(12693 / fpsInEdlFile * 1000));
-  EXPECT_EQ(edl.GetEditList().front().end, static_cast<int>(17792 / fpsInEdlFile * 1000));
+  EXPECT_EQ(edl.GetEditList().front().start, static_cast<int64_t>(12693 / fpsInEdlFile * 1000));
+  EXPECT_EQ(edl.GetEditList().front().end, static_cast<int64_t>(17792 / fpsInEdlFile * 1000));
 }
 
 TEST_F(TestEdl, TestRuntimeSetEDL)
@@ -328,7 +328,7 @@ TEST_F(TestEdl, TestCommBreakAdvancedSettings)
   EXPECT_EQ(edl.GetEditList().at(3).start, 52 * 1000);
   EXPECT_EQ(edl.GetEditList().at(3).end, 60 * 1000);
   EXPECT_EQ(edl.GetEditList().at(4).start, 62 * 1000);
-  EXPECT_EQ(edl.GetEditList().at(4).end, static_cast<int>(65.1 * 1000));
+  EXPECT_EQ(edl.GetEditList().at(4).end, static_cast<int64_t>(65.1 * 1000));
   // now lets change autowait and autowind and check the edits are correcly adjusted
   edl.Clear();
   advancedSettings->m_iEdlCommBreakAutowait = 3; // secs
@@ -420,7 +420,7 @@ TEST_F(TestEdl, TestMergeSmallCommbreaks)
   // and ending at the last edit time
   EXPECT_EQ(edl.GetEditList().size(), 1);
   EXPECT_EQ(edl.GetEditList().at(0).start, 0);
-  EXPECT_EQ(edl.GetEditList().at(0).end, static_cast<int>(65.1 * 1000));
+  EXPECT_EQ(edl.GetEditList().at(0).end, static_cast<int64_t>(65.1 * 1000));
 }
 
 TEST_F(TestEdl, TestMergeSmallCommbreaksAdvanced)
@@ -455,5 +455,5 @@ TEST_F(TestEdl, TestMergeSmallCommbreaksAdvanced)
   EXPECT_EQ(edl.GetEditList().at(0).end - edl.GetEditList().at(0).start, (32 - 10) * 1000);
   // 4th, 5th and 6th commbreaks joined
   EXPECT_EQ(edl.GetEditList().at(1).end - edl.GetEditList().at(1).start,
-            static_cast<int>((65.1 - 37) * 1000));
+            static_cast<int64_t>((65.1 - 37) * 1000));
 }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -803,6 +803,16 @@ bool CFile::ReadString(char *szLine, int iLineLength)
   return false;
 }
 
+bool CFile::ReadString(std::string& buffer, int bufferSize, std::string& line)
+{
+  bool ret = ReadString(buffer.data(), bufferSize);
+  line.resize(std::strlen(buffer.c_str()));
+  line = buffer.c_str();
+  line.erase(std::remove(line.begin(), line.end(), '\n'), line.end());
+  line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
+  return ret;
+}
+
 ssize_t CFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   if (!m_pFile)

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -80,6 +80,18 @@ public:
    */
   ssize_t Read(void* bufPtr, size_t bufSize);
   bool ReadString(char *szLine, int iLineLength);
+
+  /**
+   * Attempt to read bufferSize bytes from currently opened file into the std::string buffer.
+   * Parse the buffer to obtain the first line and copy it to line. @note: line will be returned
+   * without line breaks
+   * @param buffer  the string buffer
+   * @param bufferSize size of the read buffer
+   * @param buffer the resulting line
+   * @return true if the operation succeeds, false otherwise
+   */
+  bool ReadString(std::string& buffer, int bufferSize, std::string& line);
+
   /**
    * Attempt to write bufSize bytes from buffer bufPtr into currently opened file.
    * @param bufPtr  pointer to buffer


### PR DESCRIPTION
## Description
This PR provides a global cleanup to the EDL class and adds documentation for all the missing methods. Logic was not changed and continues to be the same. Only some generic improvements based on the current code guidelines.
We have unit tests to cover pretty much all of them, and I've been working on pretty much all EDL types. Seems the correct time to do a bulk cleanup before extending it with new types (intro/outro). If tests pass we should be ok :)

