### PR TITLE
[Backport] Do not override episodeguide and the default uniqueid type set by a scraper

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1080,13 +1080,16 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     {
       if (uniqueid->FirstChild())
       {
-      if (uniqueid->QueryStringAttribute("type", &value) == TIXML_SUCCESS)
-        SetUniqueID(uniqueid->FirstChild()->ValueStr(), value);
-      else
-        SetUniqueID(uniqueid->FirstChild()->ValueStr());
-      bool isDefault;
-      if ((uniqueid->QueryBoolAttribute("default", &isDefault) == TIXML_SUCCESS) && isDefault)
-        m_strDefaultUniqueID = value;
+        if (uniqueid->QueryStringAttribute("type", &value) == TIXML_SUCCESS)
+          SetUniqueID(uniqueid->FirstChild()->ValueStr(), value);
+        else
+          SetUniqueID(uniqueid->FirstChild()->ValueStr());
+        bool isDefault;
+        if (m_strDefaultUniqueID == "unknown" &&
+            (uniqueid->QueryBoolAttribute("default", &isDefault) == TIXML_SUCCESS) && isDefault)
+        {
+          m_strDefaultUniqueID = value;
+        }
       }
     }
   }
@@ -1323,18 +1326,23 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     m_streamDetails.DetermineBestStreams();
   }  /* if fileinfo */
 
-  const TiXmlElement *epguide = movie->FirstChildElement("episodeguide");
-  if (epguide)
+  if (m_strEpisodeGuide.empty())
   {
-    // DEPRECIATE ME - support for old XML-encoded <episodeguide> blocks.
-    if (epguide->FirstChild() &&
-        StringUtils::CompareNoCase("<episodeguide", epguide->FirstChild()->Value(), 13) == 0)
-      m_strEpisodeGuide = epguide->FirstChild()->Value();
-    else
+    const TiXmlElement* epguide = movie->FirstChildElement("episodeguide");
+    if (epguide)
     {
-      std::stringstream stream;
-      stream << *epguide;
-      m_strEpisodeGuide = stream.str();
+      // DEPRECIATE ME - support for old XML-encoded <episodeguide> blocks.
+      if (epguide->FirstChild() &&
+          StringUtils::CompareNoCase("<episodeguide", epguide->FirstChild()->Value(), 13) == 0)
+      {
+        m_strEpisodeGuide = epguide->FirstChild()->Value();
+      }
+      else
+      {
+        std::stringstream stream;
+        stream << *epguide;
+        m_strEpisodeGuide = stream.str();
+      }
     }
   }
 


### PR DESCRIPTION
This is a backport of #20685 and https://github.com/xbmc/xbmc/pull/21266 (regression fix)

## Description
This PR fixes the issue when episodeguide and the default uniqueid set by a Python scraper are replaced with the ones from NFO files.

## Motivation and context
Currently Python TV screpers do not work if TV show directories contain NFO files generated from a different scrapers because `getepisodelist` and `getartwork` calls receive episodeguide and uniqueid data from NFO and not from a screaper. For example, if NFO files contain episodeguide and the default uniqueid from TMDB and you are running TVmaze Python scraper, scraping fails because TVmaze scrapsr receives IDs from TMDB and cannot find anything on TVmaze of finds wrong data. Forum discussion: https://forum.kodi.tv/showthread.php?tid=349813&pid=3048495#pid3048495

## How has this been tested?
I have build the fix and tried to scrape some TV shows with TMDB NFOs by a TVmaze scraper. The TV shows were scraperd successfully.

## What is the effect on users?
Essentially, this fix eliminates a major limitation of Python scrapers and allows to switch scrapers without the need of removing/editing NFO files (provided a Python scraper itself can extract necessary data from NFOs).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
