### PR TITLE
[python] CPythonInvoker,XBPython: Change some LOGINFO to LOGDEBUG to …

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -355,14 +355,14 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
   InvokerState stateToSet;
   if (!failed && !PyErr_Occurred())
   {
-    CLog::Log(LOGINFO, "CPythonInvoker({}, {}): script successfully run", GetId(), m_sourceFile);
+    CLog::Log(LOGDEBUG, "CPythonInvoker({}, {}): script successfully run", GetId(), m_sourceFile);
     stateToSet = InvokerStateScriptDone;
     onSuccess();
   }
   else if (PyErr_ExceptionMatches(PyExc_SystemExit))
   {
     m_systemExitThrown = true;
-    CLog::Log(LOGINFO, "CPythonInvoker({}, {}): script aborted", GetId(), m_sourceFile);
+    CLog::Log(LOGDEBUG, "CPythonInvoker({}, {}): script aborted", GetId(), m_sourceFile);
     stateToSet = InvokerStateFailed;
     onAbort();
   }

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -468,7 +468,7 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
     return false;
 
   XBMC_TRACE;
-  CLog::Log(LOGINFO, "initializing python engine.");
+  CLog::Log(LOGDEBUG, "initializing python engine.");
   CSingleLock lock(m_critSection);
   m_iDllScriptCounter++;
   if (!m_bInitialized)
@@ -592,9 +592,9 @@ void XBPython::OnExecutionEnded(ILanguageInvoker* invoker)
     if (it->id == invoker->GetId())
     {
       if (it->pyThread->IsStopping())
-        CLog::Log(LOGINFO, "Python interpreter interrupted by user");
+        CLog::Log(LOGDEBUG, "Python interpreter interrupted by user");
       else
-        CLog::Log(LOGINFO, "Python interpreter stopped");
+        CLog::Log(LOGDEBUG, "Python interpreter stopped");
       it->bDone = true;
     }
     ++it;


### PR DESCRIPTION
Change some LOGINFO to LOGDEBUG to reduce logspam.

If you have installed some python add-ons which I consider the normal case, log gets flooded with many long lines just stating a script run successfully, the engine was initialized successfully, ... Lines are very long due to the full path to the script being logged.

I feel we should not start to log "everything" that just works. If every component would do this, oh well... ;-)

Runtime-tested on Android and macOS.

@phunkyfish  when you find some time for a review.