### PR TITLE
AESinkAUDIOTRACK: Be careful with the HW delay

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -700,7 +700,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
     hw_delay -= delay;
     // sometimes at the beginning of the stream m_timestampPos is more accurate and ahead of
     // m_headPos - don't use the computed value then and wait
-    if (hw_delay > -1.0 && hw_delay < 1.0)
+    if (hw_delay >= 0.0 && hw_delay < 1.0)
       m_hw_delay = hw_delay;
     else
       m_hw_delay = 0.0;


### PR DESCRIPTION
A large negative HW delay would mean an underrun, though that value makes
no sense when the other API still reports 500 ms buffer. Most likely the delay
function is not updating often enough or returns bogus values in general.

See: https://github.com/xbmc/xbmc/issues/20911