### PR TITLE
[cleanup] change indentifiers YES and NO to CHOICE_YES and CHOICE_NO …

### DIFF
--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -37,7 +37,7 @@ bool CAddonRepos::IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon,
                                      CheckAddonPath checkAddonPath)
 {
   auto comparator = [&](const RepoInfo& officialRepo) {
-    if (checkAddonPath == CheckAddonPath::YES)
+    if (checkAddonPath == CheckAddonPath::CHOICE_YES)
     {
       return (addon->Origin() == officialRepo.m_repoId &&
               StringUtils::StartsWithNoCase(addon->Path(), officialRepo.m_origin));
@@ -138,7 +138,7 @@ void CAddonRepos::SetupLatestVersionMaps()
     {
       const auto& addonToAdd = addonMapEntry.second;
 
-      if (IsFromOfficialRepo(addonToAdd, CheckAddonPath::YES))
+      if (IsFromOfficialRepo(addonToAdd, CheckAddonPath::CHOICE_YES))
       {
         AddAddonIfLatest(addonToAdd, m_latestOfficialVersions);
       }
@@ -239,7 +239,7 @@ bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
     if (ORIGIN_SYSTEM != addon->Origin() && !hasOfficialUpdate) // not a system addon
     {
       // If we didn't find an official update
-      if (IsFromOfficialRepo(addon, CheckAddonPath::YES)) // is an official addon
+      if (IsFromOfficialRepo(addon, CheckAddonPath::CHOICE_YES)) // is an official addon
       {
         if (updateMode == AddonRepoUpdateMode::ANY_REPOSITORY)
         {
@@ -498,7 +498,7 @@ void CAddonRepos::BuildCompatibleVersionsList(
   {
     if (m_addonMgr.IsCompatible(*addon))
     {
-      if (IsFromOfficialRepo(addon, CheckAddonPath::YES))
+      if (IsFromOfficialRepo(addon, CheckAddonPath::CHOICE_YES))
       {
         officialVersions.emplace_back(addon);
       }

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -25,8 +25,8 @@ enum class AddonCheckType : bool;
 
 enum class CheckAddonPath
 {
-  YES,
-  NO,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
 /**
@@ -104,7 +104,7 @@ public:
    *        is matching
    * \note if this function is called on locally installed add-ons, for instance when populating
    *       'My add-ons', the local installation path is returned as origin.
-   *       thus parameter CheckAddonPath::NO needs to be passed in such cases
+   *       thus parameter CheckAddonPath::CHOICE_NO needs to be passed in such cases
    * \param addon pointer to addon to be checked
    * \param checkAddonPath also check origin path
    * \return true if the repository id of a given addon is defined as official

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -118,7 +118,7 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTN_DEPENDENCIES)
       {
-        ShowDependencyList(Reactivate::YES, EntryPoint::SHOW_DEPENDENCIES);
+        ShowDependencyList(Reactivate::CHOICE_YES, EntryPoint::SHOW_DEPENDENCIES);
         return true;
       }
       else if (iControl == CONTROL_BTN_AUTOUPDATE)
@@ -166,7 +166,7 @@ void CGUIDialogAddonInfo::OnInitWindow()
 {
   CGUIDialog::OnInitWindow();
   BuildDependencyList();
-  UpdateControls(PerformButtonFocus::YES);
+  UpdateControls(PerformButtonFocus::CHOICE_YES);
 }
 
 void CGUIDialogAddonInfo::UpdateControls(PerformButtonFocus performButtonFocus)
@@ -208,7 +208,7 @@ void CGUIDialogAddonInfo::UpdateControls(PerformButtonFocus performButtonFocus)
     }
 
     CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_INSTALL, canInstall);
-    if (canInstall && performButtonFocus == PerformButtonFocus::YES)
+    if (canInstall && performButtonFocus == PerformButtonFocus::CHOICE_YES)
     {
       SET_CONTROL_FOCUS(CONTROL_BTN_INSTALL, 0);
     }
@@ -261,7 +261,8 @@ void CGUIDialogAddonInfo::UpdateControls(PerformButtonFocus performButtonFocus)
   SET_CONTROL_LABEL(CONTROL_BTN_SELECT, label);
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_SETTINGS, isInstalled && m_localAddon->HasSettings());
-  if (isInstalled && m_localAddon->HasSettings() && performButtonFocus == PerformButtonFocus::YES)
+  if (isInstalled && m_localAddon->HasSettings() &&
+      performButtonFocus == PerformButtonFocus::CHOICE_YES)
   {
     SET_CONTROL_FOCUS(CONTROL_BTN_SETTINGS, 0);
   }
@@ -328,7 +329,7 @@ void CGUIDialogAddonInfo::OnUpdate()
 
   Close();
   if (!m_depsInstalledWithAvailable.empty() &&
-      !ShowDependencyList(Reactivate::NO, EntryPoint::UPDATE))
+      !ShowDependencyList(Reactivate::CHOICE_NO, EntryPoint::UPDATE))
     return;
 
   CAddonInstaller::GetInstance().Install(addonId, version, origin);
@@ -403,7 +404,7 @@ void CGUIDialogAddonInfo::OnSelectVersion()
       else
       {
         if (!m_depsInstalledWithAvailable.empty() &&
-            !ShowDependencyList(Reactivate::NO, entryPoint))
+            !ShowDependencyList(Reactivate::CHOICE_NO, entryPoint))
           return;
         CAddonInstaller::GetInstance().Install(processAddonId, versions[i].first,
                                                versions[i].second);
@@ -481,7 +482,7 @@ void CGUIDialogAddonInfo::OnInstall()
 
   Close();
   if (!m_depsInstalledWithAvailable.empty() &&
-      !ShowDependencyList(Reactivate::NO, EntryPoint::INSTALL))
+      !ShowDependencyList(Reactivate::CHOICE_NO, EntryPoint::INSTALL))
     return;
 
   CAddonInstaller::GetInstance().Install(addonId, version, origin);
@@ -618,7 +619,7 @@ void CGUIDialogAddonInfo::OnEnableDisable()
     CServiceBroker::GetAddonMgr().EnableAddon(m_localAddon->ID());
   }
 
-  UpdateControls(PerformButtonFocus::NO);
+  UpdateControls(PerformButtonFocus::CHOICE_NO);
 }
 
 void CGUIDialogAddonInfo::OnSettings()
@@ -680,7 +681,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
 
           if (entryPoint == EntryPoint::SHOW_DEPENDENCIES ||
               infoAddon->MainType() != ADDON_SCRIPT_MODULE ||
-              !CAddonRepos::IsFromOfficialRepo(infoAddon, CheckAddonPath::NO))
+              !CAddonRepos::IsFromOfficialRepo(infoAddon, CheckAddonPath::CHOICE_NO))
           {
             item->SetLabel2(StringUtils::Format(
                 g_localizeStrings.Get(messageId), it.m_depInfo.versionMin.asString(),
@@ -708,11 +709,11 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
       while (true)
       {
         pDialog->Reset();
-        pDialog->SetHeading(reactivate == Reactivate::YES ? 39024 : 39020);
+        pDialog->SetHeading(reactivate == Reactivate::CHOICE_YES ? 39024 : 39020);
         pDialog->SetUseDetails(true);
         for (auto& it : items)
           pDialog->Add(*it);
-        pDialog->EnableButton(reactivate == Reactivate::NO, 186);
+        pDialog->EnableButton(reactivate == Reactivate::CHOICE_NO, 186);
         pDialog->SetButtonFocus(true);
         pDialog->Open();
 
@@ -734,7 +735,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
           break;
       }
       SetItem(backup_item);
-      if (reactivate == Reactivate::YES)
+      if (reactivate == Reactivate::CHOICE_YES)
         Open();
 
       return false;
@@ -859,7 +860,7 @@ void CGUIDialogAddonInfo::BuildDependencyList()
       // - the dependency is not a script/module                     OR
       // - the script/module is not available at an official repo
       if (!addonAvailable || addonAvailable->MainType() != ADDON_SCRIPT_MODULE ||
-          !CAddonRepos::IsFromOfficialRepo(addonAvailable, CheckAddonPath::NO))
+          !CAddonRepos::IsFromOfficialRepo(addonAvailable, CheckAddonPath::CHOICE_NO))
       {
         m_showDepDialogOnInstall = true;
       }

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -16,19 +16,19 @@
 #include <utility>
 #include <vector>
 
-enum class Reactivate
+enum class Reactivate : bool
 {
-  YES,
-  NO,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
-enum class PerformButtonFocus
+enum class PerformButtonFocus : bool
 {
-  YES,
-  NO,
+  CHOICE_YES = true,
+  CHOICE_NO = false,
 };
 
-enum class EntryPoint
+enum class EntryPoint : int
 {
   INSTALL,
   UPDATE,

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -819,7 +819,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
       validUpdateOrigin = mapEntry->second.m_update->Origin();
     }
 
-    bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon, CheckAddonPath::NO);
+    bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon, CheckAddonPath::CHOICE_NO);
 
     pItem->SetProperty("Addon.IsInstalled", installed);
     pItem->SetProperty("Addon.IsEnabled", installed && !disabled);


### PR DESCRIPTION
…(Part 2)

follow up to https://github.com/xbmc/xbmc/pull/20918

## Motivation and context
missed  a few in round 1

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
