### PR TITLE
[Android] Fix application shutdown sequence. 

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -138,7 +138,7 @@ public:
   bool InitWindow(RESOLUTION res = RES_INVALID);
 
   bool IsCurrentThread() const;
-  void Stop(int exitCode);
+  bool Stop(int exitCode);
   void UnloadSkin();
   bool LoadCustomWindows();
   void ReloadSkin(bool confirm = false);

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -545,11 +545,6 @@ void CXBMCApp::run()
   android_printf(" => XBMC_Run finished with %d", status);
 }
 
-void CXBMCApp::XBMC_Pause(bool pause)
-{
-  android_printf("XBMC_Pause(%s)", pause ? "true" : "false");
-}
-
 bool CXBMCApp::XBMC_SetupDisplay()
 {
   android_printf("XBMC_SetupDisplay()");

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -212,11 +212,9 @@ void CXBMCApp::onStart()
     // Register sink
     AE::CAESinkFactory::ClearSinks();
     CAESinkAUDIOTRACK::Register();
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_create(&m_thread, &attr, thread_run<CXBMCApp, &CXBMCApp::run>, this);
-    pthread_attr_destroy(&attr);
+
+    // Create thread to run Kodi main event loop
+    m_thread = std::thread(&CXBMCApp::run, this);
 
     // Some intent filters MUST be registered in code rather than through the manifest
     CJNIIntentFilter intentFilter;
@@ -433,7 +431,7 @@ void CXBMCApp::Quit()
   CApplicationMessenger::GetInstance().PostMsg(msgId);
 
   // wait for the run thread to finish
-  pthread_join(m_thread, nullptr);
+  m_thread.join();
 
   CLog::Log(LOGINFO, "XBMCApp: Application stopped!");
 }

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -22,9 +22,9 @@
 
 #include <atomic>
 #include <map>
-#include <math.h>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <android/native_activity.h>
@@ -33,7 +33,6 @@
 #include <androidjni/BroadcastReceiver.h>
 #include <androidjni/SurfaceHolder.h>
 #include <androidjni/View.h>
-#include <pthread.h>
 
 // forward declares
 class CJNIWakeLock;
@@ -247,7 +246,7 @@ private:
   std::atomic<bool> m_exiting{false};
   int m_exitCode{0};
   bool m_bResumePlayback = false;
-  pthread_t m_thread;
+  std::thread m_thread;
   static CCriticalSection m_applicationsMutex;
   static CCriticalSection m_activityResultMutex;
   static std::vector<androidPackage> m_applications;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -261,7 +261,6 @@ private:
 
   std::unique_ptr<CJNIActivityManager> m_activityManager;
 
-  void XBMC_Pause(bool pause);
   bool XBMC_DestroyDisplay();
   bool XBMC_SetupDisplay();
 

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -20,6 +20,7 @@
 #include "threads/Event.h"
 #include "utils/Geometry.h"
 
+#include <atomic>
 #include <map>
 #include <math.h>
 #include <memory>
@@ -136,6 +137,9 @@ public:
   void Initialize();
   void Deinitialize();
 
+  bool Stop(int exitCode);
+  void Quit();
+
   static ANativeWindow* GetNativeWindow(int timeout);
   static int SetBuffersGeometry(int width, int height, int format);
   static int android_printf(const char *format, ...);
@@ -240,7 +244,8 @@ private:
   static bool m_hasReqVisible;
   bool m_videosurfaceInUse;
   bool m_firstrun;
-  bool m_exiting;
+  std::atomic<bool> m_exiting{false};
+  int m_exitCode{0};
   bool m_bResumePlayback = false;
   pthread_t m_thread;
   static CCriticalSection m_applicationsMutex;
@@ -257,7 +262,6 @@ private:
   std::unique_ptr<CJNIActivityManager> m_activityManager;
 
   void XBMC_Pause(bool pause);
-  void XBMC_Stop();
   bool XBMC_DestroyDisplay();
   bool XBMC_SetupDisplay();
 

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -107,6 +107,7 @@ extern void android_main(struct android_app* state)
     {
       start_logger("Kodi");
       eventLoop.run(xbmcApp, inputHandler);
+      xbmcApp.Quit();
     }
     else
       CXBMCApp::android_printf("android_main: setup failed");

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -39,8 +39,8 @@ extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params)
   if (renderGUI && !g_application.CreateGUI())
   {
     CMessagePrinter::DisplayError("ERROR: Unable to create GUI. Exiting");
-    g_application.Stop(EXITCODE_QUIT);
-    g_application.Cleanup();
+    if (g_application.Stop(EXITCODE_QUIT))
+      g_application.Cleanup();
     return status;
   }
   if (!g_application.Initialize())


### PR DESCRIPTION
Fixes crashes while shutting down the application caused by callbacks from Android calling already destructed application components.

Logcat on my two Shields was full of fatal crashes of kodi. Literally every Kodi shutdown crashed, app never was shut down in a clean way:

```log
--------- beginning of crash
12-22 15:59:26.572 27980 20055 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x8 in tid 20055 (Thread-86), pid 27980 (org.xbmc.kodi)
12-22 15:59:26.773 20060 20060 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
12-22 15:59:26.773 20060 20060 F DEBUG   : Build fingerprint: 'NVIDIA/foster_e_hdd/foster:9/PPR1.180610.011/4079208_2740.7538:user/release-keys'
12-22 15:59:26.773 20060 20060 F DEBUG   : Revision: '0'
12-22 15:59:26.773 20060 20060 F DEBUG   : ABI: 'arm64'
12-22 15:59:26.773 20060 20060 F DEBUG   : pid: 27980, tid: 20055, name: Thread-86  >>> org.xbmc.kodi <<<
12-22 15:59:26.773 20060 20060 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x8
12-22 15:59:26.773 20060 20060 F DEBUG   : Cause: null pointer dereference
12-22 15:59:26.773 20060 20060 F DEBUG   :     x0  0000000000000000  x1  0000002a2da84094  x2  0000000000000003  x3  0000000000000033
12-22 15:59:26.773 20060 20060 F DEBUG   :     x4  0000000000000028  x5  0000000040100401  x6  0000002a2da84093  x7  7f7f7f7f7f7f7f7f
12-22 15:59:26.773 20060 20060 F DEBUG   :     x8  0000000000000006  x9  0000000000000003  x10 0000000000000003  x11 0000000000000004
12-22 15:59:26.773 20060 20060 F DEBUG   :     x12 0000002a09841470  x13 0000002a09841410  x14 0000002a09841470  x15 0000002a09841410
12-22 15:59:26.773 20060 20060 F DEBUG   :     x16 0000002a2cbf05f8  x17 0000002a29b1d660  x18 0000000000000030  x19 0000002a2da84110
12-22 15:59:26.773 20060 20060 F DEBUG   :     x20 0000002a2da86588  x21 0000002a2da84b58  x22 0000002a2da86588  x23 0000002a2da84b58
12-22 15:59:26.773 20060 20060 F DEBUG   :     x24 0000002a2da86588  x25 0000002a2c9d1e38  x26 0000002a2da86588  x27 0000002a2c9d1e48
12-22 15:59:26.773 20060 20060 F DEBUG   :     x28 0000002a2cd11700  x29 0000002a2da84100
12-22 15:59:26.773 20060 20060 F DEBUG   :     sp  0000002a2da84020  lr  0000002a29d5120c  pc  0000002a29b1d660
12-22 15:59:27.142 20060 20060 F DEBUG   : 
12-22 15:59:27.142 20060 20060 F DEBUG   : backtrace:
12-22 15:59:27.142 20060 20060 F DEBUG   :     #00 pc 0000000001459660  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (CServiceManager::GetAddonMgr())
12-22 15:59:27.142 20060 20060 F DEBUG   :     #01 pc 000000000168d208  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (MUSIC_INFO::CMusicInfoTagLoaderFactory::CreateLoader(CFileItem const&)+168)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #02 pc 00000000017272c8  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (CMusicThumbLoader::GetEmbeddedThumb(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, EmbeddedArt&)+64)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #03 pc 000000000145e390  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (CTextureCacheJob::LoadImage(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, unsigned int, unsigned int, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)+172)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #04 pc 000000000145d7b0  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (CTextureCacheJob::CacheTexture(CTexture**)+420)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #05 pc 000000000145b560  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (CTextureCache::CacheImage(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, CTexture**, CTextureDetails*)+516)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #06 pc 0000000001812124  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (XFILE::CImageFile::Open(CURL const&)+120)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #07 pc 0000000001806f18  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (XFILE::CFile::Open(CURL const&, unsigned int)+640)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #08 pc 0000000001805bc8  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (XFILE::CFile::Open(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, unsigned int)+60)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #09 pc 00000000018c591c  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/lib/arm64/libkodi.so (jni::CJNIXBMCFile::_open(_JNIEnv*, _jobject*, _jstring*)+252)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #10 pc 00000000000066f8  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/oat/arm64/base.odex (offset 0x6000) (org.xbmc.kodi.XBMCFile._open [DEDUPED]+152)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #11 pc 0000000000555388  /system/lib64/libart.so (art_quick_invoke_stub+584)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #12 pc 00000000000cf6c8  /system/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #13 pc 000000000027f450  /system/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+344)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #14 pc 0000000000279458  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+968)
12-22 15:59:27.142 20060 20060 F DEBUG   :     #15 pc 0000000000528158  /system/lib64/libart.so (MterpInvokeVirtualQuick+584)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #16 pc 000000000054b794  /system/lib64/libart.so (ExecuteMterpImpl+29972)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #17 pc 0000000000081e76  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/oat/arm64/base.vdex (org.xbmc.kodi.XBMCFile.Open+2)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #18 pc 000000000025315c  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.4286932938+488)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #19 pc 0000000000258c50  /system/lib64/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+216)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #20 pc 000000000027943c  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+940)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #21 pc 0000000000528158  /system/lib64/libart.so (MterpInvokeVirtualQuick+584)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #22 pc 000000000054b794  /system/lib64/libart.so (ExecuteMterpImpl+29972)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #23 pc 0000000000087ede  /data/app/org.xbmc.kodi-LFlrmTLo6wfGxa6TEJ0lTQ==/oat/arm64/base.vdex (org.xbmc.kodi.content.XBMCFileContentProvider$TransferThread.run+14)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #24 pc 000000000025315c  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.4286932938+488)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #25 pc 00000000005159a8  /system/lib64/libart.so (artQuickToInterpreterBridge+1020)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #26 pc 000000000055e4fc  /system/lib64/libart.so (art_quick_to_interpreter_bridge+92)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #27 pc 0000000000555388  /system/lib64/libart.so (art_quick_invoke_stub+584)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #28 pc 00000000000cf6c8  /system/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200)
12-22 15:59:27.143 20060 20060 F DEBUG   :     #29 pc 000000000045d244  /system/lib64/libart.so (art::(anonymous namespace)::InvokeWithArgArray(art::ScopedObjectAccessAlreadyRunnable const&, art::ArtMethod*, art::(anonymous namespace)::ArgArray*, art::JValue*, char const*)+104)
12-22 15:59:27.144 20060 20060 F DEBUG   :     #30 pc 000000000045e300  /system/lib64/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, jvalue*)+424)
12-22 15:59:27.144 20060 20060 F DEBUG   :     #31 pc 000000000048919c  /system/lib64/libart.so (art::Thread::CreateCallback(void*)+1120)
12-22 15:59:27.144 20060 20060 F DEBUG   :     #32 pc 000000000008196c  /system/lib64/libc.so (__pthread_start(void*)+36)
12-22 15:59:27.144 20060 20060 F DEBUG   :     #33 pc 00000000000234b8  /system/lib64/libc.so (__start_thread+68)
12-25 22:35:49.845 10946 11297 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 11297 (Thread-93), pid 10946 (org.xbmc.kodi)
12-25 22:35:50.035 11303 11303 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
12-25 22:35:50.035 11303 11303 F DEBUG   : Build fingerprint: 'NVIDIA/foster_e_hdd/foster:9/PPR1.180610.011/4079208_2740.7538:user/release-keys'
12-25 22:35:50.035 11303 11303 F DEBUG   : Revision: '0'
12-25 22:35:50.035 11303 11303 F DEBUG   : ABI: 'arm64'
12-25 22:35:50.035 11303 11303 F DEBUG   : pid: 10946, tid: 11297, name: Thread-93  >>> org.xbmc.kodi <<<
12-25 22:35:50.035 11303 11303 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
12-25 22:35:50.035 11303 11303 F DEBUG   : Cause: null pointer dereference
12-25 22:35:50.035 11303 11303 F DEBUG   :     x0  0000000000000000  x1  0000000000000000  x2  0000000000000000  x3  0000000000000010
12-25 22:35:50.036 11303 11303 F DEBUG   :     x4  0000000000000010  x5  0000000000800000  x6  756873625fff6f6f  x7  7f7f7f7f7f7f7f7f
12-25 22:35:50.036 11303 11303 F DEBUG   :     x8  0000000000000000  x9  ff743ffde2deca57  x10 0000002a09888728  x11 0000000000000003
12-25 22:35:50.036 11303 11303 F DEBUG   :     x12 0000002a09888748  x13 0000002a099c5600  x14 0000002a099c565d  x15 0000002a099c5600
12-25 22:35:50.036 11303 11303 F DEBUG   :     x16 0000002a27b66090  x17 0000002a24a9cb90  x18 0000000000000030  x19 0000002a09846400
12-25 22:35:50.036 11303 11303 F DEBUG   :     x20 0000002a29409588  x21 0000002a29409588  x22 0000000000000000  x23 0000002a29407b58
12-25 22:35:50.036 11303 11303 F DEBUG   :     x24 0000002a29409588  x25 0000002a29409588  x26 0000002a29409588  x27 0000002a29409588
12-25 22:35:50.036 11303 11303 F DEBUG   :     x28 0000002a27c93700  x29 0000002a29407400
12-25 22:35:50.036 11303 11303 F DEBUG   :     sp  0000002a294073d0  lr  0000002a248d07a4  pc  0000002a248d07a4
12-25 22:35:51.103 11303 11303 F DEBUG   : 
12-25 22:35:51.103 11303 11303 F DEBUG   : backtrace:
12-25 22:35:51.103 11303 11303 F DEBUG   :     #00 pc 00000000012897a4  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (CTexture::Allocate(unsigned int, unsigned int, unsigned int)+204)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #01 pc 0000000001298088  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (CGLTexture::CGLTexture(unsigned int, unsigned int, unsigned int)+32)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #02 pc 000000000129803c  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (CTexture::CreateTexture(unsigned int, unsigned int, unsigned int)+52)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #03 pc 0000000001289e54  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (CTexture::LoadFromFile(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, unsigned int, unsigned int, bool, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+256)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #04 pc 000000000145d2d0  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (CTextureCacheJob::LoadImage(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, unsigned int, unsigned int, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)+620)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #05 pc 000000000145c530  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (CTextureCacheJob::CacheTexture(CTexture**)+420)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #06 pc 000000000145a2e0  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (CTextureCache::CacheImage(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, CTexture**, CTextureDetails*)+516)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #07 pc 000000000180da54  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (XFILE::CImageFile::Open(CURL const&)+120)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #08 pc 0000000001802848  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (XFILE::CFile::Open(CURL const&, unsigned int)+640)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #09 pc 00000000018014f8  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (XFILE::CFile::Open(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, unsigned int)+60)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #10 pc 00000000018c024c  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/lib/arm64/libkodi.so (jni::CJNIXBMCFile::_open(_JNIEnv*, _jobject*, _jstring*)+252)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #11 pc 000000000000b6f8  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/oat/arm64/base.odex (offset 0xb000) (org.xbmc.kodi.XBMCFile._open [DEDUPED]+152)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #12 pc 0000000000555388  /system/lib64/libart.so (art_quick_invoke_stub+584)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #13 pc 00000000000cf6c8  /system/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #14 pc 000000000027f450  /system/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+344)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #15 pc 0000000000279458  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+968)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #16 pc 0000000000528158  /system/lib64/libart.so (MterpInvokeVirtualQuick+584)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #17 pc 000000000054b794  /system/lib64/libart.so (ExecuteMterpImpl+29972)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #18 pc 0000000000073cea  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/oat/arm64/base.vdex (org.xbmc.kodi.XBMCFile.Open+2)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #19 pc 000000000025315c  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.4286932938+488)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #20 pc 0000000000258c50  /system/lib64/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+216)
12-25 22:35:51.103 11303 11303 F DEBUG   :     #21 pc 000000000027943c  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+940)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #22 pc 0000000000528158  /system/lib64/libart.so (MterpInvokeVirtualQuick+584)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #23 pc 000000000054b794  /system/lib64/libart.so (ExecuteMterpImpl+29972)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #24 pc 0000000000076f0c  /data/app/org.xbmc.kodi-LgKU7FUcx4pVMS2P3VsVsQ==/oat/arm64/base.vdex (org.xbmc.kodi.content.XBMCFileContentProvider$TransferThread.run+14)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #25 pc 000000000025315c  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.4286932938+488)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #26 pc 00000000005159a8  /system/lib64/libart.so (artQuickToInterpreterBridge+1020)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #27 pc 000000000055e4fc  /system/lib64/libart.so (art_quick_to_interpreter_bridge+92)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #28 pc 0000000000555388  /system/lib64/libart.so (art_quick_invoke_stub+584)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #29 pc 00000000000cf6c8  /system/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #30 pc 000000000045d244  /system/lib64/libart.so (art::(anonymous namespace)::InvokeWithArgArray(art::ScopedObjectAccessAlreadyRunnable const&, art::ArtMethod*, art::(anonymous namespace)::ArgArray*, art::JValue*, char const*)+104)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #31 pc 000000000045e300  /system/lib64/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, jvalue*)+424)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #32 pc 000000000048919c  /system/lib64/libart.so (art::Thread::CreateCallback(void*)+1120)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #33 pc 000000000008196c  /system/lib64/libc.so (__pthread_start(void*)+36)
12-25 22:35:51.104 11303 11303 F DEBUG   :     #34 pc 00000000000234b8  /system/lib64/libc.so (__start_thread+68)
01-17 09:38:47.152 20602 21525 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10 in tid 21525 (Thread-96), pid 20602 (org.xbmc.kodi)
01-17 09:38:47.575 21531 21531 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
01-17 09:38:47.575 21531 21531 F DEBUG   : Build fingerprint: 'NVIDIA/foster_e_hdd/foster:9/PPR1.180610.011/4079208_2740.7538:user/release-keys'
01-17 09:38:47.575 21531 21531 F DEBUG   : Revision: '0'
01-17 09:38:47.575 21531 21531 F DEBUG   : ABI: 'arm64'
01-17 09:38:47.575 21531 21531 F DEBUG   : pid: 20602, tid: 21525, name: Thread-96  >>> org.xbmc.kodi <<<
01-17 09:38:47.575 21531 21531 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10
01-17 09:38:47.575 21531 21531 F DEBUG   : Cause: null pointer dereference
01-17 09:38:47.575 21531 21531 F DEBUG   :     x0  0000000000000000  x1  0000002a2b350566  x2  0000000000000000  x3  0000000000000073
01-17 09:38:47.575 21531 21531 F DEBUG   :     x4  0000000000000073  x5  0000000000000000  x6  73646c2c6f737367  x7  7f7f7f7f7f7f7f7f
01-17 09:38:47.575 21531 21531 F DEBUG   :     x8  0000002a2d504570  x9  0000000000000005  x10 0000000000000005  x11 0000000000000001
01-17 09:38:47.575 21531 21531 F DEBUG   :     x12 0000002a0988a248  x13 0033372e372e3638  x14 0000000000000000  x15 0000002a2d504328
01-17 09:38:47.575 21531 21531 F DEBUG   :     x16 0000002a2c662828  x17 0000002a29636010  x18 0000000000000001  x19 0000002a10630000
01-17 09:38:47.575 21531 21531 F DEBUG   :     x20 0000002a2d5046d8  x21 0000002a2d504778  x22 00000000000001bb  x23 0000002a2d506588
01-17 09:38:47.575 21531 21531 F DEBUG   :     x24 0000002a2d506588  x25 0000002a2d506588  x26 0000002a47d940a0  x27 0000000000000002
01-17 09:38:47.575 21531 21531 F DEBUG   :     x28 0000000000000002  x29 0000002a2d504690
01-17 09:38:47.575 21531 21531 F DEBUG   :     sp  0000002a2d504510  lr  0000002a299329b0  pc  0000002a29636010
01-17 09:38:47.914 21531 21531 F DEBUG   : 
01-17 09:38:47.914 21531 21531 F DEBUG   : backtrace:
01-17 09:38:47.914 21531 21531 F DEBUG   :     #00 pc 00000000014ec010  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (CSettingsComponent::GetSettings())
01-17 09:38:47.914 21531 21531 F DEBUG   :     #01 pc 00000000017e89ac  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (XFILE::CCurlFile::ParseAndCorrectUrl(CURL&)+1380)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #02 pc 00000000017eba68  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (XFILE::CCurlFile::Exists(CURL const&)+176)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #03 pc 00000000018018e4  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (XFILE::CFile::Exists(CURL const&, bool)+228)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #04 pc 00000000018031bc  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (XFILE::CFile::Exists(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)+56)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #05 pc 000000000180dea8  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (XFILE::CImageFile::Exists(CURL const&)+156)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #06 pc 00000000018018e4  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (XFILE::CFile::Exists(CURL const&, bool)+228)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #07 pc 00000000018031bc  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (XFILE::CFile::Exists(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)+56)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #08 pc 00000000018c14dc  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/lib/arm64/libkodi.so (jni::CJNIXBMCFile::_open(_JNIEnv*, _jobject*, _jstring*)+148)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #09 pc 00000000000066f8  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/oat/arm64/base.odex (offset 0x6000) (org.xbmc.kodi.XBMCFile._open [DEDUPED]+152)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #10 pc 0000000000555388  /system/lib64/libart.so (art_quick_invoke_stub+584)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #11 pc 00000000000cf6c8  /system/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #12 pc 000000000027f450  /system/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+344)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #13 pc 0000000000279458  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+968)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #14 pc 0000000000528158  /system/lib64/libart.so (MterpInvokeVirtualQuick+584)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #15 pc 000000000054b794  /system/lib64/libart.so (ExecuteMterpImpl+29972)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #16 pc 0000000000081e76  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/oat/arm64/base.vdex (org.xbmc.kodi.XBMCFile.Open+2)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #17 pc 000000000025315c  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.4286932938+488)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #18 pc 0000000000258c50  /system/lib64/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+216)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #19 pc 000000000027943c  /system/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+940)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #20 pc 0000000000528158  /system/lib64/libart.so (MterpInvokeVirtualQuick+584)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #21 pc 000000000054b794  /system/lib64/libart.so (ExecuteMterpImpl+29972)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #22 pc 0000000000087ede  /data/app/org.xbmc.kodi-hUUePWdozFrMDV6s1BP6sw==/oat/arm64/base.vdex (org.xbmc.kodi.content.XBMCFileContentProvider$TransferThread.run+14)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #23 pc 000000000025315c  /system/lib64/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEb.llvm.4286932938+488)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #24 pc 00000000005159a8  /system/lib64/libart.so (artQuickToInterpreterBridge+1020)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #25 pc 000000000055e4fc  /system/lib64/libart.so (art_quick_to_interpreter_bridge+92)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #26 pc 0000000000555388  /system/lib64/libart.so (art_quick_invoke_stub+584)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #27 pc 00000000000cf6c8  /system/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+200)
01-17 09:38:47.915 21531 21531 F DEBUG   :     #28 pc 000000000045d244  /system/lib64/libart.so (art::(anonymous namespace)::InvokeWithArgArray(art::ScopedObjectAccessAlreadyRunnable const&, art::ArtMethod*, art::(anonymous namespace)::ArgArray*, art::JValue*, char const*)+104)
01-17 09:38:47.916 21531 21531 F DEBUG   :     #29 pc 000000000045e300  /system/lib64/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, jvalue*)+424)
01-17 09:38:47.916 21531 21531 F DEBUG   :     #30 pc 000000000048919c  /system/lib64/libart.so (art::Thread::CreateCallback(void*)+1120)
01-17 09:38:47.916 21531 21531 F DEBUG   :     #31 pc 000000000008196c  /system/lib64/libc.so (__pthread_start(void*)+36)
01-17 09:38:47.916 21531 21531 F DEBUG   :     #32 pc 00000000000234b8  /system/lib64/libc.so (__start_thread+68)
```

Reason for this crashes is wrong application shutdown order. `ANativeActivity_finish` is called AFTER `CApplication` cleanup and destroy. The latter stops all services (json-rpc, ...) and resets alls component instances (settings, ...). So, there is a race between Android async callbacks not knowing about application shutdown, thus calling into the dying/dead application. The crashes are all related to callbacks from Leanback fetching thumbnails for Kodi suggestions I guess. But there can be other races as well.

So, this PR corrects the shutdown order by first calling `ANativeActivity_finish` and after Android has signalled that the app can be destroyed `CApplication` will be cleaned up and destructed.

I carefully tested this on two devices for a longer time. No more crashes while shutting down Kodi with this PR applied. :-)

A nice side effect of the change is that the Kodi GUI vanishes immediately (its fading out nicely) after
selecting "Exit" from Kodi. The user can start to work with other apps immediately, no longer has to wait until Kodi actually has quit, which can take a couple of seconds usually.

@koying I know you are no longer active, but maybe you still read this. Does my change make sense to you?