### PR TITLE
[repository.xbmc.org] Use dir in extension point

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.xbmc.org"
 		name="Kodi Add-on repository"
-		version="3.3.0"
+		version="3.3.1"
 		provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.addon" version="12.0.0"/>
   </requires>
 	<extension point="xbmc.addon.repository">
 		<!-- Do not forget to bump add-on version when changing paths to force a repo refresh -->
-		<info>http://mirrors.kodi.tv/addons/nexus/addons.xml.gz</info>
-		<checksum verify="sha256">http://mirrors.kodi.tv/addons/nexus/addons.xml.gz?sha256</checksum>
-		<datadir>https://mirrors.kodi.tv/addons/nexus</datadir>
-		<artdir>http://mirrors.kodi.tv/addons/nexus</artdir>
-		<hashes>sha256</hashes>
+		<dir>
+			<info>http://mirrors.kodi.tv/addons/nexus/addons.xml.gz</info>
+			<checksum verify="sha256">http://mirrors.kodi.tv/addons/nexus/addons.xml.gz?sha256</checksum>
+			<datadir>https://mirrors.kodi.tv/addons/nexus</datadir>
+			<artdir>http://mirrors.kodi.tv/addons/nexus</artdir>
+			<hashes>sha256</hashes>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="af_ZA">Installeer Byvoegsels vanaf Kodi.tv</summary>


### PR DESCRIPTION
## Description
It was brought to my attention by @Lunatixz  that our addon-checker was failing to validate valid addon.xml definitions for repository addons. That made me look into the implementation in the Kodi core and find out we currently (and since at least gotham) we support two ways of defining a repo structure, with and without `dirs`:

```xml
<extension point="xbmc.addon.repository">
  <dir>
    <info>https://example.com/addons/addons.xml</info>
    <checksum>https://example.com/addons/addons.xml.md5</checksum>
    <datadir>https://example.com/addons/</datadir>
    <hashes>sha256</hashes>
  </dir>
</extension>
```

and the ancient way (dharma compatible?):
```xml
<extension point="xbmc.addon.repository">
    <info>https://example.com/addons/addons.xml</info>
    <checksum>https://example.com/addons/addons.xml.md5</checksum>
    <datadir>https://example.com/addons/</datadir>
  </extension>
```
The wiki was also lacking most of this info, so added in https://kodi.wiki/view/Add-on_repositories

I've made the necessary changes in https://github.com/xbmc/addon-check/pull/256 but it's not fail-proof. With xsd 1.0 we can't make sure that if a dir does not exist the other elements (info/checksum, etc) must exist. Might be possible with xs:assert in higher xsd versions but that requires deep changes in addon checker.
Thinking a bit more about this, I don't think there's a reason to continue supporting the "dharma" way if the option with `dirs` is more recent and more flexible (it supports min and max versions for example).
So I plan to remove the ancient support in Kodi. As far as I could see, all the mainstream external repos use dir anyway. I am not sure about dodgy/illegal addon repos but I/we don't care for them anyway. Unfortunately our official addon repo is still stuck with the older schema :)

That's all this PR does, it updates the repo to use the up to date schema for repos.
Will remove the support for the older definition type in a follow up PR.

## How has this been tested?
Runtime tested

## What is the effect on users?
None


