### PR TITLE
CSingleLock/CSharedLock inherit from stl classes

### DIFF
--- a/xbmc/threads/Condition.h
+++ b/xbmc/threads/Condition.h
@@ -48,12 +48,12 @@ namespace XbmcThreads
       return res == std::cv_status::no_timeout;
     }
 
-    inline void wait(CSingleLock& lock) { wait(lock.get_underlying()); }
+    inline void wait(CSingleLock& lock) { wait(*lock.mutex()); }
 
     template<typename Rep, typename Period>
     inline bool wait(CSingleLock& lock, std::chrono::duration<Rep, Period> duration)
     {
-      return wait(lock.get_underlying(), duration);
+      return wait(*lock.mutex(), duration);
     }
 
     inline void notifyAll()

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <shared_mutex>
-
 namespace XbmcThreads
 {
 
@@ -98,29 +96,5 @@ namespace XbmcThreads
      */
     inline L& get_underlying() { return mutex; }
   };
-
-  /**
-   * This template can be used to define the base implementation for any SharedLock
-   * (such as CSharedLock) that uses a Shared Lockable as its mutex/critical section.
-   *
-   * Something that implements the "Shared Lockable" concept has all of the methods
-   * required by the Lockable concept and also:
-   *
-   * void lock_shared();
-   * bool try_lock_shared();
-   * void unlock_shared();
-   */
-  template<typename L>
-  class SharedLock : public std::shared_lock<L>
-  {
-  private:
-    SharedLock(const SharedLock&) = delete;
-    SharedLock& operator=(const SharedLock&) = delete;
-
-  protected:
-    inline explicit SharedLock(L& lockable) : std::shared_lock<L>(lockable) {}
-    inline ~SharedLock() = default;
-  };
-
 
 }

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <mutex>
+
 namespace XbmcThreads
 {
 
@@ -102,29 +104,16 @@ namespace XbmcThreads
    * This template can be used to define the base implementation for any UniqueLock
    * (such as CSingleLock) that uses a Lockable as its mutex/critical section.
    */
-  template<typename L> class UniqueLock
+  template<typename L>
+  class UniqueLock : public std::unique_lock<L>
   {
+  private:
     UniqueLock(const UniqueLock&) = delete;
     UniqueLock& operator=(const UniqueLock&) = delete;
+
   protected:
-    L& mutex;
-    bool owns;
-    inline explicit UniqueLock(L& lockable) : mutex(lockable), owns(true) { mutex.lock(); }
-    inline ~UniqueLock() { if (owns) mutex.unlock(); }
-
-  public:
-
-    inline bool owns_lock() const { return owns; }
-
-    //This also implements lockable
-    inline void lock() { mutex.lock(); owns=true; }
-    inline bool try_lock() { return (owns = mutex.try_lock()); }
-    inline void unlock() { if (owns) { mutex.unlock(); owns=false; } }
-
-    /**
-     * See the note on the same method on CountingLockable
-     */
-    inline L& get_underlying() { return mutex; }
+    inline explicit UniqueLock(L& lockable) : std::unique_lock<L>(lockable) {}
+    inline ~UniqueLock() = default;
   };
 
   /**

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <mutex>
+#include <shared_mutex>
 
 namespace XbmcThreads
 {
@@ -127,25 +128,16 @@ namespace XbmcThreads
    * bool try_lock_shared();
    * void unlock_shared();
    */
-  template<typename L> class SharedLock
+  template<typename L>
+  class SharedLock : public std::shared_lock<L>
   {
+  private:
     SharedLock(const SharedLock&) = delete;
     SharedLock& operator=(const SharedLock&) = delete;
+
   protected:
-    L& mutex;
-    bool owns;
-    inline explicit SharedLock(L& lockable) : mutex(lockable), owns(true) { mutex.lock_shared(); }
-    inline ~SharedLock() { if (owns) mutex.unlock_shared(); }
-
-    inline bool owns_lock() const { return owns; }
-    inline void lock() { mutex.lock_shared(); owns = true; }
-    inline bool try_lock() { return (owns = mutex.try_lock_shared()); }
-    inline void unlock() { if (owns) mutex.unlock_shared(); owns = false; }
-
-    /**
-     * See the note on the same method on CountingLockable
-     */
-    inline L& get_underlying() { return mutex; }
+    inline explicit SharedLock(L& lockable) : std::shared_lock<L>(lockable) {}
+    inline ~SharedLock() = default;
   };
 
 

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -110,7 +110,6 @@ namespace XbmcThreads
     L& mutex;
     bool owns;
     inline explicit UniqueLock(L& lockable) : mutex(lockable), owns(true) { mutex.lock(); }
-    inline UniqueLock(L& lockable, bool try_to_lock_discrim ) : mutex(lockable) { owns = mutex.try_lock(); }
     inline ~UniqueLock() { if (owns) mutex.unlock(); }
 
   public:

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <mutex>
 #include <shared_mutex>
 
 namespace XbmcThreads
@@ -98,23 +97,6 @@ namespace XbmcThreads
      *  to call this method.
      */
     inline L& get_underlying() { return mutex; }
-  };
-
-
-  /**
-   * This template can be used to define the base implementation for any UniqueLock
-   * (such as CSingleLock) that uses a Lockable as its mutex/critical section.
-   */
-  template<typename L>
-  class UniqueLock : public std::unique_lock<L>
-  {
-  private:
-    UniqueLock(const UniqueLock&) = delete;
-    UniqueLock& operator=(const UniqueLock&) = delete;
-
-  protected:
-    inline explicit UniqueLock(L& lockable) : std::unique_lock<L>(lockable) {}
-    inline ~UniqueLock() = default;
   };
 
   /**

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -12,6 +12,8 @@
 #include "threads/Helpers.h"
 #include "threads/SingleLock.h"
 
+#include <shared_mutex>
+
 /**
  * A CSharedSection is a mutex that satisfies the Shared Lockable concept (see Lockables.h).
  */
@@ -35,14 +37,18 @@ public:
   inline void unlock_shared() { CSingleLock l(sec); sharedCount--; if (!sharedCount) { cond.notifyAll(); } }
 };
 
-class CSharedLock : public XbmcThreads::SharedLock<CSharedSection>
+class CSharedLock : public std::shared_lock<CSharedSection>
 {
 public:
-  inline explicit CSharedLock(CSharedSection& cs) : XbmcThreads::SharedLock<CSharedSection>(cs) {}
+  inline explicit CSharedLock(CSharedSection& cs) : std::shared_lock<CSharedSection>(cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
   inline void Enter() { lock(); }
   inline void Leave() { unlock(); }
+
+private:
+  CSharedLock(const CSharedLock&) = delete;
+  CSharedLock& operator=(const CSharedLock&) = delete;
 };
 
 class CExclusiveLock : public std::unique_lock<CSharedSection>

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -45,13 +45,17 @@ public:
   inline void Leave() { unlock(); }
 };
 
-class CExclusiveLock : public XbmcThreads::UniqueLock<CSharedSection>
+class CExclusiveLock : public std::unique_lock<CSharedSection>
 {
 public:
-  inline explicit CExclusiveLock(CSharedSection& cs) : XbmcThreads::UniqueLock<CSharedSection>(cs) {}
+  inline explicit CExclusiveLock(CSharedSection& cs) : std::unique_lock<CSharedSection>(cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
   inline void Leave() { unlock(); }
   inline void Enter() { lock(); }
+
+private:
+  CExclusiveLock(const CExclusiveLock&) = delete;
+  CExclusiveLock& operator=(const CExclusiveLock&) = delete;
 };
 

--- a/xbmc/threads/SingleLock.h
+++ b/xbmc/threads/SingleLock.h
@@ -28,8 +28,6 @@ public:
 
   inline void Leave() { unlock(); }
   inline void Enter() { lock(); }
-protected:
-  inline CSingleLock(CCriticalSection& cs, bool dicrim) : XbmcThreads::UniqueLock<CCriticalSection>(cs,true) {}
 };
 
 

--- a/xbmc/threads/SingleLock.h
+++ b/xbmc/threads/SingleLock.h
@@ -15,19 +15,24 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "threads/CriticalSection.h"
-#include "threads/Lockables.h"
+
+#include <mutex>
 
 /**
  * This implements a "guard" pattern for a CCriticalSection that
  *  borrows most of it's functionality from boost's unique_lock.
  */
-class CSingleLock : public XbmcThreads::UniqueLock<CCriticalSection>
+class CSingleLock : public std::unique_lock<CCriticalSection>
 {
 public:
-  inline explicit CSingleLock(CCriticalSection& cs) : XbmcThreads::UniqueLock<CCriticalSection>(cs) {}
+  inline explicit CSingleLock(CCriticalSection& cs) : std::unique_lock<CCriticalSection>(cs) {}
 
   inline void Leave() { unlock(); }
   inline void Enter() { lock(); }
+
+private:
+  CSingleLock(const CSingleLock&) = delete;
+  CSingleLock& operator=(const CSingleLock&) = delete;
 };
 
 

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -168,7 +168,7 @@ CConverterType::~CConverterType()
 iconv_t CConverterType::GetConverter(CSingleLock& converterLock)
 {
   // ensure that this unique instance is locked externally
-  if (&converterLock.get_underlying() != this)
+  if (converterLock.mutex() != this)
     return NO_ICONV;
 
   if (m_iconv == NO_ICONV)


### PR DESCRIPTION
This is the first part in a bit of a cleanup for locking/conditions/events.

This changes `CUniqueLock` to inherit from `std::unique_lock`. This is possible because `CCriticalSection` meets the criteria of a `Lockable`. see: https://en.cppreference.com/w/cpp/named_req/Lockable

This changes `CSharedLock` to inherit from `std::shared_lock`. This is possible because `CSharedSection` meets the criteria of a `SharedLockable`. see: https://en.cppreference.com/w/cpp/named_req/SharedLockable

This changes `CExclusiveLock` to inherit from `std::unique_lock`.

There is the possibility of removing these three classes completely and only having the stl methods. This would require changing the Leave/Enter nomenclature to `unlock/lock`. I'm not sure yet if there is a benefit to having these wrapper classes but there is no need for now.