### PR TITLE
[Log] Log previously to concurrent busydialog crash

### DIFF
--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -14,6 +14,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "threads/IRunnable.h"
 #include "threads/Thread.h"
+#include "utils/log.h"
 
 using namespace std::chrono_literals;
 
@@ -84,6 +85,8 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
     {
       if (dialog->IsDialogRunning())
       {
+        CLog::Log(LOGFATAL, "Logic error due to two concurrent busydialogs, this is a known issue. "
+                            "The application will exit.");
         throw std::logic_error("busy dialog already running");
       }
 


### PR DESCRIPTION
## Description
Crashes due to concurrent busy dialogs are a know issue in Kodi, and will continue to be until the root cause is properly addressed. Since a `std::logic_error` is thrown in such cases, the information about the crash will only show in the crashlog. Users usually don't provide a crashlog unless requested and assistance is given into collecting one. The regular log does not contain any info about the crash (delaying the whole process for an issue that is known). Since we know kodi will crash and we are aware of the root cause, just log something to the log to make our life easier.