### PR TITLE
[Android] pass pattern encryption and mode in crypto info

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_crypto.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_crypto.h
@@ -100,6 +100,15 @@ extern "C"
 
     /// @brief Key id
     uint8_t kid[16];
+
+    /// @brief Encryption mode
+    uint16_t mode;
+
+    /// @brief Crypt blocks - number of blocks to encrypt in sample encryption pattern
+    uint8_t cryptBlocks;
+
+    /// @brief Skip blocks - number of blocks to skip in sample encryption pattern
+    uint8_t skipBlocks;
   };
   ///@}
   //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -108,8 +108,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "c-api/addon-instance/imagedecoder.h" \
                                                       "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.0.2"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.0.1"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.1.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.1.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
                                                       "c-api/addon-instance/inputstream/demux_packet.h" \

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -401,14 +401,28 @@ bool CDVDAudioCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
       CJNIMediaCodecCryptoInfo *cryptoInfo(0);
       if (!!m_crypto->get_raw() && packet.cryptoInfo)
       {
+        if (CJNIBase::GetSDKVersion() < 25 &&
+            packet.cryptoInfo->mode == CJNIMediaCodec::CRYPTO_MODE_AES_CBC)
+        {
+          CLog::LogF(LOGERROR, "Device API does not support CBCS decryption");
+          return false;
+        }
         cryptoInfo = new CJNIMediaCodecCryptoInfo();
         cryptoInfo->set(
-          packet.cryptoInfo->numSubSamples,
-          std::vector<int>(packet.cryptoInfo->clearBytes, packet.cryptoInfo->clearBytes + packet.cryptoInfo->numSubSamples),
-          std::vector<int>(packet.cryptoInfo->cipherBytes, packet.cryptoInfo->cipherBytes + packet.cryptoInfo->numSubSamples),
-          std::vector<char>(packet.cryptoInfo->kid, packet.cryptoInfo->kid + 16),
-          std::vector<char>(packet.cryptoInfo->iv, packet.cryptoInfo->iv + 16),
-          CJNIMediaCodec::CRYPTO_MODE_AES_CTR);
+            packet.cryptoInfo->numSubSamples,
+            std::vector<int>(packet.cryptoInfo->clearBytes,
+                             packet.cryptoInfo->clearBytes + packet.cryptoInfo->numSubSamples),
+            std::vector<int>(packet.cryptoInfo->cipherBytes,
+                             packet.cryptoInfo->cipherBytes + packet.cryptoInfo->numSubSamples),
+            std::vector<char>(std::begin(packet.cryptoInfo->kid), std::end(packet.cryptoInfo->kid)),
+            std::vector<char>(std::begin(packet.cryptoInfo->iv), std::end(packet.cryptoInfo->iv)),
+            packet.cryptoInfo->mode == CJNIMediaCodec::CRYPTO_MODE_AES_CBC
+                ? CJNIMediaCodec::CRYPTO_MODE_AES_CBC
+                : CJNIMediaCodec::CRYPTO_MODE_AES_CTR);
+
+        CJNIMediaCodecCryptoInfoPattern cryptoInfoPattern(packet.cryptoInfo->cryptBlocks,
+                                                          packet.cryptoInfo->skipBlocks);
+        cryptoInfo->setPattern(cryptoInfoPattern);
       }
 
       int flags = 0;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
`DEMUX_CRYPTO_INFO` which is contained in the demux packets that are sent to Kodi is modified to also describe the mode of encryption (AES-CTR or AES-CBC), and the pattern of encrypted samples and 'skipped' samples. With this information in Kodi we can do the equivalent on the Android side of things and inform MediaCodec of the mode and pattern.
In Android CBC decryption does not feature (properly, see below) until API 25. I've done the check in the appropriate place however I'm not sure of how to properly 'fail' the stream - see testing section for details.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Encrypted Android streams (Widevine/Playready) are currently limited to the typical AES-CTR cypher.  Although this mode of encryption is very popular there are some streams which use CBS, in particular coming from Apple-centric sources as it's the mode used by Fairplay. CBC decryption is supported on Android API 25+ (docos say 24 however there's a lot of evidence that it doesn't work properly until 25), as of writing that's over 85% of devices out there. As this number increases the likelihood of providers switching over to CBC increases, as they will be able to use key systems native to each platform while only encrypting once with the same key.

More info on Android MediaCodec CryptoInfo [here](https://developer.android.com/reference/android/media/MediaCodec.CryptoInfo#setPattern(android.media.MediaCodec.CryptoInfo.Pattern))

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Pixel 3/Android 12 with required changes in libandroidjni (https://github.com/xbmc/libandroidjni/pull/28) and inputstream.adaptive (https://github.com/xbmc/inputstream.adaptive/pull/887)

If the device API is too low (I simulated by altering the level required in the added check) the stream will continue without picture and/or audio and fill the log with errors. I'm not sure if there's a flag that can be set to have the stream end properly.
As no add-ons currently use this there is opportunity for add-on developers to manage user expectations.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
The increased capability will provide more options for add-on developers.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
