### PR TITLE
[Windows] Fix: WS-Discovery log message is not displayed correctly

### DIFF
--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -149,13 +149,15 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchComplete(LPCWSTR tag)
 {
   CSingleLock lock(m_criticalSection);
 
-  CLog::Log(LOGDEBUG, LOGWSDISCOVERY,
-            "[WS-Discovery]: The initial servers search has completed successfully with {} "
-            "server(s) found:",
-            m_serversIPs.size());
+  std::string list;
 
   for (const auto& ip : GetServersIPs())
-    CLog::Log(LOGDEBUG, "    {}", FromW(ip));
+    list.append('\n' + FromW(ip));
+
+  CLog::Log(LOGDEBUG,
+            "[WS-Discovery]: The initial servers search has completed successfully with {} "
+            "server(s) found:{}",
+            m_serversIPs.size(), list);
 
   return S_OK;
 }


### PR DESCRIPTION
## Description
Fix: WS-Discovery log message is not displayed correctly

## Motivation and context
Since WS-Discovery Posix/Windows was unified, there is a log message that remains hidden/incomplete because half is logged at `LOGDEBUG`, level and half at the specific `LOGWSDISCOVERY`:

https://github.com/xbmc/xbmc/blob/aa5ec0ceb68ed321c91329838c54204ca014f379/xbmc/platform/win32/network/WSDiscoveryWin32.cpp#L152-L158

I take the opportunity to optimize it a bit with a single `CLog` call. As it is a message that is shown only once at startup, I prefer to leave it visible on `LOGDEBUG`. Individual HELLO/BYE messages from each host remains in LOGWSDISCOVERY.

## How has this been tested?
Windows x64

## What is the effect on users?
Fix incomplete log message displayed in LOGDEBUG


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
