### PR TITLE
[PVR] Channel Manager Fixes

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1130,7 +1130,7 @@ bool CPVRChannelGroup::UpdateChannel(const std::pair<int, int>& storageId,
 
     RemoveFromGroup(channel);
   }
-  else
+  else if (iChannelNumber > 0)
   {
     SetChannelNumber(channel, CPVRChannelNumber(iChannelNumber, 0));
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -132,13 +132,20 @@ bool CGUIDialogPVRChannelManager::OnActionMove(const CAction& action)
         for (unsigned int iLine = 0; iLine < iLines; ++iLine)
         {
           unsigned int iNewSelect = bMoveUp ? m_iSelected - 1 : m_iSelected + 1;
-          if (m_channelItems->Get(iNewSelect)->GetProperty("Number").asString() != "0")
+
+          const CFileItemPtr newItem = m_channelItems->Get(iNewSelect);
+          const std::string number = newItem->GetProperty("Number").asString();
+          if (number != "0") // hidden
           {
-            strNumber = std::to_string(m_iSelected + 1);
-            m_channelItems->Get(iNewSelect)->SetProperty("Number", strNumber);
-            strNumber = std::to_string(iNewSelect + 1);
-            m_channelItems->Get(m_iSelected)->SetProperty("Number", strNumber);
+            // Swap channel numbers
+            const CFileItemPtr item = m_channelItems->Get(m_iSelected);
+            newItem->SetProperty("Number", item->GetProperty("Number"));
+            SetItemChanged(newItem);
+            item->SetProperty("Number", number);
+            SetItemChanged(item);
           }
+
+          // swap items
           m_channelItems->Swap(iNewSelect, m_iSelected);
           m_iSelected = iNewSelect;
         }
@@ -648,7 +655,7 @@ bool CGUIDialogPVRChannelManager::OnPopupMenu(int iItem)
   if (!pItem)
     return false;
 
-  if (m_bAllowReorder)
+  if (m_bAllowReorder && pItem->GetProperty("Number").asString() != "0")
     buttons.Add(CONTEXT_BUTTON_MOVE, 116); /* Move channel up or down */
 
   if (pItem->GetProperty("SupportsSettings").asBoolean())

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -74,7 +74,7 @@ namespace PVR
     bool OnClickButtonNewChannel();
     bool OnClickButtonRefreshChannelLogos();
 
-    bool PersistChannel(const CFileItemPtr& pItem, const std::shared_ptr<CPVRChannelGroup>& group, unsigned int* iChannelNumber);
+    bool PersistChannel(const CFileItemPtr& pItem, const std::shared_ptr<CPVRChannelGroup>& group);
 
     bool HasChangedItems() const;
     void SetItemChanged(const CFileItemPtr& pItem);
@@ -83,6 +83,7 @@ namespace PVR
     bool m_bMovingMode = false;
     bool m_bAllowNewChannel = false;
     bool m_bAllowRenumber = false;
+    bool m_bAllowReorder = false;
 
     std::shared_ptr<CFileItem> m_initialSelection;
     int m_iSelected = 0;


### PR DESCRIPTION
Fixes some errors I found while playing around with the Channel manager. 

* Fix channel renumbering. It simply did not work without closing and reopening the dialog, if "use backend channel numbers" or "use backend channel order" is active.
* Improve detection whether an item is changed. Formerly, for example activating a channel and then deactivating the channel without closing the manager dialog in between, left the channel entry "changed".

Runtime-tested on Android and macOS.

@phunkyfish  when you find some time for a review.