### PR TITLE
Application: Fix initialization of ActiveAE

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -422,12 +422,7 @@ bool CApplication::Create(const CAppParamParser &params)
   }
 
   m_pActiveAE.reset(new ActiveAE::CActiveAE());
-  m_pActiveAE->Start();
   CServiceBroker::RegisterAE(m_pActiveAE.get());
-
-  // restore AE's previous volume state
-  SetHardwareVolume(m_volumeLevel);
-  CServiceBroker::GetActiveAE()->SetMute(m_muted);
 
   // initialize m_replayGainSettings
   m_replayGainSettings.iType = settings->GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINTYPE);
@@ -609,6 +604,11 @@ bool CApplication::InitWindow(RESOLUTION res)
 
 bool CApplication::Initialize()
 {
+  m_pActiveAE->Start();
+  // restore AE's previous volume state
+  SetHardwareVolume(m_volumeLevel);
+  CServiceBroker::GetActiveAE()->SetMute(m_muted);
+
 #if defined(HAS_DVD_DRIVE) && !defined(TARGET_WINDOWS) // somehow this throws an "unresolved external symbol" on win32
   // turn off cdio logging
   cdio_loglevel_default = CDIO_LOG_ERROR;


### PR DESCRIPTION
This fixes sound dropping on refreshrate switches.
AudioEngine must not be started before the windowing system
is available, because it's registering itself for DisplayLost
and DisplayReset events.
It's OK to create the ActiveAE instance and expose it's pointer
to the ServiceBroker, but startup must be deferred until the
windowsystem pointer is available in ServiceBroker so that the
registering for the HDMI events is not lost.


I think this was broken with the "multiple window system" PR, because that moved creation of the window system into `CreateGUI` and `ActiveAE` is started before that, so now the registering doesn't happen anymore.

Would be nice to get opinions on how to handle this.
Not sure if it's good to just defer starting or if somebody has other ideas about how to deal with this.
There are plenty of other ways available.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
