### PR TITLE
[Subtitles] Fix font family name get method and fix get font list from directory

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -107,9 +107,10 @@ void CDVDSubtitlesLibass::Configure()
                                   UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
                                   XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
   // Get temporary fonts
-  XFILE::CDirectory::GetDirectory(UTILS::FONT::FONTPATH::TEMP, items,
-                                  UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
-                                  XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  XFILE::CDirectory::GetDirectory(
+      UTILS::FONT::FONTPATH::TEMP, items, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+      XFILE::DIR_FLAG_BYPASS_CACHE | XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+
   for (const auto& item : items)
   {
     if (item->m_bIsFolder)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -10,6 +10,7 @@
 
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "settings/SubtitlesSettings.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
@@ -129,7 +130,6 @@ void CDebugRenderer::CRenderer::Render(int idx)
       if (!ovAss || !ovAss->GetLibassHandler())
         continue;
 
-      KODI::SUBTITLES::style subStyle;
       bool updateStyle = !m_debugOverlayStyle;
       if (updateStyle)
         CreateSubtitlesStyle();
@@ -146,6 +146,6 @@ void CDebugRenderer::CRenderer::Render(int idx)
 void CDebugRenderer::CRenderer::CreateSubtitlesStyle()
 {
   m_debugOverlayStyle = std::make_shared<KODI::SUBTITLES::style>();
-  m_debugOverlayStyle->fontName = "arial.ttf";
+  m_debugOverlayStyle->fontName = KODI::SUBTITLES::FONT_DEFAULT_FAMILYNAME;
   m_debugOverlayStyle->fontSize = 20.0;
 }

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -46,8 +46,6 @@ CWin32Directory::~CWin32Directory(void)
 
 bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  items.Clear();
-
   std::string pathWithSlash(url.Get());
   if (!pathWithSlash.empty() && pathWithSlash.back() != '\\')
     pathWithSlash.push_back('\\');

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -834,6 +834,11 @@ bool CCharsetConverter::utf16BEtoUTF8(const std::u16string& utf16StringSrc, std:
   return CInnerConverter::stdConvert(Utf16BEtoUtf8, utf16StringSrc, utf8StringDst);
 }
 
+bool CCharsetConverter::utf16BEtoUTF8(const std::string& utf16StringSrc, std::string& utf8StringDst)
+{
+  return CInnerConverter::stdConvert(Utf16BEtoUtf8, utf16StringSrc, utf8StringDst);
+}
+
 bool CCharsetConverter::utf16LEtoUTF8(const std::u16string& utf16StringSrc,
                                       std::string& utf8StringDst)
 {

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -258,6 +258,7 @@ enum StdConversionType /* Keep it in sync with CCharsetConverter::CInnerConverte
   Utf8ToSystem,
   SystemToUtf8,
   Ucs2CharsetToUtf8,
+  MacintoshToUtf8,
   NumberOfStdConversionTypes /* Dummy sentinel entry */
 };
 
@@ -289,6 +290,7 @@ public:
 const int CCharsetConverter::m_Utf8CharMinSize = 1;
 const int CCharsetConverter::m_Utf8CharMaxSize = 4;
 
+// clang-format off
 CConverterType CCharsetConverter::CInnerConverter::m_stdConversion[NumberOfStdConversionTypes] = /* keep it in sync with enum StdConversionType */
 {
   /* Utf8ToUtf32 */         CConverterType(UTF8_SOURCE,     UTF32_CHARSET),
@@ -306,8 +308,10 @@ CConverterType CCharsetConverter::CInnerConverter::m_stdConversion[NumberOfStdCo
   /* Utf8toW */             CConverterType(UTF8_SOURCE,     WCHAR_CHARSET),
   /* Utf8ToSystem */        CConverterType(UTF8_SOURCE,     SystemCharset),
   /* SystemToUtf8 */        CConverterType(SystemCharset,   UTF8_SOURCE),
-  /* Ucs2CharsetToUtf8 */   CConverterType("UCS-2LE",       "UTF-8", CCharsetConverter::m_Utf8CharMaxSize)
+  /* Ucs2CharsetToUtf8 */   CConverterType("UCS-2LE",       "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
+  /* MacintoshToUtf8 */     CConverterType("macintosh", "UTF-8", CCharsetConverter::m_Utf8CharMaxSize)
 };
+// clang-format on
 
 CCriticalSection CCharsetConverter::CInnerConverter::m_critSectionFriBiDi;
 
@@ -869,6 +873,11 @@ bool CCharsetConverter::utf8ToSystem(std::string& stringSrcDst, bool failOnBadCh
 bool CCharsetConverter::systemToUtf8(const std::string& sysStringSrc, std::string& utf8StringDst, bool failOnBadChar /*= false*/)
 {
   return CInnerConverter::stdConvert(SystemToUtf8, sysStringSrc, utf8StringDst, failOnBadChar);
+}
+
+bool CCharsetConverter::MacintoshToUTF8(const std::string& macStringSrc, std::string& utf8StringDst)
+{
+  return CInnerConverter::stdConvert(MacintoshToUtf8, macStringSrc, utf8StringDst);
 }
 
 bool CCharsetConverter::utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst, bool failOnBadString /*= false*/)

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -160,6 +160,15 @@ public:
   static bool utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
   static bool ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
 
+  /*!
+   *  \brief Convert Macintosh (string) string to UTF-8 string.
+   *  No RTL visual-logical transformation is performed.
+   *  \param macStringSrc Is source Macintosh string to convert
+   *  \param utf8StringDst Is output UTF-8 string, empty on any error
+   *  \return True on successful conversion, false on any error
+   */
+  static bool MacintoshToUTF8(const std::string& macStringSrc, std::string& utf8StringDst);
+
   static bool utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst, bool failOnBadString = false);
 
   /**

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -138,7 +138,25 @@ public:
   static bool ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
 
   static bool wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
+
+  /*!
+   *  \brief Convert UTF-16BE (u16string) string to UTF-8 string.
+   *  No RTL visual-logical transformation is performed.
+   *  \param utf16StringSrc Is source UTF-16BE u16string string to convert
+   *  \param utf8StringDst Is output UTF-8 string, empty on any error
+   *  \return True on successful conversion, false on any error
+   */
   static bool utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+
+  /*!
+   *  \brief Convert UTF-16BE (string) string to UTF-8 string.
+   *  No RTL visual-logical transformation is performed.
+   *  \param utf16StringSrc Is source UTF-16BE string to convert
+   *  \param utf8StringDst Is output UTF-8 string, empty on any error
+   *  \return True on successful conversion, false on any error
+   */
+  static bool utf16BEtoUTF8(const std::string& utf16StringSrc, std::string& utf8StringDst);
+
   static bool utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
   static bool ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
 

--- a/xbmc/utils/FontUtils.cpp
+++ b/xbmc/utils/FontUtils.cpp
@@ -15,11 +15,14 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
+#include "utils/CharsetConverter.h"
 #include "utils/log.h"
 
 #include <ft2build.h>
 
 #include FT_FREETYPE_H
+#include FT_SFNT_NAMES_H
+#include FT_TRUETYPE_IDS_H
 
 using namespace XFILE;
 
@@ -39,7 +42,49 @@ std::string UTILS::FONT::GetFontFamily(std::vector<uint8_t>& buffer)
   if (FT_New_Memory_Face(m_library, reinterpret_cast<const FT_Byte*>(buffer.data()), buffer.size(),
                          0, &face) == 0)
   {
-    familyName = std::string(face->family_name);
+    // Get SFNT table entries to get font properties
+    for (FT_UInt index = 0; index < FT_Get_Sfnt_Name_Count(face); index++)
+    {
+      FT_SfntName name;
+      if (FT_Get_Sfnt_Name(face, index, &name) != 0)
+      {
+        CLog::LogF(LOGWARNING, "Failed to get SFNT name at index {}", index);
+        continue;
+      }
+
+      // Get the unicode font family name (format-specific interface)
+      // In properties there may be one or more font family names encoded for
+      // each platform, we take the first available converting it to UTF-8
+      if (name.name_id == TT_NAME_ID_FONT_FAMILY)
+      {
+        const std::string nameEnc{reinterpret_cast<const char*>(name.string), name.string_len};
+
+        if (name.platform_id == TT_PLATFORM_MICROSOFT ||
+            name.platform_id == TT_PLATFORM_APPLE_UNICODE)
+        {
+          if (!CCharsetConverter::utf16BEtoUTF8(nameEnc, familyName))
+            CLog::LogF(LOGERROR, "Failed to convert the font name string encoded as \"UTF-16BE\"");
+        }
+        else if (name.platform_id == TT_PLATFORM_MACINTOSH)
+        {
+          if (!CCharsetConverter::MacintoshToUTF8(nameEnc, familyName))
+            CLog::LogF(LOGERROR, "Failed to convert the font name string encoded as \"macintosh\"");
+        }
+        else
+        {
+          CLog::LogF(LOGERROR, "Unsupported font SFNT name platform \"{}\"", name.platform_id);
+        }
+        if (!familyName.empty())
+          break;
+      }
+    }
+    if (familyName.empty())
+    {
+      CLog::LogF(LOGWARNING, "Failed to get the unicode family name for \"{}\", fallback to ASCII",
+                 face->family_name);
+      // ASCII font family name may differ from the unicode one, use this as fallback only
+      familyName = std::string{face->family_name};
+    }
   }
   else
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
I was not aware that there are two ways to get the font family name from a font file, the ASCII version and the unicode version

the ASCII version could differs from the unicode, that was the main cause of the problem, but i am not a font expert to describe the reasons behind this

Before i was using `FT_Face->family_name` the ASCII version of the font family name,
where instead we have to get the font family name from the format-specific interface that is unicode encoded by platform,
then fallback to the ASCII in case the unicode is not specified, not supported or for errors cases,
in any case if the fallback family name does not work a warning or error will be reported in the log when the font cache will be builded

As addition i have add also a minor fix to get the font list from directory that was broken

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An user has reported that some fonts was not working: https://github.com/xbmc/xbmc/pull/20880#issuecomment-1030771145

After some investigations, i have found that the problem was in the way we get the font family name
therefore, if the names do not match, libass cannot find the specified font and that font will not work

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried fons specified in message https://github.com/xbmc/xbmc/pull/20880#issuecomment-1030771145:
Noto Sans CJK KR: https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKkr-hinted.zip
Noto Sans SC: https://fonts.google.com/noto/specimen/Noto+Sans+SC
A couple of font with styles separated on different ttf files
A font with font family name encoded for macintosh platform

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Able to set and display the custom font

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
