### PR TITLE
[depends] Fix build slowness caused by spdlog header only build

### DIFF
--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -94,7 +94,8 @@ if(SPDLOG_FOUND)
   set(SPDLOG_DEFINITIONS -DSPDLOG_FMT_EXTERNAL
                          -DSPDLOG_DEBUG_ON
                          -DSPDLOG_NO_ATOMIC_LEVELS
-                         -DSPDLOG_ENABLE_PATTERN_PADDING)
+                         -DSPDLOG_ENABLE_PATTERN_PADDING
+                         -DSPDLOG_COMPILED_LIB)
   if(WIN32)
     list(APPEND SPDLOG_DEFINITIONS -DSPDLOG_WCHAR_FILENAMES
                                    -DSPDLOG_WCHAR_TO_UTF8_SUPPORT)


### PR DESCRIPTION
## Description
Fix slowass build times.
According to spdlog's [README](https://github.com/gabime/spdlog), we should not be using the header only version because it is much slower to compile.

## Motivation and context
No time to waste.

## How has this been tested?
I'll let the numbers speak for themselves

### gcc 11.2

#### Before
```
binary size -> 64MB

real	28m4,155s
user	201m8,022s
sys	7m10,561s
```

#### After
```
binary size -> 62MB

real	12m46,610s
user	89m17,769s
sys	4m49,567s
```

### clang 13.0

#### Before
```
binary size -> 58MB

real	30m20,639s
user	199m38,939s
sys	6m54,137s
```

#### After
```
binary size -> 58M

real	13m45,292s
user	96m20,252s
sys	4m13,233s
```
All builds are **kodi-x11 release** on Ubuntu 22.04 aka jammy and briefly runtime tested. Nothing out of the ordinary spotted. Tested both with and without **ENABLE_INTERNAL_SPDLOG**.

**Needs testing on other OSes.**

## What is the effect on users?
Absolutely none that I can see.

## Types of change
- [X] **Improvement** (non-breaking change which improves existing functionality)