### PR TITLE
[WEBSERVER] Handle HEAD requests in exactly the same way as GET requests

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1221,11 +1221,11 @@ struct MHD_Daemon* CWebServer::StartMHD(unsigned int flags, int port)
             | MHD_USE_SSL,
         port, 0, 0, &CWebServer::AnswerToConnection, this,
 
-        MHD_OPTION_CONNECTION_LIMIT, 512, MHD_OPTION_CONNECTION_TIMEOUT, timeout,
-        MHD_OPTION_URI_LOG_CALLBACK, &CWebServer::UriRequestLogger, this,
-        MHD_OPTION_EXTERNAL_LOGGER, &logFromMHD, 0, MHD_OPTION_THREAD_STACK_SIZE,
-        m_thread_stacksize, MHD_OPTION_HTTPS_MEM_KEY, m_key.c_str(), MHD_OPTION_HTTPS_MEM_CERT,
-        m_cert.c_str(), MHD_OPTION_HTTPS_PRIORITIES, ciphers, MHD_OPTION_END);
+        MHD_OPTION_EXTERNAL_LOGGER, &logFromMHD, 0, MHD_OPTION_CONNECTION_LIMIT, 512,
+        MHD_OPTION_CONNECTION_TIMEOUT, timeout, MHD_OPTION_URI_LOG_CALLBACK,
+        &CWebServer::UriRequestLogger, this, MHD_OPTION_THREAD_STACK_SIZE, m_thread_stacksize,
+        MHD_OPTION_HTTPS_MEM_KEY, m_key.c_str(), MHD_OPTION_HTTPS_MEM_CERT, m_cert.c_str(),
+        MHD_OPTION_HTTPS_PRIORITIES, ciphers, MHD_OPTION_END);
 
   // No SSL
   return MHD_start_daemon(
@@ -1242,9 +1242,10 @@ struct MHD_Daemon* CWebServer::StartMHD(unsigned int flags, int port)
       ,
       port, 0, 0, &CWebServer::AnswerToConnection, this,
 
-      MHD_OPTION_CONNECTION_LIMIT, 512, MHD_OPTION_CONNECTION_TIMEOUT, timeout,
-      MHD_OPTION_URI_LOG_CALLBACK, &CWebServer::UriRequestLogger, this, MHD_OPTION_EXTERNAL_LOGGER,
-      &logFromMHD, 0, MHD_OPTION_THREAD_STACK_SIZE, m_thread_stacksize, MHD_OPTION_END);
+      MHD_OPTION_EXTERNAL_LOGGER, &logFromMHD, 0, MHD_OPTION_CONNECTION_LIMIT, 512,
+      MHD_OPTION_CONNECTION_TIMEOUT, timeout, MHD_OPTION_URI_LOG_CALLBACK,
+      &CWebServer::UriRequestLogger, this, MHD_OPTION_THREAD_STACK_SIZE, m_thread_stacksize,
+      MHD_OPTION_END);
 }
 
 bool CWebServer::Start(uint16_t port, const std::string& username, const std::string& password)

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -823,7 +823,7 @@ MHD_RESULT CWebServer::CreateFileDownloadResponse(
   }
 
   uint64_t totalLength = 0;
-  std::unique_ptr<HttpFileDownloadContext> context(new HttpFileDownloadContext());
+  std::unique_ptr<HttpFileDownloadContext> context = std::make_unique<HttpFileDownloadContext>();
   context->file = file;
   context->contentType = mimeType;
   context->boundaryWritten = false;

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -441,11 +441,6 @@ MHD_RESULT CWebServer::FinalizeRequest(const std::shared_ptr<IHTTPRequestHandler
   else
     handler->AddResponseHeader(MHD_HTTP_HEADER_ACCEPT_RANGES, "none");
 
-  // add MHD_HTTP_HEADER_CONTENT_LENGTH
-  if (responseDetails.totalLength > 0)
-    handler->AddResponseHeader(MHD_HTTP_HEADER_CONTENT_LENGTH,
-                               std::to_string(responseDetails.totalLength));
-
   // add all headers set by the request handler
   for (const auto& it : responseDetails.headers)
     AddHeader(response, it.first, it.second);
@@ -1406,12 +1401,9 @@ MHD_RESULT CWebServer::AddHeader(struct MHD_Response* response,
   if (CServiceBroker::GetLogging().CanLogComponent(LOGWEBSERVER))
     m_logger->debug("[OUT] {}: {}", name, value);
 
-#if MHD_VERSION >= 0x00096800
   if (name == MHD_HTTP_HEADER_CONTENT_LENGTH)
-  {
-    MHD_set_response_options(response, MHD_RF_INSANITY_HEADER_CONTENT_LENGTH, MHD_RO_END);
-  }
-#endif
+    m_logger->warn("Attempt to override MHD automatic \"Content-Length\" header");
+
   return MHD_add_response_header(response, name.c_str(), value.c_str());
 }
 

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
@@ -110,15 +110,6 @@ MHD_RESULT CHTTPImageTransformationHandler::HandleRequest()
   if (m_response.type == HTTPError)
     return MHD_YES;
 
-  // nothing else to do if this is a HEAD request
-  if (m_request.method == HEAD)
-  {
-    m_response.status = MHD_HTTP_OK;
-    m_response.type = HTTPMemoryDownloadNoFreeNoCopy;
-
-    return MHD_YES;
-  }
-
   // get the transformation options
   std::map<std::string, std::string> options;
   HTTPRequestHandlerUtils::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, options);

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -52,7 +52,7 @@ MHD_RESULT CHTTPJsonRpcHandler::HandleRequest()
 
     isRequest = true;
   }
-  else if (m_request.method == GET)
+  else if (m_request.method == GET || m_request.method == HEAD)
   {
     std::map<std::string, std::string>::const_iterator argument = arguments.find("request");
     if (argument != arguments.end() && !argument->second.empty())

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -152,6 +152,8 @@ protected:
 
     // Content-Type must be "text/html"
     EXPECT_STREQ("text/html", httpHeader.GetMimeType().c_str());
+    // Must be only one "Content-Length" header
+    ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
     // Content-Length must be "4"
     EXPECT_STREQ("4", httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
     // Accept-Ranges must be "bytes"
@@ -173,6 +175,9 @@ protected:
     // get the HTTP header details
     const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
+    // Only zero or one "Content-Length" headers
+    ASSERT_GE(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
+
     // check the protocol line for the expected HTTP status
     std::string httpStatusString = StringUtils::Format(" {} ", httpStatus);
     std::string protocolLine = httpHeader.GetProtoLine();
@@ -182,7 +187,10 @@ protected:
     EXPECT_STREQ("text/plain", httpHeader.GetMimeType().c_str());
     // check Content-Length
     if (!empty)
+    {
+      ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
       EXPECT_STREQ("20", httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
+    }
     // Accept-Ranges must be "bytes"
     EXPECT_STREQ("bytes", httpHeader.GetValue(MHD_HTTP_HEADER_ACCEPT_RANGES).c_str());
 
@@ -201,6 +209,9 @@ protected:
   {
     // get the HTTP header details
     const CHttpHeader& httpHeader = curl.GetHttpHeader();
+
+    // Only zero or one "Content-Length" headers
+    ASSERT_GE(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
 
     // check the protocol line for the expected HTTP status
     std::string httpStatusString = StringUtils::Format(" {} ", MHD_HTTP_PARTIAL_CONTENT);
@@ -223,6 +234,7 @@ protected:
     // If there's no range Content-Length must be "20"
     if (ranges.IsEmpty())
     {
+      ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
       EXPECT_STREQ("20", httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
       EXPECT_STREQ(TEST_FILES_DATA_RANGES, result.c_str());
       return;
@@ -248,6 +260,7 @@ protected:
       EXPECT_STREQ(expectedContent.c_str(), result.c_str());
 
       // and Content-Length
+      ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
       EXPECT_STREQ(std::to_string(static_cast<unsigned int>(expectedContent.size())).c_str(),
                    httpHeader.GetValue(MHD_HTTP_HEADER_CONTENT_LENGTH).c_str());
 
@@ -361,6 +374,8 @@ TEST_F(TestWebServer, CanGetJsonRpcApiDescriptionWithHttpGet)
   // get the HTTP header details
   const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
+  // Content-Length header must be present
+  ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
   // Content-Type must be "application/json"
   EXPECT_STREQ("application/json", httpHeader.GetMimeType().c_str());
   // Accept-Ranges must be "none"
@@ -391,6 +406,8 @@ TEST_F(TestWebServer, CanReadDataOverJsonRpcWithHttpGet)
   // get the HTTP header details
   const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
+  // Content-Length header must be present
+  ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
   // Content-Type must be "application/json"
   EXPECT_STREQ("application/json", httpHeader.GetMimeType().c_str());
   // Accept-Ranges must be "none"
@@ -428,6 +445,8 @@ TEST_F(TestWebServer, CannotModifyOverJsonRpcWithHttpGet)
   // get the HTTP header details
   const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
+  // Content-Length header must be present
+  ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
   // Content-Type must be "application/json"
   EXPECT_STREQ("application/json", httpHeader.GetMimeType().c_str());
   // Accept-Ranges must be "none"
@@ -462,6 +481,8 @@ TEST_F(TestWebServer, CanReadDataOverJsonRpcWithHttpPost)
   // get the HTTP header details
   const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
+  // Content-Length header must be present
+  ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
   // Content-Type must be "application/json"
   EXPECT_STREQ("application/json", httpHeader.GetMimeType().c_str());
   // Accept-Ranges must be "none"
@@ -499,6 +520,8 @@ TEST_F(TestWebServer, CanModifyOverJsonRpcWithHttpPost)
   // get the HTTP header details
   const CHttpHeader& httpHeader = curl.GetHttpHeader();
 
+  // Content-Length header must be present
+  ASSERT_EQ(1U, httpHeader.GetValues(MHD_HTTP_HEADER_CONTENT_LENGTH).size());
   // Content-Type must be "application/json"
   EXPECT_STREQ("application/json", httpHeader.GetMimeType().c_str());
   // Accept-Ranges must be "none"


### PR DESCRIPTION
I started this PR as a fix for https://github.com/xbmc/xbmc/issues/20759

While fixing duplicated `Content-Length:` headers, I discovered that Kodi uses libmicrohttpd (MHD) API incorrectly. Responses for `HEAD` requests are formed as responses with zero-length body. This is incorrect.
MHD API uses the same responses for `GET` and `HEAD` requests. When response is used to answer `GET` request, it is completely sent, including body. When the same response is used to answer `HEAD` request, response body is not sent (even if body has non-zero length).

According to HTTP RFCs, reply to `HEAD` requests should be exactly the same as reply for the `GET` requests, but reply body must not be sent.

In this PR I fixed improper use of MHD API.

This PR is fixing several things:
* Response for `HEAD` requests are handled in exactly the same way as responses for `GET` requests (as per RFC), now response headers for `HEAD` request are **exactly** the same as in response for similar `GET` request.
* Fixed wrong `Content-Length: 0` header always present in replies for `HEAD` request. This may fix a number of problems in clients that use Kodi HTTP interface.
* Fixed duplicated `Content-Length:` headers in all responses.
* Unrelated small optimisation suggested by @lrusak 
* Fixed run-time warning in log at startup.
* Fixed order of initialization parameters to avoid run-time warning at startup.