### PR TITLE
[GUI] Fix hitrect when using auto-width for button controls

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -176,7 +176,7 @@ void CGUIButtonControl::ProcessText(unsigned int currentTime)
   // auto-width - adjust hitrect
   if (m_minWidth && m_width != renderWidth)
   {
-    CRect rect(m_posX, m_posY, renderWidth, m_height);
+    CRect rect{m_posX, m_posY, m_posX + renderWidth, m_posY + m_height};
     SetHitRect(rect, m_hitColor);
   }
 


### PR DESCRIPTION
## Description
This fixes an issue found while working on https://github.com/xbmc/xbmc/pull/20927. The button control on that window is never focused when using the mouse.
This happens because the calculation for the "hit area" is wrong. We are passing `height` and `width` as Rect x2, y2 coordinates when in fact we want to add `height` and `width` to the "origin" (x1, y1) coordinates :)
