### PR TITLE
SetColor builtin - use previously saved value

### DIFF
--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -312,6 +312,11 @@ static int SetColor(const std::vector<std::string>& params)
   int string = CSkinSettings::GetInstance().TranslateString(params[0]);
   std::string value = CSkinSettings::GetInstance().GetString(string);
 
+  if (value.empty() && params.size() > 2)
+  {
+    value = params[2];
+  }
+
   CGUIDialogColorPicker* pDlgColorPicker =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogColorPicker>(
           WINDOW_DIALOG_COLOR_PICKER);
@@ -327,10 +332,7 @@ static int SetColor(const std::vector<std::string>& params)
     pDlgColorPicker->LoadColors();
   }
 
-  if (params.size() > 2)
-  {
-    pDlgColorPicker->SetSelectedColor(params[2]);
-  }
+  pDlgColorPicker->SetSelectedColor(value);
 
   pDlgColorPicker->Open();
 


### PR DESCRIPTION
## Description

This fixes a bug where the predefined color value (if set by the skinner) was always preselected in the Color Picker dialog.
If a user previously selected a color (thus saved to skin settings), that value should be preselected instead.

@enen92 mind checking if things are correct now?

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
