### PR TITLE
[MUSIC] fix discography not exported to nfo files

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2071,6 +2071,7 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* =
         discoAlbum.strAlbum = record->at(discographyOffset + 1).get_asString();
         discoAlbum.strYear = record->at(discographyOffset + 2).get_asString();
         discoAlbum.strReleaseGroupMBID = record->at(discographyOffset + 3).get_asString();
+        artist.discography.emplace_back(discoAlbum);
         m_pDS->next();
       }
     }


### PR DESCRIPTION
## Description
Whilst testing for something else, noticed that the artist discography is never exported to nfo files.
## Motivation and context
Discography should be exported to nfo files.


## What is the effect on users?
Exporting artist info to nfo files will now include the artist discography if it has previously been scraped.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
