### PR TITLE
[PVR] Rework CPVRGUIProgressHandler.

### DIFF
--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -412,7 +412,7 @@ namespace PVR
      */
     bool UpdateComponents(std::vector<std::shared_ptr<CPVRClient>>& knownClients,
                           ManagerState stateToCheck,
-                          CPVRGUIProgressHandler* progressHandler);
+                          const std::unique_ptr<CPVRGUIProgressHandler>& progressHandler);
 
     /*!
      * @brief Unload all PVR data (recordings, timers, channelgroups).

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -55,7 +55,10 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
     fileItemMap.insert({baseName, item->GetPath()});
   }
 
-  CPVRGUIProgressHandler* progressHandler = new CPVRGUIProgressHandler(g_localizeStrings.Get(19286)); // Searching for channel icons
+  std::unique_ptr<CPVRGUIProgressHandler> progressHandler;
+  if (!m_groups.empty())
+    progressHandler.reset(
+        new CPVRGUIProgressHandler(g_localizeStrings.Get(19286))); // Searching for channel icons
 
   for (const auto& group : m_groups)
   {
@@ -95,6 +98,4 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
         channel->Persist();
     }
   }
-
-  progressHandler->DestroyProgress();
 }

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
@@ -38,7 +38,7 @@ void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fP
   if (!m_bCreated)
   {
     m_bCreated = true;
-    Create(true /* bAutoDelete */);
+    Create();
   }
 }
 
@@ -49,13 +49,6 @@ void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, int iCur
     fPercentage = std::min(100.0f, fPercentage);
 
   UpdateProgress(strText, fPercentage);
-}
-
-void CPVRGUIProgressHandler::DestroyProgress()
-{
-  CSingleLock lock(m_critSection);
-  m_bStop = true;
-  m_bChanged = false;
 }
 
 void CPVRGUIProgressHandler::Process()

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.h
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.h
@@ -26,6 +26,8 @@ namespace PVR
      */
     explicit CPVRGUIProgressHandler(const std::string& strTitle);
 
+    ~CPVRGUIProgressHandler() override = default;
+
     /*!
      * @brief Update the progress dialogs's content.
      * @param strText The new progress text.
@@ -41,17 +43,11 @@ namespace PVR
      */
     void UpdateProgress(const std::string& strText, int iCurrent, int iMax);
 
-    /*!
-     * @brief Destroy the progress dialog. This happens asynchronous, instance must not be touched anymore after calling this method.
-     */
-    void DestroyProgress();
-
+  protected:
     // CThread implementation
     void Process() override;
 
   private:
-    ~CPVRGUIProgressHandler() override = default; // prevent creation of stack instances
-
     CCriticalSection m_critSection;
     const std::string m_strTitle;
     std::string m_strText;


### PR DESCRIPTION
Simplify the code (no more `DestroyProgress`needed) and get rid of the "auto-delete the instance" magic, which needs additional comments in the code to explain not deleting the heap-allocated instance this is not a resource leak. And Coverity complained about this as well. ;-)

Runtime-tested on Android and macOS.

@phunkyfish  when you find some time for a review.