### PR TITLE
AESinkAudioTrack: Revisit period length

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1197,7 +1197,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       if (buffertime > MAX_BUFFER_TIME)
       {
         CLog::Log(LOGWARNING,
-                  "ActiveAE::{} - sink returned large buffer of {} ms, reducing to {} ms",
+                  "ActiveAE::{} - sink returned large period time of {} ms, reducing to {} ms",
                   __FUNCTION__, (int)(buffertime * 1000), (int)(MAX_BUFFER_TIME * 1000));
         m_sinkFormat.m_frames = MAX_BUFFER_TIME * m_sinkFormat.m_sampleRate;
       }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -498,51 +498,37 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
     {
       m_format.m_frameSize = m_format.m_channelLayout.Count() * (CAEUtil::DataFormatToBits(m_format.m_dataFormat) / 8);
       m_sink_frameSize = m_format.m_frameSize;
-      bool isHDiec = ((m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD) ||
-                      (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD_MA));
-      if (m_passthrough && isHDiec)
+      // aim at 200 ms buffer and 50 ms periods but at least two periods of min_buffer
+      // make sure periods are actually not smaller than 32 ms (32, cause 32 * 2 = 64)
+      // but also not bigger than 64 ms
+      // which is large enough to not cause CPU hogging in case 32 ms periods are used
+      m_min_buffer_size *= 2;
+      m_audiotrackbuffer_sec =
+          static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
+
+      int c = 2;
+      while (m_audiotrackbuffer_sec < 0.15)
       {
-        // Certain boxes have issues opening DTS-HD / TrueHD with this large amount of data
-        // adjust accordingly
-        m_min_buffer_size *= 2;
-        m_format.m_frames = static_cast<int>(m_min_buffer_size / m_format.m_frameSize) / 2;
+        m_min_buffer_size += min_buffer;
+        c++;
         m_audiotrackbuffer_sec =
             static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
       }
-      else
+      unsigned int period_size = m_min_buffer_size / c;
+      double period_time =
+          static_cast<double>(period_size) / (m_sink_frameSize * m_sink_sampleRate);
+
+      while (period_time > 0.064)
       {
-        // aim at 200 ms buffer and 50 ms periods but at least two periods of min_buffer
-        // make sure periods are actually not smaller than 32 ms (32, cause 32 * 2 = 64)
-        // but also not bigger than 64 ms
-        // which is large enough to not cause CPU hogging in case 32 ms periods are used
-        m_min_buffer_size *= 2;
-        m_audiotrackbuffer_sec =
-            static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
-
-        int c = 2;
-        while (m_audiotrackbuffer_sec < 0.15)
-        {
-          m_min_buffer_size += min_buffer;
-          c++;
-          m_audiotrackbuffer_sec =
-              static_cast<double>(m_min_buffer_size) / (m_sink_frameSize * m_sink_sampleRate);
-        }
-        unsigned int period_size = m_min_buffer_size / c;
-        double period_time =
-            static_cast<double>(period_size) / (m_sink_frameSize * m_sink_sampleRate);
-
-        while (period_time > 0.064)
-        {
-          period_time /= 2;
-          period_size /= 2;
-        }
-        while (period_time < 0.032)
-        {
-          period_size *= 2;
-          period_time *= 2;
-        }
-        m_format.m_frames = static_cast<int>(period_size / m_format.m_frameSize);
+        period_time /= 2;
+        period_size /= 2;
       }
+      while (period_time < 0.032)
+      {
+        period_size *= 2;
+        period_time *= 2;
+      }
+      m_format.m_frames = static_cast<int>(period_size / m_format.m_frameSize);
     }
 
     if (m_passthrough && !m_info.m_wantsIECPassthrough)


### PR DESCRIPTION
Found an issue with period computation and sink opening for the case when the sink itself already opens large buffer by itself. This code adjusts that.

Btw. that is always an issue here. ALSA out of that reason has the "_near_" API, you just say: Give me something near 50 ms and it returns 32 or 64 or whatever the sink likes.