### PR TITLE
[Warnings] Fix -Wsemicolon-before-method-body -Wdeprecated-copy warnings

### DIFF
--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -166,7 +166,6 @@ if(NOT MSVC)
   if(CMAKE_COMPILER_IS_GNUCXX)
     add_options(ALL_LANGUAGES ALL_BUILDS
       -Wno-cast-function-type # from -Wextra
-      -Wno-deprecated-copy # from -Wextra
     )
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     add_options(ALL_LANGUAGES ALL_BUILDS

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -80,6 +80,7 @@ class CDateTimeSpan
 public:
   CDateTimeSpan();
   CDateTimeSpan(const CDateTimeSpan& span);
+  CDateTimeSpan& operator=(const CDateTimeSpan&) = default;
   CDateTimeSpan(int day, int hour, int minute, int second);
 
   bool operator >(const CDateTimeSpan& right) const;
@@ -121,6 +122,7 @@ class CDateTime final : public IArchivable
 public:
   CDateTime();
   CDateTime(const CDateTime& time);
+  CDateTime& operator=(const CDateTime&) = default;
   explicit CDateTime(const KODI::TIME::SystemTime& time);
   explicit CDateTime(const KODI::TIME::FileTime& time);
   explicit CDateTime(const time_t& time);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -269,6 +269,8 @@ public:
   /*! \cond PRIVATE */
   InputstreamMasteringMetadata() = default;
   InputstreamMasteringMetadata(const InputstreamMasteringMetadata& stream) : CStructHdl(stream) {}
+  InputstreamMasteringMetadata& operator=(const InputstreamMasteringMetadata&) = default;
+
   /*! \endcond */
 
   /// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata_Help Value Help
@@ -435,6 +437,7 @@ public:
     : CStructHdl(stream)
   {
   }
+  InputstreamContentlightMetadata& operator=(const InputstreamContentlightMetadata&) = default;
   /*! \endcond */
 
   /// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamContentlightMetadata_Help Value Help

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/inputstream/StreamCrypto.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/inputstream/StreamCrypto.h
@@ -51,6 +51,7 @@ public:
   /*! \cond PRIVATE */
   StreamCryptoSession() { memset(m_cStructure, 0, sizeof(STREAM_CRYPTO_SESSION)); }
   StreamCryptoSession(const StreamCryptoSession& session) : CStructHdl(session) {}
+  StreamCryptoSession& operator=(const StreamCryptoSession&) = default;
   /*! \endcond */
 
   /// @defgroup cpp_kodi_addon_inputstream_Defs_Info_StreamCryptoSession_Help Value Help

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
@@ -24,6 +24,7 @@ public:
   explicit CAEChannelInfo(const enum AEChannel* rhs);
   CAEChannelInfo(const enum AEStdChLayout rhs);
   ~CAEChannelInfo() = default;
+  CAEChannelInfo(const CAEChannelInfo&) = default;
   CAEChannelInfo& operator=(const CAEChannelInfo& rhs);
   CAEChannelInfo& operator=(const enum AEChannel* rhs);
   CAEChannelInfo& operator=(const enum AEStdChLayout rhs);

--- a/xbmc/interfaces/legacy/Tuple.h
+++ b/xbmc/interfaces/legacy/Tuple.h
@@ -41,6 +41,7 @@ namespace XBMCAddon
     explicit inline Tuple(T1 p1) : TupleBase(1), v1(p1) {}
     inline Tuple() : TupleBase(0) {}
     inline Tuple(const Tuple<T1>& o) : TupleBase(o), v1(o.v1) {}
+    Tuple<T1>& operator=(const Tuple<T1>& other) = default;
 
     inline T1& first() { TupleBase::nvs(1); return v1; }
     inline const T1& first() const { return v1; }
@@ -56,6 +57,7 @@ namespace XBMCAddon
     inline Tuple(T1 p1, T2 p2) : Tuple<T1>(p1), v2(p2) { TupleBase::nvs(2); }
     explicit inline Tuple(T1 p1) : Tuple<T1>(p1) {}
     inline Tuple() = default;
+    Tuple<T1, T2>& operator=(const Tuple<T1, T2>& other) = default;
     inline Tuple(const Tuple<T1,T2>& o) : Tuple<T1>(o), v2(o.v2) {}
 
     inline T2& second() { TupleBase::nvs(2); return v2; }

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -71,7 +71,7 @@ XBMCController* g_xbmcController;
   [self becomeFirstResponder];
 }
 
-- (void)nativeKeyboardActive:(bool)active;
+- (void)nativeKeyboardActive:(bool)active
 {
   // Not used on tvOS
 }
@@ -172,7 +172,7 @@ XBMCController* g_xbmcController;
 
 #pragma mark - BackgroundTask
 
-- (void)beginEnterBackgroundTask;
+- (void)beginEnterBackgroundTask
 {
   CLog::Log(LOGDEBUG, "{}", __PRETTY_FUNCTION__);
   // we have to alloc the background task for keep network working after screen lock and dark.
@@ -181,7 +181,7 @@ XBMCController* g_xbmcController;
         [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:nil];
 }
 
-- (void)endEnterBackgroundTask;
+- (void)endEnterBackgroundTask
 {
   CLog::Log(LOGDEBUG, "{}", __PRETTY_FUNCTION__);
   if (m_enterBackgroundTaskId != UIBackgroundTaskInvalid)

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -80,6 +80,7 @@ class CStreamDetailSubtitle final : public CStreamDetail
 public:
   CStreamDetailSubtitle();
   CStreamDetailSubtitle(const SubtitleStreamInfo &info);
+  CStreamDetailSubtitle(const CStreamDetailSubtitle&) = default;
   CStreamDetailSubtitle& operator=(const CStreamDetailSubtitle &that);
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -39,6 +39,7 @@ public:
     left = os.left; top = os.top;
     right = os.right; bottom = os.bottom;
   }
+  OVERSCAN& operator=(const OVERSCAN&) = default;
 };
 
 struct EdgeInsets
@@ -73,6 +74,7 @@ public:
   RESOLUTION_INFO(int width = 1280, int height = 720, float aspect = 0, const std::string &mode = "");
   float DisplayRatio() const;
   RESOLUTION_INFO(const RESOLUTION_INFO& res);
+  RESOLUTION_INFO& operator=(const RESOLUTION_INFO&) = default;
 };
 
 class CResolutionUtils


### PR DESCRIPTION
## Description
Fix some warnings

## Motivation and context
Compiled tvos for the first time in a while, and noticed a boatload of warnings that looked like low hanging fruit

## How has this been tested?
build tvos

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
