### PR TITLE
[GUI] Allow skinners to define custom dialogs with modal type modality

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1316,8 +1316,16 @@ bool CApplication::LoadCustomWindows()
 
           if (StringUtils::EqualsNoCase(strType, "dialog"))
           {
+            DialogModalityType modality = DialogModalityType::MODAL;
             hasVisibleCondition = pRootElement->FirstChildElement("visible") != nullptr;
-            pWindow = new CGUIDialog(windowId, skinFile);
+            // By default dialogs that have visible conditions are considered modeless unless explicitly
+            // set to "modal" by the skinner using the "modality" attribute in the root XML element of the window
+            if (hasVisibleCondition &&
+                (!pRootElement->Attribute("modality") ||
+                 !StringUtils::EqualsNoCase(pRootElement->Attribute("modality"), "modal")))
+              modality = DialogModalityType::MODELESS;
+
+            pWindow = new CGUIDialog(windowId, skinFile, modality);
           }
           else if (StringUtils::EqualsNoCase(strType, "submenu"))
           {

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -38,16 +38,7 @@ CGUIDialog::~CGUIDialog(void) = default;
 
 bool CGUIDialog::Load(TiXmlElement* pRootElement)
 {
-  bool retVal = CGUIWindow::Load(pRootElement);
-
-  if (retVal && IsCustom())
-  {
-    // custom dialog's modality type is modeless if visible condition is specified.
-    if (m_visibleCondition)
-      m_modalityType = DialogModalityType::MODELESS;
-  }
-
-  return retVal;
+  return CGUIWindow::Load(pRootElement);
 }
 
 void CGUIDialog::OnWindowLoaded()


### PR DESCRIPTION
## Description
Unfortunately, at the moment, any custom dialog whose visibility depends on some sort of visible condition is automatically set as modeless. If the dialog is modeless it can no longer catch input - any keystroke is automatically piped to the underlying window.
As part of my work on the intro/outro extension for EDL I need a way to show a button on top of the video OSD that depend on intolabels/visible conditions and that users are able to click to jump into the end of the intro/outro. This is not possible with the current implementation.

This PR allows skinners to define `modality=modal` as an attribute of the root element in the dialog definition to be able to set the modality of the dialog. If the dialog has a visible condition and the "modality" attribute is either not defined or not equal to "modal" the dialog continues to be modeless - thus retaining the same behaviour as before.

This has been tested by creating the following custom window in the estuary xml directory:

**Custom_1114_HitMe.xml**
```xml
<?xml version="1.0" encoding="utf-8"?>
<window type="dialog" id="1114" modality="modal">
	<visible>Window.IsActive(fullscreenvideo) + Player.Playing + !Window.IsActive(1109) + !Window.IsActive(videoosd) + !Integer.IsEqual(Window(home).Property(hitclicked),1)</visible>
	<include>Animation_BottomSlide</include>
	<depth>DepthMax</depth>
	<zorder>0</zorder>
	<defaultcontrol always="true">1</defaultcontrol>
	<controls>
		<control type="group">
			<animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>
			 <control type="button" id="1">
				<description>Hit me if you can!</description>
				<width>auto</width>
				<bottom>150</bottom>
				<left>200</left>
				<height>110</height>
				<label>Hit me if you can!</label>
				<textoffsetx>40</textoffsetx>
				<onclick>Notification(Ouch, Ouch!)</onclick>
				<onclick>SetProperty(hitclicked,1,home)</onclick>
				<align>center</align>
				<texturefocus border="23" colordiffuse="button_focus">buttons/dialogbutton-fo.png</texturefocus>
				<texturenofocus border="40">buttons/dialogbutton-nofo.png</texturenofocus>
			</control>
		</control>
	</controls>
</window>
```
This will show a button for the first time kodi plays a file and steals the input from the videoOSD until it is clicked or closed.  Note this dialog is merely illustrative, that being the reason that it only works on first playback and after first click (intro/outro requires far more work/state).

![image](https://user-images.githubusercontent.com/7375276/151672707-643bc229-7bde-4be2-acb5-984e2019391c.png)

![image](https://user-images.githubusercontent.com/7375276/151672729-fad69d6f-661c-4a60-877c-9cf12260c947.png)

@ronie I'd appreciate a lot if you could give this a spin