### PR TITLE
WASAPI: fix bad log call that causes runtime exception

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -909,7 +909,7 @@ initialize:
     CLog::Log(LOGDEBUG, "  Enc. Channels   : %d", wfxex_iec61937.dwEncodedChannelCount);
     CLog::Log(LOGDEBUG, "  Enc. Samples/Sec: %d", wfxex_iec61937.dwEncodedSamplesPerSec);
     CLog::Log(LOGDEBUG, "  Channel Mask    : %d", wfxex.dwChannelMask);
-    CLog::Log(LOGDEBUG, "  Periodicty      : %I64d", audioSinkBufferDurationMsec);
+    CLog::Log(LOGDEBUG, "  Periodicty      : {}", audioSinkBufferDurationMsec);
     return false;
   }
 


### PR DESCRIPTION
## Description
Partial backport of https://github.com/xbmc/xbmc/pull/20823

Only ported the last commit.

## Motivation and context
Bad log formatting causes runtime exception and thread abort.
This error is hidden because only is executed when WASAPI fails and only is logged in LOGDEBUG. Due thread termination, primary WASAPI error is not handled correctly and AE cannot re-initialize audio device triggering an unrecoverable state.

```
2022-02-12 20:00:20.267 T:1812    DEBUG <general>:   Sample Rate     : 44100
2022-02-12 20:00:20.267 T:1812    DEBUG <general>:   Sample Format   : AE_FMT_S24NE4MSB
2022-02-12 20:00:20.267 T:1812    DEBUG <general>:   Bits Per Sample : 32
2022-02-12 20:00:20.267 T:1812    DEBUG <general>:   Valid Bits/Samp : 24
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Channel Count   : 2
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Block Align     : 8
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Avg. Bytes Sec  : 352800
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Samples/Block   : 24
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Format cBSize   : 22
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Channel Layout  : FL, FR
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Enc. Channels   : 2
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Enc. Samples/Sec: 44100
2022-02-12 20:00:20.268 T:1812    DEBUG <general>:   Channel Mask    : 3
Exception thrown at 0x00007FF94FE14F69 in kodi.exe: Microsoft C++ exception: fmt::v6::format_error at memory location 0x000000A0F30FD688.
2022-02-12 20:00:26.272 T:1812    DEBUG <general>: Thread Terminating with Exception: invalid type specifier
```


## How has this been tested?
Runtime tested Windows x64


## What is the effect on users?
Fix sporadically no sound and video freezes.



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
