### PR TITLE
Add more source options to MSIF file browser

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1067,6 +1067,12 @@
           <default></default>
           <constraints>
             <allowempty>true</allowempty>
+            <sources>
+                <source>files</source>
+                <source>pictures</source>
+                <source>videos</source>
+            </sources>
+            <writable>false</writable>
           </constraints>
           <control type="button" format="path">
             <heading>657</heading>


### PR DESCRIPTION
Include 'files', 'videos', and 'pictures' sources

## Description
Add more options for ["Movie Set Information Folder"](https://kodi.wiki/view/Movie_set_information_folder) selection.

## Motivation and context
The original options are limited and it's not obvious how to add more. Now we can pick from the file browser sources, the "Pictures" sources (images are pictures, I'll bite), and even the Video library sources (storing movies under the movie set folders is less troublesome than albums under artist folders in the music library, so if the user knows the risk why stand in the way?).

This also adds the option to select a "non-writable" folder, for situations where something other than this Kodi instance manages artwork - media managers or multiple Kodi instances sharing a folder.

## How has this been tested?
Tweak the settings in a Kodi 19.3 installation. Just a change to the settings.xml file, no recompilation necessary.

## What is the effect on users?
Avoid a smidge of potential frustration.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
