### PR TITLE
[GUI] Fix hitrect when using auto-width for button controls

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -172,7 +172,7 @@ void CGUIButtonControl::ProcessText(unsigned int currentTime)
   // auto-width - adjust hitrect
   if (m_minWidth && m_width != renderWidth)
   {
-    CRect rect(m_posX, m_posY, renderWidth, m_height);
+    CRect rect{m_posX, m_posY, m_posX + renderWidth, m_posY + m_height};
     SetHitRect(rect, m_hitColor);
   }
 


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/20928, fix hitrect for button controls