### PR TITLE
[PVR] Fix CPVRChannel::Set(Hidden|EPGEnabled|EPGScraper): Update chan…

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -348,12 +348,6 @@ namespace PVR
                                                     const CDateTime& end) const;
 
     /*!
-     * @brief Clear the EPG for this channel.
-     * @return True if it was cleared, false if not.
-     */
-    bool ClearEPG() const;
-
-    /*!
      * @brief Get the EPG tag that is now active on this channel.
      *
      * Get the EPG tag that is now active on this channel.


### PR DESCRIPTION
Update channel data if new state is hidden/epg disabled. Force EPG data update if EPG gets enabled / scraper is reset. Decouple set/reset hidden from enable/disable EPG. 

Fixes some simple logic errors I found while playing around with the Channel manager. 

Runtime-tested on Android and macOS.

@phunkyfish  when you find some time for a review.