### PR TITLE
NetworkWin10 improvements

### DIFF
--- a/xbmc/platform/win10/network/NetworkWin10.cpp
+++ b/xbmc/platform/win10/network/NetworkWin10.cpp
@@ -55,6 +55,11 @@ typedef struct icmp_echo_reply {
 #endif //! IP_STATUS_BASE
 #include <Icmpapi.h>
 
+namespace
+{
+constexpr int MAC_LENGTH = 6; // fixed MAC length used in CNetworkInterface
+}
+
 using namespace winrt::Windows::Networking::Connectivity;
 
 CNetworkInterfaceWin10::CNetworkInterfaceWin10(const PIP_ADAPTER_ADDRESSES address)
@@ -76,16 +81,20 @@ bool CNetworkInterfaceWin10::IsConnected() const
 
 std::string CNetworkInterfaceWin10::GetMacAddress() const
 {
-  std::string result;
+  if (m_adapterAddr->PhysicalAddressLength < MAC_LENGTH)
+    return "";
+
   unsigned char* mAddr = m_adapterAddr->PhysicalAddress;
-  result = StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", mAddr[0], mAddr[1],
-                               mAddr[2], mAddr[3], mAddr[4], mAddr[5]);
-  return result;
+  return StringUtils::Format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", mAddr[0], mAddr[1],
+                             mAddr[2], mAddr[3], mAddr[4], mAddr[5]);
 }
 
 void CNetworkInterfaceWin10::GetMacAddressRaw(char rawMac[6]) const
 {
-  memcpy(rawMac, m_adapterAddr->PhysicalAddress, 6);
+  size_t len = (m_adapterAddr->PhysicalAddressLength > MAC_LENGTH)
+                   ? MAC_LENGTH
+                   : m_adapterAddr->PhysicalAddressLength;
+  memcpy(rawMac, m_adapterAddr->PhysicalAddress, len);
 }
 
 bool CNetworkInterfaceWin10::GetHostMacAddress(unsigned long host, std::string& mac) const

--- a/xbmc/platform/win10/network/NetworkWin10.h
+++ b/xbmc/platform/win10/network/NetworkWin10.h
@@ -10,7 +10,6 @@
 
 #include "network/Network.h"
 #include "threads/CriticalSection.h"
-#include "utils/stopwatch.h"
 
 #include <string>
 #include <vector>
@@ -56,6 +55,7 @@ public:
     bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) override;
 
     friend class CNetworkInterfaceWin10;
+
 private:
     int GetSocket() { return m_sock; }
     void queryInterfaceList();
@@ -63,7 +63,6 @@ private:
 
     std::vector<CNetworkInterface*> m_interfaces;
     int m_sock;
-    CStopWatch m_netrefreshTimer;
     CCriticalSection m_critSection;
     PIP_ADAPTER_ADDRESSES m_adapterAddresses;
 };

--- a/xbmc/platform/win10/network/NetworkWin10.h
+++ b/xbmc/platform/win10/network/NetworkWin10.h
@@ -64,6 +64,6 @@ private:
     std::vector<CNetworkInterface*> m_interfaces;
     int m_sock;
     CCriticalSection m_critSection;
-    PIP_ADAPTER_ADDRESSES m_adapterAddresses;
+    std::vector<uint8_t> m_adapterAddresses;
 };
 


### PR DESCRIPTION
## Description
NetworkWin10 various improvements similar to https://github.com/xbmc/xbmc/pull/20953

## Motivation and context
Sync UWP code with Win32 code.

Although since there is no memory leak in UWP, backport to Matrix is not necessary this time.

## How has this been tested?
Runtime tested on Windows 10 UWP


## What is the effect on users?
N/A


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
