### PR TITLE
[cmake] improve cppcheck behaviour for CI

### DIFF
--- a/cmake/scripts/common/StaticAnalysis.cmake
+++ b/cmake/scripts/common/StaticAnalysis.cmake
@@ -11,8 +11,6 @@ if(CPPCHECK_EXECUTABLE)
             --project=${CMAKE_BINARY_DIR}/compile_commands.json
             --std=c++${CMAKE_CXX_STANDARD}
             --enable=all
-            --verbose
-            --quiet
             --xml
             --xml-version=2
             --language=c++

--- a/cmake/scripts/common/StaticAnalysis.cmake
+++ b/cmake/scripts/common/StaticAnalysis.cmake
@@ -16,6 +16,7 @@ if(CPPCHECK_EXECUTABLE)
             --language=c++
             --relative-paths=${CMAKE_SOURCE_DIR}
             --rule-file=${CMAKE_SOURCE_DIR}/tools/static-analysis/cppcheck/cppcheck-rules.xml
+            --suppress-xml=${CMAKE_SOURCE_DIR}/tools/static-analysis/cppcheck/cppcheck-suppressions.xml
             --output-file=${CMAKE_BINARY_DIR}/cppcheck-result.xml
     COMMENT "Static code analysis using cppcheck")
 endif()

--- a/cmake/scripts/common/StaticAnalysis.cmake
+++ b/cmake/scripts/common/StaticAnalysis.cmake
@@ -15,6 +15,7 @@ if(CPPCHECK_EXECUTABLE)
             --xml-version=2
             --language=c++
             --relative-paths=${CMAKE_SOURCE_DIR}
+            --rule-file=${CMAKE_SOURCE_DIR}/tools/static-analysis/cppcheck/cppcheck-rules.xml
             --output-file=${CMAKE_BINARY_DIR}/cppcheck-result.xml
     COMMENT "Static code analysis using cppcheck")
 endif()

--- a/cmake/scripts/common/StaticAnalysis.cmake
+++ b/cmake/scripts/common/StaticAnalysis.cmake
@@ -7,7 +7,6 @@ if(CPPCHECK_EXECUTABLE)
   add_custom_target(analyze-cppcheck
     DEPENDS ${APP_NAME_LC} ${APP_NAME_LC}-test
     COMMAND ${CPPCHECK_EXECUTABLE}
-            --template="${CMAKE_SOURCE_DIR}/xbmc/\{file\}\(\{line\}\)\: \{severity\} \(\{id\}\): \{message\}"
             -j${CPU_CORES}
             --project=${CMAKE_BINARY_DIR}/compile_commands.json
             --std=c++${CMAKE_CXX_STANDARD}

--- a/cmake/scripts/common/StaticAnalysis.cmake
+++ b/cmake/scripts/common/StaticAnalysis.cmake
@@ -14,9 +14,8 @@ if(CPPCHECK_EXECUTABLE)
             --xml
             --xml-version=2
             --language=c++
+            --relative-paths=${CMAKE_SOURCE_DIR}
             --output-file=${CMAKE_BINARY_DIR}/cppcheck-result.xml
-            xbmc
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Static code analysis using cppcheck")
 endif()
 

--- a/tools/static-analysis/cppcheck/cppcheck-rules.xml
+++ b/tools/static-analysis/cppcheck/cppcheck-rules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<def>
+  <type-checks>
+    <unusedvar>
+      <suppress>CSingleLock</suppress>
+      <suppress>CSharedLock</suppress>
+      <suppress>CExclusiveLock</suppress>
+    </unusedvar>
+  </type-checks>
+</def>

--- a/tools/static-analysis/cppcheck/cppcheck-suppressions.xml
+++ b/tools/static-analysis/cppcheck/cppcheck-suppressions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<suppressions>
+  <suppress>
+    <id>*</id>
+    <fileName>lib/*</fileName>
+  </suppress>
+  <suppress>
+    <id>*</id>
+    <fileName>build/*</fileName>
+  </suppress>
+  <suppress>
+    <id>*</id>
+    <fileName>tools/*</fileName>
+  </suppress>
+  <suppress>
+    <id>*</id>
+    <fileName>*.c</fileName>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
This attempts to improve our static analysis reports on Jenkins by suppressing some warnings.

The following suppressions have been made:
 - anything in lib/*
 - anything in build/*
 - anything in tools/*
 - anything with a .c extension
 - unreadVariable warnings for `CSingleLock`, `CSharedLock`, and `CExclusiveLock`.

This greatly improves the value of our static analysis output by removing a bunch of false positives and other cruft.

The output of these changes is here: https://jenkins.kodi.tv/view/Linux/job/LINUX-64-GL-Static-Analysis/79/cppcheck/

I went with `tools/static-analysis/cppcheck/` to store the required xml files.

ref:
https://cppcheck.sourceforge.io/manual.html
