### PR TITLE
Settings: Fix wrong whitelist default placement

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2758,9 +2758,9 @@
       <group id="2" label="14126">
         <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14126" help="36443">
           <level>3</level>
+          <default></default>
           <constraints>
             <options>modes</options>
-            <default></default>
             <delimiter>,</delimiter>
             <minimumitems>0</minimumitems>
           </constraints>


### PR DESCRIPTION
The "default" tag must not be inside "constraints".
When you add a default value, it will never be copied
to a new guisettings file because it can't be
deserialized.

## How has this been tested?
Tested on Linux with no guisetitngs file.

## What is the effect on users?
In case you have default modes in your system settings
they will now correctly end up in a new guisettings file.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
