### PR TITLE
[Subtitles] Improvement to manual position/calibration and others related changes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1313,6 +1313,7 @@ msgstr ""
 
 #. Window screen calibration: calibration of subtitle bar
 #: xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+#: xbmc/video/PlayerController.cpp
 msgctxt "#277"
 msgid "Subtitle positioning"
 msgstr ""
@@ -19297,7 +19298,7 @@ msgstr ""
 #. Description of setting with label #21460 "Subtitle location on screen"
 #: system/settings/settings.xml
 msgctxt "#36192"
-msgid "Location of subtitles on the screen. [Manual] The subtitles position can be customised by using video calibration settings. [Below] / [Above video] When possible the subtitles will be positioned inside the black bars (depends on video encoding). Please note that some forced positions in the subtitles cannot be changed."
+msgid "Location of subtitles on the screen. [Below] / [Above video] When possible the subtitles will be positioned inside the black bars (depends on video encoding). Please note that some forced positions in the subtitles cannot be changed."
 msgstr ""
 
 #. Description of settings category with label #14087 "DVDs"

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -688,6 +688,15 @@ void CApplicationPlayer::SetSubtitleVisible(bool bVisible)
   }
 }
 
+void CApplicationPlayer::SetSubtitleVerticalPosition(int value, bool save)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    player->SetSubtitleVerticalPosition(value, save);
+  }
+}
+
 void CApplicationPlayer::SetTime(int64_t time)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -138,6 +138,15 @@ public:
   void SetSubtitle(int iStream);
   void SetSubTitleDelay(float fValue = 0.0f);
   void SetSubtitleVisible(bool bVisible);
+
+  /*!
+   * \brief Set the subtitle vertical position,
+   * it depends on current screen resolution
+   * \param value The subtitle position in pixels
+   * \param save If true, the value will be saved to resolution info
+   */
+  void SetSubtitleVerticalPosition(const int value, bool save);
+
   void SetTime(int64_t time);
   void SetTotalTime(int64_t time);
   void SetVideoStream(int iStream);

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -122,6 +122,14 @@ public:
   virtual bool GetSubtitleVisible() { return false; }
   virtual void SetSubtitleVisible(bool bVisible) {}
 
+  /*!
+   * \brief Set the subtitle vertical position,
+   * it depends on current screen resolution
+   * \param value The subtitle position in pixels
+   * \param save If true, the value will be saved to resolution info
+   */
+  virtual void SetSubtitleVerticalPosition(int value, bool save) {}
+
   /** \brief Adds the subtitle(s) provided by the given file to the available player streams
   *          and actives the first of the added stream(s). E.g., vob subs can contain multiple streams.
   *   \param[in] strSubPath The full path of the subtitle file.

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -128,7 +128,7 @@ public:
   /*
    * \brief Return true if the margins are handled by the subtitle codec/parser.
    */
-  bool IsForcedMargins() { return m_setForcedMargins; }
+  bool IsForcedMargins() const { return m_setForcedMargins; }
 
   double iPTSStartTime;
   double iPTSStopTime;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -11,9 +11,12 @@
 #include "DVDCodecs/DVDCodecs.h"
 #include "DVDOverlaySSA.h"
 #include "DVDStreamInfo.h"
+#include "ServiceBroker.h"
 #include "Util.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 
 #include <memory>
@@ -129,5 +132,11 @@ CDVDOverlay* CDVDOverlayCodecSSA::GetOverlay()
   m_pOverlay = new CDVDOverlaySSA(m_libass);
   m_pOverlay->iPTSStartTime = 0;
   m_pOverlay->iPTSStopTime = DVD_NOPTS_VALUE;
+  //! @todo To move GetSettings into SubtitleSettings
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  int overrideStyles = settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
+  m_pOverlay->SetForcedMargins(
+      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS) &&
+      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::POSITIONS));
   return m_pOverlay->Acquire();
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -148,6 +148,6 @@ CDVDOverlay* COverlayCodecWebVTT::GetOverlay()
     return nullptr;
   m_pOverlay = CreateOverlay();
   m_pOverlay->SetOverlayContainerFlushable(false);
-  m_pOverlay->SetForcedMargins(true);
+  m_pOverlay->SetForcedMargins(m_webvttHandler.IsForcedMargins());
   return m_pOverlay->Acquire();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -9,7 +9,10 @@
 #include "DVDSubtitleParserSSA.h"
 
 #include "DVDCodecs/Overlay/DVDOverlaySSA.h"
+#include "ServiceBroker.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 
 CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream>&& pStream,
                                              const std::string& strFile)
@@ -37,6 +40,12 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo& hints)
   CDVDOverlaySSA* overlay = new CDVDOverlaySSA(m_libass);
   overlay->iPTSStartTime = 0.0;
   overlay->iPTSStopTime = DVD_NOPTS_VALUE;
+  //! @todo To move GetSettings into SubtitleSettings
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  int overrideStyles = settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
+  overlay->SetForcedMargins(
+      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS) &&
+      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::POSITIONS));
   m_collection.Add(overlay);
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -453,9 +453,7 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLE
     // Set the margins (in pixel)
     style->MarginL = static_cast<int>(marginLR * scale);
     style->MarginR = static_cast<int>(marginLR * scale);
-    // Vertical margin (direction depends on alignment)
-    // to be set only when the video calibration position setting is not used
-    if (opts.usePosition)
+    if (opts.disableVerticalMargin)
       style->MarginV = 0;
     else
       style->MarginV = static_cast<int>(subStyle->marginVertical * scale);
@@ -528,7 +526,7 @@ void CDVDSubtitlesLibass::ConfigureAssOverride(
     }
     else if (subStyle->assOverrideStyles == OverrideStyles::POSITIONS)
     {
-      stylesFlags = ASS_OVERRIDE_BIT_ALIGNMENT;
+      stylesFlags = ASS_OVERRIDE_BIT_ALIGNMENT | ASS_OVERRIDE_BIT_MARGINS;
     }
     if (subStyle->assOverrideFont)
     {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -286,12 +286,15 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(
                      static_cast<int>(opts.frameHeight));
   ass_set_storage_size(m_renderer, static_cast<int>(opts.sourceWidth),
                        static_cast<int>(opts.sourceHeight));
+  int marginTop{0};
+  int marginLeft{0};
   if (m_drawWithinBlackBars)
   {
-    int marginTop = static_cast<int>((opts.frameHeight - opts.videoHeight) / 2);
-    int marginLeft = static_cast<int>((opts.frameWidth - opts.videoWidth) / 2);
-    ass_set_margins(m_renderer, marginTop, marginTop, marginLeft, marginLeft);
+    marginTop = static_cast<int>((opts.frameHeight - opts.videoHeight) / 2);
+    marginLeft = static_cast<int>((opts.frameWidth - opts.videoWidth) / 2);
   }
+  ass_set_margins(m_renderer, marginTop, marginTop, marginLeft, marginLeft);
+
   ass_set_use_margins(m_renderer, m_drawWithinBlackBars);
 
   // Vertical text position in percent (if 0 do nothing)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
@@ -70,7 +70,7 @@ bool CSubtitleParserWebVTT::Open(CDVDStreamInfo& hints)
   }
 
   CDVDOverlay* overlay = CreateOverlay();
-  overlay->SetForcedMargins(true);
+  overlay->SetForcedMargins(m_webvttHandler.IsForcedMargins());
   m_collection.Add(overlay);
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -20,6 +20,9 @@ namespace SUBTITLES
 constexpr double VIEWPORT_HEIGHT = 1080.0;
 constexpr double VIEWPORT_WIDTH = 1920.0;
 constexpr int MARGIN_VERTICAL = 30;
+// Vertical margin used when is selected the alignment
+// to keep the text inside the black bars
+constexpr int MARGIN_VERTICAL_BLACKBARS = 30;
 
 enum class HorizontalAlignment
 {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -19,7 +19,7 @@ namespace SUBTITLES
 
 constexpr double VIEWPORT_HEIGHT = 1080.0;
 constexpr double VIEWPORT_WIDTH = 1920.0;
-constexpr int MARGIN_VERTICAL = 30;
+constexpr int MARGIN_VERTICAL = 75;
 // Vertical margin used when is selected the alignment
 // to keep the text inside the black bars
 constexpr int MARGIN_VERTICAL_BLACKBARS = 30;
@@ -110,7 +110,7 @@ struct renderOpts
   float videoHeight;
   float sourceWidth;
   float sourceHeight;
-  bool usePosition = false;
+  bool disableVerticalMargin = false;
   // position: vertical line position of subtitles in percent. 0 = no change (bottom), 100 = on top.
   double position = 0;
   HorizontalAlignment horizontalAlignment = HorizontalAlignment::DISABLED;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -141,6 +141,11 @@ public:
   */
   void DecodeLine(std::string line, std::vector<subtitleData>* subList);
 
+  /*
+   * \brief Return true if the margins are handled by the parser.
+   */
+  bool IsForcedMargins() const { return m_overridePositions; }
+
 protected:
   void CalculateTextPosition(std::string& subtitleText);
   void ConvertSubtitle(std::string& text);

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -669,7 +669,7 @@ CVideoSettings CProcessInfo::GetVideoSettings()
   return m_videoSettings;
 }
 
-CVideoSettingsLocked& CProcessInfo::UpdateVideoSettings()
+CVideoSettingsLocked& CProcessInfo::GetVideoSettingsLocked()
 {
   std::unique_lock<CCriticalSection> lock(m_settingsSection);
   return *m_videoSettingsLocked;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -110,7 +110,7 @@ public:
   // settings
   CVideoSettings GetVideoSettings();
   void SetVideoSettings(CVideoSettings &settings);
-  CVideoSettingsLocked& UpdateVideoSettings();
+  CVideoSettingsLocked& GetVideoSettingsLocked();
 
 protected:
   CProcessInfo();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3313,6 +3313,12 @@ void CVideoPlayer::SetSubtitleVisibleInternal(bool bVisible)
   CServiceBroker::GetDataCacheCore().SignalSubtitleInfoChange();
 }
 
+void CVideoPlayer::SetSubtitleVerticalPosition(int value, bool save)
+{
+  m_processInfo->GetVideoSettingsLocked().SetSubtitleVerticalPosition(value, save);
+  m_renderManager.SetSubtitleVerticalPosition(value, save);
+}
+
 std::shared_ptr<TextCacheStruct_t> CVideoPlayer::GetTeletextCache()
 {
   if (m_CurrentTeletext.id < 0)
@@ -4874,6 +4880,8 @@ void CVideoPlayer::SetVideoSettings(CVideoSettings& settings)
   m_processInfo->SetVideoSettings(settings);
   m_renderManager.SetVideoSettings(settings);
   m_renderManager.SetDelay(static_cast<int>(settings.m_AudioDelay * 1000.0f));
+  m_renderManager.SetSubtitleVerticalPosition(settings.m_subtitleVerticalPosition,
+                                              settings.m_subtitleVerticalPositionSave);
   m_VideoPlayerVideo->EnableSubtitle(settings.m_SubtitleOn);
   m_VideoPlayerVideo->SetSubtitleDelay(static_cast<int>(-settings.m_SubtitleDelay * DVD_TIME_BASE));
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3265,7 +3265,7 @@ float CVideoPlayer::GetCachePercentage()
 
 void CVideoPlayer::SetAVDelay(float fValue)
 {
-  m_processInfo->UpdateVideoSettings().SetAudioDelay(fValue);
+  m_processInfo->GetVideoSettingsLocked().SetAudioDelay(fValue);
   m_renderManager.SetDelay(static_cast<int>(fValue * 1000.0f));
 }
 
@@ -3276,7 +3276,7 @@ float CVideoPlayer::GetAVDelay()
 
 void CVideoPlayer::SetSubTitleDelay(float fValue)
 {
-  m_processInfo->UpdateVideoSettings().SetSubtitleDelay(fValue);
+  m_processInfo->GetVideoSettingsLocked().SetSubtitleDelay(fValue);
   m_VideoPlayerVideo->SetSubtitleDelay(static_cast<double>(-fValue) * DVD_TIME_BASE);
 }
 
@@ -3300,7 +3300,7 @@ void CVideoPlayer::SetSubtitleVisible(bool bVisible)
 {
   m_messenger.Put(
       std::make_shared<CDVDMsgBool>(CDVDMsg::PLAYER_SET_SUBTITLESTREAM_VISIBLE, bVisible));
-  m_processInfo->UpdateVideoSettings().SetSubtitleVisible(bVisible);
+  m_processInfo->GetVideoSettingsLocked().SetSubtitleVisible(bVisible);
 }
 
 void CVideoPlayer::SetSubtitleVisibleInternal(bool bVisible)
@@ -4860,7 +4860,7 @@ int64_t CVideoPlayer::GetUpdatedTime()
 
 void CVideoPlayer::SetDynamicRangeCompression(long drc)
 {
-  m_processInfo->UpdateVideoSettings().SetVolumeAmplification(static_cast<float>(drc) / 100);
+  m_processInfo->GetVideoSettingsLocked().SetVolumeAmplification(static_cast<float>(drc) / 100);
   m_VideoPlayerAudio->SetDynamicRangeCompression(drc);
 }
 
@@ -4895,7 +4895,7 @@ void CVideoPlayer::FlushRenderer()
 
 void CVideoPlayer::SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch)
 {
-  m_processInfo->UpdateVideoSettings().SetViewMode(mode, zoom, par, shift, stretch);
+  m_processInfo->GetVideoSettingsLocked().SetViewMode(mode, zoom, par, shift, stretch);
   m_renderManager.SetVideoSettings(m_processInfo->GetVideoSettings());
   m_renderManager.SetViewMode(mode);
 }
@@ -5146,7 +5146,7 @@ int CVideoPlayer::GetVideoStream() const
 void CVideoPlayer::SetVideoStream(int iStream)
 {
   m_messenger.Put(std::make_shared<CDVDMsgPlayerSetVideoStream>(iStream));
-  m_processInfo->UpdateVideoSettings().SetVideoStream(iStream);
+  m_processInfo->GetVideoSettingsLocked().SetVideoStream(iStream);
   SynchronizeDemuxer();
 }
 
@@ -5195,7 +5195,7 @@ int CVideoPlayer::GetAudioStream()
 void CVideoPlayer::SetAudioStream(int iStream)
 {
   m_messenger.Put(std::make_shared<CDVDMsgPlayerSetAudioStream>(iStream));
-  m_processInfo->UpdateVideoSettings().SetAudioStream(iStream);
+  m_processInfo->GetVideoSettingsLocked().SetAudioStream(iStream);
   SynchronizeDemuxer();
 }
 
@@ -5228,7 +5228,7 @@ void CVideoPlayer::GetSubtitleStreamInfo(int index, SubtitleStreamInfo &info)
 void CVideoPlayer::SetSubtitle(int iStream)
 {
   m_messenger.Put(std::make_shared<CDVDMsgPlayerSetSubtitleStream>(iStream));
-  m_processInfo->UpdateVideoSettings().SetSubtitleStream(iStream);
+  m_processInfo->GetVideoSettingsLocked().SetSubtitleStream(iStream);
 }
 
 int CVideoPlayer::GetSubtitleCount()

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -273,6 +273,15 @@ public:
   void SetSubtitle(int iStream) override;
   bool GetSubtitleVisible() override;
   void SetSubtitleVisible(bool bVisible) override;
+
+  /*!
+   * \brief Set the subtitle vertical position,
+   * it depends on current screen resolution
+   * \param value The subtitle position in pixels
+   * \param save If true, the value will be saved to resolution info
+   */
+  void SetSubtitleVerticalPosition(const int value, bool save) override;
+
   void AddSubtitle(const std::string& strSubPath) override;
 
   int GetAudioStreamCount() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -148,4 +148,5 @@ void CDebugRenderer::CRenderer::CreateSubtitlesStyle()
   m_debugOverlayStyle = std::make_shared<KODI::SUBTITLES::style>();
   m_debugOverlayStyle->fontName = KODI::SUBTITLES::FONT_DEFAULT_FAMILYNAME;
   m_debugOverlayStyle->fontSize = 20.0;
+  m_debugOverlayStyle->marginVertical = 30;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
@@ -38,6 +38,9 @@ protected:
     void CreateSubtitlesStyle();
 
   private:
+    // Implementation of Observer
+    void Notify(const Observable& obs, const ObservableMessage msg) override{};
+
     std::shared_ptr<struct KODI::SUBTITLES::style> m_debugOverlayStyle;
   };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -323,11 +323,7 @@ void CRenderer::CreateSubtitlesStyle()
   else
     m_overlayStyle->assOverrideStyles = KODI::SUBTITLES::OverrideStyles::DISABLED;
 
-  int overrideMerginVertical =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubtitleVerticalMargin;
-  if (overrideMerginVertical >= 0 && overrideMerginVertical < m_rv.Height())
-    m_overlayStyle->marginVertical = overrideMerginVertical;
-
+  m_overlayStyle->marginVertical = GetSubtitleVerticalMargin();
   m_overlayStyle->blur = settings->GetInt(CSettings::SETTING_SUBTITLES_BLUR);
 }
 
@@ -512,4 +508,21 @@ void CRenderer::Notify(const Observable& obs, const ObservableMessage msg)
     default:
       break;
   }
+}
+
+int CRenderer::GetSubtitleVerticalMargin()
+{
+  int subAlign = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_SUBTITLES_ALIGN);
+  // If the user has set the alignment type to keep the subtitle text
+  // inside the black bars, we exclude custom vertical margin
+  // and we force our fixed margin to try avoid go off the black bars
+  if (subAlign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE || subAlign == SUBTITLE_ALIGN_TOP_OUTSIDE)
+    return KODI::SUBTITLES::MARGIN_VERTICAL_BLACKBARS;
+  // Try get the vertical margin customized by user
+  int overrideMerginVertical =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubtitleVerticalMargin;
+  if (overrideMerginVertical >= 0)
+    return overrideMerginVertical;
+  return KODI::SUBTITLES::MARGIN_VERTICAL;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -24,6 +24,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SubtitlesSettings.h"
+#include "settings/lib/Setting.h"
 #include "utils/ColorUtils.h"
 #include "windowing/GraphicContext.h"
 
@@ -198,10 +199,9 @@ void CRenderer::Render(COverlay* o)
     {
       if (align == COverlay::ALIGN_SUBTITLE)
       {
-        RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
-            CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
+        RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
         state.x += m_rv.x1 + m_rv.Width() * 0.5f;
-        state.y += m_rv.y1 + (res.iSubtitles - res.Overscan.top);
+        state.y += m_rv.y1 + (resInfo.iSubtitles - resInfo.Overscan.top);
       }
       else
       {
@@ -259,6 +259,30 @@ void CRenderer::SetStereoMode(const std::string &stereomode)
   m_stereomode = stereomode;
 }
 
+void CRenderer::SetSubtitleVerticalPosition(const int value, bool save)
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  m_subtitlePosition = value + m_subtitleVerticalMargin;
+  if (save)
+  {
+    RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+    resInfo.iSubtitles = m_subtitlePosition;
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
+        CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
+    m_subtitlePosResInfo = m_subtitlePosition;
+  }
+}
+
+void CRenderer::ResetSubtitlePosition()
+{
+  m_subtitleVerticalMargin = GetSubtitleVerticalMargin();
+  RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+  m_subtitlePosResInfo = resInfo.iSubtitles;
+  // Update player value (and callback to CRenderer::SetSubtitleVerticalPosition)
+  g_application.GetAppPlayer().SetSubtitleVerticalPosition(
+      resInfo.iSubtitles - m_subtitleVerticalMargin, false);
+}
+
 void CRenderer::CreateSubtitlesStyle()
 {
   m_overlayStyle = std::make_shared<KODI::SUBTITLES::style>();
@@ -282,8 +306,7 @@ void CRenderer::CreateSubtitlesStyle()
       settings->GetString(CSettings::SETTING_SUBTITLES_BORDERCOLOR));
   m_overlayStyle->fontOpacity = settings->GetInt(CSettings::SETTING_SUBTITLES_OPACITY);
 
-  int backgroundType = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-      CSettings::SETTING_SUBTITLES_BACKGROUNDTYPE);
+  int backgroundType = settings->GetInt(CSettings::SETTING_SUBTITLES_BACKGROUNDTYPE);
   if (backgroundType == SUBTITLE_BACKGROUNDTYPE_NONE)
     m_overlayStyle->borderStyle = KODI::SUBTITLES::BorderStyle::OUTLINE_NO_SHADOW;
   else if (backgroundType == SUBTITLE_BACKGROUNDTYPE_SHADOW)
@@ -302,8 +325,7 @@ void CRenderer::CreateSubtitlesStyle()
   m_overlayStyle->shadowOpacity = settings->GetInt(CSettings::SETTING_SUBTITLES_SHADOWOPACITY);
   m_overlayStyle->shadowSize = settings->GetInt(CSettings::SETTING_SUBTITLES_SHADOWSIZE);
 
-  int subAlign = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-      CSettings::SETTING_SUBTITLES_ALIGN);
+  int subAlign = settings->GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
   if (subAlign == SUBTITLE_ALIGN_TOP_INSIDE || subAlign == SUBTITLE_ALIGN_TOP_OUTSIDE)
     m_overlayStyle->alignment = KODI::SUBTITLES::FontAlignment::TOP_CENTER;
   else
@@ -359,46 +381,53 @@ COverlay* CRenderer::ConvertLibass(
       rOpts.sourceHeight = m_rs.Height() * 2;
   }
 
-  int subAlign = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-      CSettings::SETTING_SUBTITLES_ALIGN);
-
   // Set position of subtitles based on video calibration settings
-  if (subAlign == SUBTITLE_ALIGN_MANUAL)
+  RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+  if (m_subtitlePosResInfo != resInfo.iSubtitles)
   {
-    if (o->IsForcedMargins())
-    {
-      // rOpts.position can invalidate the text positions to subtitles that make
-      // use of margins to position text on the screen then in this case
-      // we allow to set it only when position overrides are enabled
-      int overrideStyles = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-          CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
-      if (overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::POSITIONS ||
-          overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS)
-        rOpts.usePosition = true;
-    }
-    else
-    {
-      rOpts.usePosition = true;
-    }
-    if (rOpts.usePosition)
-    {
-      RESOLUTION_INFO res;
-      res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
-          CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
-      rOpts.position =
-          100.0 - static_cast<double>(res.iSubtitles - res.Overscan.top) * 100 / res.iHeight;
-    }
+    // Keep track of subtitle position value change,
+    // can be changed by GUI Calibration or by window mode/resolution change or
+    // by user manual change (e.g. keyboard shortcut)
+    ResetSubtitlePosition();
+  }
+
+  // rOpts.position and margins (set to style) can invalidate the text
+  // positions to subtitles type that make use of margins to position text on
+  // the screen (e.g. ASS/WebVTT) then we allow to set them when position
+  // override setting is enabled only
+  if (o->IsForcedMargins())
+  {
+    rOpts.disableVerticalMargin = true;
+  }
+  else
+  {
+    double subPosPx{static_cast<double>(m_subtitlePosition)};
+    //! @todo Libass scale the margins values (style) that influence
+    // the text position. With the subtitle calibration bar we shift the
+    // position of the bar with margins, to make the bar match the text.
+    // When we move the calibration bar the text will no longer match the bar
+    // to fix this problem is needed add a kind of calculation to compensate
+    // the scale difference, its not clear what formula could be used,
+    // the following calculation works quite well but not perfectly
+    double scaledMargin{static_cast<double>(m_subtitleVerticalMargin) /
+                        KODI::SUBTITLES::VIEWPORT_HEIGHT * (subPosPx - resInfo.Overscan.top)};
+    subPosPx -= static_cast<double>(m_subtitleVerticalMargin) - scaledMargin;
+
+    // We need to scale the position to resolution based on overscan values
+    subPosPx = static_cast<double>(subPosPx - resInfo.Overscan.top) /
+               (resInfo.Overscan.bottom - resInfo.Overscan.top) * resInfo.iHeight;
+
+    // Specify the position currently works only with bottom alignment
+    rOpts.position = 100.0 - subPosPx * 100.0 / resInfo.iHeight;
   }
 
   // Set the horizontal text alignment (currently used to improve readability on CC subtitles only)
   // This setting influence style->alignment property
   if (o->IsTextAlignEnabled())
   {
-    int subTextAlign = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-        CSettings::SETTING_SUBTITLES_CAPTIONSALIGN);
-    if (subTextAlign == SUBTITLE_HORIZONTAL_ALIGN_LEFT)
+    if (m_subtitleHorizontalAlign == SubtitleHorizontalAlign::LEFT)
       rOpts.horizontalAlignment = KODI::SUBTITLES::HorizontalAlignment::LEFT;
-    else if (subTextAlign == SUBTITLE_HORIZONTAL_ALIGN_RIGHT)
+    else if (m_subtitleHorizontalAlign == SubtitleHorizontalAlign::RIGHT)
       rOpts.horizontalAlignment = KODI::SUBTITLES::HorizontalAlignment::RIGHT;
     else
       rOpts.horizontalAlignment = KODI::SUBTITLES::HorizontalAlignment::CENTER;
@@ -453,10 +482,11 @@ COverlay* CRenderer::Convert(CDVDOverlay* o, double pts)
     CDVDOverlayLibass* ovAss = static_cast<CDVDOverlayLibass*>(o);
     if (!ovAss || !ovAss->GetLibassHandler())
       return nullptr;
-    bool updateStyle = !m_overlayStyle || m_forceUpdateOverlayStyle;
+    bool updateStyle = !m_overlayStyle || m_isSettingsChanged;
     if (updateStyle)
     {
-      m_forceUpdateOverlayStyle = false;
+      m_isSettingsChanged = false;
+      LoadSettings();
       CreateSubtitlesStyle();
     }
 
@@ -502,7 +532,14 @@ void CRenderer::Notify(const Observable& obs, const ObservableMessage msg)
   {
     case ObservableMessageSettingsChanged:
     {
-      m_forceUpdateOverlayStyle = true;
+      std::unique_lock<CCriticalSection> lock(m_section);
+      m_isSettingsChanged = true;
+      break;
+    }
+    case ObservableMessagePositionChanged:
+    {
+      std::unique_lock<CCriticalSection> lock(m_section);
+      m_subtitlePosResInfo = -1; // Force call ResetSubtitlePosition()
       break;
     }
     default:
@@ -510,19 +547,30 @@ void CRenderer::Notify(const Observable& obs, const ObservableMessage msg)
   }
 }
 
+void CRenderer::LoadSettings()
+{
+  m_subtitleHorizontalAlign = static_cast<SubtitleHorizontalAlign>(
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_SUBTITLES_CAPTIONSALIGN));
+}
+
 int CRenderer::GetSubtitleVerticalMargin()
 {
   int subAlign = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
       CSettings::SETTING_SUBTITLES_ALIGN);
+
   // If the user has set the alignment type to keep the subtitle text
   // inside the black bars, we exclude custom vertical margin
   // and we force our fixed margin to try avoid go off the black bars
   if (subAlign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE || subAlign == SUBTITLE_ALIGN_TOP_OUTSIDE)
     return KODI::SUBTITLES::MARGIN_VERTICAL_BLACKBARS;
+
   // Try get the vertical margin customized by user
   int overrideMerginVertical =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubtitleVerticalMargin;
+
   if (overrideMerginVertical >= 0)
     return overrideMerginVertical;
+
   return KODI::SUBTITLES::MARGIN_VERTICAL;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -110,8 +110,12 @@ namespace OVERLAY {
     void SetVideoRect(CRect &source, CRect &dest, CRect &view);
     void SetStereoMode(const std::string &stereomode);
 
-  protected:
+    /*! \brief Get the subtitle vertical margin
+     *  \return The margin in pixel
+     */
+    static int GetSubtitleVerticalMargin();
 
+  protected:
     struct SElement
     {
       SElement()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -34,11 +34,11 @@ enum SubtitleAlign
   SUBTITLE_ALIGN_TOP_OUTSIDE
 };
 
-enum subtitleHorizontalAlign
+enum class SubtitleHorizontalAlign
 {
-  SUBTITLE_HORIZONTAL_ALIGN_LEFT = 0,
-  SUBTITLE_HORIZONTAL_ALIGN_CENTER,
-  SUBTITLE_HORIZONTAL_ALIGN_RIGHT
+  LEFT = 0,
+  CENTER,
+  RIGHT
 };
 
 enum subtitleBackgroundType
@@ -99,7 +99,7 @@ namespace OVERLAY {
     CRenderer();
     virtual ~CRenderer();
 
-    // implementation of Observer
+    // Implementation of Observer
     void Notify(const Observable& obs, const ObservableMessage msg) override;
 
     void AddOverlay(CDVDOverlay* o, double pts, int index);
@@ -110,8 +110,22 @@ namespace OVERLAY {
     void SetVideoRect(CRect &source, CRect &dest, CRect &view);
     void SetStereoMode(const std::string &stereomode);
 
-    /*! \brief Get the subtitle vertical margin
-     *  \return The margin in pixel
+    /*!
+     * \brief Set the subtitle vertical position,
+     * it depends on current screen resolution
+     * \param value The subtitle position in pixels
+     * \param save If true, the value will be saved to resolution info
+     */
+    void SetSubtitleVerticalPosition(const int value, bool save);
+
+    /*!
+     * \brief Reset the subtitle position to default value
+     */
+    void ResetSubtitlePosition();
+
+    /*!
+     * \brief Get the subtitle vertical margin
+     * \return The margin in pixel
      */
     static int GetSubtitleVerticalMargin();
 
@@ -147,14 +161,23 @@ namespace OVERLAY {
     void ReleaseCache();
     void ReleaseUnused();
 
+    /*!
+     * \brief Load and store settings locally
+     */
+    void LoadSettings();
+
     CCriticalSection m_section;
     std::vector<SElement> m_buffers[NUM_BUFFERS];
     std::map<unsigned int, COverlay*> m_textureCache;
     static unsigned int m_textureid;
     CRect m_rv, m_rs, m_rd;
     std::string m_stereomode;
+    int m_subtitlePosition{0}; // Current subtitle position
+    int m_subtitlePosResInfo{-1}; // Current subtitle position from resolution info
+    int m_subtitleVerticalMargin{0};
+    SubtitleHorizontalAlign m_subtitleHorizontalAlign{SubtitleHorizontalAlign::CENTER};
 
     std::shared_ptr<struct KODI::SUBTITLES::style> m_overlayStyle;
-    bool m_forceUpdateOverlayStyle{false};
+    bool m_isSettingsChanged{false};
   };
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -230,6 +230,7 @@ bool CRenderManager::Configure()
     m_clockSync.Reset();
     m_dvdClock.SetVsyncAdjust(0);
     m_overlays.SetStereoMode(m_stereomode);
+    m_overlays.ResetSubtitlePosition();
 
     m_renderState = STATE_CONFIGURED;
 
@@ -946,6 +947,11 @@ void CRenderManager::ToggleDebugVideo()
   m_renderDebug = isEnabled;
   m_debugTimer.SetExpired();
   m_renderDebugVideo = true;
+}
+
+void CRenderManager::SetSubtitleVerticalPosition(int value, bool save)
+{
+  m_overlays.SetSubtitleVerticalPosition(value, save);
 }
 
 bool CRenderManager::AddVideoPicture(const VideoPicture& picture, volatile std::atomic_bool& bStop, EINTERLACEMETHOD deintMethod, bool wait)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -75,6 +75,14 @@ public:
   void ToggleDebug();
   void ToggleDebugVideo();
 
+  /*!
+   * \brief Set the subtitle vertical position,
+   * it depends on current screen resolution
+   * \param value The subtitle position in pixels
+   * \param save If true, the value will be saved to resolution info
+   */
+  void SetSubtitleVerticalPosition(const int value, bool save);
+
   unsigned int AllocRenderCapture();
   void ReleaseRenderCapture(unsigned int captureId);
   void StartRenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags);

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -24,6 +24,8 @@ CVideoSettings::CVideoSettings()
   m_AudioStream = -1;
   m_SubtitleStream = -1;
   m_SubtitleDelay = 0.0f;
+  m_subtitleVerticalPosition = 0;
+  m_subtitleVerticalPositionSave = false;
   m_SubtitleOn = true;
   m_Brightness = 50.0f;
   m_Contrast = 50.0f;
@@ -55,6 +57,10 @@ bool CVideoSettings::operator!=(const CVideoSettings &right) const
   if (m_AudioStream != right.m_AudioStream) return true;
   if (m_SubtitleStream != right.m_SubtitleStream) return true;
   if (m_SubtitleDelay != right.m_SubtitleDelay) return true;
+  if (m_subtitleVerticalPosition != right.m_subtitleVerticalPosition)
+    return true;
+  if (m_subtitleVerticalPositionSave != right.m_subtitleVerticalPositionSave)
+    return true;
   if (m_SubtitleOn != right.m_SubtitleOn) return true;
   if (m_Brightness != right.m_Brightness) return true;
   if (m_Contrast != right.m_Contrast) return true;
@@ -117,6 +123,13 @@ void CVideoSettingsLocked::SetSubtitleDelay(float delay)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_SubtitleDelay = delay;
+}
+
+void CVideoSettingsLocked::SetSubtitleVerticalPosition(int value, bool save)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  m_videoSettings.m_subtitleVerticalPosition = value;
+  m_videoSettings.m_subtitleVerticalPositionSave = save;
 }
 
 void CVideoSettingsLocked::SetViewMode(int mode, float zoom, float par, float shift, bool stretch)

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -100,6 +100,8 @@ public:
   float m_VolumeAmplification;
   int m_SubtitleStream;
   float m_SubtitleDelay;
+  int m_subtitleVerticalPosition{0};
+  bool m_subtitleVerticalPositionSave{false};
   bool m_SubtitleOn;
   float m_Brightness;
   float m_Contrast;
@@ -134,6 +136,15 @@ public:
   void SetVideoStream(int stream);
   void SetAudioDelay(float delay);
   void SetSubtitleDelay(float delay);
+
+  /*!
+   * \brief Set the subtitle vertical position,
+   * it depends on current screen resolution
+   * \param value The subtitle position in pixels
+   * \param save If true, the value will be saved to resolution info
+   */
+  void SetSubtitleVerticalPosition(int value, bool save);
+
   void SetViewMode(int mode, float zoom, float par, float shift, bool stretch);
   void SetVolumeAmplification(float amp);
 

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -30,6 +30,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/PlayerController.h"
 #include "video/windows/GUIWindowVideoBase.h"
 #include "view/GUIViewState.h"
 
@@ -545,6 +546,24 @@ static int Seek(const std::vector<std::string>& params)
   return 0;
 }
 
+static int SubtitleShiftUp(const std::vector<std::string>& params)
+{
+  CAction action{ACTION_SUBTITLE_VSHIFT_UP};
+  if (!params.empty() && params[0] == "save")
+    action.SetText("save");
+  CPlayerController::GetInstance().OnAction(action);
+  return 0;
+}
+
+static int SubtitleShiftDown(const std::vector<std::string>& params)
+{
+  CAction action{ACTION_SUBTITLE_VSHIFT_DOWN};
+  if (!params.empty() && params[0] == "save")
+    action.SetText("save");
+  CPlayerController::GetInstance().OnAction(action);
+  return 0;
+}
+
 // Note: For new Texts with comma add a "\" before!!! Is used for table text.
 //
 /// \page page_List_of_built_in_functions
@@ -596,6 +615,8 @@ static int Seek(const std::vector<std::string>& params)
 ///     | Partymode(path to .xsp) | Partymode for *.xsp-file               | Partymode for *.xsp-file    |             |
 ///     | ShowVideoMenu           | Shows the DVD/BR menu if available     | none                        |             |
 ///     | FrameAdvance(n) ***     | Advance video by _n_ frames            | none                        | Kodi v18    |
+///     | SubtitleShiftUp(save)   | Shift up the subtitle position, add "save" to save the change permanently    | none | Kodi v20 |
+///     | SubtitleShiftDown(save) | Shift down the subtitle position, add "save" to save the change permanently  | none | Kodi v20 |
 ///     <br>
 ///     '*' = For these controls\, the PlayerControl built-in function can make use of the 'notify'-parameter. For example: PlayerControl(random\, notify)
 ///     <br>
@@ -653,6 +674,7 @@ static int Seek(const std::vector<std::string>& params)
 /// \table_end
 ///
 
+// clang-format off
 CBuiltins::CommandMap CPlayerBuiltins::GetOperations() const
 {
   return {
@@ -663,6 +685,9 @@ CBuiltins::CommandMap CPlayerBuiltins::GetOperations() const
            {"playercontrol",       {"Control the music or video player", 1, PlayerControl}},
            {"playmedia",           {"Play the specified media file (or playlist)", 1, PlayMedia}},
            {"playwith",            {"Play the selected item with the specified core", 1, PlayWith}},
-           {"seek",                {"Performs a seek in seconds on the current playing media file", 1, Seek}}
+           {"seek",                {"Performs a seek in seconds on the current playing media file", 1, Seek}},
+           {"subtitleshiftup",     {"Shift up the subtitle position", 0, SubtitleShiftUp}},
+           {"subtitleshiftdown",   {"Shift down the subtitle position", 0, SubtitleShiftDown}},
          };
 }
+// clang-format on

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -546,10 +546,10 @@ void CDisplaySettings::ApplyCalibrations()
           m_resolutions[res].Overscan.bottom = m_resolutions[res].iHeight * 3/2;
 
         m_resolutions[res].iSubtitles = itCal->iSubtitles;
-        if (m_resolutions[res].iSubtitles < m_resolutions[res].iHeight / 2)
-          m_resolutions[res].iSubtitles = m_resolutions[res].iHeight / 2;
-        if (m_resolutions[res].iSubtitles > m_resolutions[res].iHeight* 5/4)
-          m_resolutions[res].iSubtitles = m_resolutions[res].iHeight* 5/4;
+        if (m_resolutions[res].iSubtitles < 0)
+          m_resolutions[res].iSubtitles = 0;
+        if (m_resolutions[res].iSubtitles > m_resolutions[res].iHeight)
+          m_resolutions[res].iSubtitles = m_resolutions[res].iHeight;
 
         m_resolutions[res].fPixelRatio = itCal->fPixelRatio;
         if (m_resolutions[res].fPixelRatio < 0.5f)

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -77,6 +77,11 @@ void CSubtitlesSettings::OnSettingChanged(const std::shared_ptr<const CSetting>&
 
   SetChanged();
   NotifyObservers(ObservableMessageSettingsChanged);
+  if (setting->GetId() == CSettings::SETTING_SUBTITLES_ALIGN)
+  {
+    SetChanged();
+    NotifyObservers(ObservableMessagePositionChanged);
+  }
 }
 
 void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr& setting,

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.h
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.h
@@ -42,4 +42,5 @@ protected:
 private:
   std::map<int, std::pair<float, float>> m_controlsSize;
   int m_subtitlesHalfSpace{0};
+  int m_subtitleVerticalMargin{0};
 };

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES ActorProtocol.cpp
             Locale.cpp
             log.cpp
             Mime.cpp
+            MovingSpeed.cpp
             Observer.cpp
             POUtils.cpp
             RecentlyAddedJob.cpp
@@ -135,6 +136,7 @@ set(HEADERS ActorProtocol.h
             MathUtils.h
             MemUtils.h
             Mime.h
+            MovingSpeed.h
             Observer.h
             params_check_macros.h
             POUtils.h

--- a/xbmc/utils/MovingSpeed.cpp
+++ b/xbmc/utils/MovingSpeed.cpp
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MovingSpeed.h"
+
+#include "utils/TimeUtils.h"
+#include "utils/log.h"
+
+void UTILS::MOVING_SPEED::CMovingSpeed::AddEventConfig(uint32_t eventId,
+                                                       float acceleration,
+                                                       float maxVelocity,
+                                                       uint32_t resetTimeout)
+{
+  EventCfg eventCfg{acceleration, maxVelocity, resetTimeout};
+  m_eventsData.emplace(eventId, EventData{eventCfg});
+}
+
+void UTILS::MOVING_SPEED::CMovingSpeed::AddEventConfig(uint32_t eventId, EventCfg event)
+{
+  m_eventsData.emplace(eventId, EventData{event});
+}
+
+void UTILS::MOVING_SPEED::CMovingSpeed::Reset()
+{
+  m_currentEventId = 0;
+  for (auto& eventPair : m_eventsData)
+  {
+    Reset(eventPair.first);
+  }
+}
+
+void UTILS::MOVING_SPEED::CMovingSpeed::Reset(uint32_t eventId)
+{
+  auto mapIt = m_eventsData.find(eventId);
+  if (mapIt == m_eventsData.end())
+  {
+    CLog::LogF(LOGWARNING, "Cannot reset Event ID {} configuration", eventId);
+  }
+  else
+  {
+    EventData& event = mapIt->second;
+    event.m_currentVelocity = 1.0f;
+    event.m_lastFrameTime = 0;
+  }
+}
+
+float UTILS::MOVING_SPEED::CMovingSpeed::GetUpdatedDistance(uint32_t eventId)
+{
+  auto mapEventIt = m_eventsData.find(eventId);
+
+  if (mapEventIt == m_eventsData.end())
+  {
+    CLog::LogF(LOGERROR, "No event configuration with event ID {}", eventId);
+    return 0;
+  }
+  else
+  {
+    EventData& eventData = mapEventIt->second;
+    EventCfg& eventCfg = eventData.m_config;
+
+    uint32_t currentFrameTime{CTimeUtils::GetFrameTime()};
+    uint32_t deltaFrameTime{currentFrameTime - eventData.m_lastFrameTime};
+    float distance{1};
+
+    if (eventData.m_lastFrameTime != 0 && deltaFrameTime > eventCfg.m_resetTimeout)
+    {
+      // If the delta time exceed the timeout then reset values
+      Reset(eventId);
+    }
+    else if (m_currentEventId != eventId)
+    {
+      // If the event id is changed then reset values
+      Reset(eventId);
+    }
+    else if (eventData.m_lastFrameTime != 0)
+    {
+      // Calculate the new speed based on time so as not to depend on the frame rate
+      eventData.m_currentVelocity +=
+          eventCfg.m_acceleration * (static_cast<float>(deltaFrameTime) / 1000);
+
+      if (eventCfg.m_maxVelocity > 0 && eventData.m_currentVelocity > eventCfg.m_maxVelocity)
+        eventData.m_currentVelocity = eventCfg.m_maxVelocity;
+
+      distance = eventData.m_currentVelocity * (static_cast<float>(deltaFrameTime) / 1000);
+    }
+
+    m_currentEventId = eventId;
+    eventData.m_lastFrameTime = currentFrameTime;
+    return distance;
+  }
+}

--- a/xbmc/utils/MovingSpeed.h
+++ b/xbmc/utils/MovingSpeed.h
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <map>
+#include <stdint.h>
+
+namespace UTILS
+{
+namespace MOVING_SPEED
+{
+struct EventCfg
+{
+  /*!
+   * \param acceleration Acceleration in pixels per second (px/sec)
+   * \param maxVelocity Max movement speed, it depends from acceleration value,
+   *        a suitable value could be (acceleration value)*3. Set 0 to disable it
+   * \param resetTimeout Resets acceleration speed if idle for specified millisecs
+   */
+  EventCfg(float acceleration, float maxVelocity, uint32_t resetTimeout)
+    : m_acceleration{acceleration}, m_maxVelocity{maxVelocity}, m_resetTimeout{resetTimeout}
+  {
+  }
+
+  float m_acceleration;
+  float m_maxVelocity;
+  uint32_t m_resetTimeout;
+};
+
+/*!
+ * \brief Class to calculate the velocity for a motion effect.
+ * To ensure it works, the GetUpdatedDistance method must be called at each
+ * input received (e.g. continuous key press of same key on the keyboard).
+ * The motion effect will stop at the event ID change (different key pressed).
+ */
+class CMovingSpeed
+{
+public:
+  /*!
+   * \brief Add the configuration for an event
+   * \param eventId The id for the event, must be unique
+   * \param acceleration Acceleration in pixels per second (px/sec)
+   * \param maxVelocity Max movement speed, it depends from acceleration value,
+   *        a suitable value could be (acceleration value)*3. Set 0 to disable it
+   * \param resetTimeout Resets acceleration speed if idle for specified millisecs
+   */
+  void AddEventConfig(uint32_t eventId,
+                      float acceleration,
+                      float maxVelocity,
+                      uint32_t resetTimeout);
+
+  /*!
+   * \brief Add the configuration for an event
+   * \param event The event configuration
+   */
+  void AddEventConfig(uint32_t eventId, EventCfg event);
+
+  /*!
+   * \brief Reset stored velocity to all events
+   * \param event The event configuration
+   */
+  void Reset();
+
+  /*!
+   * \brief Reset stored velocity for a specific event
+   * \param event The event ID
+   */
+  void Reset(uint32_t eventId);
+
+  /*!
+   * \brief Get the updated distance based on acceleration speed
+   * \param eventId The id for the event to handle
+   * \return The distance
+   */
+  float GetUpdatedDistance(uint32_t eventId);
+
+private:
+  struct EventData
+  {
+    EventData(EventCfg config) : m_config{config} {}
+
+    EventCfg m_config;
+    float m_currentVelocity{1.0f};
+    uint32_t m_lastFrameTime{0};
+  };
+
+  uint32_t m_currentEventId{0};
+  std::map<uint32_t, EventData> m_eventsData;
+};
+
+} // namespace MOVING_SPEED
+} // namespace UTILS

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -22,6 +22,8 @@ typedef enum
   ObservableMessagePeripheralsChanged,
   ObservableMessageSettingsChanged,
   ObservableMessageButtonMapsChanged,
+  // Used for example when the subtitle alignment position change
+  ObservableMessagePositionChanged
 } ObservableMessage;
 
 class Observer

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -11,6 +11,7 @@
 #include "guilib/ISliderCallback.h"
 #include "input/Key.h"
 #include "interfaces/IActionListener.h"
+#include "utils/MovingSpeed.h"
 
 /*! \brief Player controller class to handle user actions.
 
@@ -35,7 +36,7 @@ public:
   void OnSliderChange(void *data, CGUISliderControl *slider) override;
 
 protected:
-  CPlayerController() = default;
+  CPlayerController();
   CPlayerController(const CPlayerController&) = delete;
   CPlayerController& operator=(CPlayerController const&) = delete;
   ~CPlayerController() override;
@@ -53,4 +54,5 @@ private:
   void ShowSlider(int action, int label, float value, float min, float delta, float max, bool modal = false);
 
   int m_sliderAction = 0; ///< \brief set to the action id for a slider being displayed \sa ShowSlider
+  UTILS::MOVING_SPEED::CMovingSpeed m_movingSpeed;
 };

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -570,7 +570,7 @@ void CGraphicContext::ResetScreenParameters(RESOLUTION res)
 {
   RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(res);
 
-  info.iSubtitles = static_cast<int>(0.965 * info.iHeight);
+  info.iSubtitles = info.iHeight;
   info.fPixelRatio = 1.0f;
   info.iScreenWidth = info.iWidth;
   info.iScreenHeight = info.iHeight;

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -40,6 +40,15 @@ public:
     right = os.right; bottom = os.bottom;
   }
   OVERSCAN& operator=(const OVERSCAN&) = default;
+
+  bool operator==(const OVERSCAN& other)
+  {
+    return left == other.left && right == other.right && top == other.top && bottom == other.bottom;
+  }
+  bool operator!=(const OVERSCAN& other)
+  {
+    return left != other.left || right != other.right || top != other.top || bottom != other.bottom;
+  }
 };
 
 struct EdgeInsets

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -55,7 +55,7 @@ void CWinSystemBase::UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std:
   newRes.Overscan.right = width;
   newRes.Overscan.bottom = height;
   newRes.bFullScreen = true;
-  newRes.iSubtitles = (int)(0.965 * height);
+  newRes.iSubtitles = height;
   newRes.dwFlags = dwFlags;
   newRes.fRefreshRate = refreshRate;
   newRes.fPixelRatio = 1.0f;
@@ -87,7 +87,7 @@ void CWinSystemBase::UpdateResolutions()
   window.iScreenWidth  = window.iWidth;
   window.iScreenHeight = window.iHeight;
   if (window.iSubtitles == 0)
-    window.iSubtitles = (int)(0.965 * window.iHeight);
+    window.iSubtitles = window.iHeight;
   window.fPixelRatio = 1.0f;
   window.strMode = "Windowed";
 }
@@ -99,7 +99,7 @@ void CWinSystemBase::SetWindowResolution(int width, int height)
   window.iHeight = height;
   window.iScreenWidth = width;
   window.iScreenHeight = height;
-  window.iSubtitles = (int)(0.965 * window.iHeight);
+  window.iSubtitles = window.iHeight;
   CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(window);
 }
 

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -416,7 +416,7 @@ void CWinSystemX11::UpdateResolutions()
       res.strMode = StringUtils::Format("{}: {} @ {:.2f}Hz", out->name, mode.name, mode.hz);
       res.strOutput    = out->name;
       res.strId        = mode.id;
-      res.iSubtitles   = (int)(0.965*mode.h);
+      res.iSubtitles = mode.h;
       res.fRefreshRate = mode.hz;
       res.bFullScreen  = true;
 
@@ -455,7 +455,7 @@ bool CWinSystemX11::HasCalibration(const RESOLUTION_INFO &resInfo)
     return true;
   if (resInfo.fPixelRatio != fPixRatio)
     return true;
-  if (resInfo.iSubtitles != (int)(0.965*resInfo.iHeight))
+  if (resInfo.iSubtitles != resInfo.iHeight)
     return true;
 
   return false;

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -93,7 +93,7 @@ static void fetchDisplayModes()
         s_res_cur_displayMode.fRefreshRate = m.getRefreshRate();
         s_res_cur_displayMode.dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
         s_res_cur_displayMode.bFullScreen   = true;
-        s_res_cur_displayMode.iSubtitles    = (int)(0.965 * s_res_cur_displayMode.iHeight);
+        s_res_cur_displayMode.iSubtitles = s_res_cur_displayMode.iHeight;
         s_res_cur_displayMode.fPixelRatio   = 1.0f;
         s_res_cur_displayMode.strMode = StringUtils::Format(
             "{}x{} @ {:.6f}{} - Full Screen", s_res_cur_displayMode.iScreenWidth,
@@ -113,7 +113,7 @@ static void fetchDisplayModes()
           res.fRefreshRate = m.getRefreshRate();
           res.dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
           res.bFullScreen   = true;
-          res.iSubtitles    = (int)(0.965 * res.iHeight);
+          res.iSubtitles = res.iHeight;
           res.fPixelRatio   = 1.0f;
           res.strMode = StringUtils::Format("{}x{} @ {:.6f}{} - Full Screen", res.iScreenWidth,
                                             res.iScreenHeight, res.fRefreshRate,
@@ -248,7 +248,7 @@ bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO* res) const
     res->iScreenWidth  = res->iWidth;
     res->iScreenHeight = res->iHeight;
   }
-  res->iSubtitles    = (int)(0.965 * res->iHeight);
+  res->iSubtitles = res->iHeight;
   res->strMode =
       StringUtils::Format("{}x{} @ {:.6f}{} - Full Screen", res->iScreenWidth, res->iScreenHeight,
                           res->fRefreshRate, res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
@@ -290,7 +290,7 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
       {
         res.iWidth = std::min(res.iWidth, m_width);
         res.iHeight = std::min(res.iHeight, m_height);
-        res.iSubtitles = static_cast<int>(0.965 * res.iHeight);
+        res.iSubtitles = res.iHeight;
       }
       resolutions.push_back(res);
     }

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -673,7 +673,7 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
     res.fRefreshRate = static_cast<float>(mode->vrefresh) * (1000.0f/1001.0f);
   else
     res.fRefreshRate = mode->vrefresh;
-  res.iSubtitles = static_cast<int>(0.965 * res.iHeight);
+  res.iSubtitles = res.iHeight;
   res.fPixelRatio = 1.0f;
   res.bFullScreen = true;
 

--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
@@ -43,7 +43,7 @@ RESOLUTION_INFO COffScreenModeSetting::GetCurrentMode()
   res.iScreenHeight = DISPLAY_HEIGHT;
   res.iHeight = DISPLAY_HEIGHT;
   res.fRefreshRate = DISPLAY_REFRESH;
-  res.iSubtitles = static_cast<int>(0.965 * res.iHeight);
+  res.iSubtitles = res.iHeight;
   res.fPixelRatio = 1.0f;
   res.bFullScreen = true;
   res.strId = "0";

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -406,7 +406,7 @@ void CWinSystemWin10::UpdateResolutions()
         res.fPixelRatio = 1.0f;
         res.iScreenWidth = res.iWidth;
         res.iScreenHeight = res.iHeight;
-        res.iSubtitles = (int)(0.965 * res.iHeight);
+        res.iSubtitles = res.iHeight;
         res.strMode = StringUtils::Format("Default: {}x{} @ {:.2f}Hz", res.iWidth, res.iHeight,
                                           res.fRefreshRate);
         GetGfxContext().ResetOverscan(res);

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -974,7 +974,7 @@ void CWinSystemWin32::UpdateResolutions()
     res.fPixelRatio = 1.0f;
     res.iScreenWidth = res.iWidth;
     res.iScreenHeight = res.iHeight;
-    res.iSubtitles = (int)(0.965 * res.iHeight);
+    res.iSubtitles = res.iHeight;
     res.strMode = StringUtils::Format("{}: {}x{} @ {:.2f}Hz", monitorName, res.iWidth, res.iHeight,
                                       res.fRefreshRate);
     GetGfxContext().ResetOverscan(res);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Main changes:
- Calibration window now can be used with all _bottom_ subtitle position alignments, **then no top alignments** due to libass limits
- Fix broken subtitle bar in calibration window when overscan has been changed
- Fix wrong subtitle position when overscan is set
- Fix wrong notification label when you move subtitle position manually (e.g. shorcut key CTRL+UP/DOWN)
- Implemented simulated acceleration speed when you move subtitle position (e.g. shorcut key CTRL+UP/DOWN), this allow very easy position without waiting an eternity to move the subtitles for every single pixel... (this implementation can be reused for each others settings)
- Fix improper positioning of subs text within the black bars (related below/above alignments), the wrong position could be influenced due to custom user margins, now have fixed value (if needed an user can still move manually)
- Increased default vertical margin (see screenshots) is now higher but not excessively so, i think now can be more accommodating for more users
- New player builtins/actions `SubtitleShiftUp(save)` `SubtitleShiftDown(save)` read below

### How works the changed functionalities

**Moving the subtitles**
Not so different from Kodi 19, you can move subtitles position as you like (e.g. shorcut key CTRL+UP/DOWN),
but the changed position will be done **as temporary way**, so when you will stop the video, in the next video played the subtitle position will be restored to the _default position value._

How to change the default position value permanently:
1) By using the calibration window
2) By changing the temporary "behaviour" to permanent, by using the new player builtins:
For example create/edit the XML keyboard keymaps then replace or map to a key:
```
<up mod="ctrl">SubtitleShiftUp(save)</up>
<down mod="ctrl">SubtitleShiftDown(save)</down>
```
The optional parameter `(save)` allow to save permanently the subtitle position change.

For the less informed: **subtitles format like ASS/SSA/WebVTT** define their own positions of text in the metadata, therefore these subtitles **cannot be moved by default**. If you wish to do so, you must set `Override subtitles styles` setting to `Positions`.

**Difference between vertical margin and manual (shift) position**
On Kodi 19 this was not existent, but now we have this difference:
- The vertical margin influence the text that can be positioned below or top of screen (also for forced tags cases see screenshot) so you can call as "margins of screen"
- The manual position shift the subtitle text from bottom only, and could also place the text offscreen (but we prevent it)

Then from here we can understand the difference of these settings behaviours, maybe we can think in future to add the vertical margin as proper GUI setting

My thoughts: The "Manual" position alignment setting has no difference from "Bottom" align funtionality, so you might want to think about keeping it as backward compat!? or delete this alignment?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After my firsts subtitles rework PR's, i was aware of problems with manual subtitle position,
which required a separate study because of the many use cases to be tested.

Meantime users reported discontent in the forum because it was no longer possible to move subtitles easily except by using the "Manual" alignment, other users report that subtitles are placed again too bottom by default (as with previous Kodi versions)
and need to adjust via xml advanced settings is uncomfortable

i hope this will make happy more users

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Switch across all alignments, then tested with shorcut key CTRL+UP/DOWN,
using Calibration window during playback,
ensure that subtitles that make use of margins (WebVTT) are not broken and are influenced only with override position setting

~The PR is ready but i have set as WIP to have more time to test it~

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Allow to use manual position with all bottom alignments positions settings (then except top align positions cases)
Better vertical margins etc...

## Screenshots (if appropriate):
COMPARISON TO VERTICAL MARGIN
BEFORE:
![Clipboard01alignBefore](https://user-images.githubusercontent.com/3257156/155180191-6e0fdc79-f6d8-4881-a61e-468792e91fb9.jpg)
AFTER:
![Clipboard01alignNow](https://user-images.githubusercontent.com/3257156/155180330-09907302-7846-4c9c-ac8b-16db314ac035.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
