### PR TITLE
[Linux][Discs][DllLoader] Always check getmntent result

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -2026,21 +2026,24 @@ extern "C"
 
   struct mntent *dll_getmntent(FILE *fp)
   {
-    if (fp == NULL)
-      return NULL;
+    if (!fp)
+      return nullptr;
 
+#if defined(TARGET_LINUX)
+    struct mntent* mountPoint = getmntent(fp);
+    if (mountPoint)
+      return mountPoint;
+
+    // warn if this is a kodi vfs file not associated with a mountpoint
     CFile* pFile = g_emuFileWrapper.GetFileXbmcByStream(fp);
     if (pFile)
     {
-      CLog::Log(LOGERROR, "{} - getmntent is not implemented for our virtual filesystem",
-                __FUNCTION__);
-      return NULL;
+      CLog::LogF(LOGWARNING, "getmntent is not implemented for our virtual filesystem");
     }
-#if defined(TARGET_LINUX)
-    return getmntent(fp);
+    return nullptr;
 #else
-    CLog::Log(LOGWARNING, "{} - unimplemented function called", __FUNCTION__);
-    return NULL;
+    CLog::LogF(LOGWARNING, "Unimplemented function called");
+    return nullptr;
 #endif
   }
 


### PR DESCRIPTION
## Description
Found a few issues while playing some optical dvds I recently got - most of them don't even play and we end up in an infinite loop. When we attempt to play a dvd we intentionally strip part of the path:

https://github.com/xbmc/xbmc/blob/c32c8dd96ebff6b3a5848c3f5ee83fa2a6e2f77b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp#L89-L98

We state libdvdnav/libdvdread is able to cope with this but I don't really think this is the case. Other players like vlc just point the optical drive path (/dev/sr0; /dev/cdrom) towards the lib and playback always work. Digging deeper and looking at the errors in my log I found that when we call `getmtent` we intentionally return null if the path is a kodi vfs path. This is wrong as if we call getmtent we are interested in knowing the actual mountpoint - at least we could warn if we couldn't find a mountpoint and the file is a kodi vfs file. This allows to translate the dvd path to the actual drive under linux.

@howie-f this should solve the issues you were having long ago in your virtual environment
@gebim would be nice if you could give this a go to check if it causes any regressions (I didn't find any with all my discs and iso files). I don't expect this to fix the other issue you reported but at least should not introduce new ones :)

Other platforms are not affected as it would always return null.
