### PR TITLE
CSingleLock/CSharedLock/CExclusiveLock: replace with stl methods

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -46,6 +46,7 @@
 #include "utils/Variant.h"
 #include "video/Bookmark.h"
 #include "video/VideoLibraryQueue.h"
+
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
 #endif
@@ -85,6 +86,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SkinSettings.h"
+#include "threads/SingleLock.h"
 #include "utils/CPUInfo.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/SystemInfo.h"
@@ -189,11 +191,13 @@
 #include <X11/Xlib.h>
 #endif
 
-#include "cores/FFmpeg.h"
-#include "utils/CharsetConverter.h"
-#include "pictures/GUIWindowSlideShow.h"
-#include "addons/AddonSystemSettings.h"
 #include "FileItem.h"
+#include "addons/AddonSystemSettings.h"
+#include "cores/FFmpeg.h"
+#include "pictures/GUIWindowSlideShow.h"
+#include "utils/CharsetConverter.h"
+
+#include <mutex>
 
 using namespace ADDON;
 using namespace XFILE;
@@ -246,14 +250,14 @@ CApplication::~CApplication(void)
 
 bool CApplication::OnEvent(XBMC_Event& newEvent)
 {
-  CSingleLock lock(m_portSection);
+  std::unique_lock<CCriticalSection> lock(m_portSection);
   m_portEvents.push_back(newEvent);
   return true;
 }
 
 void CApplication::HandlePortEvents()
 {
-  CSingleLock lock(m_portSection);
+  std::unique_lock<CCriticalSection> lock(m_portSection);
   while (!m_portEvents.empty())
   {
     auto newEvent = m_portEvents.front();
@@ -1112,7 +1116,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
 
   }
 
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   // store current active window with its focused control
   int currentWindowID = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
@@ -2298,7 +2302,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 
     if (processGUI && m_renderGUI)
     {
-      CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
       // check if there are notifications to display
       CGUIDialogKaiToast *toast = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKaiToast>(WINDOW_DIALOG_KAI_TOAST);
       if (toast && toast->DoWork())
@@ -3070,7 +3074,7 @@ void CApplication::OnPlayBackStarted(const CFileItem &file)
 
 void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &bookmarkParam)
 {
-  CSingleLock lock(m_stackHelper.m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_stackHelper.m_critSection);
 
   CFileItem fileItem(file);
   CBookmark bookmark = bookmarkParam;
@@ -4844,7 +4848,7 @@ void CApplication::CloseNetworkShares()
 
 void CApplication::RegisterActionListener(IActionListener *listener)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::vector<IActionListener *>::iterator it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
   if (it == m_actionListeners.end())
     m_actionListeners.push_back(listener);
@@ -4852,7 +4856,7 @@ void CApplication::RegisterActionListener(IActionListener *listener)
 
 void CApplication::UnregisterActionListener(IActionListener *listener)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::vector<IActionListener *>::iterator it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
   if (it != m_actionListeners.end())
     m_actionListeners.erase(it);
@@ -4860,7 +4864,7 @@ void CApplication::UnregisterActionListener(IActionListener *listener)
 
 bool CApplication::NotifyActionListeners(const CAction &action) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (std::vector<IActionListener *>::const_iterator it = m_actionListeners.begin(); it != m_actionListeners.end(); ++it)
   {
     if ((*it)->OnAction(action))

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1189,7 +1189,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
   CLog::Log(LOGINFO, "  skin loaded...");
 
   // leave the graphics lock
-  lock.Leave();
+  lock.unlock();
 
   // restore active window
   if (currentWindowID != WINDOW_INVALID)

--- a/xbmc/ApplicationStackHelper.cpp
+++ b/xbmc/ApplicationStackHelper.cpp
@@ -12,11 +12,11 @@
 #include "Util.h"
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "filesystem/StackDirectory.h"
-#include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 
+#include <mutex>
 #include <utility>
 
 using namespace XFILE;
@@ -34,7 +34,7 @@ void CApplicationStackHelper::Clear()
 
 void CApplicationStackHelper::OnPlayBackStarted(const CFileItem& item)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // time to clean up stack map
   if (!HasRegisteredStack(item))

--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -10,9 +10,10 @@
 
 #include "FileItem.h"
 #include "URL.h"
-#include "threads/SingleLock.h"
 #include "threads/Thread.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 CBackgroundInfoLoader::CBackgroundInfoLoader() : m_thread (NULL)
 {
@@ -98,7 +99,7 @@ void CBackgroundInfoLoader::Load(CFileItemList& items)
   if (items.IsEmpty())
     return;
 
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
 
   for (int nItem=0; nItem < items.Size(); nItem++)
     m_vecItems.push_back(items[nItem]);

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -20,6 +20,8 @@
 #include "video/VideoDatabase.h"
 #include "view/ViewDatabase.h"
 
+#include <mutex>
+
 using namespace PVR;
 
 CDatabaseManager::CDatabaseManager() :
@@ -34,7 +36,7 @@ CDatabaseManager::~CDatabaseManager() = default;
 
 void CDatabaseManager::Initialize()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   m_dbStatus.clear();
 
@@ -62,7 +64,7 @@ void CDatabaseManager::Initialize()
 
 bool CDatabaseManager::CanOpen(const std::string &name)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   std::map<std::string, DB_STATUS>::const_iterator i = m_dbStatus.find(name);
   if (i != m_dbStatus.end())
     return i->second == DB_READY;
@@ -206,6 +208,6 @@ bool CDatabaseManager::UpdateVersion(CDatabase &db, const std::string &dbName)
 
 void CDatabaseManager::UpdateStatus(const std::string &name, DB_STATUS status)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_dbStatus[name] = status;
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -33,6 +33,7 @@
 #include <functional>
 #include <iterator>
 #include <memory>
+#include <mutex>
 
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
@@ -10452,7 +10453,7 @@ INFO::InfoPtr CGUIInfoManager::Register(const std::string &expression, int conte
   if (condition.empty())
     return INFO::InfoPtr();
 
-  CSingleLock lock(m_critInfo);
+  std::unique_lock<CCriticalSection> lock(m_critInfo);
   std::pair<INFOBOOLTYPE::iterator, bool> res;
 
   if (condition.find_first_of("|+[]!") != condition.npos)
@@ -10767,7 +10768,7 @@ void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)
 
 void CGUIInfoManager::Clear()
 {
-  CSingleLock lock(m_critInfo);
+  std::unique_lock<CCriticalSection> lock(m_critInfo);
   m_skinVariableStrings.clear();
 
   /*
@@ -11034,7 +11035,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int contextWindow, i
 void CGUIInfoManager::ResetCache()
 {
   // mark our infobools as dirty
-  CSingleLock lock(m_critInfo);
+  std::unique_lock<CCriticalSection> lock(m_critInfo);
   ++m_refreshCounter;
 }
 
@@ -11071,7 +11072,7 @@ int CGUIInfoManager::RegisterSkinVariableString(const CSkinVariableString* info)
   if (!info)
     return 0;
 
-  CSingleLock lock(m_critInfo);
+  std::unique_lock<CCriticalSection> lock(m_critInfo);
   m_skinVariableStrings.emplace_back(*info);
   delete info;
   return CONDITIONAL_LABEL_START + m_skinVariableStrings.size() - 1;
@@ -11167,7 +11168,7 @@ void CGUIInfoManager::RegisterInfoProvider(IGUIInfoProvider *provider)
   if (!CServiceBroker::GetWinSystem())
     return;
 
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_infoProviders.RegisterProvider(provider, false);
 }
@@ -11177,7 +11178,7 @@ void CGUIInfoManager::UnregisterInfoProvider(IGUIInfoProvider *provider)
   if (!CServiceBroker::GetWinSystem())
     return;
 
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_infoProviders.UnregisterProvider(provider);
 }

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -14,9 +14,10 @@
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 CPasswordManager &CPasswordManager::GetInstance()
 {
@@ -31,7 +32,7 @@ CPasswordManager::CPasswordManager()
 
 bool CPasswordManager::AuthenticateURL(CURL &url)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!m_loaded)
     Load();
@@ -54,7 +55,7 @@ bool CPasswordManager::AuthenticateURL(CURL &url)
 
 bool CPasswordManager::PromptToAuthenticateURL(CURL &url)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   std::string passcode;
   std::string username = url.GetUserName();
@@ -95,7 +96,7 @@ void CPasswordManager::SaveAuthenticatedURL(const CURL &url, bool saveToProfile)
   if (url.GetUserName().empty())
     return;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   std::string path = GetLookupPath(url);
   std::string authenticatedPath = url.Get();

--- a/xbmc/SectionLoader.cpp
+++ b/xbmc/SectionLoader.cpp
@@ -9,10 +9,11 @@
 #include "SectionLoader.h"
 
 #include "cores/DllLoader/DllLoaderContainer.h"
-#include "threads/SingleLock.h"
 #include "utils/GlobalsHandling.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #define g_sectionLoader XBMC_GLOBAL_USE(CSectionLoader)
 
@@ -31,7 +32,7 @@ CSectionLoader::~CSectionLoader(void)
 
 LibraryLoader *CSectionLoader::LoadDLL(const std::string &dllname, bool bDelayUnload /*=true*/, bool bLoadSymbols /*=false*/)
 {
-  CSingleLock lock(g_sectionLoader.m_critSection);
+  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
 
   if (dllname.empty()) return NULL;
   // check if it's already loaded, and increase the reference count if so
@@ -63,7 +64,7 @@ LibraryLoader *CSectionLoader::LoadDLL(const std::string &dllname, bool bDelayUn
 
 void CSectionLoader::UnloadDLL(const std::string &dllname)
 {
-  CSingleLock lock(g_sectionLoader.m_critSection);
+  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
 
   if (dllname.empty()) return;
   // check if it's already loaded, and decrease the reference count if so
@@ -93,7 +94,7 @@ void CSectionLoader::UnloadDLL(const std::string &dllname)
 
 void CSectionLoader::UnloadDelayed()
 {
-  CSingleLock lock(g_sectionLoader.m_critSection);
+  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
 
   // check if we can unload any unreferenced dlls
   for (int i = 0; i < (int)g_sectionLoader.m_vecLoadedDLLs.size(); ++i)
@@ -117,7 +118,7 @@ void CSectionLoader::UnloadDelayed()
 void CSectionLoader::UnloadAll()
 {
   // delete the dll's
-  CSingleLock lock(g_sectionLoader.m_critSection);
+  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
   std::vector<CDll>::iterator it = g_sectionLoader.m_vecLoadedDLLs.begin();
   while (it != g_sectionLoader.m_vecLoadedDLLs.end())
   {

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -27,6 +27,7 @@
 #include "windowing/GraphicContext.h"
 
 #include <cmath>
+#include <mutex>
 #include <stdlib.h>
 
 CSeekHandler::~CSeekHandler()
@@ -110,7 +111,7 @@ int CSeekHandler::GetSeekStepSize(SeekType type, int step)
 
 void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bool analogSeek /* = false */, SeekType type /* = SEEK_TYPE_VIDEO */)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // not yet seeking
   if (!m_requireSeek)
@@ -171,7 +172,7 @@ void CSeekHandler::SeekSeconds(int seconds)
   if (seconds == 0)
     return;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   SetSeekSize(seconds);
 
   // perform relative seek
@@ -206,7 +207,7 @@ void CSeekHandler::FrameMove()
 {
   if (m_timer.GetElapsedMilliseconds() >= m_seekDelay && m_requireSeek)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     // perform relative seek
     g_application.GetAppPlayer().SeekTimeRelative(static_cast<int64_t>(m_seekSize * 1000));
@@ -354,7 +355,7 @@ bool CSeekHandler::SeekTimeCode(const CAction &action)
     case ACTION_PLAYER_PLAY:
     case ACTION_PAUSE:
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       g_application.SeekTime(GetTimeCodeSeconds());
       Reset();

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -17,7 +17,6 @@
 #include "guilib/Texture.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/Crc32.h"
 #include "utils/Job.h"
 #include "utils/StringUtils.h"
@@ -26,6 +25,7 @@
 
 #include <chrono>
 #include <exception>
+#include <mutex>
 #include <string.h>
 
 using namespace XFILE;
@@ -45,7 +45,7 @@ CTextureCache::~CTextureCache() = default;
 
 void CTextureCache::Initialize()
 {
-  CSingleLock lock(m_databaseSection);
+  std::unique_lock<CCriticalSection> lock(m_databaseSection);
   if (!m_database.IsOpen())
     m_database.Open();
 }
@@ -53,7 +53,7 @@ void CTextureCache::Initialize()
 void CTextureCache::Deinitialize()
 {
   CancelJobs();
-  CSingleLock lock(m_databaseSection);
+  std::unique_lock<CCriticalSection> lock(m_databaseSection);
   m_database.Close();
 }
 
@@ -143,7 +143,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
   if (url.empty())
     return "";
 
-  CSingleLock lock(m_processingSection);
+  std::unique_lock<CCriticalSection> lock(m_processingSection);
   if (m_processinglist.find(url) == m_processinglist.end())
   {
     m_processinglist.insert(url);
@@ -163,7 +163,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
   {
     m_completeEvent.Wait(1000ms);
     {
-      CSingleLock lock(m_processingSection);
+      std::unique_lock<CCriticalSection> lock(m_processingSection);
       if (m_processinglist.find(url) == m_processinglist.end())
         break;
     }
@@ -228,20 +228,20 @@ bool CTextureCache::ClearCachedImage(int id)
 
 bool CTextureCache::GetCachedTexture(const std::string &url, CTextureDetails &details)
 {
-  CSingleLock lock(m_databaseSection);
+  std::unique_lock<CCriticalSection> lock(m_databaseSection);
   return m_database.GetCachedTexture(url, details);
 }
 
 bool CTextureCache::AddCachedTexture(const std::string &url, const CTextureDetails &details)
 {
-  CSingleLock lock(m_databaseSection);
+  std::unique_lock<CCriticalSection> lock(m_databaseSection);
   return m_database.AddCachedTexture(url, details);
 }
 
 void CTextureCache::IncrementUseCount(const CTextureDetails &details)
 {
   static const size_t count_before_update = 100;
-  CSingleLock lock(m_useCountSection);
+  std::unique_lock<CCriticalSection> lock(m_useCountSection);
   m_useCounts.reserve(count_before_update);
   m_useCounts.push_back(details);
   if (m_useCounts.size() >= count_before_update)
@@ -253,19 +253,19 @@ void CTextureCache::IncrementUseCount(const CTextureDetails &details)
 
 bool CTextureCache::SetCachedTextureValid(const std::string &url, bool updateable)
 {
-  CSingleLock lock(m_databaseSection);
+  std::unique_lock<CCriticalSection> lock(m_databaseSection);
   return m_database.SetCachedTextureValid(url, updateable);
 }
 
 bool CTextureCache::ClearCachedTexture(const std::string &url, std::string &cachedURL)
 {
-  CSingleLock lock(m_databaseSection);
+  std::unique_lock<CCriticalSection> lock(m_databaseSection);
   return m_database.ClearCachedTexture(url, cachedURL);
 }
 
 bool CTextureCache::ClearCachedTexture(int id, std::string &cachedURL)
 {
-  CSingleLock lock(m_databaseSection);
+  std::unique_lock<CCriticalSection> lock(m_databaseSection);
   return m_database.ClearCachedTexture(id, cachedURL);
 }
 
@@ -295,7 +295,7 @@ void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)
   }
 
   { // remove from our processing list
-    CSingleLock lock(m_processingSection);
+    std::unique_lock<CCriticalSection> lock(m_processingSection);
     std::set<std::string>::iterator i = m_processinglist.find(job->m_url);
     if (i != m_processinglist.end())
       m_processinglist.erase(i);
@@ -316,7 +316,7 @@ void CTextureCache::OnJobProgress(unsigned int jobID, unsigned int progress, uns
   if (strcmp(job->GetType(), kJobTypeCacheImage) == 0 && !progress)
   { // check our processing list
     {
-      CSingleLock lock(m_processingSection);
+      std::unique_lock<CCriticalSection> lock(m_processingSection);
       const CTextureCacheJob *cacheJob = static_cast<const CTextureCacheJob*>(job);
       std::set<std::string>::iterator i = m_processinglist.find(cacheJob->m_url);
       if (i == m_processinglist.end())

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -147,7 +147,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
   if (m_processinglist.find(url) == m_processinglist.end())
   {
     m_processinglist.insert(url);
-    lock.Leave();
+    lock.unlock();
     // cache the texture directly
     CTextureCacheJob job(url);
     bool success = job.CacheTexture(texture);
@@ -156,7 +156,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
       *details = job.m_details;
     return success ? GetCachedPath(job.m_details.file) : "";
   }
-  lock.Leave();
+  lock.unlock();
 
   // wait for currently processing job to end.
   while (true)

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -73,7 +73,7 @@ void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
     m_downloadJobs.erase(i);
   if (m_downloadJobs.empty())
     m_idle.Set();
-  lock.Leave();
+  lock.unlock();
   PrunePackageCache();
 
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
@@ -93,7 +93,7 @@ void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, u
     i->second.downloadFinshed = std::string(job->GetType()) == CAddonInstallJob::TYPE_INSTALL;
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM);
     msg.SetStringParam(i->first);
-    lock.Leave();
+    lock.unlock();
     CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
   }
 }
@@ -113,7 +113,7 @@ void CAddonInstaller::GetInstallList(VECADDONS &addons) const
     if (i->second.jobID)
       addonIDs.push_back(i->first);
   }
-  lock.Leave();
+  lock.unlock();
 
   CAddonDatabase database;
   database.Open();
@@ -296,7 +296,7 @@ bool CAddonInstaller::DoInstall(const AddonPtr& addon,
 
   m_downloadJobs.insert(make_pair(addon->ID(), CDownloadJob(0)));
   m_idle.Reset();
-  lock.Leave();
+  lock.unlock();
 
   installJob->SetDependsInstall(dependsInstall);
   installJob->SetAllowCheckForUpdates(allowCheckForUpdates);
@@ -308,7 +308,7 @@ bool CAddonInstaller::DoInstall(const AddonPtr& addon,
     result = installJob->DoWork();
   delete installJob;
 
-  lock.Enter();
+  lock.lock();
   JobMap::iterator i = m_downloadJobs.find(addon->ID());
   m_downloadJobs.erase(i);
   if (m_downloadJobs.empty())
@@ -507,7 +507,7 @@ void CAddonInstaller::InstallAddons(const VECADDONS& addons,
     if (!m_downloadJobs.empty())
     {
       m_idle.Reset();
-      lock.Leave();
+      lock.unlock();
       m_idle.Wait();
     }
   }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -42,6 +42,7 @@
 #include "utils/log.h"
 
 #include <functional>
+#include <mutex>
 
 using namespace XFILE;
 using namespace ADDON;
@@ -65,7 +66,7 @@ CAddonInstaller &CAddonInstaller::GetInstance()
 
 void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   JobMap::iterator i = find_if(m_downloadJobs.begin(), m_downloadJobs.end(), [jobID](const std::pair<std::string, CDownloadJob>& p) {
     return p.second.jobID == jobID;
   });
@@ -82,7 +83,7 @@ void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 
 void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   JobMap::iterator i = find_if(m_downloadJobs.begin(), m_downloadJobs.end(), [jobID](const std::pair<std::string, CDownloadJob>& p) {
     return p.second.jobID == jobID;
   });
@@ -100,13 +101,13 @@ void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, u
 
 bool CAddonInstaller::IsDownloading() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return !m_downloadJobs.empty();
 }
 
 void CAddonInstaller::GetInstallList(VECADDONS &addons) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::vector<std::string> addonIDs;
   for (JobMap::const_iterator i = m_downloadJobs.begin(); i != m_downloadJobs.end(); ++i)
   {
@@ -127,7 +128,7 @@ void CAddonInstaller::GetInstallList(VECADDONS &addons) const
 
 bool CAddonInstaller::GetProgress(const std::string& addonID, unsigned int& percent, bool& downloadFinshed) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   JobMap::const_iterator i = m_downloadJobs.find(addonID);
   if (i != m_downloadJobs.end())
   {
@@ -140,7 +141,7 @@ bool CAddonInstaller::GetProgress(const std::string& addonID, unsigned int& perc
 
 bool CAddonInstaller::Cancel(const std::string &addonID)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   JobMap::iterator i = m_downloadJobs.find(addonID);
   if (i != m_downloadJobs.end())
   {
@@ -278,7 +279,7 @@ bool CAddonInstaller::DoInstall(const AddonPtr& addon,
                                 AllowCheckForUpdates allowCheckForUpdates)
 {
   // check whether we already have the addon installing
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_downloadJobs.find(addon->ID()) != m_downloadJobs.end())
     return false;
 
@@ -435,7 +436,7 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
 
 bool CAddonInstaller::HasJob(const std::string& ID) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_downloadJobs.find(ID) != m_downloadJobs.end();
 }
 
@@ -503,7 +504,7 @@ void CAddonInstaller::InstallAddons(const VECADDONS& addons,
   }
   if (wait)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (!m_downloadJobs.empty())
     {
       m_idle.Reset();

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -733,7 +733,7 @@ bool CAddonMgr::UnloadAddon(const std::string& addonId)
   m_installedAddons.erase(addonId);
   CLog::Log(LOGDEBUG, "CAddonMgr::{}: {} unloaded", __func__, addonId);
 
-  lock.Leave();
+  lock.unlock();
   AddonEvents::Unload event(addonId);
   m_unloadEvents.HandleEvent(event);
 
@@ -765,7 +765,7 @@ bool CAddonMgr::LoadAddon(const std::string& addonId,
     return false;
   }
 
-  lock.Leave();
+  lock.unlock();
 
   AddonEvents::Load event(addon->ID());
   m_unloadEvents.HandleEvent(event);

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <array>
+#include <mutex>
 #include <set>
 #include <utility>
 
@@ -106,7 +107,7 @@ void CAddonMgr::UnregisterAddonMgrCallback(TYPE type)
 
 bool CAddonMgr::Init()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!LoadManifest(m_systemAddons, m_optionalSystemAddons))
   {
@@ -144,7 +145,7 @@ void CAddonMgr::DeInit()
 
 bool CAddonMgr::HasAddons(const TYPE &type)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& addonInfo : m_installedAddons)
   {
@@ -156,7 +157,7 @@ bool CAddonMgr::HasAddons(const TYPE &type)
 
 bool CAddonMgr::HasInstalledAddons(const TYPE &type)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& addonInfo : m_installedAddons)
   {
@@ -168,13 +169,13 @@ bool CAddonMgr::HasInstalledAddons(const TYPE &type)
 
 void CAddonMgr::AddToUpdateableAddons(AddonPtr &pAddon)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_updateableAddons.push_back(pAddon);
 }
 
 void CAddonMgr::RemoveFromUpdateableAddons(AddonPtr &pAddon)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   VECADDONS::iterator it = std::find(m_updateableAddons.begin(), m_updateableAddons.end(), pAddon);
 
   if(it != m_updateableAddons.end())
@@ -199,7 +200,7 @@ struct AddonIdFinder
 
 bool CAddonMgr::ReloadSettings(const std::string &id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   VECADDONS::iterator it = std::find_if(m_updateableAddons.begin(), m_updateableAddons.end(), AddonIdFinder(id));
 
   if( it != m_updateableAddons.end())
@@ -234,7 +235,7 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetOutdatedAddons() const
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAddons(
     AddonCheckType addonCheckType) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   std::vector<std::shared_ptr<IAddon>> result;
@@ -257,7 +258,7 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAdd
 
 std::map<std::string, CAddonWithUpdate> CAddonMgr::GetAddonsWithAvailableUpdate() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   std::vector<std::shared_ptr<IAddon>> installed;
@@ -278,7 +279,7 @@ std::map<std::string, CAddonWithUpdate> CAddonMgr::GetAddonsWithAvailableUpdate(
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetCompatibleVersions(
     const std::string& addonId) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   CAddonRepos addonRepos(*this);
@@ -384,7 +385,7 @@ bool CAddonMgr::GetInstallableAddons(VECADDONS& addons)
 
 bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, const TYPE &type)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   CAddonRepos addonRepos(*this);
 
   if (!addonRepos.LoadAddonsFromDatabase(m_database))
@@ -415,7 +416,7 @@ bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, const TYPE &type)
 
 bool CAddonMgr::FindInstallableById(const std::string& addonId, AddonPtr& result)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CAddonRepos addonRepos(*this);
   addonRepos.LoadAddonsFromDatabase(m_database, addonId);
@@ -446,7 +447,7 @@ bool CAddonMgr::GetAddonsInternal(const TYPE& type,
                                   OnlyEnabled onlyEnabled,
                                   CheckIncompatible checkIncompatible) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& addonInfo : m_installedAddons)
   {
@@ -614,7 +615,7 @@ bool CAddonMgr::GetAddon(const std::string& str,
                          const TYPE& type,
                          OnlyEnabled onlyEnabled) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   AddonInfoPtr addonInfo = GetAddonInfo(str, type);
   if (addonInfo)
@@ -658,7 +659,7 @@ bool CAddonMgr::FindAddon(const std::string& addonId,
   if (it == installedAddons.cend() || it->second->Version() != addonVersion)
     return false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_database.GetInstallData(it->second);
   CLog::Log(LOGINFO, "CAddonMgr::{}: {} v{} installed", __FUNCTION__, addonId,
@@ -690,7 +691,7 @@ bool CAddonMgr::FindAddons()
   for (const auto& addon : installedAddons)
     installed.insert(addon.second->ID());
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // Sync with db
   m_database.SyncInstalled(installed, m_systemAddons, m_optionalSystemAddons);
@@ -715,7 +716,7 @@ bool CAddonMgr::FindAddons()
 
 bool CAddonMgr::UnloadAddon(const std::string& addonId)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!IsAddonInstalled(addonId))
     return true;
@@ -744,7 +745,7 @@ bool CAddonMgr::LoadAddon(const std::string& addonId,
                           const std::string& origin,
                           const AddonVersion& addonVersion)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   AddonPtr addon;
   if (GetAddon(addonId, addon, ADDON_UNKNOWN, OnlyEnabled::CHOICE_NO))
@@ -783,7 +784,7 @@ bool CAddonMgr::LoadAddon(const std::string& addonId,
 
 void CAddonMgr::OnPostUnInstall(const std::string& id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_disabled.erase(id);
   RemoveAllUpdateRulesFromList(id);
   m_events.Publish(AddonEvents::UnInstalled(id));
@@ -794,7 +795,7 @@ void CAddonMgr::UpdateLastUsed(const std::string& id)
   auto time = CDateTime::GetCurrentDateTime();
   CJobManager::GetInstance().Submit([this, id, time](){
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       m_database.SetLastUsed(id, time);
       auto addonInfo = GetAddonInfo(id);
       if (addonInfo)
@@ -824,7 +825,7 @@ static void ResolveDependencies(const std::string& addonId, std::vector<std::str
 
 bool CAddonMgr::DisableAddon(const std::string& id, AddonDisabledReason disabledReason)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!CanAddonBeDisabled(id))
     return false;
   if (m_disabled.find(id) != m_disabled.end())
@@ -850,7 +851,7 @@ bool CAddonMgr::DisableAddon(const std::string& id, AddonDisabledReason disabled
 
 bool CAddonMgr::UpdateDisabledReason(const std::string& id, AddonDisabledReason newDisabledReason)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!IsAddonDisabled(id))
     return false;
   if (!m_database.DisableAddon(id, newDisabledReason))
@@ -866,7 +867,7 @@ bool CAddonMgr::UpdateDisabledReason(const std::string& id, AddonDisabledReason 
 
 bool CAddonMgr::EnableSingle(const std::string& id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_disabled.find(id) == m_disabled.end())
     return true; //already enabled
@@ -923,14 +924,14 @@ bool CAddonMgr::EnableAddon(const std::string& id)
 
 bool CAddonMgr::IsAddonDisabled(const std::string& ID) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_disabled.find(ID) != m_disabled.end();
 }
 
 bool CAddonMgr::IsAddonDisabledExcept(const std::string& ID,
                                       AddonDisabledReason disabledReason) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto disabledAddon = m_disabled.find(ID);
   return disabledAddon != m_disabled.end() && disabledAddon->second != disabledReason;
 }
@@ -940,7 +941,7 @@ bool CAddonMgr::CanAddonBeDisabled(const std::string& ID)
   if (ID.empty())
     return false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   // Required system add-ons can not be disabled
   if (IsRequiredSystemAddon(ID))
     return false;
@@ -1032,13 +1033,13 @@ bool CAddonMgr::IsSystemAddon(const std::string& id)
 
 bool CAddonMgr::IsRequiredSystemAddon(const std::string& id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return std::find(m_systemAddons.begin(), m_systemAddons.end(), id) != m_systemAddons.end();
 }
 
 bool CAddonMgr::IsOptionalSystemAddon(const std::string& id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return std::find(m_optionalSystemAddons.begin(), m_optionalSystemAddons.end(), id) !=
          m_optionalSystemAddons.end();
 }
@@ -1169,7 +1170,7 @@ std::vector<DependencyInfo> CAddonMgr::GetDepsRecursive(const std::string& id,
 
 bool CAddonMgr::GetAddonInfos(AddonInfos& addonInfos, bool onlyEnabled, TYPE type) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bool forUnknown = type == ADDON_UNKNOWN;
   for (auto& info : m_installedAddons)
@@ -1191,7 +1192,7 @@ std::vector<AddonInfoPtr> CAddonMgr::GetAddonInfos(bool onlyEnabled,
   if (types.empty())
     return infos;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (auto& info : m_installedAddons)
   {
@@ -1219,7 +1220,7 @@ bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos,
                                       TYPE type,
                                       AddonDisabledReason disabledReason) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bool forUnknown = type == ADDON_UNKNOWN;
   for (const auto& info : m_installedAddons)
@@ -1239,7 +1240,7 @@ bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos,
 const AddonInfoPtr CAddonMgr::GetAddonInfo(const std::string& id,
                                            TYPE type /*= ADDON_UNKNOWN*/) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   auto addon = m_installedAddons.find(id);
   if (addon != m_installedAddons.end())
@@ -1295,7 +1296,7 @@ AddonOriginType CAddonMgr::GetAddonOriginType(const AddonPtr& addon) const
 bool CAddonMgr::IsAddonDisabledWithReason(const std::string& ID,
                                           AddonDisabledReason disabledReason) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto& disabledAddon = m_disabled.find(ID);
   return disabledAddon != m_disabled.end() && disabledAddon->second == disabledReason;
 }
@@ -1307,7 +1308,7 @@ bool CAddonMgr::IsAddonDisabledWithReason(const std::string& ID,
 
 bool CAddonMgr::SetAddonOrigin(const std::string& addonId, const std::string& repoAddonId, bool isUpdate)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_database.SetOrigin(addonId, repoAddonId);
   if (isUpdate)

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -16,11 +16,11 @@
 #include "guilib/GUIWindowManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <utility>
 
 using namespace KODI::MESSAGING;
@@ -81,7 +81,7 @@ void CAddonStatusHandler::OnExit()
 
 void CAddonStatusHandler::Process()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   std::string heading = StringUtils::Format(
       "{}: {}", CAddonInfo::TranslateType(m_addon->Type(), true), m_addon->Name());

--- a/xbmc/addons/AddonUpdateRules.cpp
+++ b/xbmc/addons/AddonUpdateRules.cpp
@@ -9,8 +9,9 @@
 #include "AddonUpdateRules.h"
 
 #include "AddonDatabase.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 using namespace ADDON;
 
@@ -23,13 +24,13 @@ bool CAddonUpdateRules::RefreshRulesMap(const CAddonDatabase& db)
 
 bool CAddonUpdateRules::IsAutoUpdateable(const std::string& id) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_updateRules.find(id) == m_updateRules.end();
 }
 
 bool CAddonUpdateRules::IsUpdateableByRule(const std::string& id, AddonUpdateRule updateRule) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto& updateRulesEntry = m_updateRules.find(id);
   return (updateRulesEntry == m_updateRules.end() ||
           std::none_of(updateRulesEntry->second.begin(), updateRulesEntry->second.end(),
@@ -40,7 +41,7 @@ bool CAddonUpdateRules::AddUpdateRuleToList(CAddonDatabase& db,
                                             const std::string& id,
                                             AddonUpdateRule updateRule)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!IsUpdateableByRule(id, updateRule))
   {
@@ -71,7 +72,7 @@ bool CAddonUpdateRules::RemoveFromUpdateRuleslist(CAddonDatabase& db,
                                                   const std::string& id,
                                                   AddonUpdateRule updateRule)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   const auto& updateRulesEntry = m_updateRules.find(id);
   if (updateRulesEntry != m_updateRules.end())

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -10,7 +10,8 @@
 
 #include "AddonManager.h"
 #include "ServiceBroker.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 namespace ADDON
 {
@@ -59,7 +60,7 @@ void CBinaryAddonCache::GetDisabledAddons(VECADDONS& addons, const TYPE& type)
 
 void CBinaryAddonCache::GetInstalledAddons(VECADDONS& addons, const TYPE& type)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto it = m_addons.find(type);
   if (it != m_addons.end())
     addons = it->second;
@@ -69,7 +70,7 @@ AddonPtr CBinaryAddonCache::GetAddonInstance(const std::string& strId, TYPE type
 {
   AddonPtr addon;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   auto it = m_addons.find(type);
   if (it != m_addons.end())
@@ -122,7 +123,7 @@ void CBinaryAddonCache::Update()
   }
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_addons = std::move(addonmap);
   }
 }

--- a/xbmc/addons/ExtsMimeSupportList.cpp
+++ b/xbmc/addons/ExtsMimeSupportList.cpp
@@ -14,6 +14,8 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 using namespace ADDON;
 using namespace KODI::ADDONS;
 
@@ -53,7 +55,7 @@ void CExtsMimeSupportList::Update(const std::string& id)
 {
   // Stop used instance if present, otherwise the new becomes created on already created addon base one.
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     const auto itAddon =
         std::find_if(m_supportedList.begin(), m_supportedList.end(),
@@ -73,7 +75,7 @@ void CExtsMimeSupportList::Update(const std::string& id)
     {
       SupportValues values = ScanAddonProperties(addonInfo->MainType(), addonInfo);
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         m_supportedList.emplace_back(values);
       }
     }
@@ -163,7 +165,7 @@ std::vector<CExtsMimeSupportList::SupportValues> CExtsMimeSupportList::GetSuppor
 {
   std::vector<SupportValues> addonInfos;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -177,7 +179,7 @@ std::vector<CExtsMimeSupportList::SupportValues> CExtsMimeSupportList::GetSuppor
 
 bool CExtsMimeSupportList::IsExtensionSupported(const std::string& ext)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -196,7 +198,7 @@ std::vector<std::pair<ADDON::TYPE, std::shared_ptr<ADDON::CAddonInfo>>> CExtsMim
 {
   std::vector<std::pair<ADDON::TYPE, std::shared_ptr<CAddonInfo>>> addonInfos;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -214,7 +216,7 @@ std::vector<std::pair<ADDON::TYPE, std::shared_ptr<ADDON::CAddonInfo>>> CExtsMim
 
 bool CExtsMimeSupportList::IsMimetypeSupported(const std::string& mimetype)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -234,7 +236,7 @@ std::vector<std::pair<ADDON::TYPE, std::shared_ptr<CAddonInfo>>> CExtsMimeSuppor
 {
   std::vector<std::pair<ADDON::TYPE, std::shared_ptr<CAddonInfo>>> addonInfos;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -12,6 +12,8 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 
 namespace ADDON
 {
@@ -70,7 +72,7 @@ void CServiceAddonManager::Start(const std::string& addonId)
 
 void CServiceAddonManager::Start(const AddonPtr& addon)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   if (m_services.find(addon->ID()) != m_services.end())
   {
     CLog::Log(LOGDEBUG, "CServiceAddonManager: {} already started.", addon->ID());
@@ -94,7 +96,7 @@ void CServiceAddonManager::Stop()
 {
   m_addonMgr.Events().Unsubscribe(this);
   m_addonMgr.UnloadEvents().Unsubscribe(this);
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   for (const auto& service : m_services)
   {
     Stop(service);
@@ -104,7 +106,7 @@ void CServiceAddonManager::Stop()
 
 void CServiceAddonManager::Stop(const std::string& addonId)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   auto it = m_services.find(addonId);
   if (it != m_services.end())
   {

--- a/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
@@ -15,6 +15,8 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 namespace ADDON
 {
 
@@ -104,7 +106,7 @@ ADDON_STATUS IAddonInstanceHandler::CreateInstance()
   if (!m_addon)
     return ADDON_STATUS_UNKNOWN;
 
-  CSingleLock lock(m_cdSec);
+  std::unique_lock<CCriticalSection> lock(m_cdSec);
 
   ADDON_STATUS status = m_addon->CreateInstance(&m_ifc);
   if (status != ADDON_STATUS_OK)
@@ -118,7 +120,7 @@ ADDON_STATUS IAddonInstanceHandler::CreateInstance()
 
 void IAddonInstanceHandler::DestroyInstance()
 {
-  CSingleLock lock(m_cdSec);
+  std::unique_lock<CCriticalSection> lock(m_cdSec);
   if (m_addon)
     m_addon->DestroyInstance(&m_ifc);
 }

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -8,8 +8,9 @@
 
 #include "BinaryAddonBase.h"
 
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 using namespace ADDON;
 
@@ -27,7 +28,7 @@ AddonDllPtr CBinaryAddonBase::GetAddon(IAddonInstanceHandler* handler)
     return nullptr;
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // If no 'm_activeAddon' is defined create it new.
   if (m_activeAddon == nullptr)
@@ -48,7 +49,7 @@ void CBinaryAddonBase::ReleaseAddon(IAddonInstanceHandler* handler)
     return;
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   auto presentHandler = m_activeAddonHandlers.find(handler);
   if (presentHandler == m_activeAddonHandlers.end())
@@ -65,13 +66,13 @@ void CBinaryAddonBase::ReleaseAddon(IAddonInstanceHandler* handler)
 
 size_t CBinaryAddonBase::UsedInstanceCount() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_activeAddonHandlers.size();
 }
 
 AddonDllPtr CBinaryAddonBase::GetActiveAddon()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_activeAddon;
 }
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -9,8 +9,9 @@
 #include "BinaryAddonManager.h"
 
 #include "BinaryAddonBase.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 using namespace ADDON;
 
@@ -18,7 +19,7 @@ BinaryAddonBasePtr CBinaryAddonManager::GetAddonBase(const AddonInfoPtr& addonIn
                                                      IAddonInstanceHandler* handler,
                                                      AddonDllPtr& addon)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   BinaryAddonBasePtr addonBase;
 
@@ -64,7 +65,7 @@ void CBinaryAddonManager::ReleaseAddonBase(const BinaryAddonBasePtr& addonBase,
 
 BinaryAddonBasePtr CBinaryAddonManager::GetRunningAddonBase(const std::string& addonId) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   const auto& addonInstances = m_runningAddons.find(addonId);
   if (addonInstances != m_runningAddons.end())
@@ -75,7 +76,7 @@ BinaryAddonBasePtr CBinaryAddonManager::GetRunningAddonBase(const std::string& a
 
 AddonPtr CBinaryAddonManager::GetRunningAddon(const std::string& addonId) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   const BinaryAddonBasePtr base = GetRunningAddonBase(addonId);
   if (base)

--- a/xbmc/addons/interfaces/gui/General.cpp
+++ b/xbmc/addons/interfaces/gui/General.cpp
@@ -39,6 +39,8 @@
 #include "guilib/GUIWindowManager.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 namespace ADDON
 {
 int Interface_GUIGeneral::m_iAddonGUILockRef = 0;
@@ -188,7 +190,7 @@ int Interface_GUIGeneral::get_current_window_dialog_id(KODI_HANDLE kodiBase)
     return -1;
   }
 
-  CSingleLock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
   return CServiceBroker::GetGUI()->GetWindowManager().GetTopmostModalDialog();
 }
 
@@ -201,7 +203,7 @@ int Interface_GUIGeneral::get_current_window_id(KODI_HANDLE kodiBase)
     return -1;
   }
 
-  CSingleLock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
   return CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
 }
 

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -28,7 +28,6 @@
 #include "settings/lib/SettingDefinitions.h"
 #include "settings/lib/SettingSection.h"
 #include "settings/lib/SettingsManager.h"
-#include "threads/SingleLock.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -37,6 +36,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <mutex>
 #include <vector>
 
 static const std::string OldSettingValuesSeparator = "|";
@@ -202,7 +202,7 @@ void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
 
 bool CAddonSettings::Initialize(const CXBMCTinyXML& doc, bool allowEmpty /* = false */)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (m_initialized)
     return false;
 
@@ -227,7 +227,7 @@ bool CAddonSettings::Initialize(const CXBMCTinyXML& doc, bool allowEmpty /* = fa
 
 bool CAddonSettings::Load(const CXBMCTinyXML& doc)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (!m_initialized)
     return false;
 
@@ -332,7 +332,7 @@ bool CAddonSettings::Load(const CXBMCTinyXML& doc)
 
 bool CAddonSettings::Save(CXBMCTinyXML& doc) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (!m_initialized)
     return false;
 
@@ -553,7 +553,7 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(
         {
           setting->SetLevel(SettingLevel::Basic);
         }
-        
+
         // use the setting's ID if there's no label
         if (settingLabel < 0)
         {
@@ -1357,7 +1357,7 @@ bool CAddonSettings::ParseOldLabel(const TiXmlElement* element,
   labelId = -1;
   if (element == nullptr)
     return false;
-  
+
   // label value as a string
   std::string labelString;
   element->QueryStringAttribute("label", &labelString);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -14,7 +14,6 @@
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
@@ -23,6 +22,7 @@
 
 #include <algorithm>
 #include <list>
+#include <mutex>
 
 #include <Audioclient.h>
 #include <Mmreg.h>
@@ -587,7 +587,7 @@ void CAESinkDirectSound::CheckPlayStatus()
 
 bool CAESinkDirectSound::UpdateCacheStatus()
 {
-  CSingleLock lock (m_runLock);
+  std::unique_lock<CCriticalSection> lock(m_runLock);
 
   DWORD playCursor = 0, writeCursor = 0;
   HRESULT res = m_pBuffer->GetCurrentPosition(&playCursor, &writeCursor); // Get the current playback and safe write positions
@@ -648,7 +648,7 @@ bool CAESinkDirectSound::UpdateCacheStatus()
 
 unsigned int CAESinkDirectSound::GetSpace()
 {
-  CSingleLock lock (m_runLock);
+  std::unique_lock<CCriticalSection> lock(m_runLock);
   if (!UpdateCacheStatus())
     m_isDirtyDS = true;
   unsigned int space = m_dwBufferLen - m_CacheLen;

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -10,8 +10,8 @@
 
 #include "ServiceBroker.h"
 #include "cores/EdlEdit.h"
-#include "threads/SingleLock.h"
 
+#include <mutex>
 #include <utility>
 
 CDataCacheCore::CDataCacheCore() :
@@ -34,7 +34,7 @@ CDataCacheCore& CDataCacheCore::GetInstance()
 void CDataCacheCore::Reset()
 {
   {
-    CSingleLock lock(m_stateSection);
+    std::unique_lock<CCriticalSection> lock(m_stateSection);
 
     m_stateInfo.m_speed = 1.0;
     m_stateInfo.m_tempo = 1.0;
@@ -45,7 +45,7 @@ void CDataCacheCore::Reset()
   }
 
   {
-    CSingleLock lock(m_contentSection);
+    std::unique_lock<CCriticalSection> lock(m_contentSection);
 
     m_contentInfo.Reset();
   }
@@ -75,7 +75,7 @@ void CDataCacheCore::SignalSubtitleInfoChange()
 
 void CDataCacheCore::SetVideoDecoderName(std::string name, bool isHw)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   m_playerVideoInfo.decoderName = std::move(name);
   m_playerVideoInfo.isHwDecoder = isHw;
@@ -83,14 +83,14 @@ void CDataCacheCore::SetVideoDecoderName(std::string name, bool isHw)
 
 std::string CDataCacheCore::GetVideoDecoderName()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.decoderName;
 }
 
 bool CDataCacheCore::IsVideoHwDecoder()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.isHwDecoder;
 }
@@ -98,49 +98,49 @@ bool CDataCacheCore::IsVideoHwDecoder()
 
 void CDataCacheCore::SetVideoDeintMethod(std::string method)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   m_playerVideoInfo.deintMethod = std::move(method);
 }
 
 std::string CDataCacheCore::GetVideoDeintMethod()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.deintMethod;
 }
 
 void CDataCacheCore::SetVideoPixelFormat(std::string pixFormat)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   m_playerVideoInfo.pixFormat = std::move(pixFormat);
 }
 
 std::string CDataCacheCore::GetVideoPixelFormat()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.pixFormat;
 }
 
 void CDataCacheCore::SetVideoStereoMode(std::string mode)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   m_playerVideoInfo.stereoMode = std::move(mode);
 }
 
 std::string CDataCacheCore::GetVideoStereoMode()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.stereoMode;
 }
 
 void CDataCacheCore::SetVideoDimensions(int width, int height)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   m_playerVideoInfo.width = width;
   m_playerVideoInfo.height = height;
@@ -148,173 +148,173 @@ void CDataCacheCore::SetVideoDimensions(int width, int height)
 
 int CDataCacheCore::GetVideoWidth()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.width;
 }
 
 int CDataCacheCore::GetVideoHeight()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.height;
 }
 
 void CDataCacheCore::SetVideoFps(float fps)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   m_playerVideoInfo.fps = fps;
 }
 
 float CDataCacheCore::GetVideoFps()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.fps;
 }
 
 void CDataCacheCore::SetVideoDAR(float dar)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   m_playerVideoInfo.dar = dar;
 }
 
 float CDataCacheCore::GetVideoDAR()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.dar;
 }
 
 void CDataCacheCore::SetVideoInterlaced(bool isInterlaced)
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
   m_playerVideoInfo.m_isInterlaced = isInterlaced;
 }
 
 bool CDataCacheCore::IsVideoInterlaced()
 {
-  CSingleLock lock(m_videoPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
   return m_playerVideoInfo.m_isInterlaced;
 }
 
 // player audio info
 void CDataCacheCore::SetAudioDecoderName(std::string name)
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   m_playerAudioInfo.decoderName = std::move(name);
 }
 
 std::string CDataCacheCore::GetAudioDecoderName()
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.decoderName;
 }
 
 void CDataCacheCore::SetAudioChannels(std::string channels)
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   m_playerAudioInfo.channels = std::move(channels);
 }
 
 std::string CDataCacheCore::GetAudioChannels()
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.channels;
 }
 
 void CDataCacheCore::SetAudioSampleRate(int sampleRate)
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   m_playerAudioInfo.sampleRate = sampleRate;
 }
 
 int CDataCacheCore::GetAudioSampleRate()
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.sampleRate;
 }
 
 void CDataCacheCore::SetAudioBitsPerSample(int bitsPerSample)
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   m_playerAudioInfo.bitsPerSample = bitsPerSample;
 }
 
 int CDataCacheCore::GetAudioBitsPerSample()
 {
-  CSingleLock lock(m_audioPlayerSection);
+  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.bitsPerSample;
 }
 
 void CDataCacheCore::SetEditList(const std::vector<EDL::Edit>& editList)
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   m_contentInfo.SetEditList(editList);
 }
 
 const std::vector<EDL::Edit>& CDataCacheCore::GetEditList() const
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   return m_contentInfo.GetEditList();
 }
 
 void CDataCacheCore::SetCuts(const std::vector<int64_t>& cuts)
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   m_contentInfo.SetCuts(cuts);
 }
 
 const std::vector<int64_t>& CDataCacheCore::GetCuts() const
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   return m_contentInfo.GetCuts();
 }
 
 void CDataCacheCore::SetSceneMarkers(const std::vector<int64_t>& sceneMarkers)
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   m_contentInfo.SetSceneMarkers(sceneMarkers);
 }
 
 const std::vector<int64_t>& CDataCacheCore::GetSceneMarkers() const
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   return m_contentInfo.GetSceneMarkers();
 }
 
 void CDataCacheCore::SetChapters(const std::vector<std::pair<std::string, int64_t>>& chapters)
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   m_contentInfo.SetChapters(chapters);
 }
 
 const std::vector<std::pair<std::string, int64_t>>& CDataCacheCore::GetChapters() const
 {
-  CSingleLock lock(m_contentSection);
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
   return m_contentInfo.GetChapters();
 }
 
 void CDataCacheCore::SetRenderClockSync(bool enable)
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
 
   m_renderInfo.m_isClockSync = enable;
 }
 
 bool CDataCacheCore::IsRenderClockSync()
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
 
   return m_renderInfo.m_isClockSync;
 }
@@ -322,7 +322,7 @@ bool CDataCacheCore::IsRenderClockSync()
 // player states
 void CDataCacheCore::SetStateSeeking(bool active)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_stateInfo.m_stateSeeking = active;
   m_playerStateChanged = true;
@@ -330,14 +330,14 @@ void CDataCacheCore::SetStateSeeking(bool active)
 
 bool CDataCacheCore::IsSeeking()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_stateInfo.m_stateSeeking;
 }
 
 void CDataCacheCore::SetSpeed(float tempo, float speed)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_stateInfo.m_tempo = tempo;
   m_stateInfo.m_speed = speed;
@@ -345,35 +345,35 @@ void CDataCacheCore::SetSpeed(float tempo, float speed)
 
 float CDataCacheCore::GetSpeed()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_stateInfo.m_speed;
 }
 
 float CDataCacheCore::GetTempo()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_stateInfo.m_tempo;
 }
 
 void CDataCacheCore::SetFrameAdvance(bool fa)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_stateInfo.m_frameAdvance = fa;
 }
 
 bool CDataCacheCore::IsFrameAdvance()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_stateInfo.m_frameAdvance;
 }
 
 bool CDataCacheCore::IsPlayerStateChanged()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   bool ret(m_playerStateChanged);
   m_playerStateChanged = false;
@@ -383,7 +383,7 @@ bool CDataCacheCore::IsPlayerStateChanged()
 
 void CDataCacheCore::SetGuiRender(bool gui)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_stateInfo.m_renderGuiLayer = gui;
   m_playerStateChanged = true;
@@ -391,14 +391,14 @@ void CDataCacheCore::SetGuiRender(bool gui)
 
 bool CDataCacheCore::GetGuiRender()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_stateInfo.m_renderGuiLayer;
 }
 
 void CDataCacheCore::SetVideoRender(bool video)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_stateInfo.m_renderVideoLayer = video;
   m_playerStateChanged = true;
@@ -406,14 +406,14 @@ void CDataCacheCore::SetVideoRender(bool video)
 
 bool CDataCacheCore::GetVideoRender()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_stateInfo.m_renderVideoLayer;
 }
 
 void CDataCacheCore::SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   m_timeInfo.m_startTime = start;
   m_timeInfo.m_time = current;
   m_timeInfo.m_timeMin = min;
@@ -422,7 +422,7 @@ void CDataCacheCore::SetPlayTimes(time_t start, int64_t current, int64_t min, in
 
 void CDataCacheCore::GetPlayTimes(time_t &start, int64_t &current, int64_t &min, int64_t &max)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   start = m_timeInfo.m_startTime;
   current = m_timeInfo.m_time;
   min = m_timeInfo.m_timeMin;
@@ -431,31 +431,31 @@ void CDataCacheCore::GetPlayTimes(time_t &start, int64_t &current, int64_t &min,
 
 time_t CDataCacheCore::GetStartTime()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   return m_timeInfo.m_startTime;
 }
 
 int64_t CDataCacheCore::GetPlayTime()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   return m_timeInfo.m_time;
 }
 
 int64_t CDataCacheCore::GetMinTime()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   return m_timeInfo.m_timeMin;
 }
 
 int64_t CDataCacheCore::GetMaxTime()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   return m_timeInfo.m_timeMax;
 }
 
 float CDataCacheCore::GetPlayPercentage()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   // Note: To calculate accurate percentage, all time data must be consistent,
   //       which is the case for data cache core. Calculation can not be done

--- a/xbmc/cores/DllLoader/dll_tracker.cpp
+++ b/xbmc/cores/DllLoader/dll_tracker.cpp
@@ -11,9 +11,9 @@
 #include "DllLoader.h"
 #include "dll_tracker_file.h"
 #include "dll_tracker_library.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <stdlib.h>
 
 #ifdef _cplusplus
@@ -30,13 +30,13 @@ void tracker_dll_add(DllLoader* pDll)
   trackInfo->pDll = pDll;
   trackInfo->lMinAddr = 0;
   trackInfo->lMaxAddr = 0;
-  CSingleLock locktd(g_trackerLock);
+  std::unique_lock<CCriticalSection> locktd(g_trackerLock);
   g_trackedDlls.push_back(trackInfo);
 }
 
 void tracker_dll_free(DllLoader* pDll)
 {
-  CSingleLock locktd(g_trackerLock);
+  std::unique_lock<CCriticalSection> locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end();)
   {
     // NOTE: This code assumes that the same dll pointer can be in more than one
@@ -69,7 +69,7 @@ void tracker_dll_free(DllLoader* pDll)
 
 void tracker_dll_set_addr(const DllLoader* pDll, uintptr_t min, uintptr_t max)
 {
-  CSingleLock locktd(g_trackerLock);
+  std::unique_lock<CCriticalSection> locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end(); ++it)
   {
     if ((*it)->pDll == pDll)
@@ -91,7 +91,7 @@ const char* tracker_getdllname(uintptr_t caller)
 
 DllTrackInfo* tracker_get_dlltrackinfo(uintptr_t caller)
 {
-  CSingleLock locktd(g_trackerLock);
+  std::unique_lock<CCriticalSection> locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end(); ++it)
   {
     if (caller >= (*it)->lMinAddr && caller <= (*it)->lMaxAddr)
@@ -116,7 +116,7 @@ DllTrackInfo* tracker_get_dlltrackinfo(uintptr_t caller)
 
 DllTrackInfo* tracker_get_dlltrackinfo_byobject(const DllLoader* pDll)
 {
-  CSingleLock locktd(g_trackerLock);
+  std::unique_lock<CCriticalSection> locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end(); ++it)
   {
     if ((*it)->pDll == pDll)
@@ -129,7 +129,7 @@ DllTrackInfo* tracker_get_dlltrackinfo_byobject(const DllLoader* pDll)
 
 void tracker_dll_data_track(const DllLoader* pDll, uintptr_t addr)
 {
-  CSingleLock locktd(g_trackerLock);
+  std::unique_lock<CCriticalSection> locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end(); ++it)
   {
     if (pDll == (*it)->pDll)

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -6,10 +6,11 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdarg.h>
 #include <math.h>
+#include <mutex>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #ifndef TARGET_POSIX
 #include <io.h>
 #include <direct.h>
@@ -53,7 +54,6 @@
 #include "filesystem/SpecialProtocol.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "util/EmuFileWrapper.h"
 #include "utils/log.h"
 #ifndef TARGET_POSIX
@@ -1840,7 +1840,7 @@ extern "C"
           value[size - 1] = '\0';
 
         {
-          CSingleLock lock(dll_cs_environ);
+          std::unique_lock<CCriticalSection> lock(dll_cs_environ);
 
           char** free_position = NULL;
           for (int i = 0; i < EMU_MAX_ENVIRONMENT_ITEMS && free_position == NULL; i++)
@@ -1891,7 +1891,7 @@ extern "C"
     char* value = NULL;
 
     {
-      CSingleLock lock(dll_cs_environ);
+      std::unique_lock<CCriticalSection> lock(dll_cs_environ);
 
       update_emu_environ();//apply any changes
 

--- a/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.cpp
+++ b/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.cpp
@@ -9,7 +9,8 @@
 #include "EmuFileWrapper.h"
 
 #include "filesystem/File.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 CEmuFileWrapper g_emuFileWrapper;
 
@@ -40,7 +41,7 @@ CEmuFileWrapper::~CEmuFileWrapper()
 
 void CEmuFileWrapper::CleanUp()
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   for (EmuFileObject& file : m_files)
   {
     if (file.used)
@@ -63,7 +64,7 @@ EmuFileObject* CEmuFileWrapper::RegisterFileObject(XFILE::CFile* pFile)
 {
   EmuFileObject* object = nullptr;
 
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
 
   for (int i = 0; i < MAX_EMULATED_FILES; i++)
   {
@@ -91,7 +92,7 @@ void CEmuFileWrapper::UnRegisterFileObjectByDescriptor(int fd)
   if (!m_files[i].used)
     return;
 
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
 
   // we assume the emulated function already deleted the CFile object
   if (m_files[i].file_lock)

--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -17,6 +17,7 @@
 #include "utils/log.h"
 
 #include <map>
+#include <mutex>
 
 static thread_local CFFmpegLog* CFFmpegLogTls;
 
@@ -49,7 +50,7 @@ std::map<const CThread*, std::string> g_logbuffer;
 
 void ff_flush_avutil_log_buffers(void)
 {
-  CSingleLock lock(m_logSection);
+  std::unique_lock<CCriticalSection> lock(m_logSection);
   /* Loop through the logbuffer list and remove any blank buffers
      If the thread using the buffer is still active, it will just
      add a new buffer next time it writes to the log */
@@ -63,7 +64,7 @@ void ff_flush_avutil_log_buffers(void)
 
 void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
 {
-  CSingleLock lock(m_logSection);
+  std::unique_lock<CCriticalSection> lock(m_logSection);
   const CThread* threadId = CThread::GetCurrentThread();
   std::string &buffer = g_logbuffer[threadId];
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -41,12 +41,13 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/MediaSettings.h"
-#include "threads/SingleLock.h"
 #include "utils/JobManager.h"
 #include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
+
+#include <mutex>
 
 using namespace KODI;
 using namespace GAME;
@@ -93,7 +94,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
 
   m_renderManager.reset(new CRPRenderManager(*m_processInfo));
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (IsPlaying())
     CloseFile();
@@ -209,7 +210,7 @@ bool CRetroPlayer::CloseFile(bool reopen /* = false */)
 
   m_playbackControl.reset();
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (m_gameClient && m_gameServices.GameSettings().AutosaveEnabled())
   {

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
@@ -11,9 +11,9 @@
 #include "IRenderBufferPool.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
-#include "threads/SingleLock.h"
 
 #include <algorithm>
+#include <mutex>
 
 using namespace KODI;
 using namespace RETRO;
@@ -25,7 +25,7 @@ CRenderBufferManager::~CRenderBufferManager()
 
 void CRenderBufferManager::RegisterPools(IRendererFactory* factory, RenderBufferPoolVector pools)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_pools.emplace_back(RenderBufferPools{factory, std::move(pools)});
 }
@@ -34,7 +34,7 @@ RenderBufferPoolVector CRenderBufferManager::GetPools(IRendererFactory* factory)
 {
   RenderBufferPoolVector bufferPools;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   auto it = std::find_if(m_pools.begin(), m_pools.end(), [factory](const RenderBufferPools& pools) {
     return pools.factory == factory;
@@ -50,7 +50,7 @@ std::vector<IRenderBufferPool*> CRenderBufferManager::GetBufferPools()
 {
   std::vector<IRenderBufferPool*> bufferPools;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& pools : m_pools)
   {
@@ -63,7 +63,7 @@ std::vector<IRenderBufferPool*> CRenderBufferManager::GetBufferPools()
 
 void CRenderBufferManager::FlushPools()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& pools : m_pools)
   {
@@ -74,7 +74,7 @@ void CRenderBufferManager::FlushPools()
 
 std::string CRenderBufferManager::GetRenderSystemName(IRenderBufferPool* renderBufferPool) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& pools : m_pools)
   {

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.cpp
@@ -11,7 +11,8 @@
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "settings/GameSettings.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 using namespace KODI;
 using namespace RETRO;
@@ -34,7 +35,7 @@ CGUIGameSettings::~CGUIGameSettings()
 
 CRenderSettings CGUIGameSettings::GetSettings() const
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   return m_renderSettings;
 }
@@ -55,7 +56,7 @@ void CGUIGameSettings::Notify(const Observable& obs, const ObservableMessage msg
 
 void CGUIGameSettings::UpdateSettings()
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   // Get settings from GUI
   std::string videoFilter = m_guiSettings.VideoFilter();

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.cpp
@@ -9,7 +9,8 @@
 #include "GUIRenderSettings.h"
 
 #include "GUIGameControl.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 using namespace KODI;
 using namespace RETRO;
@@ -35,56 +36,56 @@ bool CGUIRenderSettings::HasRotation() const
 
 CRenderSettings CGUIRenderSettings::GetSettings() const
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   return m_renderSettings;
 }
 
 CRect CGUIRenderSettings::GetDimensions() const
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   return m_renderDimensions;
 }
 
 void CGUIRenderSettings::Reset()
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   return m_renderSettings.Reset();
 }
 
 void CGUIRenderSettings::SetSettings(CRenderSettings settings)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   m_renderSettings = settings;
 }
 
 void CGUIRenderSettings::SetDimensions(const CRect& dimensions)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   m_renderDimensions = dimensions;
 }
 
 void CGUIRenderSettings::SetVideoFilter(const std::string& videoFilter)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetVideoFilter(videoFilter);
 }
 
 void CGUIRenderSettings::SetStretchMode(STRETCHMODE stretchMode)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetRenderStretchMode(stretchMode);
 }
 
 void CGUIRenderSettings::SetRotationDegCCW(unsigned int rotationDegCCW)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetRenderRotation(rotationDegCCW);
 }

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -15,11 +15,11 @@
 #include "games/GameServices.h"
 #include "games/GameSettings.h"
 #include "games/addons/GameClient.h"
-#include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
 #include "utils/URIUtils.h"
 
 #include <algorithm>
+#include <mutex>
 
 using namespace KODI;
 using namespace RETRO;
@@ -146,7 +146,7 @@ std::string CReversiblePlayback::CreateSavestate()
   uint8_t* memoryData = savestate->GetMemoryBuffer(memorySize);
 
   {
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
     if (m_memoryStream && m_memoryStream->CurrentFrame() != nullptr)
     {
       std::memcpy(memoryData, m_memoryStream->CurrentFrame(), memorySize);
@@ -182,7 +182,7 @@ bool CReversiblePlayback::LoadSavestate(const std::string& path)
       savestate->GetMemorySize() == memorySize)
   {
     {
-      CSingleLock lock(m_mutex);
+      std::unique_lock<CCriticalSection> lock(m_mutex);
       if (m_memoryStream)
       {
         m_memoryStream->SetFrameCounter(savestate->TimestampFrames());
@@ -217,7 +217,7 @@ void CReversiblePlayback::RewindEvent()
 
 void CReversiblePlayback::AddFrame()
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (m_memoryStream)
   {
@@ -233,7 +233,7 @@ void CReversiblePlayback::AddFrame()
 
 void CReversiblePlayback::RewindFrames(uint64_t frames)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (m_memoryStream)
   {
@@ -247,7 +247,7 @@ void CReversiblePlayback::RewindFrames(uint64_t frames)
 
 void CReversiblePlayback::AdvanceFrames(uint64_t frames)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (m_memoryStream)
   {
@@ -287,7 +287,7 @@ void CReversiblePlayback::Notify(const Observable& obs, const ObservableMessage 
 
 void CReversiblePlayback::UpdateMemoryStream()
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   bool bRewindEnabled = false;
 

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -153,7 +153,7 @@ std::string CReversiblePlayback::CreateSavestate()
     }
     else
     {
-      lock.Leave();
+      lock.unlock();
       if (!m_gameClient->Serialize(memoryData, memorySize))
         return "";
     }

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -14,10 +14,11 @@
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
+
+#include <mutex>
 
 extern "C"
 {
@@ -66,7 +67,7 @@ CRPProcessInfo* CRPProcessInfo::CreateInstance()
 {
   CRPProcessInfo* processInfo = nullptr;
 
-  CSingleLock lock(m_createSection);
+  std::unique_lock<CCriticalSection> lock(m_createSection);
 
   if (m_processControl != nullptr)
   {
@@ -90,7 +91,7 @@ void CRPProcessInfo::RegisterProcessControl(CreateRPProcessControl createFunc)
 {
   std::unique_ptr<CRPProcessInfo> processInfo(createFunc());
 
-  CSingleLock lock(m_createSection);
+  std::unique_lock<CCriticalSection> lock(m_createSection);
 
   if (processInfo)
   {
@@ -107,7 +108,7 @@ void CRPProcessInfo::RegisterProcessControl(CreateRPProcessControl createFunc)
 
 void CRPProcessInfo::RegisterRendererFactory(IRendererFactory* factory)
 {
-  CSingleLock lock(m_createSection);
+  std::unique_lock<CCriticalSection> lock(m_createSection);
 
   CLog::Log(LOGINFO, "RetroPlayer[RENDER]: Registering renderer factory for {}",
             factory->RenderSystemName());
@@ -123,7 +124,7 @@ std::string CRPProcessInfo::GetRenderSystemName(IRenderBufferPool* renderBufferP
 CRPBaseRenderer* CRPProcessInfo::CreateRenderer(IRenderBufferPool* renderBufferPool,
                                                 const CRenderSettings& renderSettings)
 {
-  CSingleLock lock(m_createSection);
+  std::unique_lock<CCriticalSection> lock(m_createSection);
 
   for (auto& rendererFactory : m_rendererFactories)
   {

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -145,9 +145,9 @@ unsigned int CAudioSinkAE::AddPackets(const DVDAudioFrame &audioframe)
       break;
     }
 
-    lock.Leave();
+    lock.unlock();
     KODI::TIME::Sleep(1ms);
-    lock.Enter();
+    lock.lock();
   } while (!m_bAbort);
 
   m_playingPts = audioframe.pts + audioframe.duration - GetDelay();

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -14,6 +14,7 @@
 #include "threads/CriticalSection.h"
 
 #include <atomic>
+#include <mutex>
 
 #include "PlatformDefs.h"
 
@@ -23,7 +24,6 @@ extern "C" {
 
 typedef struct stDVDAudioFrame DVDAudioFrame;
 
-class CSingleLock;
 class CDVDClock;
 
 class CAudioSinkAE : IAEClockCallback

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -8,7 +8,8 @@
 
 #include "VideoBufferDRMPRIME.h"
 
-#include "threads/SingleLock.h"
+#include <mutex>
+
 
 extern "C"
 {
@@ -116,7 +117,7 @@ CVideoBufferPoolDRMPRIMEFFmpeg::~CVideoBufferPoolDRMPRIMEFFmpeg()
 
 CVideoBuffer* CVideoBufferPoolDRMPRIMEFFmpeg::Get()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CVideoBufferDRMPRIMEFFmpeg* buf = nullptr;
   if (!m_free.empty())
@@ -140,7 +141,7 @@ CVideoBuffer* CVideoBufferPoolDRMPRIMEFFmpeg::Get()
 
 void CVideoBufferPoolDRMPRIMEFFmpeg::Return(int id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
@@ -9,8 +9,9 @@
 #include "VideoBufferPoolDMA.h"
 
 #include "cores/VideoPlayer/Buffers/VideoBufferDMA.h"
-#include "threads/SingleLock.h"
 #include "utils/BufferObjectFactory.h"
+
+#include <mutex>
 
 #include <drm_fourcc.h>
 
@@ -21,7 +22,7 @@ extern "C"
 
 CVideoBufferPoolDMA::~CVideoBufferPoolDMA()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (auto buf : m_all)
     delete buf;
@@ -29,7 +30,7 @@ CVideoBufferPoolDMA::~CVideoBufferPoolDMA()
 
 CVideoBuffer* CVideoBufferPoolDMA::Get()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CVideoBufferDMA* buf = nullptr;
   if (!m_free.empty())
@@ -60,7 +61,7 @@ CVideoBuffer* CVideoBufferPoolDMA::Get()
 
 void CVideoBufferPoolDMA::Return(int id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();
@@ -79,7 +80,7 @@ void CVideoBufferPoolDMA::Return(int id)
 
 void CVideoBufferPoolDMA::Configure(AVPixelFormat format, int size)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_fourcc = TranslateFormat(format);
   m_size = static_cast<uint64_t>(size);
@@ -87,14 +88,14 @@ void CVideoBufferPoolDMA::Configure(AVPixelFormat format, int size)
 
 bool CVideoBufferPoolDMA::IsConfigured()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   return (m_fourcc != 0 && m_size != 0);
 }
 
 bool CVideoBufferPoolDMA::IsCompatible(AVPixelFormat format, int size)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_fourcc != TranslateFormat(format) || m_size != static_cast<uint64_t>(size))
     return false;

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -10,17 +10,17 @@
 
 #include "VideoReferenceClock.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
-#include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 
 #include <inttypes.h>
 #include <math.h>
+#include <mutex>
 
 CDVDClock::CDVDClock()
 {
-  CSingleLock lock(m_systemsection);
+  std::unique_lock<CCriticalSection> lock(m_systemsection);
 
   m_pauseClock = 0;
   m_bReset = true;
@@ -46,7 +46,7 @@ CDVDClock::~CDVDClock() = default;
 // Returns the current absolute clock in units of DVD_TIME_BASE (usually microseconds).
 double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
 {
-  CSingleLock lock(m_systemsection);
+  std::unique_lock<CCriticalSection> lock(m_systemsection);
 
   int64_t current;
   current = m_videoRefClock->GetTime(interpolated);
@@ -56,7 +56,7 @@ double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
 
 double CDVDClock::GetClock(bool interpolated /*= true*/)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   int64_t current = m_videoRefClock->GetTime(interpolated);
   m_systemAdjust += m_speedAdjust * (current - m_lastSystemTime);
@@ -69,7 +69,7 @@ double CDVDClock::GetClock(double& absolute, bool interpolated /*= true*/)
 {
   int64_t current = m_videoRefClock->GetTime(interpolated);
 
-  CSingleLock lock(m_systemsection);
+  std::unique_lock<CCriticalSection> lock(m_systemsection);
   absolute = SystemToAbsolute(current);
 
   m_systemAdjust += m_speedAdjust * (current - m_lastSystemTime);
@@ -80,19 +80,19 @@ double CDVDClock::GetClock(double& absolute, bool interpolated /*= true*/)
 
 void CDVDClock::SetVsyncAdjust(double adjustment)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_vSyncAdjust = adjustment;
 }
 
 double CDVDClock::GetVsyncAdjust()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_vSyncAdjust;
 }
 
 void CDVDClock::Pause(bool pause)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (pause && !m_paused)
   {
@@ -113,7 +113,7 @@ void CDVDClock::Pause(bool pause)
 
 void CDVDClock::Advance(double time)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_pauseClock)
   {
@@ -124,7 +124,7 @@ void CDVDClock::Advance(double time)
 void CDVDClock::SetSpeed(int iSpeed)
 {
   // this will sometimes be a little bit of due to rounding errors, ie clock might jump a bit when changing speed
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_paused)
   {
@@ -157,19 +157,19 @@ void CDVDClock::SetSpeedAdjust(double adjust)
 {
   CLog::Log(LOGDEBUG, "CDVDClock::SetSpeedAdjust - adjusted:{:f}", adjust);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_speedAdjust = adjust;
 }
 
 double CDVDClock::GetSpeedAdjust()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_speedAdjust;
 }
 
 double CDVDClock::ErrorAdjust(double error, const char* log)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   double clock, absolute, adjustment;
   clock = GetClock(absolute);
@@ -209,7 +209,7 @@ double CDVDClock::ErrorAdjust(double error, const char* log)
 
 void CDVDClock::Discontinuity(double clock, double absolute)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_startClock = AbsoluteToSystem(absolute);
   if(m_pauseClock)
     m_pauseClock = m_startClock;
@@ -221,7 +221,7 @@ void CDVDClock::Discontinuity(double clock, double absolute)
 
 void CDVDClock::SetMaxSpeedAdjust(double speed)
 {
-  CSingleLock lock(m_speedsection);
+  std::unique_lock<CCriticalSection> lock(m_speedsection);
 
   m_maxspeedadjust = speed;
 }
@@ -241,7 +241,7 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
   if (rate <= 0)
     return -1;
 
-  CSingleLock lock(m_speedsection);
+  std::unique_lock<CCriticalSection> lock(m_speedsection);
 
   double weight = (rate * 2) / fps;
 
@@ -302,7 +302,7 @@ double CDVDClock::SystemToPlaying(int64_t system)
 
 double CDVDClock::GetClockSpeed()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   double speed = (double)m_systemFrequency / m_systemUsed;
   return m_videoRefClock->GetSpeed() * speed + m_speedAdjust;

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -253,7 +253,7 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
       weight = MathUtils::round_int(weight);
   }
   double speed = (rate * 2.0 ) / (fps * weight);
-  lock.Leave();
+  lock.unlock();
 
   m_videoRefClock->SetSpeed(speed);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -24,10 +24,10 @@
 #include "Video/DVDVideoCodecFFmpeg.h"
 #include "addons/AddonProvider.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDCodecs.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <utility>
 
 //------------------------------------------------------------------------------
@@ -44,7 +44,7 @@ CCriticalSection videoCodecSection, audioCodecSection;
 std::unique_ptr<CDVDVideoCodec> CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo& hint,
                                                                    CProcessInfo& processInfo)
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   std::unique_ptr<CDVDVideoCodec> pCodec;
   CDVDCodecOptions options;
@@ -94,7 +94,7 @@ std::unique_ptr<CDVDVideoCodec> CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInf
 std::unique_ptr<CDVDVideoCodec> CDVDFactoryCodec::CreateVideoCodecHW(const std::string& id,
                                                                      CProcessInfo& processInfo)
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   auto it = m_hwVideoCodecs.find(id);
   if (it != m_hwVideoCodecs.end())
@@ -110,7 +110,7 @@ IHardwareDecoder* CDVDFactoryCodec::CreateVideoCodecHWAccel(const std::string& i
                                                             CProcessInfo& processInfo,
                                                             AVPixelFormat fmt)
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   auto it = m_hwAccels.find(id);
   if (it != m_hwAccels.end())
@@ -124,21 +124,21 @@ IHardwareDecoder* CDVDFactoryCodec::CreateVideoCodecHWAccel(const std::string& i
 
 void CDVDFactoryCodec::RegisterHWVideoCodec(const std::string& id, CreateHWVideoCodec createFunc)
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   m_hwVideoCodecs[id] = std::move(createFunc);
 }
 
 void CDVDFactoryCodec::ClearHWVideoCodecs()
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   m_hwVideoCodecs.clear();
 }
 
 std::vector<std::string> CDVDFactoryCodec::GetHWAccels()
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   std::vector<std::string> ret;
   ret.reserve(m_hwAccels.size());
@@ -151,14 +151,14 @@ std::vector<std::string> CDVDFactoryCodec::GetHWAccels()
 
 void CDVDFactoryCodec::RegisterHWAccel(const std::string& id, CreateHWAccel createFunc)
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   m_hwAccels[id] = std::move(createFunc);
 }
 
 void CDVDFactoryCodec::ClearHWAccels()
 {
-  CSingleLock lock(videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(videoCodecSection);
 
   m_hwAccels.clear();
 }
@@ -214,14 +214,14 @@ std::unique_ptr<CDVDAudioCodec> CDVDFactoryCodec::CreateAudioCodec(
 
 void CDVDFactoryCodec::RegisterHWAudioCodec(const std::string& id, CreateHWAudioCodec createFunc)
 {
-  CSingleLock lock(audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(audioCodecSection);
 
   m_hwAudioCodecs[id] = std::move(createFunc);
 }
 
 void CDVDFactoryCodec::ClearHWAudioCodecs()
 {
-  CSingleLock lock(audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(audioCodecSection);
 
   m_hwAudioCodecs.clear();
 }
@@ -229,7 +229,7 @@ void CDVDFactoryCodec::ClearHWAudioCodecs()
 std::unique_ptr<CDVDAudioCodec> CDVDFactoryCodec::CreateAudioCodecHW(const std::string& id,
                                                                      CProcessInfo& processInfo)
 {
-  CSingleLock lock(audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(audioCodecSection);
 
   auto it = m_hwAudioCodecs.find(id);
   if (it != m_hwAudioCodecs.end())

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -39,6 +39,7 @@
 
 #include <cassert>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -271,7 +272,7 @@ CMediaCodecVideoBufferPool::~CMediaCodecVideoBufferPool()
 
 CVideoBuffer* CMediaCodecVideoBufferPool::Get()
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
 
   if (m_freeBuffers.empty())
   {
@@ -288,14 +289,14 @@ CVideoBuffer* CMediaCodecVideoBufferPool::Get()
 
 void CMediaCodecVideoBufferPool::Return(int id)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   m_videoBuffers[id]->ReleaseOutputBuffer(false, 0, this);
   m_freeBuffers.push_back(id);
 }
 
 std::shared_ptr<CJNIMediaCodec> CMediaCodecVideoBufferPool::GetMediaCodec()
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   return m_codec;
 }
 
@@ -303,13 +304,13 @@ void CMediaCodecVideoBufferPool::ResetMediaCodec()
 {
   ReleaseMediaCodecBuffers();
 
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   m_codec = nullptr;
 }
 
 void CMediaCodecVideoBufferPool::ReleaseMediaCodecBuffers()
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   for (auto buffer : m_videoBuffers)
     buffer->ReleaseOutputBuffer(false, 0, this);
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 
 #include <memory>
+#include <mutex>
 
 extern "C" {
 #include <libavutil/opt.h>
@@ -141,7 +142,7 @@ CVideoBufferPoolFFmpeg::~CVideoBufferPoolFFmpeg()
 
 CVideoBuffer* CVideoBufferPoolFFmpeg::Get()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CVideoBufferFFmpeg *buf = nullptr;
   if (!m_free.empty())
@@ -165,7 +166,7 @@ CVideoBuffer* CVideoBufferPoolFFmpeg::Get()
 
 void CVideoBufferPoolFFmpeg::Return(int id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -651,8 +651,7 @@ bool CContext::Reset()
 
     ComPtr<IDXGIDevice> ctxDevice;
     ComPtr<IDXGIAdapter> ctxAdapter;
-    if (SUCCEEDED(m_pD3D11Device.As(&ctxDevice)) && 
-      SUCCEEDED(ctxDevice->GetAdapter(&ctxAdapter)))
+    if (SUCCEEDED(m_pD3D11Device.As(&ctxDevice)) && SUCCEEDED(ctxDevice->GetAdapter(&ctxAdapter)))
     {
       DXGI_ADAPTER_DESC ctxDesc = {};
       ctxAdapter->GetDesc(&ctxDesc);
@@ -1346,10 +1345,10 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   // app device is lost
   if (m_state == DXVA_LOST)
   {
-    lock.Leave();
+    lock.unlock();
     // wait app device restoration
     m_event.Wait(2000ms);
-    lock.Enter();
+    lock.lock();
 
     // still in lost state after 2sec
     if (m_state == DXVA_LOST)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -13,6 +13,7 @@
 #include "guilib/D3DResource.h"
 #include "threads/Event.h"
 
+#include <mutex>
 #include <vector>
 
 #include <wrl/client.h>
@@ -229,13 +230,13 @@ protected:
   // ID3DResource overrides
   void OnCreateDevice() override
   {
-    CSingleLock lock(m_section);
+    std::unique_lock<CCriticalSection> lock(m_section);
     m_state = DXVA_RESET;
     m_event.Set();
   }
   void OnDestroyDevice(bool fatal) override
   {
-    CSingleLock lock(m_section);
+    std::unique_lock<CCriticalSection> lock(m_section);
     m_state = DXVA_LOST;
     m_event.Reset();
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -23,6 +23,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -67,21 +68,93 @@ public:
   int processCmd;
   bool isVpp;
 
-  void IncDecoded() { CSingleLock l(m_sec); decodedPics++;}
-  void DecDecoded() { CSingleLock l(m_sec); decodedPics--;}
-  void IncProcessed() { CSingleLock l(m_sec); processedPics++;}
-  void DecProcessed() { CSingleLock l(m_sec); processedPics--;}
-  void IncRender() { CSingleLock l(m_sec); renderPics++;}
-  void DecRender() { CSingleLock l(m_sec); renderPics--;}
-  void Reset() { CSingleLock l(m_sec); decodedPics=0; processedPics=0;renderPics=0;latency=0;isVpp=false;}
-  void Get(uint16_t &decoded, uint16_t &processed, uint16_t &render, bool &vpp) {CSingleLock l(m_sec); decoded = decodedPics, processed=processedPics, render=renderPics; vpp=isVpp;}
-  void SetParams(uint64_t time, int flags) { CSingleLock l(m_sec); latency = time; codecFlags = flags; }
-  void GetParams(uint64_t &lat, int &flags) { CSingleLock l(m_sec); lat = latency; flags = codecFlags; }
-  void SetCmd(int cmd) { CSingleLock l(m_sec); processCmd = cmd; }
-  void GetCmd(int &cmd) { CSingleLock l(m_sec); cmd = processCmd; processCmd = 0; }
-  void SetCanSkipDeint(bool canSkip) { CSingleLock l(m_sec); canSkipDeint = canSkip; }
-  bool CanSkipDeint() { CSingleLock l(m_sec); if (canSkipDeint) return true; else return false;}
-  void SetVpp(bool vpp) {CSingleLock l(m_sec); isVpp = vpp;}
+  void IncDecoded()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decodedPics++;
+  }
+  void DecDecoded()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decodedPics--;
+  }
+  void IncProcessed()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    processedPics++;
+  }
+  void DecProcessed()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    processedPics--;
+  }
+  void IncRender()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    renderPics++;
+  }
+  void DecRender()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    renderPics--;
+  }
+  void Reset()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decodedPics = 0;
+    processedPics = 0;
+    renderPics = 0;
+    latency = 0;
+    isVpp = false;
+  }
+  void Get(uint16_t& decoded, uint16_t& processed, uint16_t& render, bool& vpp)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decoded = decodedPics, processed = processedPics, render = renderPics;
+    vpp = isVpp;
+  }
+  void SetParams(uint64_t time, int flags)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    latency = time;
+    codecFlags = flags;
+  }
+  void GetParams(uint64_t& lat, int& flags)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    lat = latency;
+    flags = codecFlags;
+  }
+  void SetCmd(int cmd)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    processCmd = cmd;
+  }
+  void GetCmd(int& cmd)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    cmd = processCmd;
+    processCmd = 0;
+  }
+  void SetCanSkipDeint(bool canSkip)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    canSkipDeint = canSkip;
+  }
+  bool CanSkipDeint()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    if (canSkipDeint)
+      return true;
+    else
+      return false;
+  }
+  void SetVpp(bool vpp)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    isVpp = vpp;
+  }
+
 private:
   CCriticalSection m_sec;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -28,6 +28,8 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/X11/WinSystemX11.h"
 
+#include <mutex>
+
 #include <dlfcn.h>
 
 using namespace Actor;
@@ -90,7 +92,7 @@ CVDPAUContext::CVDPAUContext()
 
 void CVDPAUContext::Release()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   m_refCount--;
   if (m_refCount <= 0)
@@ -109,7 +111,7 @@ void CVDPAUContext::Close()
 
 bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (m_context)
   {
@@ -121,7 +123,7 @@ bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx)
   m_context = new CVDPAUContext();
   *ctx = m_context;
   {
-    CSingleLock gLock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock<CCriticalSection> gLock(CServiceBroker::GetWinSystem()->GetGfxContext());
     if (!m_context->LoadSymbols() || !m_context->CreateContext())
     {
       delete m_context;
@@ -186,7 +188,8 @@ bool CVDPAUContext::CreateContext()
   CLog::Log(LOGINFO, "VDPAU::CreateContext - creating decoder context");
 
   int screen;
-  { CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  {
+    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
     if (!m_display)
       m_display = XOpenDisplay(NULL);
@@ -343,13 +346,13 @@ bool CVDPAUContext::Supports(VdpVideoMixerFeature feature)
 
 void CVideoSurfaces::AddSurface(VdpVideoSurface surf)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_state[surf] = SURFACE_USED_FOR_REFERENCE;
 }
 
 void CVideoSurfaces::ClearReference(VdpVideoSurface surf)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::ClearReference - surface invalid");
@@ -364,7 +367,7 @@ void CVideoSurfaces::ClearReference(VdpVideoSurface surf)
 
 bool CVideoSurfaces::MarkRender(VdpVideoSurface surf)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::MarkRender - surface invalid");
@@ -382,7 +385,7 @@ bool CVideoSurfaces::MarkRender(VdpVideoSurface surf)
 
 void CVideoSurfaces::ClearRender(VdpVideoSurface surf)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::ClearRender - surface invalid");
@@ -397,7 +400,7 @@ void CVideoSurfaces::ClearRender(VdpVideoSurface surf)
 
 bool CVideoSurfaces::IsValid(VdpVideoSurface surf)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_state.find(surf) != m_state.end())
     return true;
   else
@@ -406,7 +409,7 @@ bool CVideoSurfaces::IsValid(VdpVideoSurface surf)
 
 VdpVideoSurface CVideoSurfaces::GetFree(VdpVideoSurface surf)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_state.find(surf) != m_state.end())
   {
     std::list<VdpVideoSurface>::iterator it;
@@ -436,7 +439,7 @@ VdpVideoSurface CVideoSurfaces::GetFree(VdpVideoSurface surf)
 
 VdpVideoSurface CVideoSurfaces::RemoveNext(bool skiprender)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   VdpVideoSurface surf;
   std::map<VdpVideoSurface, int>::iterator it;
   for(it = m_state.begin(); it != m_state.end(); ++it)
@@ -457,20 +460,20 @@ VdpVideoSurface CVideoSurfaces::RemoveNext(bool skiprender)
 
 void CVideoSurfaces::Reset()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_freeSurfaces.clear();
   m_state.clear();
 }
 
 int CVideoSurfaces::Size()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   return m_state.size();
 }
 
 bool CVideoSurfaces::HasRefs()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   for (const auto &i : m_state)
   {
     if (i.second & SURFACE_USED_FOR_REFERENCE)
@@ -641,7 +644,7 @@ void CDecoder::Close()
 
   CServiceBroker::GetWinSystem()->Unregister(this);
 
-  CSingleLock lock(m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
 
   FiniVDPAUOutput();
   m_vdpauOutput.Dispose();
@@ -663,7 +666,7 @@ long CDecoder::Release()
   // a second decoder might need resources
   if (m_vdpauConfigured == true)
   {
-    CSingleLock lock(m_DecoderSection);
+    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
     CLog::Log(LOGINFO, "CVDPAU::Release pre-cleanup");
 
     Message *reply;
@@ -734,7 +737,7 @@ void CDecoder::OnLostDisplay()
 
   int count = CServiceBroker::GetWinSystem()->GetGfxContext().exit();
 
-  CSingleLock lock(m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
   FiniVDPAUOutput();
   if (m_vdpauConfig.context)
     m_vdpauConfig.context->Release();
@@ -753,7 +756,7 @@ void CDecoder::OnResetDisplay()
 
   int count = CServiceBroker::GetWinSystem()->GetGfxContext().exit();
 
-  CSingleLock lock(m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
   if (m_DisplayState == VDPAU_LOST)
   {
     m_DisplayState = VDPAU_RESET;
@@ -768,7 +771,8 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
 {
   EDisplayState state;
 
-  { CSingleLock lock(m_DecoderSection);
+  {
+    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
     state = m_DisplayState;
   }
 
@@ -782,13 +786,13 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
     }
     else
     {
-      CSingleLock lock(m_DecoderSection);
+      std::unique_lock<CCriticalSection> lock(m_DecoderSection);
       state = m_DisplayState;
     }
   }
   if (state == VDPAU_RESET || state == VDPAU_ERROR)
   {
-    CSingleLock lock(m_DecoderSection);
+    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
 
     avcodec_flush_buffers(avctx);
     FiniVDPAUOutput();
@@ -956,7 +960,7 @@ bool CDecoder::ConfigVDPAU(AVCodecContext* avctx, int ref_frames)
     return false;
 
   // initialize output
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_vdpauConfig.stats = &m_bufferStats;
   m_vdpauConfig.vdpau = this;
   m_bufferStats.Reset();
@@ -997,7 +1001,7 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   CDecoder* vdp = static_cast<CDecoder*>(cb->GetHWAccel());
 
   // while we are waiting to recover we can't do anything
-  CSingleLock lock(vdp->m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(vdp->m_DecoderSection);
 
   if(vdp->m_DisplayState != VDPAU_OPEN)
   {
@@ -1051,7 +1055,7 @@ void CDecoder::FFReleaseBuffer(void *opaque, uint8_t *data)
 
   VdpVideoSurface surf;
 
-  CSingleLock lock(vdp->m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(vdp->m_DecoderSection);
 
   surf = (VdpVideoSurface)(uintptr_t)data;
 
@@ -1066,7 +1070,7 @@ int CDecoder::Render(struct AVCodecContext *s, struct AVFrame *src,
   CDecoder* vdp = static_cast<CDecoder*>(ctx->GetHWAccel());
 
   // while we are waiting to recover we can't do anything
-  CSingleLock lock(vdp->m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(vdp->m_DecoderSection);
 
   if(vdp->m_DisplayState != VDPAU_OPEN)
     return -1;
@@ -1132,7 +1136,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext *avctx, AVFrame *pFrame
   if (result != CDVDVideoCodec::VC_NONE)
     return result;
 
-  CSingleLock lock(m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
 
   if (!m_vdpauConfigured)
     return CDVDVideoCodec::VC_ERROR;
@@ -1246,7 +1250,7 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
     picture->videoBuffer = nullptr;
   }
 
-  CSingleLock lock(m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
 
   if (m_DisplayState != VDPAU_OPEN)
     return false;
@@ -1260,7 +1264,7 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
 
 void CDecoder::Reset()
 {
-  CSingleLock lock(m_DecoderSection);
+  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
 
   if (m_presentPicture)
   {
@@ -2849,7 +2853,7 @@ COutput::~COutput()
 
 void COutput::Dispose()
 {
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_bStop = true;
   m_outMsgEvent.Set();
   StopThread();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -741,7 +741,7 @@ void CDecoder::OnLostDisplay()
   m_vdpauConfig.context = 0;
 
   m_DisplayState = VDPAU_LOST;
-  lock.Leave();
+  lock.unlock();
   m_DisplayEvent.Reset();
 
   CServiceBroker::GetWinSystem()->GetGfxContext().restore(count);
@@ -757,7 +757,7 @@ void CDecoder::OnResetDisplay()
   if (m_DisplayState == VDPAU_LOST)
   {
     m_DisplayState = VDPAU_RESET;
-    lock.Leave();
+    lock.unlock();
     m_DisplayEvent.Set();
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -40,6 +40,7 @@
 #include <deque>
 #include <list>
 #include <map>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -119,20 +120,88 @@ public:
   bool canSkipDeint;
   bool draining;
 
-  void IncDecoded() { CSingleLock l(m_sec); decodedPics++;}
-  void DecDecoded() { CSingleLock l(m_sec); decodedPics--;}
-  void IncProcessed() { CSingleLock l(m_sec); processedPics++;}
-  void DecProcessed() { CSingleLock l(m_sec); processedPics--;}
-  void IncRender() { CSingleLock l(m_sec); renderPics++;}
-  void DecRender() { CSingleLock l(m_sec); renderPics--;}
-  void Reset() { CSingleLock l(m_sec); decodedPics=0; processedPics=0;renderPics=0;latency=0;}
-  void Get(uint16_t &decoded, uint16_t &processed, uint16_t &render) {CSingleLock l(m_sec); decoded = decodedPics, processed=processedPics, render=renderPics;}
-  void SetParams(uint64_t time, int flags) { CSingleLock l(m_sec); latency = time; codecFlags = flags; }
-  void GetParams(uint64_t &lat, int &flags) { CSingleLock l(m_sec); lat = latency; flags = codecFlags; }
-  void SetCanSkipDeint(bool canSkip) { CSingleLock l(m_sec); canSkipDeint = canSkip; }
-  bool CanSkipDeint() { CSingleLock l(m_sec); if (canSkipDeint) return true; else return false;}
-  void SetDraining(bool drain) { CSingleLock l(m_sec); draining = drain; }
-  bool IsDraining() { CSingleLock l(m_sec); if (draining) return true; else return false;}
+  void IncDecoded()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decodedPics++;
+  }
+  void DecDecoded()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decodedPics--;
+  }
+  void IncProcessed()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    processedPics++;
+  }
+  void DecProcessed()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    processedPics--;
+  }
+  void IncRender()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    renderPics++;
+  }
+  void DecRender()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    renderPics--;
+  }
+  void Reset()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decodedPics = 0;
+    processedPics = 0;
+    renderPics = 0;
+    latency = 0;
+  }
+  void Get(uint16_t& decoded, uint16_t& processed, uint16_t& render)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    decoded = decodedPics, processed = processedPics, render = renderPics;
+  }
+  void SetParams(uint64_t time, int flags)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    latency = time;
+    codecFlags = flags;
+  }
+  void GetParams(uint64_t& lat, int& flags)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    lat = latency;
+    flags = codecFlags;
+  }
+  void SetCanSkipDeint(bool canSkip)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    canSkipDeint = canSkip;
+  }
+  bool CanSkipDeint()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    if (canSkipDeint)
+      return true;
+    else
+      return false;
+  }
+  void SetDraining(bool drain)
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    draining = drain;
+  }
+  bool IsDraining()
+  {
+    std::unique_lock<CCriticalSection> l(m_sec);
+    if (draining)
+      return true;
+    else
+      return false;
+  }
+
 private:
   CCriticalSection m_sec;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -6,16 +6,18 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "cores/VideoPlayer/Process/ProcessInfo.h"
-#include "DVDVideoCodec.h"
+#include "VTB.h"
+
 #include "DVDCodecs/DVDCodecUtils.h"
 #include "DVDCodecs/DVDFactoryCodec.h"
-#include "utils/log.h"
-#include "VTB.h"
+#include "DVDVideoCodec.h"
+#include "ServiceBroker.h"
+#include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
-#include "ServiceBroker.h"
+#include "utils/log.h"
+
+#include <mutex>
 
 extern "C" {
 #include <libavcodec/videotoolbox.h>
@@ -81,7 +83,7 @@ CVideoBufferPoolVTB::~CVideoBufferPoolVTB()
 
 CVideoBuffer* CVideoBufferPoolVTB::Get()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CVideoBufferVTB *buf = nullptr;
   if (!m_free.empty())
@@ -105,7 +107,7 @@ CVideoBuffer* CVideoBufferPoolVTB::Get()
 
 void CVideoBufferPoolVTB::Return(int id)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();

--- a/xbmc/cores/VideoPlayer/DVDMessage.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessage.cpp
@@ -16,6 +16,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <mutex>
 
 using namespace std::chrono_literals;
 
@@ -50,7 +51,7 @@ CDVDMsgGeneralSynchronize::~CDVDMsgGeneralSynchronize()
 
 bool CDVDMsgGeneralSynchronize::Wait(std::chrono::milliseconds timeout, unsigned int source)
 {
-  CSingleLock lock(m_p->section);
+  std::unique_lock<CCriticalSection> lock(m_p->section);
 
   XbmcThreads::EndTime<> timer{timeout};
 

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -10,10 +10,10 @@
 
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <math.h>
+#include <mutex>
 
 using namespace std::chrono_literals;
 
@@ -47,7 +47,7 @@ void CDVDMessageQueue::Init()
 
 void CDVDMessageQueue::Flush(CDVDMsg::Message type)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   m_messages.remove_if([type](const DVDMessageListItem &item){
     return type == CDVDMsg::NONE || item.message->IsType(type);
@@ -67,7 +67,7 @@ void CDVDMessageQueue::Flush(CDVDMsg::Message type)
 
 void CDVDMessageQueue::Abort()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   m_bAbortRequest = true;
 
@@ -77,7 +77,7 @@ void CDVDMessageQueue::Abort()
 
 void CDVDMessageQueue::End()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   Flush(CDVDMsg::NONE);
 
@@ -100,7 +100,7 @@ MsgQueueReturnCode CDVDMessageQueue::Put(const std::shared_ptr<CDVDMsg>& pMsg,
                                          int priority,
                                          bool front)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (!m_bInitialized)
   {
@@ -163,7 +163,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
                                          unsigned int iTimeoutInMilliSeconds,
                                          int& priority)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   int ret = 0;
 
@@ -270,7 +270,7 @@ void CDVDMessageQueue::UpdateTimeBack()
 
 unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (!m_bInitialized)
     return 0;
@@ -293,7 +293,7 @@ unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type)
 void CDVDMessageQueue::WaitUntilEmpty()
 {
   {
-    CSingleLock lock(m_section);
+    std::unique_lock<CCriticalSection> lock(m_section);
     m_drain = true;
   }
 
@@ -303,14 +303,14 @@ void CDVDMessageQueue::WaitUntilEmpty()
   msg->Wait(m_bAbortRequest, 0);
 
   {
-    CSingleLock lock(m_section);
+    std::unique_lock<CCriticalSection> lock(m_section);
     m_drain = false;
   }
 }
 
 int CDVDMessageQueue::GetLevel() const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (m_iDataSize > m_iMaxDataSize)
     return 100;
@@ -336,7 +336,7 @@ int CDVDMessageQueue::GetLevel() const
 
 int CDVDMessageQueue::GetTimeSize() const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (IsDataBased())
     return 0;

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -206,13 +206,13 @@ MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
     else
     {
       m_hEvent.Reset();
-      lock.Leave();
+      lock.unlock();
 
       // wait for a new message
       if (!m_hEvent.Wait(std::chrono::milliseconds(iTimeoutInMilliSeconds)))
         return MSGQ_TIMEOUT;
 
-      lock.Enter();
+      lock.lock();
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -9,7 +9,8 @@
 #include "DVDOverlayContainer.h"
 
 #include "DVDInputStreams/DVDInputStreamNavigator.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 CDVDOverlayContainer::CDVDOverlayContainer() = default;
 
@@ -22,7 +23,7 @@ void CDVDOverlayContainer::ProcessAndAddOverlayIfValid(CDVDOverlay* pOverlay)
 {
   pOverlay->Acquire();
 
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   // markup any non ending overlays, to finish
   // when this new one starts, there can be
@@ -58,7 +59,7 @@ VecOverlaysIter CDVDOverlayContainer::Remove(VecOverlaysIter itOverlay)
   CDVDOverlay* pOverlay = *itOverlay;
 
   {
-    CSingleLock lock(*this);
+    std::unique_lock<CCriticalSection> lock(*this);
     itNext = m_overlays.erase(itOverlay);
   }
 
@@ -69,7 +70,7 @@ VecOverlaysIter CDVDOverlayContainer::Remove(VecOverlaysIter itOverlay)
 
 void CDVDOverlayContainer::CleanUp(double pts)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   VecOverlaysIter it = m_overlays.begin();
   while (it != m_overlays.end())
@@ -111,7 +112,7 @@ void CDVDOverlayContainer::CleanUp(double pts)
 
 void CDVDOverlayContainer::Flush()
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   // Flush only the overlays marked as flushable
   m_overlays.erase(
@@ -122,7 +123,7 @@ void CDVDOverlayContainer::Flush()
 
 void CDVDOverlayContainer::Clear()
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   for (auto &overlay : m_overlays)
   {
     overlay->Release();
@@ -139,7 +140,7 @@ bool CDVDOverlayContainer::ContainsOverlayType(DVDOverlayType type)
 {
   bool result = false;
 
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   VecOverlaysIter it = m_overlays.begin();
   while (!result && it != m_overlays.end())
@@ -157,7 +158,7 @@ bool CDVDOverlayContainer::ContainsOverlayType(DVDOverlayType type)
 void CDVDOverlayContainer::UpdateOverlayInfo(
     const std::shared_ptr<CDVDInputStreamNavigator>& pStream, CDVDDemuxSPU* pSpu, int iAction)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   pStream->CheckButtons();
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -18,13 +18,13 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SubtitlesSettings.h"
-#include "threads/SingleLock.h"
 #include "utils/FontUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include <cstring>
+#include <mutex>
 
 using namespace KODI::SUBTITLES;
 using namespace UTILS;
@@ -157,7 +157,7 @@ void CDVDSubtitlesLibass::Configure()
 
 bool CDVDSubtitlesLibass::DecodeHeader(char* data, int size)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library || !data)
     return false;
 
@@ -170,7 +170,7 @@ bool CDVDSubtitlesLibass::DecodeHeader(char* data, int size)
 
 bool CDVDSubtitlesLibass::DecodeDemuxPkt(const char* data, int size, double start, double duration)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_track)
   {
     CLog::Log(LOGERROR, "{} - No SSA header found.", __FUNCTION__);
@@ -185,7 +185,7 @@ bool CDVDSubtitlesLibass::DecodeDemuxPkt(const char* data, int size, double star
 
 bool CDVDSubtitlesLibass::CreateTrack()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library)
   {
     CLog::Log(LOGERROR, "{} - Failed to create ASS track, library not initialized.", __FUNCTION__);
@@ -213,7 +213,7 @@ bool CDVDSubtitlesLibass::CreateTrack()
 
 bool CDVDSubtitlesLibass::CreateStyle()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library)
   {
     CLog::Log(LOGERROR, "{} - Failed to create ASS style, library not initialized.", __FUNCTION__);
@@ -232,7 +232,7 @@ bool CDVDSubtitlesLibass::CreateStyle()
 
 bool CDVDSubtitlesLibass::CreateTrack(char* buf, size_t size)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library)
   {
     CLog::Log(LOGERROR, "{} - No ASS library struct (m_library)", __FUNCTION__);
@@ -255,7 +255,7 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(
     const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
     int* changes)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_renderer || !m_track)
   {
     CLog::Log(LOGERROR, "{} - ASS renderer/ASS track not initialized.", __FUNCTION__);
@@ -533,7 +533,7 @@ void CDVDSubtitlesLibass::ConfigureAssOverride(
 
 ASS_Event* CDVDSubtitlesLibass::GetEvents()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_track)
   {
     CLog::Log(LOGERROR, "{} -  Missing ASS structs (m_track)", __FUNCTION__);
@@ -544,7 +544,7 @@ ASS_Event* CDVDSubtitlesLibass::GetEvents()
 
 int CDVDSubtitlesLibass::GetNrOfEvents() const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_track)
     return 0;
   return m_track->n_events;
@@ -568,7 +568,7 @@ int CDVDSubtitlesLibass::AddEvent(const char* text,
     return ASS_NO_ID;
   }
 
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library || !m_track)
   {
     CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);
@@ -599,7 +599,7 @@ int CDVDSubtitlesLibass::AddEvent(const char* text,
 
 void CDVDSubtitlesLibass::AppendTextToEvent(int eventId, const char* text)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (eventId == ASS_NO_ID || text == NULL || text[0] == '\0')
     return;
   if (!m_track)
@@ -631,7 +631,7 @@ void CDVDSubtitlesLibass::AppendTextToEvent(int eventId, const char* text)
 
 void CDVDSubtitlesLibass::ChangeEventStopTime(int eventId, double stopTime)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (eventId == ASS_NO_ID)
     return;
   if (!m_track)
@@ -655,7 +655,7 @@ void CDVDSubtitlesLibass::ChangeEventStopTime(int eventId, double stopTime)
 
 void CDVDSubtitlesLibass::FlushEvents()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library || !m_track)
   {
     CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);
@@ -667,7 +667,7 @@ void CDVDSubtitlesLibass::FlushEvents()
 
 int CDVDSubtitlesLibass::DeleteEvents(int nEvents, int threshold)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library || !m_track)
   {
     CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -12,14 +12,15 @@
 #include "cores/DataCacheCore.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 CCriticalSection createSection;
 std::map<std::string, CreateProcessControl> CProcessInfo::m_processControls;
 
 void CProcessInfo::RegisterProcessControl(const std::string& id, CreateProcessControl createFunc)
 {
-  CSingleLock lock(createSection);
+  std::unique_lock<CCriticalSection> lock(createSection);
 
   m_processControls.clear();
   m_processControls[id] = createFunc;
@@ -27,7 +28,7 @@ void CProcessInfo::RegisterProcessControl(const std::string& id, CreateProcessCo
 
 CProcessInfo* CProcessInfo::CreateInstance()
 {
-  CSingleLock lock(createSection);
+  std::unique_lock<CCriticalSection> lock(createSection);
 
   CProcessInfo *ret = nullptr;
   for (auto &info : m_processControls)
@@ -60,7 +61,7 @@ void CProcessInfo::SetDataCache(CDataCacheCore *cache)
 //******************************************************************************
 void CProcessInfo::ResetVideoCodecInfo()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoIsHWDecoder = false;
   m_videoDecoderName = "unknown";
@@ -92,7 +93,7 @@ void CProcessInfo::ResetVideoCodecInfo()
 
 void CProcessInfo::SetVideoDecoderName(const std::string &name, bool isHw)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoIsHWDecoder = isHw;
   m_videoDecoderName = name;
@@ -103,21 +104,21 @@ void CProcessInfo::SetVideoDecoderName(const std::string &name, bool isHw)
 
 std::string CProcessInfo::GetVideoDecoderName()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoDecoderName;
 }
 
 bool CProcessInfo::IsVideoHwDecoder()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoIsHWDecoder;
 }
 
 void CProcessInfo::SetVideoDeintMethod(const std::string &method)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoDeintMethod = method;
 
@@ -127,14 +128,14 @@ void CProcessInfo::SetVideoDeintMethod(const std::string &method)
 
 std::string CProcessInfo::GetVideoDeintMethod()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoDeintMethod;
 }
 
 void CProcessInfo::SetVideoPixelFormat(const std::string &pixFormat)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoPixelFormat = pixFormat;
 
@@ -144,14 +145,14 @@ void CProcessInfo::SetVideoPixelFormat(const std::string &pixFormat)
 
 std::string CProcessInfo::GetVideoPixelFormat()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoPixelFormat;
 }
 
 void CProcessInfo::SetVideoStereoMode(const std::string &mode)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoStereoMode = mode;
 
@@ -161,14 +162,14 @@ void CProcessInfo::SetVideoStereoMode(const std::string &mode)
 
 std::string CProcessInfo::GetVideoStereoMode()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoStereoMode;
 }
 
 void CProcessInfo::SetVideoDimensions(int width, int height)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoWidth = width;
   m_videoHeight = height;
@@ -179,7 +180,7 @@ void CProcessInfo::SetVideoDimensions(int width, int height)
 
 void CProcessInfo::GetVideoDimensions(int &width, int &height)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   width = m_videoWidth;
   height = m_videoHeight;
@@ -187,7 +188,7 @@ void CProcessInfo::GetVideoDimensions(int &width, int &height)
 
 void CProcessInfo::SetVideoFps(float fps)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoFPS = fps;
 
@@ -197,14 +198,14 @@ void CProcessInfo::SetVideoFps(float fps)
 
 float CProcessInfo::GetVideoFps()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoFPS;
 }
 
 void CProcessInfo::SetVideoDAR(float dar)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoDAR = dar;
 
@@ -214,14 +215,14 @@ void CProcessInfo::SetVideoDAR(float dar)
 
 float CProcessInfo::GetVideoDAR()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoDAR;
 }
 
 void CProcessInfo::SetVideoInterlaced(bool interlaced)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_videoIsInterlaced = interlaced;
 
@@ -231,7 +232,7 @@ void CProcessInfo::SetVideoInterlaced(bool interlaced)
 
 bool CProcessInfo::GetVideoInterlaced()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_videoIsInterlaced;
 }
@@ -254,7 +255,7 @@ void CProcessInfo::SetSwDeinterlacingMethods()
 
 void CProcessInfo::UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_deintMethods = methods;
 
@@ -270,7 +271,7 @@ void CProcessInfo::UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &metho
 
 bool CProcessInfo::Supports(EINTERLACEMETHOD method)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   auto it = std::find(m_deintMethods.begin(), m_deintMethods.end(), method);
   if (it != m_deintMethods.end())
@@ -281,14 +282,14 @@ bool CProcessInfo::Supports(EINTERLACEMETHOD method)
 
 void CProcessInfo::SetDeinterlacingMethodDefault(EINTERLACEMETHOD method)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_deintMethodDefault = method;
 }
 
 EINTERLACEMETHOD CProcessInfo::GetDeinterlacingMethodDefault()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   return m_deintMethodDefault;
 }
@@ -300,7 +301,7 @@ CVideoBufferManager& CProcessInfo::GetVideoBufferManager()
 
 std::vector<AVPixelFormat> CProcessInfo::GetPixFormats()
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   if (m_pixFormats.empty())
   {
@@ -311,7 +312,7 @@ std::vector<AVPixelFormat> CProcessInfo::GetPixFormats()
 
 void CProcessInfo::SetPixFormats(std::vector<AVPixelFormat> &formats)
 {
-  CSingleLock lock(m_videoCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
 
   m_pixFormats = formats;
 }
@@ -321,7 +322,7 @@ void CProcessInfo::SetPixFormats(std::vector<AVPixelFormat> &formats)
 //******************************************************************************
 void CProcessInfo::ResetAudioCodecInfo()
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   m_audioDecoderName = "unknown";
   m_audioChannels = "unknown";
@@ -339,7 +340,7 @@ void CProcessInfo::ResetAudioCodecInfo()
 
 void CProcessInfo::SetAudioDecoderName(const std::string &name)
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   m_audioDecoderName = name;
 
@@ -349,14 +350,14 @@ void CProcessInfo::SetAudioDecoderName(const std::string &name)
 
 std::string CProcessInfo::GetAudioDecoderName()
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   return m_audioDecoderName;
 }
 
 void CProcessInfo::SetAudioChannels(const std::string &channels)
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   m_audioChannels = channels;
 
@@ -366,14 +367,14 @@ void CProcessInfo::SetAudioChannels(const std::string &channels)
 
 std::string CProcessInfo::GetAudioChannels()
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   return m_audioChannels;
 }
 
 void CProcessInfo::SetAudioSampleRate(int sampleRate)
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   m_audioSampleRate = sampleRate;
 
@@ -383,14 +384,14 @@ void CProcessInfo::SetAudioSampleRate(int sampleRate)
 
 int CProcessInfo::GetAudioSampleRate()
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   return m_audioSampleRate;
 }
 
 void CProcessInfo::SetAudioBitsPerSample(int bitsPerSample)
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   m_audioBitsPerSample = bitsPerSample;
 
@@ -400,7 +401,7 @@ void CProcessInfo::SetAudioBitsPerSample(int bitsPerSample)
 
 int CProcessInfo::GetAudioBitsPerSample()
 {
-  CSingleLock lock(m_audioCodecSection);
+  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
 
   return m_audioBitsPerSample;
 }
@@ -412,7 +413,7 @@ bool CProcessInfo::AllowDTSHDDecode()
 
 void CProcessInfo::SetRenderClockSync(bool enabled)
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
 
   m_isClockSync = enabled;
 
@@ -422,14 +423,14 @@ void CProcessInfo::SetRenderClockSync(bool enabled)
 
 bool CProcessInfo::IsRenderClockSync()
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
 
   return m_isClockSync;
 }
 
 void CProcessInfo::UpdateRenderInfo(CRenderInfo &info)
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
 
   m_renderInfo = info;
 
@@ -442,7 +443,7 @@ void CProcessInfo::UpdateRenderInfo(CRenderInfo &info)
 
 void CProcessInfo::UpdateRenderBuffers(int queued, int discard, int free)
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
   m_renderBufQueued = queued;
   m_renderBufDiscard = discard;
   m_renderBufFree = free;
@@ -450,7 +451,7 @@ void CProcessInfo::UpdateRenderBuffers(int queued, int discard, int free)
 
 void CProcessInfo::GetRenderBuffers(int &queued, int &discard, int &free)
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
   queued = m_renderBufQueued;
   discard = m_renderBufDiscard;
   free = m_renderBufFree;
@@ -468,7 +469,7 @@ std::vector<AVPixelFormat> CProcessInfo::GetRenderFormats()
 //******************************************************************************
 void CProcessInfo::SetStateSeeking(bool active)
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
 
   m_stateSeeking = active;
 
@@ -478,28 +479,28 @@ void CProcessInfo::SetStateSeeking(bool active)
 
 bool CProcessInfo::IsSeeking()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_stateSeeking;
 }
 
 void CProcessInfo::SetStateRealtime(bool state)
 {
-  CSingleLock lock(m_renderSection);
+  std::unique_lock<CCriticalSection> lock(m_renderSection);
 
   m_realTimeStream = state;
 }
 
 bool CProcessInfo::IsRealtimeStream()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_realTimeStream;
 }
 
 void CProcessInfo::SetSpeed(float speed)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_speed = speed;
   m_newSpeed = speed;
@@ -510,7 +511,7 @@ void CProcessInfo::SetSpeed(float speed)
 
 void CProcessInfo::SetNewSpeed(float speed)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_newSpeed = speed;
 
@@ -520,14 +521,14 @@ void CProcessInfo::SetNewSpeed(float speed)
 
 float CProcessInfo::GetNewSpeed()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_newSpeed;
 }
 
 void CProcessInfo::SetFrameAdvance(bool fa)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_frameAdvance = fa;
 
@@ -537,14 +538,14 @@ void CProcessInfo::SetFrameAdvance(bool fa)
 
 bool CProcessInfo::IsFrameAdvance()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_frameAdvance;
 }
 
 void CProcessInfo::SetTempo(float tempo)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_tempo = tempo;
   m_newTempo = tempo;
@@ -555,7 +556,7 @@ void CProcessInfo::SetTempo(float tempo)
 
 void CProcessInfo::SetNewTempo(float tempo)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   m_newTempo = tempo;
 
@@ -565,7 +566,7 @@ void CProcessInfo::SetNewTempo(float tempo)
 
 float CProcessInfo::GetNewTempo()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_newTempo;
 }
@@ -601,7 +602,7 @@ int CProcessInfo::GetLevelVQ()
 
 void CProcessInfo::SetGuiRender(bool gui)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   bool change = (m_renderGuiLayer != gui);
   m_renderGuiLayer = gui;
@@ -614,14 +615,14 @@ void CProcessInfo::SetGuiRender(bool gui)
 
 bool CProcessInfo::GetGuiRender()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_renderGuiLayer;
 }
 
 void CProcessInfo::SetVideoRender(bool video)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   bool change = (m_renderVideoLayer != video);
   m_renderVideoLayer = video;
@@ -634,14 +635,14 @@ void CProcessInfo::SetVideoRender(bool video)
 
 bool CProcessInfo::GetVideoRender()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
 
   return m_renderVideoLayer;
 }
 
 void CProcessInfo::SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max)
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   m_startTime = start;
   m_time = current;
   m_timeMin = min;
@@ -655,7 +656,7 @@ void CProcessInfo::SetPlayTimes(time_t start, int64_t current, int64_t min, int6
 
 int64_t CProcessInfo::GetMaxTime()
 {
-  CSingleLock lock(m_stateSection);
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
   return m_timeMax;
 }
 
@@ -664,18 +665,18 @@ int64_t CProcessInfo::GetMaxTime()
 //******************************************************************************
 CVideoSettings CProcessInfo::GetVideoSettings()
 {
-  CSingleLock lock(m_settingsSection);
+  std::unique_lock<CCriticalSection> lock(m_settingsSection);
   return m_videoSettings;
 }
 
 CVideoSettingsLocked& CProcessInfo::UpdateVideoSettings()
 {
-  CSingleLock lock(m_settingsSection);
+  std::unique_lock<CCriticalSection> lock(m_settingsSection);
   return *m_videoSettingsLocked;
 }
 
 void CProcessInfo::SetVideoSettings(CVideoSettings &settings)
 {
-  CSingleLock lock(m_settingsSection);
+  std::unique_lock<CCriticalSection> lock(m_settingsSection);
   m_videoSettings = settings;
 }

--- a/xbmc/cores/VideoPlayer/Process/X11/ProcessInfoX11.cpp
+++ b/xbmc/cores/VideoPlayer/Process/X11/ProcessInfoX11.cpp
@@ -8,7 +8,8 @@
 
 #include "ProcessInfoX11.h"
 
-#include "threads/SingleLock.h"
+#include <mutex>
+
 
 using namespace VIDEOPLAYER;
 
@@ -30,7 +31,7 @@ void CProcessInfoX11::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    CSingleLock lock(m_videoCodecSection);
+    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob and blend deinterlacer for osx

--- a/xbmc/cores/VideoPlayer/Process/ios/ProcessInfoIos.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ios/ProcessInfoIos.cpp
@@ -8,7 +8,8 @@
 
 #include "ProcessInfoIOS.h"
 
-#include "threads/SingleLock.h"
+#include <mutex>
+
 
 using namespace VIDEOPLAYER;
 
@@ -30,7 +31,7 @@ void CProcessInfoIOS::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    CSingleLock lock(m_videoCodecSection);
+    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob deinterlacer for ios

--- a/xbmc/cores/VideoPlayer/Process/osx/ProcessInfoOSX.cpp
+++ b/xbmc/cores/VideoPlayer/Process/osx/ProcessInfoOSX.cpp
@@ -9,7 +9,8 @@
 #include "ProcessInfoOSX.h"
 
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 using namespace VIDEOPLAYER;
 
@@ -31,7 +32,7 @@ void CProcessInfoOSX::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    CSingleLock lock(m_videoCodecSection);
+    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob and blend deinterlacer for osx

--- a/xbmc/cores/VideoPlayer/Process/wayland/ProcessInfoWayland.cpp
+++ b/xbmc/cores/VideoPlayer/Process/wayland/ProcessInfoWayland.cpp
@@ -9,7 +9,8 @@
 #include "ProcessInfoWayland.h"
 
 #include "cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 using namespace VIDEOPLAYER;
 
@@ -36,7 +37,7 @@ void CProcessInfoWayland::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    CSingleLock lock(m_videoCodecSection);
+    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob and blend deinterlacer

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -16,9 +16,10 @@
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #ifdef TARGET_RASPBERRY_PI
 #include "platform/linux/RBP.h"
@@ -204,7 +205,8 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
   info.pts         = m_audioSink.GetPlayingPts();
   info.passthrough = m_pAudioCodec && m_pAudioCodec->NeedPassthrough();
 
-  { CSingleLock lock(m_info_section);
+  {
+    std::unique_lock<CCriticalSection> lock(m_info_section);
     m_info = info;
   }
 }
@@ -652,7 +654,7 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
 
 std::string CVideoPlayerAudio::GetPlayerInfo()
 {
-  CSingleLock lock(m_info_section);
+  std::unique_lock<CCriticalSection> lock(m_info_section);
   return m_info.info;
 }
 
@@ -663,6 +665,6 @@ int CVideoPlayerAudio::GetAudioChannels()
 
 bool CVideoPlayerAudio::IsPassthrough() const
 {
-  CSingleLock lock(m_info_section);
+  std::unique_lock<CCriticalSection> lock(m_info_section);
   return m_info.passthrough;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -19,6 +19,7 @@
 #include "utils/BitstreamStats.h"
 
 #include <list>
+#include <mutex>
 #include <utility>
 
 
@@ -55,7 +56,11 @@ public:
   std::string GetPlayerInfo() override;
   int GetAudioChannels() override;
 
-  double GetCurrentPts() override { CSingleLock lock(m_info_section); return m_info.pts; }
+  double GetCurrentPts() override
+  {
+    std::unique_lock<CCriticalSection> lock(m_info_section);
+    return m_info.pts;
+  }
 
   bool IsStalled() const override { return m_stalled;  }
   bool IsPassthrough() const override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -43,10 +43,11 @@
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 using namespace XFILE;
 using namespace PVR;
@@ -553,7 +554,7 @@ void CDVDRadioRDSData::CloseStream(bool bWaitForBuffers)
 
 void CDVDRadioRDSData::ResetRDSCache()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_currentFileUpdate = false;
 
@@ -646,7 +647,7 @@ void CDVDRadioRDSData::Process()
 
     if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -15,8 +15,9 @@
 #include "DVDSubtitles/DVDSubtitleParser.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 CVideoPlayerSubtitle::CVideoPlayerSubtitle(CDVDOverlayContainer* pOverlayContainer, CProcessInfo &processInfo)
 : IDVDStreamPlayer(processInfo)
@@ -38,7 +39,7 @@ void CVideoPlayerSubtitle::Flush()
 
 void CVideoPlayerSubtitle::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
   {
@@ -115,7 +116,7 @@ void CVideoPlayerSubtitle::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priori
 
 bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filename)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   CloseStream(true);
   m_streaminfo = hints;
@@ -160,7 +161,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
 
 void CVideoPlayerSubtitle::CloseStream(bool bWaitForBuffers)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   m_pSubtitleFileParser.reset();
   m_pOverlayCodec.reset();
@@ -173,7 +174,7 @@ void CVideoPlayerSubtitle::CloseStream(bool bWaitForBuffers)
 
 void CVideoPlayerSubtitle::Process(double pts, double offset)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (m_pSubtitleFileParser)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
@@ -11,8 +11,9 @@
 #include "DVDStreamInfo.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 const uint8_t rev_lut[32] =
 {
@@ -139,7 +140,7 @@ void CDVDTeletextData::CloseStream(bool bWaitForBuffers)
 
 void CDVDTeletextData::ResetTeletextCache()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   /* Reset Data structures */
   for (auto& pages : m_TXTCache->astCachetable)
@@ -245,7 +246,7 @@ void CDVDTeletextData::Process()
 
     if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
       uint8_t *Datai       = pPacket->pData;
@@ -706,7 +707,7 @@ void CDVDTeletextData::Decode_p2829(unsigned char *vtxt_row, TextExtData_t **ptE
 
 void CDVDTeletextData::SavePage(int p, int sp, unsigned char* buffer)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   TextCachedPage_t* pg = m_TXTCache->astCachetable[p][sp];
   if (!pg)
   {
@@ -719,7 +720,7 @@ void CDVDTeletextData::SavePage(int p, int sp, unsigned char* buffer)
 
 void CDVDTeletextData::LoadPage(int p, int sp, unsigned char* buffer)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   TextCachedPage_t* pg = m_TXTCache->astCachetable[p][sp];
   if (!pg)
   {
@@ -732,7 +733,7 @@ void CDVDTeletextData::LoadPage(int p, int sp, unsigned char* buffer)
 
 void CDVDTeletextData::ErasePage(int magazine)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   TextCachedPage_t* pg = m_TXTCache->astCachetable[m_TXTCache->CurrentPage[magazine]][m_TXTCache->CurrentSubPage[magazine]];
   if (pg)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -23,6 +23,7 @@
 
 #include <iomanip>
 #include <iterator>
+#include <mutex>
 #include <numeric>
 #include <sstream>
 
@@ -798,7 +799,7 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
   VecOverlays overlays;
 
   {
-    CSingleLock lock(*m_pOverlayContainer);
+    std::unique_lock<CCriticalSection> lock(*m_pOverlayContainer);
 
     VecOverlays* pVecOverlays = m_pOverlayContainer->GetOverlays();
     VecOverlaysIter it = pVecOverlays->begin();

--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
@@ -87,7 +87,7 @@ void CVideoReferenceClock::Process()
     {
       m_UseVblank = true;          //tell other threads we're using vblank as clock
       m_VblankTime = Now;          //initialize the timestamp of the last vblank
-      SingleLock.Leave();
+      SingleLock.unlock();
 
       // we might got signalled while we did not wait
       if (!m_vsyncStopEvent.Signaled())
@@ -99,13 +99,13 @@ void CVideoReferenceClock::Process()
     }
     else
     {
-      SingleLock.Leave();
+      SingleLock.unlock();
       CLog::Log(LOGDEBUG, "CVideoReferenceClock: Setup failed, falling back to CurrentHostCounter()");
     }
 
-    SingleLock.Enter();
+    SingleLock.lock();
     m_UseVblank = false;                       //we're back to using the systemclock
-    SingleLock.Leave();
+    SingleLock.unlock();
 
     //clean up the vblank clock
     if (m_pVideoSync)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -19,6 +19,8 @@
 #include "rendering/dx/RenderContext.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 #include <Windows.h>
 #include <d3d11_4.h>
 #include <dxgi1_5.h>
@@ -49,13 +51,13 @@ CProcessorHD::~CProcessorHD()
 
 void CProcessorHD::UnInit()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   Close();
 }
 
 void CProcessorHD::Close()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_pEnumerator = nullptr;
   m_pVideoProcessor = nullptr;
   m_pVideoContext = nullptr;
@@ -256,7 +258,7 @@ bool CProcessorHD::Open(UINT width, UINT height)
 {
   Close();
 
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   m_width = width;
   m_height = height;
@@ -272,7 +274,7 @@ bool CProcessorHD::Open(UINT width, UINT height)
 
 bool CProcessorHD::ReInit()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   Close();
 
   if (!InitProcessor())
@@ -286,7 +288,7 @@ bool CProcessorHD::ReInit()
 
 bool CProcessorHD::OpenProcessor()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   // restore the device if it was lost
   if (!m_pEnumerator && !ReInit())
@@ -451,7 +453,7 @@ DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceTarget(CRenderBuffer* view,
 
 bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer** views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   // restore processor if it was lost
   if (!m_pVideoProcessor && !OpenProcessor())

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -13,6 +13,8 @@
 #include "guilib/D3DResource.h"
 #include "utils/Geometry.h"
 
+#include <mutex>
+
 #include <wrl/client.h>
 
 class CRenderBuffer;
@@ -46,7 +48,11 @@ public:
 
   // ID3DResource overrides
   void OnCreateDevice() override  {}
-  void OnDestroyDevice(bool) override { CSingleLock lock(m_section); UnInit(); }
+  void OnDestroyDevice(bool) override
+  {
+    std::unique_lock<CCriticalSection> lock(m_section);
+    UnInit();
+  }
 
   static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(CRenderBuffer* view, bool supportHDR, bool supportHLG);
   static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(CRenderBuffer* view, bool supportHDR);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -31,13 +31,13 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/GLUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
 #include <locale.h>
+#include <mutex>
 
 #ifdef TARGET_DARWIN_OSX
 #include "platform/darwin/osx/CocoaInterface.h"
@@ -970,7 +970,7 @@ void CLinuxRendererGL::LoadShaders(int field)
 void CLinuxRendererGL::UnInit()
 {
   CLog::Log(LOGDEBUG, "LinuxRendererGL: Cleaning up GL resources");
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   glFinish();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -24,11 +24,12 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/GLUtils.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
+
+#include <mutex>
 
 using namespace Shaders;
 using namespace Shaders::GLES;
@@ -703,7 +704,7 @@ void CLinuxRendererGLES::ReleaseShaders()
 void CLinuxRendererGLES::UnInit()
 {
   CLog::Log(LOGDEBUG, "LinuxRendererGLES: Cleaning up GLES resources");
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   glFinish();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -24,9 +24,10 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SubtitlesSettings.h"
-#include "threads/SingleLock.h"
 #include "utils/ColorUtils.h"
 #include "windowing/GraphicContext.h"
+
+#include <mutex>
 #if defined(HAS_GL) || defined(HAS_GLES)
 #include "OverlayRendererGL.h"
 #elif defined(HAS_DX)
@@ -63,7 +64,7 @@ CRenderer::~CRenderer()
 
 void CRenderer::AddOverlay(CDVDOverlay* o, double pts, int index)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   SElement   e;
   e.pts = pts;
@@ -85,7 +86,7 @@ void CRenderer::Release(std::vector<SElement>& list)
 
 void CRenderer::Flush()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   for(std::vector<SElement>& buffer : m_buffers)
     Release(buffer);
@@ -95,7 +96,7 @@ void CRenderer::Flush()
 
 void CRenderer::Release(int idx)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   Release(m_buffers[idx]);
 }
 
@@ -139,7 +140,7 @@ void CRenderer::ReleaseUnused()
 
 void CRenderer::Render(int idx)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   std::vector<SElement>& list = m_buffers[idx];
   for(std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
@@ -232,7 +233,7 @@ bool CRenderer::HasOverlay(int idx)
 {
   bool hasOverlay = false;
 
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   std::vector<SElement>& list = m_buffers[idx];
   for(std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderFactory.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderFactory.cpp
@@ -8,7 +8,8 @@
 
 #include "RenderFactory.h"
 
-#include "threads/SingleLock.h"
+#include <mutex>
+
 
 using namespace VIDEOPLAYER;
 
@@ -17,7 +18,7 @@ std::map<std::string, VIDEOPLAYER::CreateRenderer> CRendererFactory::m_renderers
 
 CBaseRenderer* CRendererFactory::CreateRenderer(const std::string& id, CVideoBuffer* buffer)
 {
-  CSingleLock lock(renderSection);
+  std::unique_lock<CCriticalSection> lock(renderSection);
 
   auto it = m_renderers.find(id);
   if (it != m_renderers.end())
@@ -30,7 +31,7 @@ CBaseRenderer* CRendererFactory::CreateRenderer(const std::string& id, CVideoBuf
 
 std::vector<std::string> CRendererFactory::GetRenderers()
 {
-  CSingleLock lock(renderSection);
+  std::unique_lock<CCriticalSection> lock(renderSection);
 
   std::vector<std::string> ret;
   ret.reserve(m_renderers.size());
@@ -43,14 +44,14 @@ std::vector<std::string> CRendererFactory::GetRenderers()
 
 void CRendererFactory::RegisterRenderer(const std::string& id, ::CreateRenderer createFunc)
 {
-  CSingleLock lock(renderSection);
+  std::unique_lock<CCriticalSection> lock(renderSection);
 
   m_renderers[id] = createFunc;
 }
 
 void CRendererFactory::ClearRenderer()
 {
-  CSingleLock lock(renderSection);
+  std::unique_lock<CCriticalSection> lock(renderSection);
 
   m_renderers.clear();
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -27,6 +27,8 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
+#include <mutex>
+
 /* to use the same as player */
 #include "../VideoPlayer/DVDClock.h"
 #include "../VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
@@ -57,14 +59,14 @@ CRenderManager::~CRenderManager()
 
 void CRenderManager::GetVideoRect(CRect &source, CRect &dest, CRect &view)
 {
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_pRenderer)
     m_pRenderer->GetVideoRect(source, dest, view);
 }
 
 float CRenderManager::GetAspectRatio()
 {
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_pRenderer)
     return m_pRenderer->GetAspectRatio();
   else
@@ -73,7 +75,7 @@ float CRenderManager::GetAspectRatio()
 
 void CRenderManager::SetVideoSettings(CVideoSettings settings)
 {
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_pRenderer)
   {
     m_pRenderer->SetVideoSettings(settings);
@@ -85,7 +87,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
 
   // check if something has changed
   {
-    CSingleLock lock(m_statelock);
+    std::unique_lock<CCriticalSection> lock(m_statelock);
 
     if (!m_bRenderGUI)
       return true;
@@ -112,7 +114,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
 
   // make sure any queued frame was fully presented
   {
-    CSingleLock lock(m_presentlock);
+    std::unique_lock<CCriticalSection> lock(m_presentlock);
     XbmcThreads::EndTime<> endtime(5000ms);
     m_forceNext = true;
     while (m_presentstep != PRESENT_IDLE)
@@ -129,7 +131,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
   }
 
   {
-    CSingleLock lock(m_statelock);
+    std::unique_lock<CCriticalSection> lock(m_statelock);
     m_width = picture.iWidth;
     m_height = picture.iHeight,
     m_dwidth = picture.iDisplayWidth;
@@ -145,7 +147,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
     m_pConfigPicture.reset(new VideoPicture());
     m_pConfigPicture->CopyRef(picture);
 
-    CSingleLock lock2(m_presentlock);
+    std::unique_lock<CCriticalSection> lock2(m_presentlock);
     m_presentstep = PRESENT_READY;
     m_presentevent.notifyAll();
   }
@@ -153,11 +155,11 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
   if (!m_stateEvent.Wait(1000ms))
   {
     CLog::Log(LOGWARNING, "CRenderManager::Configure - timeout waiting for configure");
-    CSingleLock lock(m_statelock);
+    std::unique_lock<CCriticalSection> lock(m_statelock);
     return false;
   }
 
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_renderState != STATE_CONFIGURED)
   {
     CLog::Log(LOGWARNING, "CRenderManager::Configure - failed to configure");
@@ -170,9 +172,9 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
 bool CRenderManager::Configure()
 {
   // lock all interfaces
-  CSingleLock lock(m_statelock);
-  CSingleLock lock2(m_presentlock);
-  CSingleLock lock3(m_datalock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock2(m_presentlock);
+  std::unique_lock<CCriticalSection> lock3(m_datalock);
 
   if (m_pRenderer)
   {
@@ -246,7 +248,7 @@ bool CRenderManager::Configure()
 
 bool CRenderManager::IsConfigured() const
 {
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_renderState == STATE_CONFIGURED)
     return true;
   else
@@ -263,7 +265,7 @@ void CRenderManager::ShowVideo(bool enable)
 void CRenderManager::FrameWait(std::chrono::milliseconds duration)
 {
   XbmcThreads::EndTime<> timeout{duration};
-  CSingleLock lock(m_presentlock);
+  std::unique_lock<CCriticalSection> lock(m_presentlock);
   while(m_presentstep == PRESENT_IDLE && !timeout.IsTimePast())
     m_presentevent.wait(lock, timeout.GetTimeLeft());
 }
@@ -273,7 +275,7 @@ bool CRenderManager::IsPresenting()
   if (!IsConfigured())
     return false;
 
-  CSingleLock lock(m_presentlock);
+  std::unique_lock<CCriticalSection> lock(m_presentlock);
   if (!m_presentTimer.IsTimePast())
     return true;
   else
@@ -286,7 +288,7 @@ void CRenderManager::FrameMove()
   UpdateResolution();
 
   {
-    CSingleLock lock(m_statelock);
+    std::unique_lock<CCriticalSection> lock(m_statelock);
 
     if (m_renderState == STATE_UNCONFIGURED)
       return;
@@ -303,7 +305,7 @@ void CRenderManager::FrameMove()
     CheckEnableClockSync();
   }
   {
-    CSingleLock lock2(m_presentlock);
+    std::unique_lock<CCriticalSection> lock2(m_presentlock);
 
     if (m_queued.empty())
     {
@@ -350,7 +352,7 @@ void CRenderManager::FrameMove()
 void CRenderManager::PreInit()
 {
   {
-    CSingleLock lock(m_statelock);
+    std::unique_lock<CCriticalSection> lock(m_statelock);
     if (m_renderState != STATE_UNCONFIGURED)
       return;
   }
@@ -365,7 +367,7 @@ void CRenderManager::PreInit()
     }
   }
 
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
 
   if (!m_pRenderer)
   {
@@ -394,7 +396,7 @@ void CRenderManager::UnInit()
     }
   }
 
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
 
   m_overlays.Flush();
   m_debugRenderer.Dispose();
@@ -424,9 +426,9 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
     CSingleExit exitlock(CServiceBroker::GetWinSystem()->GetGfxContext());
 #endif
 
-    CSingleLock lock(m_statelock);
-    CSingleLock lock2(m_presentlock);
-    CSingleLock lock3(m_datalock);
+    std::unique_lock<CCriticalSection> lock(m_statelock);
+    std::unique_lock<CCriticalSection> lock2(m_presentlock);
+    std::unique_lock<CCriticalSection> lock3(m_datalock);
 
     if (m_pRenderer)
     {
@@ -518,7 +520,7 @@ unsigned int CRenderManager::AllocRenderCapture()
 
 void CRenderManager::ReleaseRenderCapture(unsigned int captureId)
 {
-  CSingleLock lock(m_captCritSect);
+  std::unique_lock<CCriticalSection> lock(m_captCritSect);
 
   std::map<unsigned int, CRenderCapture*>::iterator it;
   it = m_captures.find(captureId);
@@ -529,7 +531,7 @@ void CRenderManager::ReleaseRenderCapture(unsigned int captureId)
 
 void CRenderManager::StartRenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags)
 {
-  CSingleLock lock(m_captCritSect);
+  std::unique_lock<CCriticalSection> lock(m_captCritSect);
 
   std::map<unsigned int, CRenderCapture*>::iterator it;
   it = m_captures.find(captureId);
@@ -565,7 +567,7 @@ void CRenderManager::StartRenderCapture(unsigned int captureId, unsigned int wid
 
 bool CRenderManager::RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size)
 {
-  CSingleLock lock(m_captCritSect);
+  std::unique_lock<CCriticalSection> lock(m_captCritSect);
 
   std::map<unsigned int, CRenderCapture*>::iterator it;
   it = m_captures.find(captureId);
@@ -604,7 +606,7 @@ void CRenderManager::ManageCaptures()
   if (!m_hasCaptures)
     return;
 
-  CSingleLock lock(m_captCritSect);
+  std::unique_lock<CCriticalSection> lock(m_captCritSect);
 
   std::map<unsigned int, CRenderCapture*>::iterator it = m_captures.begin();
   while (it != m_captures.end())
@@ -657,7 +659,7 @@ void CRenderManager::RenderCapture(CRenderCapture* capture)
 
 void CRenderManager::RemoveCaptures()
 {
-  CSingleLock lock(m_captCritSect);
+  std::unique_lock<CCriticalSection> lock(m_captCritSect);
 
   while (m_captureWaitCounter > 0)
   {
@@ -678,7 +680,7 @@ void CRenderManager::RemoveCaptures()
 
 void CRenderManager::SetViewMode(int iViewMode)
 {
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_pRenderer)
     m_pRenderer->SetViewMode(iViewMode);
   m_playerPort->VideoParamsChange();
@@ -688,7 +690,7 @@ RESOLUTION CRenderManager::GetResolution()
 {
   RESOLUTION res = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
 
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_renderState == STATE_UNCONFIGURED)
     return res;
 
@@ -703,7 +705,7 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
   CSingleExit exitLock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   {
-    CSingleLock lock(m_statelock);
+    std::unique_lock<CCriticalSection> lock(m_statelock);
     if (m_renderState != STATE_CONFIGURED)
       return;
   }
@@ -773,7 +775,8 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
 
   SPresent& m = m_Queue[m_presentsource];
 
-  { CSingleLock lock(m_presentlock);
+  {
+    std::unique_lock<CCriticalSection> lock(m_presentlock);
 
     if (m_presentstep == PRESENT_FRAME)
     {
@@ -797,7 +800,8 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
 
 bool CRenderManager::IsGuiLayer()
 {
-  { CSingleLock lock(m_statelock);
+  {
+    std::unique_lock<CCriticalSection> lock(m_statelock);
 
     if (!m_pRenderer)
       return false;
@@ -814,7 +818,8 @@ bool CRenderManager::IsGuiLayer()
 
 bool CRenderManager::IsVideoLayer()
 {
-  { CSingleLock lock(m_statelock);
+  {
+    std::unique_lock<CCriticalSection> lock(m_statelock);
 
     if (!m_pRenderer)
       return false;
@@ -946,7 +951,7 @@ void CRenderManager::ToggleDebugVideo()
 
 bool CRenderManager::AddVideoPicture(const VideoPicture& picture, volatile std::atomic_bool& bStop, EINTERLACEMETHOD deintMethod, bool wait)
 {
-  CSingleLock lock(m_presentlock);
+  std::unique_lock<CCriticalSection> lock(m_presentlock);
 
   if (m_free.empty())
     return false;
@@ -954,7 +959,7 @@ bool CRenderManager::AddVideoPicture(const VideoPicture& picture, volatile std::
   int index = m_free.front();
 
   {
-    CSingleLock lock(m_datalock);
+    std::unique_lock<CCriticalSection> lock(m_datalock);
     if (!m_pRenderer)
       return false;
 
@@ -1042,18 +1047,19 @@ bool CRenderManager::AddVideoPicture(const VideoPicture& picture, volatile std::
 void CRenderManager::AddOverlay(CDVDOverlay* o, double pts)
 {
   int idx;
-  { CSingleLock lock(m_presentlock);
+  {
+    std::unique_lock<CCriticalSection> lock(m_presentlock);
     if (m_free.empty())
       return;
     idx = m_free.front();
   }
-  CSingleLock lock(m_datalock);
+  std::unique_lock<CCriticalSection> lock(m_datalock);
   m_overlays.AddOverlay(o, pts, idx);
 }
 
 bool CRenderManager::Supports(ERENDERFEATURE feature)
 {
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_pRenderer)
     return m_pRenderer->Supports(feature);
   else
@@ -1062,7 +1068,7 @@ bool CRenderManager::Supports(ERENDERFEATURE feature)
 
 bool CRenderManager::Supports(ESCALINGMETHOD method)
 {
-  CSingleLock lock(m_statelock);
+  std::unique_lock<CCriticalSection> lock(m_statelock);
   if (m_pRenderer)
     return m_pRenderer->Supports(method);
   else
@@ -1072,7 +1078,7 @@ bool CRenderManager::Supports(ESCALINGMETHOD method)
 int CRenderManager::WaitForBuffer(volatile std::atomic_bool& bStop,
                                   std::chrono::milliseconds timeout)
 {
-  CSingleLock lock(m_presentlock);
+  std::unique_lock<CCriticalSection> lock(m_presentlock);
 
   // check if gui is active and discard buffer if not
   // this keeps videoplayer going
@@ -1241,7 +1247,7 @@ void CRenderManager::PrepareNextRender()
 
 void CRenderManager::DiscardBuffer()
 {
-  CSingleLock lock2(m_presentlock);
+  std::unique_lock<CCriticalSection> lock2(m_presentlock);
 
   while(!m_queued.empty())
   {
@@ -1256,7 +1262,7 @@ void CRenderManager::DiscardBuffer()
 
 bool CRenderManager::GetStats(int &lateframes, double &pts, int &queued, int &discard)
 {
-  CSingleLock lock(m_presentlock);
+  std::unique_lock<CCriticalSection> lock(m_presentlock);
   lateframes = m_lateframes / 10;
   pts = m_presentpts;
   queued = m_queued.size();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -292,7 +292,7 @@ void CRenderManager::FrameMove()
       return;
     else if (m_renderState == STATE_CONFIGURING)
     {
-      lock.Leave();
+      lock.unlock();
       if (!Configure())
         return;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -22,6 +22,8 @@
 #include "windows/RendererShaders.h"
 #include "windows/RendererSoftware.h"
 
+#include <mutex>
+
 struct render_details
 {
   using map = std::map<RenderMethod, int>;
@@ -247,14 +249,14 @@ void CWinRenderer::SetBufferSize(int numBuffers)
 
 void CWinRenderer::PreInit()
 {
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_bConfigured = false;
   UnInit();
 }
 
 void CWinRenderer::UnInit()
 {
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_renderer.reset();
   m_bConfigured = false;

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -9,7 +9,8 @@
 #include "VideoSettings.h"
 
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 CVideoSettings::CVideoSettings()
 {
@@ -84,43 +85,43 @@ CVideoSettingsLocked::CVideoSettingsLocked(CVideoSettings &vs, CCriticalSection 
 
 void CVideoSettingsLocked::SetSubtitleStream(int stream)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_SubtitleStream = stream;
 }
 
 void CVideoSettingsLocked::SetSubtitleVisible(bool visible)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_SubtitleOn = visible;
 }
 
 void CVideoSettingsLocked::SetAudioStream(int stream)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_AudioStream = stream;
 }
 
 void CVideoSettingsLocked::SetVideoStream(int stream)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_VideoStream = stream;
 }
 
 void CVideoSettingsLocked::SetAudioDelay(float delay)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_AudioDelay = delay;
 }
 
 void CVideoSettingsLocked::SetSubtitleDelay(float delay)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_SubtitleDelay = delay;
 }
 
 void CVideoSettingsLocked::SetViewMode(int mode, float zoom, float par, float shift, bool stretch)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_ViewMode = mode;
   m_videoSettings.m_CustomZoomAmount = zoom;
   m_videoSettings.m_CustomPixelRatio = par;
@@ -130,6 +131,6 @@ void CVideoSettingsLocked::SetViewMode(int mode, float zoom, float par, float sh
 
 void CVideoSettingsLocked::SetVolumeAmplification(float amp)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_VolumeAmplification = amp;
 }

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -15,10 +15,10 @@
 #include "music/tags/MusicInfoTag.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <math.h>
+#include <mutex>
 
 CAudioDecoder::CAudioDecoder()
 {
@@ -45,7 +45,7 @@ CAudioDecoder::~CAudioDecoder()
 
 void CAudioDecoder::Destroy()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_status = STATUS_NO_FILE;
 
   m_pcmBuffer.Destroy();
@@ -61,7 +61,7 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
 {
   Destroy();
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // reset our playback timing variables
   m_eof = false;
@@ -244,7 +244,7 @@ int CAudioDecoder::ReadSamples(int numsamples)
     m_status = STATUS_PLAYING;
 
   // grab a lock to ensure the codec is created at this point.
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_codec->m_format.m_dataFormat != AE_FMT_RAW)
   {

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -79,9 +79,9 @@ void PAPlayer::SoftStart(bool wait/* = false */)
   if (wait)
   {
     /* wait for them to fade in */
-    lock.Leave();
+    lock.unlock();
     CThread::Sleep(std::chrono::milliseconds(FAST_XFADE_TIME));
-    lock.Enter();
+    lock.lock();
 
     /* be sure they have faded in */
     while(wait)
@@ -92,10 +92,10 @@ void PAPlayer::SoftStart(bool wait/* = false */)
         StreamInfo* si = *itt;
         if (si->m_stream->IsFading())
         {
-          lock.Leave();
+          lock.unlock();
           wait = true;
           CThread::Sleep(1ms);
-          lock.Enter();
+          lock.lock();
           break;
         }
       }
@@ -128,9 +128,9 @@ void PAPlayer::SoftStop(bool wait/* = false */, bool close/* = true */)
     XbmcThreads::EndTime<> timer(1000ms);
 
     /* wait for them to fade out */
-    lock.Leave();
+    lock.unlock();
     CThread::Sleep(std::chrono::milliseconds(FAST_XFADE_TIME));
-    lock.Enter();
+    lock.lock();
 
     /* be sure they have faded out */
     while(wait && !CServiceBroker::GetActiveAE()->IsSuspended() && !timer.IsTimePast())
@@ -141,10 +141,10 @@ void PAPlayer::SoftStop(bool wait/* = false */, bool close/* = true */)
         StreamInfo* si = *itt;
         if (si->m_stream && si->m_stream->IsFading())
         {
-          lock.Leave();
+          lock.unlock();
           wait = true;
           CThread::Sleep(1ms);
-          lock.Enter();
+          lock.lock();
           break;
         }
       }
@@ -239,7 +239,7 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     si->m_playNextAtFrame  = si->m_framesSent; //start next track at current frame
     si->m_prepareTriggered = true; //next track is ready to go
   }
-  lock.Leave();
+  lock.unlock();
 
   if (!IsRunning())
     Create();
@@ -517,9 +517,9 @@ bool PAPlayer::CloseFile(bool reopen)
     CSingleLock lock(m_streamsLock);
     while (m_jobCounter > 0)
     {
-      lock.Leave();
+      lock.unlock();
       m_jobEvent.Wait(100ms);
-      lock.Enter();
+      lock.lock();
     }
   }
 
@@ -599,7 +599,7 @@ inline void PAPlayer::ProcessStreams(double &freeBufferTime)
       ++itt;
   }
 
-  sharedLock.Leave();
+  sharedLock.unlock();
   CSingleLock lock(m_streamsLock);
 
   for(StreamList::iterator itt = m_streams.begin(); itt != m_streams.end(); ++itt)

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -22,10 +22,10 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 
+#include <mutex>
 #include <sstream>
 
 #define PLAYERCOREFACTORY_XML "playercorefactory.xml"
@@ -55,7 +55,7 @@ void CPlayerCoreFactory::OnSettingsLoaded()
 std::shared_ptr<IPlayer> CPlayerCoreFactory::CreatePlayer(const std::string& nameId,
                                                           IPlayerCallback& callback) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   size_t idx = GetPlayerIndex(nameId);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -66,7 +66,7 @@ std::shared_ptr<IPlayer> CPlayerCoreFactory::CreatePlayer(const std::string& nam
 
 void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   players.clear();
   for (auto& conf : m_vecPlayerConfigs)
   {
@@ -77,7 +77,7 @@ void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players) const
 
 void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players, const bool audio, const bool video) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: for video={}, audio={}", video, audio);
 
   for (auto& conf : m_vecPlayerConfigs)
@@ -183,7 +183,7 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
 
 int CPlayerCoreFactory::GetPlayerIndex(const std::string& strCoreName) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (!strCoreName.empty())
   {
     // Dereference "*default*player" aliases
@@ -208,7 +208,7 @@ int CPlayerCoreFactory::GetPlayerIndex(const std::string& strCoreName) const
 
 std::string CPlayerCoreFactory::GetPlayerName(size_t idx) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
     return "";
 
@@ -217,7 +217,7 @@ std::string CPlayerCoreFactory::GetPlayerName(size_t idx) const
 
 void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players, std::string &type) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   for (auto& config : m_vecPlayerConfigs)
   {
     if (config->m_type != type)
@@ -228,7 +228,7 @@ void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players, std::strin
 
 void CPlayerCoreFactory::GetRemotePlayers(std::vector<std::string>&players) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   for (auto& config : m_vecPlayerConfigs)
   {
     if (config->m_type != "remote")
@@ -239,7 +239,7 @@ void CPlayerCoreFactory::GetRemotePlayers(std::vector<std::string>&players) cons
 
 std::string CPlayerCoreFactory::GetPlayerType(const std::string& player) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   size_t idx = GetPlayerIndex(player);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -250,7 +250,7 @@ std::string CPlayerCoreFactory::GetPlayerType(const std::string& player) const
 
 bool CPlayerCoreFactory::PlaysAudio(const std::string& player) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   size_t idx = GetPlayerIndex(player);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -261,7 +261,7 @@ bool CPlayerCoreFactory::PlaysAudio(const std::string& player) const
 
 bool CPlayerCoreFactory::PlaysVideo(const std::string& player) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   size_t idx = GetPlayerIndex(player);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -314,7 +314,7 @@ std::string CPlayerCoreFactory::SelectPlayerDialog(float posX, float posY) const
 
 bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   CLog::Log(LOGINFO, "Loading player core factory settings from {}.", file);
   if (!XFILE::CFile::Exists(file))
@@ -438,7 +438,7 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
 
 void CPlayerCoreFactory::OnPlayerDiscovered(const std::string& id, const std::string& name)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   for (auto& playerConfig : m_vecPlayerConfigs)
   {
     if (playerConfig->GetId() == id)
@@ -467,7 +467,7 @@ void CPlayerCoreFactory::OnPlayerDiscovered(const std::string& id, const std::st
 
 void CPlayerCoreFactory::OnPlayerRemoved(const std::string& id)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   for (auto& playerConfig : m_vecPlayerConfigs)
   {
     if (playerConfig->GetId() == id)

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -14,10 +14,11 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
-#include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 
 using namespace KODI::MESSAGING;
@@ -131,7 +132,7 @@ void CGUIDialogCache::Process()
 
       try
       {
-        CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+        std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
         m_pDlg->Progress();
         if( bSentCancel )
         {

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -10,10 +10,10 @@
 
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIProgressControl.h"
-#include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 
 #include <cmath>
+#include <mutex>
 
 #define CONTROL_LABELHEADER       30
 #define CONTROL_LABELTITLE        31
@@ -23,20 +23,20 @@
 
 std::string CGUIDialogProgressBarHandle::Text(void) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::string retVal(m_strText);
   return retVal;
 }
 
 void CGUIDialogProgressBarHandle::SetText(const std::string &strText)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strText = strText;
 }
 
 void CGUIDialogProgressBarHandle::SetTitle(const std::string &strTitle)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strTitle = strTitle;
 }
 
@@ -59,7 +59,7 @@ CGUIDialogProgressBarHandle *CGUIDialogExtendedProgressBar::GetHandle(const std:
 {
   CGUIDialogProgressBarHandle *handle = new CGUIDialogProgressBarHandle(strTitle);
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_handles.push_back(handle);
   }
 
@@ -102,7 +102,7 @@ void CGUIDialogExtendedProgressBar::UpdateState(unsigned int currentTime)
   float  fProgress(-1.0f);
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     // delete finished items
     for (int iPtr = m_handles.size() - 1; iPtr >= 0; iPtr--)

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -12,8 +12,9 @@
 #include "guilib/GUIFadeLabelControl.h"
 #include "guilib/GUIMessage.h"
 #include "peripherals/Peripherals.h"
-#include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
+
+#include <mutex>
 
 #define POPUP_ICON                400
 #define POPUP_CAPTION_TEXT        401
@@ -70,7 +71,7 @@ void CGUIDialogKaiToast::QueueNotification(const std::string& aImageFile, const 
 
 void CGUIDialogKaiToast::AddToQueue(const std::string& aImageFile, const eMessageType eType, const std::string& aCaption, const std::string& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   if (!m_notifications.empty())
   {
@@ -94,7 +95,7 @@ void CGUIDialogKaiToast::AddToQueue(const std::string& aImageFile, const eMessag
 
 bool CGUIDialogKaiToast::DoWork()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   if (!m_notifications.empty() &&
       CTimeUtils::GetFrameTime() - m_timer > m_toastMessageTime)
@@ -113,7 +114,7 @@ bool CGUIDialogKaiToast::DoWork()
     m_toastDisplayTime = toast.displayTime;
     m_toastMessageTime = toast.messageTime;
 
-    CSingleLock lock2(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock<CCriticalSection> lock2(CServiceBroker::GetWinSystem()->GetGfxContext());
 
     if(!Initialize())
       return false;
@@ -173,7 +174,7 @@ void CGUIDialogKaiToast::FrameMove()
         dynamic_cast<const CGUIFadeLabelControl*>(GetControl(POPUP_NOTIFICATION_BUTTON));
     if (notificationText)
     {
-      CSingleLock lock(m_critical);
+      std::unique_lock<CCriticalSection> lock(m_critical);
       bClose = notificationText->AllLabelsShown() && m_notifications.empty();
     }
 

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -108,7 +108,7 @@ bool CGUIDialogKaiToast::DoWork()
 
     Notification toast = m_notifications.front();
     m_notifications.pop();
-    lock.Leave();
+    lock.unlock();
 
     m_toastDisplayTime = toast.displayTime;
     m_toastMessageTime = toast.messageTime;

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -31,6 +31,8 @@
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
+#include <mutex>
+
 #ifdef TARGET_ANDROID
 #include <androidjni/Intent.h>
 #include <androidjni/RecognizerIntent.h>
@@ -696,7 +698,7 @@ void CGUIDialogKeyboardGeneric::ChangeWordList(int direct)
 
 void CGUIDialogKeyboardGeneric::ShowWordList(int direct)
 {
-  CSingleLock lock(m_CS);
+  std::unique_lock<CCriticalSection> lock(m_CS);
   std::wstring hzlist = L"";
   CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(m_coordsRes, true);
   float width = m_listfont->GetCharWidth(L'<') + m_listfont->GetCharWidth(L'>');

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -13,9 +13,10 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
-#include "threads/SingleLock.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 using namespace std::chrono_literals;
 
@@ -29,7 +30,7 @@ CGUIDialogProgress::~CGUIDialogProgress(void) = default;
 
 void CGUIDialogProgress::Reset()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_iCurrent = 0;
   m_iMax = 0;
   m_percentage = 0;
@@ -43,7 +44,7 @@ void CGUIDialogProgress::Reset()
 
 void CGUIDialogProgress::SetCanCancel(bool bCanCancel)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_bCanCancel = bCanCancel;
   SetInvalid();
 }
@@ -68,7 +69,7 @@ void CGUIDialogProgress::Open(const std::string &param /* = "" */)
   CLog::Log(LOGDEBUG, "DialogProgress::Open called {}", m_active ? "(already running)!" : "");
 
   {
-    CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
     ShowProgressBar(true);
   }
 
@@ -190,7 +191,7 @@ bool CGUIDialogProgress::Abort()
 
 void CGUIDialogProgress::ShowProgressBar(bool bOnOff)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_showProgress = bOnOff;
   SetInvalid();
 }
@@ -224,7 +225,7 @@ void CGUIDialogProgress::UpdateControls()
   bool bShowCancel;
   std::array<bool, DIALOG_MAX_CHOICES> choices;
   {
-    CSingleLock lock(m_section);
+    std::unique_lock<CCriticalSection> lock(m_section);
     bShowProgress = m_showProgress;
     bShowCancel = m_bCanCancel;
     choices = m_supportedChoices;

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -11,7 +11,8 @@
 #include "Application.h"
 #include "IGUIVolumeBarCallback.h"
 #include "input/Key.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 #define VOLUME_BAR_DISPLAY_TIME 1000L
 
@@ -54,21 +55,21 @@ bool CGUIDialogVolumeBar::OnMessage(CGUIMessage& message)
 
 void CGUIDialogVolumeBar::RegisterCallback(IGUIVolumeBarCallback *callback)
 {
-  CSingleLock lock(m_callbackMutex);
+  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
 
   m_callbacks.insert(callback);
 }
 
 void CGUIDialogVolumeBar::UnregisterCallback(IGUIVolumeBarCallback *callback)
 {
-  CSingleLock lock(m_callbackMutex);
+  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
 
   m_callbacks.erase(callback);
 }
 
 bool CGUIDialogVolumeBar::IsVolumeBarEnabled() const
 {
-  CSingleLock lock(m_callbackMutex);
+  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
 
   // Hide volume bar if any callbacks are shown
   for (const auto &callback : m_callbacks)

--- a/xbmc/events/EventLog.cpp
+++ b/xbmc/events/EventLog.cpp
@@ -19,8 +19,8 @@
 #include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 
+#include <mutex>
 #include <utility>
 
 std::string CEventLog::EventLevelToString(EventLevel level)
@@ -65,7 +65,7 @@ Events CEventLog::Get(EventLevel level, bool includeHigherLevels /* = false */) 
 {
   Events events;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   for (const auto& eventPtr : m_events)
   {
     if (eventPtr->GetLevel() == level ||
@@ -81,7 +81,7 @@ EventPtr CEventLog::Get(const std::string& eventPtrIdentifier) const
   if (eventPtrIdentifier.empty())
     return EventPtr();
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   const auto& eventPtr = m_eventsMap.find(eventPtrIdentifier);
   if (eventPtr == m_eventsMap.end())
     return EventPtr();
@@ -96,7 +96,7 @@ void CEventLog::Add(const EventPtr& eventPtr)
      (eventPtr->GetLevel() == EventLevel::Information && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_EVENTLOG_ENABLED_NOTIFICATIONS)))
     return;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (m_eventsMap.find(eventPtr->GetIdentifier()) != m_eventsMap.end())
     return;
 
@@ -158,7 +158,7 @@ void CEventLog::Remove(const std::string& eventPtrIdentifier)
   if (eventPtrIdentifier.empty())
     return;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   const auto& itEvent = m_eventsMap.find(eventPtrIdentifier);
   if (itEvent == m_eventsMap.end())
     return;
@@ -172,7 +172,7 @@ void CEventLog::Remove(const std::string& eventPtrIdentifier)
 
 void CEventLog::Clear()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_events.clear();
   m_eventsMap.clear();
 }
@@ -194,7 +194,7 @@ bool CEventLog::Execute(const std::string& eventPtrIdentifier)
   if (eventPtrIdentifier.empty())
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   const auto& itEvent = m_eventsMap.find(eventPtrIdentifier);
   if (itEvent == m_eventsMap.end())
     return false;

--- a/xbmc/events/EventLogManager.cpp
+++ b/xbmc/events/EventLogManager.cpp
@@ -9,13 +9,13 @@
 #include "EventLogManager.h"
 
 #include "EventLog.h"
-#include "threads/SingleLock.h"
 
+#include <mutex>
 #include <utility>
 
 CEventLog& CEventLogManager::GetEventLog(unsigned int profileId)
 {
-  CSingleLock lock(m_eventMutex);
+  std::unique_lock<CCriticalSection> lock(m_eventMutex);
 
   auto eventLog = m_eventLogs.find(profileId);
   if (eventLog == m_eventLogs.end())

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -25,6 +25,8 @@
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 
+#include <mutex>
+
 namespace
 {
 bool IsMediasourceOfFavItemUnlocked(const std::shared_ptr<CFileItem>& item)
@@ -191,7 +193,7 @@ bool CFavouritesService::Persist()
 bool CFavouritesService::Save(const CFileItemList& items)
 {
   {
-    CSingleLock lock(m_criticalSection);
+    std::unique_lock<CCriticalSection> lock(m_criticalSection);
     m_favourites.Clear();
     m_favourites.Copy(items);
     Persist();
@@ -217,7 +219,7 @@ bool CFavouritesService::AddOrRemove(const CFileItem& item, int contextWindow)
 {
   auto favUrl = GetFavouritesUrl(item, contextWindow);
   {
-    CSingleLock lock(m_criticalSection);
+    std::unique_lock<CCriticalSection> lock(m_criticalSection);
     CFileItemPtr match = m_favourites.Get(favUrl);
     if (match)
     { // remove the item
@@ -240,7 +242,7 @@ bool CFavouritesService::AddOrRemove(const CFileItem& item, int contextWindow)
 
 bool CFavouritesService::IsFavourited(const CFileItem& item, int contextWindow) const
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   return m_favourites.Contains(GetFavouritesUrl(item, contextWindow));
 }
 
@@ -296,7 +298,7 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
 
 void CFavouritesService::GetAll(CFileItemList& items) const
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   items.Clear();
   if (g_passwordManager.IsMasterLockUnlocked(false)) // don't prompt
   {

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -195,9 +195,9 @@ int64_t CCircularCache::WaitForData(uint32_t minimum, std::chrono::milliseconds 
   XbmcThreads::EndTime<> endtime{timeout};
   while (!IsEndOfInput() && avail < minimum && !endtime.IsTimePast() )
   {
-    lock.Leave();
+    lock.unlock();
     m_written.Wait(50ms); // may miss the deadline. shouldn't be a problem.
-    lock.Enter();
+    lock.lock();
     avail = m_end - m_cur;
   }
 
@@ -218,9 +218,9 @@ int64_t CCircularCache::Seek(int64_t pos)
      */
     m_cur = m_end;
 
-    lock.Leave();
+    lock.unlock();
     WaitForData((size_t)(pos - m_cur), 5s);
-    lock.Enter();
+    lock.lock();
 
     if (pos < m_beg || pos > m_end)
       CLog::Log(LOGDEBUG,

--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -8,11 +8,11 @@
 
 #include "DllLibCurl.h"
 
-#include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
 #include "utils/log.h"
 
 #include <assert.h>
+#include <mutex>
 
 namespace XCURL
 {
@@ -129,7 +129,7 @@ DllLibCurlGlobal::~DllLibCurlGlobal()
 
 void DllLibCurlGlobal::CheckIdle()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   /* 20 seconds idle time before closing handle */
   const unsigned int idletime = 30000;
 
@@ -166,7 +166,7 @@ void DllLibCurlGlobal::easy_acquire(const char* protocol,
 {
   assert(easy_handle != NULL);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (auto& it : m_sessions)
   {
@@ -222,7 +222,7 @@ void DllLibCurlGlobal::easy_acquire(const char* protocol,
 
 void DllLibCurlGlobal::easy_release(CURL_HANDLE** easy_handle, CURLM** multi_handle)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CURL_HANDLE* easy = NULL;
   CURLM* multi = NULL;
@@ -255,7 +255,7 @@ void DllLibCurlGlobal::easy_release(CURL_HANDLE** easy_handle, CURLM** multi_han
 
 CURL_HANDLE* DllLibCurlGlobal::easy_duphandle(CURL_HANDLE* easy_handle)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& it : m_sessions)
   {
@@ -275,7 +275,7 @@ void DllLibCurlGlobal::easy_duplicate(CURL_HANDLE* easy,
                                       CURL_HANDLE** easy_out,
                                       CURLM** multi_out)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (easy_out && easy)
     *easy_out = DllLibCurl::easy_duphandle(easy);

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -217,7 +217,7 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
               nfs_get_error(gNfsConnection.GetNfsContext()));
     return false;
   }
-  lock.Leave();
+  lock.unlock();
 
   while((nfsdirent = nfs_readdir(gNfsConnection.GetNfsContext(), nfsdir)) != NULL)
   {
@@ -283,9 +283,9 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     }
   }
 
-  lock.Enter();
+  lock.lock();
   nfs_closedir(gNfsConnection.GetNfsContext(), nfsdir);//close the dir
-  lock.Leave();
+  lock.unlock();
   return true;
 }
 

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -7,12 +7,13 @@
  */
 
 #ifdef TARGET_WINDOWS
+#include <mutex>
+
 #include <sys\stat.h>
 #endif
 
 #include "FileItem.h"
 #include "NFSDirectory.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
@@ -101,7 +102,7 @@ bool CNFSDirectory::GetServerList(CFileItemList &items)
 
 bool CNFSDirectory::ResolveSymlink( const std::string &dirName, struct nfsdirent *dirent, CURL &resolvedUrl)
 {
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   int ret = 0;
   bool retVal = true;
   std::string fullpath = dirName;
@@ -181,7 +182,7 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   // We accept nfs://server/path[/file]]]]
   int ret = 0;
   KODI::TIME::FileTime fileTime, localTime;
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string strDirName="";
   std::string myStrPath(url.Get());
   URIUtils::AddSlashAtEnd(myStrPath); //be sure the dir ends with a slash
@@ -294,7 +295,7 @@ bool CNFSDirectory::Create(const CURL& url2)
   int ret = 0;
   bool success=true;
 
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//mkdir fails if a slash is at the end!!!
   CURL url(folderName);
@@ -316,7 +317,7 @@ bool CNFSDirectory::Remove(const CURL& url2)
 {
   int ret = 0;
 
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//rmdir fails if a slash is at the end!!!
   CURL url(folderName);
@@ -340,7 +341,7 @@ bool CNFSDirectory::Exists(const CURL& url2)
 {
   int ret = 0;
 
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//remove slash at end or URIUtils::GetFileName won't return what we want...
   CURL url(folderName);

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -16,12 +16,12 @@
 #include "network/DNSNameCache.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include <inttypes.h>
+#include <mutex>
 
 #include <nfsc/libnfs-raw-mount.h>
 #include <nfsc/libnfs.h>
@@ -113,7 +113,7 @@ void CNfsConnection::clearMembers()
 
 void CNfsConnection::destroyOpenContexts()
 {
-  CSingleLock lock(openContextLock);
+  std::unique_lock<CCriticalSection> lock(openContextLock);
   for (auto& it : m_openContextMap)
   {
     nfs_destroy_context(it.second.pContext);
@@ -123,7 +123,7 @@ void CNfsConnection::destroyOpenContexts()
 
 void CNfsConnection::destroyContext(const std::string &exportName)
 {
-  CSingleLock lock(openContextLock);
+  std::unique_lock<CCriticalSection> lock(openContextLock);
   tOpenContextMap::iterator it = m_openContextMap.find(exportName.c_str());
   if (it != m_openContextMap.end())
   {
@@ -135,7 +135,7 @@ void CNfsConnection::destroyContext(const std::string &exportName)
 struct nfs_context *CNfsConnection::getContextFromMap(const std::string &exportname, bool forceCacheHit/* = false*/)
 {
   struct nfs_context *pRet = NULL;
-  CSingleLock lock(openContextLock);
+  std::unique_lock<CCriticalSection> lock(openContextLock);
 
   tOpenContextMap::iterator it = m_openContextMap.find(exportname.c_str());
   if (it != m_openContextMap.end())
@@ -188,7 +188,7 @@ int CNfsConnection::getContextForExport(const std::string &exportname)
     else
     {
       struct contextTimeout tmp;
-      CSingleLock lock(openContextLock);
+      std::unique_lock<CCriticalSection> lock(openContextLock);
       setOptions(m_pNfsContext);
       tmp.pContext = m_pNfsContext;
       tmp.lastAccessedTime = std::chrono::steady_clock::now();
@@ -268,7 +268,7 @@ bool CNfsConnection::splitUrlIntoExportAndPath(const CURL& url,std::string &expo
 
 bool CNfsConnection::Connect(const CURL& url, std::string &relativePath)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   int nfsRet = 0;
   std::string exportPath;
 
@@ -337,7 +337,7 @@ void CNfsConnection::CheckIfIdle()
    worst case scenario is that m_OpenConnections could read 0 and then changed to 1 if this happens it will enter the if which will lead to another check, which is locked.  */
   if (m_OpenConnections == 0 && m_pNfsContext != NULL)
   { /* I've set the the maximum IDLE time to be 1 min and 30 sec. */
-    CSingleLock lock(*this);
+    std::unique_lock<CCriticalSection> lock(*this);
     if (m_OpenConnections == 0 /* check again - when locked */)
     {
       if (m_IdleTimeout > 0)
@@ -354,7 +354,7 @@ void CNfsConnection::CheckIfIdle()
 
   if( m_pNfsContext != NULL )
   {
-    CSingleLock lock(keepAliveLock);
+    std::unique_lock<CCriticalSection> lock(keepAliveLock);
     //handle keep alive on opened files
     for (auto& it : m_KeepAliveTimeouts)
     {
@@ -375,14 +375,14 @@ void CNfsConnection::CheckIfIdle()
 //remove file handle from keep alive list on file close
 void CNfsConnection::removeFromKeepAliveList(struct nfsfh  *_pFileHandle)
 {
-  CSingleLock lock(keepAliveLock);
+  std::unique_lock<CCriticalSection> lock(keepAliveLock);
   m_KeepAliveTimeouts.erase(_pFileHandle);
 }
 
 //reset timeouts on read
 void CNfsConnection::resetKeepAlive(const std::string& _exportPath, struct nfsfh* _pFileHandle)
 {
-  CSingleLock lock(keepAliveLock);
+  std::unique_lock<CCriticalSection> lock(keepAliveLock);
   //refresh last access time of the context aswell
   struct nfs_context *pContext = getContextFromMap(_exportPath, true);
 
@@ -415,7 +415,7 @@ void CNfsConnection::keepAlive(const std::string& _exportPath, struct nfsfh* _pF
     pContext = m_pNfsContext;
 
   CLog::Log(LOGINFO, "NFS: sending keep alive after {} s.", KEEP_ALIVE_TIMEOUT / 2);
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   nfs_lseek(pContext, _pFileHandle, 0, SEEK_CUR, &offset);
   nfs_read(pContext, _pFileHandle, 32, buffer);
   nfs_lseek(pContext, _pFileHandle, offset, SEEK_SET, &offset);
@@ -423,7 +423,7 @@ void CNfsConnection::keepAlive(const std::string& _exportPath, struct nfsfh* _pF
 
 int CNfsConnection::stat(const CURL &url, NFSSTAT *statbuff)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   int nfsRet = 0;
   std::string exportPath;
   std::string relativePath;
@@ -464,13 +464,13 @@ int CNfsConnection::stat(const CURL &url, NFSSTAT *statbuff)
 needed for unloading the dylib*/
 void CNfsConnection::AddActiveConnection()
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   m_OpenConnections++;
 }
 
 void CNfsConnection::AddIdleConnection()
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   m_OpenConnections--;
   /* If we close a file we reset the idle timer so that we don't have any weird behaviours if a user
    leaves the movie paused for a long while and then press stop */
@@ -507,7 +507,7 @@ int64_t CNFSFile::GetPosition()
 {
   int ret = 0;
   uint64_t offset = 0;
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
 
   if (gNfsConnection.GetNfsContext() == NULL || m_pFileHandle == NULL) return 0;
 
@@ -540,7 +540,7 @@ bool CNFSFile::Open(const CURL& url)
 
   std::string filename;
 
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
 
   if(!gNfsConnection.Connect(url, filename))
     return false;
@@ -591,7 +591,7 @@ int CNFSFile::Stat(struct __stat64* buffer)
 int CNFSFile::Stat(const CURL& url, struct __stat64* buffer)
 {
   int ret = 0;
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string filename;
 
   if(!gNfsConnection.Connect(url,filename))
@@ -640,7 +640,7 @@ ssize_t CNFSFile::Read(void *lpBuf, size_t uiBufSize)
     uiBufSize = SSIZE_MAX;
 
   ssize_t numberOfBytesRead = 0;
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
 
   if (m_pFileHandle == NULL || m_pNfsContext == NULL )
     return -1;
@@ -664,7 +664,7 @@ int64_t CNFSFile::Seek(int64_t iFilePosition, int iWhence)
   int ret = 0;
   uint64_t offset = 0;
 
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   if (m_pFileHandle == NULL || m_pNfsContext == NULL) return -1;
 
 
@@ -682,7 +682,7 @@ int CNFSFile::Truncate(int64_t iSize)
 {
   int ret = 0;
 
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   if (m_pFileHandle == NULL || m_pNfsContext == NULL) return -1;
 
 
@@ -698,7 +698,7 @@ int CNFSFile::Truncate(int64_t iSize)
 
 void CNFSFile::Close()
 {
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
 
   if (m_pFileHandle != NULL && m_pNfsContext != NULL)
   {
@@ -732,7 +732,7 @@ ssize_t CNFSFile::Write(const void* lpBuf, size_t uiBufSize)
   //clamp max write chunksize to 32kb - fixme - this might be superfluous with future libnfs versions
   size_t chunkSize = gNfsConnection.GetMaxWriteChunkSize() > 32768 ? 32768 : (size_t)gNfsConnection.GetMaxWriteChunkSize();
 
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
 
   if (m_pFileHandle == NULL || m_pNfsContext == NULL) return -1;
 
@@ -773,7 +773,7 @@ ssize_t CNFSFile::Write(const void* lpBuf, size_t uiBufSize)
 bool CNFSFile::Delete(const CURL& url)
 {
   int ret = 0;
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string filename;
 
   if(!gNfsConnection.Connect(url, filename))
@@ -793,7 +793,7 @@ bool CNFSFile::Delete(const CURL& url)
 bool CNFSFile::Rename(const CURL& url, const CURL& urlnew)
 {
   int ret = 0;
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string strFile;
 
   if(!gNfsConnection.Connect(url,strFile))
@@ -821,7 +821,7 @@ bool CNFSFile::OpenForWrite(const CURL& url, bool bOverWrite)
   if (!IsValidFile(url.GetFileName())) return false;
 
   Close();
-  CSingleLock lock(gNfsConnection);
+  std::unique_lock<CCriticalSection> lock(gNfsConnection);
   std::string filename;
 
   if(!gNfsConnection.Connect(url,filename))

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -647,7 +647,7 @@ ssize_t CNFSFile::Read(void *lpBuf, size_t uiBufSize)
 
   numberOfBytesRead = nfs_read(m_pNfsContext, m_pFileHandle, uiBufSize, (char *)lpBuf);
 
-  lock.Leave();//no need to keep the connection lock after that
+  lock.unlock(); //no need to keep the connection lock after that
 
   gNfsConnection.resetKeepAlive(m_exportPath, m_pFileHandle);//triggers keep alive timer reset for this filehandle
 

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -10,7 +10,8 @@
 
 #include "PipesManager.h"
 #include "URL.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 using namespace XFILE;
 
@@ -166,7 +167,7 @@ std::string CPipeFile::GetName() const
 
 void CPipeFile::OnPipeOverFlow()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   for (size_t l=0; l<m_listeners.size(); l++)
     m_listeners[l]->OnPipeOverFlow();
 }
@@ -184,7 +185,7 @@ void CPipeFile::OnPipeUnderFlow()
 
 void CPipeFile::AddListener(IPipeListener *l)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   for (size_t i=0; i<m_listeners.size(); i++)
   {
     if (m_listeners[i] == l)
@@ -195,7 +196,7 @@ void CPipeFile::AddListener(IPipeListener *l)
 
 void CPipeFile::RemoveListener(IPipeListener *l)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   std::vector<XFILE::IPipeListener *>::iterator i = m_listeners.begin();
   while(i != m_listeners.end())
   {

--- a/xbmc/filesystem/PipesManager.cpp
+++ b/xbmc/filesystem/PipesManager.cpp
@@ -8,10 +8,10 @@
 
 #include "PipesManager.h"
 
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 
 #include <algorithm>
+#include <mutex>
 
 using namespace XFILE;
 using namespace std::chrono_literals;
@@ -43,19 +43,19 @@ const std::string &Pipe::GetName()
 
 void Pipe::AddRef()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   m_nRefCount++;
 }
 
 void Pipe::DecRef()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   m_nRefCount--;
 }
 
 int  Pipe::RefCount()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   return m_nRefCount;
 }
 
@@ -76,7 +76,7 @@ bool Pipe::IsEmpty()
 
 void Pipe::Flush()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
 
   if (!m_bOpen || !m_bReadyForRead || m_bEof)
   {
@@ -88,7 +88,7 @@ void Pipe::Flush()
 
 int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
 
   if (!m_bOpen)
   {
@@ -152,7 +152,7 @@ int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
 
 bool Pipe::Write(const char *buf, int nSize, int nWaitMillis)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   if (!m_bOpen)
     return false;
   bool bOk = false;
@@ -217,7 +217,7 @@ void Pipe::CheckStatus()
 
 void Pipe::Close()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   m_bOpen = false;
   m_readEvent.Set();
   m_writeEvent.Set();
@@ -225,7 +225,7 @@ void Pipe::Close()
 
 void Pipe::AddListener(IPipeListener *l)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   for (size_t i=0; i<m_listeners.size(); i++)
   {
     if (m_listeners[i] == l)
@@ -236,7 +236,7 @@ void Pipe::AddListener(IPipeListener *l)
 
 void Pipe::RemoveListener(IPipeListener *l)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   std::vector<XFILE::IPipeListener *>::iterator i = m_listeners.begin();
   while(i != m_listeners.end())
   {
@@ -249,7 +249,7 @@ void Pipe::RemoveListener(IPipeListener *l)
 
 int	Pipe::GetAvailableRead()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   return m_buffer.getMaxReadSize();
 }
 
@@ -263,7 +263,7 @@ PipesManager &PipesManager::GetInstance()
 
 std::string   PipesManager::GetUniquePipeName()
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   return StringUtils::Format("pipe://{}/", m_nGenIdHelper++);
 }
 
@@ -273,7 +273,7 @@ XFILE::Pipe *PipesManager::CreatePipe(const std::string &name, int nMaxPipeSize)
   if (pName.empty())
     pName = GetUniquePipeName();
 
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   if (m_pipes.find(pName) != m_pipes.end())
     return NULL;
 
@@ -284,7 +284,7 @@ XFILE::Pipe *PipesManager::CreatePipe(const std::string &name, int nMaxPipeSize)
 
 XFILE::Pipe *PipesManager::OpenPipe(const std::string &name)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   if (m_pipes.find(name) == m_pipes.end())
     return NULL;
   m_pipes[name]->AddRef();
@@ -293,7 +293,7 @@ XFILE::Pipe *PipesManager::OpenPipe(const std::string &name)
 
 void         PipesManager::ClosePipe(XFILE::Pipe *pipe)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   if (!pipe)
     return ;
 
@@ -308,7 +308,7 @@ void         PipesManager::ClosePipe(XFILE::Pipe *pipe)
 
 bool         PipesManager::Exists(const std::string &name)
 {
-  CSingleLock lock(m_lock);
+  std::unique_lock<CCriticalSection> lock(m_lock);
   return (m_pipes.find(name) != m_pipes.end());
 }
 

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -19,10 +19,11 @@
 #include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
+
+#include <mutex>
 
 using namespace XFILE;
 using namespace ADDON;
@@ -164,7 +165,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
 
 bool CPluginDirectory::AddItem(int handle, const CFileItem *item, int totalItems)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return false;
@@ -178,7 +179,7 @@ bool CPluginDirectory::AddItem(int handle, const CFileItem *item, int totalItems
 
 bool CPluginDirectory::AddItems(int handle, const CFileItemList *items, int totalItems)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return false;
@@ -193,7 +194,7 @@ bool CPluginDirectory::AddItems(int handle, const CFileItemList *items, int tota
 
 void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceListing, bool cacheToDisc)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
@@ -213,7 +214,7 @@ void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceList
 
 void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const std::string &labelMask, const std::string &label2Mask)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
@@ -440,7 +441,7 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
 
 void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem *resultItem)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
@@ -454,7 +455,7 @@ void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem 
 
 std::string CPluginDirectory::GetSetting(int handle, const std::string &strID)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (dir && dir->GetAddon())
     return dir->GetAddon()->GetSetting(strID);
@@ -464,7 +465,7 @@ std::string CPluginDirectory::GetSetting(int handle, const std::string &strID)
 
 void CPluginDirectory::SetSetting(int handle, const std::string &strID, const std::string &value)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (dir && dir->GetAddon())
     dir->GetAddon()->UpdateSetting(strID, value);
@@ -472,7 +473,7 @@ void CPluginDirectory::SetSetting(int handle, const std::string &strID, const st
 
 void CPluginDirectory::SetContent(int handle, const std::string &strContent)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (dir)
     dir->m_listItems->SetContent(strContent);
@@ -480,7 +481,7 @@ void CPluginDirectory::SetContent(int handle, const std::string &strContent)
 
 void CPluginDirectory::SetProperty(int handle, const std::string &strProperty, const std::string &strValue)
 {
-  CSingleLock lock(GetScriptsLock());
+  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -555,7 +555,7 @@ bool CRSSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       return true;
     m_cache.erase(it);
   }
-  lock.Leave();
+  lock.unlock();
 
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(strPath))

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -15,7 +15,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/HTMLUtil.h"
 #include "utils/StringUtils.h"
@@ -26,6 +25,7 @@
 #include "video/VideoInfoTag.h"
 
 #include <climits>
+#include <mutex>
 #include <utility>
 
 using namespace XFILE;
@@ -547,7 +547,7 @@ bool CRSSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   URIUtils::RemoveSlashAtEnd(strPath);
   std::map<std::string,CDateTime>::iterator it;
   items.SetPath(strPath);
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if ((it=m_cache.find(strPath)) != m_cache.end())
   {
     if (it->second > CDateTime::GetCurrentDateTime() &&
@@ -610,7 +610,7 @@ bool CRSSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   time += CDateTimeSpan(0,0,mins,0);
   items.SetPath(strPath);
   items.Save();
-  CSingleLock lock2(m_section);
+  std::unique_lock<CCriticalSection> lock2(m_section);
   m_cache.insert(make_pair(strPath,time));
 
   return true;

--- a/xbmc/filesystem/UDFBlockInput.cpp
+++ b/xbmc/filesystem/UDFBlockInput.cpp
@@ -8,7 +8,7 @@
 
 #include "UDFBlockInput.h"
 
-#include "threads/SingleLock.h"
+#include <mutex>
 
 #include <udfread/udfread.h>
 
@@ -32,7 +32,7 @@ int CUDFBlockInput::Read(
     udfread_block_input* bi, uint32_t lba, void* buf, uint32_t blocks, int flags)
 {
   auto m_bi = reinterpret_cast<UDF_BI*>(bi);
-  CSingleLock lock(m_bi->lock);
+  std::unique_lock<CCriticalSection> lock(m_bi->lock);
 
   int64_t pos = static_cast<int64_t>(lba) * UDF_BLOCK_SIZE;
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -31,7 +31,6 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -39,6 +38,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iterator>
+#include <mutex>
 #include <utility>
 
 using namespace KODI;
@@ -220,7 +220,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
   std::string path = translatedUrl.Get();
   CLog::Log(LOGDEBUG, "GameClient: Loading {}", CURL::GetRedacted(path));
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!Initialized())
     return false;
@@ -256,7 +256,7 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
 {
   CLog::Log(LOGDEBUG, "GameClient: Loading {} in standalone mode", ID());
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!Initialized())
     return false;
@@ -434,7 +434,7 @@ std::string CGameClient::GetMissingResource()
 
 void CGameClient::Reset()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_bIsPlaying)
   {
@@ -451,7 +451,7 @@ void CGameClient::Reset()
 
 void CGameClient::CloseFile()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_bIsPlaying)
   {
@@ -483,14 +483,14 @@ void CGameClient::RunFrame()
   IGameInputCallback* input;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     input = m_input;
   }
 
   if (input)
     input->PollInput();
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_bIsPlaying)
   {
@@ -510,7 +510,7 @@ bool CGameClient::Serialize(uint8_t* data, size_t size)
   if (data == nullptr || size == 0)
     return false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bool bSuccess = false;
   if (m_bIsPlaying)
@@ -533,7 +533,7 @@ bool CGameClient::Deserialize(const uint8_t* data, size_t size)
   if (data == nullptr || size == 0)
     return false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bool bSuccess = false;
   if (m_bIsPlaying)

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -27,10 +27,10 @@
 #include "input/joysticks/JoystickTypes.h"
 #include "peripherals/EventLockHandle.h"
 #include "peripherals/Peripherals.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <algorithm>
+#include <mutex>
 
 using namespace KODI;
 using namespace GAME;
@@ -335,7 +335,7 @@ bool CGameClientInput::ConnectController(const std::string& portAddress,
   CloseJoysticks(currentPort);
 
   {
-    CSingleLock lock(m_clientAccess);
+    std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
     if (!m_gameClient.Initialized())
       return false;
@@ -384,7 +384,7 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
   CloseJoysticks(currentPort);
 
   {
-    CSingleLock lock(m_clientAccess);
+    std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
     if (!m_gameClient.Initialized())
       return false;
@@ -463,7 +463,7 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr& controller)
   bool bSuccess = false;
 
   {
-    CSingleLock lock(m_clientAccess);
+    std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {
@@ -493,7 +493,7 @@ void CGameClientInput::CloseKeyboard()
   m_keyboard.reset();
 
   {
-    CSingleLock lock(m_clientAccess);
+    std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {
@@ -528,7 +528,7 @@ bool CGameClientInput::OpenMouse(const ControllerPtr& controller)
   bool bSuccess = false;
 
   {
-    CSingleLock lock(m_clientAccess);
+    std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {
@@ -557,7 +557,7 @@ void CGameClientInput::CloseMouse()
   m_mouse.reset();
 
   {
-    CSingleLock lock(m_clientAccess);
+    std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -55,7 +55,7 @@ void CGUIGameController::ActivateController(const ControllerPtr& controller)
   {
     m_currentController = controller;
 
-    lock.Leave();
+    lock.unlock();
 
     //! @todo Sometimes this fails on window init
     SetFileName(m_currentController->Layout().ImagePath());

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -10,8 +10,9 @@
 
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 using namespace KODI;
 using namespace GAME;
@@ -39,7 +40,7 @@ void CGUIGameController::Render(void)
 {
   CGUIImage::Render();
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (m_currentController)
   {
@@ -49,7 +50,7 @@ void CGUIGameController::Render(void)
 
 void CGUIGameController::ActivateController(const ControllerPtr& controller)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (controller && controller != m_currentController)
   {

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -9,11 +9,12 @@
 #include "GUIFont.h"
 
 #include "GUIFontTTF.h"
-#include "threads/SingleLock.h"
 #include "utils/CharsetConverter.h"
 #include "utils/MathUtils.h"
 #include "utils/TimeUtils.h"
 #include "windowing/GraphicContext.h"
+
+#include <mutex>
 
 #define ROUND(x) (float)(MathUtils::round_int(x))
 
@@ -271,7 +272,7 @@ float CGUIFont::GetTextWidth(const vecText& text)
 
   CGraphicContext& context = winSystem->GetGfxContext();
 
-  CSingleLock lock(context);
+  std::unique_lock<CCriticalSection> lock(context);
   return m_font->GetTextWidthInternal(text) * context.GetGUIScaleX();
 }
 
@@ -283,7 +284,7 @@ float CGUIFont::GetCharWidth(character_t ch)
 
   CGraphicContext& context = winSystem->GetGfxContext();
 
-  CSingleLock lock(context);
+  std::unique_lock<CCriticalSection> lock(context);
   return m_font->GetCharWidthInternal(ch) * context.GetGUIScaleX();
 }
 

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -15,6 +15,8 @@
 #include "addons/FontResource.h"
 #include "addons/Skin.h"
 #include "windowing/GraphicContext.h"
+
+#include <mutex>
 #if defined(HAS_GLES) || defined(HAS_GL)
 #include "GUIFontTTFGL.h"
 #endif
@@ -548,7 +550,7 @@ void GUIFontManager::SettingOptionsFontsFiller(const SettingConstPtr& setting,
 
 void GUIFontManager::Initialize()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   LoadUserFonts();
 }
 

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -22,6 +22,8 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
+#include <mutex>
+
 using namespace KODI::GUILIB;
 using namespace XFILE;
 
@@ -234,7 +236,7 @@ void CGUIMultiImage::LoadDirectory()
     return;
   }
   // slow(er) checks necessary - do them in the background
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_directoryStatus = LOADING;
   m_jobID = CJobManager::GetInstance().AddJob(new CMultiImageJob(m_currentPath), this, CJob::PRIORITY_NORMAL);
 }
@@ -256,7 +258,7 @@ void CGUIMultiImage::OnDirectoryLoaded()
 
 void CGUIMultiImage::CancelLoading()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_directoryStatus == LOADING)
     CJobManager::GetInstance().CancelJob(m_jobID);
   m_directoryStatus = UNLOADED;
@@ -264,7 +266,7 @@ void CGUIMultiImage::CancelLoading()
 
 void CGUIMultiImage::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   if (m_directoryStatus == LOADING && strncmp(job->GetType(), "multiimage", 10) == 0)
   {
     m_files = ((CMultiImageJob *)job)->m_files;

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -11,11 +11,12 @@
 #include "ServiceBroker.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/ColorUtils.h"
 #include "utils/RssManager.h"
 #include "utils/RssReader.h"
 #include "utils/StringUtils.h"
+
+#include <mutex>
 
 using namespace KODI::GUILIB;
 
@@ -58,7 +59,7 @@ CGUIRSSControl::CGUIRSSControl(const CGUIRSSControl &from)
 
 CGUIRSSControl::~CGUIRSSControl(void)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   if (m_pReader)
     m_pReader->SetObserver(NULL);
   m_pReader = NULL;
@@ -93,7 +94,7 @@ void CGUIRSSControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyre
   bool dirty = false;
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_LOOKANDFEEL_ENABLERSSFEEDS) && CRssManager::GetInstance().IsActive())
   {
-    CSingleLock lock(m_criticalSection);
+    std::unique_lock<CCriticalSection> lock(m_criticalSection);
     // Create RSS background/worker thread if needed
     if (m_pReader == NULL)
     {
@@ -182,7 +183,7 @@ CRect CGUIRSSControl::CalcRenderRegion() const
 
 void CGUIRSSControl::OnFeedUpdate(const vecText &feed)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   m_feed = feed;
   m_dirty = true;
 }

--- a/xbmc/guilib/GUIRenderingControl.cpp
+++ b/xbmc/guilib/GUIRenderingControl.cpp
@@ -7,8 +7,10 @@
  */
 
 #include "GUIRenderingControl.h"
-#include "threads/SingleLock.h"
+
 #include "guilib/IRenderingCallback.h"
+
+#include <mutex>
 #ifdef TARGET_WINDOWS
 #include "rendering/dx/DeviceResources.h"
 #endif
@@ -36,7 +38,7 @@ bool CGUIRenderingControl::InitCallback(IRenderingCallback *callback)
   if (!callback)
     return false;
 
-  CSingleLock lock(m_rendering);
+  std::unique_lock<CCriticalSection> lock(m_rendering);
   CServiceBroker::GetWinSystem()->GetGfxContext().CaptureStateBlock();
   float x = CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalXCoord(GetXPosition(), GetYPosition());
   float y = CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(GetXPosition(), GetYPosition());
@@ -72,7 +74,7 @@ void CGUIRenderingControl::UpdateVisibility(const CGUIListItem *item)
 void CGUIRenderingControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   //! @todo Add processing to the addon so it could mark when actually changing
-  CSingleLock lock(m_rendering);
+  std::unique_lock<CCriticalSection> lock(m_rendering);
   if (m_callback && m_callback->IsDirty())
     MarkDirtyRegion();
 
@@ -81,7 +83,7 @@ void CGUIRenderingControl::Process(unsigned int currentTime, CDirtyRegionList &d
 
 void CGUIRenderingControl::Render()
 {
-  CSingleLock lock(m_rendering);
+  std::unique_lock<CCriticalSection> lock(m_rendering);
   if (m_callback)
   {
     // set the viewport - note: We currently don't have any control over how
@@ -99,7 +101,7 @@ void CGUIRenderingControl::Render()
 
 void CGUIRenderingControl::FreeResources(bool immediately)
 {
-  CSingleLock lock(m_rendering);
+  std::unique_lock<CCriticalSection> lock(m_rendering);
 
   if (!m_callback) return;
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -31,6 +31,8 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 using namespace KODI::MESSAGING;
 
 bool CGUIWindow::icompare::operator()(const std::string &s1, const std::string &s2) const
@@ -370,7 +372,7 @@ void CGUIWindow::AfterRender()
 
 void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   if (!m_active)
     return;
@@ -735,7 +737,7 @@ bool CGUIWindow::NeedLoad() const
 
 void CGUIWindow::AllocResources(bool forceLoad /*= false */)
 {
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
 #ifdef _DEBUG
   const auto start = std::chrono::steady_clock::now();
@@ -998,7 +1000,7 @@ void CGUIWindow::SetDefaults()
 
 CRect CGUIWindow::GetScaledBounds() const
 {
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(m_coordsRes, m_needsScaling);
   CPoint pos(GetPosition());
   CRect rect(pos.x, pos.y, pos.x + m_width, pos.y + m_height);
@@ -1030,13 +1032,13 @@ void CGUIWindow::DumpTextureUse()
 
 void CGUIWindow::SetProperty(const std::string &strKey, const CVariant &value)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   m_mapProperties[strKey] = value;
 }
 
 CVariant CGUIWindow::GetProperty(const std::string &strKey) const
 {
-  CSingleLock lock(const_cast<CGUIWindow&>(*this));
+  std::unique_lock<CCriticalSection> lock(const_cast<CGUIWindow&>(*this));
   std::map<std::string, CVariant, icompare>::const_iterator iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
     return CVariant(CVariant::VariantTypeNull);
@@ -1046,7 +1048,7 @@ CVariant CGUIWindow::GetProperty(const std::string &strKey) const
 
 void CGUIWindow::ClearProperties()
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   m_mapProperties.clear();
 }
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1131,7 +1131,7 @@ bool CGUIWindowManager::HandleAction(CAction const& action) const
   while (topmost)
   {
     CGUIWindow *dialog = m_activeDialogs[--topmost];
-    lock.Leave();
+    lock.unlock();
     if (dialog->IsModalDialog())
     { // we have the topmost modal dialog
       if (!dialog->IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
@@ -1151,11 +1151,11 @@ bool CGUIWindowManager::HandleAction(CAction const& action) const
                 __FUNCTION__, action.GetID());
       return true; // do nothing with the action until the anim is finished
     }
-    lock.Enter();
+    lock.lock();
     if (topmost > m_activeDialogs.size())
       topmost = m_activeDialogs.size();
   }
-  lock.Leave();
+  lock.unlock();
   CGUIWindow* window = GetWindow(GetActiveWindow());
   if (window)
     return window->OnAction(action);
@@ -1524,7 +1524,7 @@ void CGUIWindowManager::DispatchThreadMessages()
     int window = m_vecThreadMessages.front().second;
     m_vecThreadMessages.pop_front();
 
-    lock.Leave();
+    lock.unlock();
 
     // XXX: during SendMessage(), there could be a deeper 'xbmc main loop' inited by e.g. doModal
     //      which may loop there and callback to DispatchThreadMessages() multiple times.
@@ -1534,7 +1534,7 @@ void CGUIWindowManager::DispatchThreadMessages()
       SendMessage( *pMsg );
     delete pMsg;
 
-    lock.Enter();
+    lock.lock();
   }
 }
 

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -18,6 +18,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <shared_mutex>
 
 /*! \brief Tries to load ids and strings from a strings.po file to the `strings` map.
  * It should only be called from the LoadStr2Mem function to have a fallback.
@@ -191,7 +192,7 @@ bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& s
 
 const std::string& CLocalizeStrings::Get(uint32_t dwCode) const
 {
-  CSharedLock lock(m_stringsMutex);
+  std::shared_lock<CSharedSection> lock(m_stringsMutex);
   ciStrings i = m_strings.find(dwCode);
   if (i == m_strings.end())
   {
@@ -235,7 +236,7 @@ bool CLocalizeStrings::LoadAddonStrings(const std::string& path, const std::stri
 
 std::string CLocalizeStrings::GetAddonString(const std::string& addonId, uint32_t code)
 {
-  CSharedLock lock(m_addonStringsMutex);
+  std::shared_lock<CSharedSection> lock(m_addonStringsMutex);
   auto i = m_addonStrings.find(addonId);
   if (i == m_addonStrings.end())
     return StringUtils::Empty;

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -18,6 +18,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <shared_mutex>
 
 /*! \brief Tries to load ids and strings from a strings.po file to the `strings` map.
@@ -141,14 +142,14 @@ CLocalizeStrings::~CLocalizeStrings(void) = default;
 void CLocalizeStrings::ClearSkinStrings()
 {
   // clear the skin strings
-  CExclusiveLock lock(m_stringsMutex);
+  std::unique_lock<CSharedSection> lock(m_stringsMutex);
   Clear(31000, 31999);
 }
 
 bool CLocalizeStrings::LoadSkinStrings(const std::string& path, const std::string& language)
 {
   //! @todo shouldn't hold lock while loading file
-  CExclusiveLock lock(m_stringsMutex);
+  std::unique_lock<CSharedSection> lock(m_stringsMutex);
   ClearSkinStrings();
   // load the skin strings in.
   return LoadWithFallback(path, language, m_strings);
@@ -184,7 +185,7 @@ bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& s
   strings[20210].strTranslated = "yard/s";
   strings[20211].strTranslated = "Furlong/Fortnight";
 
-  CExclusiveLock lock(m_stringsMutex);
+  std::unique_lock<CSharedSection> lock(m_stringsMutex);
   Clear();
   m_strings = std::move(strings);
   return true;
@@ -203,13 +204,13 @@ const std::string& CLocalizeStrings::Get(uint32_t dwCode) const
 
 void CLocalizeStrings::Clear()
 {
-  CExclusiveLock lock(m_stringsMutex);
+  std::unique_lock<CSharedSection> lock(m_stringsMutex);
   m_strings.clear();
 }
 
 void CLocalizeStrings::Clear(uint32_t start, uint32_t end)
 {
-  CExclusiveLock lock(m_stringsMutex);
+  std::unique_lock<CSharedSection> lock(m_stringsMutex);
   iStrings it = m_strings.begin();
   while (it != m_strings.end())
   {
@@ -226,7 +227,7 @@ bool CLocalizeStrings::LoadAddonStrings(const std::string& path, const std::stri
   if (!LoadWithFallback(path, language, strings))
     return false;
 
-  CExclusiveLock lock(m_addonStringsMutex);
+  std::unique_lock<CSharedSection> lock(m_addonStringsMutex);
   auto it = m_addonStrings.find(addonId);
   if (it != m_addonStrings.end())
     m_addonStrings.erase(it);

--- a/xbmc/guilib/imagefactory.cpp
+++ b/xbmc/guilib/imagefactory.cpp
@@ -14,6 +14,8 @@
 #include "guilib/FFmpegImage.h"
 #include "utils/Mime.h"
 
+#include <mutex>
+
 CCriticalSection ImageFactory::m_createSec;
 
 using namespace KODI::ADDONS;
@@ -42,7 +44,7 @@ IImage* ImageFactory::CreateLoaderFromMimeType(const std::string& strMimeType)
     if (addonInfo.first != ADDON::ADDON_IMAGEDECODER)
       continue;
 
-    CSingleLock lock(m_createSec);
+    std::unique_lock<CCriticalSection> lock(m_createSec);
     std::unique_ptr<CImageDecoder> result =
         std::make_unique<CImageDecoder>(addonInfo.second, strMimeType);
     if (!result->IsCreated())

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -43,6 +43,7 @@
 
 #include <algorithm>
 #include <math.h>
+#include <mutex>
 
 using EVENTSERVER::CEventServer;
 
@@ -290,7 +291,7 @@ void CInputManager::ProcessQueuedActions()
 {
   std::vector<CAction> queuedActions;
   {
-    CSingleLock lock(m_actionMutex);
+    std::unique_lock<CCriticalSection> lock(m_actionMutex);
     queuedActions.swap(m_queuedActions);
   }
 
@@ -300,7 +301,7 @@ void CInputManager::ProcessQueuedActions()
 
 void CInputManager::QueueAction(const CAction& action)
 {
-  CSingleLock lock(m_actionMutex);
+  std::unique_lock<CCriticalSection> lock(m_actionMutex);
 
   // Avoid dispatching multiple analog actions per frame with the same ID
   if (action.IsAnalog())

--- a/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
@@ -11,11 +11,11 @@
 #include "input/touch/generic/GenericTouchPinchDetector.h"
 #include "input/touch/generic/GenericTouchRotateDetector.h"
 #include "input/touch/generic/GenericTouchSwipeDetector.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <algorithm>
 #include <cmath>
+#include <mutex>
 
 using namespace std::chrono_literals;
 
@@ -57,7 +57,7 @@ bool CGenericTouchInputHandler::HandleTouchInput(TouchInput event,
   if (time < 0 || pointer < 0 || pointer >= MAX_POINTERS)
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   bool result = true;
 
@@ -292,7 +292,7 @@ bool CGenericTouchInputHandler::UpdateTouchPointer(
   if (pointer < 0 || pointer >= MAX_POINTERS)
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   m_pointers[pointer].last.copy(m_pointers[pointer].current);
 
@@ -326,7 +326,7 @@ void CGenericTouchInputHandler::saveLastTouch()
 
 void CGenericTouchInputHandler::OnTimeout()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   switch (m_gestureState)
   {

--- a/xbmc/interfaces/generic/RunningScriptsHandler.h
+++ b/xbmc/interfaces/generic/RunningScriptsHandler.h
@@ -12,10 +12,10 @@
 #include "interfaces/generic/ScriptRunner.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
-#include "threads/SingleLock.h"
 
 #include <cstdint>
 #include <map>
+#include <mutex>
 
 template<class TScript>
 class CRunningScriptsHandler : protected CScriptRunner
@@ -57,7 +57,7 @@ protected:
 
   static HandleType GetNewScriptHandle(TScript* script)
   {
-    CSingleLock lock(s_critical);
+    std::unique_lock<CCriticalSection> lock(s_critical);
     uint32_t handle = ++s_scriptHandleCounter;
     s_scriptHandles[handle] = script;
 
@@ -66,19 +66,19 @@ protected:
 
   static void ReuseScriptHandle(HandleType handle, TScript* script)
   {
-    CSingleLock lock(s_critical);
+    std::unique_lock<CCriticalSection> lock(s_critical);
     s_scriptHandles[handle] = script;
   }
 
   static void RemoveScriptHandle(HandleType handle)
   {
-    CSingleLock lock(s_critical);
+    std::unique_lock<CCriticalSection> lock(s_critical);
     s_scriptHandles.erase(handle);
   }
 
   static TScript* GetScriptFromHandle(HandleType handle)
   {
-    CSingleLock lock(s_critical);
+    std::unique_lock<CCriticalSection> lock(s_critical);
     auto scriptHandle = s_scriptHandles.find(handle);
     if (scriptHandle == s_scriptHandles.end())
       return nullptr;

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -56,7 +56,7 @@ void CScriptInvocationManager::Process()
     m_scriptPaths.erase(it.script);
 
   // we can leave the lock now
-  lock.Leave();
+  lock.unlock();
 
   // finally remove the finished threads but we do it outside of any locks in
   // case of any callbacks from the destruction of the CLanguageInvokerThread
@@ -86,7 +86,7 @@ void CScriptInvocationManager::Uninitialize()
   m_scriptPaths.clear();
 
   // we can leave the lock now
-  lock.Leave();
+  lock.unlock();
 
   // finally stop and remove the finished threads but we do it outside of any
   // locks in case of any callbacks from the stop or destruction logic of
@@ -97,7 +97,7 @@ void CScriptInvocationManager::Uninitialize()
       it.thread->Stop(true);
   }
 
-  lock.Enter();
+  lock.lock();
 
   tempList.clear();
 
@@ -264,7 +264,7 @@ int CScriptInvocationManager::ExecuteAsync(
 
     // After we leave the lock, m_lastInvokerThread can be released -> copy!
     CLanguageInvokerThreadPtr invokerThread = m_lastInvokerThread;
-    lock.Leave();
+    lock.unlock();
     invokerThread->Execute(script, arguments);
 
     return invokerThread->GetId();
@@ -286,7 +286,7 @@ int CScriptInvocationManager::ExecuteAsync(
   m_scriptPaths.insert(std::make_pair(script, m_lastInvokerThread->GetId()));
   // After we leave the lock, m_lastInvokerThread can be released -> copy!
   CLanguageInvokerThreadPtr invokerThread = m_lastInvokerThread;
-  lock.Leave();
+  lock.unlock();
   invokerThread->Execute(script, arguments);
 
   return invokerThread->GetId();

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -12,13 +12,13 @@
 #include "interfaces/generic/ILanguageInvocationHandler.h"
 #include "interfaces/generic/ILanguageInvoker.h"
 #include "interfaces/generic/LanguageInvokerThread.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
 #include <cerrno>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -37,7 +37,7 @@ CScriptInvocationManager& CScriptInvocationManager::GetInstance()
 
 void CScriptInvocationManager::Process()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   // go through all active threads and find and remove all which are done
   std::vector<LanguageInvokerThread> tempList;
   for (LanguageInvokerThreadMap::iterator it = m_scripts.begin(); it != m_scripts.end(); )
@@ -69,7 +69,7 @@ void CScriptInvocationManager::Process()
 
 void CScriptInvocationManager::Uninitialize()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // execute Process() once more to handle the remaining scripts
   Process();
@@ -118,7 +118,7 @@ void CScriptInvocationManager::RegisterLanguageInvocationHandler(ILanguageInvoca
   if (!StringUtils::StartsWithNoCase(ext, "."))
     ext = "." + ext;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_invocationHandlers.find(ext) != m_invocationHandlers.end())
     return;
 
@@ -153,7 +153,7 @@ void CScriptInvocationManager::UnregisterLanguageInvocationHandler(ILanguageInvo
   if (invocationHandler == NULL)
     return;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   //  get all extensions of the given language invoker
   for (std::map<std::string, ILanguageInvocationHandler*>::iterator it = m_invocationHandlers.begin(); it != m_invocationHandlers.end(); )
   {
@@ -172,14 +172,14 @@ bool CScriptInvocationManager::HasLanguageInvoker(const std::string &script) con
   std::string extension = URIUtils::GetExtension(script);
   StringUtils::ToLower(extension);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::map<std::string, ILanguageInvocationHandler*>::const_iterator it = m_invocationHandlers.find(extension);
   return it != m_invocationHandlers.end() && it->second != NULL;
 }
 
 int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_lastInvokerThread)
   {
@@ -193,7 +193,7 @@ int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
 
 LanguageInvokerPtr CScriptInvocationManager::GetLanguageInvoker(const std::string& script)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_lastInvokerThread)
   {
@@ -255,7 +255,7 @@ int CScriptInvocationManager::ExecuteAsync(
     return -1;
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_lastInvokerThread && m_lastInvokerThread->GetInvoker() == languageInvoker)
   {
@@ -351,7 +351,7 @@ bool CScriptInvocationManager::Stop(int scriptId, bool wait /* = false */)
   if (scriptId < 0)
     return false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   CLanguageInvokerThreadPtr invokerThread = getInvokerThread(scriptId).thread;
   if (invokerThread == NULL)
     return false;
@@ -373,7 +373,7 @@ bool CScriptInvocationManager::Stop(const std::string &scriptPath, bool wait /* 
   if (scriptPath.empty())
     return false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::map<std::string, int>::const_iterator script = m_scriptPaths.find(scriptPath);
   if (script == m_scriptPaths.end())
     return false;
@@ -383,7 +383,7 @@ bool CScriptInvocationManager::Stop(const std::string &scriptPath, bool wait /* 
 
 bool CScriptInvocationManager::IsRunning(int scriptId) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   LanguageInvokerThread invokerThread = getInvokerThread(scriptId);
   if (invokerThread.thread == NULL)
     return false;
@@ -393,7 +393,7 @@ bool CScriptInvocationManager::IsRunning(int scriptId) const
 
 bool CScriptInvocationManager::IsRunning(const std::string& scriptPath) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto it = m_scriptPaths.find(scriptPath);
   if (it == m_scriptPaths.end())
     return false;
@@ -406,7 +406,7 @@ void CScriptInvocationManager::OnExecutionDone(int scriptId)
   if (scriptId < 0)
     return;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   LanguageInvokerThreadMap::iterator script = m_scripts.find(scriptId);
   if (script != m_scripts.end())
     script->second.done = true;

--- a/xbmc/interfaces/legacy/AddonClass.h
+++ b/xbmc/interfaces/legacy/AddonClass.h
@@ -30,7 +30,8 @@
 //#define XBMC_ADDON_DEBUG_MEMORY
 
 #include "AddonString.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 #ifdef XBMC_ADDON_DEBUG_MEMORY
 #include "utils/log.h"
 #endif
@@ -80,7 +81,7 @@ namespace XBMCAddon
      */
     virtual void deallocating()
     {
-      CSingleLock lock(*this);
+      std::unique_lock<CCriticalSection> lock(*this);
       m_isDeallocating = true;
     }
 

--- a/xbmc/interfaces/legacy/AddonUtils.h
+++ b/xbmc/interfaces/legacy/AddonUtils.h
@@ -53,8 +53,8 @@ namespace XBMCAddonUtils
   {
     CSingleLock& lock;
   public:
-    explicit InvertSingleLockGuard(CSingleLock& _lock) : lock(_lock) { lock.Leave(); }
-    ~InvertSingleLockGuard() { lock.Enter(); }
+    explicit InvertSingleLockGuard(CSingleLock& _lock) : lock(_lock) { lock.unlock(); }
+    ~InvertSingleLockGuard() { lock.lock(); }
   };
 
 

--- a/xbmc/interfaces/legacy/AddonUtils.h
+++ b/xbmc/interfaces/legacy/AddonUtils.h
@@ -17,9 +17,10 @@
 
 //#define ENABLE_XBMC_TRACE_API
 
-#include "threads/SingleLock.h"
+#include "threads/CriticalSection.h"
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #ifdef TARGET_WINDOWS
@@ -51,9 +52,13 @@ namespace XBMCAddonUtils
 
   class InvertSingleLockGuard
   {
-    CSingleLock& lock;
+    std::unique_lock<CCriticalSection>& lock;
+
   public:
-    explicit InvertSingleLockGuard(CSingleLock& _lock) : lock(_lock) { lock.unlock(); }
+    explicit InvertSingleLockGuard(std::unique_lock<CCriticalSection>& _lock) : lock(_lock)
+    {
+      lock.unlock();
+    }
     ~InvertSingleLockGuard() { lock.lock(); }
   };
 

--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -10,9 +10,9 @@
 
 #include "AddonUtils.h"
 #include "commons/Exception.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <vector>
 
 namespace XBMCAddon
@@ -38,14 +38,14 @@ namespace XBMCAddon
   void RetardedAsyncCallbackHandler::invokeCallback(Callback* cb)
   {
     XBMC_TRACE;
-    CSingleLock lock(critSection);
+    std::unique_lock<CCriticalSection> lock(critSection);
     g_callQueue.push_back(new AsyncCallbackMessage(cb,this));
   }
 
   RetardedAsyncCallbackHandler::~RetardedAsyncCallbackHandler()
   {
     XBMC_TRACE;
-    CSingleLock lock(critSection);
+    std::unique_lock<CCriticalSection> lock(critSection);
 
     // find any messages that might be there because of me ... and remove them
     CallbackQueue::iterator iter = g_callQueue.begin();
@@ -64,7 +64,7 @@ namespace XBMCAddon
   void RetardedAsyncCallbackHandler::makePendingCalls()
   {
     XBMC_TRACE;
-    CSingleLock lock(critSection);
+    std::unique_lock<CCriticalSection> lock(critSection);
     CallbackQueue::iterator iter = g_callQueue.begin();
     while (iter != g_callQueue.end())
     {
@@ -94,7 +94,7 @@ namespace XBMCAddon
 #endif
           AddonClass* obj = (p->cb->getObject());
           AddonClass::Ref<AddonClass> ref(obj);
-          CSingleLock lock2(*obj);
+          std::unique_lock<CCriticalSection> lock2(*obj);
           if (!p->cb->getObject()->isDeallocating())
           {
             try
@@ -125,7 +125,7 @@ namespace XBMCAddon
   void RetardedAsyncCallbackHandler::clearPendingCalls(void* userData)
   {
     XBMC_TRACE;
-    CSingleLock lock(critSection);
+    std::unique_lock<CCriticalSection> lock(critSection);
     CallbackQueue::iterator iter = g_callQueue.begin();
     while (iter != g_callQueue.end())
     {

--- a/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
@@ -14,6 +14,8 @@
 #include "guilib/GUIWindowManager.h"
 #include "windowing/GraphicContext.h"
 
+#include <mutex>
+
 #define NOTIFICATION_INFO     "info"
 #define NOTIFICATION_WARNING  "warning"
 #define NOTIFICATION_ERROR    "error"
@@ -25,14 +27,14 @@ namespace XBMCAddon
     long getCurrentWindowId()
     {
       DelayedCallGuard dg;
-      CSingleLock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
       return CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
     }
 
     long getCurrentWindowDialogId()
     {
       DelayedCallGuard dg;
-      CSingleLock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
       return CServiceBroker::GetGUI()->GetWindowManager().GetTopmostModalDialog();
     }
 

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -14,6 +14,7 @@
 #include "swighelper.h"
 
 #include <limits.h>
+#include <mutex>
 #include <vector>
 
 namespace XBMCAddon
@@ -283,7 +284,11 @@ namespace XBMCAddon
        * This is called from the InterceptorBase destructor to prevent further
        * use of the interceptor from the window.
        */
-      inline void interceptorClear() { CSingleLock lock(*this); window = NULL; }
+      inline void interceptorClear()
+      {
+        std::unique_lock<CCriticalSection> lock(*this);
+        window = NULL;
+      }
 #endif
 
       //

--- a/xbmc/interfaces/legacy/WindowDialog.cpp
+++ b/xbmc/interfaces/legacy/WindowDialog.cpp
@@ -14,6 +14,8 @@
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
 
+#include <mutex>
+
 namespace XBMCAddon
 {
   namespace xbmcgui
@@ -21,7 +23,7 @@ namespace XBMCAddon
     WindowDialog::WindowDialog() :
       Window(true), WindowDialogMixin(this)
     {
-      CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
       InterceptorBase* interceptor = new Interceptor<CGUIWindow>("CGUIWindow", this, getNextAvailableWindowId());
       // set the render order to the dialog's default because this dialog is mapped to CGUIWindow instead of CGUIDialog
       interceptor->SetRenderOrder(RENDER_ORDER_DIALOG);

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -20,6 +20,8 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
+#include <mutex>
+
 // These #defs are for WindowXML
 #define CONTROL_BTNVIEWASICONS  2
 #define CONTROL_BTNSORTBY       3
@@ -141,7 +143,7 @@ namespace XBMCAddon
     int WindowXML::lockingGetNextAvailableWindowId()
     {
       XBMC_TRACE;
-      CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
       return getNextAvailableWindowId();
     }
 

--- a/xbmc/interfaces/python/LanguageHook.cpp
+++ b/xbmc/interfaces/python/LanguageHook.cpp
@@ -16,6 +16,8 @@
 #include "interfaces/legacy/AddonUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 namespace XBMCAddon
 {
   namespace Python
@@ -53,14 +55,14 @@ namespace XBMCAddon
     void PythonLanguageHook::RegisterMe()
     {
       XBMC_TRACE;
-      CSingleLock lock(hooksMutex);
+      std::unique_lock<CCriticalSection> lock(hooksMutex);
       hooks[m_interp] = AddonClass::Ref<PythonLanguageHook>(this);
     }
 
     void PythonLanguageHook::UnregisterMe()
     {
       XBMC_TRACE;
-      CSingleLock lock(hooksMutex);
+      std::unique_lock<CCriticalSection> lock(hooksMutex);
       hooks.erase(m_interp);
     }
 
@@ -74,7 +76,7 @@ namespace XBMCAddon
     AddonClass::Ref<PythonLanguageHook> PythonLanguageHook::GetIfExists(PyInterpreterState* interp)
     {
       XBMC_TRACE;
-      CSingleLock lock(hooksMutex);
+      std::unique_lock<CCriticalSection> lock(hooksMutex);
       std::map<PyInterpreterState*,AddonClass::Ref<PythonLanguageHook> >::iterator iter = hooks.find(interp);
       if (iter != hooks.end())
         return iter->second;
@@ -206,7 +208,7 @@ namespace XBMCAddon
     void PythonLanguageHook::RegisterAddonClassInstance(AddonClass* obj)
     {
       XBMC_TRACE;
-      CSingleLock l(*this);
+      std::unique_lock<CCriticalSection> l(*this);
       obj->Acquire();
       currentObjects.insert(obj);
     }
@@ -214,7 +216,7 @@ namespace XBMCAddon
     void PythonLanguageHook::UnregisterAddonClassInstance(AddonClass* obj)
     {
       XBMC_TRACE;
-      CSingleLock l(*this);
+      std::unique_lock<CCriticalSection> l(*this);
       if (currentObjects.erase(obj) > 0)
         obj->Release();
     }
@@ -222,7 +224,7 @@ namespace XBMCAddon
     bool PythonLanguageHook::HasRegisteredAddonClassInstance(AddonClass* obj)
     {
       XBMC_TRACE;
-      CSingleLock l(*this);
+      std::unique_lock<CCriticalSection> l(*this);
       return currentObjects.find(obj) != currentObjects.end();
     }
   }

--- a/xbmc/interfaces/python/LanguageHook.h
+++ b/xbmc/interfaces/python/LanguageHook.h
@@ -12,6 +12,7 @@
 #include "threads/Event.h"
 
 #include <map>
+#include <mutex>
 #include <set>
 
 #include <Python.h>
@@ -75,7 +76,11 @@ namespace XBMCAddon
       void RegisterAddonClassInstance(AddonClass* obj);
       void UnregisterAddonClassInstance(AddonClass* obj);
       bool HasRegisteredAddonClassInstance(AddonClass* obj);
-      inline bool HasRegisteredAddonClasses() { CSingleLock l(*this); return !currentObjects.empty(); }
+      inline bool HasRegisteredAddonClasses()
+      {
+        std::unique_lock<CCriticalSection> l(*this);
+        return !currentObjects.empty();
+      }
 
       // You should hold the lock on the LanguageHook itself if you're
       // going to do anything with the set that gets returned.

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -8,6 +8,7 @@
 
 // clang-format off
 // python.h should always be included first before any other includes
+#include <mutex>
 #include <Python.h>
 // clang-format on
 
@@ -70,7 +71,7 @@ static const std::string getListOfAddonClassesAsString(
     XBMCAddon::AddonClass::Ref<XBMCAddon::Python::PythonLanguageHook>& languageHook)
 {
   std::string message;
-  CSingleLock l(*(languageHook.get()));
+  std::unique_lock<CCriticalSection> l(*(languageHook.get()));
   std::set<XBMCAddon::AddonClass*>& acs = languageHook->GetRegisteredAddonClasses();
   bool firstTime = true;
   for (const auto& iter : acs)
@@ -282,7 +283,7 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
     PySys_SetPath(pypath.c_str());
 
     { // set the m_threadState to this new interp
-      CSingleLock lockMe(m_critical);
+      std::unique_lock<CCriticalSection> lockMe(m_critical);
       m_threadState = l_threadState;
     }
   }
@@ -388,7 +389,7 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
     onError(exceptionType, exceptionValue, exceptionTraceback);
   }
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // no need to do anything else because the script has already stopped
   if (failed)
   {
@@ -466,7 +467,7 @@ FILE* CPythonInvoker::PyFile_AsFileWithMode(PyObject* py_file, const char* mode)
 
 bool CPythonInvoker::stop(bool abort)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_stop = true;
 
   if (!IsRunning() && !m_threadState)
@@ -562,7 +563,7 @@ bool CPythonInvoker::stop(bool abort)
 // Always called from Invoker thread
 void CPythonInvoker::onExecutionDone()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (m_threadState != NULL)
   {
     CLog::Log(LOGDEBUG, "{}({}, {})", __FUNCTION__, GetId(), m_sourceFile);
@@ -625,7 +626,7 @@ void CPythonInvoker::onExecutionFailed()
   CLog::Log(LOGERROR, "CPythonInvoker({}, {}): abnormally terminating python thread", GetId(),
             m_sourceFile);
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_threadState = NULL;
 
   ILanguageInvoker::onExecutionFailed();
@@ -682,7 +683,7 @@ void CPythonInvoker::onError(const std::string& exceptionType /* = "" */,
                              const std::string& exceptionTraceback /* = "" */)
 {
   CPyThreadState releaseGil;
-  CSingleLock gc(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> gc(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   CGUIDialogKaiToast* pDlgToast =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKaiToast>(

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -415,11 +415,11 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
         old = s;
       }
 
-      lock.Leave();
+      lock.unlock();
       CPyThreadState pyState;
       KODI::TIME::Sleep(100ms);
       pyState.Restore();
-      lock.Enter();
+      lock.lock();
     }
   }
 
@@ -477,7 +477,7 @@ bool CPythonInvoker::stop(bool abort)
     if (IsRunning())
     {
       setState(InvokerStateStopping);
-      lock.Leave();
+      lock.unlock();
 
       PyEval_RestoreThread((PyThreadState*)m_threadState);
 
@@ -493,7 +493,7 @@ bool CPythonInvoker::stop(bool abort)
     }
     else
       //Release the lock while waiting for threads to finish
-      lock.Leave();
+      lock.unlock();
 
     XbmcThreads::EndTime<> timeout(PYTHON_SCRIPT_TIMEOUT);
     while (!m_stoppedEvent.Wait(15ms))
@@ -516,7 +516,7 @@ bool CPythonInvoker::stop(bool abort)
       }
     }
 
-    lock.Enter();
+    lock.lock();
 
     setState(InvokerStateExecutionDone);
 
@@ -551,7 +551,7 @@ bool CPythonInvoker::stop(bool abort)
 
       PyEval_ReleaseThread(m_threadState);
     }
-    lock.Leave();
+    lock.unlock();
 
     setState(InvokerStateFailed);
   }

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -8,6 +8,7 @@
 
 // clang-format off
 // python.h should always be included first before any other includes
+#include <mutex>
 #include <Python.h>
 // clang-format on
 
@@ -60,7 +61,7 @@ XBPython::~XBPython()
 #define LOCK_AND_COPY(type, dest, src) \
   if (!m_bInitialized) \
     return; \
-  CSingleLock lock(src); \
+  std::unique_lock<CCriticalSection> lock(src); \
   src.hadSomethingRemoved = false; \
   type dest; \
   dest = src
@@ -264,14 +265,14 @@ void XBPython::OnQueueNextItem()
 void XBPython::RegisterPythonPlayerCallBack(IPlayerCallback* pCallback)
 {
   XBMC_TRACE;
-  CSingleLock lock(m_vecPlayerCallbackList);
+  std::unique_lock<CCriticalSection> lock(m_vecPlayerCallbackList);
   m_vecPlayerCallbackList.push_back(pCallback);
 }
 
 void XBPython::UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback)
 {
   XBMC_TRACE;
-  CSingleLock lock(m_vecPlayerCallbackList);
+  std::unique_lock<CCriticalSection> lock(m_vecPlayerCallbackList);
   PlayerCallbackList::iterator it = m_vecPlayerCallbackList.begin();
   while (it != m_vecPlayerCallbackList.end())
   {
@@ -288,14 +289,14 @@ void XBPython::UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback)
 void XBPython::RegisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback)
 {
   XBMC_TRACE;
-  CSingleLock lock(m_vecMonitorCallbackList);
+  std::unique_lock<CCriticalSection> lock(m_vecMonitorCallbackList);
   m_vecMonitorCallbackList.push_back(pCallback);
 }
 
 void XBPython::UnregisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback)
 {
   XBMC_TRACE;
-  CSingleLock lock(m_vecMonitorCallbackList);
+  std::unique_lock<CCriticalSection> lock(m_vecMonitorCallbackList);
   MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
   while (it != m_vecMonitorCallbackList.end())
   {
@@ -443,7 +444,7 @@ void XBPython::Process()
   if (m_bInitialized)
   {
     PyList tmpvec;
-    CSingleLock lock(m_vecPyList);
+    std::unique_lock<CCriticalSection> lock(m_vecPyList);
     for (PyList::iterator it = m_vecPyList.begin(); it != m_vecPyList.end();)
     {
       if (it->bDone)
@@ -469,7 +470,7 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
 
   XBMC_TRACE;
   CLog::Log(LOGDEBUG, "initializing python engine.");
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_iDllScriptCounter++;
   if (!m_bInitialized)
   {
@@ -560,7 +561,7 @@ void XBPython::OnScriptStarted(ILanguageInvoker* invoker)
   inf.id = invoker->GetId();
   inf.bDone = false;
   inf.pyThread = static_cast<CPythonInvoker*>(invoker);
-  CSingleLock lock(m_vecPyList);
+  std::unique_lock<CCriticalSection> lock(m_vecPyList);
   m_vecPyList.push_back(inf);
 }
 
@@ -585,7 +586,7 @@ void XBPython::NotifyScriptAborting(ILanguageInvoker* invoker)
 
 void XBPython::OnExecutionEnded(ILanguageInvoker* invoker)
 {
-  CSingleLock lock(m_vecPyList);
+  std::unique_lock<CCriticalSection> lock(m_vecPyList);
   PyList::iterator it = m_vecPyList.begin();
   while (it != m_vecPyList.end())
   {
@@ -604,7 +605,7 @@ void XBPython::OnExecutionEnded(ILanguageInvoker* invoker)
 void XBPython::OnScriptFinalized(ILanguageInvoker* invoker)
 {
   XBMC_TRACE;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   // for linux - we never release the library. its loaded and stays in memory.
   if (m_iDllScriptCounter)
     m_iDllScriptCounter--;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -432,7 +432,7 @@ void XBPython::Uninitialize()
   m_vecPyList.clear();
   m_vecPyList.hadSomethingRemoved = true;
 
-  lock.Leave(); //unlock here because the python thread might lock when it exits
+  lock.unlock(); //unlock here because the python thread might lock when it exits
 
   // cleanup threads that are still running
   tmpvec.clear();
@@ -455,7 +455,7 @@ void XBPython::Process()
       else
         ++it;
     }
-    lock.Leave();
+    lock.unlock();
 
     //delete scripts which are done
     tmpvec.clear();

--- a/xbmc/interfaces/python/pythreadstate.h
+++ b/xbmc/interfaces/python/pythreadstate.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "threads/SingleLock.h"
 
 //WARNING: since this will unlock/lock the python global interpreter lock,
 //         it will not work recursively
@@ -50,12 +49,16 @@ class CPyThreadState
 };
 
 /**
- * A CSingleLock that will relinquish the GIL during the time
+ * A std::unique_lock<CCriticalSection> that will relinquish the GIL during the time
  *  it takes to obtain the CriticalSection
  */
-class GilSafeSingleLock : public CPyThreadState, public CSingleLock
+class GilSafeSingleLock : public CPyThreadState, public std::unique_lock<CCriticalSection>
 {
 public:
-  explicit GilSafeSingleLock(CCriticalSection& critSec) : CPyThreadState(true), CSingleLock(critSec) { CPyThreadState::Restore(); }
+  explicit GilSafeSingleLock(CCriticalSection& critSec)
+    : CPyThreadState(true), std::unique_lock<CCriticalSection>(critSec)
+  {
+    CPyThreadState::Restore();
+  }
 };
 

--- a/xbmc/listproviders/MultiProvider.cpp
+++ b/xbmc/listproviders/MultiProvider.cpp
@@ -8,8 +8,9 @@
 
 #include "MultiProvider.h"
 
-#include "threads/SingleLock.h"
 #include "utils/XBMCTinyXML.h"
+
+#include <mutex>
 
 CMultiProvider::CMultiProvider(const TiXmlNode *first, int parentID)
  : IListProvider(parentID)
@@ -47,7 +48,7 @@ bool CMultiProvider::Update(bool forceRefresh)
 
 void CMultiProvider::Fetch(std::vector<CGUIListItemPtr> &items)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   std::vector<CGUIListItemPtr> subItems;
   items.clear();
   m_itemMap.clear();
@@ -75,7 +76,7 @@ bool CMultiProvider::IsUpdating() const
 void CMultiProvider::Reset()
 {
   {
-    CSingleLock lock(m_section);
+    std::unique_lock<CCriticalSection> lock(m_section);
     m_itemMap.clear();
   }
 
@@ -85,7 +86,7 @@ void CMultiProvider::Reset()
 
 bool CMultiProvider::OnClick(const CGUIListItemPtr &item)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   auto key = GetItemKey(item);
   auto it = m_itemMap.find(key);
   if (it != m_itemMap.end())
@@ -96,7 +97,7 @@ bool CMultiProvider::OnClick(const CGUIListItemPtr &item)
 
 bool CMultiProvider::OnInfo(const CGUIListItemPtr &item)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   auto key = GetItemKey(item);
   auto it = m_itemMap.find(key);
   if (it != m_itemMap.end())
@@ -107,7 +108,7 @@ bool CMultiProvider::OnInfo(const CGUIListItemPtr &item)
 
 bool CMultiProvider::OnContextMenu(const CGUIListItemPtr &item)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   auto key = GetItemKey(item);
   auto it = m_itemMap.find(key);
   if (it != m_itemMap.end())

--- a/xbmc/media/decoderfilter/DecoderFilterManager.cpp
+++ b/xbmc/media/decoderfilter/DecoderFilterManager.cpp
@@ -18,9 +18,10 @@
 #include "Util.h"
 #include "cores/VideoPlayer/DVDStreamInfo.h"
 #include "filesystem/File.h"
-#include "threads/SingleLock.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 static const char* TAG_ROOT = "decoderfilter";
 static const char* TAG_FILTER = "filter";
@@ -99,21 +100,21 @@ bool CDecoderFilter::Save(TiXmlNode *node) const
 
 bool CDecoderFilterManager::isValid(const std::string& name, const CDVDStreamInfo& streamInfo)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   std::set<CDecoderFilter>::const_iterator filter(m_filters.find(name));
   return filter != m_filters.end() ? filter->isValid(streamInfo) : m_filters.empty();
 }
 
 void CDecoderFilterManager::add(const CDecoderFilter& filter)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   std::pair<std::set<CDecoderFilter>::iterator, bool> res = m_filters.insert(filter);
   m_dirty = m_dirty || res.second;
 }
 
 bool CDecoderFilterManager::Load()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   m_filters.clear();
 
@@ -151,7 +152,7 @@ bool CDecoderFilterManager::Load()
 
 bool CDecoderFilterManager::Save() const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (!m_dirty || m_filters.empty())
     return true;
 

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -128,12 +128,12 @@ int CApplicationMessenger::SendMsg(ThreadMessage&& message, bool wait)
     m_vecWindowMessages.push(msg);
   else
     m_vecMessages.push(msg);
-  lock.Leave();  // this releases the lock on the vec of messages and
-                 //   allows the ProcessMessage to execute and therefore
-                 //   delete the message itself. Therefore any access
-                 //   of the message itself after this point constitutes
-                 //   a race condition (yarc - "yet another race condition")
-                 //
+  lock.unlock(); // this releases the lock on the vec of messages and
+      //   allows the ProcessMessage to execute and therefore
+      //   delete the message itself. Therefore any access
+      //   of the message itself after this point constitutes
+      //   a race condition (yarc - "yet another race condition")
+      //
   if (waitEvent) // ... it just so happens we have a spare reference to the
                  //  waitEvent ... just for such contingencies :)
   {
@@ -219,7 +219,7 @@ void CApplicationMessenger::ProcessMessages()
     //thread call processmessages or sendmessage
 
     std::shared_ptr<CEvent> waitEvent = pMsg->waitEvent;
-    lock.Leave(); // <- see the large comment in SendMessage ^
+    lock.unlock(); // <- see the large comment in SendMessage ^
 
     ProcessMessage(pMsg);
 
@@ -227,7 +227,7 @@ void CApplicationMessenger::ProcessMessages()
       waitEvent->Set();
     delete pMsg;
 
-    lock.Enter();
+    lock.lock();
   }
 }
 
@@ -267,14 +267,14 @@ void CApplicationMessenger::ProcessWindowMessages()
     // leave here in case we make more thread messages from this one
 
     std::shared_ptr<CEvent> waitEvent = pMsg->waitEvent;
-    lock.Leave(); // <- see the large comment in SendMessage ^
+    lock.unlock(); // <- see the large comment in SendMessage ^
 
     ProcessMessage(pMsg);
     if (waitEvent)
       waitEvent->Set();
     delete pMsg;
 
-    lock.Enter();
+    lock.lock();
   }
 }
 

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -22,9 +22,9 @@
 #include "music/jobs/MusicLibraryScanningJob.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/Variant.h"
 
+#include <mutex>
 #include <utility>
 
 CMusicLibraryQueue::CMusicLibraryQueue()
@@ -34,7 +34,7 @@ CMusicLibraryQueue::CMusicLibraryQueue()
 
 CMusicLibraryQueue::~CMusicLibraryQueue()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_jobs.clear();
 }
 
@@ -175,7 +175,7 @@ bool CMusicLibraryQueue::IsScanningLibrary() const
 
 void CMusicLibraryQueue::StopLibraryScanning()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   MusicLibraryJobMap::const_iterator scanningJobs = m_jobs.find("MusicLibraryScanningJob");
   if (scanningJobs == m_jobs.end())
     return;
@@ -243,7 +243,7 @@ void CMusicLibraryQueue::AddJob(CMusicLibraryJob *job)
   if (job == NULL)
     return;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (!CJobQueue::AddJob(job))
     return;
 
@@ -265,7 +265,7 @@ void CMusicLibraryQueue::CancelJob(CMusicLibraryJob *job)
   if (job == NULL)
     return;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // remember the job type needed later because the job might be deleted
   // in the call to CJobQueue::CancelJob()
   std::string jobType;
@@ -287,7 +287,7 @@ void CMusicLibraryQueue::CancelJob(CMusicLibraryJob *job)
 
 void CMusicLibraryQueue::CancelAllJobs()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   CJobQueue::CancelJobs();
 
   // remove all scanning jobs
@@ -315,7 +315,7 @@ void CMusicLibraryQueue::OnJobComplete(unsigned int jobID, bool success, CJob *j
   }
 
   {
-    CSingleLock lock(m_critical);
+    std::unique_lock<CCriticalSection> lock(m_critical);
     // remove the job from our list of queued/running jobs
     MusicLibraryJobMap::iterator jobsIt = m_jobs.find(job->GetType());
     if (jobsIt != m_jobs.end())

--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -8,9 +8,11 @@
 
 #include "DNSNameCache.h"
 
-#include "threads/SingleLock.h"
+#include "threads/CriticalSection.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #if !defined(TARGET_WINDOWS) && defined(HAS_FILESYSTEM_SMB)
 #include "ServiceBroker.h"
@@ -113,7 +115,7 @@ bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAdd
 bool CDNSNameCache::GetCached(const std::string& strHostName, std::string& strIpAddress)
 {
   {
-    CSingleLock lock(m_critical);
+    std::unique_lock<CCriticalSection> lock(m_critical);
 
     // loop through all DNSname entries and see if strHostName is cached
     for (const auto& DNSname : g_DNSCache.m_vecDNSNames)
@@ -150,7 +152,7 @@ void CDNSNameCache::Add(const std::string& strHostName, const std::string& strIp
   dnsName.m_strHostName = strHostName;
   dnsName.m_strIpAddress  = strIpAddress;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   g_DNSCache.m_vecDNSNames.push_back(dnsName);
 }
 

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -19,12 +19,12 @@
 #include "input/Key.h"
 #include "input/actions/ActionTranslator.h"
 #include "interfaces/builtins/Builtins.h"
-#include "threads/SingleLock.h"
 #include "utils/SystemInfo.h"
 #include "utils/log.h"
 
 #include <cassert>
 #include <map>
+#include <mutex>
 #include <queue>
 
 using namespace EVENTSERVER;
@@ -63,7 +63,7 @@ CEventServer* CEventServer::GetInstance()
 
 void CEventServer::StartServer()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_bRunning)
     return;
 
@@ -94,14 +94,14 @@ void CEventServer::Cleanup()
   if (m_pSocket)
     m_pSocket->Close();
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_clients.clear();
 }
 
 int CEventServer::GetNumberOfClients()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_clients.size();
 }
 
@@ -219,7 +219,7 @@ void CEventServer::ProcessPacket(CAddress& addr, int pSize)
   if (!clientToken)
     clientToken = addr.ULong(); // use IP if packet doesn't have a token
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // first check if we have a client for this address
   auto iter = m_clients.find(clientToken);
@@ -247,7 +247,7 @@ void CEventServer::ProcessPacket(CAddress& addr, int pSize)
 
 void CEventServer::RefreshClients()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto iter = m_clients.begin();
 
   while ( iter != m_clients.end() )
@@ -273,7 +273,7 @@ void CEventServer::RefreshClients()
 
 void CEventServer::ProcessEvents()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto iter = m_clients.begin();
 
   while (iter != m_clients.end())
@@ -285,7 +285,7 @@ void CEventServer::ProcessEvents()
 
 bool CEventServer::ExecuteNextAction()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CEventAction actionEvent;
   auto iter = m_clients.begin();
@@ -325,7 +325,7 @@ bool CEventServer::ExecuteNextAction()
 
 unsigned int CEventServer::GetButtonCode(std::string& strMapName, bool& isAxis, float& fAmount, bool &isJoystick)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto iter = m_clients.begin();
   unsigned int bcode = 0;
 
@@ -341,7 +341,7 @@ unsigned int CEventServer::GetButtonCode(std::string& strMapName, bool& isAxis, 
 
 bool CEventServer::GetMousePos(float &x, float &y)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto iter = m_clients.begin();
 
   while (iter != m_clients.end())

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -295,7 +295,7 @@ bool CEventServer::ExecuteNextAction()
     if (iter->second->GetNextAction(actionEvent))
     {
       // Leave critical section before processing action
-      lock.Leave();
+      lock.unlock();
       switch(actionEvent.actionType)
       {
       case AT_EXEC_BUILTIN:

--- a/xbmc/network/EventServer.h
+++ b/xbmc/network/EventServer.h
@@ -11,11 +11,11 @@
 #include "EventClient.h"
 #include "Socket.h"
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 #include "threads/Thread.h"
 
 #include <atomic>
 #include <map>
+#include <mutex>
 #include <queue>
 #include <vector>
 
@@ -44,7 +44,7 @@ namespace EVENTSERVER
 
     void RefreshSettings()
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       m_bRefreshSettings = true;
     }
 

--- a/xbmc/network/UdpClient.cpp
+++ b/xbmc/network/UdpClient.cpp
@@ -7,11 +7,12 @@
  */
 
 #include "UdpClient.h"
+
+#include <mutex>
 #ifdef TARGET_POSIX
 #include <sys/ioctl.h>
 #endif
 #include "Network.h"
-#include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -78,7 +79,7 @@ void CUdpClient::OnStartup()
 
 bool CUdpClient::Broadcast(int aPort, const std::string& aMessage)
 {
-  CSingleLock lock(critical_section);
+  std::unique_lock<CCriticalSection> lock(critical_section);
 
   struct sockaddr_in addr;
   addr.sin_family = AF_INET;
@@ -95,7 +96,7 @@ bool CUdpClient::Broadcast(int aPort, const std::string& aMessage)
 
 bool CUdpClient::Send(const std::string& aIpAddress, int aPort, const std::string& aMessage)
 {
-  CSingleLock lock(critical_section);
+  std::unique_lock<CCriticalSection> lock(critical_section);
 
   struct sockaddr_in addr;
   addr.sin_family = AF_INET;
@@ -111,7 +112,7 @@ bool CUdpClient::Send(const std::string& aIpAddress, int aPort, const std::strin
 
 bool CUdpClient::Send(struct sockaddr_in aAddress, const std::string& aMessage)
 {
-  CSingleLock lock(critical_section);
+  std::unique_lock<CCriticalSection> lock(critical_section);
 
   UdpCommand transmit = {aAddress, aMessage, NULL, 0};
   commands.push_back(transmit);
@@ -121,7 +122,7 @@ bool CUdpClient::Send(struct sockaddr_in aAddress, const std::string& aMessage)
 
 bool CUdpClient::Send(struct sockaddr_in aAddress, unsigned char* pMessage, DWORD dwSize)
 {
-  CSingleLock lock(critical_section);
+  std::unique_lock<CCriticalSection> lock(critical_section);
 
   UdpCommand transmit = {aAddress, "", pMessage, dwSize};
   commands.push_back(transmit);
@@ -211,7 +212,7 @@ bool CUdpClient::DispatchNextCommand()
 {
   UdpCommand command;
   {
-    CSingleLock lock(critical_section);
+    std::unique_lock<CCriticalSection> lock(critical_section);
 
     if (commands.size() <= 0)
       return false;

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 
 #include <limits.h>
+#include <mutex>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -564,7 +565,7 @@ bool CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
 
 bool CWakeOnAccess::FindOrTouchHostEntry(const std::string& hostName, bool upnpMode, WakeUpEntry& result)
 {
-  CSingleLock lock (m_entrylist_protect);
+  std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
 
   bool need_wakeup = false;
 
@@ -604,7 +605,7 @@ bool CWakeOnAccess::FindOrTouchHostEntry(const std::string& hostName, bool upnpM
 
 void CWakeOnAccess::TouchHostEntry(const std::string& hostName, bool upnpMode)
 {
-  CSingleLock lock (m_entrylist_protect);
+  std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
 
   UPnPServer* upnp = upnpMode ? LookupUPnPServer(m_UPnPServers, hostName) : nullptr;
 
@@ -745,7 +746,7 @@ void CWakeOnAccess::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 
   if (success)
   {
-    CSingleLock lock (m_entrylist_protect);
+    std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
 
     SaveMACDiscoveryResult(host, mac);
   }
@@ -786,7 +787,7 @@ std::string CWakeOnAccess::GetSettingFile()
 
 void CWakeOnAccess::OnSettingsLoaded()
 {
-  CSingleLock lock (m_entrylist_protect);
+  std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
 
   LoadFromXML();
 }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -17,7 +17,6 @@
 #include "network/httprequesthandler/IHTTPRequestHandler.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/FileUtils.h"
 #include "utils/Mime.h"
 #include "utils/StringUtils.h"
@@ -27,6 +26,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <utility>
 
@@ -125,7 +125,7 @@ MHD_RESULT CWebServer::AskForAuthentication(const HTTPRequest& request) const
 
 bool CWebServer::IsAuthenticated(const HTTPRequest& request) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!m_authenticationRequired)
     return true;
@@ -1302,7 +1302,7 @@ bool CWebServer::WebServerSupportsSSL()
 
 void CWebServer::SetCredentials(const std::string& username, const std::string& password)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_authenticationUsername = username;
   m_authenticationPassword = password;

--- a/xbmc/network/Zeroconf.cpp
+++ b/xbmc/network/Zeroconf.cpp
@@ -8,6 +8,8 @@
 #include "Zeroconf.h"
 
 #include "ServiceBroker.h"
+
+#include <mutex>
 #if defined(HAS_MDNS)
 #include "mdns/ZeroconfMDNS.h"
 #endif
@@ -15,7 +17,6 @@
 #include "settings/SettingsComponent.h"
 #include "threads/Atomics.h"
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 #include "utils/JobManager.h"
 
 #if defined(TARGET_ANDROID)
@@ -64,7 +65,7 @@ bool CZeroconf::PublishService(const std::string& fcr_identifier,
                                unsigned int f_port,
                                std::vector<std::pair<std::string, std::string> > txt /* = std::vector<std::pair<std::string, std::string> >() */)
 {
-  CSingleLock lock(*mp_crit_sec);
+  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
   CZeroconf::PublishInfo info = {fcr_type, fcr_name, f_port, std::move(txt)};
   std::pair<tServiceMap::const_iterator, bool> ret = m_service_map.insert(std::make_pair(fcr_identifier, info));
   if(!ret.second) //identifier exists
@@ -78,7 +79,7 @@ bool CZeroconf::PublishService(const std::string& fcr_identifier,
 
 bool CZeroconf::RemoveService(const std::string& fcr_identifier)
 {
-  CSingleLock lock(*mp_crit_sec);
+  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
   tServiceMap::iterator it = m_service_map.find(fcr_identifier);
   if(it == m_service_map.end())
     return false;
@@ -105,7 +106,7 @@ bool CZeroconf::HasService(const std::string& fcr_identifier) const
 
 bool CZeroconf::Start()
 {
-  CSingleLock lock(*mp_crit_sec);
+  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
   if(!IsZCdaemonRunning())
   {
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -124,7 +125,7 @@ bool CZeroconf::Start()
 
 void CZeroconf::Stop()
 {
-  CSingleLock lock(*mp_crit_sec);
+  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
   if(!m_started)
     return;
   doStop();

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -34,6 +34,7 @@
 #include "xbmc/interfaces/AnnouncementManager.h"
 
 #include <inttypes.h>
+#include <mutex>
 
 #include <Platinum/Source/Platinum/Platinum.h>
 
@@ -585,12 +586,13 @@ CUPnPRenderer::OnSetNextAVTransportURI(PLT_ActionReference& action)
         if(item->IsVideo())
           playlist = PLAYLIST_VIDEO;
 
-        {   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-            CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlist);
-            CServiceBroker::GetPlaylistPlayer().Add(playlist, item);
+        {
+          std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+          CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlist);
+          CServiceBroker::GetPlaylistPlayer().Add(playlist, item);
 
-            CServiceBroker::GetPlaylistPlayer().SetCurrentSong(-1);
-            CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
+          CServiceBroker::GetPlaylistPlayer().SetCurrentSong(-1);
+          CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
         }
 
         CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);

--- a/xbmc/network/upnp/UPnPSettings.cpp
+++ b/xbmc/network/upnp/UPnPSettings.cpp
@@ -10,11 +10,12 @@
 
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #define XML_UPNP          "upnpserver"
 #define XML_SERVER_UUID   "UUID"
@@ -48,7 +49,7 @@ void CUPnPSettings::OnSettingsUnloaded()
 
 bool CUPnPSettings::Load(const std::string &file)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   Clear();
 
@@ -81,7 +82,7 @@ bool CUPnPSettings::Load(const std::string &file)
 
 bool CUPnPSettings::Save(const std::string &file) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   CXBMCTinyXML doc;
   TiXmlElement xmlRootElement(XML_UPNP);
@@ -101,7 +102,7 @@ bool CUPnPSettings::Save(const std::string &file) const
 
 void CUPnPSettings::Clear()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   m_serverUUID.clear();
   m_serverPort = 0;

--- a/xbmc/peripherals/EventScanner.cpp
+++ b/xbmc/peripherals/EventScanner.cpp
@@ -9,10 +9,10 @@
 #include "EventScanner.h"
 
 #include "IEventScannerCallback.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <algorithm>
+#include <mutex>
 
 using namespace PERIPHERALS;
 
@@ -45,7 +45,7 @@ EventPollHandlePtr CEventScanner::RegisterPollHandle()
   EventPollHandlePtr handle(new CEventPollHandle(*this));
 
   {
-    CSingleLock lock(m_handleMutex);
+    std::unique_lock<CCriticalSection> lock(m_handleMutex);
     m_activeHandles.insert(handle.get());
   }
 
@@ -57,7 +57,7 @@ EventPollHandlePtr CEventScanner::RegisterPollHandle()
 void CEventScanner::Activate(CEventPollHandle& handle)
 {
   {
-    CSingleLock lock(m_handleMutex);
+    std::unique_lock<CCriticalSection> lock(m_handleMutex);
     m_activeHandles.insert(&handle);
   }
 
@@ -67,7 +67,7 @@ void CEventScanner::Activate(CEventPollHandle& handle)
 void CEventScanner::Deactivate(CEventPollHandle& handle)
 {
   {
-    CSingleLock lock(m_handleMutex);
+    std::unique_lock<CCriticalSection> lock(m_handleMutex);
     m_activeHandles.erase(&handle);
   }
 
@@ -78,7 +78,7 @@ void CEventScanner::HandleEvents(bool bWait)
 {
   if (bWait)
   {
-    CSingleLock lock(m_pollMutex);
+    std::unique_lock<CCriticalSection> lock(m_pollMutex);
 
     m_scanFinishedEvent.Reset();
     m_scanEvent.Set();
@@ -93,7 +93,7 @@ void CEventScanner::HandleEvents(bool bWait)
 void CEventScanner::Release(CEventPollHandle& handle)
 {
   {
-    CSingleLock lock(m_handleMutex);
+    std::unique_lock<CCriticalSection> lock(m_handleMutex);
     m_activeHandles.erase(&handle);
   }
 
@@ -105,7 +105,7 @@ EventLockHandlePtr CEventScanner::RegisterLock()
   EventLockHandlePtr handle(new CEventLockHandle(*this));
 
   {
-    CSingleLock lock(m_lockMutex);
+    std::unique_lock<CCriticalSection> lock(m_lockMutex);
     m_activeLocks.insert(handle.get());
   }
 
@@ -117,7 +117,7 @@ EventLockHandlePtr CEventScanner::RegisterLock()
 void CEventScanner::ReleaseLock(CEventLockHandle& handle)
 {
   {
-    CSingleLock lock(m_lockMutex);
+    std::unique_lock<CCriticalSection> lock(m_lockMutex);
     m_activeLocks.erase(&handle);
   }
 
@@ -131,7 +131,7 @@ void CEventScanner::Process()
   while (!m_bStop)
   {
     {
-      CSingleLock lock(m_lockMutex);
+      std::unique_lock<CCriticalSection> lock(m_lockMutex);
       if (m_activeLocks.empty())
         m_callback.ProcessEvents();
     }
@@ -160,7 +160,7 @@ std::chrono::milliseconds CEventScanner::GetScanIntervalMs() const
   bool bHasActiveHandle;
 
   {
-    CSingleLock lock(m_handleMutex);
+    std::unique_lock<CCriticalSection> lock(m_handleMutex);
     bHasActiveHandle = !m_activeHandles.empty();
   }
 

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <mutex>
 #include <vector>
 
 using namespace KODI;
@@ -68,7 +69,7 @@ bool CAddonButtonMap::Load(void)
     CLog::Log(LOGDEBUG, "Failed to load button map for \"{}\"", m_device->Location());
 
   {
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
     m_features = std::move(features);
     m_driverMap = std::move(driverMap);
     m_ignoredPrimitives = CPeripheralAddonTranslator::TranslatePrimitives(ignoredPrimitives);
@@ -85,14 +86,14 @@ void CAddonButtonMap::Reset(void)
 
 bool CAddonButtonMap::IsEmpty(void) const
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   return m_driverMap.empty();
 }
 
 bool CAddonButtonMap::GetFeature(const CDriverPrimitive& primitive, FeatureName& feature)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   DriverMap::const_iterator it = m_driverMap.find(primitive);
   if (it != m_driverMap.end())
@@ -108,7 +109,7 @@ FEATURE_TYPE CAddonButtonMap::GetFeatureType(const FeatureName& feature)
 {
   FEATURE_TYPE type = FEATURE_TYPE::UNKNOWN;
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -121,7 +122,7 @@ bool CAddonButtonMap::GetScalar(const FeatureName& feature, CDriverPrimitive& pr
 {
   bool retVal(false);
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -159,7 +160,7 @@ bool CAddonButtonMap::GetAnalogStick(const FeatureName& feature,
 {
   bool retVal(false);
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -190,7 +191,7 @@ void CAddonButtonMap::AddAnalogStick(const FeatureName& feature,
   kodi::addon::JoystickFeature analogStick(feature, JOYSTICK_FEATURE_TYPE_ANALOG_STICK);
 
   {
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       analogStick = it->second;
@@ -216,7 +217,7 @@ bool CAddonButtonMap::GetRelativePointer(const FeatureName& feature,
 {
   bool retVal(false);
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -247,7 +248,7 @@ void CAddonButtonMap::AddRelativePointer(const FeatureName& feature,
   kodi::addon::JoystickFeature relPointer(feature, JOYSTICK_FEATURE_TYPE_RELPOINTER);
 
   {
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       relPointer = it->second;
@@ -274,7 +275,7 @@ bool CAddonButtonMap::GetAccelerometer(const FeatureName& feature,
 {
   bool retVal(false);
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -322,7 +323,7 @@ bool CAddonButtonMap::GetWheel(const KODI::JOYSTICK::FeatureName& feature,
 {
   bool retVal(false);
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -353,7 +354,7 @@ void CAddonButtonMap::AddWheel(const KODI::JOYSTICK::FeatureName& feature,
   kodi::addon::JoystickFeature joystickFeature(feature, JOYSTICK_FEATURE_TYPE_WHEEL);
 
   {
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       joystickFeature = it->second;
@@ -379,7 +380,7 @@ bool CAddonButtonMap::GetThrottle(const KODI::JOYSTICK::FeatureName& feature,
 {
   bool retVal(false);
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -410,7 +411,7 @@ void CAddonButtonMap::AddThrottle(const KODI::JOYSTICK::FeatureName& feature,
   kodi::addon::JoystickFeature joystickFeature(feature, JOYSTICK_FEATURE_TYPE_THROTTLE);
 
   {
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       joystickFeature = it->second;
@@ -434,7 +435,7 @@ bool CAddonButtonMap::GetKey(const FeatureName& feature, CDriverPrimitive& primi
 {
   bool retVal(false);
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -478,7 +479,7 @@ bool CAddonButtonMap::IsIgnored(const JOYSTICK::CDriverPrimitive& primitive)
 
 bool CAddonButtonMap::GetAxisProperties(unsigned int axisIndex, int& center, unsigned int& range)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   for (const auto& it : m_driverMap)
   {

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <shared_mutex>
 #include <string.h>
 #include <utility>
 
@@ -362,7 +363,7 @@ bool CPeripheralAddon::PerformDeviceScan(PeripheralScanResults& results)
   PERIPHERAL_INFO* pScanResults;
   PERIPHERAL_ERROR retVal;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->perform_device_scan)
     return false;
@@ -411,7 +412,7 @@ bool CPeripheralAddon::ProcessEvents(void)
   if (!m_bProvidesJoysticks)
     return false;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->get_events)
     return false;
@@ -490,7 +491,7 @@ bool CPeripheralAddon::SendRumbleEvent(unsigned int peripheralIndex,
   if (!m_bProvidesJoysticks)
     return false;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->send_event)
     return false;
@@ -510,7 +511,7 @@ bool CPeripheralAddon::GetJoystickProperties(unsigned int index, CPeripheralJoys
   if (!m_bProvidesJoysticks)
     return false;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->get_joystick_info)
     return false;
@@ -542,7 +543,7 @@ bool CPeripheralAddon::GetFeatures(const CPeripheral* device,
   if (!m_bProvidesButtonMaps)
     return false;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->get_features)
     return false;
@@ -589,7 +590,7 @@ bool CPeripheralAddon::MapFeature(const CPeripheral* device,
   if (!m_bProvidesButtonMaps)
     return false;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->map_features)
     return false;
@@ -620,7 +621,7 @@ bool CPeripheralAddon::GetIgnoredPrimitives(const CPeripheral* device, Primitive
   if (!m_bProvidesButtonMaps)
     return false;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->get_ignored_primitives)
     return false;
@@ -661,7 +662,7 @@ bool CPeripheralAddon::SetIgnoredPrimitives(const CPeripheral* device,
   if (!m_bProvidesButtonMaps)
     return false;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->set_ignored_primitives)
     return false;
@@ -693,7 +694,7 @@ void CPeripheralAddon::SaveButtonMap(const CPeripheral* device)
   if (!m_bProvidesButtonMaps)
     return;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->save_button_map)
     return;
@@ -717,7 +718,7 @@ void CPeripheralAddon::RevertButtonMap(const CPeripheral* device)
   if (!m_bProvidesButtonMaps)
     return;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->revert_button_map)
     return;
@@ -761,7 +762,7 @@ void CPeripheralAddon::PowerOffJoystick(unsigned int index)
   if (!SupportsFeature(FEATURE_POWER_OFF))
     return;
 
-  CSharedLock lock(m_dllSection);
+  std::shared_lock<CSharedSection> lock(m_dllSection);
 
   if (!m_ifc.peripheral->toAddon->power_off_joystick)
     return;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -101,7 +101,7 @@ void CPeripheralAddon::ResetProperties(void)
 
 bool CPeripheralAddon::CreateAddon(void)
 {
-  CExclusiveLock lock(m_dllSection);
+  std::unique_lock<CSharedSection> lock(m_dllSection);
 
   // Reset all properties to defaults
   ResetProperties();
@@ -141,7 +141,7 @@ void CPeripheralAddon::DestroyAddon()
   }
 
   {
-    CExclusiveLock lock(m_dllSection);
+    std::unique_lock<CSharedSection> lock(m_dllSection);
     DestroyInstance();
   }
 }

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -16,6 +16,8 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 using namespace PERIPHERALS;
 using namespace std::chrono_literals;
 
@@ -65,7 +67,7 @@ void CPeripheralBus::Clear(void)
     StopThread(true);
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_peripherals.clear();
 }
@@ -75,7 +77,7 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults& resul
   PeripheralVector removedPeripherals;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (int iDevicePtr = (int)m_peripherals.size() - 1; iDevicePtr >= 0; iDevicePtr--)
     {
       const PeripheralPtr& peripheral = m_peripherals.at(iDevicePtr);
@@ -140,7 +142,7 @@ bool CPeripheralBus::ScanForDevices(void)
 bool CPeripheralBus::HasFeature(const PeripheralFeature feature) const
 {
   bool bReturn(false);
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < m_peripherals.size(); iPeripheralPtr++)
   {
     if (m_peripherals.at(iPeripheralPtr)->HasFeature(feature))
@@ -154,7 +156,7 @@ bool CPeripheralBus::HasFeature(const PeripheralFeature feature) const
 
 void CPeripheralBus::GetFeatures(std::vector<PeripheralFeature>& features) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < m_peripherals.size(); iPeripheralPtr++)
     m_peripherals.at(iPeripheralPtr)->GetFeatures(features);
 }
@@ -162,7 +164,7 @@ void CPeripheralBus::GetFeatures(std::vector<PeripheralFeature>& features) const
 PeripheralPtr CPeripheralBus::GetPeripheral(const std::string& strLocation) const
 {
   PeripheralPtr result;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (auto& peripheral : m_peripherals)
   {
     if (peripheral->Location() == strLocation)
@@ -178,7 +180,7 @@ unsigned int CPeripheralBus::GetPeripheralsWithFeature(PeripheralVector& results
                                                        const PeripheralFeature feature) const
 {
   unsigned int iReturn = 0;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (auto& peripheral : m_peripherals)
   {
     if (peripheral->HasFeature(feature))
@@ -195,7 +197,7 @@ unsigned int CPeripheralBus::GetNumberOfPeripheralsWithId(const int iVendorId,
                                                           const int iProductId) const
 {
   unsigned int iReturn = 0;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& peripheral : m_peripherals)
   {
     if (peripheral->VendorId() == iVendorId && peripheral->ProductId() == iProductId)
@@ -232,7 +234,7 @@ void CPeripheralBus::Initialise(void)
 
   if (!IsRunning())
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     bNeedsPolling = m_bNeedsPolling;
   }
 
@@ -252,7 +254,7 @@ void CPeripheralBus::Register(const PeripheralPtr& peripheral)
   bool bPeripheralAdded = false;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (!HasPeripheral(peripheral->Location()))
     {
       m_peripherals.push_back(peripheral);
@@ -276,7 +278,7 @@ void CPeripheralBus::TriggerDeviceScan(void)
   bool bNeedsPolling;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     bNeedsPolling = m_bNeedsPolling;
   }
 
@@ -293,7 +295,7 @@ bool CPeripheralBus::HasPeripheral(const std::string& strLocation) const
 
 void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& items) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& peripheral : m_peripherals)
   {
     if (peripheral->IsHidden())
@@ -329,7 +331,7 @@ PeripheralPtr CPeripheralBus::GetByPath(const std::string& strPath) const
 {
   PeripheralPtr result;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (auto& peripheral : m_peripherals)
   {
     if (StringUtils::EqualsNoCase(strPath, peripheral->FileLocation()))
@@ -344,6 +346,6 @@ PeripheralPtr CPeripheralBus::GetByPath(const std::string& strPath) const
 
 unsigned int CPeripheralBus::GetNumberOfPeripherals() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return static_cast<unsigned int>(m_peripherals.size());
 }

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -12,6 +12,7 @@
 #include "threads/Thread.h"
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 class CFileItemList;
@@ -47,7 +48,7 @@ public:
    */
   bool NeedsPolling(void) const
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     return m_bNeedsPolling;
   }
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 
 using namespace KODI;
 using namespace PERIPHERALS;
@@ -52,7 +53,7 @@ CPeripheralBusAddon::~CPeripheralBusAddon()
 
 bool CPeripheralBusAddon::GetAddonWithButtonMap(PeripheralAddonPtr& addon) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   auto it = std::find_if(m_addons.begin(), m_addons.end(),
                          [](const PeripheralAddonPtr& addon) { return addon->HasButtonMaps(); });
@@ -69,7 +70,7 @@ bool CPeripheralBusAddon::GetAddonWithButtonMap(PeripheralAddonPtr& addon) const
 bool CPeripheralBusAddon::GetAddonWithButtonMap(const CPeripheral* device,
                                                 PeripheralAddonPtr& addon) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // If device is from an add-on, try to use that add-on
   if (device && device->GetBusType() == PERIPHERAL_BUS_ADDON)
@@ -102,7 +103,7 @@ bool CPeripheralBusAddon::PerformDeviceScan(PeripheralScanResults& results)
 {
   PeripheralAddonVector addons;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     addons = m_addons;
   }
 
@@ -159,7 +160,7 @@ void CPeripheralBusAddon::ProcessEvents(void)
   PeripheralAddonVector addons;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     addons = m_addons;
   }
 
@@ -171,7 +172,7 @@ void CPeripheralBusAddon::EnableButtonMapping()
 {
   using namespace ADDON;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   PeripheralAddonPtr dummy;
 
@@ -194,7 +195,7 @@ void CPeripheralBusAddon::PowerOff(const std::string& strLocation)
 
 void CPeripheralBusAddon::UnregisterRemovedDevices(const PeripheralScanResults& results)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   PeripheralVector removedPeripherals;
 
@@ -213,7 +214,7 @@ void CPeripheralBusAddon::Register(const PeripheralPtr& peripheral)
   PeripheralAddonPtr addon;
   unsigned int peripheralIndex;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (SplitLocation(peripheral->Location(), addon, peripheralIndex))
   {
@@ -224,7 +225,7 @@ void CPeripheralBusAddon::Register(const PeripheralPtr& peripheral)
 
 void CPeripheralBusAddon::GetFeatures(std::vector<PeripheralFeature>& features) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& addon : m_addons)
     addon->GetFeatures(features);
 }
@@ -232,7 +233,7 @@ void CPeripheralBusAddon::GetFeatures(std::vector<PeripheralFeature>& features) 
 bool CPeripheralBusAddon::HasFeature(const PeripheralFeature feature) const
 {
   bool bReturn(false);
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& addon : m_addons)
     bReturn = bReturn || addon->HasFeature(feature);
   return bReturn;
@@ -244,7 +245,7 @@ PeripheralPtr CPeripheralBusAddon::GetPeripheral(const std::string& strLocation)
   PeripheralAddonPtr addon;
   unsigned int peripheralIndex;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (SplitLocation(strLocation, addon, peripheralIndex))
     peripheral = addon->GetPeripheral(peripheralIndex);
@@ -256,7 +257,7 @@ PeripheralPtr CPeripheralBusAddon::GetByPath(const std::string& strPath) const
 {
   PeripheralPtr result;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& addon : m_addons)
   {
@@ -275,7 +276,7 @@ bool CPeripheralBusAddon::SupportsFeature(PeripheralFeature feature) const
 {
   bool bSupportsFeature = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& addon : m_addons)
     bSupportsFeature |= addon->SupportsFeature(feature);
 
@@ -286,7 +287,7 @@ unsigned int CPeripheralBusAddon::GetPeripheralsWithFeature(PeripheralVector& re
                                                             const PeripheralFeature feature) const
 {
   unsigned int iReturn = 0;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& addon : m_addons)
     iReturn += addon->GetPeripheralsWithFeature(results, feature);
   return iReturn;
@@ -295,7 +296,7 @@ unsigned int CPeripheralBusAddon::GetPeripheralsWithFeature(PeripheralVector& re
 unsigned int CPeripheralBusAddon::GetNumberOfPeripherals(void) const
 {
   unsigned int iReturn = 0;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& addon : m_addons)
     iReturn += addon->GetNumberOfPeripherals();
   return iReturn;
@@ -305,7 +306,7 @@ unsigned int CPeripheralBusAddon::GetNumberOfPeripheralsWithId(const int iVendor
                                                                const int iProductId) const
 {
   unsigned int iReturn = 0;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& addon : m_addons)
     iReturn += addon->GetNumberOfPeripheralsWithId(iVendorId, iProductId);
   return iReturn;
@@ -313,7 +314,7 @@ unsigned int CPeripheralBusAddon::GetNumberOfPeripheralsWithId(const int iVendor
 
 void CPeripheralBusAddon::GetDirectory(const std::string& strPath, CFileItemList& items) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& addon : m_addons)
     addon->GetDirectory(strPath, items);
 }
@@ -346,7 +347,7 @@ bool CPeripheralBusAddon::SplitLocation(const std::string& strLocation,
   {
     addon.reset();
 
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     const std::string& strAddonId = parts[0];
     for (const auto& addonIt : m_addons)
@@ -389,7 +390,7 @@ void CPeripheralBusAddon::UpdateAddons(void)
   std::transform(newAddons.begin(), newAddons.end(), std::inserter(newIds, newIds.end()),
                  GetAddonID);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // Get current add-ons
   std::transform(m_addons.begin(), m_addons.end(), std::inserter(currentIds, currentIds.end()),

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -18,11 +18,12 @@
 #include "input/remote/IRRemote.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pictures/GUIWindowSlideShow.h"
-#include "threads/SingleLock.h"
 #include "utils/JobManager.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "xbmc/interfaces/AnnouncementManager.h"
+
+#include <mutex>
 
 #include <libcec/cec.h>
 
@@ -70,7 +71,7 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(CPeripherals& manager,
 CPeripheralCecAdapter::~CPeripheralCecAdapter(void)
 {
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
     m_bStop = true;
   }
@@ -132,7 +133,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   if (flag == ANNOUNCEMENT::System && sender == CAnnouncementManager::ANNOUNCEMENT_SENDER &&
       message == "OnQuit" && m_bIsReady)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_iExitCode = static_cast<int>(data["exitcode"].asInteger(EXITCODE_QUIT));
     CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
     StopThread(false);
@@ -172,7 +173,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   {
     // this will also power off devices when we're the active source
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       m_bGoingToStandby = true;
     }
     StopThread();
@@ -185,7 +186,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
     {
       bool bActivate(false);
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         bActivate = m_bActiveSourceBeforeStandby;
         m_bActiveSourceBeforeStandby = false;
       }
@@ -196,7 +197,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   else if (flag == ANNOUNCEMENT::Player && sender == CAnnouncementManager::ANNOUNCEMENT_SENDER &&
            message == "OnStop")
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_preventActivateSourceOnPlay = CDateTime::GetCurrentDateTime();
     m_bOnPlayReceived = false;
   }
@@ -206,7 +207,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
     // activate the source when playback started, and the option is enabled
     bool bActivateSource(false);
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       bActivateSource = (m_configuration.bActivateSource && !m_bOnPlayReceived &&
                          !m_cecAdapter->IsLibCECActiveSource() &&
                          (!m_preventActivateSourceOnPlay.IsValid() ||
@@ -340,7 +341,7 @@ bool CPeripheralCecAdapter::OpenConnection(void)
     if (m_cecAdapter->GetCurrentConfiguration(&config))
     {
       // update the local configuration
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       SetConfigurationFromLibCEC(config);
     }
   }
@@ -354,7 +355,7 @@ void CPeripheralCecAdapter::Process(void)
     return;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_iExitCode = EXITCODE_QUIT;
     m_bGoingToStandby = false;
     m_bIsRunning = true;
@@ -385,7 +386,7 @@ void CPeripheralCecAdapter::Process(void)
 
   bool bSendStandbyCommands(false);
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     bSendStandbyCommands = m_iExitCode != EXITCODE_REBOOT && m_iExitCode != EXITCODE_RESTARTAPP &&
                            !m_bDeviceRemoved &&
                            (!m_bGoingToStandby || GetSettingBool("standby_tv_on_pc_standby")) &&
@@ -423,7 +424,7 @@ void CPeripheralCecAdapter::Process(void)
   CLog::Log(LOGDEBUG, "{} - CEC adapter processor thread ended", __FUNCTION__);
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_bStarted = false;
     m_bIsRunning = false;
   }
@@ -431,13 +432,13 @@ void CPeripheralCecAdapter::Process(void)
 
 bool CPeripheralCecAdapter::HasAudioControl(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bHasConnectedAudioSystem;
 }
 
 void CPeripheralCecAdapter::SetAudioSystemConnected(bool bSetTo)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bHasConnectedAudioSystem = bSetTo;
 }
 
@@ -446,7 +447,7 @@ void CPeripheralCecAdapter::ProcessVolumeChange(void)
   bool bSendRelease(false);
   CecVolumeChange pendingVolumeChange = VOLUME_CHANGE_NONE;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     auto now = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastKeypress);
     if (!m_volumeChangeQueue.empty())
@@ -498,7 +499,7 @@ void CPeripheralCecAdapter::ProcessVolumeChange(void)
     case VOLUME_CHANGE_MUTE:
       m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_MUTE, false);
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         m_bIsMuted = !m_bIsMuted;
       }
       break;
@@ -513,7 +514,7 @@ void CPeripheralCecAdapter::VolumeUp(void)
 {
   if (HasAudioControl())
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_volumeChangeQueue.push(VOLUME_CHANGE_UP);
   }
 }
@@ -522,7 +523,7 @@ void CPeripheralCecAdapter::VolumeDown(void)
 {
   if (HasAudioControl())
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_volumeChangeQueue.push(VOLUME_CHANGE_DOWN);
   }
 }
@@ -531,7 +532,7 @@ void CPeripheralCecAdapter::ToggleMute(void)
 {
   if (HasAudioControl())
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_volumeChangeQueue.push(VOLUME_CHANGE_MUTE);
   }
 }
@@ -540,7 +541,7 @@ bool CPeripheralCecAdapter::IsMuted(void)
 {
   if (HasAudioControl())
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     return m_bIsMuted;
   }
   return false;
@@ -721,7 +722,7 @@ void CPeripheralCecAdapter::CecConfiguration(void* cbParam, const libcec_configu
   if (!adapter)
     return;
 
-  CSingleLock lock(adapter->m_critSection);
+  std::unique_lock<CCriticalSection> lock(adapter->m_critSection);
   adapter->SetConfigurationFromLibCEC(*config);
 }
 
@@ -786,7 +787,7 @@ void CPeripheralCecAdapter::CecKeyPress(void* cbParam, const cec_keypress* key)
 
 void CPeripheralCecAdapter::GetNextKey(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bHasButton = false;
   if (m_bIsReady)
   {
@@ -805,7 +806,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress& key)
   CLog::Log(LOGDEBUG, "{} - received key {:2x} duration {}", __FUNCTION__, key.iButton,
             key.iDuration);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   // avoid the queue getting too long
   if (m_configuration.iButtonRepeatRateMs && m_buttonQueue.size() > 5)
     return;
@@ -1122,7 +1123,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress& key)
 
 int CPeripheralCecAdapter::GetButton(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!m_bHasButton)
     GetNextKey();
 
@@ -1131,7 +1132,7 @@ int CPeripheralCecAdapter::GetButton(void)
 
 unsigned int CPeripheralCecAdapter::GetHoldTime(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!m_bHasButton)
     GetNextKey();
 
@@ -1140,7 +1141,7 @@ unsigned int CPeripheralCecAdapter::GetHoldTime(void)
 
 void CPeripheralCecAdapter::ResetButton(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bHasButton = false;
 
   // wait for the key release if the duration isn't 0
@@ -1522,7 +1523,7 @@ void CPeripheralCecAdapterUpdateThread::Signal(void)
 
 bool CPeripheralCecAdapterUpdateThread::UpdateConfiguration(libcec_configuration* configuration)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!configuration)
     return false;
 
@@ -1642,14 +1643,14 @@ bool CPeripheralCecAdapterUpdateThread::SetInitialConfiguration(void)
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000),
                                         strNotification);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bIsUpdating = false;
   return true;
 }
 
 bool CPeripheralCecAdapter::IsRunning(void) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bIsRunning;
 }
 
@@ -1671,7 +1672,7 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
       // set the new configuration
       libcec_configuration configuration;
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         configuration = m_configuration;
         m_bIsUpdating = false;
       }
@@ -1691,7 +1692,7 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
                                             g_localizeStrings.Get(bConfigSet ? 36023 : 36024));
 
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         if ((bUpdate = m_bNextConfigurationScheduled) == true)
         {
           // another update is scheduled
@@ -1711,7 +1712,7 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
 
 void CPeripheralCecAdapter::OnDeviceRemoved(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bDeviceRemoved = true;
 }
 
@@ -1743,7 +1744,7 @@ bool CPeripheralCecAdapter::ReopenConnection(bool bAsync /* = false */)
 
   // stop running thread
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_iExitCode = EXITCODE_RESTARTAPP;
     CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
     StopThread(false);
@@ -1759,7 +1760,7 @@ bool CPeripheralCecAdapter::ReopenConnection(bool bAsync /* = false */)
 
 void CPeripheralCecAdapter::ActivateSource(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bActiveSourcePending = true;
 }
 
@@ -1768,7 +1769,7 @@ void CPeripheralCecAdapter::ProcessActivateSource(void)
   bool bActivate(false);
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     bActivate = m_bActiveSourcePending;
     m_bActiveSourcePending = false;
   }
@@ -1779,7 +1780,7 @@ void CPeripheralCecAdapter::ProcessActivateSource(void)
 
 void CPeripheralCecAdapter::StandbyDevices(void)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bStandbyPending = true;
 }
 
@@ -1788,7 +1789,7 @@ void CPeripheralCecAdapter::ProcessStandbyDevices(void)
   bool bStandby(false);
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     bStandby = m_bStandbyPending;
     m_bStandbyPending = false;
     if (bStandby)

--- a/xbmc/peripherals/devices/PeripheralKeyboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.cpp
@@ -10,8 +10,8 @@
 
 #include "input/InputManager.h"
 #include "peripherals/Peripherals.h"
-#include "threads/SingleLock.h"
 
+#include <mutex>
 #include <sstream>
 
 using namespace KODI;
@@ -57,7 +57,7 @@ bool CPeripheralKeyboard::InitialiseFeature(const PeripheralFeature feature)
 void CPeripheralKeyboard::RegisterKeyboardDriverHandler(
     KODI::KEYBOARD::IKeyboardDriverHandler* handler, bool bPromiscuous)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   KeyboardHandle handle{handler, bPromiscuous};
   m_keyboardHandlers.insert(m_keyboardHandlers.begin(), handle);
@@ -66,7 +66,7 @@ void CPeripheralKeyboard::RegisterKeyboardDriverHandler(
 void CPeripheralKeyboard::UnregisterKeyboardDriverHandler(
     KODI::KEYBOARD::IKeyboardDriverHandler* handler)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   auto it =
       std::find_if(m_keyboardHandlers.begin(), m_keyboardHandlers.end(),
@@ -80,7 +80,7 @@ bool CPeripheralKeyboard::OnKeyPress(const CKey& key)
 {
   m_lastActive = CDateTime::GetCurrentDateTime();
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   bool bHandled = false;
 
@@ -107,7 +107,7 @@ bool CPeripheralKeyboard::OnKeyPress(const CKey& key)
 
 void CPeripheralKeyboard::OnKeyRelease(const CKey& key)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   for (const KeyboardHandle& handle : m_keyboardHandlers)
     handle.handler->OnKeyRelease(key);

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -10,8 +10,8 @@
 
 #include "input/InputManager.h"
 #include "peripherals/Peripherals.h"
-#include "threads/SingleLock.h"
 
+#include <mutex>
 #include <sstream>
 
 using namespace KODI;
@@ -53,7 +53,7 @@ void CPeripheralMouse::RegisterMouseDriverHandler(MOUSE::IMouseDriverHandler* ha
 {
   using namespace KEYBOARD;
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   MouseHandle handle{handler, bPromiscuous};
   m_mouseHandlers.insert(m_mouseHandlers.begin(), handle);
@@ -61,7 +61,7 @@ void CPeripheralMouse::RegisterMouseDriverHandler(MOUSE::IMouseDriverHandler* ha
 
 void CPeripheralMouse::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* handler)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   auto it =
       std::find_if(m_mouseHandlers.begin(), m_mouseHandlers.end(),
@@ -73,7 +73,7 @@ void CPeripheralMouse::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* 
 
 bool CPeripheralMouse::OnPosition(int x, int y)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   bool bHandled = false;
 
@@ -105,7 +105,7 @@ bool CPeripheralMouse::OnButtonPress(MOUSE::BUTTON_ID button)
 {
   m_lastActive = CDateTime::GetCurrentDateTime();
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   bool bHandled = false;
 
@@ -132,7 +132,7 @@ bool CPeripheralMouse::OnButtonPress(MOUSE::BUTTON_ID button)
 
 void CPeripheralMouse::OnButtonRelease(MOUSE::BUTTON_ID button)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   for (const MouseHandle& handle : m_mouseHandlers)
     handle.handler->OnButtonRelease(button);

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -18,8 +18,9 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/dialogs/GUIDialogPeripheralSettings.h"
-#include "threads/SingleLock.h"
 #include "utils/Variant.h"
+
+#include <mutex>
 
 using namespace KODI;
 using namespace PERIPHERALS;
@@ -57,7 +58,7 @@ CFileItemPtr CGUIDialogPeripherals::GetItem(unsigned int pos) const
 {
   CFileItemPtr item;
 
-  CSingleLock lock(m_peripheralsMutex);
+  std::unique_lock<CCriticalSection> lock(m_peripheralsMutex);
 
   if (static_cast<int>(pos) < m_peripherals.Size())
     item = m_peripherals[pos];
@@ -162,7 +163,7 @@ void CGUIDialogPeripherals::UpdatePeripheralsSync()
 {
   int iPos = GetSelectedItem();
 
-  CSingleLock lock(m_peripheralsMutex);
+  std::unique_lock<CCriticalSection> lock(m_peripheralsMutex);
 
   CFileItemPtr selectedItem;
   if (iPos > 0)

--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -14,6 +14,8 @@
 
 #include "platform/android/activity/XBMCApp.h"
 
+#include <mutex>
+
 #include <androidjni/ConnectivityManager.h>
 #include <androidjni/InetAddress.h>
 #include <androidjni/LinkAddress.h>
@@ -259,13 +261,13 @@ bool CNetworkAndroid::GetHostName(std::string& hostname)
 
 std::vector<CNetworkInterface*>& CNetworkAndroid::GetInterfaceList()
 {
-  CSingleLock lock(m_refreshMutex);
+  std::unique_lock<CCriticalSection> lock(m_refreshMutex);
   return m_interfaces;
 }
 
 CNetworkInterface* CNetworkAndroid::GetFirstConnectedInterface()
 {
-  CSingleLock lock(m_refreshMutex);
+  std::unique_lock<CCriticalSection> lock(m_refreshMutex);
 
   for(CNetworkInterface* intf : m_interfaces)
   {
@@ -311,7 +313,7 @@ bool CNetworkAndroid::PingHost(unsigned long remote_ip, unsigned int timeout_ms)
 
 void CNetworkAndroid::RetrieveInterfaces()
 {
-  CSingleLock lock(m_refreshMutex);
+  std::unique_lock<CCriticalSection> lock(m_refreshMutex);
 
   // Cannot delete interfaces here, as there still might have references to it
   for (auto intf : m_oldInterfaces)

--- a/xbmc/platform/android/network/ZeroconfAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfAndroid.cpp
@@ -8,8 +8,9 @@
 
 #include "ZeroconfAndroid.h"
 
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #include <androidjni/Context.h>
 
@@ -43,7 +44,7 @@ bool CZeroconfAndroid::doPublishService(const std::string& fcr_identifier, const
 
   m_manager.registerService(newService.serviceInfo, 1 /* PROTOCOL_DNS_SD */, newService.registrationListener);
 
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   newService.updateNumber = 0;
   m_services.insert(make_pair(fcr_identifier, newService));
 
@@ -53,7 +54,7 @@ bool CZeroconfAndroid::doPublishService(const std::string& fcr_identifier, const
 bool CZeroconfAndroid::doForceReAnnounceService(const std::string& fcr_identifier)
 {
   bool ret = false;
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_identifier);
   if(it != m_services.end())
   {
@@ -75,7 +76,7 @@ bool CZeroconfAndroid::doForceReAnnounceService(const std::string& fcr_identifie
 
 bool CZeroconfAndroid::doRemoveService(const std::string& fcr_ident)
 {
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_ident);
   if(it != m_services.end())
   {
@@ -91,7 +92,7 @@ bool CZeroconfAndroid::doRemoveService(const std::string& fcr_ident)
 void CZeroconfAndroid::doStop()
 {
   {
-    CSingleLock lock(m_data_guard);
+    std::unique_lock<CCriticalSection> lock(m_data_guard);
     CLog::Log(LOGDEBUG, "ZeroconfAndroid: Shutdown services");
     for (const auto& it : m_services)
     {

--- a/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
@@ -14,8 +14,9 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "network/DNSNameCache.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #include <androidjni/Context.h>
 #include <androidjni/jutils-details.hpp>
@@ -27,7 +28,7 @@ CZeroconfBrowserAndroid::CZeroconfBrowserAndroid()
 
 CZeroconfBrowserAndroid::~CZeroconfBrowserAndroid()
 {
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   //make sure there are no browsers anymore
   for (const auto& it : m_service_browsers)
     doRemoveServiceType(it.first);
@@ -47,7 +48,7 @@ bool CZeroconfBrowserAndroid::doAddServiceType(const std::string& fcr_service_ty
 
   //store the browser
   {
-    CSingleLock lock(m_data_guard);
+    std::unique_lock<CCriticalSection> lock(m_data_guard);
     m_service_browsers.insert(std::make_pair(fcr_service_type, discover));
   }
   return true;
@@ -60,7 +61,7 @@ bool CZeroconfBrowserAndroid::doRemoveServiceType(const std::string& fcr_service
   CZeroconfBrowserAndroidDiscover* discover;
   //search for this browser and remove it from the map
   {
-    CSingleLock lock(m_data_guard);
+    std::unique_lock<CCriticalSection> lock(m_data_guard);
     tBrowserMap::iterator it = m_service_browsers.find(fcr_service_type);
     if(it == m_service_browsers.end())
     {
@@ -75,7 +76,7 @@ bool CZeroconfBrowserAndroid::doRemoveServiceType(const std::string& fcr_service
 
   //remove the services of this browser
   {
-    CSingleLock lock(m_data_guard);
+    std::unique_lock<CCriticalSection> lock(m_data_guard);
     tDiscoveredServicesMap::iterator it = m_discovered_services.find(discover);
     if(it != m_discovered_services.end())
       m_discovered_services.erase(it);
@@ -88,7 +89,7 @@ bool CZeroconfBrowserAndroid::doRemoveServiceType(const std::string& fcr_service
 std::vector<CZeroconfBrowser::ZeroconfService> CZeroconfBrowserAndroid::doGetFoundServices()
 {
   std::vector<CZeroconfBrowser::ZeroconfService> ret;
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   for (const auto& it : m_discovered_services)
   {
     const auto& services = it.second;
@@ -149,7 +150,7 @@ bool CZeroconfBrowserAndroid::doResolveService(CZeroconfBrowser::ZeroconfService
 /// adds the service to list of found services
 void CZeroconfBrowserAndroid::addDiscoveredService(CZeroconfBrowserAndroidDiscover* browser, CZeroconfBrowser::ZeroconfService const& fcr_service)
 {
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   if(browserIt == m_discovered_services.end())
   {
@@ -172,7 +173,7 @@ void CZeroconfBrowserAndroid::addDiscoveredService(CZeroconfBrowserAndroidDiscov
 
 void CZeroconfBrowserAndroid::removeDiscoveredService(CZeroconfBrowserAndroidDiscover* browser, CZeroconfBrowser::ZeroconfService const& fcr_service)
 {
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   //search this service
   std::vector<std::pair<ZeroconfService, unsigned int> >& services = browserIt->second;

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -9,11 +9,11 @@
 #include "AndroidJoystickState.h"
 
 #include "AndroidJoystickTranslator.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
+#include <mutex>
 #include <utility>
 
 #include <android/input.h>
@@ -269,7 +269,7 @@ void CAndroidJoystickState::GetEvents(std::vector<kodi::addon::PeripheralEvent>&
 
 void CAndroidJoystickState::GetButtonEvents(std::vector<kodi::addon::PeripheralEvent>& events)
 {
-  CSingleLock lock(m_eventMutex);
+  std::unique_lock<CCriticalSection> lock(m_eventMutex);
 
   // Only report a single event per button (avoids dropping rapid presses)
   std::vector<kodi::addon::PeripheralEvent> repeatButtons;
@@ -304,7 +304,7 @@ bool CAndroidJoystickState::SetButtonValue(int axisId, JOYSTICK_STATE_BUTTON but
   if (!GetAxesIndex({ axisId }, m_buttons, buttonIndex) || buttonIndex >= GetButtonCount())
     return false;
 
-  CSingleLock lock(m_eventMutex);
+  std::unique_lock<CCriticalSection> lock(m_eventMutex);
 
   m_digitalEvents.emplace_back(m_deviceId, buttonIndex, buttonValue);
 

--- a/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
+++ b/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
@@ -8,10 +8,10 @@
 
 #include "ZeroconfDarwin.h"
 
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <inttypes.h>
+#include <mutex>
 #include <sstream>
 #include <string>
 
@@ -102,7 +102,7 @@ bool CZeroconfDarwin::doPublishService(const std::string& fcr_identifier,
               (int)error.domain, (int64_t)error.error);
   } else
   {
-    CSingleLock lock(m_data_guard);
+    std::unique_lock<CCriticalSection> lock(m_data_guard);
     m_services.insert(make_pair(fcr_identifier, netService));
   }
 
@@ -112,7 +112,7 @@ bool CZeroconfDarwin::doPublishService(const std::string& fcr_identifier,
 bool CZeroconfDarwin::doForceReAnnounceService(const std::string& fcr_identifier)
 {
   bool ret = false;
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_identifier);
   if(it != m_services.end())
   {
@@ -137,7 +137,7 @@ bool CZeroconfDarwin::doForceReAnnounceService(const std::string& fcr_identifier
 
 bool CZeroconfDarwin::doRemoveService(const std::string& fcr_ident)
 {
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_ident);
   if(it != m_services.end())
   {
@@ -150,7 +150,7 @@ bool CZeroconfDarwin::doRemoveService(const std::string& fcr_ident)
 
 void CZeroconfDarwin::doStop()
 {
-  CSingleLock lock(m_data_guard);
+  std::unique_lock<CCriticalSection> lock(m_data_guard);
   for (const auto& it : m_services)
     cancelRegistration(it.second);
   m_services.clear();
@@ -175,7 +175,7 @@ void CZeroconfDarwin::registerCallback(CFNetServiceRef theService, CFStreamError
     }
     p_this->cancelRegistration(theService);
     //remove it
-    CSingleLock lock(p_this->m_data_guard);
+    std::unique_lock<CCriticalSection> lock(p_this->m_data_guard);
     for (tServiceMap::iterator it = p_this->m_services.begin(); it != p_this->m_services.end();
          ++it)
     {

--- a/xbmc/platform/darwin/peripherals/PeripheralBusGCController.mm
+++ b/xbmc/platform/darwin/peripherals/PeripheralBusGCController.mm
@@ -13,11 +13,12 @@
 #include "peripherals/bus/PeripheralBus.h"
 #include "peripherals/devices/PeripheralJoystick.h"
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include "platform/darwin/peripherals/InputKey.h"
 #import "platform/darwin/peripherals/PeripheralBusGCControllerManager.h"
+
+#include <mutex>
 
 #define JOYSTICK_PROVIDER_DARWIN_GCController "GCController"
 
@@ -114,7 +115,7 @@ void PERIPHERALS::CPeripheralBusGCController::Initialise(void)
 
 bool PERIPHERALS::CPeripheralBusGCController::PerformDeviceScan(PeripheralScanResults& results)
 {
-  CSingleLock lock(m_critSectionResults);
+  std::unique_lock<CCriticalSection> lock(m_critSectionResults);
   results = m_scanResults;
 
   return true;
@@ -123,14 +124,14 @@ bool PERIPHERALS::CPeripheralBusGCController::PerformDeviceScan(PeripheralScanRe
 void PERIPHERALS::CPeripheralBusGCController::SetScanResults(
     const PERIPHERALS::PeripheralScanResults& resScanResults)
 {
-  CSingleLock lock(m_critSectionResults);
+  std::unique_lock<CCriticalSection> lock(m_critSectionResults);
   m_scanResults = resScanResults;
 }
 
 void PERIPHERALS::CPeripheralBusGCController::GetEvents(
     std::vector<kodi::addon::PeripheralEvent>& events)
 {
-  CSingleLock lock(m_critSectionStates);
+  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
   std::vector<kodi::addon::PeripheralEvent> digitalEvents;
   digitalEvents = [m_peripheralGCController->callbackClass GetButtonEvents];
 
@@ -162,7 +163,7 @@ void PERIPHERALS::CPeripheralBusGCController::ProcessEvents()
 {
   std::vector<kodi::addon::PeripheralEvent> events;
   {
-    CSingleLock lock(m_critSectionStates);
+    std::unique_lock<CCriticalSection> lock(m_critSectionStates);
 
     //! @todo Multiple controller event processing
     GetEvents(events);
@@ -193,7 +194,7 @@ void PERIPHERALS::CPeripheralBusGCController::ProcessEvents()
     }
   }
   {
-    CSingleLock lock(m_critSectionStates);
+    std::unique_lock<CCriticalSection> lock(m_critSectionStates);
     //! @todo Multiple controller handling
     PeripheralPtr device = GetPeripheral(GetDeviceLocation(0));
 

--- a/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
+++ b/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
@@ -9,13 +9,14 @@
 #import "PeripheralBusGCControllerManager.h"
 
 #include "peripherals/PeripheralTypes.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include "platform/darwin/peripherals/InputKey.h"
 #import "platform/darwin/peripherals/Input_Gamecontroller.h"
 #include "platform/darwin/peripherals/PeripheralBusGCController.h"
+
+#include <mutex>
 
 #pragma mark - objc implementation
 
@@ -65,14 +66,14 @@
 
 - (void)SetDigitalEvent:(kodi::addon::PeripheralEvent)event
 {
-  CSingleLock lock(m_eventMutex);
+  std::unique_lock<CCriticalSection> lock(m_eventMutex);
 
   m_digitalEvents.emplace_back(event);
 }
 
 - (void)SetAxisEvent:(kodi::addon::PeripheralEvent)event
 {
-  CSingleLock lock(m_eventMutex);
+  std::unique_lock<CCriticalSection> lock(m_eventMutex);
 
   m_axisEvents.emplace_back(event);
 }
@@ -82,7 +83,7 @@
 - (std::vector<kodi::addon::PeripheralEvent>)GetAxisEvents
 {
   std::vector<kodi::addon::PeripheralEvent> events;
-  CSingleLock lock(m_eventMutex);
+  std::unique_lock<CCriticalSection> lock(m_eventMutex);
 
   for (unsigned int i = 0; i < m_axisEvents.size(); i++)
     events.emplace_back(m_axisEvents[i]);
@@ -96,7 +97,7 @@
 {
   std::vector<kodi::addon::PeripheralEvent> events;
 
-  CSingleLock lock(m_eventMutex);
+  std::unique_lock<CCriticalSection> lock(m_eventMutex);
   // Only report a single event per button (avoids dropping rapid presses)
   std::vector<kodi::addon::PeripheralEvent> repeatButtons;
 

--- a/xbmc/platform/linux/FDEventMonitor.cpp
+++ b/xbmc/platform/linux/FDEventMonitor.cpp
@@ -118,7 +118,7 @@ void CFDEventMonitor::Process()
      * wake up poll and wait for the processing to pause at
      * the above lock(m_mutex).
      */
-    lock.Leave();
+    lock.unlock();
 
     int err = poll(&m_pollDescs[0], m_pollDescs.size(), -1);
 

--- a/xbmc/platform/linux/FDEventMonitor.cpp
+++ b/xbmc/platform/linux/FDEventMonitor.cpp
@@ -8,9 +8,11 @@
 
 #include "FDEventMonitor.h"
 
+#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <errno.h>
+#include <mutex>
 
 #include <poll.h>
 #include <sys/eventfd.h>
@@ -22,7 +24,7 @@ CFDEventMonitor::CFDEventMonitor() :
 
 CFDEventMonitor::~CFDEventMonitor()
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
   InterruptPoll();
 
   if (m_wakeupfd >= 0)
@@ -45,7 +47,7 @@ CFDEventMonitor::~CFDEventMonitor()
 
 void CFDEventMonitor::AddFD(const MonitoredFD& monitoredFD, int& id)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
   InterruptPoll();
 
   AddFDLocked(monitoredFD, id);
@@ -56,7 +58,7 @@ void CFDEventMonitor::AddFD(const MonitoredFD& monitoredFD, int& id)
 void CFDEventMonitor::AddFDs(const std::vector<MonitoredFD>& monitoredFDs,
                              std::vector<int>& ids)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
   InterruptPoll();
 
   for (unsigned int i = 0; i < monitoredFDs.size(); ++i)
@@ -71,7 +73,7 @@ void CFDEventMonitor::AddFDs(const std::vector<MonitoredFD>& monitoredFDs,
 
 void CFDEventMonitor::RemoveFD(int id)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
   InterruptPoll();
 
   if (m_monitoredFDs.erase(id) != 1)
@@ -85,7 +87,7 @@ void CFDEventMonitor::RemoveFD(int id)
 
 void CFDEventMonitor::RemoveFDs(const std::vector<int>& ids)
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
   InterruptPoll();
 
   for (unsigned int i = 0; i < ids.size(); ++i)
@@ -108,8 +110,8 @@ void CFDEventMonitor::Process()
 
   while (!m_bStop)
   {
-    CSingleLock lock(m_mutex);
-    CSingleLock pollLock(m_pollMutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock<CCriticalSection> pollLock(m_pollMutex);
 
     /*
      * Leave the main mutex here to allow another thread to
@@ -233,6 +235,6 @@ void CFDEventMonitor::InterruptPoll()
   {
     eventfd_write(m_wakeupfd, 1);
     /* wait for the poll() result handling (if any) to end */
-    CSingleLock pollLock(m_pollMutex);
+    std::unique_lock<CCriticalSection> pollLock(m_pollMutex);
   }
 }

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -14,7 +14,10 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #include <fcntl.h>
 #include <lirc/lirc_client.h>
@@ -30,7 +33,7 @@ CLirc::CLirc() : CThread("Lirc")
 CLirc::~CLirc()
 {
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (m_fd > 0)
       shutdown(m_fd, SHUT_RDWR);
   }
@@ -67,7 +70,7 @@ void CLirc::Process()
   while (!m_bStop)
   {
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       // lirc_client is buggy because it does not close socket, if connect fails
       // work around by checking if daemon is running before calling lirc_init

--- a/xbmc/platform/posix/XHandle.cpp
+++ b/xbmc/platform/posix/XHandle.cpp
@@ -8,10 +8,10 @@
 
 #include "XHandle.h"
 
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <cassert>
+#include <mutex>
 
 int CXHandle::m_objectTracker[10] = {};
 
@@ -124,7 +124,7 @@ bool CloseHandle(HANDLE hObject) {
 
   bool bDelete = false;
   {
-    CSingleLock lock((*hObject->m_internalLock));
+    std::unique_lock<CCriticalSection> lock((*hObject->m_internalLock));
     if (--hObject->m_nRefCount == 0)
       bDelete = true;
   }

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -27,13 +27,14 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
 #include "platform/posix/filesystem/SMBWSDiscovery.h"
+
+#include <mutex>
 
 #include <libsmbclient.h>
 
@@ -60,7 +61,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   // We accept smb://[[[domain;]user[:password@]]server[/share[/path[/file]]]]
 
   /* samba isn't thread safe with old interface, always lock */
-  CSingleLock lock(smb);
+  std::unique_lock<CCriticalSection> lock(smb);
 
   smb.Init();
 
@@ -274,7 +275,8 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
 
   CLog::LogFC(LOGDEBUG, LOGSAMBA, "Using authentication url {}", CURL::GetRedacted(s));
 
-  { CSingleLock lock(smb);
+  {
+    std::unique_lock<CCriticalSection> lock(smb);
     if (!smb.IsSmbValid())
       return -1;
     fd = smbc_opendir(s.c_str());
@@ -315,7 +317,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
 
 bool CSMBDirectory::Create(const CURL& url2)
 {
-  CSingleLock lock(smb);
+  std::unique_lock<CCriticalSection> lock(smb);
   smb.Init();
 
   CURL url = CSMB::GetResolvedUrl(url2);
@@ -332,7 +334,7 @@ bool CSMBDirectory::Create(const CURL& url2)
 
 bool CSMBDirectory::Remove(const CURL& url2)
 {
-  CSingleLock lock(smb);
+  std::unique_lock<CCriticalSection> lock(smb);
   smb.Init();
 
   CURL url = CSMB::GetResolvedUrl(url2);
@@ -352,7 +354,7 @@ bool CSMBDirectory::Remove(const CURL& url2)
 
 bool CSMBDirectory::Exists(const CURL& url2)
 {
-  CSingleLock lock(smb);
+  std::unique_lock<CCriticalSection> lock(smb);
   smb.Init();
 
   CURL url = CSMB::GetResolvedUrl(url2);

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -68,7 +68,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   std::string strRoot = url.Get();
   std::string strAuth;
 
-  lock.Leave(); // OpenDir is locked
+  lock.unlock(); // OpenDir is locked
 
   // if url provided does not having anything except smb protocol
   // Do a WS-Discovery search to find possible smb servers to mimic smbv1 behaviour
@@ -110,7 +110,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   std::vector<CachedDirEntry> vecEntries;
   struct smbc_dirent* dirEnt;
 
-  lock.Enter();
+  lock.lock();
   if (!smb.IsSmbValid())
     return false;
   while ((dirEnt = smbc_readdir(fd)))
@@ -121,7 +121,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     vecEntries.push_back(aDir);
   }
   smbc_closedir(fd);
-  lock.Leave();
+  lock.unlock();
 
   for (size_t i=0; i<vecEntries.size(); i++)
   {
@@ -158,7 +158,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
           // make sure we use the authenticated path which contains any default username
           const std::string strFullName = strAuth + smb.URLEncode(strFile);
 
-          lock.Enter();
+          lock.lock();
           if (!smb.IsSmbValid())
           {
             items.ClearItems();
@@ -193,7 +193,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
             CLog::Log(LOGERROR, "{} - Failed to stat file {}", __FUNCTION__,
                       CURL::GetRedacted(strFullName));
 
-          lock.Leave();
+          lock.unlock();
         }
       }
 

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -11,7 +11,6 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "network/IWSDiscovery.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -20,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -73,7 +73,7 @@ bool CWSDiscoveryPosix::IsRunning()
 bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
 {
   {
-    CSingleLock lock(m_critWSD);
+    std::unique_lock<CCriticalSection> lock(m_critWSD);
 
     for (const auto& item : m_vecWSDInfo)
     {
@@ -101,7 +101,7 @@ bool CWSDiscoveryPosix::GetCached(const std::string& strHostName, std::string& s
 {
   const std::string match = strHostName + "/";
 
-  CSingleLock lock(m_critWSD);
+  std::unique_lock<CCriticalSection> lock(m_critWSD);
   for (const auto& item : m_vecWSDInfo)
   {
     if (!item.computer.empty() && StringUtils::StartsWithNoCase(item.computer, match))
@@ -119,7 +119,7 @@ bool CWSDiscoveryPosix::GetCached(const std::string& strHostName, std::string& s
 void CWSDiscoveryPosix::SetItems(std::vector<wsd_req_info> entries)
 {
   {
-    CSingleLock lock(m_critWSD);
+    std::unique_lock<CCriticalSection> lock(m_critWSD);
     m_vecWSDInfo = std::move(entries);
   }
 }

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <chrono>
+#include <mutex>
 #include <stdio.h>
 #include <string>
 #include <utility>
@@ -319,7 +320,7 @@ bool CWSDiscoveryListenerUDP::DispatchCommand()
 {
   Command sendCommand;
   {
-    CSingleLock lock(crit_commandqueue);
+    std::unique_lock<CCriticalSection> lock(crit_commandqueue);
     if (m_commandbuffer.size() <= 0)
       return false;
 
@@ -352,7 +353,7 @@ void CWSDiscoveryListenerUDP::AddCommand(const std::string& message,
                                          const std::string& extraparameter /* = "" */)
 {
 
-  CSingleLock lock(crit_commandqueue);
+  std::unique_lock<CCriticalSection> lock(crit_commandqueue);
 
   std::string msg{};
 
@@ -444,7 +445,7 @@ void CWSDiscoveryListenerUDP::ParseBuffer(const std::string& buffer)
   }
 
   {
-    CSingleLock lock(crit_wsdqueue);
+    std::unique_lock<CCriticalSection> lock(crit_wsdqueue);
     auto searchitem = std::find_if(m_vecWSDInfo.begin(), m_vecWSDInfo.end(),
                                    [info](const wsd_req_info& item) { return item == info; });
 

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -17,6 +17,8 @@
 
 #include "platform/win32/CharsetConverter.h"
 
+#include <mutex>
+
 #include <WS2tcpip.h>
 
 using namespace std::chrono_literals;
@@ -36,7 +38,7 @@ CIRServerSuite::~CIRServerSuite()
 {
   m_event.Set();
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     Close();
   }
   StopThread();
@@ -411,7 +413,7 @@ int CIRServerSuite::ReadN(char *buffer, int n)
   {
     int nBytes = 0;
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       nBytes = recv(m_socket, ptr, n, 0);
     }
 
@@ -450,7 +452,7 @@ bool CIRServerSuite::WriteN(const char *buffer, int n)
   {
     int nBytes;
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       nBytes = send(m_socket, ptr, n, 0);
     }
 

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -8,13 +8,13 @@
 
 #include "NetworkWin32.h"
 
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include "platform/win32/WIN32Util.h"
 
 #include <errno.h>
+#include <mutex>
 
 #include <IcmpAPI.h>
 #include <Mstcpip.h>
@@ -128,7 +128,7 @@ void CNetworkWin32::CleanInterfaceList()
 
 std::vector<CNetworkInterface*>& CNetworkWin32::GetInterfaceList(void)
 {
-  CSingleLock lock (m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if(m_netrefreshTimer.GetElapsedSeconds() >= 5.0f)
     queryInterfaceList();
 

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -8,10 +8,11 @@
 
 #include "WSDiscoveryWin32.h"
 
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include "platform/win32/CharsetConverter.h"
+
+#include <mutex>
 
 #include <windns.h>
 #pragma comment(lib, "dnsapi.lib")
@@ -55,7 +56,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
   if (!service)
     return E_INVALIDARG;
 
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
 
   WSD_NAME_LIST* list = nullptr;
   service->GetTypes(&list);
@@ -107,7 +108,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* 
   if (!service)
     return E_INVALIDARG;
 
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
 
   LPCWSTR address = nullptr;
   service->GetRemoteTransportAddress(&address);
@@ -136,7 +137,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* 
 
 HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchFailed(HRESULT hr, LPCWSTR tag)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
 
   // This must not happen. At least localhost (127.0.0.1) has to be found
   CLog::Log(LOGWARNING,
@@ -147,7 +148,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchFailed(HRESULT hr, LPCW
 
 HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchComplete(LPCWSTR tag)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
 
   std::string list;
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -32,14 +32,15 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
+#include "threads/SingleLock.h"
 
 #include <algorithm>
+#include <mutex>
 #include <string>
 #include <vector>
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
 #include "storage/DetectDVDType.h"
 #endif
-#include "threads/SingleLock.h"
 #include "utils/FileUtils.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -138,7 +139,7 @@ bool CProfileManager::Load()
   bool ret = true;
   const std::string file = PROFILES_FILE;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   // clear out our profiles
   m_profiles.clear();
@@ -223,7 +224,7 @@ bool CProfileManager::Save() const
 {
   const std::string file = PROFILES_FILE;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   CXBMCTinyXML xmlDoc;
   TiXmlElement xmlRootElement(XML_PROFILES);
@@ -245,7 +246,7 @@ bool CProfileManager::Save() const
 
 void CProfileManager::Clear()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_usingLoginScreen = false;
   m_profileLoadedForLogin = false;
   m_previousProfileLoadedForLogin = false;
@@ -289,7 +290,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
     return true;
   }
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // check if the index is valid or not
   if (index >= m_profiles.size())
     return false;
@@ -467,7 +468,7 @@ void CProfileManager::LogOff()
 
 bool CProfileManager::DeleteProfile(unsigned int index)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   const CProfile *profile = GetProfile(index);
   if (profile == NULL)
     return false;
@@ -534,7 +535,7 @@ void CProfileManager::CreateProfileFolders()
 
 const CProfile& CProfileManager::GetMasterProfile() const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (!m_profiles.empty())
     return m_profiles[0];
 
@@ -544,7 +545,7 @@ const CProfile& CProfileManager::GetMasterProfile() const
 
 const CProfile& CProfileManager::GetCurrentProfile() const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (m_currentProfile < m_profiles.size())
     return m_profiles[m_currentProfile];
 
@@ -554,7 +555,7 @@ const CProfile& CProfileManager::GetCurrentProfile() const
 
 const CProfile* CProfileManager::GetProfile(unsigned int index) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (index < m_profiles.size())
     return &m_profiles[index];
 
@@ -563,7 +564,7 @@ const CProfile* CProfileManager::GetProfile(unsigned int index) const
 
 CProfile* CProfileManager::GetProfile(unsigned int index)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (index < m_profiles.size())
     return &m_profiles[index];
 
@@ -572,7 +573,7 @@ CProfile* CProfileManager::GetProfile(unsigned int index)
 
 int CProfileManager::GetProfileIndex(const std::string &name) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   for (int i = 0; i < static_cast<int>(m_profiles.size()); i++)
   {
     if (StringUtils::EqualsNoCase(m_profiles[i].getName(), name))
@@ -585,7 +586,7 @@ int CProfileManager::GetProfileIndex(const std::string &name) const
 void CProfileManager::AddProfile(const CProfile &profile)
 {
   {
-    CSingleLock lock(m_critical);
+    std::unique_lock<CCriticalSection> lock(m_critical);
     // data integrity check - covers off migration from old profiles.xml,
     // incrementing of the m_nextIdProfile,and bad data coming in
     m_nextProfileId = std::max(m_nextProfileId, profile.getId() + 1);
@@ -597,7 +598,7 @@ void CProfileManager::AddProfile(const CProfile &profile)
 
 void CProfileManager::UpdateCurrentProfileDate()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (m_currentProfile < m_profiles.size())
   {
     m_profiles[m_currentProfile].setDate();
@@ -608,7 +609,7 @@ void CProfileManager::UpdateCurrentProfileDate()
 
 void CProfileManager::LoadMasterProfileForLogin()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // save the previous user
   m_lastUsedProfile = m_currentProfile;
   if (m_currentProfile != 0)
@@ -625,7 +626,7 @@ void CProfileManager::LoadMasterProfileForLogin()
 
 bool CProfileManager::GetProfileName(const unsigned int profileId, std::string& name) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   const CProfile *profile = GetProfile(profileId);
   if (!profile)
     return false;
@@ -734,7 +735,7 @@ void CProfileManager::OnSettingAction(const std::shared_ptr<const CSetting>& set
 void CProfileManager::SetCurrentProfileId(unsigned int profileId)
 {
   {
-    CSingleLock lock(m_critical);
+    std::unique_lock<CCriticalSection> lock(m_critical);
     m_currentProfile = profileId;
     CSpecialProtocol::SetProfilePath(GetProfileUserDataFolder());
   }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -361,7 +361,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
   CUtil::DeleteDirectoryCache();
   g_directoryCache.Clear();
 
-  lock.Leave();
+  lock.unlock();
 
   UpdateCurrentProfileDate();
   FinalizeLoadProfile();

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -11,11 +11,11 @@
 #include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 
 #include <algorithm>
 #include <cstdlib>
+#include <mutex>
 #include <string>
 
 using namespace std::chrono_literals;
@@ -39,7 +39,7 @@ void CPVRChannelNumberInputHandler::OnTimeout()
 {
   if (m_inputBuffer.empty())
   {
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
     m_label.erase();
   }
   else
@@ -47,7 +47,7 @@ void CPVRChannelNumberInputHandler::OnTimeout()
     // call the overridden worker method
     OnInputDone();
 
-    CSingleLock lock(m_mutex);
+    std::unique_lock<CCriticalSection> lock(m_mutex);
 
     // erase input buffer immediately , but...
     m_inputBuffer.erase();
@@ -83,7 +83,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter
   if (cCharacter != CPVRChannelNumber::SEPARATOR && (cCharacter < '0' || cCharacter > '9'))
     return;
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   if (cCharacter == CPVRChannelNumber::SEPARATOR)
   {
@@ -144,7 +144,7 @@ CPVRChannelNumber CPVRChannelNumberInputHandler::GetChannelNumber() const
   int iChannelNumber = 0;
   int iSubChannelNumber = 0;
 
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
 
   size_t pos = m_inputBuffer.find(CPVRChannelNumber::SEPARATOR);
   if (pos != std::string::npos)
@@ -173,7 +173,7 @@ bool CPVRChannelNumberInputHandler::HasChannelNumber() const
 
 std::string CPVRChannelNumberInputHandler::GetChannelNumberLabel() const
 {
-  CSingleLock lock(m_mutex);
+  std::unique_lock<CCriticalSection> lock(m_mutex);
   return m_label;
 }
 

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -29,6 +29,8 @@
 #include "threads/Timer.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 using namespace PVR;
 
 class CPVRPlaybackState::CLastWatchedUpdateTimer : public CTimer, private ITimerCallback
@@ -62,7 +64,7 @@ CPVRPlaybackState::~CPVRPlaybackState() = default;
 
 void CPVRPlaybackState::ReInit()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   Clear();
 
@@ -126,7 +128,7 @@ void CPVRPlaybackState::ClearData()
 
 void CPVRPlaybackState::Clear()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_playingChannel.reset();
   m_playingRecording.reset();
@@ -142,7 +144,7 @@ void CPVRPlaybackState::Clear()
 
 void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_playingChannel.reset();
   m_playingRecording.reset();
@@ -223,7 +225,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem>& item
 {
   // Playback ended due to user interaction
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bool bChanged = false;
 
@@ -286,43 +288,43 @@ void CPVRPlaybackState::OnPlaybackEnded(const std::shared_ptr<CFileItem>& item)
 
 bool CPVRPlaybackState::IsPlaying() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingChannel != nullptr || m_playingRecording != nullptr || m_playingEpgTag != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingTV() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingChannel && !m_playingChannel->Channel()->IsRadio();
 }
 
 bool CPVRPlaybackState::IsPlayingRadio() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingChannel && m_playingChannel->Channel()->IsRadio();
 }
 
 bool CPVRPlaybackState::IsPlayingEncryptedChannel() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingChannel && m_playingChannel->Channel()->IsEncrypted();
 }
 
 bool CPVRPlaybackState::IsPlayingRecording() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingRecording != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingEpgTag() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingEpgTag != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingChannel(int iClientID, int iUniqueChannelID) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingClientId == iClientID && m_playingChannelUniqueId == iUniqueChannelID;
 }
 
@@ -368,37 +370,37 @@ bool CPVRPlaybackState::IsPlayingEpgTag(const std::shared_ptr<CPVREpgInfoTag>& e
 
 std::shared_ptr<CPVRChannel> CPVRPlaybackState::GetPlayingChannel() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingChannel ? m_playingChannel->Channel() : std::shared_ptr<CPVRChannel>();
 }
 
 std::shared_ptr<CPVRRecording> CPVRPlaybackState::GetPlayingRecording() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingRecording;
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVRPlaybackState::GetPlayingEpgTag() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingEpgTag;
 }
 
 int CPVRPlaybackState::GetPlayingChannelUniqueID() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingChannelUniqueId;
 }
 
 std::string CPVRPlaybackState::GetPlayingClientName() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strPlayingClientName;
 }
 
 int CPVRPlaybackState::GetPlayingClientID() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_playingClientId;
 }
 
@@ -544,13 +546,13 @@ void CPVRPlaybackState::UpdateLastWatched(const std::shared_ptr<CPVRChannelGroup
 std::shared_ptr<CPVRChannelGroupMember> CPVRPlaybackState::GetLastPlayedChannelGroupMember(
     bool bRadio) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return bRadio ? m_lastPlayedChannelRadio : m_lastPlayedChannelTV;
 }
 
 std::shared_ptr<CPVRChannelGroupMember> CPVRPlaybackState::
     GetPreviousToLastPlayedChannelGroupMember(bool bRadio) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return bRadio ? m_previousToLastPlayedChannelRadio : m_previousToLastPlayedChannelTV;
 }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -44,6 +44,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -105,7 +106,7 @@ void CPVRClient::OnPreUnInstall()
 
 void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   /* initialise members */
   m_strUserPath = CSpecialProtocol::TranslatePath(Profile());
@@ -233,7 +234,7 @@ bool CPVRClient::ReadyToUse() const
 
 PVR_CONNECTION_STATE CPVRClient::GetConnectionState() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_connectionState;
 }
 
@@ -246,7 +247,7 @@ void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
       CLog::LogF(LOGERROR, "Error reading PVR client properties");
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_prevConnectionState = m_connectionState;
   m_connectionState = state;
@@ -260,13 +261,13 @@ void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
 
 PVR_CONNECTION_STATE CPVRClient::GetPreviousConnectionState() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_prevConnectionState;
 }
 
 bool CPVRClient::IgnoreClient() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_ignoreClient;
 }
 
@@ -580,7 +581,7 @@ bool CPVRClient::GetAddonProperties()
     retVal = PVR_ERROR_NO_ERROR; // timer support is optional.
 
   /* update the members */
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strBackendName = strBackendName;
   m_strConnectionString = strConnectionString;
   m_strFriendlyName = strFriendlyName;
@@ -1188,7 +1189,7 @@ PVR_ERROR CPVRClient::UpdateTimer(const CPVRTimerInfoTag& timer)
 
 PVR_ERROR CPVRClient::GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   results = m_timertypes;
   return PVR_ERROR_NO_ERROR;
 }
@@ -1692,7 +1693,7 @@ PVR_ERROR CPVRClient::CallSettingsMenuHook(const CPVRClientMenuHook& hook)
 
 void CPVRClient::SetPriority(int iPriority)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_iPriority != iPriority)
   {
     m_iPriority = iPriority;
@@ -1706,7 +1707,7 @@ void CPVRClient::SetPriority(int iPriority)
 
 int CPVRClient::GetPriority() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!m_bPriorityFetched && m_iClientId > PVR_INVALID_CLIENT_ID)
   {
     m_iPriority = CServiceBroker::GetPVRManager().GetTVDatabase()->GetPriority(*this);

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -325,7 +325,7 @@ GroupMemberPair CPVRChannelGroup::GetLastAndPreviousToLastPlayedChannelGroupMemb
     return {};
 
   auto members = m_sortedMembers;
-  lock.Leave();
+  lock.unlock();
 
   std::sort(members.begin(), members.end(), [](const auto& a, const auto& b) {
     return a->Channel()->LastWatched() > b->Channel()->LastWatched();

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -23,12 +23,12 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgInfoTag.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -75,10 +75,10 @@ std::weak_ptr<CPVRChannelGroupSettings> CPVRChannelGroup::m_settingsSingleton;
 
 std::shared_ptr<CPVRChannelGroupSettings> CPVRChannelGroup::GetSettings() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!m_settings)
   {
-    CSingleLock singletonLock(m_settingsSingletonCritSection);
+    std::unique_lock<CCriticalSection> singletonLock(m_settingsSingletonCritSection);
     const std::shared_ptr<CPVRChannelGroupSettings> settings = m_settingsSingleton.lock();
     if (settings)
     {
@@ -122,7 +122,7 @@ bool CPVRChannelGroup::LoadFromDatabase(
 
 void CPVRChannelGroup::Unload()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_sortedMembers.clear();
   m_members.clear();
   m_failedClients.clear();
@@ -142,13 +142,13 @@ bool CPVRChannelGroup::UpdateFromClients(const std::vector<std::shared_ptr<CPVRC
 
 const CPVRChannelsPath& CPVRChannelGroup::GetPath() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_path;
 }
 
 void CPVRChannelGroup::SetPath(const CPVRChannelsPath& path)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_path != path)
   {
     m_path = path;
@@ -164,7 +164,7 @@ void CPVRChannelGroup::SetPath(const CPVRChannelsPath& path)
 bool CPVRChannelGroup::SetChannelNumber(const std::shared_ptr<CPVRChannel>& channel, const CPVRChannelNumber& channelNumber)
 {
   bool bReturn(false);
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (auto& member : m_sortedMembers)
   {
@@ -219,20 +219,20 @@ void CPVRChannelGroup::Sort()
 
 bool CPVRChannelGroup::SortAndRenumber()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   Sort();
   return Renumber();
 }
 
 void CPVRChannelGroup::SortByClientChannelNumber()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::sort(m_sortedMembers.begin(), m_sortedMembers.end(), sortByClientChannelNumber());
 }
 
 void CPVRChannelGroup::SortByChannelNumber()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::sort(m_sortedMembers.begin(), m_sortedMembers.end(), sortByChannelNumber());
 }
 
@@ -241,7 +241,7 @@ bool CPVRChannelGroup::UpdateClientPriorities()
   const std::shared_ptr<CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
   bool bChanged = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   const bool bUseBackendChannelOrder = GetSettings()->UseBackendChannelOrder();
   for (auto& member : m_sortedMembers)
@@ -272,7 +272,7 @@ bool CPVRChannelGroup::UpdateClientPriorities()
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByUniqueID(
     const std::pair<int, int>& id) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto it = m_members.find(id);
   return it != m_members.end() ? it->second : std::shared_ptr<CPVRChannelGroupMember>();
 }
@@ -286,7 +286,7 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByUniqueID(int iUniqueChannelI
 
 std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByChannelID(int iChannelID) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& memberPair : m_members)
   {
@@ -300,7 +300,7 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByChannelID(int iChannelID) co
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetLastPlayedChannelGroupMember(
     int iCurrentChannel /* = -1 */) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   std::shared_ptr<CPVRChannelGroupMember> groupMember;
   for (const auto& memberPair : m_members)
@@ -320,7 +320,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetLastPlayedChannelGr
 
 GroupMemberPair CPVRChannelGroup::GetLastAndPreviousToLastPlayedChannelGroupMember() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_sortedMembers.empty())
     return {};
 
@@ -345,14 +345,14 @@ GroupMemberPair CPVRChannelGroup::GetLastAndPreviousToLastPlayedChannelGroupMemb
 
 CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
   return member ? member->ChannelNumber() : CPVRChannelNumber();
 }
 
 CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
   return member ? member->ClientChannelNumber() : CPVRChannelNumber();
 }
@@ -360,7 +360,7 @@ CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(const std::shared_ptr
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByChannelNumber(
     const CPVRChannelNumber& channelNumber) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   for (const auto& member : m_sortedMembers)
   {
@@ -380,7 +380,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetNextChannelGroupMem
 
   if (groupMember)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (auto it = m_sortedMembers.cbegin(); !nextMember && it != m_sortedMembers.cend(); ++it)
     {
       if (*it == groupMember)
@@ -408,7 +408,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetPreviousChannelGrou
 
   if (groupMember)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (auto it = m_sortedMembers.crbegin(); !previousMember && it != m_sortedMembers.crend();
          ++it)
     {
@@ -432,7 +432,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetPreviousChannelGrou
 std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::GetMembers(
     Include eFilter /* = Include::ALL */) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (eFilter == Include::ALL)
     return m_sortedMembers;
 
@@ -461,7 +461,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::GetMember
 
 void CPVRChannelGroup::GetChannelNumbers(std::vector<std::string>& channelNumbers) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   for (const auto& member : m_sortedMembers)
   {
@@ -485,7 +485,7 @@ int CPVRChannelGroup::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRCli
   {
     const std::shared_ptr<CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
 
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (const auto& member : results)
     {
       // Consistency check.
@@ -553,7 +553,7 @@ bool CPVRChannelGroup::UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMe
 {
   bool bChanged = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
   const std::shared_ptr<CPVRChannelGroupMember> existingMember =
@@ -629,7 +629,7 @@ bool CPVRChannelGroup::HasValidDataForAllClients() const
 
 bool CPVRChannelGroup::UpdateChannelNumbersFromAllChannelsGroup()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bool bChanged = false;
 
@@ -652,7 +652,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::RemoveDel
 {
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> membersToRemove;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   /* check for deleted channels */
   for (auto it = m_sortedMembers.begin(); it != m_sortedMembers.end();)
@@ -689,7 +689,7 @@ bool CPVRChannelGroup::UpdateGroupEntries(
   bool bChanged = false;
   bool bRemoved = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bRemoved = !RemoveDeletedGroupMembers(groupMembers).empty();
   bChanged = AddAndUpdateGroupMembers(groupMembers) || bRemoved;
@@ -716,7 +716,7 @@ bool CPVRChannelGroup::RemoveFromGroup(const std::shared_ptr<CPVRChannel>& chann
 {
   bool bReturn = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (auto it = m_sortedMembers.begin(); it != m_sortedMembers.end(); ++it)
   {
@@ -741,7 +741,7 @@ bool CPVRChannelGroup::AppendToGroup(const std::shared_ptr<CPVRChannel>& channel
 {
   bool bReturn = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!CPVRChannelGroup::IsGroupMember(channel))
   {
@@ -774,7 +774,7 @@ bool CPVRChannelGroup::AppendToGroup(const std::shared_ptr<CPVRChannel>& channel
 
 bool CPVRChannelGroup::IsGroupMember(const std::shared_ptr<CPVRChannel>& channel) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_members.find(channel->StorageId()) != m_members.end();
 }
 
@@ -783,7 +783,7 @@ bool CPVRChannelGroup::Persist()
   bool bReturn(true);
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // do not persist if the group is not fully loaded and was saved before.
   if (!m_bLoaded && m_iGroupId != INVALID_GROUP_ID)
@@ -818,7 +818,7 @@ void CPVRChannelGroup::Delete()
     return;
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_iGroupId > 0)
   {
@@ -832,7 +832,7 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
   bool bReturn(false);
   unsigned int iChannelNumber(0);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   const bool bStartGroupChannelNumbersFromOne = GetSettings()->StartGroupChannelNumbersFromOne();
 
@@ -885,7 +885,7 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
 
 bool CPVRChannelGroup::HasNewChannels() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& memberPair : m_members)
   {
@@ -898,19 +898,19 @@ bool CPVRChannelGroup::HasNewChannels() const
 
 bool CPVRChannelGroup::HasChanges() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bChanged;
 }
 
 bool CPVRChannelGroup::IsNew() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iGroupId <= 0;
 }
 
 void CPVRChannelGroup::UseBackendChannelOrderChanged()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   UpdateClientPriorities();
   OnSettingChanged();
 }
@@ -934,7 +934,7 @@ void CPVRChannelGroup::OnSettingChanged()
     return;
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CLog::LogFC(LOGDEBUG, LOGPVR,
               "Renumbering channel group '{}' to use the backend channel order and/or numbers",
@@ -956,7 +956,7 @@ CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
   CDateTime date;
   std::shared_ptr<CPVREpg> epg;
   std::shared_ptr<CPVRChannel> channel;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& memberPair : m_members)
   {
@@ -1001,7 +1001,7 @@ int CPVRChannelGroup::GroupID() const
 
 void CPVRChannelGroup::SetGroupID(int iGroupId)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (iGroupId >= 0 && m_iGroupId != iGroupId)
   {
     m_iGroupId = iGroupId;
@@ -1014,7 +1014,7 @@ void CPVRChannelGroup::SetGroupID(int iGroupId)
 
 void CPVRChannelGroup::SetGroupType(int iGroupType)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_iGroupType != iGroupType)
   {
     m_iGroupType = iGroupType;
@@ -1030,13 +1030,13 @@ int CPVRChannelGroup::GroupType() const
 
 std::string CPVRChannelGroup::GroupName() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_path.GetGroupName();
 }
 
 void CPVRChannelGroup::SetGroupName(const std::string& strGroupName)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_path.GetGroupName() != strGroupName)
   {
     m_path = CPVRChannelsPath(m_path.IsRadio(), strGroupName);
@@ -1050,13 +1050,13 @@ void CPVRChannelGroup::SetGroupName(const std::string& strGroupName)
 
 bool CPVRChannelGroup::IsRadio() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_path.IsRadio();
 }
 
 time_t CPVRChannelGroup::LastWatched() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iLastWatched;
 }
 
@@ -1064,7 +1064,7 @@ void CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
 {
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_iLastWatched != iLastWatched)
   {
@@ -1076,7 +1076,7 @@ void CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
 
 uint64_t CPVRChannelGroup::LastOpened() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iLastOpened;
 }
 
@@ -1084,7 +1084,7 @@ void CPVRChannelGroup::SetLastOpened(uint64_t iLastOpened)
 {
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_iLastOpened != iLastOpened)
   {
@@ -1104,7 +1104,7 @@ bool CPVRChannelGroup::UpdateChannel(const std::pair<int, int>& storageId,
                                      bool bParentalLocked,
                                      bool bUserSetIcon)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   /* get the real channel from the group */
   const std::shared_ptr<CPVRChannel> channel = GetByUniqueID(storageId)->Channel();
@@ -1140,13 +1140,13 @@ bool CPVRChannelGroup::UpdateChannel(const std::pair<int, int>& storageId,
 
 size_t CPVRChannelGroup::Size() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_members.size();
 }
 
 bool CPVRChannelGroup::HasChannels() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return !m_members.empty();
 }
 
@@ -1158,7 +1158,7 @@ bool CPVRChannelGroup::CreateChannelEpgs(bool bForce /* = false */)
 
 bool CPVRChannelGroup::SetHidden(bool bHidden)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_bHidden != bHidden)
   {
@@ -1172,19 +1172,19 @@ bool CPVRChannelGroup::SetHidden(bool bHidden)
 
 bool CPVRChannelGroup::IsHidden() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bHidden;
 }
 
 int CPVRChannelGroup::GetPosition() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iPosition;
 }
 
 void CPVRChannelGroup::SetPosition(int iPosition)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_iPosition != iPosition)
   {
@@ -1198,7 +1198,7 @@ int CPVRChannelGroup::CleanupCachedImages()
 {
   std::vector<std::string> urlsToCheck;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (const auto& groupMember : m_members)
     {
       urlsToCheck.emplace_back(groupMember.second->Channel()->ClientIconPath());

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -20,6 +20,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -79,7 +80,7 @@ void CPVRChannelGroupInternal::Unload()
 
 void CPVRChannelGroupInternal::CheckGroupName()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   /* check whether the group name is still correct, or channels will fail to load after the language setting changed */
   const std::string& strNewGroupName = g_localizeStrings.Get(19287);
@@ -92,7 +93,7 @@ void CPVRChannelGroupInternal::CheckGroupName()
 
 void CPVRChannelGroupInternal::UpdateChannelPaths()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_iHiddenChannels = 0;
   for (auto& groupMemberPair : m_members)
   {
@@ -192,7 +193,7 @@ bool CPVRChannelGroupInternal::AppendToGroup(const std::shared_ptr<CPVRChannel>&
 
   channel->SetHidden(false);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_iHiddenChannels > 0)
     m_iHiddenChannels--;
@@ -211,7 +212,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const std::shared_ptr<CPVRChannel
 
   channel->SetHidden(true);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   ++m_iHiddenChannels;
 
@@ -230,7 +231,7 @@ bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)
     return false;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (auto& groupMemberPair : m_members)
       groupMemberPair.second->Channel()->CreateEPG();
   }

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -393,7 +393,7 @@ GroupMemberPair CPVRChannelGroups::GetLastAndPreviousToLastPlayedChannelGroupMem
     return {};
 
   auto groups = m_groups;
-  lock.Leave();
+  lock.unlock();
 
   std::sort(groups.begin(), groups.end(),
             [](const auto& a, const auto& b) { return a->LastWatched() > b->LastWatched(); });

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -44,7 +45,7 @@ CPVRChannelGroups::~CPVRChannelGroups()
 
 void CPVRChannelGroups::Unload()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& group : m_groups)
     group->Unload();
 
@@ -60,7 +61,7 @@ bool CPVRChannelGroups::Update(const std::shared_ptr<CPVRChannelGroup>& group,
 
   std::shared_ptr<CPVRChannelGroup> updateGroup;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     // There can be only one internal group! Make sure we never push a new one!
     if (group->IsInternalGroup())
@@ -108,7 +109,7 @@ bool CPVRChannelGroups::Update(const std::shared_ptr<CPVRChannelGroup>& group,
 
 void CPVRChannelGroups::SortGroups()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // check if one of the group holds a valid sort position
   std::vector<std::shared_ptr<CPVRChannelGroup>>::iterator it = std::find_if(m_groups.begin(), m_groups.end(), [](const std::shared_ptr<CPVRChannelGroup>& group) {
@@ -141,7 +142,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroups::GetChannelGroupMember
 
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetById(int iGroupId) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (std::vector<std::shared_ptr<CPVRChannelGroup>>::const_iterator it = m_groups.begin(); it != m_groups.end(); ++it)
   {
     if ((*it)->GroupID() == iGroupId)
@@ -156,7 +157,7 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroups::GetGroupsByCha
 {
   std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const std::shared_ptr<CPVRChannelGroup>& group : m_groups)
   {
     if ((!bExcludeHidden || !group->IsHidden()) && group->IsGroupMember(channel))
@@ -170,7 +171,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupByPath(const std::s
   const CPVRChannelsPath path(strInPath);
   if (path.IsChannelGroup())
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (const auto& group : m_groups)
     {
       if (group->GetPath() == path)
@@ -182,7 +183,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupByPath(const std::s
 
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetByName(const std::string& strName) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (std::vector<std::shared_ptr<CPVRChannelGroup>>::const_iterator it = m_groups.begin(); it != m_groups.end(); ++it)
   {
     if ((*it)->GroupName() == strName)
@@ -224,7 +225,7 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
   // sync channels in groups
   std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     groups = m_groups;
   }
 
@@ -284,7 +285,7 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
 
 bool CPVRChannelGroups::UpdateChannelNumbersFromAllChannelsGroup()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   bool bChanged = false;
   for (auto& group : m_groups)
@@ -308,7 +309,7 @@ bool CPVRChannelGroups::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRC
   if (!database)
     return false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // Ensure we have an internal group. It is important that the internal group is created before
   // loading contents from database and that it gets inserted in front of m_groups. Look at
@@ -361,7 +362,7 @@ bool CPVRChannelGroups::PersistAll()
   bool bReturn(true);
   CLog::LogFC(LOGDEBUG, LOGPVR, "Persisting all channel group changes");
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (std::vector<std::shared_ptr<CPVRChannelGroup>>::iterator it = m_groups.begin(); it != m_groups.end(); ++it)
     bReturn &= (*it)->Persist();
 
@@ -370,7 +371,7 @@ bool CPVRChannelGroups::PersistAll()
 
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupAll() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!m_groups.empty())
     return m_groups.front();
 
@@ -379,7 +380,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupAll() const
 
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastGroup() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!m_groups.empty())
     return m_groups.back();
 
@@ -388,7 +389,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastGroup() const
 
 GroupMemberPair CPVRChannelGroups::GetLastAndPreviousToLastPlayedChannelGroupMember() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_groups.empty())
     return {};
 
@@ -422,7 +423,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastOpenedGroup() const
 {
   std::shared_ptr<CPVRChannelGroup> lastOpenedGroup;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& group : m_groups)
   {
     if (group->LastOpened() > 0 &&
@@ -437,7 +438,7 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroups::GetMembers(boo
 {
   std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const std::shared_ptr<CPVRChannelGroup>& group : m_groups)
   {
     if (!bExcludeHidden || !group->IsHidden())
@@ -451,7 +452,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetPreviousGroup(const CPVR
   bool bReturnNext(false);
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (std::vector<std::shared_ptr<CPVRChannelGroup>>::const_reverse_iterator it = m_groups.rbegin(); it != m_groups.rend(); ++it)
     {
       // return this entry
@@ -480,7 +481,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetNextGroup(const CPVRChan
   bool bReturnNext(false);
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (std::vector<std::shared_ptr<CPVRChannelGroup>>::const_iterator it = m_groups.begin(); it != m_groups.end(); ++it)
     {
       // return this entry
@@ -510,7 +511,7 @@ bool CPVRChannelGroups::AddGroup(const std::string& strName)
   std::shared_ptr<CPVRChannelGroup> group;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     // check if there's no group with the same name yet
     group = GetByName(strName);
@@ -543,7 +544,7 @@ bool CPVRChannelGroups::DeleteGroup(const std::shared_ptr<CPVRChannelGroup>& gro
 
   // delete the group in this container
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (auto it = m_groups.begin(); it != m_groups.end(); ++it)
     {
       if (*it == group || (group->GroupID() > 0 && (*it)->GroupID() == group->GroupID()))
@@ -584,7 +585,7 @@ bool CPVRChannelGroups::CreateChannelEpgs()
 {
   bool bReturn(false);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (std::vector<std::shared_ptr<CPVRChannelGroup>>::iterator it = m_groups.begin(); it != m_groups.end(); ++it)
   {
     /* Only create EPGs for the internal groups */
@@ -604,7 +605,7 @@ int CPVRChannelGroups::CleanupCachedImages()
   // cleanup groups
   std::vector<std::string> urlsToCheck;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (const auto& group : m_groups)
     {
       urlsToCheck.emplace_back(group->GetPath());

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -10,9 +10,9 @@
 
 #include "pvr/channels/PVRChannelGroup.h"
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -56,7 +56,11 @@ namespace PVR
     /*!
      * @return Amount of groups in this container
      */
-    size_t Size() const { CSingleLock lock(m_critSection); return m_groups.size(); }
+    size_t Size() const
+    {
+      std::unique_lock<CCriticalSection> lock(m_critSection);
+      return m_groups.size();
+    }
 
     /*!
      * @brief Update a group or add it if it's not in here yet.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -50,15 +50,15 @@ bool CPVRChannelGroupsContainer::UpdateFromClients(
   if (m_bIsUpdating)
     return false;
   m_bIsUpdating = true;
-  lock.Leave();
+  lock.unlock();
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Updating {}", bChannelsOnly ? "channels" : "channel groups");
   bool bReturn = m_groupsTV->UpdateFromClients(clients, bChannelsOnly) &&
                  m_groupsRadio->UpdateFromClients(clients, bChannelsOnly);
 
-  lock.Enter();
+  lock.lock();
   m_bIsUpdating = false;
-  lock.Leave();
+  lock.unlock();
 
   return bReturn;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -12,10 +12,10 @@
 #include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/epg/EpgInfoTag.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <memory>
+#include <mutex>
 
 using namespace PVR;
 
@@ -46,7 +46,7 @@ bool CPVRChannelGroupsContainer::LoadFromDatabase(
 bool CPVRChannelGroupsContainer::UpdateFromClients(
     const std::vector<std::shared_ptr<CPVRClient>>& clients, bool bChannelsOnly /* = false */)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_bIsUpdating)
     return false;
   m_bIsUpdating = true;

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -13,13 +13,13 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "threads/SingleLock.h"
 #include "utils/Archive.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
 #include <algorithm>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -32,7 +32,7 @@ CPVRRadioRDSInfoTag::CPVRRadioRDSInfoTag()
 
 void CPVRRadioRDSInfoTag::Serialize(CVariant& value) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   value["strLanguage"] = m_strLanguage;
   value["strCountry"] = m_strCountry;
@@ -59,7 +59,7 @@ void CPVRRadioRDSInfoTag::Serialize(CVariant& value) const
 
 void CPVRRadioRDSInfoTag::Archive(CArchive& ar)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (ar.IsStoring())
   {
@@ -116,7 +116,7 @@ bool CPVRRadioRDSInfoTag::operator==(const CPVRRadioRDSInfoTag& right) const
   if (this == &right)
     return true;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return (m_strLanguage == right.m_strLanguage &&
           m_strCountry == right.m_strCountry &&
           m_strTitle == right.m_strTitle &&
@@ -163,7 +163,7 @@ bool CPVRRadioRDSInfoTag::operator !=(const CPVRRadioRDSInfoTag& right) const
 
 void CPVRRadioRDSInfoTag::Clear()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_RDS_SpeechActive = false;
 
@@ -199,7 +199,7 @@ void CPVRRadioRDSInfoTag::Clear()
 
 void CPVRRadioRDSInfoTag::ResetSongInformation()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_strTitle.erase();
   m_strBand.erase();
@@ -212,431 +212,431 @@ void CPVRRadioRDSInfoTag::ResetSongInformation()
 
 void CPVRRadioRDSInfoTag::SetSpeechActive(bool active)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_RDS_SpeechActive = active;
 }
 
 void CPVRRadioRDSInfoTag::SetLanguage(const std::string& strLanguage)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strLanguage = Trim(strLanguage);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetLanguage() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strLanguage;
 }
 
 void CPVRRadioRDSInfoTag::SetCountry(const std::string& strCountry)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strCountry = Trim(strCountry);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetCountry() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strCountry;
 }
 
 void CPVRRadioRDSInfoTag::SetTitle(const std::string& strTitle)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strTitle = Trim(strTitle);
 }
 
 void CPVRRadioRDSInfoTag::SetArtist(const std::string& strArtist)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strArtist = Trim(strArtist);
 }
 
 void CPVRRadioRDSInfoTag::SetBand(const std::string& strBand)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strBand = Trim(strBand);
   g_charsetConverter.unknownToUTF8(m_strBand);
 }
 
 void CPVRRadioRDSInfoTag::SetComposer(const std::string& strComposer)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strComposer = Trim(strComposer);
   g_charsetConverter.unknownToUTF8(m_strComposer);
 }
 
 void CPVRRadioRDSInfoTag::SetConductor(const std::string& strConductor)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strConductor = Trim(strConductor);
   g_charsetConverter.unknownToUTF8(m_strConductor);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbum(const std::string& strAlbum)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strAlbum = Trim(strAlbum);
   g_charsetConverter.unknownToUTF8(m_strAlbum);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbumTrackNumber(int track)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_iAlbumTracknumber = track;
 }
 
 void CPVRRadioRDSInfoTag::SetComment(const std::string& strComment)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strComment = Trim(strComment);
   g_charsetConverter.unknownToUTF8(m_strComment);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetTitle() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strTitle;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetArtist() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strArtist;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetBand() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strBand;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetComposer() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strComposer;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetConductor() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strConductor;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetAlbum() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strAlbum;
 }
 
 int CPVRRadioRDSInfoTag::GetAlbumTrackNumber() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iAlbumTracknumber;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetComment() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strComment;
 }
 
 void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoNews.Add(strNews);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoNews.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoNewsLocal.Add(strNews);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoNewsLocal.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoSport.Add(strSport);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoSport.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoStock.Add(strStock);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoStock.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoWeather.Add(strWeather);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoWeather.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoLottery.Add(strLottery);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoLottery.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strEditorialStaff.Add(strEditorialStaff);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strEditorialStaff.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoHoroscope.Add(strHoroscope);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoHoroscope.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoCinema.Add(strCinema);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoCinema.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strInfoOther.Add(strOther);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strInfoOther.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetProgStation(const std::string& strProgStation)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strProgStation = Trim(strProgStation);
   g_charsetConverter.unknownToUTF8(m_strProgStation);
 }
 
 void CPVRRadioRDSInfoTag::SetProgHost(const std::string& strProgHost)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strProgHost = Trim(strProgHost);
   g_charsetConverter.unknownToUTF8(m_strProgHost);
 }
 
 void CPVRRadioRDSInfoTag::SetProgStyle(const std::string& strProgStyle)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strProgStyle = Trim(strProgStyle);
   g_charsetConverter.unknownToUTF8(m_strProgStyle);
 }
 
 void CPVRRadioRDSInfoTag::SetProgWebsite(const std::string& strWebsite)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strProgWebsite = Trim(strWebsite);
   g_charsetConverter.unknownToUTF8(m_strProgWebsite);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNow(const std::string& strNow)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strProgNow = Trim(strNow);
   g_charsetConverter.unknownToUTF8(m_strProgNow);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNext(const std::string& strNext)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strProgNext = Trim(strNext);
   g_charsetConverter.unknownToUTF8(m_strProgNext);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneHotline(const std::string& strHotline)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strPhoneHotline = Trim(strHotline);
   g_charsetConverter.unknownToUTF8(m_strPhoneHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailHotline(const std::string& strHotline)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strEMailHotline = Trim(strHotline);
   g_charsetConverter.unknownToUTF8(m_strEMailHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneStudio(const std::string& strPhone)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strPhoneStudio = Trim(strPhone);
   g_charsetConverter.unknownToUTF8(m_strPhoneStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailStudio(const std::string& strEMail)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strEMailStudio = Trim(strEMail);
   g_charsetConverter.unknownToUTF8(m_strEMailStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetSMSStudio(const std::string& strSMS)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strSMSStudio = Trim(strSMS);
   g_charsetConverter.unknownToUTF8(m_strSMSStudio);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStyle() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strProgStyle;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgHost() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strProgHost;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStation() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strProgStation;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgWebsite() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strProgWebsite;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgNow() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strProgNow;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgNext() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strProgNext;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetPhoneHotline() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strPhoneHotline;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetEMailHotline() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strEMailHotline;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetPhoneStudio() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strPhoneStudio;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetEMailStudio() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strEMailStudio;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetSMSStudio() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strSMSStudio;
 }
 
 void CPVRRadioRDSInfoTag::SetRadioStyle(const std::string& style)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strRadioStyle = style;
 }
 
 const std::string CPVRRadioRDSInfoTag::GetRadioStyle() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strRadioStyle;
 }
 
 void CPVRRadioRDSInfoTag::SetPlayingRadiotext(bool yesNo)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bHaveRadiotext = yesNo;
 }
 
 bool CPVRRadioRDSInfoTag::IsPlayingRadiotext() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bHaveRadiotext;
 }
 
 void CPVRRadioRDSInfoTag::SetPlayingRadiotextPlus(bool yesNo)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bHaveRadiotextPlus = yesNo;
 }
 
 bool CPVRRadioRDSInfoTag::IsPlayingRadiotextPlus() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bHaveRadiotextPlus;
 }
 

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -17,12 +17,12 @@
 #include "pvr/epg/EpgDatabase.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -136,7 +136,7 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data,
 
 void CPVREpgInfoTag::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (data)
     m_channelData = data;
   else
@@ -148,7 +148,7 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
   if (this == &right)
     return true;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return (m_iUniqueBroadcastID == right.m_iUniqueBroadcastID && m_channelData &&
           right.m_channelData &&
           m_channelData->UniqueClientChannelId() == right.m_channelData->UniqueClientChannelId() &&
@@ -165,7 +165,7 @@ bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const
 
 void CPVREpgInfoTag::Serialize(CVariant& value) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   value["broadcastid"] = m_iDatabaseID; // Use DB id here as it is unique across PVR clients
   value["channeluid"] = m_channelData->UniqueClientChannelId();
   value["parentalrating"] = m_iParentalRating;
@@ -202,7 +202,7 @@ void CPVREpgInfoTag::Serialize(CVariant& value) const
 
 int CPVREpgInfoTag::ClientID() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_channelData->ClientId();
 }
 
@@ -278,7 +278,7 @@ int CPVREpgInfoTag::DatabaseID() const
 
 int CPVREpgInfoTag::UniqueChannelID() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_channelData->UniqueClientChannelId();
 }
 
@@ -489,7 +489,7 @@ std::string CPVREpgInfoTag::Path() const
 
 bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /* = true */)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   bool bChanged =
       (m_strTitle != tag.m_strTitle || m_strPlotOutline != tag.m_strPlotOutline ||
        m_strPlot != tag.m_strPlot || m_strOriginalTitle != tag.m_strOriginalTitle ||
@@ -575,7 +575,7 @@ std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
 {
   std::vector<PVR_EDL_ENTRY> edls;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
 
   if (client && client->GetClientCapabilities().SupportsEpgTagEdl())
@@ -606,7 +606,7 @@ bool CPVREpgInfoTag::IsRecordable() const
 {
   bool bIsRecordable = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsRecordable(shared_from_this(), bIsRecordable) != PVR_ERROR_NO_ERROR))
   {
@@ -620,7 +620,7 @@ bool CPVREpgInfoTag::IsPlayable() const
 {
   bool bIsPlayable = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
   {
@@ -640,19 +640,19 @@ bool CPVREpgInfoTag::IsSeries() const
 
 bool CPVREpgInfoTag::IsRadio() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_channelData->IsRadio();
 }
 
 bool CPVREpgInfoTag::IsParentalLocked() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_channelData->IsLocked();
 }
 
 bool CPVREpgInfoTag::IsGapTag() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bIsGapTag;
 }
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -671,7 +672,7 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
 
 void CGUIEPGGridContainer::UpdateItems()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!m_updatedGridModel)
     return;
@@ -1152,7 +1153,7 @@ bool CGUIEPGGridContainer::SetChannel(const CPVRChannelNumber& channelNumber)
 
 void CGUIEPGGridContainer::SetChannel(int channel)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   int channelIndex = channel + m_channelOffset;
   int blockIndex = m_blockCursor + m_blockOffset;
@@ -1170,7 +1171,7 @@ void CGUIEPGGridContainer::SetChannel(int channel)
 
 void CGUIEPGGridContainer::SetBlock(int block, bool bUpdateBlockTravelAxis /* = true */)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (block < 0)
     m_blockCursor = 0;
@@ -1298,7 +1299,7 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point, const CMous
       m_channelScrollOffset -= event.m_offsetY;
 
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
 
         m_channelOffset = MathUtils::round_int(
             static_cast<double>(m_channelScrollOffset / m_channelLayout->Size(m_orientation)));
@@ -1371,7 +1372,7 @@ std::shared_ptr<CPVRChannelGroupMember> CGUIEPGGridContainer::GetSelectedChannel
 {
   CFileItemPtr fileItem;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (m_channelCursor + m_channelOffset < m_gridModel->ChannelItemsSize())
       fileItem = m_gridModel->GetChannelItem(m_channelCursor + m_channelOffset);
   }
@@ -1528,7 +1529,7 @@ void CGUIEPGGridContainer::SetFocus(bool focus)
 
 void CGUIEPGGridContainer::ScrollToChannelOffset(int offset)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   float size = m_programmeLayout->Size(m_orientation);
   int range = m_channelsPerPage / 4;
@@ -1555,7 +1556,7 @@ void CGUIEPGGridContainer::ScrollToChannelOffset(int offset)
 
 void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // make sure offset is in valid range
   offset = std::max(0, std::min(offset, m_gridModel->GridItemsSize() - m_blocksPerPage));
@@ -1585,7 +1586,7 @@ void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
 
 void CGUIEPGGridContainer::ValidateOffset()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (!m_programmeLayout)
     return;
@@ -1678,7 +1679,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement* layout)
 
 std::string CGUIEPGGridContainer::GetDescription() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   const int channelIndex = m_channelCursor + m_channelOffset;
   const int blockIndex = m_blockCursor + m_blockOffset;
@@ -1825,7 +1826,7 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
   int iFirstBlock;
   float fBlockSize;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     iRulerUnit = m_rulerUnit;
     iFirstChannel = m_channelOffset;
@@ -1841,7 +1842,7 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
   newUpdatedGridModel->Initialize(items, gridStart, gridEnd, iFirstChannel, iChannelsPerPage,
                                   iFirstBlock, iBlocksPerPage, iRulerUnit, fBlockSize);
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     // grid contains CFileItem instances. CFileItem dtor locks global graphics mutex.
     // by increasing its refcount make sure, old data are not deleted while we're holding own mutex.
@@ -1913,7 +1914,7 @@ void CGUIEPGGridContainer::UpdateLayout()
       oldRulerLayout == m_rulerLayout && oldRulerDateLayout == m_rulerDateLayout)
     return; // nothing has changed, so don't update stuff
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_channelHeight = m_channelLayout->Size(VERTICAL);
   m_channelWidth = m_channelLayout->Size(HORIZONTAL);
@@ -2506,7 +2507,7 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
           }
 
           {
-            CSingleLock lock(m_critSection);
+            std::unique_lock<CCriticalSection> lock(m_critSection);
             // truncate item's width
             m_gridModel->DecreaseGridItemWidth(channel, block, truncateSize);
           }

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -61,7 +61,6 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "threads/IRunnable.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/URIUtils.h"
@@ -73,6 +72,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -2450,7 +2450,7 @@ namespace PVR
 
   void CPVRGUIActions::SetSelectedItemPath(bool bRadio, const std::string& path)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (bRadio)
       m_selectedItemPathRadio = path;
     else
@@ -2478,7 +2478,7 @@ namespace PVR
       }
     }
 
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     return bRadio ? m_selectedItemPathRadio : m_selectedItemPathTV;
   }
 

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -18,11 +18,12 @@
 #include "pvr/guilib/PVRGUIActions.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
 #include "utils/Job.h"
 #include "utils/JobManager.h"
 #include "utils/XTimeUtils.h"
+
+#include <mutex>
 
 using namespace std::chrono_literals;
 
@@ -134,7 +135,7 @@ namespace PVR
           CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bPlayingRadio);
       if (group)
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         return bNext ? group->GetNextChannelGroupMember(m_currentChannel)
                      : group->GetPreviousChannelGroupMember(m_currentChannel);
       }
@@ -147,7 +148,7 @@ namespace PVR
   {
     CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(CFileItem(groupMember));
 
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_currentChannel = groupMember;
     ShowInfo(false);
 
@@ -178,7 +179,7 @@ namespace PVR
     CFileItemPtr item;
 
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       if (m_iChannelEntryJobId >= 0)
       {
@@ -195,7 +196,7 @@ namespace PVR
 
   bool CPVRGUIChannelNavigator::IsPreview() const
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     return m_currentChannel != m_playingChannel;
   }
 
@@ -219,7 +220,7 @@ namespace PVR
     {
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetShowInfo(true);
 
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       if (m_iChannelInfoJobId >= 0)
       {
@@ -242,7 +243,7 @@ namespace PVR
     CFileItemPtr item;
 
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       if (m_iChannelInfoJobId >= 0)
       {
@@ -277,7 +278,7 @@ namespace PVR
 
     if (groupMember)
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
 
       m_playingChannel = groupMember;
       if (m_currentChannel != m_playingChannel)
@@ -296,7 +297,7 @@ namespace PVR
 
   void CPVRGUIChannelNavigator::ClearPlayingChannel()
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_playingChannel.reset();
     HideInfo();
   }

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <mutex>
 #include <string>
 
 using namespace std::chrono_literals;
@@ -30,7 +31,7 @@ CPVRGUIProgressHandler::CPVRGUIProgressHandler(const std::string& strTitle)
 
 void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fProgress)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bChanged = true;
   m_strText = strText;
   m_fProgress = fProgress;
@@ -70,7 +71,7 @@ void CPVRGUIProgressHandler::Process()
     bool bUpdate = false;
 
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       if (m_bChanged)
       {
         m_bChanged = false;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -45,6 +45,7 @@
 #include <cmath>
 #include <ctime>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -59,7 +60,7 @@ CPVRGUIInfo::CPVRGUIInfo() : CThread("PVRGUIInfo")
 
 void CPVRGUIInfo::ResetProperties()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_anyTimersInfo.ResetProperties();
   m_tvTimersInfo.ResetProperties();
@@ -221,7 +222,7 @@ void CPVRGUIInfo::UpdateQualityData()
       client->SignalQuality(channelUid, qualityInfo);
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_qualityInfo = qualityInfo;
 }
 
@@ -245,7 +246,7 @@ void CPVRGUIInfo::UpdateDescrambleData()
       client->GetDescrambleInfo(channelUid, descrambleInfo);
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_descrambleInfo = descrambleInfo;
 }
 
@@ -274,7 +275,7 @@ void CPVRGUIInfo::UpdateMisc()
   const std::string strPlayingRadioGroup =
       (bStarted && bIsPlayingRadio) ? state->GetActiveChannelGroup(true)->GroupName() : "";
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strPlayingClientName = strPlayingClientName;
   m_bHasTVRecordings = bHasTVRecordings;
   m_bHasRadioRecordings = bHasRadioRecordings;
@@ -495,7 +496,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         return false;
       case VIDEOPLAYER_CHANNEL_GROUP:
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         strValue = recording->IsRadio() ? m_strPlayingRadioGroup : m_strPlayingTVGroup;
         return true;
       }
@@ -775,7 +776,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case MUSICPLAYER_CHANNEL_GROUP:
       case VIDEOPLAYER_CHANNEL_GROUP:
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         strValue = channel->IsRadio() ? m_strPlayingRadioGroup : m_strPlayingTVGroup;
         return true;
       }
@@ -787,7 +788,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
 
 bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::string& strValue) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   switch (info.m_info)
   {
@@ -1196,7 +1197,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem* item, const CGUIInfo&
 
 bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iValue) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   switch (info.m_info)
   {
@@ -1547,7 +1548,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
 
 bool CPVRGUIInfo::GetPVRBool(const CFileItem* item, const CGUIInfo& info, bool& bValue) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   switch (info.m_info)
   {
@@ -1828,7 +1829,7 @@ void CPVRGUIInfo::CharInfoProvider(std::string& strValue) const
 
 void CPVRGUIInfo::UpdateBackendCache()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   // Update the backend information for all backends if
   // an update has been requested

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -15,10 +15,10 @@
 #include "pvr/timers/PVRTimers.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -31,7 +31,7 @@ CPVRGUITimerInfo::CPVRGUITimerInfo()
 
 void CPVRGUITimerInfo::ResetProperties()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strActiveTimerTitle.clear();
   m_strActiveTimerChannelName.clear();
   m_strActiveTimerChannelIcon.clear();
@@ -49,7 +49,7 @@ void CPVRGUITimerInfo::ResetProperties()
 
 bool CPVRGUITimerInfo::TimerInfoToggle()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_iTimerInfoToggleStart.time_since_epoch().count() == 0)
   {
     m_iTimerInfoToggleStart = std::chrono::steady_clock::now();
@@ -103,7 +103,7 @@ void CPVRGUITimerInfo::UpdateTimersToggle()
     }
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strActiveTimerTitle = strActiveTimerTitle;
   m_strActiveTimerChannelName = strActiveTimerChannelName;
   m_strActiveTimerChannelIcon = strActiveTimerChannelIcon;
@@ -116,7 +116,7 @@ void CPVRGUITimerInfo::UpdateTimersCache()
   int iRecordingTimerAmount = AmountActiveRecordings();
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_iTimerAmount = iTimerAmount;
     m_iRecordingTimerAmount = iRecordingTimerAmount;
     m_iTimerInfoToggleStart = {};
@@ -147,7 +147,7 @@ void CPVRGUITimerInfo::UpdateNextTimer()
                                            timer->StartAsLocalTime().GetAsLocalizedTime("", false));
   }
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_strNextRecordingTitle = strNextRecordingTitle;
   m_strNextRecordingChannelName = strNextRecordingChannelName;
   m_strNextRecordingChannelIcon = strNextRecordingChannelIcon;
@@ -157,55 +157,55 @@ void CPVRGUITimerInfo::UpdateNextTimer()
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerTitle() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strActiveTimerTitle;
 }
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerChannelName() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strActiveTimerChannelName;
 }
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerChannelIcon() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strActiveTimerChannelIcon;
 }
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerDateTime() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strActiveTimerTime;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerTitle() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strNextRecordingTitle;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerChannelName() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strNextRecordingChannelName;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerChannelIcon() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strNextRecordingChannelIcon;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerDateTime() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strNextRecordingTime;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimer() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strNextTimerInfo;
 }
 

--- a/xbmc/pvr/providers/PVRProvider.cpp
+++ b/xbmc/pvr/providers/PVRProvider.cpp
@@ -19,6 +19,7 @@
 #include "utils/log.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 using namespace PVR;
@@ -105,13 +106,13 @@ void CPVRProvider::Serialize(CVariant& value) const
 
 int CPVRProvider::GetDatabaseId() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iDatabaseId;
 }
 
 bool CPVRProvider::SetDatabaseId(int iDatabaseId)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_iDatabaseId != iDatabaseId)
   {
@@ -124,25 +125,25 @@ bool CPVRProvider::SetDatabaseId(int iDatabaseId)
 
 int CPVRProvider::GetUniqueId() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iUniqueId;
 }
 
 int CPVRProvider::GetClientId() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iClientId;
 }
 
 std::string CPVRProvider::GetName() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strName;
 }
 
 bool CPVRProvider::SetName(const std::string& strName)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_strName != strName)
   {
     m_strName = strName;
@@ -154,13 +155,13 @@ bool CPVRProvider::SetName(const std::string& strName)
 
 PVR_PROVIDER_TYPE CPVRProvider::GetType() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_type;
 }
 
 bool CPVRProvider::SetType(PVR_PROVIDER_TYPE type)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_type != type)
   {
     m_type = type;
@@ -172,19 +173,19 @@ bool CPVRProvider::SetType(PVR_PROVIDER_TYPE type)
 
 std::string CPVRProvider::GetClientIconPath() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iconPath.GetClientImage();
 }
 
 std::string CPVRProvider::GetIconPath() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iconPath.GetLocalImage();
 }
 
 bool CPVRProvider::SetIconPath(const std::string& strIconPath)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (GetClientIconPath() != strIconPath)
   {
     m_iconPath.SetClientImage(strIconPath);
@@ -211,14 +212,14 @@ const std::string DeTokenize(const std::vector<std::string>& tokens)
 
 std::vector<std::string> CPVRProvider::GetCountries() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   return Tokenize(m_strCountries);
 }
 
 bool CPVRProvider::SetCountries(const std::vector<std::string>& countries)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strCountries = DeTokenize(countries);
   if (m_strCountries != strCountries)
   {
@@ -231,13 +232,13 @@ bool CPVRProvider::SetCountries(const std::vector<std::string>& countries)
 
 std::string CPVRProvider::GetCountriesDBString() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strCountries;
 }
 
 bool CPVRProvider::SetCountriesFromDBString(const std::string& strCountries)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_strCountries != strCountries)
   {
     m_strCountries = strCountries;
@@ -249,13 +250,13 @@ bool CPVRProvider::SetCountriesFromDBString(const std::string& strCountries)
 
 std::vector<std::string> CPVRProvider::GetLanguages() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return Tokenize(m_strLanguages);
 }
 
 bool CPVRProvider::SetLanguages(const std::vector<std::string>& languages)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strLanguages = DeTokenize(languages);
   if (m_strLanguages != strLanguages)
   {
@@ -268,13 +269,13 @@ bool CPVRProvider::SetLanguages(const std::vector<std::string>& languages)
 
 std::string CPVRProvider::GetLanguagesDBString() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strLanguages;
 }
 
 bool CPVRProvider::SetLanguagesFromDBString(const std::string& strLanguages)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_strLanguages != strLanguages)
   {
     m_strLanguages = strLanguages;
@@ -289,7 +290,7 @@ bool CPVRProvider::Persist(bool updateRecord /* = false */)
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     return database->Persist(*this, updateRecord);
   }
 
@@ -301,7 +302,7 @@ bool CPVRProvider::DeleteFromDatabase()
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     return database->Delete(*this);
   }
 
@@ -312,7 +313,7 @@ bool CPVRProvider::UpdateEntry(const std::shared_ptr<CPVRProvider>& fromProvider
                                ProviderUpdateMode updateMode)
 {
   bool bChanged = false;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (updateMode == ProviderUpdateMode::BY_DATABASE)
   {
@@ -375,18 +376,18 @@ bool CPVRProvider::UpdateEntry(const std::shared_ptr<CPVRProvider>& fromProvider
 
 bool CPVRProvider::HasThumbPath() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return (m_type == PVR_PROVIDER_TYPE_ADDON && !m_thumbPath.GetLocalImage().empty());
 }
 
 std::string CPVRProvider::GetThumbPath() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_thumbPath.GetLocalImage();
 }
 
 std::string CPVRProvider::GetClientThumbPath() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_thumbPath.GetClientImage();
 }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -29,6 +29,7 @@
 #include "video/VideoDatabase.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -149,7 +150,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
 
 bool CPVRRecording::operator ==(const CPVRRecording& right) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return (this == &right) ||
          (m_strRecordingId == right.m_strRecordingId && m_iClientId == right.m_iClientId &&
           m_strChannelName == right.m_strChannelName && m_recordingTime == right.m_recordingTime &&
@@ -204,7 +205,7 @@ void CPVRRecording::Serialize(CVariant& value) const
 
 void CPVRRecording::ToSortable(SortItem& sortable, Field field) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (field == FieldSize)
     sortable[FieldSize] = m_sizeInBytes;
   else
@@ -231,7 +232,7 @@ void CPVRRecording::Reset()
   m_bRadio = false;
   m_iFlags = PVR_RECORDING_FLAG_UNDEFINED;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_sizeInBytes = 0;
   }
   m_strProviderName.clear();
@@ -343,7 +344,7 @@ bool CPVRRecording::UpdateRecordingSize()
     int64_t sizeInBytes = -1;
     client->GetRecordingSize(*this, sizeInBytes);
 
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (sizeInBytes >= 0 && sizeInBytes != m_sizeInBytes)
     {
       m_sizeInBytes = sizeInBytes;
@@ -410,7 +411,7 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
   m_firstAired = tag.m_firstAired;
   m_iFlags = tag.m_iFlags;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_sizeInBytes = tag.m_sizeInBytes;
     m_strProviderName = tag.m_strProviderName;
     m_iClientProviderUniqueId = tag.m_iClientProviderUniqueId;
@@ -623,19 +624,19 @@ bool CPVRRecording::IsFinale() const
 
 int64_t CPVRRecording::GetSizeInBytes() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_sizeInBytes;
 }
 
 int CPVRRecording::ClientProviderUniqueId() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iClientProviderUniqueId;
 }
 
 std::string CPVRRecording::ProviderName() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_strProviderName;
 }
 
@@ -647,7 +648,7 @@ std::shared_ptr<CPVRProvider> CPVRRecording::GetDefaultProvider() const
 
 bool CPVRRecording::HasClientProvider() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iClientProviderUniqueId != PVR_PROVIDER_INVALID_UID;
 }
 

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -20,6 +20,7 @@
 #include "utils/log.h"
 
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <utility>
@@ -64,13 +65,13 @@ CPVRSettings::~CPVRSettings()
 
 void CPVRSettings::RegisterCallback(ISettingCallback* callback)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_callbacks.insert(callback);
 }
 
 void CPVRSettings::UnregisterCallback(ISettingCallback* callback)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_callbacks.erase(callback);
 }
 
@@ -85,7 +86,7 @@ void CPVRSettings::Init(const std::set<std::string>& settingNames)
       continue;
     }
 
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_settings.insert(std::make_pair(settingName, setting->Clone(settingName)));
   }
 }
@@ -95,7 +96,7 @@ void CPVRSettings::OnSettingsLoaded()
   std::set<std::string> settingNames;
 
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     for (const auto& settingName : m_settings)
       settingNames.insert(settingName.first);
 
@@ -110,7 +111,7 @@ void CPVRSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setti
   if (setting == nullptr)
     return;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_settings[setting->GetId()] = setting->Clone(setting->GetId());
   const auto callbacks(m_callbacks);
   lock.unlock();
@@ -121,7 +122,7 @@ void CPVRSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setti
 
 bool CPVRSettings::GetBoolValue(const std::string& settingName) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
   if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::Boolean)
   {
@@ -136,7 +137,7 @@ bool CPVRSettings::GetBoolValue(const std::string& settingName) const
 
 int CPVRSettings::GetIntValue(const std::string& settingName) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
   if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::Integer)
   {
@@ -151,7 +152,7 @@ int CPVRSettings::GetIntValue(const std::string& settingName) const
 
 std::string CPVRSettings::GetStringValue(const std::string& settingName) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
   if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::String)
   {

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -113,7 +113,7 @@ void CPVRSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setti
   CSingleLock lock(m_critSection);
   m_settings[setting->GetId()] = setting->Clone(setting->GetId());
   const auto callbacks(m_callbacks);
-  lock.Leave();
+  lock.unlock();
 
   for (const auto& callback : callbacks)
     callback->OnSettingChanged(setting);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -371,7 +371,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer& timers, const std::vec
   if (bChanged)
   {
     UpdateChannels();
-    lock.Leave();
+    lock.unlock();
 
     NotifyTimersEvent(bAddedOrDeleted);
 
@@ -1038,7 +1038,7 @@ bool CPVRTimers::AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, boo
 
   if (bNotify && bReturn)
   {
-    lock.Leave();
+    lock.unlock();
     NotifyTimersEvent();
   }
 
@@ -1082,7 +1082,7 @@ bool CPVRTimers::DeleteLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, 
 
   if (bNotify && bReturn)
   {
-    lock.Leave();
+    lock.unlock();
     NotifyTimersEvent();
   }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -21,12 +21,12 @@
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimerRuleMatcher.h"
 #include "settings/Settings.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -41,7 +41,7 @@ constexpr auto MAX_NOTIFICATION_DELAY = 10s;
 
 bool CPVRTimersContainer::UpdateFromClient(const std::shared_ptr<CPVRTimerInfoTag>& timer)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::shared_ptr<CPVRTimerInfoTag> tag = GetByClient(timer->m_iClientId, timer->m_iClientIndex);
   if (tag)
   {
@@ -58,7 +58,7 @@ bool CPVRTimersContainer::UpdateFromClient(const std::shared_ptr<CPVRTimerInfoTa
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimersContainer::GetByClient(int iClientId, int iClientIndex) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& startDates : m_tags)
   {
     for (const auto& timer : startDates.second)
@@ -128,7 +128,7 @@ bool CPVRTimers::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>
 void CPVRTimers::Unload()
 {
   // remove all tags
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_tags.clear();
 }
 
@@ -149,7 +149,7 @@ void CPVRTimers::Stop()
 bool CPVRTimers::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (m_bIsUpdating)
       return false;
     m_bIsUpdating = true;
@@ -175,7 +175,7 @@ void CPVRTimers::Process()
 
 bool CPVRTimers::IsRecording() const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (MapTags::const_iterator it = m_tags.begin(); it != m_tags.end(); ++it)
     for (VecTimerInfoTag::const_iterator timerIt = it->second.begin(); timerIt != it->second.end(); ++timerIt)
@@ -187,7 +187,7 @@ bool CPVRTimers::IsRecording() const
 
 void CPVRTimers::RemoveEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   auto it = m_tags.find(tag->m_bStartAnyTime ? CDateTime() : tag->StartAsUTC());
   if (it != m_tags.end())
@@ -229,7 +229,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer& timers, const std::vec
   bool bAddedOrDeleted(false);
   std::vector< std::pair< int, std::string> > timerNotifications;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   /* go through the timer list and check for updated or new timers */
   for (MapTags::const_iterator it = timers.GetTags().begin(); it != timers.GetTags().end(); ++it)
@@ -496,7 +496,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
   bool bFetchedAllEpgs = false;
   std::map<std::shared_ptr<CPVREpg>, std::vector<std::shared_ptr<CPVRTimerRuleMatcher>>> epgMap;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (MapTags::iterator it = m_tags.begin(); it != m_tags.end();)
   {
@@ -678,7 +678,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetNextReminderToAnnnounce()
 {
   std::shared_ptr<CPVRTimerInfoTag> ret;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (!m_remindersToAnnounce.empty())
   {
     ret = m_remindersToAnnounce.front();
@@ -696,7 +696,7 @@ bool CPVRTimers::KindMatchesTag(const TimerKind& eKind, const std::shared_ptr<CP
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetNextActiveTimer(const TimerKind& eKind, bool bIgnoreReminders) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -735,7 +735,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetNextActiveRadioTimer() const
 std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveTimers() const
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> tags;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (MapTags::const_iterator it = m_tags.begin(); it != m_tags.end(); ++it)
   {
@@ -758,7 +758,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveTimers() con
 int CPVRTimers::AmountActiveTimers(const TimerKind& eKind) const
 {
   int iReturn = 0;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -794,7 +794,7 @@ int CPVRTimers::AmountActiveRadioTimers() const
 std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveRecordings(const TimerKind& eKind) const
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> tags;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -832,7 +832,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveRadioRecordi
 int CPVRTimers::AmountActiveRecordings(const TimerKind& eKind) const
 {
   int iReturn = 0;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -872,7 +872,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const std::shared_ptr<CPVRChannel>& chann
   bool bReturn = false;
   bool bChanged = false;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     for (MapTags::reverse_iterator it = m_tags.rbegin(); it != m_tags.rend(); ++it)
     {
@@ -903,7 +903,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::UpdateEntry(const std::shared_ptr<
 {
   bool bChanged = false;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   std::shared_ptr<CPVRTimerInfoTag> tag = GetByClient(timer->m_iClientId, timer->m_iClientIndex);
   if (tag)
   {
@@ -998,7 +998,7 @@ bool CPVRTimers::UpdateTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag)
 
 bool CPVRTimers::AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   const std::shared_ptr<CPVRTimerInfoTag> persistedTimer = PersistAndUpdateLocalTimer(tag, nullptr);
   bool bReturn = !!persistedTimer;
@@ -1047,7 +1047,7 @@ bool CPVRTimers::AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, boo
 
 bool CPVRTimers::DeleteLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   RemoveEntry(tag);
 
@@ -1119,7 +1119,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::PersistAndUpdateLocalTimer(
 
 bool CPVRTimers::IsRecordingOnChannel(const CPVRChannel& channel) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
 
   for (MapTags::const_iterator it = m_tags.begin(); it != m_tags.end(); ++it)
   {
@@ -1137,7 +1137,7 @@ bool CPVRTimers::IsRecordingOnChannel(const CPVRChannel& channel) const
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetActiveTimerForChannel(const std::shared_ptr<CPVRChannel>& channel) const
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& tagsEntry : m_tags)
   {
     for (const auto& timersEntry : tagsEntry.second)
@@ -1156,7 +1156,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerForEpgTag(const std::share
 {
   if (epgTag)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     for (const auto& tagsEntry : m_tags)
     {
@@ -1196,7 +1196,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerRule(const std::shared_ptr
     {
       int iClientId = timer->m_iClientId;
 
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       for (const auto& tagsEntry : m_tags)
       {
         for (const auto& timersEntry : tagsEntry.second)
@@ -1220,7 +1220,7 @@ void CPVRTimers::Notify(const PVREvent& event)
     case PVREvent::Epg:
     case PVREvent::EpgItemUpdate:
     {
-      CSingleLock lock(m_critSection);
+      std::unique_lock<CCriticalSection> lock(m_critSection);
       m_bReminderRulesUpdatePending = true;
       break;
     }
@@ -1276,7 +1276,7 @@ CDateTime CPVRTimers::GetNextEventTime() const
 
 void CPVRTimers::UpdateChannels()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (MapTags::iterator it = m_tags.begin(); it != m_tags.end(); ++it)
   {
     for (VecTimerInfoTag::iterator timerIt = it->second.begin(); timerIt != it->second.end(); ++timerIt)
@@ -1288,7 +1288,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetAll() const
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> timers;
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& tagsEntry : m_tags)
   {
     for (const auto& timer : tagsEntry.second)
@@ -1303,7 +1303,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetAll() const
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetById(unsigned int iTimerId) const
 {
   std::shared_ptr<CPVRTimerInfoTag> item;
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   for (MapTags::const_iterator it = m_tags.begin(); !item && it != m_tags.end(); ++it)
   {
     for (VecTimerInfoTag::const_iterator timerIt = it->second.begin(); !item && timerIt != it->second.end(); ++timerIt)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -34,6 +34,7 @@
 
 #include <iterator>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -150,7 +151,7 @@ void CGUIWindowPVRBase::RegisterObservers()
 {
   CServiceBroker::GetPVRManager().Events().Subscribe(this, &CGUIWindowPVRBase::Notify);
 
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_channelGroup)
     m_channelGroup->Events().Subscribe(this, &CGUIWindowPVRBase::Notify);
 };
@@ -158,7 +159,7 @@ void CGUIWindowPVRBase::RegisterObservers()
 void CGUIWindowPVRBase::UnregisterObservers()
 {
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (m_channelGroup)
       m_channelGroup->Events().Unsubscribe(this);
   }
@@ -271,7 +272,7 @@ bool CGUIWindowPVRBase::ActivateNextChannelGroup()
 
 void CGUIWindowPVRBase::ClearData()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_channelGroup.reset();
   m_channelGroupsSelector.reset(new CGUIPVRChannelGroupsSelector);
 }
@@ -468,7 +469,7 @@ bool CGUIWindowPVRBase::InitChannelGroup()
 
   if (group)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (m_channelGroup != group)
     {
       m_viewControl.SetSelectedItem(0);
@@ -483,7 +484,7 @@ bool CGUIWindowPVRBase::InitChannelGroup()
 
 std::shared_ptr<CPVRChannelGroup> CGUIWindowPVRBase::GetChannelGroup()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_channelGroup;
 }
 
@@ -494,7 +495,7 @@ void CGUIWindowPVRBase::SetChannelGroup(std::shared_ptr<CPVRChannelGroup> &&grou
 
   std::shared_ptr<CPVRChannelGroup> updateChannelGroup;
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     if (m_channelGroup != group)
     {
       if (m_channelGroup)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -33,10 +33,10 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/guilib/PVRGUIActions.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
+#include <mutex>
 #include <string>
 
 using namespace PVR;
@@ -72,7 +72,7 @@ bool CGUIWindowPVRChannelsBase::Update(const std::string& strDirectory, bool upd
 
   if (bReturn)
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     /* empty list for hidden channels */
     if (m_vecItems->GetObjectCount() == 0 && m_bShowHiddenChannels)
     {

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -78,7 +78,7 @@ bool CGUIWindowPVRChannelsBase::Update(const std::string& strDirectory, bool upd
     {
       /* show the visible channels instead */
       m_bShowHiddenChannels = false;
-      lock.Leave();
+      lock.unlock();
       Update(GetDirectoryPath());
     }
   }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -39,11 +39,11 @@
 #include "pvr/timers/PVRTimers.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "view/GUIViewState.h"
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -102,7 +102,7 @@ void CGUIWindowPVRGuideBase::InitEpgGridControl()
 void CGUIWindowPVRGuideBase::ClearData()
 {
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
     m_cachedChannelGroup.reset();
   }
 
@@ -235,7 +235,7 @@ bool CGUIWindowPVRGuideBase::Update(const std::string& strDirectory, bool update
 bool CGUIWindowPVRGuideBase::GetDirectory(const std::string& strDirectory, CFileItemList& items)
 {
   {
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     if (m_cachedChannelGroup && *m_cachedChannelGroup != *GetChannelGroup())
     {
@@ -732,7 +732,7 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       epgGridContainer->SetTimelineItems(channels, startDate, endDate);
 
       {
-        CSingleLock lock(m_critSection);
+        std::unique_lock<CCriticalSection> lock(m_critSection);
         m_cachedChannelGroup = group;
       }
       return true;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -153,7 +153,7 @@ bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory, bool u
     {
       /* show the normal recordings instead */
       m_bShowDeletedRecordings = false;
-      lock.Leave();
+      lock.unlock();
       Update(GetDirectoryPath());
       return bReturn;
     }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -25,12 +25,12 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
 #include "video/VideoLibraryQueue.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 using namespace PVR;
@@ -146,7 +146,7 @@ bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory, bool u
     //       to see the deleted recordings? Or is this just another hack to avoid misbehavior
     //       of CGUIMediaWindow if it has no content?
 
-    CSingleLock lock(m_critSection);
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
     /* empty list for deleted recordings */
     if (m_vecItems->GetObjectCount() == 0 && m_bShowDeletedRecordings)

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -12,10 +12,11 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "rendering/dx/DeviceResources.h"
-#include "threads/SingleLock.h"
 #include "utils/Screenshot.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
+
+#include <mutex>
 
 #include <wrl/client.h>
 
@@ -41,7 +42,7 @@ bool CScreenshotSurfaceWindows::Capture()
   if (!gui)
     return false;
 
-  CSingleLock lock(winsystem->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(winsystem->GetGfxContext());
   gui->GetWindowManager().Render();
 
   auto deviceResources = DX::DeviceResources::Get();

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -11,10 +11,10 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "threads/SingleLock.h"
 #include "utils/Screenshot.h"
 #include "windowing/GraphicContext.h"
 
+#include <mutex>
 #include <vector>
 
 #include "system_gl.h"
@@ -39,7 +39,7 @@ bool CScreenshotSurfaceGL::Capture()
   if (!gui)
     return false;
 
-  CSingleLock lock(winsystem->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(winsystem->GetGfxContext());
   gui->GetWindowManager().Render();
 
   glReadBuffer(GL_BACK);

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -11,10 +11,10 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "threads/SingleLock.h"
 #include "utils/Screenshot.h"
 #include "windowing/GraphicContext.h"
 
+#include <mutex>
 #include <vector>
 
 #include "system_gl.h"
@@ -39,7 +39,7 @@ bool CScreenshotSurfaceGLES::Capture()
   if (!gui)
     return false;
 
-  CSingleLock lock(winsystem->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(winsystem->GetGfxContext());
   gui->GetWindowManager().Render();
 
   //get current viewport

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -8,34 +8,34 @@
 
 #include "DisplaySettings.h"
 
-#include <cstdlib>
-#include <float.h>
-#include <algorithm>
-#include <string>
-#include <utility>
-#include <vector>
-
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/VideoRenderers/ColorManager.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "windowing/GraphicContext.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "rendering/RenderSystem.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/lib/Setting.h"
-#include "settings/lib/SettingDefinitions.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
+#include "settings/lib/SettingDefinitions.h"
 #include "storage/MediaManager.h"
-#include "threads/SingleLock.h"
-#include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
-#include "rendering/RenderSystem.h"
+#include "utils/log.h"
+#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <float.h>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
 
 #ifdef TARGET_WINDOWS
 #include "rendering/dx/DeviceResources.h"
@@ -99,7 +99,7 @@ CDisplaySettings& CDisplaySettings::GetInstance()
 
 bool CDisplaySettings::Load(const TiXmlNode *settings)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_calibrations.clear();
 
   if (settings == NULL)
@@ -166,7 +166,7 @@ bool CDisplaySettings::Save(TiXmlNode *settings) const
   if (settings == NULL)
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   TiXmlElement xmlRootElement("resolutions");
   TiXmlNode *pRoot = settings->InsertEndChild(xmlRootElement);
   if (pRoot == NULL)
@@ -208,7 +208,7 @@ bool CDisplaySettings::Save(TiXmlNode *settings) const
 
 void CDisplaySettings::Clear()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_calibrations.clear();
   m_resolutions.clear();
   m_resolutions.resize(RES_CUSTOM);
@@ -445,7 +445,7 @@ RESOLUTION CDisplaySettings::GetDisplayResolution() const
 
 const RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(size_t index) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (index >= m_resolutions.size())
     return EmptyResolution;
 
@@ -462,7 +462,7 @@ const RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(RESOLUTION resolution
 
 RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(size_t index)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (index >= m_resolutions.size())
   {
     EmptyModifiableResolution = RESOLUTION_INFO();
@@ -485,7 +485,7 @@ RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(RESOLUTION resolution)
 
 void CDisplaySettings::AddResolutionInfo(const RESOLUTION_INFO &resolution)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   RESOLUTION_INFO res(resolution);
 
   if((res.dwFlags & D3DPRESENTFLAG_MODE3DTB) == 0)
@@ -511,7 +511,7 @@ void CDisplaySettings::AddResolutionInfo(const RESOLUTION_INFO &resolution)
 
 void CDisplaySettings::ApplyCalibrations()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // apply all calibrations to the resolutions
   for (ResolutionInfos::const_iterator itCal = m_calibrations.begin(); itCal != m_calibrations.end(); ++itCal)
   {
@@ -564,7 +564,7 @@ void CDisplaySettings::ApplyCalibrations()
 
 void CDisplaySettings::UpdateCalibrations()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   if (m_resolutions.size() <= RES_DESKTOP)
     return;
@@ -590,7 +590,7 @@ void CDisplaySettings::UpdateCalibrations()
 
 void CDisplaySettings::ClearCalibrations()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_calibrations.clear();
 }
 

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -22,7 +22,6 @@
 #include "settings/dialogs/GUIDialogLibExportSettings.h"
 #include "settings/lib/Setting.h"
 #include "storage/MediaManager.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/XBMCTinyXML.h"
@@ -32,6 +31,7 @@
 #include "video/VideoLibraryQueue.h"
 
 #include <limits.h>
+#include <mutex>
 #include <string>
 
 using namespace KODI;
@@ -72,7 +72,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
   if (settings == NULL)
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   const TiXmlElement *pElement = settings->FirstChildElement("defaultvideosettings");
   if (pElement != NULL)
   {
@@ -201,7 +201,7 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
   if (settings == NULL)
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // default video settings
   TiXmlElement videoSettingsNode("defaultvideosettings");
   TiXmlNode *pNode = settings->InsertEndChild(videoSettingsNode);
@@ -369,7 +369,7 @@ void CMediaSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& set
 
 int CMediaSettings::GetWatchedMode(const std::string &content) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   WatchedModes::const_iterator it = m_watchedModes.find(GetWatchedContent(content));
   if (it != m_watchedModes.end())
     return it->second;
@@ -379,7 +379,7 @@ int CMediaSettings::GetWatchedMode(const std::string &content) const
 
 void CMediaSettings::SetWatchedMode(const std::string &content, WatchedMode mode)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   WatchedModes::iterator it = m_watchedModes.find(GetWatchedContent(content));
   if (it != m_watchedModes.end())
     it->second = mode;
@@ -387,7 +387,7 @@ void CMediaSettings::SetWatchedMode(const std::string &content, WatchedMode mode
 
 void CMediaSettings::CycleWatchedMode(const std::string &content)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   WatchedModes::iterator it = m_watchedModes.find(GetWatchedContent(content));
   if (it != m_watchedModes.end())
   {

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -14,6 +14,8 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 CSettingAddon::CSettingAddon(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
   : CSettingString(id, settingsManager)
 { }
@@ -35,7 +37,7 @@ SettingPtr CSettingAddon::Clone(const std::string &id) const
 
 bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (!CSettingString::Deserialize(node, update))
     return false;
@@ -75,6 +77,6 @@ void CSettingAddon::copyaddontype(const CSettingAddon &setting)
 {
   CSettingString::Copy(setting);
 
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
   m_addonType = setting.m_addonType;
 }

--- a/xbmc/settings/SettingDateTime.cpp
+++ b/xbmc/settings/SettingDateTime.cpp
@@ -10,6 +10,8 @@
 
 #include "XBDateTime.h"
 
+#include <shared_mutex>
+
 CSettingDate::CSettingDate(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : CSettingString(id, settingsManager)
 { }
@@ -29,7 +31,7 @@ SettingPtr CSettingDate::Clone(const std::string &id) const
 
 bool CSettingDate::CheckValidity(const std::string &value) const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
 
   if (!CSettingString::CheckValidity(value))
     return false;
@@ -56,7 +58,7 @@ SettingPtr CSettingTime::Clone(const std::string &id) const
 
 bool CSettingTime::CheckValidity(const std::string &value) const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
 
   if (!CSettingString::CheckValidity(value))
     return false;

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -15,6 +15,8 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 #define XML_ELM_DEFAULT     "default"
 #define XML_ELM_CONSTRAINTS "constraints"
 
@@ -39,7 +41,7 @@ SettingPtr CSettingPath::Clone(const std::string &id) const
 
 bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (!CSettingString::Deserialize(node, update))
     return false;
@@ -135,7 +137,7 @@ void CSettingPath::copy(const CSettingPath& setting)
 {
   CSettingString::Copy(setting);
 
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
   m_writable = setting.m_writable;
   m_sources = setting.m_sources;
   m_hideExtension = setting.m_hideExtension;

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -15,6 +15,8 @@
 #include "utils/Variant.h"
 #include "utils/XBMCTinyXML.h"
 
+#include <mutex>
+
 #define SETTINGS_XML_ROOT   "settings"
 
 CSettingsBase::CSettingsBase()
@@ -30,7 +32,7 @@ CSettingsBase::~CSettingsBase()
 
 bool CSettingsBase::Initialize()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (m_initialized)
     return false;
 
@@ -133,7 +135,7 @@ void CSettingsBase::Unload()
 
 void CSettingsBase::Uninitialize()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (!m_initialized)
     return;
 

--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -14,12 +14,12 @@
 #include "guilib/GUIComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 #define XML_SKINSETTINGS  "skinsettings"
@@ -96,7 +96,7 @@ bool CSkinSettings::Load(const TiXmlNode *settings)
     return true;
   }
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_settings.clear();
   m_settings = ADDON::CSkinInfo::ParseSettings(rootElement);
 
@@ -115,7 +115,7 @@ bool CSkinSettings::Save(TiXmlNode *settings) const
 
 void CSkinSettings::Clear()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_settings.clear();
 }
 
@@ -124,7 +124,7 @@ void CSkinSettings::MigrateSettings(const ADDON::SkinPtr& skin)
   if (skin == nullptr)
     return;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   bool settingsMigrated = false;
   const std::string& skinId = skin->ID();

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -16,6 +16,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <shared_mutex>
 #include <sstream>
 #include <utility>
@@ -395,7 +396,7 @@ void CSettingList::MergeDetails(const CSetting& other)
 
 bool CSettingList::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (m_definition == nullptr)
     return false;
@@ -503,7 +504,7 @@ bool CSettingList::CheckValidity(const std::string &value) const
 
 void CSettingList::Reset()
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
   SettingList values;
   for (const auto& it : m_defaults)
     values.push_back(it->Clone(it->GetId()));
@@ -522,7 +523,7 @@ bool CSettingList::FromString(const std::vector<std::string> &value)
 
 bool CSettingList::SetValue(const SettingList &values)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if ((int)values.size() < m_minimumItems ||
      (m_maximumItems > 0 && (int)values.size() > m_maximumItems))
@@ -565,7 +566,7 @@ bool CSettingList::SetValue(const SettingList &values)
 
 void CSettingList::SetDefault(const SettingList &values)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   m_defaults.clear();
   m_defaults.insert(m_defaults.begin(), values.begin(), values.end());
@@ -702,7 +703,7 @@ void CSettingBool::MergeDetails(const CSetting& other)
 
 bool CSettingBool::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (!CSetting::Deserialize(node, update))
     return false;
@@ -748,7 +749,7 @@ bool CSettingBool::CheckValidity(const std::string &value) const
 
 bool CSettingBool::SetValue(bool value)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (value == m_value)
     return true;
@@ -775,7 +776,7 @@ bool CSettingBool::SetValue(bool value)
 
 void CSettingBool::SetDefault(bool value)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   m_default = value;
   if (!m_changed)
@@ -897,7 +898,7 @@ void CSettingInt::MergeDetails(const CSetting& other)
 
 bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (!CSetting::Deserialize(node, update))
     return false;
@@ -1025,7 +1026,7 @@ bool CSettingInt::CheckValidity(int value) const
 
 bool CSettingInt::SetValue(int value)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (value == m_value)
     return true;
@@ -1055,7 +1056,7 @@ bool CSettingInt::SetValue(int value)
 
 void CSettingInt::SetDefault(int value)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   m_default = value;
   if (!m_changed)
@@ -1077,7 +1078,7 @@ SettingOptionsType CSettingInt::GetOptionsType() const
 
 IntegerSettingOptions CSettingInt::UpdateDynamicOptions()
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
   IntegerSettingOptions options;
   if (m_optionsFiller == nullptr &&
      (m_optionsFillerName.empty() || m_settingsManager == nullptr))
@@ -1126,7 +1127,7 @@ void CSettingInt::copy(const CSettingInt &setting)
 {
   CSetting::Copy(setting);
 
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   m_value = setting.m_value;
   m_default = setting.m_default;
@@ -1220,7 +1221,7 @@ void CSettingNumber::MergeDetails(const CSetting& other)
 
 bool CSettingNumber::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (!CSetting::Deserialize(node, update))
     return false;
@@ -1294,7 +1295,7 @@ bool CSettingNumber::CheckValidity(double value) const
 
 bool CSettingNumber::SetValue(double value)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (value == m_value)
     return true;
@@ -1324,7 +1325,7 @@ bool CSettingNumber::SetValue(double value)
 
 void CSettingNumber::SetDefault(double value)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   m_default = value;
   if (!m_changed)
@@ -1334,7 +1335,7 @@ void CSettingNumber::SetDefault(double value)
 void CSettingNumber::copy(const CSettingNumber &setting)
 {
   CSetting::Copy(setting);
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   m_value = setting.m_value;
   m_default = setting.m_default;
@@ -1420,7 +1421,7 @@ void CSettingString::MergeDetails(const CSetting& other)
 
 bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (!CSetting::Deserialize(node, update))
     return false;
@@ -1514,7 +1515,7 @@ bool CSettingString::CheckValidity(const std::string &value) const
 
 bool CSettingString::SetValue(const std::string &value)
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
 
   if (value == m_value)
     return true;
@@ -1566,7 +1567,7 @@ SettingOptionsType CSettingString::GetOptionsType() const
 
 StringSettingOptions CSettingString::UpdateDynamicOptions()
 {
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
   StringSettingOptions options;
   if (m_optionsFiller == nullptr &&
      (m_optionsFillerName.empty() || m_settingsManager == nullptr))
@@ -1616,7 +1617,7 @@ void CSettingString::copy(const CSettingString &setting)
 {
   CSetting::Copy(setting);
 
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
   m_value = setting.m_value;
   m_default = setting.m_default;
   m_allowEmpty = setting.m_allowEmpty;
@@ -1684,6 +1685,6 @@ void CSettingAction::copy(const CSettingAction& setting)
 {
   CSetting::Copy(setting);
 
-  CExclusiveLock lock(m_critical);
+  std::unique_lock<CSharedSection> lock(m_critical);
   m_data = setting.m_data;
 }

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -16,6 +16,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <shared_mutex>
 #include <sstream>
 #include <utility>
 
@@ -453,7 +454,7 @@ bool CSettingList::Deserialize(const TiXmlNode *node, bool update /* = false */)
 
 SettingType CSettingList::GetElementType() const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
 
   if (m_definition == nullptr)
     return SettingType::Unknown;
@@ -1063,7 +1064,7 @@ void CSettingInt::SetDefault(int value)
 
 SettingOptionsType CSettingInt::GetOptionsType() const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   if (!m_translatableOptions.empty())
     return SettingOptionsType::StaticTranslatable;
   if (!m_options.empty())
@@ -1268,7 +1269,7 @@ std::string CSettingNumber::ToString() const
 bool CSettingNumber::Equals(const std::string &value) const
 {
   double dValue;
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   return (fromString(value, dValue) && m_value == dValue);
 }
 
@@ -1283,7 +1284,7 @@ bool CSettingNumber::CheckValidity(const std::string &value) const
 
 bool CSettingNumber::CheckValidity(double value) const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   if (m_min != m_max &&
      (value < m_min || value > m_max))
     return false;
@@ -1493,7 +1494,7 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
 
 bool CSettingString::CheckValidity(const std::string &value) const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   if (!m_allowEmpty && value.empty())
     return false;
 
@@ -1543,7 +1544,7 @@ bool CSettingString::SetValue(const std::string &value)
 
 void CSettingString::SetDefault(const std::string &value)
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
 
   m_default = value;
   if (!m_changed)
@@ -1552,7 +1553,7 @@ void CSettingString::SetDefault(const std::string &value)
 
 SettingOptionsType CSettingString::GetOptionsType() const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   if (!m_translatableOptions.empty())
     return SettingOptionsType::StaticTranslatable;
   if (!m_options.empty())
@@ -1669,7 +1670,7 @@ void CSettingAction::MergeDetails(const CSetting& other)
 
 bool CSettingAction::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
 
   if (!CSetting::Deserialize(node, update))
     return false;

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -244,7 +245,11 @@ public:
   bool CheckValidity(const std::string &value) const override;
   void Reset() override { SetValue(m_default); }
 
-  bool GetValue() const { CSharedLock lock(m_critical); return m_value; }
+  bool GetValue() const
+  {
+    std::shared_lock<CSharedSection> lock(m_critical);
+    return m_value;
+  }
   bool SetValue(bool value);
   bool GetDefault() const { return m_default; }
   void SetDefault(bool value);
@@ -288,7 +293,11 @@ public:
   virtual bool CheckValidity(int value) const;
   void Reset() override { SetValue(m_default); }
 
-  int GetValue() const { CSharedLock lock(m_critical); return m_value; }
+  int GetValue() const
+  {
+    std::shared_lock<CSharedSection> lock(m_critical);
+    return m_value;
+  }
   bool SetValue(int value);
   int GetDefault() const { return m_default; }
   void SetDefault(int value);
@@ -372,7 +381,11 @@ public:
   virtual bool CheckValidity(double value) const;
   void Reset() override { SetValue(m_default); }
 
-  double GetValue() const { CSharedLock lock(m_critical); return m_value; }
+  double GetValue() const
+  {
+    std::shared_lock<CSharedSection> lock(m_critical);
+    return m_value;
+  }
   bool SetValue(double value);
   double GetDefault() const { return m_default; }
   void SetDefault(double value);
@@ -426,7 +439,11 @@ public:
   bool CheckValidity(const std::string &value) const override;
   void Reset() override { SetValue(m_default); }
 
-  virtual const std::string& GetValue() const { CSharedLock lock(m_critical); return m_value; }
+  virtual const std::string& GetValue() const
+  {
+    std::shared_lock<CSharedSection> lock(m_critical);
+    return m_value;
+  }
   virtual bool SetValue(const std::string &value);
   virtual const std::string& GetDefault() const { return m_default; }
   virtual void SetDefault(const std::string &value);

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <map>
+#include <shared_mutex>
 #include <unordered_set>
 #include <utility>
 
@@ -138,7 +139,7 @@ bool CSettingsManager::Initialize(const TiXmlElement *root)
 
 bool CSettingsManager::Load(const TiXmlElement *root, bool &updated, bool triggerEvents /* = true */, std::map<std::string, SettingPtr> *loadedSettings /* = nullptr */)
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   CExclusiveLock settingsLock(m_settingsCritical);
   if (m_loaded || root == nullptr)
     return false;
@@ -179,8 +180,8 @@ bool CSettingsManager::Save(
   if (serializer == nullptr)
     return false;
 
-  CSharedLock lock(m_critical);
-  CSharedLock settingsLock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock<CSharedSection> settingsLock(m_settingsCritical);
   if (!m_initialized)
     return false;
 
@@ -463,7 +464,7 @@ void CSettingsManager::UnregisterSettingOptionsFiller(const std::string &identif
 
 void* CSettingsManager::GetSettingOptionsFiller(const SettingConstPtr& setting)
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   if (setting == nullptr)
     return nullptr;
 
@@ -518,7 +519,7 @@ bool CSettingsManager::HasSettings() const
 
 SettingPtr CSettingsManager::GetSetting(const std::string &id) const
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   if (id.empty())
     return nullptr;
 
@@ -536,7 +537,7 @@ SettingPtr CSettingsManager::GetSetting(const std::string &id) const
 
 SettingSectionList CSettingsManager::GetSections() const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   SettingSectionList sections;
   for (const auto& section : m_sections)
     sections.push_back(section.second);
@@ -546,7 +547,7 @@ SettingSectionList CSettingsManager::GetSections() const
 
 SettingSectionPtr CSettingsManager::GetSection(std::string section) const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   if (section.empty())
     return nullptr;
 
@@ -562,7 +563,7 @@ SettingSectionPtr CSettingsManager::GetSection(std::string section) const
 
 SettingDependencyMap CSettingsManager::GetDependencies(const std::string &id) const
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   auto setting = FindSetting(id);
   if (setting == m_settings.end())
     return SettingDependencyMap();
@@ -580,7 +581,7 @@ SettingDependencyMap CSettingsManager::GetDependencies(const SettingConstPtr& se
 
 bool CSettingsManager::GetBool(const std::string &id) const
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::Boolean)
     return false;
@@ -590,7 +591,7 @@ bool CSettingsManager::GetBool(const std::string &id) const
 
 bool CSettingsManager::SetBool(const std::string &id, bool value)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::Boolean)
     return false;
@@ -600,7 +601,7 @@ bool CSettingsManager::SetBool(const std::string &id, bool value)
 
 bool CSettingsManager::ToggleBool(const std::string &id)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::Boolean)
     return false;
@@ -610,7 +611,7 @@ bool CSettingsManager::ToggleBool(const std::string &id)
 
 int CSettingsManager::GetInt(const std::string &id) const
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::Integer)
     return 0;
@@ -620,7 +621,7 @@ int CSettingsManager::GetInt(const std::string &id) const
 
 bool CSettingsManager::SetInt(const std::string &id, int value)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::Integer)
     return false;
@@ -630,7 +631,7 @@ bool CSettingsManager::SetInt(const std::string &id, int value)
 
 double CSettingsManager::GetNumber(const std::string &id) const
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::Number)
     return 0.0;
@@ -640,7 +641,7 @@ double CSettingsManager::GetNumber(const std::string &id) const
 
 bool CSettingsManager::SetNumber(const std::string &id, double value)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::Number)
     return false;
@@ -650,7 +651,7 @@ bool CSettingsManager::SetNumber(const std::string &id, double value)
 
 std::string CSettingsManager::GetString(const std::string &id) const
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::String)
     return "";
@@ -660,7 +661,7 @@ std::string CSettingsManager::GetString(const std::string &id) const
 
 bool CSettingsManager::SetString(const std::string &id, const std::string &value)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::String)
     return false;
@@ -670,7 +671,7 @@ bool CSettingsManager::SetString(const std::string &id, const std::string &value
 
 std::vector< std::shared_ptr<CSetting> > CSettingsManager::GetList(const std::string &id) const
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::List)
     return std::vector< std::shared_ptr<CSetting> >();
@@ -680,7 +681,7 @@ std::vector< std::shared_ptr<CSetting> > CSettingsManager::GetList(const std::st
 
 bool CSettingsManager::SetList(const std::string &id, const std::vector< std::shared_ptr<CSetting> > &value)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr || setting->GetType() != SettingType::List)
     return false;
@@ -690,7 +691,7 @@ bool CSettingsManager::SetList(const std::string &id, const std::vector< std::sh
 
 bool CSettingsManager::SetDefault(const std::string &id)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
   if (setting == nullptr)
     return false;
@@ -701,7 +702,7 @@ bool CSettingsManager::SetDefault(const std::string &id)
 
 void CSettingsManager::SetDefaults()
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   for (auto& setting : m_settings)
     setting.second.setting->Reset();
 }
@@ -738,7 +739,7 @@ bool CSettingsManager::Serialize(TiXmlNode *parent) const
   if (parent == nullptr)
     return false;
 
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
 
   for (const auto& setting : m_settings)
   {
@@ -775,7 +776,7 @@ bool CSettingsManager::Deserialize(const TiXmlNode *node, bool &updated, std::ma
   if (node == nullptr)
     return false;
 
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
 
   // TODO: ideally this would be done by going through all <setting> elements
   // in node but as long as we have to support the v1- format that's not possible
@@ -798,7 +799,7 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   if (setting == nullptr)
     return false;
 
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   if (!m_loaded)
     return true;
 
@@ -819,7 +820,7 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   // if this is a reference setting apply the same change to the referenced setting
   if (setting->IsReference())
   {
-    CSharedLock lock(m_settingsCritical);
+    std::shared_lock<CSharedSection> lock(m_settingsCritical);
     auto referencedSettingIt = FindSetting(setting->GetReferencedId());
     if (referencedSettingIt != m_settings.end())
     {
@@ -834,7 +835,7 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   {
     // if the changed setting is referenced by other settings apply the same change to the referencing settings
     std::unordered_set<SettingPtr> referenceSettings;
-    CSharedLock lock(m_settingsCritical);
+    std::shared_lock<CSharedSection> lock(m_settingsCritical);
     for (const auto& reference : settingData.references)
     {
       auto referenceSettingIt = FindSetting(reference);
@@ -853,7 +854,7 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
 
 void CSettingsManager::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   if (!m_loaded || setting == nullptr)
     return;
 
@@ -879,7 +880,7 @@ void CSettingsManager::OnSettingChanged(const std::shared_ptr<const CSetting>& s
 
 void CSettingsManager::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   if (!m_loaded || setting == nullptr)
     return;
 
@@ -899,7 +900,7 @@ bool CSettingsManager::OnSettingUpdate(const SettingPtr& setting,
                                        const char* oldSettingId,
                                        const TiXmlNode* oldSettingNode)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   if (setting == nullptr)
     return false;
 
@@ -921,7 +922,7 @@ bool CSettingsManager::OnSettingUpdate(const SettingPtr& setting,
 void CSettingsManager::OnSettingPropertyChanged(const std::shared_ptr<const CSetting>& setting,
                                                 const char* propertyName)
 {
-  CSharedLock lock(m_settingsCritical);
+  std::shared_lock<CSharedSection> lock(m_settingsCritical);
   if (!m_loaded || setting == nullptr)
     return;
 
@@ -973,7 +974,7 @@ SettingPtr CSettingsManager::CreateSetting(const std::string &settingType, const
       return std::make_shared<CSettingList>(settingId, elementSetting, const_cast<CSettingsManager*>(this));
   }
 
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   auto creator = m_settingCreators.find(settingType);
   if (creator != m_settingCreators.end())
     return creator->second->CreateSetting(settingType, settingId, const_cast<CSettingsManager*>(this));
@@ -986,7 +987,7 @@ std::shared_ptr<ISettingControl> CSettingsManager::CreateControl(const std::stri
   if (controlType.empty())
     return nullptr;
 
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   auto creator = m_settingControlCreators.find(controlType);
   if (creator != m_settingControlCreators.end() && creator->second != nullptr)
     return creator->second->CreateControl(controlType);
@@ -996,7 +997,7 @@ std::shared_ptr<ISettingControl> CSettingsManager::CreateControl(const std::stri
 
 bool CSettingsManager::OnSettingsLoading()
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
   {
     if (!settingsHandler->OnSettingsLoading())
@@ -1008,21 +1009,21 @@ bool CSettingsManager::OnSettingsLoading()
 
 void CSettingsManager::OnSettingsUnloaded()
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsUnloaded();
 }
 
 void CSettingsManager::OnSettingsLoaded()
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsLoaded();
 }
 
 bool CSettingsManager::OnSettingsSaving() const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
   {
     if (!settingsHandler->OnSettingsSaving())
@@ -1034,14 +1035,14 @@ bool CSettingsManager::OnSettingsSaving() const
 
 void CSettingsManager::OnSettingsSaved() const
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsSaved();
 }
 
 void CSettingsManager::OnSettingsCleared()
 {
-  CSharedLock lock(m_critical);
+  std::shared_lock<CSharedSection> lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsCleared();
 }

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -808,7 +808,7 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
 
   Setting settingData = settingIt->second;
   // now that we have a copy of the setting's data, we can leave the lock
-  lock.Leave();
+  lock.unlock();
 
   for (auto& callback : settingData.callbacks)
   {
@@ -825,7 +825,7 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
     {
       Setting referencedSettingData = referencedSettingIt->second;
       // now that we have a copy of the setting's data, we can leave the lock
-      lock.Leave();
+      lock.unlock();
 
       referencedSettingData.setting->FromString(setting->ToString());
     }
@@ -842,7 +842,7 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
         referenceSettings.insert(referenceSettingIt->second.setting);
     }
     // now that we have a copy of the setting's data, we can leave the lock
-    lock.Leave();
+    lock.unlock();
 
     for (auto& referenceSetting : referenceSettings)
       referenceSetting->FromString(setting->ToString());
@@ -863,7 +863,7 @@ void CSettingsManager::OnSettingChanged(const std::shared_ptr<const CSetting>& s
 
   Setting settingData = settingIt->second;
   // now that we have a copy of the setting's data, we can leave the lock
-  lock.Leave();
+  lock.unlock();
 
   for (auto& callback : settingData.callbacks)
     callback->OnSettingChanged(setting);
@@ -889,7 +889,7 @@ void CSettingsManager::OnSettingAction(const std::shared_ptr<const CSetting>& se
 
   Setting settingData = settingIt->second;
   // now that we have a copy of the setting's data, we can leave the lock
-  lock.Leave();
+  lock.unlock();
 
   for (auto& callback : settingData.callbacks)
     callback->OnSettingAction(setting);
@@ -909,7 +909,7 @@ bool CSettingsManager::OnSettingUpdate(const SettingPtr& setting,
 
   Setting settingData = settingIt->second;
   // now that we have a copy of the setting's data, we can leave the lock
-  lock.Leave();
+  lock.unlock();
 
   bool ret = false;
   for (auto& callback : settingData.callbacks)
@@ -931,7 +931,7 @@ void CSettingsManager::OnSettingPropertyChanged(const std::shared_ptr<const CSet
 
   Setting settingData = settingIt->second;
   // now that we have a copy of the setting's data, we can leave the lock
-  lock.Leave();
+  lock.unlock();
 
   for (auto& callback : settingData.callbacks)
     callback->OnSettingPropertyChanged(setting, propertyName);

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -7,12 +7,14 @@
  */
 
 #include "DetectDVDType.h"
+
+#include "cdioSupport.h"
+#include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
-#include "cdioSupport.h"
-#include "filesystem/File.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 #ifdef TARGET_POSIX
 #include <sys/types.h>
 #include <sys/ioctl.h>
@@ -104,7 +106,7 @@ void CDetectDVDMedia::UpdateDvdrom()
   // that we are busy detecting the
   // newly inserted media.
   {
-    CSingleLock waitLock(m_muReadingMedia);
+    std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
     switch (GetTrayState())
     {
       case DRIVE_NONE:
@@ -379,7 +381,7 @@ DWORD CDetectDVDMedia::GetTrayState()
 
 void CDetectDVDMedia::UpdateState()
 {
-  CSingleLock waitLock(m_muReadingMedia);
+  std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
   m_pInstance->DetectMediaType();
 }
 
@@ -387,7 +389,7 @@ void CDetectDVDMedia::UpdateState()
 // Wait for drive, to finish media detection.
 void CDetectDVDMedia::WaitMediaReady()
 {
-  CSingleLock waitLock(m_muReadingMedia);
+  std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
 }
 
 // Static function
@@ -410,7 +412,7 @@ bool CDetectDVDMedia::IsDiscInDrive()
 // Can be NULL
 CCdInfo* CDetectDVDMedia::GetCdInfo()
 {
-  CSingleLock waitLock(m_muReadingMedia);
+  std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
   CCdInfo* pCdInfo = m_pCdInfo;
   return pCdInfo;
 }

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -117,7 +117,7 @@ void CDetectDVDMedia::UpdateDvdrom()
           SetNewDVDShareUrl("D:\\", false, g_localizeStrings.Get(502));
           CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REMOVED_MEDIA);
           CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
-          waitLock.Leave();
+          waitLock.unlock();
           m_DriveState = DRIVE_OPEN;
           return;
         }
@@ -135,7 +135,7 @@ void CDetectDVDMedia::UpdateDvdrom()
             delete m_pCdInfo;
             m_pCdInfo = NULL;
           }
-          waitLock.Leave();
+          waitLock.unlock();
           CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
           CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
           // Do we really need sleep here? This will fix: [ 1530771 ] "Open tray" problem
@@ -151,7 +151,7 @@ void CDetectDVDMedia::UpdateDvdrom()
           m_DriveState = DRIVE_CLOSED_NO_MEDIA;
           // Send Message to GUI that disc has changed
           CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-          waitLock.Leave();
+          waitLock.unlock();
           CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
           return ;
         }
@@ -168,7 +168,7 @@ void CDetectDVDMedia::UpdateDvdrom()
             // Detect ISO9660(mode1/mode2) or CDDA filesystem
             DetectMediaType();
             CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-            waitLock.Leave();
+            waitLock.unlock();
             CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
             // Tell the application object that a new Cd is inserted
             // So autorun can be started.

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -9,8 +9,9 @@
 #include "cdioSupport.h"
 
 #include "platform/Environment.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
+
+#include <mutex>
 
 #include <cdio/cd_types.h>
 #include <cdio/cdio.h>
@@ -108,63 +109,63 @@ std::shared_ptr<CLibcdio> CLibcdio::GetInstance()
 
 CdIo_t* CLibcdio::cdio_open(const char *psz_source, driver_id_t driver_id)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_open(psz_source, driver_id) );
 }
 
 CdIo_t* CLibcdio::cdio_open_win32(const char *psz_source)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_open_win32(psz_source) );
 }
 
 void CLibcdio::cdio_destroy(CdIo_t *p_cdio)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   ::cdio_destroy(p_cdio);
 }
 
 discmode_t CLibcdio::cdio_get_discmode(CdIo_t *p_cdio)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_get_discmode(p_cdio) );
 }
 
 int CLibcdio::mmc_get_tray_status(const CdIo_t *p_cdio)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::mmc_get_tray_status(p_cdio) );
 }
 
 int CLibcdio::cdio_eject_media(CdIo_t **p_cdio)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_eject_media(p_cdio) );
 }
 
 track_t CLibcdio::cdio_get_last_track_num(const CdIo_t *p_cdio)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_get_last_track_num(p_cdio) );
 }
 
 lsn_t CLibcdio::cdio_get_track_lsn(const CdIo_t *p_cdio, track_t i_track)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_get_track_lsn(p_cdio, i_track) );
 }
 
 lsn_t CLibcdio::cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t i_track)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_get_track_last_lsn(p_cdio, i_track) );
 }
@@ -172,14 +173,14 @@ lsn_t CLibcdio::cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t i_track)
 driver_return_code_t CLibcdio::cdio_read_audio_sectors(
     const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn, uint32_t i_blocks)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   return( ::cdio_read_audio_sectors(p_cdio, p_buf, i_lsn, i_blocks) );
 }
 
 char* CLibcdio::GetDeviceFileName()
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   // If We don't have a DVD device initially present (Darwin or a USB DVD drive),
   // We have to keep checking in case one appears.
@@ -245,7 +246,7 @@ bool CCdIoSupport::CloseTray()
 
 HANDLE CCdIoSupport::OpenCDROM()
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   char* source_name = m_cdio->GetDeviceFileName();
   CdIo* cdio = ::cdio_open(source_name, DRIVER_UNKNOWN);
@@ -255,7 +256,7 @@ HANDLE CCdIoSupport::OpenCDROM()
 
 HANDLE CCdIoSupport::OpenIMAGE( std::string& strFilename )
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   CdIo* cdio = ::cdio_open(strFilename.c_str(), DRIVER_UNKNOWN);
 
@@ -264,7 +265,7 @@ HANDLE CCdIoSupport::OpenIMAGE( std::string& strFilename )
 
 int CCdIoSupport::ReadSector(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
   if ( cdio == NULL )
@@ -278,7 +279,7 @@ int CCdIoSupport::ReadSector(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 
 int CCdIoSupport::ReadSectorMode2(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
   if ( cdio == NULL )
@@ -292,7 +293,7 @@ int CCdIoSupport::ReadSectorMode2(HANDLE hDevice, DWORD dwSector, char* lpczBuff
 
 int CCdIoSupport::ReadSectorCDDA(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
   if ( cdio == NULL )
@@ -306,7 +307,7 @@ int CCdIoSupport::ReadSectorCDDA(HANDLE hDevice, DWORD dwSector, char* lpczBuffe
 
 void CCdIoSupport::CloseCDROM(HANDLE hDevice)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
 
@@ -439,7 +440,7 @@ void CCdIoSupport::PrintAnalysis(int fs, int num_audio)
 
 int CCdIoSupport::ReadBlock(int superblock, uint32_t offset, uint8_t bufnum, track_t track_num)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   unsigned int track_sec_count = ::cdio_get_track_sec_count(cdio, track_num);
   memset(buffer[bufnum], 0, CDIO_CD_FRAMESIZE);
@@ -530,7 +531,7 @@ int CCdIoSupport::GetJolietLevel( void )
 
 int CCdIoSupport::GuessFilesystem(int start_session, track_t track_num)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   int ret = FS_UNKNOWN;
   cdio_iso_analysis_t anal;
@@ -612,7 +613,7 @@ void CCdIoSupport::GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum)
   // cdtext disabled for windows as some setup doesn't like mmc commands
   // and stall for over a minute in cdio_get_cdtext 83
 #if !defined(TARGET_WINDOWS)
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   // Get the CD-Text , if any
 #if defined(LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM >= 84)
@@ -641,7 +642,7 @@ void CCdIoSupport::GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum)
 
 CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   char* source_name;
   if(cDeviceFileName == NULL)
@@ -889,7 +890,7 @@ int CCdIoSupport::CddbDecDigitSum(int n)
 // Return the number of seconds (discarding frame portion) of an MSF
 unsigned int CCdIoSupport::MsfSeconds(msf_t *msf)
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   return ::cdio_from_bcd8(msf->m)*60 + ::cdio_from_bcd8(msf->s);
 }
@@ -903,7 +904,7 @@ unsigned int CCdIoSupport::MsfSeconds(msf_t *msf)
 
 uint32_t CCdIoSupport::CddbDiscId()
 {
-  CSingleLock lock(*m_cdio);
+  std::unique_lock<CCriticalSection> lock(*m_cdio);
 
   int i, t, n = 0;
   msf_t start_msf;

--- a/xbmc/threads/Condition.h
+++ b/xbmc/threads/Condition.h
@@ -8,11 +8,12 @@
 
 #pragma once
 
-#include "threads/SingleLock.h"
+#include "threads/CriticalSection.h"
 
 #include <chrono>
 #include <condition_variable>
 #include <functional>
+#include <mutex>
 
 namespace XbmcThreads
 {
@@ -69,15 +70,15 @@ namespace XbmcThreads
       return res == std::cv_status::no_timeout;
     }
 
-    inline void wait(CSingleLock& lock, std::function<bool()> predicate)
+    inline void wait(std::unique_lock<CCriticalSection>& lock, std::function<bool()> predicate)
     {
       cond.wait(*lock.mutex(), predicate);
     }
 
-    inline void wait(CSingleLock& lock) { wait(*lock.mutex()); }
+    inline void wait(std::unique_lock<CCriticalSection>& lock) { wait(*lock.mutex()); }
 
     template<typename Rep, typename Period>
-    inline bool wait(CSingleLock& lock,
+    inline bool wait(std::unique_lock<CCriticalSection>& lock,
                      std::chrono::duration<Rep, Period> duration,
                      std::function<bool()> predicate)
     {
@@ -85,7 +86,8 @@ namespace XbmcThreads
     }
 
     template<typename Rep, typename Period>
-    inline bool wait(CSingleLock& lock, std::chrono::duration<Rep, Period> duration)
+    inline bool wait(std::unique_lock<CCriticalSection>& lock,
+                     std::chrono::duration<Rep, Period> duration)
     {
       return wait(*lock.mutex(), duration);
     }

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include "threads/Condition.h"
-#include "threads/SingleLock.h"
 
 #include <initializer_list>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 // forward declare the CEventGroup
@@ -69,7 +69,7 @@ public:
 
   inline void Reset()
   {
-    CSingleLock lock(mutex);
+    std::unique_lock<CCriticalSection> lock(mutex);
     signaled = false;
   }
   void Set();
@@ -80,7 +80,7 @@ public:
    */
   inline bool Signaled()
   {
-    CSingleLock lock(mutex);
+    std::unique_lock<CCriticalSection> lock(mutex);
     return signaled;
   }
 
@@ -93,7 +93,7 @@ public:
   template<typename Rep, typename Period>
   inline bool Wait(std::chrono::duration<Rep, Period> duration)
   {
-    CSingleLock lock(mutex);
+    std::unique_lock<CCriticalSection> lock(mutex);
     numWaits++;
     actualCv.wait(mutex, duration, std::bind(&CEvent::Signaled, this));
     numWaits--;
@@ -108,7 +108,7 @@ public:
    */
   inline bool Wait()
   {
-    CSingleLock lock(mutex);
+    std::unique_lock<CCriticalSection> lock(mutex);
     numWaits++;
     actualCv.wait(mutex, std::bind(&CEvent::Signaled, this));
     numWaits--;
@@ -122,7 +122,7 @@ public:
    */
   inline int getNumWaits()
   {
-    CSingleLock lock(mutex);
+    std::unique_lock<CCriticalSection> lock(mutex);
     return numWaits;
   }
 };
@@ -147,7 +147,7 @@ class CEventGroup
   // This is ONLY called from CEvent::Set.
   inline void Set(CEvent* child)
   {
-    CSingleLock l(mutex);
+    std::unique_lock<CCriticalSection> l(mutex);
     signaled = child;
     actualCv.notifyAll();
   }
@@ -185,7 +185,7 @@ public:
   template<typename Rep, typename Period>
   CEvent* wait(std::chrono::duration<Rep, Period> duration)
   {
-    CSingleLock lock(mutex); // grab CEventGroup::mutex
+    std::unique_lock<CCriticalSection> lock(mutex); // grab CEventGroup::mutex
     numWaits++;
 
     // ==================================================
@@ -196,7 +196,7 @@ public:
     signaled = nullptr;
     for (auto* cur : events)
     {
-      CSingleLock lock2(cur->mutex);
+      std::unique_lock<CCriticalSection> lock2(cur->mutex);
       if (cur->signaled)
         signaled = cur;
     }
@@ -232,7 +232,7 @@ public:
    */
   inline int getNumWaits()
   {
-    CSingleLock lock(mutex);
+    std::unique_lock<CCriticalSection> lock(mutex);
     return numWaits;
   }
 };

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -55,8 +55,6 @@ public:
   inline explicit CSharedLock(CSharedSection& cs) : std::shared_lock<CSharedSection>(cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
-  inline void Enter() { lock(); }
-  inline void Leave() { unlock(); }
 
 private:
   CSharedLock(const CSharedLock&) = delete;

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -67,8 +67,6 @@ public:
   inline explicit CExclusiveLock(CSharedSection& cs) : std::unique_lock<CSharedSection>(cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
-  inline void Leave() { unlock(); }
-  inline void Enter() { lock(); }
 
 private:
   CExclusiveLock(const CExclusiveLock&) = delete;

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -11,6 +11,7 @@
 #include "threads/Condition.h"
 
 #include <mutex>
+#include <shared_mutex>
 
 /**
  * A CSharedSection is a mutex that satisfies the Shared Lockable concept (see Lockables.h).
@@ -50,18 +51,6 @@ public:
       actualCv.notifyAll();
     }
   }
-};
-
-class CSharedLock : public std::shared_lock<CSharedSection>
-{
-public:
-  inline explicit CSharedLock(CSharedSection& cs) : std::shared_lock<CSharedSection>(cs) {}
-
-  inline bool IsOwner() const { return owns_lock(); }
-
-private:
-  CSharedLock(const CSharedLock&) = delete;
-  CSharedLock& operator=(const CSharedLock&) = delete;
 };
 
 class CExclusiveLock : public std::unique_lock<CSharedSection>

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -52,16 +52,3 @@ public:
     }
   }
 };
-
-class CExclusiveLock : public std::unique_lock<CSharedSection>
-{
-public:
-  inline explicit CExclusiveLock(CSharedSection& cs) : std::unique_lock<CSharedSection>(cs) {}
-
-  inline bool IsOwner() const { return owns_lock(); }
-
-private:
-  CExclusiveLock(const CExclusiveLock&) = delete;
-  CExclusiveLock& operator=(const CExclusiveLock&) = delete;
-};
-

--- a/xbmc/threads/SingleLock.h
+++ b/xbmc/threads/SingleLock.h
@@ -27,9 +27,6 @@ class CSingleLock : public std::unique_lock<CCriticalSection>
 public:
   inline explicit CSingleLock(CCriticalSection& cs) : std::unique_lock<CCriticalSection>(cs) {}
 
-  inline void Leave() { unlock(); }
-  inline void Enter() { lock(); }
-
 private:
   CSingleLock(const CSingleLock&) = delete;
   CSingleLock& operator=(const CSingleLock&) = delete;

--- a/xbmc/threads/SingleLock.h
+++ b/xbmc/threads/SingleLock.h
@@ -10,28 +10,9 @@
 
 #pragma once
 
-// SingleLock.h: interface for the CSingleLock class.
-//
-//////////////////////////////////////////////////////////////////////
-
 #include "threads/CriticalSection.h"
 
 #include <mutex>
-
-/**
- * This implements a "guard" pattern for a CCriticalSection that
- *  borrows most of it's functionality from boost's unique_lock.
- */
-class CSingleLock : public std::unique_lock<CCriticalSection>
-{
-public:
-  inline explicit CSingleLock(CCriticalSection& cs) : std::unique_lock<CCriticalSection>(cs) {}
-
-private:
-  CSingleLock(const CSingleLock&) = delete;
-  CSingleLock& operator=(const CSingleLock&) = delete;
-};
-
 
 /**
  * This implements a "guard" pattern for exiting all locks
@@ -49,4 +30,3 @@ public:
   inline explicit CSingleExit(CCriticalSection& cs) : sec(cs), count(cs.exit()) { }
   inline ~CSingleExit() { sec.restore(count); }
 };
-

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -193,7 +193,7 @@ void CThread::StopThread(bool bWait /*= true*/)
   std::thread* lthread = m_thread;
   if (lthread != nullptr && bWait && !IsCurrentThread())
   {
-    lock.Leave();
+    lock.unlock();
     if (!Join(std::chrono::milliseconds::max())) // eh?
       lthread->join();
     m_thread = nullptr;

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <limits.h>
+#include <mutex>
 #if defined(TARGET_ANDROID)
 #include <unistd.h>
 #else
@@ -165,7 +166,7 @@ bool CThread::SetPriority(const ThreadPriority& priority)
 {
   bool bReturn = false;
 
-  CSingleLock lockIt(m_CriticalSection);
+  std::unique_lock<CCriticalSection> lockIt(m_CriticalSection);
 
   pid_t tid = static_cast<pid_t>(m_lwpId);
 

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -11,6 +11,7 @@
 #include "platform/win32/WIN32Util.h"
 
 #include <array>
+#include <mutex>
 
 #include <process.h>
 #include <windows.h>
@@ -78,7 +79,7 @@ bool CThread::SetPriority(const ThreadPriority& priority)
 {
   bool bReturn = false;
 
-  CSingleLock lock(m_CriticalSection);
+  std::unique_lock<CCriticalSection> lock(m_CriticalSection);
   if (m_thread)
     bReturn = SetThreadPriority(m_lwpId, ThreadPriorityToNativePriority(priority)) == TRUE;
 

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -11,6 +11,7 @@
 #include "threads/Thread.h"
 
 #include <memory>
+#include <mutex>
 
 #include <gtest/gtest.h>
 
@@ -39,7 +40,7 @@ inline static bool waitForThread(std::atomic<long>& mutex,
       return true;
 
     {
-      CSingleLock tmplock(sec); // kick any memory syncs
+      std::unique_lock<CCriticalSection> tmplock(sec); // kick any memory syncs
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -101,7 +101,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   EXPECT_TRUE(!l2.obtainedlock);  // this thread is waiting ...
 
   // let it go
-  l1.Leave(); // the last shared lock leaves.
+  l1.unlock(); // the last shared lock leaves.
 
   EXPECT_TRUE(waitThread1.timed_join(10000ms));
 

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -194,7 +194,7 @@ TEST(TestMultipleSharedSection, General)
     EXPECT_TRUE(!l4.haslock);
     EXPECT_TRUE(!l5.haslock);
 
-    lock.Leave();
+    lock.unlock();
 
     EXPECT_TRUE(waitForWaiters(event, 4, 10000ms));
 

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -9,9 +9,9 @@
 #include "threads/Event.h"
 #include "threads/IRunnable.h"
 #include "threads/SharedSection.h"
-#include "threads/SingleLock.h"
 #include "threads/test/TestHelpers.h"
 
+#include <mutex>
 #include <stdio.h>
 
 using namespace std::chrono_literals;
@@ -53,8 +53,8 @@ TEST(TestCritSection, General)
 {
   CCriticalSection sec;
 
-  CSingleLock l1(sec);
-  CSingleLock l2(sec);
+  std::unique_lock<CCriticalSection> l1(sec);
+  std::unique_lock<CCriticalSection> l2(sec);
 }
 
 TEST(TestSharedSection, General)

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -140,7 +140,7 @@ TEST(TestSharedSection, TwoCase)
 
     EXPECT_TRUE(!l2.haslock);
 
-    lock.Leave();
+    lock.unlock();
 
     EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
     std::this_thread::sleep_for(10ms);

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -75,7 +75,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
 
   std::shared_lock<CSharedSection> l1(sec); // get a shared lock
 
-  locker<CExclusiveLock> l2(sec,&mutex);
+  locker<std::unique_lock<CSharedSection>> l2(sec, &mutex);
   thread waitThread1(l2); // try to get an exclusive lock
 
   EXPECT_TRUE(waitForThread(mutex, 1, 10000ms));
@@ -133,7 +133,7 @@ TEST(TestSharedSection, TwoCase)
 
   locker<std::shared_lock<CSharedSection>> l2(sec, &mutex, &event);
   {
-    CExclusiveLock lock(sec); // get exclusive lock
+    std::unique_lock<CSharedSection> lock(sec); // get exclusive lock
     thread waitThread2(l2); // thread should block
 
     EXPECT_TRUE(waitForThread(mutex, 1, 10000ms));
@@ -181,7 +181,7 @@ TEST(TestMultipleSharedSection, General)
   locker<std::shared_lock<CSharedSection>> l4(sec, &mutex, &event);
   locker<std::shared_lock<CSharedSection>> l5(sec, &mutex, &event);
   {
-    CExclusiveLock lock(sec);
+    std::unique_lock<CSharedSection> lock(sec);
     thread waitThread1(l2);
     thread waitThread2(l3);
     thread waitThread3(l4);

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -12,6 +12,7 @@
 #include "threads/test/TestHelpers.h"
 
 #include <mutex>
+#include <shared_mutex>
 #include <stdio.h>
 
 using namespace std::chrono_literals;
@@ -61,8 +62,8 @@ TEST(TestSharedSection, General)
 {
   CSharedSection sec;
 
-  CSharedLock l1(sec);
-  CSharedLock l2(sec);
+  std::shared_lock<CSharedSection> l1(sec);
+  std::shared_lock<CSharedSection> l2(sec);
 }
 
 TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
@@ -72,7 +73,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
 
   CSharedSection sec;
 
-  CSharedLock l1(sec); // get a shared lock
+  std::shared_lock<CSharedSection> l1(sec); // get a shared lock
 
   locker<CExclusiveLock> l2(sec,&mutex);
   thread waitThread1(l2); // try to get an exclusive lock
@@ -84,7 +85,7 @@ TEST(TestSharedSection, GetSharedLockWhileTryingExclusiveLock)
   EXPECT_TRUE(!l2.obtainedlock);  // this thread is waiting ...
 
   // now try and get a SharedLock
-  locker<CSharedLock> l3(sec,&mutex,&event);
+  locker<std::shared_lock<CSharedSection>> l3(sec, &mutex, &event);
   thread waitThread3(l3); // try to get a shared lock
   EXPECT_TRUE(waitForThread(mutex, 2, 10000ms));
   std::this_thread::sleep_for(10ms);
@@ -116,10 +117,10 @@ TEST(TestSharedSection, TwoCase)
   CEvent event;
   std::atomic<long> mutex(0L);
 
-  locker<CSharedLock> l1(sec,&mutex,&event);
+  locker<std::shared_lock<CSharedSection>> l1(sec, &mutex, &event);
 
   {
-    CSharedLock lock(sec);
+    std::shared_lock<CSharedSection> lock(sec);
     thread waitThread1(l1);
 
     EXPECT_TRUE(waitForWaiters(event, 1, 10000ms));
@@ -130,7 +131,7 @@ TEST(TestSharedSection, TwoCase)
     EXPECT_TRUE(waitThread1.timed_join(10000ms));
   }
 
-  locker<CSharedLock> l2(sec,&mutex,&event);
+  locker<std::shared_lock<CSharedSection>> l2(sec, &mutex, &event);
   {
     CExclusiveLock lock(sec); // get exclusive lock
     thread waitThread2(l2); // thread should block
@@ -159,10 +160,10 @@ TEST(TestMultipleSharedSection, General)
   CEvent event;
   std::atomic<long> mutex(0L);
 
-  locker<CSharedLock> l1(sec,&mutex, &event);
+  locker<std::shared_lock<CSharedSection>> l1(sec, &mutex, &event);
 
   {
-    CSharedLock lock(sec);
+    std::shared_lock<CSharedSection> lock(sec);
     thread waitThread1(l1);
 
     EXPECT_TRUE(waitForThread(mutex, 1, 10000ms));
@@ -175,10 +176,10 @@ TEST(TestMultipleSharedSection, General)
     EXPECT_TRUE(waitThread1.timed_join(10000ms));
   }
 
-  locker<CSharedLock> l2(sec,&mutex,&event);
-  locker<CSharedLock> l3(sec,&mutex,&event);
-  locker<CSharedLock> l4(sec,&mutex,&event);
-  locker<CSharedLock> l5(sec,&mutex,&event);
+  locker<std::shared_lock<CSharedSection>> l2(sec, &mutex, &event);
+  locker<std::shared_lock<CSharedSection>> l3(sec, &mutex, &event);
+  locker<std::shared_lock<CSharedSection>> l4(sec, &mutex, &event);
+  locker<std::shared_lock<CSharedSection>> l5(sec, &mutex, &event);
   {
     CExclusiveLock lock(sec);
     thread waitThread1(l2);

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -15,9 +15,9 @@
 #include "guilib/LocalizeStrings.h"
 #include "log.h"
 #include "messaging/ApplicationMessenger.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 
+#include <mutex>
 #include <utility>
 
 using namespace KODI::MESSAGING;
@@ -74,14 +74,14 @@ void CAlarmClock::Start(const std::string& strName, float n_secs, const std::str
   }
 
   event.watch.StartZero();
-  CSingleLock lock(m_events);
+  std::unique_lock<CCriticalSection> lock(m_events);
   m_event.insert(make_pair(lowerName,event));
   CLog::Log(LOGDEBUG, "started alarm with name: {}", lowerName);
 }
 
 void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
 {
-  CSingleLock lock(m_events);
+  std::unique_lock<CCriticalSection> lock(m_events);
 
   std::string lowerName(strName);
   StringUtils::ToLower(lowerName);          // lookup as lowercase only
@@ -143,7 +143,7 @@ void CAlarmClock::Process()
   {
     std::string strLast;
     {
-      CSingleLock lock(m_events);
+      std::unique_lock<CCriticalSection> lock(m_events);
       for (std::map<std::string,SAlarmClockEvent>::iterator iter=m_event.begin();iter != m_event.end(); ++iter)
         if (iter->second.watch.IsRunning() &&
             iter->second.watch.GetElapsedSeconds() >= static_cast<float>(iter->second.m_fSecs))

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -18,6 +18,7 @@
 #include "utils/Utf8Utils.h"
 
 #include <algorithm>
+#include <mutex>
 
 #include <fribidi.h>
 #include <iconv.h>
@@ -88,7 +89,7 @@ public:
   CConverterType(const CConverterType& other);
   ~CConverterType();
 
-  iconv_t GetConverter(CSingleLock& converterLock);
+  iconv_t GetConverter(std::unique_lock<CCriticalSection>& converterLock);
 
   void Reset(void);
   void ReinitTo(const std::string& sourceCharset, const std::string& targetCharset, unsigned int targetSingleCharMaxLen = 1);
@@ -159,13 +160,13 @@ CConverterType::CConverterType(const CConverterType& other) : CCriticalSection()
 
 CConverterType::~CConverterType()
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   if (m_iconv != NO_ICONV)
     iconv_close(m_iconv);
   lock.unlock(); // ensure unlocking before final destruction
 }
 
-iconv_t CConverterType::GetConverter(CSingleLock& converterLock)
+iconv_t CConverterType::GetConverter(std::unique_lock<CCriticalSection>& converterLock)
 {
   // ensure that this unique instance is locked externally
   if (converterLock.mutex() != this)
@@ -190,7 +191,7 @@ iconv_t CConverterType::GetConverter(CSingleLock& converterLock)
 
 void CConverterType::Reset(void)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   if (m_iconv != NO_ICONV)
   {
     iconv_close(m_iconv);
@@ -206,7 +207,7 @@ void CConverterType::Reset(void)
 
 void CConverterType::ReinitTo(const std::string& sourceCharset, const std::string& targetCharset, unsigned int targetSingleCharMaxLen /*= 1*/)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
   if (sourceCharset != m_sourceCharset || targetCharset != m_targetCharset)
   {
     if (m_iconv != NO_ICONV)
@@ -326,7 +327,7 @@ bool CCharsetConverter::CInnerConverter::stdConvert(StdConversionType convertTyp
     return false;
 
   CConverterType& convType = m_stdConversion[convertType];
-  CSingleLock converterLock(convType);
+  std::unique_lock<CCriticalSection> converterLock(convType);
 
   return convert(convType.GetConverter(converterLock), convType.GetTargetSingleCharMaxLen(), strSource, strDest, failOnInvalidChar);
 }
@@ -488,7 +489,7 @@ bool CCharsetConverter::CInnerConverter::logicalToVisualBiDi(
   size_t lineStart = 0;
 
   // libfribidi is not threadsafe, so make sure we make it so
-  CSingleLock lock(m_critSectionFriBiDi);
+  std::unique_lock<CCriticalSection> lock(m_critSectionFriBiDi);
   do
   {
     size_t lineEnd = stringSrc.find('\n', lineStart);

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -162,7 +162,7 @@ CConverterType::~CConverterType()
   CSingleLock lock(*this);
   if (m_iconv != NO_ICONV)
     iconv_close(m_iconv);
-  lock.Leave(); // ensure unlocking before final destruction
+  lock.unlock(); // ensure unlocking before final destruction
 }
 
 iconv_t CConverterType::GetConverter(CSingleLock& converterLock)

--- a/xbmc/utils/EventStream.h
+++ b/xbmc/utils/EventStream.h
@@ -11,10 +11,10 @@
 #include "EventStreamDetail.h"
 #include "JobManager.h"
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 
@@ -27,7 +27,7 @@ public:
   void Subscribe(A* owner, void (A::*fn)(const Event&))
   {
     auto subscription = std::make_shared<detail::CSubscription<Event, A>>(owner, fn);
-    CSingleLock lock(m_criticalSection);
+    std::unique_lock<CCriticalSection> lock(m_criticalSection);
     m_subscriptions.emplace_back(std::move(subscription));
   }
 
@@ -36,7 +36,7 @@ public:
   {
     std::vector<std::shared_ptr<detail::ISubscription<Event>>> toCancel;
     {
-      CSingleLock lock(m_criticalSection);
+      std::unique_lock<CCriticalSection> lock(m_criticalSection);
       auto it = m_subscriptions.begin();
       while (it != m_subscriptions.end())
       {
@@ -70,7 +70,7 @@ public:
   template<typename A>
   void Publish(A event)
   {
-    CSingleLock lock(this->m_criticalSection);
+    std::unique_lock<CCriticalSection> lock(this->m_criticalSection);
     auto& subscriptions = this->m_subscriptions;
     auto task = [subscriptions, event](){
       for (auto& s: subscriptions)
@@ -91,7 +91,7 @@ public:
   template<typename A>
   void HandleEvent(A event)
   {
-    CSingleLock lock(this->m_criticalSection);
+    std::unique_lock<CCriticalSection> lock(this->m_criticalSection);
     for (const auto& subscription : this->m_subscriptions)
     {
       subscription->HandleEvent(event);

--- a/xbmc/utils/EventStream.h
+++ b/xbmc/utils/EventStream.h
@@ -76,7 +76,7 @@ public:
       for (auto& s: subscriptions)
         s->HandleEvent(event);
     };
-    lock.Leave();
+    lock.unlock();
     m_queue.Submit(std::move(task));
   }
 

--- a/xbmc/utils/EventStreamDetail.h
+++ b/xbmc/utils/EventStreamDetail.h
@@ -9,7 +9,8 @@
 #pragma once
 
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
+
+#include <mutex>
 
 namespace detail
 {
@@ -48,21 +49,21 @@ CSubscription<Event, Owner>::CSubscription(Owner* owner, Fn fn)
 template<typename Event, typename Owner>
 bool CSubscription<Event, Owner>::IsOwnedBy(void* obj)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   return obj != nullptr && obj == m_owner;
 }
 
 template<typename Event, typename Owner>
 void CSubscription<Event, Owner>::Cancel()
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   m_owner = nullptr;
 }
 
 template<typename Event, typename Owner>
 void CSubscription<Event, Owner>::HandleEvent(const Event& event)
 {
-  CSingleLock lock(m_criticalSection);
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
   if (m_owner)
     (m_owner->*m_eventHandler)(event);
 }

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -8,12 +8,12 @@
 
 #include "JobManager.h"
 
-#include "threads/SingleLock.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
 #include <functional>
+#include <mutex>
 #include <stdexcept>
 
 using namespace std::chrono_literals;
@@ -92,7 +92,7 @@ void CJobQueue::OnJobAbort(unsigned int jobID, CJob* job)
 
 void CJobQueue::CancelJob(const CJob *job)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   Processing::iterator i = find(m_processing.begin(), m_processing.end(), job);
   if (i != m_processing.end())
   {
@@ -110,7 +110,7 @@ void CJobQueue::CancelJob(const CJob *job)
 
 bool CJobQueue::AddJob(CJob *job)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   // check if we have this job already.  If so, we're done.
   if (find(m_jobQueue.begin(), m_jobQueue.end(), job) != m_jobQueue.end() ||
       find(m_processing.begin(), m_processing.end(), job) != m_processing.end())
@@ -130,7 +130,7 @@ bool CJobQueue::AddJob(CJob *job)
 
 void CJobQueue::OnJobNotify(CJob* job)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   // check if this job is in our processing list
   const auto it = std::find(m_processing.begin(), m_processing.end(), job);
@@ -142,7 +142,7 @@ void CJobQueue::OnJobNotify(CJob* job)
 
 void CJobQueue::QueueNextJob()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   while (m_jobQueue.size() && m_processing.size() < m_jobsAtOnce)
   {
     CJobPointer &job = m_jobQueue.back();
@@ -159,7 +159,7 @@ void CJobQueue::QueueNextJob()
 
 void CJobQueue::CancelJobs()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   for_each(m_processing.begin(), m_processing.end(), [](CJobPointer& jp) { jp.CancelJob(); });
   for_each(m_jobQueue.begin(), m_jobQueue.end(), [](CJobPointer& jp) { jp.FreeJob(); });
   m_jobQueue.clear();
@@ -173,7 +173,7 @@ bool CJobQueue::IsProcessing() const
 
 bool CJobQueue::QueueEmpty() const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   return m_jobQueue.empty();
 }
 
@@ -192,7 +192,7 @@ CJobManager::CJobManager()
 
 void CJobManager::Restart()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (m_running)
     throw std::logic_error("CJobManager already running");
@@ -201,7 +201,7 @@ void CJobManager::Restart()
 
 void CJobManager::CancelJobs()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_running = false;
 
   // clear any pending jobs
@@ -234,7 +234,7 @@ void CJobManager::CancelJobs()
 
 unsigned int CJobManager::AddJob(CJob *job, IJobCallback *callback, CJob::PRIORITY priority)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (!m_running)
   {
@@ -257,7 +257,7 @@ unsigned int CJobManager::AddJob(CJob *job, IJobCallback *callback, CJob::PRIORI
 
 void CJobManager::CancelJob(unsigned int jobID)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   // check whether we have this job in the queue
   for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_DEDICATED; ++priority)
@@ -278,7 +278,7 @@ void CJobManager::CancelJob(unsigned int jobID)
 
 void CJobManager::StartWorkers(CJob::PRIORITY priority)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   // check how many free threads we have
   if (m_processing.size() >= GetMaxWorkers(priority))
@@ -297,7 +297,7 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
 
 CJob *CJobManager::PopJob()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   for (int priority = CJob::PRIORITY_DEDICATED; priority >= CJob::PRIORITY_LOW_PAUSABLE; --priority)
   {
     // Check whether we're pausing pausable jobs
@@ -321,19 +321,19 @@ CJob *CJobManager::PopJob()
 
 void CJobManager::PauseJobs()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_pauseJobs = true;
 }
 
 void CJobManager::UnPauseJobs()
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   m_pauseJobs = false;
 }
 
 bool CJobManager::IsProcessing(const CJob::PRIORITY &priority) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (m_pauseJobs)
     return false;
@@ -349,7 +349,7 @@ bool CJobManager::IsProcessing(const CJob::PRIORITY &priority) const
 int CJobManager::IsProcessing(const std::string &type) const
 {
   int jobsMatched = 0;
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
 
   if (m_pauseJobs)
     return 0;
@@ -364,7 +364,7 @@ int CJobManager::IsProcessing(const std::string &type) const
 
 CJob *CJobManager::GetNextJob(const CJobWorker *worker)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   while (m_running)
   {
     // grab a job off the queue if we have one
@@ -390,7 +390,7 @@ CJob *CJobManager::GetNextJob(const CJobWorker *worker)
 
 bool CJobManager::OnJobProgress(unsigned int progress, unsigned int total, const CJob *job) const
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   // find the job in the processing queue, and check whether it's cancelled (no callback)
   Processing::const_iterator i = find(m_processing.begin(), m_processing.end(), job);
   if (i != m_processing.end())
@@ -408,7 +408,7 @@ bool CJobManager::OnJobProgress(unsigned int progress, unsigned int total, const
 
 void CJobManager::OnJobComplete(bool success, CJob *job)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   // remove the job from the processing queue
   Processing::iterator i = find(m_processing.begin(), m_processing.end(), job);
   if (i != m_processing.end())
@@ -436,7 +436,7 @@ void CJobManager::OnJobComplete(bool success, CJob *job)
 
 void CJobManager::RemoveWorker(const CJobWorker *worker)
 {
-  CSingleLock lock(m_section);
+  std::unique_lock<CCriticalSection> lock(m_section);
   // remove our worker
   Workers::iterator i = find(m_workers.begin(), m_workers.end(), worker);
   if (i != m_workers.end())

--- a/xbmc/utils/Observer.cpp
+++ b/xbmc/utils/Observer.cpp
@@ -9,13 +9,12 @@
 
 #include "Observer.h"
 
-#include "threads/SingleLock.h"
-
 #include <algorithm>
+#include <mutex>
 
 Observable &Observable::operator=(const Observable &observable)
 {
-  CSingleLock lock(m_obsCritSection);
+  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
 
   m_bObservableChanged = static_cast<bool>(observable.m_bObservableChanged);
   m_observers = observable.m_observers;
@@ -25,13 +24,13 @@ Observable &Observable::operator=(const Observable &observable)
 
 bool Observable::IsObserving(const Observer &obs) const
 {
-  CSingleLock lock(m_obsCritSection);
+  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
   return std::find(m_observers.begin(), m_observers.end(), &obs) != m_observers.end();
 }
 
 void Observable::RegisterObserver(Observer *obs)
 {
-  CSingleLock lock(m_obsCritSection);
+  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
   if (!IsObserving(*obs))
   {
     m_observers.push_back(obs);
@@ -40,7 +39,7 @@ void Observable::RegisterObserver(Observer *obs)
 
 void Observable::UnregisterObserver(Observer *obs)
 {
-  CSingleLock lock(m_obsCritSection);
+  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
   auto iter = std::remove(m_observers.begin(), m_observers.end(), obs);
   if (iter != m_observers.end())
     m_observers.erase(iter);
@@ -63,7 +62,7 @@ void Observable::SetChanged(bool SetTo)
 
 void Observable::SendMessage(const ObservableMessage message)
 {
-  CSingleLock lock(m_obsCritSection);
+  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
 
   for (auto& observer : m_observers)
   {

--- a/xbmc/utils/RingBuffer.cpp
+++ b/xbmc/utils/RingBuffer.cpp
@@ -8,11 +8,10 @@
 
 #include "RingBuffer.h"
 
-#include "threads/SingleLock.h"
-
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 
 /* Constructor */
 CRingBuffer::CRingBuffer()
@@ -33,7 +32,7 @@ CRingBuffer::~CRingBuffer()
 /* Create a ring buffer with the specified 'size' */
 bool CRingBuffer::Create(unsigned int size)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_buffer = (char*)malloc(size);
   if (m_buffer != NULL)
   {
@@ -46,7 +45,7 @@ bool CRingBuffer::Create(unsigned int size)
 /* Free the ring buffer and set all values to NULL or 0 */
 void CRingBuffer::Destroy()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_buffer != NULL)
   {
     free(m_buffer);
@@ -61,7 +60,7 @@ void CRingBuffer::Destroy()
 /* Clear the ring buffer */
 void CRingBuffer::Clear()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   m_readPtr = 0;
   m_writePtr = 0;
   m_fillCount = 0;
@@ -72,7 +71,7 @@ void CRingBuffer::Clear()
  */
 bool CRingBuffer::ReadData(char *buf, unsigned int size)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (size > m_fillCount)
   {
     return false;
@@ -100,7 +99,7 @@ bool CRingBuffer::ReadData(char *buf, unsigned int size)
  */
 bool CRingBuffer::ReadData(CRingBuffer &rBuf, unsigned int size)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (rBuf.getBuffer() == NULL)
     rBuf.Create(size);
 
@@ -123,7 +122,7 @@ bool CRingBuffer::ReadData(CRingBuffer &rBuf, unsigned int size)
  */
 bool CRingBuffer::WriteData(const char *buf, unsigned int size)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (size > m_size - m_fillCount)
   {
     return false;
@@ -151,7 +150,7 @@ bool CRingBuffer::WriteData(const char *buf, unsigned int size)
  */
 bool CRingBuffer::WriteData(CRingBuffer &rBuf, unsigned int size)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (m_buffer == NULL)
     Create(size);
 
@@ -171,7 +170,7 @@ bool CRingBuffer::WriteData(CRingBuffer &rBuf, unsigned int size)
 /* Skip bytes in buffer to be read */
 bool CRingBuffer::SkipBytes(int skipSize)
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   if (skipSize < 0)
   {
     return false; // skipping backwards is not supported
@@ -218,7 +217,7 @@ char *CRingBuffer::getBuffer()
 
 unsigned int CRingBuffer::getSize()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_size;
 }
 
@@ -229,18 +228,18 @@ unsigned int CRingBuffer::getReadPtr() const
 
 unsigned int CRingBuffer::getWritePtr()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_writePtr;
 }
 
 unsigned int CRingBuffer::getMaxReadSize()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_fillCount;
 }
 
 unsigned int CRingBuffer::getMaxWriteSize()
 {
-  CSingleLock lock(m_critSection);
+  std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_size - m_fillCount;
 }

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -18,12 +18,12 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
-#include "threads/SingleLock.h"
 #include "utils/RssReader.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <mutex>
 #include <utility>
 
 using namespace XFILE;
@@ -83,7 +83,7 @@ void CRssManager::Start()
 
 void CRssManager::Stop()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_bActive = false;
   for (unsigned int i = 0; i < m_readers.size(); i++)
   {
@@ -97,7 +97,7 @@ bool CRssManager::Load()
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   std::string rssXML = profileManager->GetUserDataItem("RssFeeds.xml");
   if (!CFile::Exists(rssXML))
@@ -172,14 +172,14 @@ bool CRssManager::Reload()
 
 void CRssManager::Clear()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   m_mapRssUrls.clear();
 }
 
 // returns true if the reader doesn't need creating, false otherwise
 bool CRssManager::GetReader(int controlID, int windowID, IRssObserver* observer, CRssReader *&reader)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // check to see if we've already created this reader
   for (unsigned int i = 0; i < m_readers.size(); i++)
   {

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -19,10 +19,11 @@
 #include "network/Network.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
 #include "utils/HTMLUtil.h"
 #include "utils/XTimeUtils.h"
+
+#include <mutex>
 
 #define RSS_COLOR_BODY      0
 #define RSS_COLOR_HEADLINE  1
@@ -56,7 +57,7 @@ CRssReader::~CRssReader()
 
 void CRssReader::Create(IRssObserver* aObserver, const std::vector<std::string>& aUrls, const std::vector<int> &times, int spacesBetweenFeeds, bool rtl)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
 
   m_pObserver = aObserver;
   m_spacesBetweenFeeds = spacesBetweenFeeds;
@@ -85,7 +86,7 @@ void CRssReader::requestRefresh()
 
 void CRssReader::AddToQueue(int iAdd)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   if (iAdd < (int)m_vecUrls.size())
     m_vecQueue.push_back(iAdd);
   if (!m_bIsRunning)
@@ -103,7 +104,7 @@ void CRssReader::OnExit()
 
 int CRssReader::GetQueueSize()
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   return m_vecQueue.size();
 }
 
@@ -111,7 +112,7 @@ void CRssReader::Process()
 {
   while (GetQueueSize())
   {
-    CSingleLock lock(m_critical);
+    std::unique_lock<CCriticalSection> lock(m_critical);
 
     int iFeed = m_vecQueue.front();
     m_vecQueue.erase(m_vecQueue.begin());
@@ -386,7 +387,7 @@ void CRssReader::UpdateObserver()
   getFeed(feed);
   if (!feed.empty())
   {
-    CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
     if (m_pObserver) // need to check again when locked to make sure observer wasnt removed
       m_pObserver->OnFeedUpdate(feed);
   }

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -124,7 +124,7 @@ void CRssReader::Process()
     http.SetTimeout(2);
     std::string strXML;
     std::string strUrl = m_vecUrls[iFeed];
-    lock.Leave();
+    lock.unlock();
 
     int nRetries = 3;
     CURL url(strUrl);

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -38,6 +38,8 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 
+#include <mutex>
+
 using namespace ADDON;
 using namespace XFILE;
 
@@ -206,7 +208,7 @@ void CGUIDialogSubtitles::Process(unsigned int currentTime, CDirtyRegionList &di
     std::string status;
     CFileItemList subs;
     {
-      CSingleLock lock(m_critsection);
+      std::unique_lock<CCriticalSection> lock(m_critsection);
       status = m_status;
       subs.Assign(*m_subtitles);
     }
@@ -387,7 +389,7 @@ void CGUIDialogSubtitles::OnJobComplete(unsigned int jobID, bool success, CJob *
 
 void CGUIDialogSubtitles::OnSearchComplete(const CFileItemList *items)
 {
-  CSingleLock lock(m_critsection);
+  std::unique_lock<CCriticalSection> lock(m_critsection);
   m_subtitles->Assign(*items);
   UpdateStatus(SEARCH_COMPLETE);
   m_updateSubsList = true;
@@ -462,7 +464,7 @@ void CGUIDialogSubtitles::OnSubtitleServiceContextMenu(int itemIdx)
 
 void CGUIDialogSubtitles::UpdateStatus(STATUS status)
 {
-  CSingleLock lock(m_critsection);
+  std::unique_lock<CCriticalSection> lock(m_critsection);
   std::string label;
   switch (status)
   {
@@ -660,7 +662,7 @@ void CGUIDialogSubtitles::ClearSubtitles()
 {
   CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_SUBLIST);
   OnMessage(msg);
-  CSingleLock lock(m_critsection);
+  std::unique_lock<CCriticalSection> lock(m_critsection);
   m_subtitles->Clear();
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -26,7 +26,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/Crc32.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -36,6 +35,7 @@
 #include "video/VideoThumbLoader.h"
 #include "view/ViewState.h"
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -201,7 +201,7 @@ void CGUIDialogVideoBookmarks::Delete(int item)
 
 void CGUIDialogVideoBookmarks::UpdateItem(unsigned int chapterIdx)
 {
-  CSingleLock lock(m_refreshSection);
+  std::unique_lock<CCriticalSection> lock(m_refreshSection);
 
   int itemPos = 0;
   for (const auto& item : *m_vecItems)
@@ -239,7 +239,7 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   videoDatabase.GetBookMarksForFile(m_filePath, m_bookmarks, CBookmark::EPISODE, true);
   videoDatabase.Close();
 
-  CSingleLock lock(m_refreshSection);
+  std::unique_lock<CCriticalSection> lock(m_refreshSection);
   m_vecItems->Clear();
 
   // cycle through each stored bookmark and add it to our list control

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -8,13 +8,13 @@
 
 #include "ViewStateSettings.h"
 
-#include "threads/SingleLock.h"
 #include "utils/SortUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
 #include <cstring>
+#include <mutex>
 #include <utility>
 
 #define XML_VIEWSTATESETTINGS       "viewstates"
@@ -70,7 +70,7 @@ bool CViewStateSettings::Load(const TiXmlNode *settings)
   if (settings == NULL)
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   const TiXmlNode *pElement = settings->FirstChildElement(XML_VIEWSTATESETTINGS);
   if (pElement == NULL)
   {
@@ -138,7 +138,7 @@ bool CViewStateSettings::Save(TiXmlNode *settings) const
   if (settings == NULL)
     return false;
 
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   // add the <viewstates> tag
   TiXmlElement xmlViewStateElement(XML_VIEWSTATESETTINGS);
   TiXmlNode *pViewStateNode = settings->InsertEndChild(xmlViewStateElement);
@@ -194,7 +194,7 @@ void CViewStateSettings::Clear()
 
 const CViewState* CViewStateSettings::Get(const std::string &viewState) const
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   std::map<std::string, CViewState*>::const_iterator view = m_viewStates.find(viewState);
   if (view != m_viewStates.end())
     return view->second;
@@ -204,7 +204,7 @@ const CViewState* CViewStateSettings::Get(const std::string &viewState) const
 
 CViewState* CViewStateSettings::Get(const std::string &viewState)
 {
-  CSingleLock lock(m_critical);
+  std::unique_lock<CCriticalSection> lock(m_critical);
   std::map<std::string, CViewState*>::iterator view = m_viewStates.find(viewState);
   if (view != m_viewStates.end())
     return view->second;

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -26,6 +26,7 @@
 #include "utils/log.h"
 
 #include <cassert>
+#include <mutex>
 
 using namespace KODI::MESSAGING;
 
@@ -318,7 +319,7 @@ void CGraphicContext::SetViewWindow(float left, float top, float right, float bo
 
 void CGraphicContext::SetFullScreenVideo(bool bOnOff)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   m_bFullScreenVideo = bOnOff;
 
@@ -420,7 +421,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
     m_bFullScreenRoot = false;
   }
 
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   // FIXME Wayland windowing needs some way to "deny" resolution updates since what Kodi
   // requests might not get actually set by the compositor.
@@ -506,7 +507,7 @@ void CGraphicContext::ApplyVideoResolution(RESOLUTION res)
     m_bFullScreenRoot = false;
   }
 
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   UpdateInternalStateWithResolution(res);
 
@@ -729,7 +730,7 @@ void CGraphicContext::SetScalingResolution(const RESOLUTION_INFO &res, bool need
 
 void CGraphicContext::SetRenderingResolution(const RESOLUTION_INFO &res, bool needsScaling)
 {
-  CSingleLock lock(*this);
+  std::unique_lock<CCriticalSection> lock(*this);
 
   SetScalingResolution(res, needsScaling);
   UpdateCameraPosition(m_cameras.top(), m_stereoFactors.top());

--- a/xbmc/windowing/X11/VideoSyncGLX.cpp
+++ b/xbmc/windowing/X11/VideoSyncGLX.cpp
@@ -8,13 +8,13 @@
 
 #include "VideoSyncGLX.h"
 
-#include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/X11/WinSystemX11GLContext.h"
 
+#include <mutex>
 #include <sstream>
 
 #include <X11/extensions/Xrandr.h>
@@ -41,7 +41,7 @@ void CVideoSyncGLX::OnResetDisplay()
 
 bool CVideoSyncGLX::Setup(PUPDATECLOCK func)
 {
-  CSingleLock lock(m_winSystem.GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(m_winSystem.GetGfxContext());
 
   m_glXWaitVideoSyncSGI = NULL;
   m_glXGetVideoSyncSGI = NULL;
@@ -246,7 +246,7 @@ void CVideoSyncGLX::Cleanup()
   CLog::Log(LOGDEBUG, "CVideoReferenceClock: Cleaning up GLX");
 
   {
-    CSingleLock lock(m_winSystem.GetGfxContext());
+    std::unique_lock<CCriticalSection> lock(m_winSystem.GetGfxContext());
 
     if (m_vInfo)
     {

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -21,12 +21,12 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "guilib/DispResource.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WindowSystemFactory.h"
 
+#include <mutex>
 #include <vector>
 
 #include <X11/Xlib.h>
@@ -59,7 +59,7 @@ void CWinSystemX11GLContext::PresentRenderImpl(bool rendered)
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;
-    CSingleLock lock(m_resourceSection);
+    std::unique_lock<CCriticalSection> lock(m_resourceSection);
     // tell any shared resources
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
@@ -127,7 +127,7 @@ bool CWinSystemX11GLContext::SetWindow(int width, int height, bool fullscreen, c
 
     if (!m_delayDispReset)
     {
-      CSingleLock lock(m_resourceSection);
+      std::unique_lock<CCriticalSection> lock(m_resourceSection);
       // tell any shared resources
       for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
         (*i)->OnResetDisplay();

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -20,10 +20,11 @@
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "guilib/DispResource.h"
-#include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WindowSystemFactory.h"
+
+#include <mutex>
 
 using namespace KODI;
 using namespace KODI::WINDOWING::X11;
@@ -51,7 +52,7 @@ void CWinSystemX11GLESContext::PresentRenderImpl(bool rendered)
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;
-    CSingleLock lock(m_resourceSection);
+    std::unique_lock<CCriticalSection> lock(m_resourceSection);
     // tell any shared resources
     for (std::vector<IDispResource*>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
@@ -109,7 +110,7 @@ bool CWinSystemX11GLESContext::SetWindow(int width, int height, bool fullscreen,
 
     if (!m_delayDispReset)
     {
-      CSingleLock lock(m_resourceSection);
+      std::unique_lock<CCriticalSection> lock(m_resourceSection);
       // tell any shared resources
       for (std::vector<IDispResource*>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
         (*i)->OnResetDisplay();

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -25,7 +25,6 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "system_egl.h"
-#include "threads/SingleLock.h"
 #include "utils/HDRCapabilities.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -36,6 +35,7 @@
 #include "platform/android/media/drm/MediaDrmCryptoSession.h"
 
 #include <float.h>
+#include <mutex>
 #include <string.h>
 
 #include <EGL/eglplatform.h>
@@ -237,7 +237,7 @@ void CWinSystemAndroid::InitiateModeChange()
 
 void CWinSystemAndroid::SetHdmiState(bool connected)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   CLog::Log(LOGDEBUG, "CWinSystemAndroid::SetHdmiState: state: {}", static_cast<int>(connected));
 
   if (connected)
@@ -293,13 +293,13 @@ bool CWinSystemAndroid::Show(bool raise)
 
 void CWinSystemAndroid::Register(IDispResource *resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemAndroid::Unregister(IDispResource *resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+#include <mutex>
 #include <string.h>
 
 using namespace KODI::WINDOWING::GBM;
@@ -248,13 +249,13 @@ bool CWinSystemGbm::Show(bool raise)
 
 void CWinSystemGbm::Register(IDispResource *resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemGbm::Unregister(IDispResource *resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
   {
@@ -267,7 +268,7 @@ void CWinSystemGbm::OnLostDevice()
   CLog::Log(LOGDEBUG, "{} - notify display change event", __FUNCTION__);
   m_dispReset = true;
 
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   for (auto resource : m_resources)
     resource->OnLostDisplay();
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -25,6 +25,8 @@
 #include "utils/log.h"
 #include "windowing/WindowSystemFactory.h"
 
+#include <mutex>
+
 #include <EGL/eglext.h>
 
 using namespace KODI::WINDOWING::GBM;
@@ -130,7 +132,7 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
       CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::{} - Sending display reset to all clients",
                 __FUNCTION__);
       m_dispReset = false;
-      CSingleLock lock(m_resourceSection);
+      std::unique_lock<CCriticalSection> lock(m_resourceSection);
 
       for (auto resource : m_resources)
         resource->OnResetDisplay();

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -29,6 +29,8 @@
 #include "utils/log.h"
 #include "windowing/WindowSystemFactory.h"
 
+#include <mutex>
+
 #include <gbm.h>
 
 using namespace KODI::WINDOWING::GBM;
@@ -139,7 +141,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
       CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::{} - Sending display reset to all clients",
                 __FUNCTION__);
       m_dispReset = false;
-      CSingleLock lock(m_resourceSection);
+      std::unique_lock<CCriticalSection> lock(m_resourceSection);
 
       for (auto resource : m_resources)
         resource->OnResetDisplay();

--- a/xbmc/windowing/ios/WinEventsIOS.mm
+++ b/xbmc/windowing/ios/WinEventsIOS.mm
@@ -16,6 +16,7 @@
 #include "utils/log.h"
 
 #include <list>
+#include <mutex>
 
 static CCriticalSection g_inputCond;
 
@@ -34,7 +35,7 @@ bool CWinEventsIOS::MessagePump()
     // deeper message loop and call the deeper MessagePump from there.
     XBMC_Event pumpEvent;
     {
-      CSingleLock lock(g_inputCond);
+      std::unique_lock<CCriticalSection> lock(g_inputCond);
       if (events.empty())
         return ret;
       pumpEvent = events.front();
@@ -49,6 +50,6 @@ bool CWinEventsIOS::MessagePump()
 
 size_t CWinEventsIOS::GetQueueSize()
 {
-  CSingleLock lock(g_inputCond);
+  std::unique_lock<CCriticalSection> lock(g_inputCond);
   return events.size();
 }

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -27,7 +27,6 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -36,6 +35,7 @@
 #import "platform/darwin/ios/IOSScreenManager.h"
 #import "platform/darwin/ios/XBMCController.h"
 
+#include <mutex>
 #include <vector>
 
 #import <Foundation/Foundation.h>
@@ -349,13 +349,13 @@ bool CWinSystemIOS::EndRender()
 
 void CWinSystemIOS::Register(IDispResource *resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemIOS::Unregister(IDispResource* resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -363,7 +363,7 @@ void CWinSystemIOS::Unregister(IDispResource* resource)
 
 void CWinSystemIOS::OnAppFocusChange(bool focus)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   m_bIsBackgrounded = !focus;
   CLog::Log(LOGDEBUG, "CWinSystemIOS::OnAppFocusChange: {}", focus ? 1 : 0);
   for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -29,7 +29,6 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/log.h"
@@ -45,6 +44,7 @@
 #include "platform/darwin/osx/XBMCHelper.h"
 
 #include <cstdlib>
+#include <mutex>
 #include <signal.h>
 
 #import <Cocoa/Cocoa.h>
@@ -1709,13 +1709,13 @@ void CWinSystemOSX::StopTextInput()
 
 void CWinSystemOSX::Register(IDispResource *resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemOSX::Unregister(IDispResource* resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -1770,7 +1770,7 @@ void CWinSystemOSX::WindowChangedScreen()
 
 void CWinSystemOSX::AnnounceOnLostDevice()
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemOSX::AnnounceOnLostDevice");
   for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
@@ -1807,7 +1807,7 @@ void CWinSystemOSX::AnnounceOnResetDevice()
 
   CServiceBroker::GetWinSystem()->GetGfxContext().SetFPS(currentFps);
 
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemOSX::AnnounceOnResetDevice");
   for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)

--- a/xbmc/windowing/tvos/WinEventsTVOS.mm
+++ b/xbmc/windowing/tvos/WinEventsTVOS.mm
@@ -18,6 +18,7 @@
 #include "utils/log.h"
 
 #include <list>
+#include <mutex>
 
 static CCriticalSection g_inputCond;
 
@@ -37,14 +38,14 @@ CWinEventsTVOS::~CWinEventsTVOS()
 
 void CWinEventsTVOS::MessagePush(XBMC_Event* newEvent)
 {
-  CSingleLock lock(m_eventsCond);
+  std::unique_lock<CCriticalSection> lock(m_eventsCond);
 
   m_events.push_back(*newEvent);
 }
 
 size_t CWinEventsTVOS::GetQueueSize()
 {
-  CSingleLock lock(g_inputCond);
+  std::unique_lock<CCriticalSection> lock(g_inputCond);
   return events.size();
 }
 
@@ -62,7 +63,7 @@ bool CWinEventsTVOS::MessagePump()
     // deeper message loop and call the deeper MessagePump from there.
     XBMC_Event pumpEvent;
     {
-      CSingleLock lock(g_inputCond);
+      std::unique_lock<CCriticalSection> lock(g_inputCond);
       if (events.empty())
         return ret;
       pumpEvent = events.front();

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -24,7 +24,6 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -39,6 +38,7 @@
 #import "platform/darwin/tvos/XBMCController.h"
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #import <Foundation/Foundation.h>
@@ -97,7 +97,7 @@ size_t CWinSystemTVOS::GetQueueSize()
 
 void CWinSystemTVOS::AnnounceOnLostDevice()
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemTVOS::AnnounceOnLostDevice");
   for (auto dispResource : m_resources)
@@ -106,7 +106,7 @@ void CWinSystemTVOS::AnnounceOnLostDevice()
 
 void CWinSystemTVOS::AnnounceOnResetDevice()
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemTVOS::AnnounceOnResetDevice");
   for (auto dispResource : m_resources)
@@ -328,13 +328,13 @@ bool CWinSystemTVOS::EndRender()
 
 void CWinSystemTVOS::Register(IDispResource* resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemTVOS::Unregister(IDispResource* resource)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -342,7 +342,7 @@ void CWinSystemTVOS::Unregister(IDispResource* resource)
 
 void CWinSystemTVOS::OnAppFocusChange(bool focus)
 {
-  CSingleLock lock(m_resourceSection);
+  std::unique_lock<CCriticalSection> lock(m_resourceSection);
   m_bIsBackgrounded = !focus;
   CLog::Log(LOGDEBUG, "CWinSystemTVOS::OnAppFocusChange: {}", focus ? 1 : 0);
   for (auto dispResource : m_resources)

--- a/xbmc/windowing/wayland/Output.h
+++ b/xbmc/windowing/wayland/Output.h
@@ -9,11 +9,11 @@
 #pragma once
 
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 #include "utils/Geometry.h"
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 #include <set>
 #include <tuple>
 
@@ -50,7 +50,7 @@ public:
    */
   CPointInt GetPosition() const
   {
-    CSingleLock lock(m_geometryCriticalSection);
+    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
     return m_position;
   }
   /**
@@ -59,17 +59,17 @@ public:
    */
   CSizeInt GetPhysicalSize() const
   {
-    CSingleLock lock(m_geometryCriticalSection);
+    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
     return m_physicalSize;
   }
   std::string const& GetMake() const
   {
-    CSingleLock lock(m_geometryCriticalSection);
+    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
     return m_make;
   }
   std::string const& GetModel() const
   {
-    CSingleLock lock(m_geometryCriticalSection);
+    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
     return m_model;
   }
   std::int32_t GetScale() const

--- a/xbmc/windowing/wayland/SeatSelection.cpp
+++ b/xbmc/windowing/wayland/SeatSelection.cpp
@@ -11,7 +11,6 @@
 #include "Connection.h"
 #include "Registry.h"
 #include "WinEventsWayland.h"
-#include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -20,6 +19,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <mutex>
 #include <system_error>
 #include <utility>
 
@@ -71,8 +71,9 @@ CSeatSelection::CSeatSelection(CConnection& connection, wayland::seat_t const& s
       m_mimeTypeOffers.push_back(std::move(mime));
     };
   };
-  m_dataDevice.on_selection() = [this](const wayland::data_offer_t& offer) {
-    CSingleLock lock(m_currentSelectionMutex);
+  m_dataDevice.on_selection() = [this](const wayland::data_offer_t& offer)
+  {
+    std::unique_lock<CCriticalSection> lock(m_currentSelectionMutex);
     m_matchedMimeType.clear();
 
     if (offer != m_currentOffer)
@@ -109,7 +110,7 @@ CSeatSelection::CSeatSelection(CConnection& connection, wayland::seat_t const& s
 
 std::string CSeatSelection::GetSelectionText() const
 {
-  CSingleLock lock(m_currentSelectionMutex);
+  std::unique_lock<CCriticalSection> lock(m_currentSelectionMutex);
   if (!m_currentSelection || m_matchedMimeType.empty())
   {
     return "";

--- a/xbmc/windowing/wayland/SeatSelection.cpp
+++ b/xbmc/windowing/wayland/SeatSelection.cpp
@@ -127,7 +127,7 @@ std::string CSeatSelection::GetSelectionText() const
   CFileHandle writeFd{fds[1]};
 
   m_currentSelection.receive(m_matchedMimeType, writeFd);
-  lock.Leave();
+  lock.unlock();
   // Make sure the other party gets the request as soon as possible
   CWinEventsWayland::Flush();
   // Fd now gets sent to the other party -> make sure our write end is closed

--- a/xbmc/windowing/wayland/Signals.h
+++ b/xbmc/windowing/wayland/Signals.h
@@ -9,11 +9,11 @@
 #pragma once
 
 #include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 
 #include <iterator>
 #include <map>
 #include <memory>
+#include <mutex>
 
 namespace KODI
 {
@@ -92,7 +92,7 @@ class CSignalHandlerList
 
     void Unregister(RegistrationIdentifierType id) override
     {
-      CSingleLock lock(m_handlerCriticalSection);
+      std::unique_lock<CCriticalSection> lock(m_handlerCriticalSection);
       m_handlers.erase(id);
     }
   };
@@ -143,7 +143,7 @@ public:
 
   CSignalRegistration Register(ManagedT const& handler)
   {
-    CSingleLock lock(m_data->m_handlerCriticalSection);
+    std::unique_lock<CCriticalSection> lock(m_data->m_handlerCriticalSection);
     bool inserted{false};
     while(!inserted)
     {
@@ -160,7 +160,7 @@ public:
   template<typename... ArgsT>
   void Invoke(ArgsT&&... args)
   {
-    CSingleLock lock(m_data->m_handlerCriticalSection);
+    std::unique_lock<CCriticalSection> lock(m_data->m_handlerCriticalSection);
     for (auto const& handler : *this)
     {
       handler.operator() (std::forward<ArgsT>(args)...);

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -35,7 +35,6 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
-#include "threads/SingleLock.h"
 #include "utils/ActorProtocol.h"
 #include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
@@ -47,6 +46,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <mutex>
 #include <numeric>
 
 #if defined(HAS_DBUS)
@@ -247,7 +247,7 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
     {
       CLog::Log(LOGDEBUG, "Entering output \"{}\" with scale {} and {:.3f} dpi",
                 UserFriendlyOutputName(output), output->GetScale(), output->GetCurrentDpi());
-      CSingleLock lock(m_surfaceOutputsMutex);
+      std::unique_lock<CCriticalSection> lock(m_surfaceOutputsMutex);
       m_surfaceOutputs.emplace(output);
       lock.unlock();
       UpdateBufferScale();
@@ -263,7 +263,7 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
     {
       CLog::Log(LOGDEBUG, "Leaving output \"{}\" with scale {}", UserFriendlyOutputName(output),
                 output->GetScale());
-      CSingleLock lock(m_surfaceOutputsMutex);
+      std::unique_lock<CCriticalSection> lock(m_surfaceOutputsMutex);
       m_surfaceOutputs.erase(output);
       lock.unlock();
       UpdateBufferScale();
@@ -401,7 +401,7 @@ bool CWinSystemWayland::CanDoWindowed()
 
 std::vector<std::string> CWinSystemWayland::GetConnectedOutputs()
 {
-  CSingleLock lock(m_outputsMutex);
+  std::unique_lock<CCriticalSection> lock(m_outputsMutex);
   std::vector<std::string> outputs;
   std::transform(m_outputs.cbegin(), m_outputs.cend(), std::back_inserter(outputs),
                  [this](decltype(m_outputs)::value_type const& pair)
@@ -425,7 +425,7 @@ void CWinSystemWayland::UpdateResolutions()
   // Only show resolutions for the currently selected output
   std::string userOutput = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
 
-  CSingleLock lock(m_outputsMutex);
+  std::unique_lock<CCriticalSection> lock(m_outputsMutex);
 
   if (m_outputs.empty())
   {
@@ -481,7 +481,7 @@ void CWinSystemWayland::UpdateResolutions()
 
 std::shared_ptr<COutput> CWinSystemWayland::FindOutputByUserFriendlyName(const std::string& name)
 {
-  CSingleLock lock(m_outputsMutex);
+  std::unique_lock<CCriticalSection> lock(m_outputsMutex);
   auto outputIt = std::find_if(m_outputs.begin(), m_outputs.end(),
                                [this, &name](decltype(m_outputs)::value_type const& entry)
                                {
@@ -493,7 +493,7 @@ std::shared_ptr<COutput> CWinSystemWayland::FindOutputByUserFriendlyName(const s
 
 std::shared_ptr<COutput> CWinSystemWayland::FindOutputByWaylandOutput(wayland::output_t const& output)
 {
-  CSingleLock lock(m_outputsMutex);
+  std::unique_lock<CCriticalSection> lock(m_outputsMutex);
   auto outputIt = std::find_if(m_outputs.begin(), m_outputs.end(),
                                [&output](decltype(m_outputs)::value_type const& entry)
                                {
@@ -697,7 +697,7 @@ void CWinSystemWayland::ProcessMessages()
       {
         CLog::LogF(LOGDEBUG, "Output hotplug, re-reading resolutions");
         UpdateResolutions();
-        CSingleLock lock(m_outputsMutex);
+        std::unique_lock<CCriticalSection> lock(m_outputsMutex);
         auto const& desktopRes = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
         auto output = FindOutputByUserFriendlyName(desktopRes.strOutput);
         auto const& wlOutput = output->GetWaylandOutput();
@@ -842,7 +842,7 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
   // Get actual frame rate from monitor, take highest frame rate if multiple
   float refreshRate{m_fRefreshRate};
   {
-    CSingleLock lock(m_surfaceOutputsMutex);
+    std::unique_lock<CCriticalSection> lock(m_surfaceOutputsMutex);
     auto maxRefreshIt = std::max_element(m_surfaceOutputs.cbegin(), m_surfaceOutputs.cend(), OutputCurrentRefreshRateComparer());
     if (maxRefreshIt != m_surfaceOutputs.cend())
     {
@@ -1076,7 +1076,7 @@ bool CWinSystemWayland::Minimize()
 
 bool CWinSystemWayland::HasCursor()
 {
-  CSingleLock lock(m_seatsMutex);
+  std::unique_lock<CCriticalSection> lock(m_seatsMutex);
   return std::any_of(m_seats.cbegin(), m_seats.cend(),
                      [](decltype(m_seats)::value_type const& entry)
                      {
@@ -1120,19 +1120,19 @@ void CWinSystemWayland::LoadDefaultCursor()
 
 void CWinSystemWayland::Register(IDispResource* resource)
 {
-  CSingleLock lock(m_dispResourcesMutex);
+  std::unique_lock<CCriticalSection> lock(m_dispResourcesMutex);
   m_dispResources.emplace(resource);
 }
 
 void CWinSystemWayland::Unregister(IDispResource* resource)
 {
-  CSingleLock lock(m_dispResourcesMutex);
+  std::unique_lock<CCriticalSection> lock(m_dispResourcesMutex);
   m_dispResources.erase(resource);
 }
 
 void CWinSystemWayland::OnSeatAdded(std::uint32_t name, wayland::proxy_t&& proxy)
 {
-  CSingleLock lock(m_seatsMutex);
+  std::unique_lock<CCriticalSection> lock(m_seatsMutex);
 
   wayland::seat_t seat(proxy);
   auto newSeatEmplace = m_seats.emplace(std::piecewise_construct,
@@ -1146,7 +1146,7 @@ void CWinSystemWayland::OnSeatAdded(std::uint32_t name, wayland::proxy_t&& proxy
 
 void CWinSystemWayland::OnSeatRemoved(std::uint32_t name)
 {
-  CSingleLock lock(m_seatsMutex);
+  std::unique_lock<CCriticalSection> lock(m_seatsMutex);
 
   auto seatI = m_seats.find(name);
   if (seatI != m_seats.end())
@@ -1173,7 +1173,7 @@ void CWinSystemWayland::OnOutputDone(std::uint32_t name)
     // output parameters change later
 
     {
-      CSingleLock lock(m_outputsMutex);
+      std::unique_lock<CCriticalSection> lock(m_outputsMutex);
       // Move from m_outputsInPreparation to m_outputs
       m_outputs.emplace(std::move(*it));
       m_outputsInPreparation.erase(it);
@@ -1189,7 +1189,7 @@ void CWinSystemWayland::OnOutputRemoved(std::uint32_t name)
 {
   m_outputsInPreparation.erase(name);
 
-  CSingleLock lock(m_outputsMutex);
+  std::unique_lock<CCriticalSection> lock(m_outputsMutex);
   if (m_outputs.erase(name) != 0)
   {
     // Theoretically, the compositor should automatically put us on another
@@ -1201,7 +1201,7 @@ void CWinSystemWayland::OnOutputRemoved(std::uint32_t name)
 void CWinSystemWayland::SendFocusChange(bool focus)
 {
   g_application.m_AppFocused = focus;
-  CSingleLock lock(m_dispResourcesMutex);
+  std::unique_lock<CCriticalSection> lock(m_dispResourcesMutex);
   for (auto dispResource : m_dispResources)
   {
     dispResource->OnAppFocusChange(focus);
@@ -1329,7 +1329,7 @@ void CWinSystemWayland::PrepareFramePresentation()
     // to the actual object
     decltype(m_surfaceSubmissions)::iterator iter;
     {
-      CSingleLock lock(m_surfaceSubmissionsMutex);
+      std::unique_lock<CCriticalSection> lock(m_surfaceSubmissionsMutex);
       iter = m_surfaceSubmissions.emplace(m_surfaceSubmissions.end(), tStart, feedback);
     }
 
@@ -1357,7 +1357,7 @@ void CWinSystemWayland::PrepareFramePresentation()
       iter->latency = latency / 1e9f; // nanoseconds to seconds
       float adjust{};
       {
-        CSingleLock lock(m_surfaceSubmissionsMutex);
+        std::unique_lock<CCriticalSection> lock(m_surfaceSubmissionsMutex);
         if (m_surfaceSubmissions.size() > LATENCY_MOVING_AVERAGE_SIZE)
         {
           adjust = - m_surfaceSubmissions.front().latency / LATENCY_MOVING_AVERAGE_SIZE;
@@ -1372,7 +1372,7 @@ void CWinSystemWayland::PrepareFramePresentation()
     feedback.on_discarded() = [this,iter]()
     {
       CLog::Log(LOGDEBUG, "Presentation: Frame was discarded by compositor");
-      CSingleLock lock(m_surfaceSubmissionsMutex);
+      std::unique_lock<CCriticalSection> lock(m_surfaceSubmissionsMutex);
       m_surfaceSubmissions.erase(iter);
     };
   }
@@ -1501,7 +1501,7 @@ std::unique_ptr<IOSScreenSaver> CWinSystemWayland::GetOSScreenSaverImpl()
 
 std::string CWinSystemWayland::GetClipboardText()
 {
-  CSingleLock lock(m_seatsMutex);
+  std::unique_lock<CCriticalSection> lock(m_seatsMutex);
   // Get text of first seat with non-empty selection
   // Actually, the value of the seat that received the Ctrl+V keypress should be used,
   // but this would need a workaround or proper multi-seat support in Kodi - it's

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -249,7 +249,7 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
                 UserFriendlyOutputName(output), output->GetScale(), output->GetCurrentDpi());
       CSingleLock lock(m_surfaceOutputsMutex);
       m_surfaceOutputs.emplace(output);
-      lock.Leave();
+      lock.unlock();
       UpdateBufferScale();
       UpdateTouchDpi();
     }
@@ -265,7 +265,7 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
                 output->GetScale());
       CSingleLock lock(m_surfaceOutputsMutex);
       m_surfaceOutputs.erase(output);
-      lock.Leave();
+      lock.unlock();
       UpdateBufferScale();
       UpdateTouchDpi();
     }

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -17,6 +17,8 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+#include <mutex>
+
 using namespace std::chrono_literals;
 
 void CVideoSyncD3D::OnLostDisplay()
@@ -41,7 +43,7 @@ void CVideoSyncD3D::RefreshChanged()
 bool CVideoSyncD3D::Setup(PUPDATECLOCK func)
 {
   CLog::Log(LOGDEBUG, "CVideoSyncD3D: Setting up Direct3d");
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   DX::Windowing()->Register(this);
   m_displayLost = false;
   m_displayReset = false;

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -23,6 +23,8 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 CGUIWindowHome::CGUIWindowHome(void) : CGUIWindow(WINDOW_HOME, "Home.xml")
 {
   m_updateRA = (Audio | Video | Totals);
@@ -108,7 +110,7 @@ void CGUIWindowHome::AddRecentlyAddedJobs(int flag)
   // this block checks to see if another one is running
   // and keeps track of the flag
   {
-    CSingleLock lockMe(*this);
+    std::unique_lock<CCriticalSection> lockMe(*this);
     if (!m_recentlyAddedRunning)
     {
       getAJob = true;
@@ -138,7 +140,7 @@ void CGUIWindowHome::OnJobComplete(unsigned int jobID, bool success, CJob *job)
   int flag = 0;
 
   {
-    CSingleLock lockMe(*this);
+    std::unique_lock<CCriticalSection> lockMe(*this);
 
     // the job is finished.
     // did one come in the meantime?


### PR DESCRIPTION
This PR is a follow up to #20949. Reviewers felt that it would be best to just replace the classes completely.

The amount of changes is quite large. Most of it is find and replace.

`CSingleLock` -> `std::unique_lock<CCriticalSection>`
`CSharedLock` -> `std::shared_lock<CSharedSection>`
`CExclusiveLock` -> `std::unique_lock<CSharedSection>`

We also now use the `lock` and `unlock` methods directly.

My only concern here is that people may start using `std::mutex` and `std::shared_mutex` instead of our custom `CCriticalSection` and `CSharedSection` mutexes. That is something we may have to watch for and enforce.

clang-format did a number on [xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp](https://github.com/xbmc/xbmc/compare/master...lrusak:locking-cleanup-PR-3?expand=1#diff-bad369057589a59119615d8f380bff839b51c2100f2e8b5fd92b24fb61ea3fc6) so it's probably better to look at the changes with whitespace changes off, click [here](https://github.com/xbmc/xbmc/pull/20980/files?w=1).

