### PR TITLE
[GUI] add Skin.SetColor builtin

### DIFF
--- a/xbmc/guilib/GUIColorButtonControl.cpp
+++ b/xbmc/guilib/GUIColorButtonControl.cpp
@@ -14,6 +14,9 @@
 #include "utils/ColorUtils.h"
 #include "utils/StringUtils.h"
 
+using namespace KODI;
+using namespace GUILIB;
+
 CGUIColorButtonControl::CGUIColorButtonControl(int parentID,
                                                int controlID,
                                                float posX,
@@ -35,7 +38,7 @@ CGUIColorButtonControl::CGUIColorButtonControl(int parentID,
   m_colorPosY = 0;
   m_imgColorMask->SetAspectRatio(CAspectRatio::AR_KEEP);
   m_imgColorDisabledMask->SetAspectRatio(CAspectRatio::AR_KEEP);
-  m_imgBoxColor = UTILS::COLOR::NONE;
+  m_imgBoxColor = GUIINFO::CGUIInfoColor(UTILS::COLOR::NONE);
   ControlType = GUICONTROL_COLORBUTTON;
   // offsetX is like a left/right padding, "hex" label does not require high values
   m_labelInfo.GetLabelInfo().offsetX = 2;
@@ -154,7 +157,7 @@ std::string CGUIColorButtonControl::GetDescription() const
   return CGUIButtonControl::GetDescription();
 }
 
-void CGUIColorButtonControl::SetImageBoxColor(KODI::GUILIB::GUIINFO::CGUIInfoColor color)
+void CGUIColorButtonControl::SetImageBoxColor(GUIINFO::CGUIInfoColor color)
 {
   m_imgBoxColor = color;
 }
@@ -162,14 +165,15 @@ void CGUIColorButtonControl::SetImageBoxColor(KODI::GUILIB::GUIINFO::CGUIInfoCol
 void CGUIColorButtonControl::SetImageBoxColor(const std::string& hexColor)
 {
   if (hexColor.empty())
-    m_imgBoxColor = UTILS::COLOR::NONE;
+    m_imgBoxColor = GUIINFO::CGUIInfoColor(UTILS::COLOR::NONE);
   else
-    m_imgBoxColor = UTILS::COLOR::ConvertHexToColor(hexColor);
+    m_imgBoxColor = GUIINFO::CGUIInfoColor(UTILS::COLOR::ConvertHexToColor(hexColor));
 }
 
 bool CGUIColorButtonControl::UpdateColors(const CGUIListItem* item)
 {
   bool changed = CGUIButtonControl::UpdateColors(nullptr);
+  changed |= m_imgBoxColor.Update();
   changed |= m_imgColorMask->SetDiffuseColor(m_imgBoxColor, item);
   changed |= m_imgColorDisabledMask->SetDiffuseColor(m_diffuseColor);
   changed |= m_labelInfo.UpdateColors();

--- a/xbmc/guilib/GUIColorButtonControl.h
+++ b/xbmc/guilib/GUIColorButtonControl.h
@@ -66,6 +66,6 @@ protected:
   std::unique_ptr<CGUITexture> m_imgColorDisabledMask;
   float m_colorPosX;
   float m_colorPosY;
-  UTILS::COLOR::Color m_imgBoxColor;
+  KODI::GUILIB::GUIINFO::CGUIInfoColor m_imgBoxColor;
   CGUILabel m_labelInfo;
 };

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -14,6 +14,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "addons/gui/GUIWindowAddonBrowser.h"
+#include "dialogs/GUIDialogColorPicker.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogSelect.h"
@@ -299,6 +300,49 @@ static int SetImage(const std::vector<std::string>& params)
   return 0;
 }
 
+/*! \brief Set a skin color setting.
+ *  \param params The parameters.
+ *  \details params[0] = Name of skin setting.
+ *           params[1] = Dialog header text.
+ *           params[2] = Hex value of the preselected color (optional).
+ *           params[3] = XML file containing color definitions (optional).
+ */
+static int SetColor(const std::vector<std::string>& params)
+{
+  int string = CSkinSettings::GetInstance().TranslateString(params[0]);
+  std::string value = CSkinSettings::GetInstance().GetString(string);
+
+  CGUIDialogColorPicker* pDlgColorPicker =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogColorPicker>(
+          WINDOW_DIALOG_COLOR_PICKER);
+  pDlgColorPicker->Reset();
+  pDlgColorPicker->SetHeading(CVariant{g_localizeStrings.Get(atoi(params[1].c_str()))});
+
+  if (params.size() > 3)
+  {
+    pDlgColorPicker->LoadColors(params[3]);
+  }
+  else
+  {
+    pDlgColorPicker->LoadColors();
+  }
+
+  if (params.size() > 2)
+  {
+    pDlgColorPicker->SetSelectedColor(params[2]);
+  }
+
+  pDlgColorPicker->Open();
+
+  if (pDlgColorPicker->IsConfirmed())
+  {
+    value = pDlgColorPicker->GetSelectedColor();
+    CSkinSettings::GetInstance().SetString(string, value);
+  }
+
+  return 0;
+}
+
 /*! \brief Set a string skin setting.
  *  \param params The parameters.
  *  \details params[0] = Name of skin setting.
@@ -492,6 +536,24 @@ static int SkinDebug(const std::vector<std::string>& params)
 ///     @param[in] url                   Extra URL to allow selection from (optional).
 ///   }
 ///   \table_row2_l{
+///     <b>`Skin.SetColor(string\,header[\,colorfile\,selectedcolor])`</b>
+///     \anchor Builtin_SetColor,
+///     Pops up a color selection dialog and allows the user to select a color to be
+///     used to define the color of a label control or as a colordiffuse value for a texture
+///     elsewhere in the skin via the info tag `Skin.String(string)`.
+///     Skinners can optionally set the color that needs to be preselected in the
+///     dialog by specifying the hex value of this color.
+///     Also optionally\,skinners can include their own color definition file. If not specified\,
+///     the default colorfile included with Kodi will be used.
+///     @param[in] string                Name of skin setting.
+///     @param[in] string                Dialog header text.
+///     @param[in] string                Hex value of the color to preselect (optional).
+///     @param[in] string                Filepath of the color definition file (optional).
+///     <p><hr>
+///     @skinning_v20 **[New builtin]** \link Builtin_SetColor `SetColor(string\,header[\,colorfile\,selectedcolor])`\endlink
+///     <p>
+///   }
+///   \table_row2_l{
 ///     <b>`Skin.SetNumeric(numeric[\,value])`</b>
 ///     ,
 ///     Pops up a keyboard dialog and allows the user to input a numerical.
@@ -551,6 +613,7 @@ CBuiltins::CommandMap CSkinBuiltins::GetOperations() const
            {"skin.setbool",       {"Sets a skin setting on", 1, SetBool}},
            {"skin.setfile",       {"Prompts and sets a file", 1, SetFile}},
            {"skin.setimage",      {"Prompts and sets a skin image", 1, SetImage}},
+           {"skin.setcolor",      {"Prompts and sets a skin color", 1, SetColor}},
            {"skin.setnumeric",    {"Prompts and sets numeric input", 1, SetNumeric}},
            {"skin.setpath",       {"Prompts and sets a skin path", 1, SetPath}},
            {"skin.setstring",     {"Prompts and sets skin string", 1, SetString}},

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -543,11 +543,12 @@ static int SkinDebug(const std::vector<std::string>& params)
 ///     elsewhere in the skin via the info tag `Skin.String(string)`.
 ///     Skinners can optionally set the color that needs to be preselected in the
 ///     dialog by specifying the hex value of this color.
-///     Also optionally\,skinners can include their own color definition file. If not specified\,
+///     Also optionally\, skinners can include their own color definition file. If not specified\,
 ///     the default colorfile included with Kodi will be used.
 ///     @param[in] string                Name of skin setting.
 ///     @param[in] string                Dialog header text.
-///     @param[in] string                Hex value of the color to preselect (optional).
+///     @param[in] string                Hex value of the color to preselect (optional),
+///                                      example: FF00FF00.
 ///     @param[in] string                Filepath of the color definition file (optional).
 ///     <p><hr>
 ///     @skinning_v20 **[New builtin]** \link Builtin_SetColor `SetColor(string\,header[\,colorfile\,selectedcolor])`\endlink


### PR DESCRIPTION
## Description
this is an effort [WIP] to make the new `colorbutton` control available to skin settings as well.
(it currently can only be used inside kodi settings)

the PR adds a new built-in function: `Skin.SetColor()`
while this built-in works fine, i'm bumping in to an issue with the colorbutton color.
it looks like the `<colorbox>` tag does not accept `$INFO[]` labels.
i'm hoping @CastagnaIT will be able to help me out here, as i'm clueless as to what's needed to make that work.


## Motivation and context
several skins offer users to option to make changes to the used color scheme.
to accomplish this, skin have to depend on external (colorpicker) addons.
since this functionality is now available in core, it should be made available to skins as well.

## How has this been tested?
testing is done by adding this code to the SkinSettings.xml file of Estuary:
```
<control type="colorbutton" id="321">
	<label>Background colour</label>
	<include>DefaultSettingButton</include>
	<colorbox>$INFO[Skin.String(bgcolor)]</colorbox>
	<onclick>Skin.SetColor(bgcolor, Please select a colour)</onclick>
</control>
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
