### PR TITLE
[guilib] Font style bits were not being applied in SetStyledText lead…

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIEditControl.h"
 
+#include "GUIFont.h"
 #include "GUIKeyboardFactory.h"
 #include "GUIUserMessages.h"
 #include "GUIWindowManager.h"
@@ -552,9 +553,12 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   unsigned int startSelection = m_cursorPos + m_editOffset;
   unsigned int endSelection   = m_cursorPos + m_editOffset + m_editLength;
 
+  CGUIFont* font = m_label2.GetLabelInfo().font;
+  uint32_t style = (font ? font->GetStyle() : (FONT_STYLE_NORMAL & FONT_STYLE_MASK)) << 24;
+
   for (unsigned int i = 0; i < text.size(); i++)
   {
-    unsigned int ch = text[i];
+    uint32_t ch = text[i] | style;
     if (m_editLength > 0 && startSelection <= i && i < endSelection)
       ch |= (2 << 16); // highlight the letters we're playing with
     else if (!m_edit.empty() && (i < startHighlight || i >= endHighlight))
@@ -563,7 +567,7 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   }
 
   // show the cursor
-  unsigned int ch = L'|';
+  uint32_t ch = L'|' | style;
   if ((++m_cursorBlink % 64) > 32)
     ch |= (3 << 16);
   styled.insert(styled.begin() + m_cursorPos, ch);

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -8,6 +8,7 @@
 
 #include "GUILabelControl.h"
 
+#include "GUIFont.h"
 #include "GUIMessage.h"
 #include "utils/CharsetConverter.h"
 #include "utils/Color.h"
@@ -82,9 +83,13 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
       select = 0xFFFF0000;
     colors.push_back(select);
     colors.push_back(0xFF000000);
+
+    CGUIFont* font = m_label.GetLabelInfo().font;
+    uint32_t style = (font ? font->GetStyle() : (FONT_STYLE_NORMAL & FONT_STYLE_MASK)) << 24;
+
     for (unsigned int i = 0; i < utf16.size(); i++)
     {
-      unsigned int ch = utf16[i];
+      uint32_t ch = utf16[i] | style;
       if ((m_startSelection < m_endSelection) && (m_startSelection <= i && i < m_endSelection))
         ch |= (2 << 16);
       else if ((m_startHighlight < m_endHighlight) && (i < m_startHighlight || i >= m_endHighlight))
@@ -93,7 +98,7 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
     }
     if (m_bShowCursor && m_iCursorPos >= 0 && (unsigned int)m_iCursorPos <= utf16.size())
     {
-      unsigned int ch = L'|';
+      uint32_t ch = L'|' | style;
       if ((++m_dwCounter % 50) <= 25)
         ch |= (3 << 16);
       text.insert(text.begin() + m_iCursorPos, ch);


### PR DESCRIPTION
…ing to incorrect width being returned by CGUITextLayout::GetTextWidth(const std::wstring&).

## Description
Backported [20871](https://github.com/xbmc/xbmc/pull/20871) to Matrix branch as requested by [CastagnaIT](https://github.com/CastagnaIT).

## Motivation and context
See https://github.com/xbmc/xbmc/pull/20871

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
