### PR TITLE
[cleanup] change indentifiers YES and NO to CHOICE_YES and CHOICE_NO

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -909,7 +909,7 @@ void CApplication::OnSettingAction(const std::shared_ptr<const CSetting>& settin
     if (CServiceBroker::GetAddonMgr().GetAddon(
             CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
                 CSettings::SETTING_SCREENSAVER_MODE),
-            addon, ADDON_SCREENSAVER, OnlyEnabled::YES))
+            addon, ADDON_SCREENSAVER, OnlyEnabled::CHOICE_YES))
       CGUIDialogAddonSettings::ShowForAddon(addon);
   }
   else if (settingId == CSettings::SETTING_AUDIOCDS_SETTINGS)
@@ -918,7 +918,7 @@ void CApplication::OnSettingAction(const std::shared_ptr<const CSetting>& settin
     if (CServiceBroker::GetAddonMgr().GetAddon(
             CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
                 CSettings::SETTING_AUDIOCDS_ENCODER),
-            addon, ADDON_AUDIOENCODER, OnlyEnabled::YES))
+            addon, ADDON_AUDIOENCODER, OnlyEnabled::CHOICE_YES))
       CGUIDialogAddonSettings::ShowForAddon(addon);
   }
   else if (settingId == CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION)
@@ -989,8 +989,8 @@ void CApplication::ReloadSkin(bool confirm/*=false*/)
        user as to whether they want to keep the current skin. */
     if (confirm && m_confirmSkinChange)
     {
-      if (HELPERS::ShowYesNoDialogText(CVariant{13123}, CVariant{13111}, CVariant{""}, CVariant{""}, 10000) !=
-        DialogResponse::YES)
+      if (HELPERS::ShowYesNoDialogText(CVariant{13123}, CVariant{13111}, CVariant{""}, CVariant{""},
+                                       10000) != DialogResponse::CHOICE_YES)
       {
         m_confirmSkinChange = false;
         settings->SetString(CSettings::SETTING_LOOKANDFEEL_SKIN, oldSkin);
@@ -1057,7 +1057,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
   SkinPtr skin;
   {
     AddonPtr addon;
-    if (!CServiceBroker::GetAddonMgr().GetAddon(skinID, addon, ADDON_SKIN, OnlyEnabled::YES))
+    if (!CServiceBroker::GetAddonMgr().GetAddon(skinID, addon, ADDON_SKIN, OnlyEnabled::CHOICE_YES))
       return false;
     skin = std::static_pointer_cast<ADDON::CSkinInfo>(addon);
   }
@@ -2654,7 +2654,7 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPl
   {
     AddonPtr addon;
     if (CServiceBroker::GetAddonMgr().GetAddon(path.GetHostName(), addon, ADDON_GAMEDLL,
-                                               OnlyEnabled::YES))
+                                               OnlyEnabled::CHOICE_YES))
     {
       CFileItem addonItem(addon);
       return PlayFile(addonItem, player, false);
@@ -3617,7 +3617,7 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     return;
   }
   else if (CServiceBroker::GetAddonMgr().GetAddon(m_screensaverIdInUse, m_pythonScreenSaver,
-                                                  ADDON_SCREENSAVER, OnlyEnabled::YES))
+                                                  ADDON_SCREENSAVER, OnlyEnabled::CHOICE_YES))
   {
     std::string libPath = m_pythonScreenSaver->LibPath();
     if (CScriptInvocationManager::GetInstance().HasLanguageInvoker(libPath))
@@ -4051,7 +4051,7 @@ void CApplication::ConfigureAndEnableAddons()
       {
         if (HELPERS::ShowYesNoDialogLines(CVariant{24039}, // Disabled add-ons
                                           CVariant{24059}, // Would you like to enable this add-on?
-                                          CVariant{addon->Name()}) == DialogResponse::YES)
+                                          CVariant{addon->Name()}) == DialogResponse::CHOICE_YES)
         {
           if (addon->HasSettings())
           {

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -508,9 +508,10 @@ bool CAutorun::IsEnabled() const
 
 bool CAutorun::PlayDiscAskResume(const std::string& path)
 {
-  return PlayDisc(path, true, !CanResumePlayDVD(path) ||
-    HELPERS::ShowYesNoDialogText(CVariant{341}, CVariant{""}, CVariant{13404}, CVariant{12021}) ==
-    DialogResponse::YES);
+  return PlayDisc(path, true,
+                  !CanResumePlayDVD(path) ||
+                      HELPERS::ShowYesNoDialogText(CVariant{341}, CVariant{""}, CVariant{13404},
+                                                   CVariant{12021}) == DialogResponse::CHOICE_YES);
 }
 
 bool CAutorun::CanResumePlayDVD(const std::string& path)

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -48,7 +48,7 @@ bool CContextMenuItem::Execute(const CFileItemPtr& item) const
 
   ADDON::AddonPtr addon;
   if (!CServiceBroker::GetAddonMgr().GetAddon(m_addonId, addon, ADDON::ADDON_UNKNOWN,
-                                              ADDON::OnlyEnabled::YES))
+                                              ADDON::OnlyEnabled::CHOICE_YES))
     return false;
 
   bool reuseLanguageInvoker = false;

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -121,7 +121,7 @@ void CContextMenuManager::OnEvent(const ADDON::AddonEvent& event)
   else if (typeid(event) == typeid(AddonEvents::Enabled))
   {
     AddonPtr addon;
-    if (m_addonMgr.GetAddon(event.id, addon, ADDON_CONTEXT_ITEM, OnlyEnabled::YES))
+    if (m_addonMgr.GetAddon(event.id, addon, ADDON_CONTEXT_ITEM, OnlyEnabled::CHOICE_YES))
     {
       CSingleLock lock(m_criticalSection);
       auto items = std::static_pointer_cast<CContextMenuAddon>(addon)->GetItems();

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -662,7 +662,7 @@ LanguageResourcePtr CLangInfo::GetLanguageAddon(const std::string& locale /* = "
 
   ADDON::AddonPtr addon;
   if (CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON::ADDON_RESOURCE_LANGUAGE,
-                                             ADDON::OnlyEnabled::YES) &&
+                                             ADDON::OnlyEnabled::CHOICE_YES) &&
       addon != NULL)
     return std::dynamic_pointer_cast<ADDON::CLanguageResource>(addon);
 
@@ -687,7 +687,8 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   ADDON::AddonPtr addon;
 
   // Find the chosen language add-on if it's enabled
-  if (!addonMgr.GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, ADDON::OnlyEnabled::YES))
+  if (!addonMgr.GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE,
+                         ADDON::OnlyEnabled::CHOICE_YES))
   {
     if (!addonMgr.IsAddonInstalled(language) ||
         (addonMgr.IsAddonDisabled(language) && !addonMgr.EnableAddon(language)))
@@ -701,7 +702,7 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
                      ->GetDefault();
 
       if (!addonMgr.GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE,
-                             ADDON::OnlyEnabled::NO))
+                             ADDON::OnlyEnabled::CHOICE_NO))
       {
         CLog::Log(LOGFATAL, "CLangInfo::{}: could not find default language add-on '{}'", __func__,
                   language);

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -28,44 +28,44 @@ class CAddonDatabase;
 
 enum class BackgroundJob : bool
 {
-  YES = true,
-  NO = false,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 enum class ModalJob : bool
 {
-  YES = true,
-  NO = false,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 enum class AutoUpdateJob : bool
 {
-  YES = true,
-  NO = false,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 enum class DependencyJob : bool
 {
-  YES = true,
-  NO = false,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 enum class InstallModalPrompt : bool
 {
-  PROMPT = true,
-  NO_PROMPT = false,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 enum class AllowCheckForUpdates : bool
 {
-  YES = true,
-  NO = false,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 enum class RecurseOrphaned : bool
 {
-  YES = true,
-  NO = false,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 class CAddonInstaller : public IJobCallback
@@ -281,8 +281,8 @@ private:
   ADDON::RepositoryPtr m_repo;
   bool m_isUpdate;
   AutoUpdateJob m_isAutoUpdate;
-  DependencyJob m_dependsInstall = DependencyJob::NO;
-  AllowCheckForUpdates m_allowCheckForUpdates = AllowCheckForUpdates::YES;
+  DependencyJob m_dependsInstall = DependencyJob::CHOICE_NO;
+  AllowCheckForUpdates m_allowCheckForUpdates = AllowCheckForUpdates::CHOICE_YES;
   const char* m_currentType = TYPE_DOWNLOAD;
 };
 
@@ -299,7 +299,7 @@ private:
 
   ADDON::AddonPtr m_addon;
   bool m_removeData;
-  RecurseOrphaned m_recurseOrphaned = RecurseOrphaned::YES;
+  RecurseOrphaned m_recurseOrphaned = RecurseOrphaned::CHOICE_YES;
 };
 
 }; // namespace ADDON

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -28,28 +28,28 @@ namespace ADDON
 
   enum class AllowCheckForUpdates : bool;
 
-  enum class AddonCheckType
+  enum class AddonCheckType : bool
   {
     OUTDATED_ADDONS,
-    AVAILABLE_UPDATES
+    AVAILABLE_UPDATES,
   };
 
   enum class OnlyEnabled : bool
   {
-    YES = true,
-    NO = false,
+    CHOICE_YES = true,
+    CHOICE_NO = false,
   };
 
   enum class OnlyEnabledRootAddon : bool
   {
-    YES = true,
-    NO = false,
+    CHOICE_YES = true,
+    CHOICE_NO = false,
   };
 
   enum class CheckIncompatible : bool
   {
-    YES = true,
-    NO = false,
+    CHOICE_YES = true,
+    CHOICE_NO = false,
   };
 
   struct CAddonWithUpdate;

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -453,7 +453,8 @@ bool CAddonRepos::FindDependency(const std::string& dependsId,
   // we got the dependency, so now get a repository-pointer to return
 
   std::shared_ptr<IAddon> tmp;
-  if (!m_addonMgr.GetAddon(dependencyToInstall->Origin(), tmp, ADDON_REPOSITORY, OnlyEnabled::YES))
+  if (!m_addonMgr.GetAddon(dependencyToInstall->Origin(), tmp, ADDON_REPOSITORY,
+                           OnlyEnabled::CHOICE_YES))
     return false;
 
   repoForDep = std::static_pointer_cast<CRepository>(tmp);

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -21,7 +21,7 @@ class CAddonDatabase;
 class CAddonMgr;
 class CRepository;
 class IAddon;
-enum class AddonCheckType;
+enum class AddonCheckType : bool;
 
 enum class CheckAddonPath
 {

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -44,7 +44,8 @@ CAddonStatusHandler::CAddonStatusHandler(const std::string &addonID, ADDON_STATU
 {
   //! @todo The status handled CAddonStatusHandler by is related to the class, not the instance
   //! having CAddonMgr construct an instance makes no sense
-  if (!CServiceBroker::GetAddonMgr().GetAddon(addonID, m_addon, ADDON_UNKNOWN, OnlyEnabled::YES))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addonID, m_addon, ADDON_UNKNOWN,
+                                              OnlyEnabled::CHOICE_YES))
     return;
 
   CLog::Log(LOGINFO,

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -84,9 +84,10 @@ void CAddonSystemSettings::OnSettingChanged(const std::shared_ptr<const CSetting
 {
   using namespace KODI::MESSAGING::HELPERS;
 
-  if (setting->GetId() == CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES
-    && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES)
-    && ShowYesNoDialogText(19098, 36618) != DialogResponse::YES)
+  if (setting->GetId() == CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES &&
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES) &&
+      ShowYesNoDialogText(19098, 36618) != DialogResponse::CHOICE_YES)
   {
     CServiceBroker::GetSettingsComponent()->GetSettings()->SetBool(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES, false);
   }
@@ -98,7 +99,8 @@ bool CAddonSystemSettings::GetActive(const TYPE& type, AddonPtr& addon)
   if (it != m_activeSettings.end())
   {
     auto settingValue = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(it->second);
-    return CServiceBroker::GetAddonMgr().GetAddon(settingValue, addon, type, OnlyEnabled::YES);
+    return CServiceBroker::GetAddonMgr().GetAddon(settingValue, addon, type,
+                                                  OnlyEnabled::CHOICE_YES);
   }
   return false;
 }

--- a/xbmc/addons/ContextMenus.cpp
+++ b/xbmc/addons/ContextMenus.cpp
@@ -25,7 +25,7 @@ bool CAddonSettings::IsVisible(const CFileItem& item) const
   AddonPtr addon;
   return item.HasAddonInfo() &&
          CServiceBroker::GetAddonMgr().GetAddon(item.GetAddonInfo()->ID(), addon, ADDON_UNKNOWN,
-                                                OnlyEnabled::NO) &&
+                                                OnlyEnabled::CHOICE_NO) &&
          addon->HasSettings();
 }
 
@@ -33,7 +33,7 @@ bool CAddonSettings::Execute(const CFileItemPtr& item) const
 {
   AddonPtr addon;
   return CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), addon, ADDON_UNKNOWN,
-                                                OnlyEnabled::NO) &&
+                                                OnlyEnabled::CHOICE_NO) &&
          CGUIDialogAddonSettings::ShowForAddon(addon);
 }
 
@@ -47,7 +47,7 @@ bool CCheckForUpdates::Execute(const CFileItemPtr& item) const
   AddonPtr addon;
   if (item->HasAddonInfo() &&
       CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), addon, ADDON_REPOSITORY,
-                                             OnlyEnabled::YES))
+                                             OnlyEnabled::CHOICE_YES))
   {
     CServiceBroker::GetRepositoryUpdater().CheckForUpdates(std::static_pointer_cast<CRepository>(addon), true);
     return true;

--- a/xbmc/addons/FontResource.cpp
+++ b/xbmc/addons/FontResource.cpp
@@ -28,7 +28,7 @@ void CFontResource::OnPostInstall(bool update, bool modal)
 {
   std::string skin = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN);
   const auto& deps =
-      CServiceBroker::GetAddonMgr().GetDepsRecursive(skin, OnlyEnabledRootAddon::YES);
+      CServiceBroker::GetAddonMgr().GetDepsRecursive(skin, OnlyEnabledRootAddon::CHOICE_YES);
   for (const auto& it : deps)
     if (it.id == ID())
       CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -97,9 +97,9 @@ void CLanguageResource::OnPostInstall(bool update, bool modal)
   if (!g_SkinInfo)
     return;
 
-  if (IsInUse() ||
-     (!update && !modal &&
-       (HELPERS::ShowYesNoDialogText(CVariant{Name()}, CVariant{24132}) == DialogResponse::YES)))
+  if (IsInUse() || (!update && !modal &&
+                    (HELPERS::ShowYesNoDialogText(CVariant{Name()}, CVariant{24132}) ==
+                     DialogResponse::CHOICE_YES)))
   {
     if (IsInUse())
       g_langInfo.SetLanguage(ID());
@@ -137,7 +137,7 @@ bool CLanguageResource::FindLegacyLanguage(const std::string &locale, std::strin
 
   AddonPtr addon;
   if (!CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON_RESOURCE_LANGUAGE,
-                                              OnlyEnabled::YES))
+                                              OnlyEnabled::CHOICE_YES))
     return false;
 
   legacyLanguage = addon->Name();

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -369,7 +369,7 @@ bool CScraper::Load()
       bool bOptional = itr->optional;
 
       if (CServiceBroker::GetAddonMgr().GetAddon((*itr).id, dep, ADDON::ADDON_UNKNOWN,
-                                                 ADDON::OnlyEnabled::YES))
+                                                 ADDON::OnlyEnabled::CHOICE_YES))
       {
         CXBMCTinyXML doc;
         if (dep->Type() == ADDON_SCRAPER_LIBRARY && doc.LoadFile(dep->LibPath()))

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -62,7 +62,7 @@ void CServiceAddonManager::Start()
 void CServiceAddonManager::Start(const std::string& addonId)
 {
   AddonPtr addon;
-  if (m_addonMgr.GetAddon(addonId, addon, ADDON_SERVICE, OnlyEnabled::YES))
+  if (m_addonMgr.GetAddon(addonId, addon, ADDON_SERVICE, OnlyEnabled::CHOICE_YES))
   {
     Start(addon);
   }

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -381,7 +381,8 @@ void CSkinInfo::OnPostInstall(bool update, bool modal)
     return;
 
   if (IsInUse() || (!update && !modal &&
-    HELPERS::ShowYesNoDialogText(CVariant{Name()}, CVariant{24099}) == DialogResponse::YES))
+                    HELPERS::ShowYesNoDialogText(CVariant{Name()}, CVariant{24099}) ==
+                        DialogResponse::CHOICE_YES))
   {
     CGUIDialogKaiToast *toast = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKaiToast>(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -79,7 +79,7 @@ const std::string& CAddonInfo::OriginName() const
   {
     ADDON::AddonPtr origin;
     if (CServiceBroker::GetAddonMgr().GetAddon(m_origin, origin, ADDON::ADDON_UNKNOWN,
-                                               ADDON::OnlyEnabled::NO))
+                                               ADDON::OnlyEnabled::CHOICE_NO))
       m_originName = std::make_unique<std::string>(origin->Name());
     else
       m_originName = std::make_unique<std::string>(); // remember we tried to fetch the name

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -306,7 +306,7 @@ int CGUIDialogAddonInfo::AskForVersion(std::vector<std::pair<AddonVersion, std::
       dialog->Add(item);
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(versionInfo.second, repo, ADDON_REPOSITORY,
-                                                    OnlyEnabled::YES))
+                                                    OnlyEnabled::CHOICE_YES))
     {
       item.SetLabel2(repo->Name());
       item.SetArt("icon", repo->Icon());
@@ -814,7 +814,7 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
   m_item = std::make_shared<CFileItem>(*item);
   m_localAddon.reset();
   if (CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon,
-                                             ADDON_UNKNOWN, OnlyEnabled::NO))
+                                             ADDON_UNKNOWN, OnlyEnabled::CHOICE_NO))
   {
     CLog::Log(LOGDEBUG, "{} - Addon with id {} not found locally.", __FUNCTION__,
               item->GetAddonInfo()->ID());
@@ -830,7 +830,7 @@ void CGUIDialogAddonInfo::BuildDependencyList()
   m_showDepDialogOnInstall = false;
   m_depsInstalledWithAvailable.clear();
   m_deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(m_item->GetAddonInfo()->ID(),
-                                                          OnlyEnabledRootAddon::NO);
+                                                          OnlyEnabledRootAddon::CHOICE_NO);
 
   for (const auto& dep : m_deps)
   {
@@ -839,7 +839,7 @@ void CGUIDialogAddonInfo::BuildDependencyList()
 
     // Find add-on in local installation
     if (!CServiceBroker::GetAddonMgr().GetAddon(dep.id, addonInstalled, ADDON_UNKNOWN,
-                                                OnlyEnabled::YES))
+                                                OnlyEnabled::CHOICE_YES))
     {
       addonInstalled = nullptr;
     }

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -162,7 +162,8 @@ class UpdateAddons : public IRunnable
   void Run() override
   {
     for (const auto& addon : CServiceBroker::GetAddonMgr().GetAvailableUpdates())
-      CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), BackgroundJob::YES, ModalJob::NO);
+      CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), BackgroundJob::CHOICE_YES,
+                                                     ModalJob::CHOICE_NO);
   }
 };
 
@@ -172,8 +173,8 @@ class UpdateAllowedAddons : public IRunnable
   {
     for (const auto& addon : CServiceBroker::GetAddonMgr().GetAvailableUpdates())
       if (CServiceBroker::GetAddonMgr().IsAutoUpdateable(addon->ID()))
-        CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), BackgroundJob::YES,
-                                                       ModalJob::NO);
+        CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), BackgroundJob::CHOICE_YES,
+                                                       ModalJob::CHOICE_NO);
   }
 };
 
@@ -196,13 +197,13 @@ void CGUIWindowAddonBrowser::InstallFromZip()
   if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES))
   {
-    if (ShowYesNoDialogText(13106, 36617, 186, 10004) == DialogResponse::YES)
+    if (ShowYesNoDialogText(13106, 36617, 186, 10004) == DialogResponse::CHOICE_YES)
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(
           WINDOW_SETTINGS_SYSTEM, CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES);
   }
   else
   {
-    if (ShowYesNoDialogText(19098, 36637) == DialogResponse::YES)
+    if (ShowYesNoDialogText(19098, 36637) == DialogResponse::CHOICE_YES)
     {
       // pop up filebrowser to grab an installed folder
       VECSOURCES shares = *CMediaSourceSettings::GetInstance().GetSources("files");
@@ -329,7 +330,8 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory, CFile
           //check if it's installed
           AddonPtr addon;
           if (!CServiceBroker::GetAddonMgr().GetAddon(items[i]->GetProperty("Addon.ID").asString(),
-                                                      addon, ADDON_UNKNOWN, OnlyEnabled::YES))
+                                                      addon, ADDON_UNKNOWN,
+                                                      OnlyEnabled::CHOICE_YES))
             items.Remove(i);
         }
       }
@@ -610,7 +612,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE>& types,
         {
           AddonPtr installedAddon;
           if (!CAddonInstaller::GetInstance().InstallModal(addon->ID(), installedAddon,
-                                                           InstallModalPrompt::NO_PROMPT))
+                                                           InstallModalPrompt::CHOICE_NO))
             continue;
         }
 

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -313,7 +313,7 @@ bool Interface_Base::open_settings_dialog(const KODI_ADDON_BACKEND_HDL hdl)
   // show settings dialog
   AddonPtr addonInfo;
   if (!CServiceBroker::GetAddonMgr().GetAddon(addon->ID(), addonInfo, ADDON_UNKNOWN,
-                                              OnlyEnabled::YES))
+                                              OnlyEnabled::CHOICE_YES))
   {
     CLog::Log(LOGERROR, "Interface_Base::{} - Could not get addon information for '{}'", __func__,
               addon->ID());

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -322,7 +322,7 @@ bool Interface_General::is_addon_avilable(void* kodiBase,
   }
 
   AddonPtr addonInfo;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addonInfo, ADDON_UNKNOWN, OnlyEnabled::NO))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addonInfo, ADDON_UNKNOWN, OnlyEnabled::CHOICE_NO))
     return false;
 
   *version = strdup(addonInfo->Version().asString().c_str());

--- a/xbmc/addons/interfaces/gui/dialogs/YesNo.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/YesNo.cpp
@@ -63,8 +63,8 @@ bool Interface_GUIDialogYesNo::show_and_get_input_single_text(KODI_HANDLE kodiBa
   }
 
   DialogResponse result = HELPERS::ShowYesNoDialogText(heading, text, noLabel, yesLabel);
-  *canceled = (result == DialogResponse::CANCELLED);
-  return (result == DialogResponse::YES);
+  *canceled = (result == DialogResponse::CHOICE_CANCELLED);
+  return (result == DialogResponse::CHOICE_YES);
 }
 
 bool Interface_GUIDialogYesNo::show_and_get_input_line_text(KODI_HANDLE kodiBase,
@@ -95,7 +95,7 @@ bool Interface_GUIDialogYesNo::show_and_get_input_line_text(KODI_HANDLE kodiBase
   }
 
   return HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel) ==
-         DialogResponse::YES;
+         DialogResponse::CHOICE_YES;
 }
 
 bool Interface_GUIDialogYesNo::show_and_get_input_line_button_text(KODI_HANDLE kodiBase,
@@ -129,8 +129,8 @@ bool Interface_GUIDialogYesNo::show_and_get_input_line_button_text(KODI_HANDLE k
 
   DialogResponse result =
       HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel);
-  *canceled = (result == DialogResponse::CANCELLED);
-  return (result == DialogResponse::YES);
+  *canceled = (result == DialogResponse::CHOICE_CANCELLED);
+  return (result == DialogResponse::CHOICE_YES);
 }
 
 } /* namespace ADDON */

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -43,7 +43,7 @@ bool CEncoderFFmpeg::Init()
     const std::string addonId = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
         CSettings::SETTING_AUDIOCDS_ENCODER);
     bool success = CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON::ADDON_UNKNOWN,
-                                                          ADDON::OnlyEnabled::YES);
+                                                          ADDON::OnlyEnabled::CHOICE_YES);
     int bitrate;
     if (success && addon)
     {

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -110,7 +110,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
     CLog::Log(LOGERROR, "RetroPlayer[PLAYER]: Can't play game, no game client was passed!");
   }
   else if (!CServiceBroker::GetAddonMgr().GetAddon(gameClientId, addon, ADDON::ADDON_GAMEDLL,
-                                                   ADDON::OnlyEnabled::YES))
+                                                   ADDON::OnlyEnabled::CHOICE_YES))
   {
     CLog::Log(LOGERROR, "RetroPlayer[PLAYER]: Can't find add-on {} for game file!", gameClientId);
   }
@@ -155,8 +155,8 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
       if (save->GameClientID() != m_gameClient->ID())
       {
         ADDON::AddonPtr addon;
-        if (CServiceBroker::GetAddonMgr().GetAddon(save->GameClientID(), addon,
-                                                   ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::YES))
+        if (CServiceBroker::GetAddonMgr().GetAddon(
+                save->GameClientID(), addon, ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::CHOICE_YES))
         {
           // Warn the user that continuing with a different game client will
           // overwrite the save

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -543,7 +543,7 @@ static bool Browse(const CURL& path, CFileItemList &items)
     AddonPtr repoAddon;
     const auto& addonMgr = CServiceBroker::GetAddonMgr();
 
-    if (!addonMgr.GetAddon(repoId, repoAddon, ADDON_REPOSITORY, OnlyEnabled::YES))
+    if (!addonMgr.GetAddon(repoId, repoAddon, ADDON_REPOSITORY, OnlyEnabled::CHOICE_YES))
       return false;
 
     CAddonRepos addonRepos(addonMgr);
@@ -770,7 +770,7 @@ bool CAddonsDirectory::IsRepoDirectory(const CURL& url)
   return url.GetHostName() == "repos" || url.GetHostName() == "all" ||
          url.GetHostName() == "search" ||
          CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), tmp, ADDON_REPOSITORY,
-                                                OnlyEnabled::YES);
+                                                OnlyEnabled::CHOICE_YES);
 }
 
 void CAddonsDirectory::GenerateAddonListing(const CURL& path,

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -71,11 +71,11 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)
   ADDON::AddonPtr addon;
   // try the plugin type first, and if not found, try an unknown type
   if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN,
-                                              OnlyEnabled::YES) &&
+                                              OnlyEnabled::CHOICE_YES) &&
       !CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_UNKNOWN,
-                                              OnlyEnabled::YES) &&
+                                              OnlyEnabled::CHOICE_YES) &&
       !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), addon,
-                                                   InstallModalPrompt::PROMPT))
+                                                   InstallModalPrompt::CHOICE_YES))
   {
     CLog::Log(LOGERROR, "Unable to find plugin {}", url.GetHostName());
     return false;
@@ -427,9 +427,9 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
 
   AddonPtr addon;
   if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN,
-                                              OnlyEnabled::YES) &&
+                                              OnlyEnabled::CHOICE_YES) &&
       !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), addon,
-                                                   InstallModalPrompt::PROMPT))
+                                                   InstallModalPrompt::CHOICE_YES))
   {
     CLog::Log(LOGERROR, "Unable to find plugin {}", url.GetHostName());
     return false;
@@ -512,7 +512,7 @@ bool CPluginDirectory::IsMediaLibraryScanningAllowed(const std::string& content,
     return false;
   AddonPtr addon;
   if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN,
-                                              OnlyEnabled::YES))
+                                              OnlyEnabled::CHOICE_YES))
   {
     CLog::Log(LOGERROR, "Unable to find plugin {}", url.GetHostName());
     return false;

--- a/xbmc/filesystem/ResourceFile.cpp
+++ b/xbmc/filesystem/ResourceFile.cpp
@@ -46,7 +46,8 @@ bool CResourceFile::TranslatePath(const CURL &url, std::string &translatedPath)
     return false;
 
   AddonPtr addon;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON_UNKNOWN, OnlyEnabled::YES) ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON_UNKNOWN,
+                                              OnlyEnabled::CHOICE_YES) ||
       addon == NULL)
     return false;
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -420,7 +420,7 @@ std::string CGameClient::GetMissingResource()
     {
       AddonPtr addon;
       const bool bInstalled = CServiceBroker::GetAddonMgr().GetAddon(
-          strDependencyId, addon, ADDON_UNKNOWN, OnlyEnabled::YES);
+          strDependencyId, addon, ADDON_UNKNOWN, OnlyEnabled::CHOICE_YES);
       if (!bInstalled)
       {
         strAddonId = strDependencyId;

--- a/xbmc/games/addons/GameClientProperties.cpp
+++ b/xbmc/games/addons/GameClientProperties.cpp
@@ -113,7 +113,7 @@ const char** CGameClientProperties::GetResourceDirectories(void)
       const std::string& strAddonId = it->id;
       AddonPtr addon;
       if (CServiceBroker::GetAddonMgr().GetAddon(strAddonId, addon, ADDON_RESOURCE_GAMES,
-                                                 OnlyEnabled::YES))
+                                                 OnlyEnabled::CHOICE_YES))
       {
         std::shared_ptr<CGameResource> resource = std::static_pointer_cast<CGameResource>(addon);
 
@@ -204,7 +204,7 @@ bool CGameClientProperties::GetProxyAddons(ADDON::VECADDONS& addons)
   {
     AddonPtr addon;
     if (CServiceBroker::GetAddonMgr().GetAddon(dependency.id, addon, ADDON_UNKNOWN,
-                                               OnlyEnabled::NO))
+                                               OnlyEnabled::CHOICE_NO))
     {
       // If add-on is disabled, ask the user to enable it
       if (CServiceBroker::GetAddonMgr().IsAddonDisabled(dependency.id))

--- a/xbmc/games/controllers/ControllerManager.cpp
+++ b/xbmc/games/controllers/ControllerManager.cpp
@@ -26,7 +26,7 @@ ControllerPtr CControllerManager::GetController(const std::string& controllerId)
   {
     AddonPtr addon;
     if (CServiceBroker::GetAddonMgr().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER,
-                                               OnlyEnabled::NO))
+                                               OnlyEnabled::CHOICE_NO))
       cachedController = LoadController(addon);
   }
 

--- a/xbmc/games/controllers/windows/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/windows/ControllerInstaller.cpp
@@ -108,7 +108,7 @@ void CControllerInstaller::Process()
     pProgressDialog->SetPercentage(percentage);
 
     if (!ADDON::CAddonInstaller::GetInstance().InstallOrUpdate(
-            addon->ID(), ADDON::BackgroundJob::NO, ADDON::ModalJob::NO))
+            addon->ID(), ADDON::BackgroundJob::CHOICE_NO, ADDON::ModalJob::CHOICE_NO))
     {
       CLog::Log(LOGERROR, "Controller installer: Failed to install {}", addon->ID());
       // "Error"

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -223,7 +223,8 @@ void CGUIControllerWindow::OnInitWindow(void)
     {
       ADDON::AddonPtr addon;
       if (CServiceBroker::GetAddonMgr().GetAddon(gameSettingsHandle->GameClientID(), addon,
-                                                 ADDON::ADDON_GAMEDLL, ADDON::OnlyEnabled::YES))
+                                                 ADDON::ADDON_GAMEDLL,
+                                                 ADDON::OnlyEnabled::CHOICE_YES))
         gameClient = std::static_pointer_cast<CGameClient>(addon);
     }
   }

--- a/xbmc/games/controllers/windows/GUIPortWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIPortWindow.cpp
@@ -119,7 +119,8 @@ void CGUIPortWindow::OnInitWindow()
     {
       ADDON::AddonPtr addon;
       if (CServiceBroker::GetAddonMgr().GetAddon(gameSettingsHandle->GameClientID(), addon,
-                                                 ADDON::ADDON_GAMEDLL, ADDON::OnlyEnabled::YES))
+                                                 ADDON::ADDON_GAMEDLL,
+                                                 ADDON::OnlyEnabled::CHOICE_YES))
         gameClient = std::static_pointer_cast<CGameClient>(addon);
     }
   }

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -133,7 +133,7 @@ bool CGUIDialogSelectGameClient::Install(const std::string& gameClient)
   {
     ADDON::AddonPtr installedAddon;
     bInstalled = ADDON::CAddonInstaller::GetInstance().InstallModal(
-        gameClient, installedAddon, ADDON::InstallModalPrompt::NO_PROMPT);
+        gameClient, installedAddon, ADDON::InstallModalPrompt::CHOICE_NO);
     if (!bInstalled)
     {
       CLog::Log(LOGERROR, "Select game client dialog: Failed to install {}", gameClient);

--- a/xbmc/games/dialogs/osd/DialogGameAdvancedSettings.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameAdvancedSettings.cpp
@@ -35,7 +35,8 @@ bool CDialogGameAdvancedSettings::OnMessage(CGUIMessage& message)
       {
         ADDON::AddonPtr addon;
         if (CServiceBroker::GetAddonMgr().GetAddon(gameSettingsHandle->GameClientID(), addon,
-                                                   ADDON::ADDON_GAMEDLL, ADDON::OnlyEnabled::YES))
+                                                   ADDON::ADDON_GAMEDLL,
+                                                   ADDON::OnlyEnabled::CHOICE_YES))
         {
           gameSettingsHandle.reset();
           CGUIDialogAddonSettings::ShowForAddon(addon);

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -199,7 +199,7 @@ std::string GetSoundSkinPath()
 
   ADDON::AddonPtr addon;
   if (!CServiceBroker::GetAddonMgr().GetAddon(value, addon, ADDON::ADDON_RESOURCE_UISOUNDS,
-                                              ADDON::OnlyEnabled::YES))
+                                              ADDON::OnlyEnabled::CHOICE_YES))
   {
     CLog::Log(LOGINFO, "Unknown sounds addon '{}'. Setting default sounds.", value);
     setting->Reset();

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -155,7 +155,7 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       if (!info.GetData3().empty())
       {
         bool success = CServiceBroker::GetAddonMgr().GetAddon(
-            info.GetData3(), addon, ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::YES);
+            info.GetData3(), addon, ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::CHOICE_YES);
         if (!success || !addon)
           break;
 
@@ -205,7 +205,7 @@ bool CAddonsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = false;
       ADDON::AddonPtr addon;
       if (CServiceBroker::GetAddonMgr().GetAddon(info.GetData3(), addon, ADDON::ADDON_UNKNOWN,
-                                                 ADDON::OnlyEnabled::YES))
+                                                 ADDON::OnlyEnabled::CHOICE_YES))
         value = !CServiceBroker::GetAddonMgr().IsAddonDisabled(info.GetData3());
       return true;
     }

--- a/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
@@ -55,7 +55,7 @@ bool CVisualisationGUIInfo::GetLabel(std::string& value, const CFileItem *item, 
       ADDON::AddonPtr addon;
       value = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION);
       if (CServiceBroker::GetAddonMgr().GetAddon(value, addon, ADDON::ADDON_UNKNOWN,
-                                                 ADDON::OnlyEnabled::YES) &&
+                                                 ADDON::OnlyEnabled::CHOICE_YES) &&
           addon)
       {
         value = addon->Name();

--- a/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
+++ b/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
@@ -47,7 +47,7 @@ void CGUIDialogNewJoystick::Process()
   // "New controller detected"
   // "A new controller has been detected. Configuration can be done at any time in "Settings ->
   // System Settings -> Input". Would you like to configure it now?"
-  if (ShowYesNoDialogText(CVariant{35011}, CVariant{35012}) == DialogResponse::YES)
+  if (ShowYesNoDialogText(CVariant{35011}, CVariant{35012}) == DialogResponse::CHOICE_YES)
   {
     CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_DIALOG_GAME_CONTROLLERS);
   }

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -53,7 +53,7 @@ static int InstallAddon(const std::vector<std::string>& params)
   const std::string& addonid = params[0];
 
   AddonPtr addon;
-  CAddonInstaller::GetInstance().InstallModal(addonid, addon, InstallModalPrompt::PROMPT);
+  CAddonInstaller::GetInstance().InstallModal(addonid, addon, InstallModalPrompt::CHOICE_YES);
 
   return 0;
 }
@@ -70,11 +70,12 @@ static int EnableAddon(const std::vector<std::string>& params)
     return -1;
 
   AddonPtr addon;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_UNKNOWN, OnlyEnabled::NO))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_UNKNOWN,
+                                              OnlyEnabled::CHOICE_NO))
     return -1;
 
   auto response = HELPERS::ShowYesNoDialogLines(CVariant{24076}, CVariant{24135}, CVariant{addon->Name()}, CVariant{24136});
-  if (response == DialogResponse::YES)
+  if (response == DialogResponse::CHOICE_YES)
     CServiceBroker::GetAddonMgr().EnableAddon(addonid);
 
   return 0;
@@ -117,7 +118,8 @@ static int RunAddon(const std::vector<std::string>& params)
     const std::string& addonid = params[0];
 
     AddonPtr addon;
-    if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_PLUGIN, OnlyEnabled::YES))
+    if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_PLUGIN,
+                                               OnlyEnabled::CHOICE_YES))
     {
       PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
       std::string urlParameters;
@@ -160,13 +162,13 @@ static int RunAddon(const std::vector<std::string>& params)
       CBuiltins::GetInstance().Execute(cmd);
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT,
-                                                    OnlyEnabled::YES) ||
+                                                    OnlyEnabled::CHOICE_YES) ||
              CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT_WEATHER,
-                                                    OnlyEnabled::YES) ||
+                                                    OnlyEnabled::CHOICE_YES) ||
              CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT_LYRICS,
-                                                    OnlyEnabled::YES) ||
+                                                    OnlyEnabled::CHOICE_YES) ||
              CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT_LIBRARY,
-                                                    OnlyEnabled::YES))
+                                                    OnlyEnabled::CHOICE_YES))
     {
       // Pass the script name (addonid) and all the parameters
       // (params[1] ... params[x]) separated by a comma to RunScript
@@ -174,7 +176,7 @@ static int RunAddon(const std::vector<std::string>& params)
           StringUtils::Format("RunScript({})", StringUtils::Join(params, ",")));
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_GAMEDLL,
-                                                    OnlyEnabled::YES))
+                                                    OnlyEnabled::CHOICE_YES))
     {
       CFileItem item;
 
@@ -236,17 +238,18 @@ static int RunScript(const std::vector<std::string>& params)
     AddonPtr addon;
     std::string scriptpath;
     // Test to see if the param is an addon ID
-    if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_UNKNOWN, OnlyEnabled::YES))
+    if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_UNKNOWN,
+                                               OnlyEnabled::CHOICE_YES))
     {
       //Get the correct extension point to run
       if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT,
-                                                 OnlyEnabled::YES) ||
+                                                 OnlyEnabled::CHOICE_YES) ||
           CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER,
-                                                 OnlyEnabled::YES) ||
+                                                 OnlyEnabled::CHOICE_YES) ||
           CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS,
-                                                 OnlyEnabled::YES) ||
+                                                 OnlyEnabled::CHOICE_YES) ||
           CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT_LIBRARY,
-                                                 OnlyEnabled::YES))
+                                                 OnlyEnabled::CHOICE_YES))
       {
         scriptpath = addon->LibPath();
       }
@@ -254,7 +257,7 @@ static int RunScript(const std::vector<std::string>& params)
       {
         // Run a random extension point (old behaviour).
         if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_UNKNOWN,
-                                                   OnlyEnabled::YES))
+                                                   OnlyEnabled::CHOICE_YES))
         {
           scriptpath = addon->LibPath();
           CLog::Log(LOGWARNING,
@@ -330,7 +333,8 @@ static int SetDefaultAddon(const std::vector<std::string>& params)
 static int AddonSettings(const std::vector<std::string>& params)
 {
   AddonPtr addon;
-  if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_UNKNOWN, OnlyEnabled::YES))
+  if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_UNKNOWN,
+                                             OnlyEnabled::CHOICE_YES))
     CGUIDialogAddonSettings::ShowForAddon(addon);
 
   return 0;
@@ -358,7 +362,8 @@ static int StopScript(const std::vector<std::string>& params)
   std::string scriptpath(params[0]);
   // Test to see if the param is an addon ID
   AddonPtr script;
-  if (CServiceBroker::GetAddonMgr().GetAddon(params[0], script, ADDON_UNKNOWN, OnlyEnabled::YES))
+  if (CServiceBroker::GetAddonMgr().GetAddon(params[0], script, ADDON_UNKNOWN,
+                                             OnlyEnabled::CHOICE_YES))
     scriptpath = script->LibPath();
   CScriptInvocationManager::GetInstance().Stop(scriptpath);
 

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -135,8 +135,8 @@ static int ExportLibrary(const std::vector<std::string>& params)
   else
   {
     HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20426}, CVariant{20428}, CVariant{20429});
-    cancelled = result == HELPERS::DialogResponse::CANCELLED;
-    singleFile = result != HELPERS::DialogResponse::YES;
+    cancelled = result == HELPERS::DialogResponse::CHOICE_CANCELLED;
+    singleFile = result != HELPERS::DialogResponse::CHOICE_YES;
   }
 
   if (cancelled)
@@ -149,8 +149,8 @@ static int ExportLibrary(const std::vector<std::string>& params)
     else
     {
       HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20430});
-      cancelled = result == HELPERS::DialogResponse::CANCELLED;
-      thumbs = result == HELPERS::DialogResponse::YES;
+      cancelled = result == HELPERS::DialogResponse::CHOICE_CANCELLED;
+      thumbs = result == HELPERS::DialogResponse::CHOICE_YES;
     }
   }
 
@@ -164,7 +164,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
     if (movieSetsInfoPath.empty())
     {
       auto result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{36301});
-      cancelled = result != HELPERS::DialogResponse::YES;
+      cancelled = result != HELPERS::DialogResponse::CHOICE_YES;
     }
   }
 
@@ -178,8 +178,8 @@ static int ExportLibrary(const std::vector<std::string>& params)
     else
     {
       HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20436});
-      cancelled = result == HELPERS::DialogResponse::CANCELLED;
-      actorThumbs = result == HELPERS::DialogResponse::YES;
+      cancelled = result == HELPERS::DialogResponse::CHOICE_CANCELLED;
+      actorThumbs = result == HELPERS::DialogResponse::CHOICE_YES;
     }
   }
 
@@ -193,8 +193,8 @@ static int ExportLibrary(const std::vector<std::string>& params)
     else
     {
       HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20431});
-      cancelled = result == HELPERS::DialogResponse::CANCELLED;
-      overwrite = result == HELPERS::DialogResponse::YES;
+      cancelled = result == HELPERS::DialogResponse::CHOICE_CANCELLED;
+      overwrite = result == HELPERS::DialogResponse::CHOICE_YES;
     }
   }
 

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -131,7 +131,8 @@ JSONRPC_STATUS CAddonsOperations::GetAddonDetails(const std::string &method, ITr
 {
   std::string id = parameterObject["addonid"].asString();
   AddonPtr addon;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON::ADDON_UNKNOWN, OnlyEnabled::NO) ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON::ADDON_UNKNOWN,
+                                              OnlyEnabled::CHOICE_NO) ||
       addon.get() == NULL || addon->Type() <= ADDON_UNKNOWN || addon->Type() >= ADDON_MAX)
     return InvalidParams;
 
@@ -145,7 +146,8 @@ JSONRPC_STATUS CAddonsOperations::SetAddonEnabled(const std::string &method, ITr
 {
   std::string id = parameterObject["addonid"].asString();
   AddonPtr addon;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON::ADDON_UNKNOWN, OnlyEnabled::NO) ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON::ADDON_UNKNOWN,
+                                              OnlyEnabled::CHOICE_NO) ||
       addon == nullptr || addon->Type() <= ADDON_UNKNOWN || addon->Type() >= ADDON_MAX)
     return InvalidParams;
 
@@ -175,7 +177,7 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITrans
 {
   std::string id = parameterObject["addonid"].asString();
   AddonPtr addon;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON_UNKNOWN, OnlyEnabled::YES) ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON_UNKNOWN, OnlyEnabled::CHOICE_YES) ||
       addon.get() == NULL || addon->Type() < ADDON_VIZ || addon->Type() >= ADDON_MAX)
     return InvalidParams;
 

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -136,7 +136,7 @@ JSONRPC_STATUS CGUIOperations::GetPropertyValue(const std::string &property, CVa
   {
     std::string skinId = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN);
     AddonPtr addon;
-    if (!CServiceBroker::GetAddonMgr().GetAddon(skinId, addon, ADDON_SKIN, OnlyEnabled::YES))
+    if (!CServiceBroker::GetAddonMgr().GetAddon(skinId, addon, ADDON_SKIN, OnlyEnabled::CHOICE_YES))
       return InternalError;
 
     result["id"] = skinId;

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -64,7 +64,7 @@ namespace XBMCAddon
                              "wasn't executed in a normal Kodi manner.");
 
       if (!CServiceBroker::GetAddonMgr().GetAddon(id.c_str(), pAddon, ADDON_UNKNOWN,
-                                                  OnlyEnabled::YES))
+                                                  OnlyEnabled::CHOICE_YES))
         throw AddonException("Unknown addon id '%s'.", id.c_str());
 
       CServiceBroker::GetAddonMgr().AddToUpdateableAddons(pAddon);

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -724,7 +724,7 @@ void CPythonInvoker::getAddonModuleDeps(const ADDON::AddonPtr& addon, std::set<s
     //Check if dependency is a module addon
     ADDON::AddonPtr dependency;
     if (CServiceBroker::GetAddonMgr().GetAddon(it.id, dependency, ADDON::ADDON_SCRIPT_MODULE,
-                                               ADDON::OnlyEnabled::YES))
+                                               ADDON::OnlyEnabled::CHOICE_YES))
     {
       std::string path = CSpecialProtocol::TranslatePath(dependency->LibPath());
       if (paths.find(path) == paths.end())

--- a/xbmc/messaging/helpers/DialogHelper.cpp
+++ b/xbmc/messaging/helpers/DialogHelper.cpp
@@ -38,20 +38,20 @@ DialogResponse ShowYesNoCustomDialog(CVariant heading, CVariant text, CVariant n
   switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
   {
   case -1:
-    return DialogResponse::CANCELLED;
+    return DialogResponse::CHOICE_CANCELLED;
   case 0:
-    return DialogResponse::NO;
+    return DialogResponse::CHOICE_NO;
   case 1:
-    return DialogResponse::YES;
+    return DialogResponse::CHOICE_YES;
   case 2:
-    return DialogResponse::CUSTOM;
+    return DialogResponse::CHOICE_CUSTOM;
   default:
     //If we get here someone changed the return values without updating this code
     assert(false);
   }
   //This is unreachable code but we need to return something to suppress warnings about
   //no return
-  return DialogResponse::CANCELLED;
+  return DialogResponse::CHOICE_CANCELLED;
 }
 
 DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant line1, CVariant line2,
@@ -70,20 +70,20 @@ DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant l
   switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
   {
   case -1:
-    return DialogResponse::CANCELLED;
+    return DialogResponse::CHOICE_CANCELLED;
   case 0:
-    return DialogResponse::NO;
+    return DialogResponse::CHOICE_NO;
   case 1:
-    return DialogResponse::YES;
+    return DialogResponse::CHOICE_YES;
   case 2:
-    return DialogResponse::CUSTOM;
+    return DialogResponse::CHOICE_CUSTOM;
   default:
     //If we get here someone changed the return values without updating this code
     assert(false);
   }
   //This is unreachable code but we need to return something to suppress warnings about
   //no return
-  return DialogResponse::CANCELLED;
+  return DialogResponse::CHOICE_CANCELLED;
 }
 
 }

--- a/xbmc/messaging/helpers/DialogHelper.h
+++ b/xbmc/messaging/helpers/DialogHelper.h
@@ -20,12 +20,12 @@ namespace MESSAGING
 namespace HELPERS
 {
 
-enum class DialogResponse
+enum class DialogResponse : int
 {
-  CANCELLED,
-  YES,
-  NO,
-  CUSTOM
+  CHOICE_CANCELLED,
+  CHOICE_YES,
+  CHOICE_NO,
+  CHOICE_CUSTOM,
 };
 
 /*! \struct DialogYesNoMessage DialogHelper.h "messaging/helpers/DialogHelper.h"

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4810,7 +4810,7 @@ void CMusicDatabase::Clean()
     return;
   }
 
-  if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
+  if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::CHOICE_YES)
   {
     CMusicDatabase musicdatabase;
     if (musicdatabase.Open())
@@ -11594,7 +11594,7 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE& content, ADDON::Scra
       ADDON::AddonPtr addon;
       if (!scraperUUID.empty() &&
           CServiceBroker::GetAddonMgr().GetAddon(scraperUUID, addon, ADDON::ADDON_UNKNOWN,
-                                                 ADDON::OnlyEnabled::YES) &&
+                                                 ADDON::OnlyEnabled::CHOICE_YES) &&
           addon)
       {
         scraper = std::dynamic_pointer_cast<ADDON::CScraper>(addon);

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -180,7 +180,7 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
     {
       AddonPtr scraperAddon;
       if (CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon, ADDON_UNKNOWN,
-                                                 OnlyEnabled::YES))
+                                                 OnlyEnabled::CHOICE_YES))
       {
         m_albumscraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
         SetupView();
@@ -205,7 +205,7 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
     {
       AddonPtr scraperAddon;
       if (CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon, ADDON_UNKNOWN,
-                                                 OnlyEnabled::YES))
+                                                 OnlyEnabled::CHOICE_YES))
       {
         m_artistscraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
         SetupView();

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1233,15 +1233,15 @@ void CGUIWindowMusicBase::OnAssignContent(const std::string& oldName, const CMed
 
   // "Add to library" yes/no dialog with additional "settings" custom button
   // "Do you want to add the media from this source to your library?"
-  DialogResponse rep = DialogResponse::CUSTOM;
-  while (rep == DialogResponse::CUSTOM)
+  DialogResponse rep = DialogResponse::CHOICE_CUSTOM;
+  while (rep == DialogResponse::CHOICE_CUSTOM)
   {
     rep = HELPERS::ShowYesNoCustomDialog(CVariant{20444}, CVariant{20447}, CVariant{106}, CVariant{107}, CVariant{10004});
-    if (rep == DialogResponse::CUSTOM)
+    if (rep == DialogResponse::CHOICE_CUSTOM)
       // Edit default info provider settings so can be applied during scan
       CGUIDialogInfoProviderSettings::Show();
   }
-  if (rep == DialogResponse::YES)
+  if (rep == DialogResponse::CHOICE_YES)
     CMusicLibraryQueue::GetInstance().ScanLibrary(source.strPath,
                                                   MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL, true);
 }

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -189,7 +189,7 @@ bool CNetworkServices::OnSettingChanging(const std::shared_ptr<const CSetting>& 
       (!m_settings->GetBool(CSettings::SETTING_SERVICES_WEBSERVER) ||
        (m_settings->GetBool(CSettings::SETTING_SERVICES_WEBSERVER) &&
         !m_settings->GetString(CSettings::SETTING_SERVICES_WEBSERVERPASSWORD).empty())) &&
-      HELPERS::ShowYesNoDialogText(19098, 36634) != DialogResponse::YES)
+      HELPERS::ShowYesNoDialogText(19098, 36634) != DialogResponse::CHOICE_YES)
   {
     // Leave it as-is
     return false;
@@ -227,7 +227,7 @@ bool CNetworkServices::OnSettingChanging(const std::shared_ptr<const CSetting>& 
 
       // Ask for confirmation when enabling the web server
       if (settingId == CSettings::SETTING_SERVICES_WEBSERVER &&
-          HELPERS::ShowYesNoDialogText(19098, 36632) != DialogResponse::YES)
+          HELPERS::ShowYesNoDialogText(19098, 36632) != DialogResponse::CHOICE_YES)
       {
         // Revert change, do not start server
         return false;
@@ -438,7 +438,7 @@ bool CNetworkServices::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   else if (settingId == CSettings::SETTING_SERVICES_ESALLINTERFACES)
   {
     if (m_settings->GetBool(CSettings::SETTING_SERVICES_ESALLINTERFACES) &&
-        HELPERS::ShowYesNoDialogText(19098, 36633) != DialogResponse::YES)
+        HELPERS::ShowYesNoDialogText(19098, 36633) != DialogResponse::CHOICE_YES)
     {
       // Revert change, do not start server
       return false;
@@ -506,7 +506,8 @@ void CNetworkServices::OnSettingChanged(const std::shared_ptr<const CSetting>& s
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     //! @todo - General way of handling setting changes that require restart
-    if (HELPERS::ShowYesNoDialogText(CVariant{14038}, CVariant{14039}) == DialogResponse::YES)
+    if (HELPERS::ShowYesNoDialogText(CVariant{14038}, CVariant{14039}) ==
+        DialogResponse::CHOICE_YES)
     {
       m_settings->Save();
       CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTARTAPP);
@@ -940,8 +941,8 @@ bool CNetworkServices::StopEventServer(bool bWait, bool promptuser)
   {
     if (server->GetNumberOfClients() > 0)
     {
-      if (HELPERS::ShowYesNoDialogText(CVariant{13140}, CVariant{13141}, CVariant{""}, CVariant{""}, 10000) !=
-        DialogResponse::YES)
+      if (HELPERS::ShowYesNoDialogText(CVariant{13140}, CVariant{13141}, CVariant{""}, CVariant{""},
+                                       10000) != DialogResponse::CHOICE_YES)
       {
         CLog::Log(LOGINFO, "ES: Not stopping event server");
         return false;

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -91,7 +91,7 @@ bool CHTTPWebinterfaceHandler::ResolveAddon(const std::string &url, ADDON::Addon
       return false;
 
     if (!CServiceBroker::GetAddonMgr().GetAddon(components.at(1), addon, ADDON::ADDON_UNKNOWN,
-                                                ADDON::OnlyEnabled::YES) ||
+                                                ADDON::OnlyEnabled::CHOICE_YES) ||
         addon == NULL)
       return false;
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -603,7 +603,8 @@ bool CUPnPPlayer::OnAction(const CAction &action)
       if(IsPlaying())
       {
         //stop on remote system
-        m_stopremote = HELPERS::ShowYesNoDialogText(CVariant{37022}, CVariant{37023}) == DialogResponse::YES;
+        m_stopremote = HELPERS::ShowYesNoDialogText(CVariant{37022}, CVariant{37023}) ==
+                       DialogResponse::CHOICE_YES;
 
         return false; /* let normal code handle the action */
       }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -975,7 +975,7 @@ void CPeripherals::OnSettingAction(const std::shared_ptr<const CSetting>& settin
     {
       ADDON::AddonPtr addon;
       if (CServiceBroker::GetAddonMgr().GetAddon(strAddonId, addon, ADDON::ADDON_UNKNOWN,
-                                                 ADDON::OnlyEnabled::YES))
+                                                 ADDON::OnlyEnabled::CHOICE_YES))
         CGUIDialogAddonSettings::ShowForAddon(addon);
     }
   }

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -482,7 +482,8 @@ void CPeripheralBusAddon::PromptEnableAddons(const std::vector<ADDON::AddonInfoP
   {
     // "Unable to configure controllers"
     // "Controller configuration depends on a disabled add-on. Would you like to enable it?"
-    bAccepted = (ShowYesNoDialogLines(CVariant{35017}, CVariant{35018}) == DialogResponse::YES);
+    bAccepted =
+        (ShowYesNoDialogLines(CVariant{35017}, CVariant{35018}) == DialogResponse::CHOICE_YES);
   }
 
   if (bAccepted)

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -136,7 +136,7 @@ bool CGUIDialogPVRRecordingSettings::OnSettingChanging(
               CVariant{19068}, // "Recording settings"
               StringUtils::Format(g_localizeStrings.Get(19147),
                                   iNewLifetime)) // "Setting the lifetime..."
-          != HELPERS::DialogResponse::YES)
+          != HELPERS::DialogResponse::CHOICE_YES)
         return false;
     }
   }

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -950,9 +950,11 @@ namespace PVR
       case TimerOperationResult::RECORDING:
       {
         // recording running. ask the user if it should be deleted anyway
-        if (HELPERS::ShowYesNoDialogText(CVariant{122},   // "Confirm delete"
-                                         CVariant{19122}) // "This timer is still recording. Are you sure you want to delete this timer?"
-            != HELPERS::DialogResponse::YES)
+        if (HELPERS::ShowYesNoDialogText(
+                CVariant{122}, // "Confirm delete"
+                CVariant{
+                    19122}) // "This timer is still recording. Are you sure you want to delete this timer?"
+            != HELPERS::DialogResponse::CHOICE_YES)
           return false;
 
         return DeleteTimer(timer, true, bDeleteRule);
@@ -2168,12 +2170,12 @@ namespace PVR
           }
 
           // Inform user about PVR being busy. Ask if user wants to powerdown anyway.
-          bReturn = HELPERS::ShowYesNoDialogText(CVariant{19685}, // "Confirm shutdown"
-                                                 CVariant{text},
-                                                 CVariant{222}, // "Shutdown anyway",
-                                                 CVariant{19696}, // "Cancel"
-                                                 10000) // timeout value before closing
-                    == HELPERS::DialogResponse::YES;
+          bReturn =
+              HELPERS::ShowYesNoDialogText(CVariant{19685}, // "Confirm shutdown"
+                                           CVariant{text}, CVariant{222}, // "Shutdown anyway",
+                                           CVariant{19696}, // "Cancel"
+                                           10000) // timeout value before closing
+              == HELPERS::DialogResponse::CHOICE_YES;
         }
         else
           bReturn = false; // do not powerdown (busy, but no user interaction requested).

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -486,9 +486,9 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                             HELPERS::ShowYesNoDialogText(CVariant{19096}, // "Smart select"
                                                          CVariant{iTextID}, CVariant{iNoButtonID},
                                                          CVariant{19165}); // Yes => "Switch"
-                        if (ret == HELPERS::DialogResponse::NO)
+                        if (ret == HELPERS::DialogResponse::CHOICE_NO)
                           CServiceBroker::GetPVRManager().GUIActions()->AddTimer(pItem, false);
-                        else if (ret == HELPERS::DialogResponse::YES)
+                        else if (ret == HELPERS::DialogResponse::CHOICE_YES)
                           CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(pItem, true);
                       }
                     }

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -290,8 +290,8 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
     {
       if (!m_resolutionChangeAborted)
       {
-        if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""}, CVariant{""}, 15000) !=
-          DialogResponse::YES)
+        if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""},
+                                         CVariant{""}, 15000) != DialogResponse::CHOICE_YES)
         {
           m_resolutionChangeAborted = true;
           return false;
@@ -311,8 +311,8 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
 
     if (!m_resolutionChangeAborted)
     {
-      if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""}, CVariant{""}, 10000) !=
-        DialogResponse::YES)
+      if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""}, CVariant{""},
+                                       10000) != DialogResponse::CHOICE_YES)
       {
         m_resolutionChangeAborted = true;
         return false;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -301,7 +301,7 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   const std::string &settingId = setting->GetId();
   if (settingId == CSettings::SETTING_MUSICLIBRARY_CLEANUP)
   {
-    if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
+    if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::CHOICE_YES)
     {
       if (!CMusicLibraryQueue::GetInstance().IsRunning())
         CMusicLibraryQueue::GetInstance().CleanLibrary(true);
@@ -332,7 +332,7 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   }
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_CLEANUP)
   {
-    if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
+    if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::CHOICE_YES)
     {
       if (!CVideoLibraryQueue::GetInstance().IsRunning())
         CVideoLibraryQueue::GetInstance().CleanLibraryModal();

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -41,8 +41,9 @@ bool AddonHasSettings(const std::string& condition,
     return false;
 
   ADDON::AddonPtr addon;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(
-          settingAddon->GetValue(), addon, settingAddon->GetAddonType(), ADDON::OnlyEnabled::YES) ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(settingAddon->GetValue(), addon,
+                                              settingAddon->GetAddonType(),
+                                              ADDON::OnlyEnabled::CHOICE_YES) ||
       addon == NULL)
     return false;
 

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -248,8 +248,8 @@ void CGUIDialogContentSettings::OnSettingAction(const std::shared_ptr<const CSet
         && selectedAddonId != currentScraperId)
     {
       AddonPtr scraperAddon;
-      if (CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon,
-                                                 ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::YES))
+      if (CServiceBroker::GetAddonMgr().GetAddon(
+              selectedAddonId, scraperAddon, ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::CHOICE_YES))
       {
         m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
         SetupView();

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -211,7 +211,7 @@ void CGUIDialogLibExportSettings::OnOK()
     {
       //"Unable to export to library folders as the system artist information folder setting is empty"
       //Settings (YES) button takes user to enter the artist info folder setting
-      if (HELPERS::ShowYesNoDialogText(20223, 38317, 186, 10004) == DialogResponse::YES)
+      if (HELPERS::ShowYesNoDialogText(20223, 38317, 186, 10004) == DialogResponse::CHOICE_YES)
       {
         m_confirmed = false;
         Close();

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -1089,7 +1089,7 @@ void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
             {
               ADDON::AddonPtr addon;
               if (CServiceBroker::GetAddonMgr().GetAddon(addonID, addon, ADDON::ADDON_UNKNOWN,
-                                                         ADDON::OnlyEnabled::YES))
+                                                         ADDON::OnlyEnabled::CHOICE_YES))
                 addonNames.push_back(addon->Name());
             }
 

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -66,10 +66,10 @@ void CRssManager::OnSettingAction(const std::shared_ptr<const CSetting>& setting
   {
     ADDON::AddonPtr addon;
     if (!CServiceBroker::GetAddonMgr().GetAddon("script.rss.editor", addon, ADDON::ADDON_UNKNOWN,
-                                                ADDON::OnlyEnabled::YES))
+                                                ADDON::OnlyEnabled::CHOICE_YES))
     {
-      if (!ADDON::CAddonInstaller::GetInstance().InstallModal("script.rss.editor", addon,
-                                                              ADDON::InstallModalPrompt::PROMPT))
+      if (!ADDON::CAddonInstaller::GetInstance().InstallModal(
+              "script.rss.editor", addon, ADDON::InstallModalPrompt::CHOICE_YES))
         return;
     }
     CBuiltins::GetInstance().Execute("RunScript(script.rss.editor)");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8082,7 +8082,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath, SScanSe
       AddonPtr addon;
       if (!scraperID.empty() &&
           CServiceBroker::GetAddonMgr().GetAddon(scraperID, addon, ADDON::ADDON_UNKNOWN,
-                                                 ADDON::OnlyEnabled::YES))
+                                                 ADDON::OnlyEnabled::CHOICE_YES))
       {
         scraper = std::dynamic_pointer_cast<CScraper>(addon);
         if (!scraper)
@@ -8130,7 +8130,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath, SScanSe
           AddonPtr addon;
           if (content != CONTENT_NONE && CServiceBroker::GetAddonMgr().GetAddon(
                                              m_pDS->fv("path.strScraper").get_asString(), addon,
-                                             ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::YES))
+                                             ADDON::ADDON_UNKNOWN, ADDON::OnlyEnabled::CHOICE_YES))
           {
             scraper = std::dynamic_pointer_cast<CScraper>(addon);
             scraper->SetPathSettings(content, m_pDS->fv("path.strSettings").get_asString());
@@ -10434,7 +10434,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         std::string id;
         XMLUtils::GetString(path,"scraperpath",id);
         if (CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON::ADDON_UNKNOWN,
-                                                   ADDON::OnlyEnabled::YES))
+                                                   ADDON::OnlyEnabled::CHOICE_YES))
         {
           SScanSettings settings;
           ScraperPtr scraper = std::dynamic_pointer_cast<CScraper>(addon);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2166,7 +2166,8 @@ namespace VIDEO
       HELPERS::ShowOKDialogText(CVariant{20448}, CVariant{20449});
       return false;
     }
-    return HELPERS::ShowYesNoDialogText(CVariant{20448}, CVariant{20450}) == DialogResponse::YES;
+    return HELPERS::ShowYesNoDialogText(CVariant{20448}, CVariant{20450}) ==
+           DialogResponse::CHOICE_YES;
   }
 
   bool CVideoInfoScanner::ProgressCancelled(CGUIDialogProgress* progress, int heading, const std::string &line1)

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -425,7 +425,7 @@ void CGUIDialogSubtitles::OnSubtitleServiceContextMenu(int itemIdx)
     {
       AddonPtr addon;
       if (CServiceBroker::GetAddonMgr().GetAddon(service->GetProperty("Addon.ID").asString(), addon,
-                                                 ADDON_SUBTITLE_MODULE, OnlyEnabled::YES))
+                                                 ADDON_SUBTITLE_MODULE, OnlyEnabled::CHOICE_YES))
       {
         CGUIDialogAddonSettings::ShowForAddon(addon);
       }

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -598,7 +598,7 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
     CURL url(items.GetPath());
     AddonPtr addon;
     if (CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN,
-                                               OnlyEnabled::YES))
+                                               OnlyEnabled::CHOICE_YES))
     {
       PluginPtr plugin = std::static_pointer_cast<CPluginSource>(addon);
       if (plugin->Provides(CPluginSource::AUDIO))

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -53,7 +53,7 @@ bool CWeatherJob::DoWork()
   if (!CServiceBroker::GetAddonMgr().GetAddon(
           CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
               CSettings::SETTING_WEATHER_ADDON),
-          addon, ADDON_SCRIPT_WEATHER, OnlyEnabled::YES))
+          addon, ADDON_SCRIPT_WEATHER, OnlyEnabled::CHOICE_YES))
     return false;
 
   // initialize our sys.argv variables

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -177,7 +177,7 @@ void CWeatherManager::OnSettingAction(const std::shared_ptr<const CSetting>& set
     if (CServiceBroker::GetAddonMgr().GetAddon(
             CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
                 CSettings::SETTING_WEATHER_ADDON),
-            addon, ADDON_SCRIPT_WEATHER, OnlyEnabled::YES) &&
+            addon, ADDON_SCRIPT_WEATHER, OnlyEnabled::CHOICE_YES) &&
         addon != NULL)
     { //! @todo maybe have ShowAndGetInput return a bool if settings changed, then only reset weather if true.
       CGUIDialogAddonSettings::ShowForAddon(addon);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1052,7 +1052,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     CURL url(pItem->GetPath());
     AddonPtr addon;
     if (CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_SCRIPT,
-                                               OnlyEnabled::YES))
+                                               OnlyEnabled::CHOICE_YES))
     {
       if (!CScriptInvocationManager::GetInstance().Stop(addon->LibPath()))
       {
@@ -1156,7 +1156,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
       CURL url(m_vecItems->GetPath());
       AddonPtr addon;
       if (CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_UNKNOWN,
-                                                 OnlyEnabled::YES))
+                                                 OnlyEnabled::CHOICE_YES))
       {
         PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
         if (plugin && plugin->Provides(CPluginSource::AUDIO))

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -38,7 +38,7 @@ void CGUIWindowScreensaverDim::UpdateVisibility()
       m_visible = true;
       ADDON::AddonPtr info;
       bool success = CServiceBroker::GetAddonMgr().GetAddon(usedId, info, ADDON::ADDON_SCREENSAVER,
-                                                            ADDON::OnlyEnabled::YES);
+                                                            ADDON::OnlyEnabled::CHOICE_YES);
       if (success && info && !info->GetSetting("level").empty())
         m_newDimLevel = 100.0f - (float)atof(info->GetSetting("level").c_str());
       else


### PR DESCRIPTION
## Description
identifiers `YES` and `NO` are perfect candidates for name clashes.
they're bulk changed to `Y` and `N`

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
