### PR TITLE
[CPPCHECK] fix various warnings

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -439,7 +439,7 @@ bool CApplication::Create(const CAppParamParser &params)
   {
     if (XFILE::CFile::Exists(caCert))
     {
-      CEnvironment::setenv("SSL_CERT_FILE", caCert.c_str(), 1);
+      CEnvironment::setenv("SSL_CERT_FILE", caCert, 1);
       CLog::Log(LOGDEBUG, "CApplication::Create - SSL_CERT_FILE: {}", caCert);
     }
     else
@@ -2125,7 +2125,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     break;
 
   case TMSG_EXECUTE_BUILT_IN:
-    CBuiltins::GetInstance().Execute(pMsg->strParam.c_str());
+    CBuiltins::GetInstance().Execute(pMsg->strParam);
     break;
 
   case TMSG_PICTURE_SHOW:

--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -246,7 +246,7 @@ std::string CDatabaseQueryRule::FormatParameter(const std::string &operatorStrin
     parameter = " IN (" + parameter + ")";
   }
   else
-    parameter = db.PrepareSQL(operatorString.c_str(), ValidateParameter(param).c_str());
+    parameter = db.PrepareSQL(operatorString, ValidateParameter(param).c_str());
 
   if (GetFieldType(m_field) == DATE_FIELD)
   {
@@ -256,7 +256,7 @@ std::string CDatabaseQueryRule::FormatParameter(const std::string &operatorStrin
       CDateTimeSpan span;
       span.SetFromPeriod(param);
       date-=span;
-      parameter = db.PrepareSQL(operatorString.c_str(), date.GetAsDBDate().c_str());
+      parameter = db.PrepareSQL(operatorString, date.GetAsDBDate().c_str());
     }
   }
   return parameter;

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -89,7 +89,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
         // fall back to the old method in that case
         if (!CDirectory::Create(url))
         {
-          StringUtils::Tokenize(url.GetFileName(), tokens, pathsep.c_str());
+          StringUtils::Tokenize(url.GetFileName(), tokens, pathsep);
           std::string strCurrPath;
           // Handle special
           if (!url.GetProtocol().empty())

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -205,10 +205,10 @@ bool CTextureMap::IsEmpty() const
 
 void CTextureMap::Add(std::unique_ptr<CTexture> texture, int delay)
 {
-  m_texture.Add(std::move(texture), delay);
-
   if (texture)
     m_memUsage += sizeof(CTexture) + (texture->GetTextureWidth() * texture->GetTextureHeight() * 4);
+
+  m_texture.Add(std::move(texture), delay);
 }
 
 /************************************************************************/

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -628,7 +628,7 @@ std::string CGUITextureManager::GetTexturePath(const std::string &textureName, b
     CSingleLock lock(m_section);
     for (const std::string& it : m_texturePaths)
     {
-      std::string path = URIUtils::AddFileToFolder(it.c_str(), "media", textureName);
+      std::string path = URIUtils::AddFileToFolder(it, "media", textureName);
       if (directory)
       {
         if (XFILE::CDirectory::Exists(path))

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -323,7 +323,8 @@ void CAnnouncementManager::Process()
       m_announcementQueue.pop_front();
       {
         CSingleExit ex(m_queueCritSection);
-        DoAnnounce(announcement.flag, announcement.sender.c_str(), announcement.message.c_str(), announcement.item, announcement.data);
+        DoAnnounce(announcement.flag, announcement.sender, announcement.message, announcement.item,
+                   announcement.data);
       }
     }
     else

--- a/xbmc/interfaces/legacy/Alternative.h
+++ b/xbmc/interfaces/legacy/Alternative.h
@@ -23,6 +23,8 @@ namespace XBMCAddon
     T2 d2;
 
   public:
+    Alternative() = default;
+
     inline WhichAlternative which() const { return pos; }
 
     inline T1& former()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -230,7 +230,7 @@ namespace XBMCAddon
       }
       else if (lowerKey == "mimetype")
       { // special case for mime type - don't actually stored in a property,
-        item->SetMimeType(value.c_str());
+        item->SetMimeType(value);
       }
       else if (lowerKey == "totaltime")
       {

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -289,14 +289,11 @@ bool CEventClient::OnPacketHELO(CEventPacket *packet)
   m_bGreeted = true;
   if (m_eLogoType == LT_NONE)
   {
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(33200),
-                                          m_deviceName.c_str());
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(33200), m_deviceName);
   }
   else
   {
-    CGUIDialogKaiToast::QueueNotification(iconfile.c_str(),
-                                          g_localizeStrings.Get(33200),
-                                          m_deviceName.c_str());
+    CGUIDialogKaiToast::QueueNotification(iconfile, g_localizeStrings.Get(33200), m_deviceName);
   }
   return true;
 }
@@ -570,14 +567,11 @@ bool CEventClient::OnPacketNOTIFICATION(CEventPacket *packet)
 
   if (m_eLogoType == LT_NONE)
   {
-    CGUIDialogKaiToast::QueueNotification(title.c_str(),
-                                          message.c_str());
+    CGUIDialogKaiToast::QueueNotification(title, message);
   }
   else
   {
-    CGUIDialogKaiToast::QueueNotification(iconfile.c_str(),
-                                          title.c_str(),
-                                          message.c_str());
+    CGUIDialogKaiToast::QueueNotification(iconfile, title, message);
   }
   return true;
 }

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -34,7 +34,9 @@ bool CPicture::GetThumbnailFromSurface(const unsigned char* buffer, int width, i
 
   // get an image handler
   IImage* image = ImageFactory::CreateLoader(thumbFile);
-  if (image == NULL || !image->CreateThumbnailFromSurface(const_cast<unsigned char*>(buffer), width, height, XB_FMT_A8R8G8B8, stride, thumbFile.c_str(), thumb, thumbsize))
+  if (image == NULL ||
+      !image->CreateThumbnailFromSurface(const_cast<unsigned char*>(buffer), width, height,
+                                         XB_FMT_A8R8G8B8, stride, thumbFile, thumb, thumbsize))
   {
     delete image;
     return false;

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -622,7 +622,7 @@ bool CSMBFile::Delete(const CURL& url)
 
   CSingleLock lock(smb);
   if (!smb.IsSmbValid())
-    return -1;
+    return false;
 
   int result = smbc_unlink(strFile.c_str());
 

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -831,7 +831,7 @@ std::string CSmartPlaylistRule::FormatParameter(const std::string &operatorStrin
   if (m_field == FieldTime || m_field == FieldAlbumDuration)
   { // translate time to seconds
     std::string seconds = std::to_string(StringUtils::TimeStringToSeconds(param));
-    return db.PrepareSQL(operatorString.c_str(), seconds.c_str());
+    return db.PrepareSQL(operatorString, seconds.c_str());
   }
   return CDatabaseQueryRule::FormatParameter(operatorString, param, db, strType);
 }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -113,7 +113,7 @@ void CProfileManager::OnSettingsLoaded()
   if (strDir == "set default" || strDir.empty())
   {
     strDir = "special://profile/playlists/";
-    m_settings->SetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH, strDir.c_str());
+    m_settings->SetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH, strDir);
   }
 
   CDirectory::Create(strDir);

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -1041,7 +1041,7 @@ bool CPVREpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime* lastScan)
 
   if (!strValue.empty())
   {
-    lastScan->SetFromDBDateTime(strValue.c_str());
+    lastScan->SetFromDBDateTime(strValue);
     bReturn = true;
   }
   else

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -678,7 +678,7 @@ bool CPVREpgInfoTag::IsLive() const
 
 const std::vector<std::string> CPVREpgInfoTag::Tokenize(const std::string& str)
 {
-  return StringUtils::Split(str.c_str(), EPG_STRING_TOKEN_SEPARATOR);
+  return StringUtils::Split(str, EPG_STRING_TOKEN_SEPARATOR);
 }
 
 const std::string CPVREpgInfoTag::DeTokenize(const std::vector<std::string>& tokens)

--- a/xbmc/pvr/providers/PVRProvider.cpp
+++ b/xbmc/pvr/providers/PVRProvider.cpp
@@ -199,7 +199,7 @@ namespace
 
 const std::vector<std::string> Tokenize(const std::string& str)
 {
-  return StringUtils::Split(str.c_str(), PROVIDER_STRING_TOKEN_SEPARATOR);
+  return StringUtils::Split(str, PROVIDER_STRING_TOKEN_SEPARATOR);
 }
 
 const std::string DeTokenize(const std::vector<std::string>& tokens)

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -1702,7 +1702,7 @@ void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
       else
       {
         strTextLower = StringUtils::Format(valueFormat, valueLower);
-        strTextUpper = StringUtils::Format(valueFormat.c_str(), valueUpper);
+        strTextUpper = StringUtils::Format(valueFormat, valueUpper);
       }
 
       if (valueLower != valueUpper)

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -44,7 +44,7 @@ public:
     if (m_ptempFilePath.empty())
       return false;
 
-    OpenForWrite(m_ptempFilePath.c_str(), true);
+    OpenForWrite(m_ptempFilePath, true);
     return true;
   }
   bool Delete()

--- a/xbmc/utils/Crc32.cpp
+++ b/xbmc/utils/Crc32.cpp
@@ -105,6 +105,6 @@ uint32_t Crc32::ComputeFromLowerCase(const std::string& strValue)
 {
   std::string strLower = strValue;
   StringUtils::ToLower(strLower);
-  return Compute(strLower.c_str());
+  return Compute(strLower);
 }
 

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -299,7 +299,7 @@ void CScraperParser::ParseExpression(const std::string& input, std::string& dest
       int iLen = reg.GetFindLen();
       // nasty hack #1 - & means \0 in a replace string
       StringUtils::Replace(strCurOutput, "&","!!!AMPAMP!!!");
-      std::string result = reg.GetReplaceString(strCurOutput.c_str());
+      std::string result = reg.GetReplaceString(strCurOutput);
       if (!result.empty())
       {
         std::string strResult(result);

--- a/xbmc/windowing/linux/OSScreenSaverFreedesktop.h
+++ b/xbmc/windowing/linux/OSScreenSaverFreedesktop.h
@@ -24,6 +24,8 @@ namespace LINUX
 class COSScreenSaverFreedesktop : public IOSScreenSaver
 {
 public:
+  COSScreenSaverFreedesktop() = default;
+
   static bool IsAvailable();
   void Inhibit() override;
   void Uninhibit() override;


### PR DESCRIPTION
This PR corrects some simple issues found by cppcheck that runs in our CI.

The point of this PR is not only to fix these issues, but to encourage others to actively check the reports for new warnings and to fix old ones.

For those unaware the cppcheck analysis can be found here: https://jenkins.kodi.tv/view/Reports/job/LINUX-64-GL-Static-Analysis/lastBuild/cppcheck/

The following issues are being addressed:
 1) remove necessary c_str() usage
 2) fix unique_ptr usage after std::move
 3) fix non bool return in a bool function
 4) add constructors where needed