### PR TITLE
powermanagement: don't store paused items on suspend

### DIFF
--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -240,7 +240,7 @@ void CPowerManager::OnLowBattery()
 void CPowerManager::StorePlayerState()
 {
   CApplicationPlayer &appPlayer = g_application.GetAppPlayer();
-  if (appPlayer.IsPlaying())
+  if (appPlayer.IsPlaying() && !appPlayer.IsPaused())
   {
     m_lastUsedPlayer = appPlayer.GetCurrentPlayer();
     m_lastPlayedFileItem.reset(new CFileItem(g_application.CurrentFileItem()));


### PR DESCRIPTION
Suspending Kodi with some item playing, it gets restored on wakeup, which is fine and useful.
Unlike restoring and blasting item that was paused before the suspend, thats plain annoying.

I see no reliable way to PlayFile() and force it to Pause(), so simply don't store state on paused items.

Build and run tested on LibreElec.
Fixes  xbmc/xbmc#15737
