### PR TITLE
Cppcheck: fix some unreadvariable and knownconditiontruefalse warnings

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3475,7 +3475,7 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
     {
       return true;
     }
-    else if (!m_screensaverIdInUse.empty())
+    else
     { // we're in screensaver window
       if (m_pythonScreenSaver)
       {

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -376,8 +376,6 @@ bool CApplication::Create(const CAppParamParser &params)
 
   PrintStartupLog();
 
-  std::string strExecutablePath = CUtil::GetHomePath();
-
   // initialize network protocols
   avformat_network_init();
   // set avutil callback

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -102,7 +102,7 @@ bool CAutorun::PlayDisc(const std::string& path, bool bypassSettings, bool start
   if (pInfo == NULL)
     return false;
 
-  if (mediaPath.empty() && pInfo->IsAudio(1))
+  if (pInfo->IsAudio(1))
     mediaPath = "cdda://local/";
 
   if (mediaPath.empty() && (pInfo->IsISOUDF(1) || pInfo->IsISOHFS(1) || pInfo->IsIso9660(1) || pInfo->IsIso9660Interactive(1)))

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -84,7 +84,7 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format, bool allow_planar_input
   AVCodec *codec = NULL;
 
   /* fallback to ac3 if we support it, we might not have DTS support */
-  if (!codec && ac3)
+  if (ac3)
   {
     m_CodecName = "AC3";
     m_CodecID = AV_CODEC_ID_AC3;

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -179,7 +179,7 @@ int CAEStreamParser::AddData(uint8_t *data, unsigned int size, uint8_t **buffer/
       m_needBytes = 0;
       offset = (this->*m_syncFunc)(m_buffer, m_bufferSize);
 
-      if (m_hasSync || m_needBytes)
+      if (m_hasSync)
         break;
       else
       {

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -252,11 +252,7 @@ double CAudioSinkAE::GetCacheTime()
   if (!m_pAudioStream)
     return 0.0;
 
-  double delay = 0.0;
-  if(m_pAudioStream)
-    delay = m_pAudioStream->GetCacheTime();
-
-  return delay;
+  return m_pAudioStream->GetCacheTime();
 }
 
 double CAudioSinkAE::GetCacheTotal()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -167,19 +167,16 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
   if (!m_dataSize)
     return true;
 
-  if (m_dataSize)
+  m_format.m_dataFormat = AE_FMT_RAW;
+  m_format.m_streamInfo = m_parser.GetStreamInfo();
+  m_format.m_sampleRate = m_parser.GetSampleRate();
+  m_format.m_frameSize = 1;
+  CAEChannelInfo layout;
+  for (unsigned int i = 0; i < m_parser.GetChannels(); i++)
   {
-    m_format.m_dataFormat = AE_FMT_RAW;
-    m_format.m_streamInfo = m_parser.GetStreamInfo();
-    m_format.m_sampleRate = m_parser.GetSampleRate();
-    m_format.m_frameSize = 1;
-    CAEChannelInfo layout;
-    for (unsigned int i=0; i<m_parser.GetChannels(); i++)
-    {
-      layout += AE_CH_RAW;
-    }
-    m_format.m_channelLayout = layout;
+    layout += AE_CH_RAW;
   }
+  m_format.m_channelLayout = layout;
 
   if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1169,7 +1169,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
     return nullptr;
 
   // check streams, can we make this a bit more simple?
-  if (pPacket && pPacket->iStreamId >= 0)
+  if (pPacket->iStreamId >= 0)
   {
     CDemuxStream* stream = GetStream(pPacket->iStreamId);
     if (!stream ||

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -333,7 +333,8 @@ bool CDVDInputStreamBluray::Open()
   else
   {
     m_navmode = true;
-    if (m_navmode && !disc_info->first_play_supported) {
+    if (!disc_info->first_play_supported)
+    {
       CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - Can't play disc in HDMV navigation mode - First Play title not supported");
       m_navmode = false;
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -77,8 +77,6 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect, EShaderFormat format, bo
     m_defines += "#define XBMC_YUY2\n";
   else if (m_format == SHADER_UYVY)
     m_defines += "#define XBMC_UYVY\n";
-  else if (m_format == SHADER_YV12)
-    m_defines += "#define XBMC_YV12\n";
   else
     CLog::Log(LOGERROR, "GL: BaseYUV2RGBGLSLShader - unsupported format {}", m_format);
 
@@ -188,12 +186,12 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
       glUniform3f(m_hCoefsDst, coefs[0], coefs[1], coefs[2]);
       glUniform1f(m_hToneP1, param);
     }
-    else if (m_toneMapping && m_toneMappingMethod == VS_TONEMAPMETHOD_ACES)
+    else if (m_toneMappingMethod == VS_TONEMAPMETHOD_ACES)
     {
       glUniform1f(m_hLuminance, GetLuminanceValue());
       glUniform1f(m_hToneP1, m_toneMappingParam);
     }
-    else if (m_toneMapping && m_toneMappingMethod == VS_TONEMAPMETHOD_HABLE)
+    else if (m_toneMappingMethod == VS_TONEMAPMETHOD_HABLE)
     {
       float lumin = GetLuminanceValue();
       float param = (10000.0f / lumin) * (2.0f / m_toneMappingParam);

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -357,7 +357,7 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
     m_vecPlayerConfigs.emplace_back(std::move(retroPlayer));
   }
 
-  if (!pConfig || StringUtils::CompareNoCase(pConfig->Value(), "playercorefactory") != 0)
+  if (StringUtils::CompareNoCase(pConfig->Value(), "playercorefactory") != 0)
   {
     CLog::Log(LOGERROR, "Error loading configuration, no <playercorefactory> node");
     return false;

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -53,12 +53,6 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK) != BD_PLAYBACK_SIMPLE_MENU)
     return true;
 
-  std::string path;
-  if (item.IsVideoDb())
-    path = item.GetVideoInfoTag()->m_strFileNameAndPath;
-  else
-    path = item.GetPath();
-
   if (item.IsBDFile())
   {
     std::string root = URIUtils::GetParentPath(item.GetDynPath());

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -985,14 +985,12 @@ bool CCurlFile::Service(const std::string& strURL, std::string& strHTML)
 bool CCurlFile::ReadData(std::string& strHTML)
 {
   int size_read = 0;
-  int data_size = 0;
   strHTML = "";
   char buffer[16384];
   while( (size_read = Read(buffer, sizeof(buffer)-1) ) > 0 )
   {
     buffer[size_read] = 0;
     strHTML.append(buffer, size_read);
-    data_size += size_read;
   }
   if (m_state->m_cancelled)
     return false;

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -182,10 +182,10 @@ bool CDirectory::GetDirectory(const CURL& url,
 
       pDirectory->SetFlags(hints.flags);
 
-      bool result = false, cancel = false;
+      bool result = false;
       CURL authUrl = realURL;
 
-      while (!result && !cancel)
+      while (!result)
       {
         const std::string pathToUrl(url.Get());
 
@@ -198,18 +198,16 @@ bool CDirectory::GetDirectory(const CURL& url,
 
         if (!result)
         {
-          if (!cancel)
+          // @TODO ProcessRequirements() can bring up the keyboard input dialog
+          // filesystem must not depend on GUI
+          if (g_application.IsCurrentThread() && pDirectory->ProcessRequirements())
           {
-            // @TODO ProcessRequirements() can bring up the keyboard input dialog
-            // filesystem must not depend on GUI
-            if (g_application.IsCurrentThread() && pDirectory->ProcessRequirements())
-            {
-              authUrl.SetDomain("");
-              authUrl.SetUserName("");
-              authUrl.SetPassword("");
-              continue;
-            }
+            authUrl.SetDomain("");
+            authUrl.SetUserName("");
+            authUrl.SetPassword("");
+            continue;
           }
+
           CLog::Log(LOGERROR, "{} - Error getting {}", __FUNCTION__, url.GetRedacted());
           return false;
         }

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -69,15 +69,6 @@ void CTextureBundleXBT::CloseBundle()
 bool CTextureBundleXBT::OpenBundle()
 {
   // Find the correct texture file (skin or theme)
-
-  auto mediaDir = CServiceBroker::GetWinSystem()->GetGfxContext().GetMediaDir();
-  if (mediaDir.empty())
-  {
-    mediaDir = CSpecialProtocol::TranslatePath(
-      URIUtils::AddFileToFolder("special://home/addons",
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN)));
-  }
-
   if (m_themeBundle)
   {
     // if we are the theme bundle, we only load if the user has chosen

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -546,7 +546,6 @@ void GetNewValueForViewModeParameter(const CVariant &parameter, float stepSize, 
   }
   else if (parameter.isString())
   {
-    std::string parameterStr = parameter.asString();
     if (parameter == "decrease")
     {
       stepSize *= -1;

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -207,27 +207,27 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
         if ((additionalInfo) &&
             videodatabase.Open())
         {
-          if (additionalInfo)
+          switch (fileItem->GetVideoContentType())
           {
-            switch (fileItem->GetVideoContentType())
-            {
-              case VIDEODB_CONTENT_MOVIES:
-                videodatabase.GetMovieInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
-                break;
+            case VIDEODB_CONTENT_MOVIES:
+              videodatabase.GetMovieInfo("", *(fileItem->GetVideoInfoTag()),
+                                         fileItem->GetVideoInfoTag()->m_iDbId);
+              break;
 
-              case VIDEODB_CONTENT_MUSICVIDEOS:
-                videodatabase.GetMusicVideoInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
-                break;
+            case VIDEODB_CONTENT_MUSICVIDEOS:
+              videodatabase.GetMusicVideoInfo("", *(fileItem->GetVideoInfoTag()),
+                                              fileItem->GetVideoInfoTag()->m_iDbId);
+              break;
 
-              case VIDEODB_CONTENT_EPISODES:
-                videodatabase.GetEpisodeInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
-                break;
+            case VIDEODB_CONTENT_EPISODES:
+              videodatabase.GetEpisodeInfo("", *(fileItem->GetVideoInfoTag()),
+                                           fileItem->GetVideoInfoTag()->m_iDbId);
+              break;
 
-              case VIDEODB_CONTENT_TVSHOWS:
-              case VIDEODB_CONTENT_MOVIE_SETS:
-              default:
-                break;
-            }
+            case VIDEODB_CONTENT_TVSHOWS:
+            case VIDEODB_CONTENT_MOVIE_SETS:
+            default:
+              break;
           }
 
           videodatabase.Close();

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -570,7 +570,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
       return;
     }
 
-    if (item && !item->IsParentFolder())
+    if (!item->IsParentFolder())
     {
       if (item->CanQueue() && !item->IsAddonsPath() && !item->IsScript())
       {

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -1257,7 +1257,7 @@ bool CNetworkServices::ValidatePort(int port)
     return false;
 
 #ifdef TARGET_LINUX
-  if (!CUtil::CanBindPrivileged() && (port < 1024 || port > 65535))
+  if (!CUtil::CanBindPrivileged() && (port < 1024))
     return false;
 #endif
 

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -163,11 +163,6 @@ MHD_RESULT CWebServer::AnswerToConnection(void* cls,
   }
 
   CWebServer* webServer = reinterpret_cast<CWebServer*>(cls);
-  if (webServer == nullptr)
-  {
-    GetLogger()->error("invalid request received");
-    return MHD_NO;
-  }
 
   ConnectionHandler* connectionHandler = reinterpret_cast<ConnectionHandler*>(*con_cls);
   HTTPMethod methodType = GetHTTPMethod(method);

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -397,7 +397,6 @@ void CGUIWindowPictures::OnSlideShowRecursive(const std::string &strPicture)
 
 void CGUIWindowPictures::OnSlideShowRecursive()
 {
-  std::string strEmpty = "";
   OnSlideShowRecursive(m_vecItems->GetPath());
 }
 

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1201,7 +1201,7 @@ const TiXmlNode* CSmartPlaylist::readName(const TiXmlNode *root)
   if (rootElem == NULL)
     return NULL;
 
-  if (!root || !StringUtils::EqualsNoCase(root->Value(),"smartplaylist"))
+  if (!StringUtils::EqualsNoCase(root->Value(), "smartplaylist"))
   {
     CLog::Log(LOGERROR, "Error loading Smart playlist");
     return NULL;

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -702,9 +702,6 @@ void CDisplaySettings::SettingOptionsModesFiller(const std::shared_ptr<const CSe
                                                  std::string& current,
                                                  void* data)
 {
-  RESOLUTION res = CDisplaySettings::GetInstance().GetDisplayResolution();
-  RESOLUTION_INFO info = CDisplaySettings::GetInstance().GetResolutionInfo(res);
-
   for (auto index = (unsigned int)RES_CUSTOM; index < CDisplaySettings::GetInstance().ResolutionInfoSize(); ++index)
   {
     const auto mode = CDisplaySettings::GetInstance().GetResolutionInfo(index);

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -167,12 +167,6 @@ bool CSettingsComponent::InitDirectoriesLinux(bool bPlatformDirectories)
   const char* envAppBinHome = "KODI_BIN_HOME";
   const char* envAppTemp = "KODI_TEMP";
 
-  std::string userName;
-  if (getenv("USER"))
-    userName = getenv("USER");
-  else
-    userName = "root";
-
   std::string userHome;
   if (getenv("KODI_DATA"))
     userHome = getenv("KODI_DATA");
@@ -267,12 +261,6 @@ bool CSettingsComponent::InitDirectoriesLinux(bool bPlatformDirectories)
 bool CSettingsComponent::InitDirectoriesOSX(bool bPlatformDirectories)
 {
 #if defined(TARGET_DARWIN)
-  std::string userName;
-  if (getenv("USER"))
-    userName = getenv("USER");
-  else
-    userName = "root";
-
   std::string userHome;
   if (getenv("HOME"))
     userHome = getenv("HOME");

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -1352,7 +1352,7 @@ bool CGUIControlEditSetting::InputValidation(const std::string& input, void* dat
     return true;
 
   CGUIControlEditSetting* editControl = reinterpret_cast<CGUIControlEditSetting*>(data);
-  if (editControl == NULL || editControl->GetSetting() == NULL)
+  if (editControl->GetSetting() == NULL)
     return true;
 
   editControl->SetValid(editControl->GetSetting()->CheckValidity(input));

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -538,7 +538,7 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
   if (pInfo == NULL)
     return "";
 
-  if (mediaPath.empty() && pInfo->IsAudio(1))
+  if (pInfo->IsAudio(1))
     mediaPath = "cdda://local/";
 
   if (mediaPath.empty() && (pInfo->IsISOUDF(1) || pInfo->IsISOHFS(1) || pInfo->IsIso9660(1) || pInfo->IsIso9660Interactive(1)))

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -536,7 +536,7 @@ bool preliminarySort(const SortItem &left, const SortItem &right, bool handleFol
     return true;
   }
   // both have either sort on top or sort on bottom -> leave as-is
-  else if (leftSortSpecial != SortSpecialNone && leftSortSpecial == rightSortSpecial)
+  else if (leftSortSpecial != SortSpecialNone)
   {
     result = false;
     return true;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -484,9 +484,6 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
 
   if (pItem->m_bIsFolder)
   {
-    if (pItem->IsParentFolder())
-      return;
-
     // check if it's a folder with dvd or bluray files, then just add the relevant file
     std::string mediapath(pItem->GetOpticalMediaPath());
     if (!mediapath.empty())


### PR DESCRIPTION
## Description
Fix more cppcheck warnings

## Motivation and context
Remove warnings

## How has this been tested?


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
