### PR TITLE
[kodi-dev-kit] Resolve C4521 warning when compiling binary addons in Visual C++

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -346,7 +346,6 @@ public:
 
 private:
   IInstanceInfo() = delete;
-  IInstanceInfo(IInstanceInfo&) = delete;
   IInstanceInfo(const IInstanceInfo&) = delete;
 
   KODI_ADDON_INSTANCE_STRUCT* m_instance;


### PR DESCRIPTION
## Description
When compiling binary addons in Visual C++, a C4521 warning is produced to indicate that there are multiple copy constructors in IInstanceInfo, which is accurate:

`\xbmc\xbmc\addons\kodi-dev-kit\include\kodi\addonbase.h(353): warning C4521: 'kodi::addon::IInstanceInfo': multiple copy constructors specified`

## Motivation and context
Resolves a compile-time warning on Visual C++ caused by kodi-dev-kit addon code, the non-const version of the default copy constructor does not need to exist (even for '= delete') and can be safely removed without any impact or ability for code to access the deleted copy constructor.  I found no other instances where a deleted default copy constructor with a non-const argument was present in kodi-dev-kit.

## How has this been tested?
Tested on Windows 11 x64, master branch current as of 2022.02.05.

## What is the effect on users?
None

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
