### PR TITLE
[PVR] Fix CPVREpgTagsContainer::GetTimeline to merge in memory data …

### DIFF
--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -200,6 +200,16 @@ private:
   std::shared_ptr<CPVREpgInfoTag> CreateGapTag(const CDateTime& start, const CDateTime& end) const;
 
   /*!
+   * @brief Merge m_changedTags tags into given tags, resolving conflicts.
+   * @param minEventEnd The minimum end time of the events to return
+   * @param maxEventStart The maximum start time of the events to return
+   * @param tags The merged tags.
+   */
+  void MergeTags(const CDateTime& minEventEnd,
+                 const CDateTime& maxEventStart,
+                 std::vector<std::shared_ptr<CPVREpgInfoTag>>& tags) const;
+
+  /*!
    * @brief Fix overlapping events.
    * @param tags The events to check/fix.
    */


### PR DESCRIPTION
…if database contains no or only some data.

There was an important use case missing: If database has only data outside the requested timeline our only partial data, but there is data in memory which have not yet been committed to the db (`m_changedTags` container not empty), those memory data were not merged into the data returned by `GetTimeline`. Visual effect was, when opening the guide directly after Kodi startup after not having Kodi started for a longer time (epg database ran dry), it could take up to some minutes (!) until EPG data appear in the guide, depending on the asynchrounous bulk database commits for changed EPG tags.

Runtime-tested on Android and macOS, latest Kodi master.

@phunkyfish  when you find some time for a review.