### PR TITLE
[Windows] Fix possible crash Network related + fix memory leak

### DIFF
--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -146,9 +146,8 @@ void CNetworkWin32::queryInterfaceList()
   if (GetAdaptersAddresses(AF_INET, flags, nullptr, nullptr, &ulOutBufLen) != ERROR_BUFFER_OVERFLOW)
     return;
 
-  PIP_ADAPTER_ADDRESSES adapterAddresses = static_cast<PIP_ADAPTER_ADDRESSES>(malloc(ulOutBufLen));
-  if (adapterAddresses == nullptr)
-    return;
+  m_adapterAddresses.resize(ulOutBufLen);
+  auto adapterAddresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(m_adapterAddresses.data());
 
   if (GetAdaptersAddresses(AF_INET, flags, nullptr, adapterAddresses, &ulOutBufLen) == NO_ERROR)
   {
@@ -173,9 +172,8 @@ std::vector<std::string> CNetworkWin32::GetNameServers(void)
   if (GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, nullptr, &ulOutBufLen) != ERROR_BUFFER_OVERFLOW)
     return result;
 
-  PIP_ADAPTER_ADDRESSES adapterAddresses = static_cast<PIP_ADAPTER_ADDRESSES>(malloc(ulOutBufLen));
-  if (adapterAddresses == nullptr)
-    return result;
+  std::vector<uint8_t> buffer(ulOutBufLen);
+  auto adapterAddresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
 
   if (GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, adapterAddresses, &ulOutBufLen) == NO_ERROR)
   {
@@ -191,7 +189,6 @@ std::vector<std::string> CNetworkWin32::GetNameServers(void)
       }
     }
   }
-  free(adapterAddresses);
 
   return result;
 }

--- a/xbmc/platform/win32/network/NetworkWin32.h
+++ b/xbmc/platform/win32/network/NetworkWin32.h
@@ -70,5 +70,6 @@ private:
    int m_sock;
    CStopWatch m_netrefreshTimer;
    CCriticalSection m_critSection;
+   std::vector<uint8_t> m_adapterAddresses;
 };
 


### PR DESCRIPTION
## Description
- Fix possible crash Network related
- Fix memory leak

## Motivation and context
`m_adapter.FirstUnicastAddress` may be `nullptr` under some circumstances:

![Captura de pantalla 2022-02-05 115117](https://user-images.githubusercontent.com/58434170/152640002-f6cb31a8-807b-47a1-a128-085bda0c596d.png)

Also see: https://forum.kodi.tv/showthread.php?tid=366749

Maybe related: https://github.com/xbmc/xbmc/issues/19280

## How has this been tested?
Runtime Windows x64. Enable/disable networks adapters while in System info / Network triggers the crash.

A forum user has tested in Matrix branch and confirmed that network related crash is gone:
https://forum.kodi.tv/showthread.php?tid=366749&pid=3086196#pid3086196

## What is the effect on users?
- Fix possible crash network related
- Fix memory leak

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
