### PR TITLE
cppcheck: fix (some) constParameter warnings

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -54,7 +54,7 @@ void CEngineStats::UpdateSinkDelay(const AEDelayStatus& status, int samples)
     m_bufferedSamples -= samples;
 }
 
-void CEngineStats::AddSamples(int samples, std::list<CActiveAEStream*> &streams)
+void CEngineStats::AddSamples(int samples, const std::list<CActiveAEStream*>& streams)
 {
   CSingleLock lock(m_lock);
   m_bufferedSamples += samples;
@@ -1646,7 +1646,9 @@ void CActiveAE::ChangeResamplers()
   }
 }
 
-void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &settings, int *mode)
+void CActiveAE::ApplySettingsToFormat(AEAudioFormat& format,
+                                      const AudioSettings& settings,
+                                      int* mode)
 {
   int oldMode = m_mode;
   if (mode)
@@ -2984,7 +2986,7 @@ void CActiveAE::FreeSoundSample(uint8_t **data)
   delete [] data;
 }
 
-bool CActiveAE::CompareFormat(AEAudioFormat &lhs, AEAudioFormat &rhs)
+bool CActiveAE::CompareFormat(const AEAudioFormat& lhs, const AEAudioFormat& rhs)
 {
   if (lhs.m_channelLayout != rhs.m_channelLayout ||
       lhs.m_dataFormat != rhs.m_dataFormat ||

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -183,7 +183,7 @@ class CEngineStats
 public:
   void Reset(unsigned int sampleRate, bool pcm);
   void UpdateSinkDelay(const AEDelayStatus& status, int samples);
-  void AddSamples(int samples, std::list<CActiveAEStream*> &streams);
+  void AddSamples(int samples, const std::list<CActiveAEStream*>& streams);
   void GetDelay(AEDelayStatus& status);
   void AddStream(unsigned int streamid);
   void RemoveStream(unsigned int streamid);
@@ -307,7 +307,9 @@ protected:
   void LoadSettings();
   bool NeedReconfigureBuffers();
   bool NeedReconfigureSink();
-  void ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &settings, int *mode = NULL);
+  void ApplySettingsToFormat(AEAudioFormat& format,
+                             const AudioSettings& settings,
+                             int* mode = NULL);
   void Configure(AEAudioFormat *desiredFmt = NULL);
   AEAudioFormat GetInputFormat(AEAudioFormat *desiredFmt = NULL);
   CActiveAEStream* CreateStream(MsgStreamNew *streamMsg);
@@ -328,7 +330,7 @@ protected:
   void MixSounds(CSoundPacket &dstSample);
   void Deamplify(CSoundPacket &dstSample);
 
-  bool CompareFormat(AEAudioFormat &lhs, AEAudioFormat &rhs);
+  bool CompareFormat(const AEAudioFormat& lhs, const AEAudioFormat& rhs);
 
   CEvent m_inMsgEvent;
   CEvent m_outMsgEvent;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -777,7 +777,7 @@ void CActiveAESink::EnumerateOutputDevices(AEDeviceList &devices, bool passthrou
   }
 }
 
-void CActiveAESink::GetDeviceFriendlyName(std::string &device)
+void CActiveAESink::GetDeviceFriendlyName(const std::string& device)
 {
   m_deviceFriendlyName = "Device not found";
   /* Match the device and find its friendly name */

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -107,7 +107,7 @@ protected:
   void Process() override;
   void StateMachine(int signal, Protocol *port, Message *msg);
   void PrintSinks(std::string& driver);
-  void GetDeviceFriendlyName(std::string &device);
+  void GetDeviceFriendlyName(const std::string& device);
   void OpenSink();
   void ReturnBuffers();
   void SetSilenceTimer();

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -368,7 +368,7 @@ void CAEBitstreamPacker::PackEAC3(CAEStreamInfo &info, uint8_t* data, int size)
   }
 }
 
-unsigned int CAEBitstreamPacker::GetOutputRate(CAEStreamInfo &info)
+unsigned int CAEBitstreamPacker::GetOutputRate(const CAEStreamInfo& info)
 {
   unsigned int rate;
   switch (info.m_type)
@@ -404,7 +404,7 @@ unsigned int CAEBitstreamPacker::GetOutputRate(CAEStreamInfo &info)
   return rate;
 }
 
-CAEChannelInfo CAEBitstreamPacker::GetOutputChannelMap(CAEStreamInfo &info)
+CAEChannelInfo CAEBitstreamPacker::GetOutputChannelMap(const CAEStreamInfo& info)
 {
   int channels = 2;
   switch (info.m_type)

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -28,8 +28,8 @@ public:
   void Reset();
   uint8_t* GetBuffer();
   unsigned int GetSize() const;
-  static unsigned int GetOutputRate(CAEStreamInfo &info);
-  static CAEChannelInfo GetOutputChannelMap(CAEStreamInfo &info);
+  static unsigned int GetOutputRate(const CAEStreamInfo& info);
+  static CAEChannelInfo GetOutputChannelMap(const CAEStreamInfo& info);
 
 private:
   void PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size);

--- a/xbmc/cores/DllLoader/DllLoaderContainer.cpp
+++ b/xbmc/cores/DllLoader/DllLoaderContainer.cpp
@@ -82,7 +82,7 @@ LibraryLoader* DllLoaderContainer::GetModule(const char* sName)
   return NULL;
 }
 
-LibraryLoader* DllLoaderContainer::GetModule(HMODULE hModule)
+LibraryLoader* DllLoaderContainer::GetModule(const HMODULE hModule)
 {
   for (int i = 0; i < m_iNrOfDlls && m_dlls[i] != NULL; i++)
   {

--- a/xbmc/cores/DllLoader/DllLoaderContainer.h
+++ b/xbmc/cores/DllLoader/DllLoaderContainer.h
@@ -18,7 +18,7 @@ public:
   static int        GetNrOfModules();
   static LibraryLoader* GetModule(int iPos);
   static LibraryLoader* GetModule(const char* sName);
-  static LibraryLoader* GetModule(HMODULE hModule);
+  static LibraryLoader* GetModule(const HMODULE hModule);
   static LibraryLoader* LoadModule(const char* sName, const char* sCurrentDir=NULL, bool bLoadSymbols=false);
   static void       ReleaseModule(LibraryLoader*& pDll);
 

--- a/xbmc/cores/DllLoader/coff.cpp
+++ b/xbmc/cores/DllLoader/coff.cpp
@@ -720,7 +720,7 @@ void CoffLoader::PrintWindowsHeader(WindowsHeader_t *WinHdr)
   printf("\n");
 }
 
-void CoffLoader::PrintSection(SectionHeader_t *ScnHdr, char* data)
+void CoffLoader::PrintSection(SectionHeader_t* ScnHdr, const char* data)
 {
   char SectionName[9];
 

--- a/xbmc/cores/DllLoader/coffldr.h
+++ b/xbmc/cores/DllLoader/coffldr.h
@@ -53,7 +53,7 @@ protected:
   static void PrintFileHeader(COFF_FileHeader_t *FileHeader);
   static void PrintWindowsHeader(WindowsHeader_t *WinHdr);
   static void PrintOptionHeader(OptionHeader_t *OptHdr);
-  static void PrintSection(SectionHeader_t *ScnHdr, char *data);
+  static void PrintSection(SectionHeader_t* ScnHdr, const char* data);
   void PrintStringTable(void);
   void PrintSymbolTable(void);
 

--- a/xbmc/cores/DllLoader/dll_tracker.cpp
+++ b/xbmc/cores/DllLoader/dll_tracker.cpp
@@ -67,7 +67,7 @@ void tracker_dll_free(DllLoader* pDll)
   }
 }
 
-void tracker_dll_set_addr(DllLoader* pDll, uintptr_t min, uintptr_t max)
+void tracker_dll_set_addr(const DllLoader* pDll, uintptr_t min, uintptr_t max)
 {
   CSingleLock locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end(); ++it)
@@ -114,7 +114,7 @@ DllTrackInfo* tracker_get_dlltrackinfo(uintptr_t caller)
   return NULL;
 }
 
-DllTrackInfo* tracker_get_dlltrackinfo_byobject(DllLoader* pDll)
+DllTrackInfo* tracker_get_dlltrackinfo_byobject(const DllLoader* pDll)
 {
   CSingleLock locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end(); ++it)
@@ -127,7 +127,7 @@ DllTrackInfo* tracker_get_dlltrackinfo_byobject(DllLoader* pDll)
   return NULL;
 }
 
-void tracker_dll_data_track(DllLoader* pDll, uintptr_t addr)
+void tracker_dll_data_track(const DllLoader* pDll, uintptr_t addr)
 {
   CSingleLock locktd(g_trackerLock);
   for (TrackedDllsIter it = g_trackedDlls.begin(); it != g_trackedDlls.end(); ++it)

--- a/xbmc/cores/DllLoader/dll_tracker.h
+++ b/xbmc/cores/DllLoader/dll_tracker.h
@@ -103,7 +103,7 @@ void tracker_dll_add(DllLoader* pDll);
 void tracker_dll_free(DllLoader* pDll);
 
 // sets the dll base address and size
-void tracker_dll_set_addr(DllLoader* pDll, uintptr_t min, uintptr_t max);
+void tracker_dll_set_addr(const DllLoader* pDll, uintptr_t min, uintptr_t max);
 
 // returns the name from the dll that contains this address or "" if not found
 const char* tracker_getdllname(uintptr_t caller);
@@ -111,11 +111,11 @@ const char* tracker_getdllname(uintptr_t caller);
 // returns a function pointer if there is one available for it, or NULL if not ofund
 void* tracker_dll_get_function(DllLoader* pDll, char* sFunctionName);
 
-DllTrackInfo* tracker_get_dlltrackinfo_byobject(DllLoader* pDll);
+DllTrackInfo* tracker_get_dlltrackinfo_byobject(const DllLoader* pDll);
 
 DllTrackInfo* tracker_get_dlltrackinfo(uintptr_t caller);
 
-void tracker_dll_data_track(DllLoader* pDll, uintptr_t addr);
+void tracker_dll_data_track(const DllLoader* pDll, uintptr_t addr);
 
 #ifdef TARGET_POSIX
 #define _ReturnAddress() __builtin_return_address(0)

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1591,7 +1591,7 @@ extern "C"
 
   //Critical Section has been fixed in EMUkernel32.cpp
 
-  int dll_initterm(PFV * start, PFV * end)        //pncrt.dll
+  int dll_initterm(PFV* start, const PFV* end) //pncrt.dll
   {
     PFV * temp;
     for (temp = start; temp < end; temp ++)

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.h
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.h
@@ -122,7 +122,7 @@ extern "C"
   int dll_fileno(FILE* stream);
   void dll_rewind(FILE* stream);
   void dll_clearerr(FILE* stream);
-  int dll_initterm(PFV * start, PFV * end);
+  int dll_initterm(PFV* start, const PFV* end);
   uintptr_t dll_beginthread(void( *start_address )( void * ),unsigned stack_size,void *arglist);
   int dll_stati64(const char *path, struct _stati64 *buffer);
   int dll_stat64(const char *path, struct __stat64 *buffer);

--- a/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.cpp
+++ b/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.cpp
@@ -16,7 +16,7 @@ CEmuFileWrapper g_emuFileWrapper;
 namespace
 {
 
-constexpr bool isValidFilePtr(FILE* f)
+constexpr bool isValidFilePtr(const FILE* f)
 {
   return (f != nullptr);
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
@@ -328,7 +328,7 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParsePacket(SPUData* pSPUData)
 /*****************************************************************************
  * AddNibble: read a nibble from a source packet and add it to our integer.
  *****************************************************************************/
-inline unsigned int AddNibble( unsigned int i_code, uint8_t* p_src, unsigned int* pi_index )
+inline unsigned int AddNibble(unsigned int i_code, const uint8_t* p_src, unsigned int* pi_index)
 {
   if ( *pi_index & 0x1 )
   {
@@ -650,7 +650,7 @@ void CDVDDemuxSPU::FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySp
   }
 }
 
-bool CDVDDemuxSPU::CanDisplayWithAlphas(int a[4], int stats[4])
+bool CDVDDemuxSPU::CanDisplayWithAlphas(const int a[4], const int stats[4])
 {
   return(
     a[0] * stats[0] > 0 ||

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.h
@@ -36,7 +36,7 @@ public:
 
   CDVDOverlaySpu* ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedData);
   static void FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySpu* pSPU);
-  static bool CanDisplayWithAlphas(int a[4], int stats[4]);
+  static bool CanDisplayWithAlphas(const int a[4], const int stats[4]);
 
   void Reset();
   void FlushCurrentPacket(); // flushes current unparsed data

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -230,7 +230,7 @@ bool CDVDDemuxVobsub::ParseId(SState& state, std::string& line)
   return true;
 }
 
-bool CDVDDemuxVobsub::ParseExtra(SState& state, std::string& line)
+bool CDVDDemuxVobsub::ParseExtra(SState& state, const std::string& line)
 {
   state.extra += line;
   state.extra += '\n';

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -83,6 +83,6 @@ private:
   bool ParseLangIdx(SState& state, std::string& line);
   bool ParseDelay(SState& state, std::string& line);
   bool ParseId(SState& state, std::string& line);
-  bool ParseExtra(SState& state, std::string& line);
+  bool ParseExtra(SState& state, const std::string& line);
   bool ParseTimestamp(SState& state, std::string& line);
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1077,7 +1077,7 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
   return false;
 }
 
-bool CVideoPlayer::IsValidStream(CCurrentStream& stream)
+bool CVideoPlayer::IsValidStream(const CCurrentStream& stream)
 {
   if(stream.id<0)
     return true; // we consider non selected as valid
@@ -1125,7 +1125,7 @@ bool CVideoPlayer::IsValidStream(CCurrentStream& stream)
   return false;
 }
 
-bool CVideoPlayer::IsBetterStream(CCurrentStream& current, CDemuxStream* stream)
+bool CVideoPlayer::IsBetterStream(const CCurrentStream& current, CDemuxStream* stream)
 {
   // Do not reopen non-video streams if we're in video-only mode
   if (m_playerOptions.videoOnly && current.type != STREAM_VIDEO)
@@ -1587,7 +1587,9 @@ void CVideoPlayer::Process()
   }
 }
 
-bool CVideoPlayer::CheckIsCurrent(CCurrentStream& current, CDemuxStream* stream, DemuxPacket* pkg)
+bool CVideoPlayer::CheckIsCurrent(const CCurrentStream& current,
+                                  CDemuxStream* stream,
+                                  DemuxPacket* pkg)
 {
   if(current.id == pkg->iStreamId &&
      current.demuxerId == stream->demuxerId &&
@@ -2306,7 +2308,7 @@ bool CVideoPlayer::CheckContinuity(CCurrentStream& current, DemuxPacket* pPacket
   return true;
 }
 
-bool CVideoPlayer::CheckSceneSkip(CCurrentStream& current)
+bool CVideoPlayer::CheckSceneSkip(const CCurrentStream& current)
 {
   if (!m_Edl.HasEdits())
     return false;
@@ -3726,7 +3728,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   return true;
 }
 
-bool CVideoPlayer::OpenSubtitleStream(CDVDStreamInfo& hint)
+bool CVideoPlayer::OpenSubtitleStream(const CDVDStreamInfo& hint)
 {
   IDVDStreamPlayer* player = GetStreamPlayer(m_CurrentSubtitle.player);
   if(player == nullptr)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -365,7 +365,7 @@ protected:
   bool OpenStream(CCurrentStream& current, int64_t demuxerId, int iStream, int source, bool reset = true);
   bool OpenAudioStream(CDVDStreamInfo& hint, bool reset = true);
   bool OpenVideoStream(CDVDStreamInfo& hint, bool reset = true);
-  bool OpenSubtitleStream(CDVDStreamInfo& hint);
+  bool OpenSubtitleStream(const CDVDStreamInfo& hint);
   bool OpenTeletextStream(CDVDStreamInfo& hint);
   bool OpenRadioRDSStream(CDVDStreamInfo& hint);
 
@@ -375,7 +375,7 @@ protected:
   void AdaptForcedSubtitles();
   bool CloseStream(CCurrentStream& current, bool bWaitForBuffers);
 
-  bool CheckIsCurrent(CCurrentStream& current, CDemuxStream* stream, DemuxPacket* pkg);
+  bool CheckIsCurrent(const CCurrentStream& current, CDemuxStream* stream, DemuxPacket* pkg);
   void ProcessPacket(CDemuxStream* pStream, DemuxPacket* pPacket);
   void ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket);
   void ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket);
@@ -413,7 +413,7 @@ protected:
   void SynchronizeDemuxer();
   void CheckAutoSceneSkip();
   bool CheckContinuity(CCurrentStream& current, DemuxPacket* pPacket);
-  bool CheckSceneSkip(CCurrentStream& current);
+  bool CheckSceneSkip(const CCurrentStream& current);
   bool CheckPlayerInit(CCurrentStream& current);
   void UpdateCorrection(DemuxPacket* pkt, double correction);
   void UpdateTimestamps(CCurrentStream& current, DemuxPacket* pPacket);
@@ -421,8 +421,8 @@ protected:
   void SendPlayerMessage(std::shared_ptr<CDVDMsg> pMsg, unsigned int target);
 
   bool ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream);
-  bool IsValidStream(CCurrentStream& stream);
-  bool IsBetterStream(CCurrentStream& current, CDemuxStream* stream);
+  bool IsValidStream(const CCurrentStream& stream);
+  bool IsBetterStream(const CCurrentStream& current, CDemuxStream* stream);
   void CheckBetterStream(CCurrentStream& current, CDemuxStream* stream);
   void CheckStreamChanges(CCurrentStream& current, CDemuxStream* stream);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -512,7 +512,7 @@ CDVDRadioRDSData::~CDVDRadioRDSData()
   StopThread();
 }
 
-bool CDVDRadioRDSData::CheckStream(CDVDStreamInfo &hints)
+bool CDVDRadioRDSData::CheckStream(const CDVDStreamInfo& hints)
 {
   if (hints.type == STREAM_RADIO_RDS)
     return true;
@@ -853,7 +853,7 @@ void CDVDRadioRDSData::ProcessUECP(const unsigned char *data, unsigned int len)
   }
 }
 
-unsigned int CDVDRadioRDSData::DecodePI(uint8_t *msgElement)
+unsigned int CDVDRadioRDSData::DecodePI(const uint8_t* msgElement)
 {
   uint16_t PICode = (msgElement[3] << 8) | msgElement[4];
   if (m_PI_Current != PICode)
@@ -891,7 +891,7 @@ unsigned int CDVDRadioRDSData::DecodePS(uint8_t *msgElement)
   return 11;
 }
 
-unsigned int CDVDRadioRDSData::DecodeDI(uint8_t *msgElement)
+unsigned int CDVDRadioRDSData::DecodeDI(const uint8_t* msgElement)
 {
   bool value;
 
@@ -932,7 +932,7 @@ unsigned int CDVDRadioRDSData::DecodeDI(uint8_t *msgElement)
   return 4;
 }
 
-unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
+unsigned int CDVDRadioRDSData::DecodeTA_TP(const uint8_t* msgElement)
 {
   uint8_t dsn = msgElement[1];
   bool traffic_announcement = (msgElement[3] & 1) != 0;
@@ -965,7 +965,7 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
   return 4;
 }
 
-unsigned int CDVDRadioRDSData::DecodeMS(uint8_t *msgElement)
+unsigned int CDVDRadioRDSData::DecodeMS(const uint8_t* msgElement)
 {
   bool speechActive = msgElement[3] == 0;
   if (m_MS_SpeechActive != speechActive)
@@ -1021,7 +1021,7 @@ pty_skin_info pty_skin_info_table[32][2] =
   { { "alarm-alarm",    29971 }, { "alarm-alarm",     29971 } }
 };
 
-unsigned int CDVDRadioRDSData::DecodePTY(uint8_t *msgElement)
+unsigned int CDVDRadioRDSData::DecodePTY(const uint8_t* msgElement)
 {
   int pty = msgElement[3];
   if (pty >= 0 && pty < 32 && m_PTY != pty)
@@ -1544,7 +1544,7 @@ unsigned int CDVDRadioRDSData::DecodeTMC(uint8_t *msgElement, unsigned int len)
   return msgElementLength + 2;
 }
 
-unsigned int CDVDRadioRDSData::DecodeEPPTransmitterInfo(uint8_t *msgElement)
+unsigned int CDVDRadioRDSData::DecodeEPPTransmitterInfo(const uint8_t* msgElement)
 {
   if (!m_RDS_SlowLabelingCodesPresent && m_PI_CountryCode != 0)
   {
@@ -1598,7 +1598,7 @@ unsigned int CDVDRadioRDSData::DecodeEPPTransmitterInfo(uint8_t *msgElement)
 #define VARCODE_LANGUAGE_CODES          3
 #define VARCODE_OWN_BROADCASTER         6
 #define VARCODE_EWS_CHANNEL_IDENT       7
-unsigned int CDVDRadioRDSData::DecodeSlowLabelingCodes(uint8_t *msgElement)
+unsigned int CDVDRadioRDSData::DecodeSlowLabelingCodes(const uint8_t* msgElement)
 {
   uint16_t slowLabellingCode = (msgElement[2]<<8 | msgElement[3]) & 0xfff;
   int      VariantCode       = (msgElement[2]>>4) & 0x7;
@@ -1669,7 +1669,7 @@ unsigned int CDVDRadioRDSData::DecodeSlowLabelingCodes(uint8_t *msgElement)
 /*!
  * currently unused need to be checked on DAB, processed here to have length of it
  */
-unsigned int CDVDRadioRDSData::DecodeDABDynLabelCmd(uint8_t *msgElement, unsigned int len)
+unsigned int CDVDRadioRDSData::DecodeDABDynLabelCmd(const uint8_t* msgElement, unsigned int len)
 {
   unsigned int msgElementLength = msgElement[1];
   if (msgElementLength < 1 || msgElementLength + 2 > len)
@@ -1684,7 +1684,7 @@ unsigned int CDVDRadioRDSData::DecodeDABDynLabelCmd(uint8_t *msgElement, unsigne
 /*!
  * currently unused need to be checked on DAB, processed here to have length of it
  */
-unsigned int CDVDRadioRDSData::DecodeDABDynLabelMsg(uint8_t *msgElement, unsigned int len)
+unsigned int CDVDRadioRDSData::DecodeDABDynLabelMsg(const uint8_t* msgElement, unsigned int len)
 {
   unsigned int msgElementLength = msgElement[1];
   if (msgElementLength < 2 || msgElementLength + 2 > len)

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
@@ -41,7 +41,7 @@ public:
   explicit CDVDRadioRDSData(CProcessInfo &processInfo);
   ~CDVDRadioRDSData() override;
 
-  bool CheckStream(CDVDStreamInfo &hints);
+  bool CheckStream(const CDVDStreamInfo& hints);
   bool OpenStream(CDVDStreamInfo hints) override;
   void CloseStream(bool bWaitForBuffers) override;
   void Flush();
@@ -68,22 +68,22 @@ private:
   void ResetRDSCache();
   void ProcessUECP(const unsigned char *Data, unsigned int Length);
 
-  inline unsigned int DecodePI(uint8_t *msgElement);
+  inline unsigned int DecodePI(const uint8_t* msgElement);
   inline unsigned int DecodePS(uint8_t *msgElement);
-  inline unsigned int DecodeDI(uint8_t *msgElement);
-  inline unsigned int DecodeTA_TP(uint8_t *msgElement);
-  inline unsigned int DecodeMS(uint8_t *msgElement);
-  inline unsigned int DecodePTY(uint8_t *msgElement);
+  inline unsigned int DecodeDI(const uint8_t* msgElement);
+  inline unsigned int DecodeTA_TP(const uint8_t* msgElement);
+  inline unsigned int DecodeMS(const uint8_t* msgElement);
+  inline unsigned int DecodePTY(const uint8_t* msgElement);
   inline unsigned int DecodePTYN(uint8_t *msgElement);
   inline unsigned int DecodeRT(uint8_t *msgElement, unsigned int len);
   inline unsigned int DecodeRTC(uint8_t *msgElement);
   inline unsigned int DecodeODA(uint8_t *msgElement, unsigned int len);
   inline unsigned int DecodeRTPlus(uint8_t *msgElement, unsigned int len);
   inline unsigned int DecodeTMC(uint8_t *msgElement, unsigned int len);
-  inline unsigned int DecodeEPPTransmitterInfo(uint8_t *msgElement);
-  inline unsigned int DecodeSlowLabelingCodes(uint8_t *msgElement);
-  inline unsigned int DecodeDABDynLabelCmd(uint8_t *msgElement, unsigned int len);
-  inline unsigned int DecodeDABDynLabelMsg(uint8_t *msgElement, unsigned int len);
+  inline unsigned int DecodeEPPTransmitterInfo(const uint8_t* msgElement);
+  inline unsigned int DecodeSlowLabelingCodes(const uint8_t* msgElement);
+  inline unsigned int DecodeDABDynLabelCmd(const uint8_t* msgElement, unsigned int len);
+  inline unsigned int DecodeDABDynLabelMsg(const uint8_t* msgElement, unsigned int len);
   inline unsigned int DecodeAF(uint8_t *msgElement, unsigned int len);
   inline unsigned int DecodeEonAF(uint8_t *msgElement, unsigned int len);
   inline unsigned int DecodeTDC(uint8_t *msgElement, unsigned int len);

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -199,7 +199,7 @@ void CDirectoryCache::Clear()
   m_cache.clear();
 }
 
-void CDirectoryCache::InitCache(std::set<std::string>& dirs)
+void CDirectoryCache::InitCache(const std::set<std::string>& dirs)
 {
   for (const std::string& strDir : dirs)
   {

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -54,7 +54,7 @@ namespace XFILE
     void PrintStats() const;
 #endif
   protected:
-    void InitCache(std::set<std::string>& dirs);
+    void InitCache(const std::set<std::string>& dirs);
     void ClearCache(std::set<std::string>& dirs);
     void CheckIfFull();
 

--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -271,7 +271,7 @@ CURL_HANDLE* DllLibCurlGlobal::easy_duphandle(CURL_HANDLE* easy_handle)
 }
 
 void DllLibCurlGlobal::easy_duplicate(CURL_HANDLE* easy,
-                                      CURLM* multi,
+                                      const CURLM* multi,
                                       CURL_HANDLE** easy_out,
                                       CURLM** multi_out)
 {

--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -75,7 +75,10 @@ public:
                     CURL_HANDLE** easy_handle,
                     CURLM** multi_handle);
   void easy_release(CURL_HANDLE** easy_handle, CURLM** multi_handle);
-  void easy_duplicate(CURL_HANDLE* easy, CURLM* multi, CURL_HANDLE** easy_out, CURLM** multi_out);
+  void easy_duplicate(CURL_HANDLE* easy,
+                      const CURLM* multi,
+                      CURL_HANDLE** easy_out,
+                      CURLM** multi_out);
   CURL_HANDLE* easy_duphandle(CURL_HANDLE* easy_handle) override;
   void CheckIdle();
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -399,7 +399,7 @@ void CButtonTranslator::RegisterMapper(const std::string& device, IButtonMapper*
   m_buttonMappers[device] = mapper;
 }
 
-void CButtonTranslator::UnregisterMapper(IButtonMapper* mapper)
+void CButtonTranslator::UnregisterMapper(const IButtonMapper* mapper)
 {
   for (auto it = m_buttonMappers.begin(); it != m_buttonMappers.end(); ++it)
   {

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -61,7 +61,7 @@ public:
   CAction GetAction(int window, const CKey& key, bool fallback = true);
 
   void RegisterMapper(const std::string& device, IButtonMapper* mapper);
-  void UnregisterMapper(IButtonMapper* mapper);
+  void UnregisterMapper(const IButtonMapper* mapper);
 
   static uint32_t TranslateString(const std::string& strMap, const std::string& strButton);
 

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1202,7 +1202,9 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalDetails(const CVariant &parameterObje
   return OK;
 }
 
-JSONRPC_STATUS CAudioLibrary::GetAdditionalArtistDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase)
+JSONRPC_STATUS CAudioLibrary::GetAdditionalArtistDetails(const CVariant& parameterObject,
+                                                         const CFileItemList& items,
+                                                         CMusicDatabase& musicdatabase)
 {
   if (!musicdatabase.Open())
     return InternalError;
@@ -1252,7 +1254,9 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalArtistDetails(const CVariant &paramet
   return OK;
 }
 
-JSONRPC_STATUS CAudioLibrary::GetAdditionalAlbumDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase)
+JSONRPC_STATUS CAudioLibrary::GetAdditionalAlbumDetails(const CVariant& parameterObject,
+                                                        const CFileItemList& items,
+                                                        CMusicDatabase& musicdatabase)
 {
   if (!musicdatabase.Open())
     return InternalError;
@@ -1284,7 +1288,9 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalAlbumDetails(const CVariant &paramete
   return OK;
 }
 
-JSONRPC_STATUS CAudioLibrary::GetAdditionalSongDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase)
+JSONRPC_STATUS CAudioLibrary::GetAdditionalSongDetails(const CVariant& parameterObject,
+                                                       const CFileItemList& items,
+                                                       CMusicDatabase& musicdatabase)
 {
   if (!musicdatabase.Open())
     return InternalError;

--- a/xbmc/interfaces/json-rpc/AudioLibrary.h
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.h
@@ -53,9 +53,15 @@ namespace JSONRPC
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
 
     static JSONRPC_STATUS GetAdditionalDetails(const CVariant &parameterObject, CFileItemList &items);
-    static JSONRPC_STATUS GetAdditionalArtistDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase);
-    static JSONRPC_STATUS GetAdditionalAlbumDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase);
-    static JSONRPC_STATUS GetAdditionalSongDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase);
+    static JSONRPC_STATUS GetAdditionalArtistDetails(const CVariant& parameterObject,
+                                                     const CFileItemList& items,
+                                                     CMusicDatabase& musicdatabase);
+    static JSONRPC_STATUS GetAdditionalAlbumDetails(const CVariant& parameterObject,
+                                                    const CFileItemList& items,
+                                                    CMusicDatabase& musicdatabase);
+    static JSONRPC_STATUS GetAdditionalSongDetails(const CVariant& parameterObject,
+                                                   const CFileItemList& items,
+                                                   CMusicDatabase& musicdatabase);
 
   private:
     static void FillAlbumItem(const CAlbum &album, const std::string &path, CFileItemPtr &item);

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -94,7 +94,7 @@ public:
     return true;
   }
 
-  std::shared_ptr<CThumbLoader> getThumbLoader(CGUIStaticItemPtr &item)
+  std::shared_ptr<CThumbLoader> getThumbLoader(const CGUIStaticItemPtr& item)
   {
     if (item->IsVideo())
     {

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -25,7 +25,7 @@ namespace MESSAGING
 class CDelayedMessage : public CThread
 {
   public:
-    CDelayedMessage(ThreadMessage& msg, unsigned int delay);
+    CDelayedMessage(const ThreadMessage& msg, unsigned int delay);
     void Process() override;
 
   private:
@@ -33,7 +33,8 @@ class CDelayedMessage : public CThread
     ThreadMessage  m_msg;
 };
 
-CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay) : CThread("DelayedMessage")
+CDelayedMessage::CDelayedMessage(const ThreadMessage& msg, unsigned int delay)
+  : CThread("DelayedMessage")
 {
   m_msg = msg;
 

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -390,7 +390,9 @@ bool CPicture::OrientateImage(uint32_t *&pixels, unsigned int &width, unsigned i
   return out;
 }
 
-bool CPicture::FlipHorizontal(uint32_t *&pixels, unsigned int &width, unsigned int &height)
+bool CPicture::FlipHorizontal(uint32_t*& pixels,
+                              const unsigned int& width,
+                              const unsigned int& height)
 {
   // this can be done in-place easily enough
   for (unsigned int y = 0; y < height; ++y)
@@ -402,7 +404,9 @@ bool CPicture::FlipHorizontal(uint32_t *&pixels, unsigned int &width, unsigned i
   return true;
 }
 
-bool CPicture::FlipVertical(uint32_t *&pixels, unsigned int &width, unsigned int &height)
+bool CPicture::FlipVertical(uint32_t*& pixels,
+                            const unsigned int& width,
+                            const unsigned int& height)
 {
   // this can be done in-place easily enough
   for (unsigned int y = 0; y < height / 2; ++y)
@@ -415,7 +419,9 @@ bool CPicture::FlipVertical(uint32_t *&pixels, unsigned int &width, unsigned int
   return true;
 }
 
-bool CPicture::Rotate180CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height)
+bool CPicture::Rotate180CCW(uint32_t*& pixels,
+                            const unsigned int& width,
+                            const unsigned int& height)
 {
   // this can be done in-place easily enough
   for (unsigned int y = 0; y < height / 2; ++y)

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -64,11 +64,17 @@ private:
                          CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
   static bool OrientateImage(uint32_t *&pixels, unsigned int &width, unsigned int &height, int orientation);
 
-  static bool FlipHorizontal(uint32_t *&pixels, unsigned int &width, unsigned int &height);
-  static bool FlipVertical(uint32_t *&pixels, unsigned int &width, unsigned int &height);
+  static bool FlipHorizontal(uint32_t*& pixels,
+                             const unsigned int& width,
+                             const unsigned int& height);
+  static bool FlipVertical(uint32_t*& pixels,
+                           const unsigned int& width,
+                           const unsigned int& height);
   static bool Rotate90CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height);
   static bool Rotate270CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height);
-  static bool Rotate180CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height);
+  static bool Rotate180CCW(uint32_t*& pixels,
+                           const unsigned int& width,
+                           const unsigned int& height);
   static bool Transpose(uint32_t *&pixels, unsigned int &width, unsigned int &height);
   static bool TransposeOffAxis(uint32_t *&pixels, unsigned int &width, unsigned int &height);
 };

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -49,7 +49,9 @@ CFileOperationJob::CFileOperationJob(FileAction action, CFileItemList & items,
   SetFileOperation(action, items, strDestFile);
 }
 
-void CFileOperationJob::SetFileOperation(FileAction action, CFileItemList &items, const std::string &strDestFile)
+void CFileOperationJob::SetFileOperation(FileAction action,
+                                         const CFileItemList& items,
+                                         const std::string& strDestFile)
 {
   m_action = action;
   m_strDestFile = strDestFile;
@@ -138,7 +140,11 @@ bool CFileOperationJob::DoProcessFolder(FileAction action, const std::string& st
   return true;
 }
 
-bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, const std::string& strDestFile, FileOperationList &fileOperations, double &totalTime)
+bool CFileOperationJob::DoProcess(FileAction action,
+                                  const CFileItemList& items,
+                                  const std::string& strDestFile,
+                                  FileOperationList& fileOperations,
+                                  double& totalTime)
 {
   for (int iItem = 0; iItem < items.Size(); ++iItem)
   {

--- a/xbmc/utils/FileOperationJob.h
+++ b/xbmc/utils/FileOperationJob.h
@@ -41,7 +41,9 @@ public:
   const char* GetType() const override { return m_displayProgress ? "filemanager" : ""; }
   bool operator==(const CJob *job) const override;
 
-  void SetFileOperation(FileAction action, CFileItemList &items, const std::string &strDestFile);
+  void SetFileOperation(FileAction action,
+                        const CFileItemList& items,
+                        const std::string& strDestFile);
 
   const std::string &GetAverageSpeed() const { return m_avgSpeed; }
   const std::string &GetCurrentOperation() const { return m_currentOperation; }
@@ -69,7 +71,11 @@ private:
   friend class CFileOperation;
 
   typedef std::vector<CFileOperation> FileOperationList;
-  bool DoProcess(FileAction action, CFileItemList & items, const std::string& strDestFile, FileOperationList &fileOperations, double &totalTime);
+  bool DoProcess(FileAction action,
+                 const CFileItemList& items,
+                 const std::string& strDestFile,
+                 FileOperationList& fileOperations,
+                 double& totalTime);
   bool DoProcessFolder(FileAction action, const std::string& strPath, const std::string& strDestFile, FileOperationList &fileOperations, double &totalTime);
   bool DoProcessFile(FileAction action, const std::string& strFileA, const std::string& strFileB, FileOperationList &fileOperations, double &totalTime);
 

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -36,7 +36,7 @@ CDRMObject::CDRMObject(int fd) : m_fd(fd)
 std::string CDRMObject::GetTypeName() const
 {
   auto name = std::find_if(DrmModeObjectTypes.begin(), DrmModeObjectTypes.end(),
-                           [this](auto& p) { return p.first == m_type; });
+                           [this](const auto& p) { return p.first == m_type; });
   if (name != DrmModeObjectTypes.end())
     return name->second;
 
@@ -46,7 +46,7 @@ std::string CDRMObject::GetTypeName() const
 std::string CDRMObject::GetPropertyName(uint32_t propertyId) const
 {
   auto prop = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                           [&propertyId](auto& p) { return p->prop_id == propertyId; });
+                           [&propertyId](const auto& p) { return p->prop_id == propertyId; });
   if (prop != m_propsInfo.end())
     return prop->get()->name;
 
@@ -56,7 +56,7 @@ std::string CDRMObject::GetPropertyName(uint32_t propertyId) const
 uint32_t CDRMObject::GetPropertyId(const std::string& name) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                               [&name](auto& prop) { return prop->name == name; });
+                               [&name](const auto& prop) { return prop->name == name; });
 
   if (property != m_propsInfo.end())
     return property->get()->prop_id;
@@ -85,7 +85,7 @@ std::tuple<bool, uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
                                                         const std::string& valueName) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                               [&name](auto& prop) { return prop->name == name; });
+                               [&name](const auto& prop) { return prop->name == name; });
 
   if (property == m_propsInfo.end())
     return std::make_tuple(false, 0);
@@ -109,7 +109,7 @@ std::tuple<bool, uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                               [&name](auto& prop) { return prop->name == name; });
+                               [&name](const auto& prop) { return prop->name == name; });
 
   if (property != m_propsInfo.end())
   {
@@ -124,7 +124,7 @@ bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 bool CDRMObject::SupportsProperty(const std::string& name)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                               [&name](auto& prop) { return prop->name == name; });
+                               [&name](const auto& prop) { return prop->name == name; });
 
   if (property != m_propsInfo.end())
     return true;


### PR DESCRIPTION
## Description
fix some of the constParameter warnings

## Motivation and context
Got a bit bored, started some shit-kicker work.

## How has this been tested?
build osx

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
