### PR TITLE
changed: Always process RunAddon/RunScript/etc. like we also do for v…

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -684,7 +684,10 @@ bool CInputManager::AlwaysProcess(const CAction& action)
         builtInFunction == "suspend" || builtInFunction == "hibernate" ||
         builtInFunction == "quit" || builtInFunction == "shutdown" ||
         builtInFunction == "volumeup" || builtInFunction == "volumedown" ||
-        builtInFunction == "mute")
+        builtInFunction == "mute" || builtInFunction == "RunAppleScript" ||
+        builtInFunction == "RunAddon" || builtInFunction == "RunPlugin" ||
+        builtInFunction == "RunScript" || builtInFunction == "System.Exec" ||
+        builtInFunction == "System.ExecWait")
     {
       return true;
     }


### PR DESCRIPTION
…olume and power builtins in the input manager. This allows running eg. scripts/addons in the background from the inputmanager without interrupting the screensaver. Perhaps the list could be extended further (not sure)?....
