### PR TITLE
[Addons][Repository] Remove backwards dharma compatible definitions

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -115,9 +115,24 @@ CRepository::CRepository(const AddonInfoPtr& addonInfo)
         (dir.maxversion.empty() || version <= dir.maxversion))
       m_dirs.push_back(std::move(dir));
   }
+
+  // old (dharma compatible) way of defining the addon repository structure, is no longer supported
+  // we error out so the user knows how to migrate. The <dir> way is supported since gotham.
+  //! @todo remove if block completely in v21
   if (!Type(ADDON_REPOSITORY)->GetValue("info").empty())
   {
-    m_dirs.push_back(ParseDirConfiguration(*Type(ADDON_REPOSITORY)));
+    CLog::Log(LOGERROR,
+              "Repository add-on {} uses old schema definition for the repository extension point! "
+              "This is no longer supported, please update your addon to use <dir> definitions.",
+              ID());
+  }
+
+  if (m_dirs.empty())
+  {
+    CLog::Log(LOGERROR,
+              "Repository add-on {} does not have any directory and won't be able to update/serve "
+              "addons! Please fix the addon.xml definition",
+              ID());
   }
 
   for (auto const& dir : m_dirs)


### PR DESCRIPTION
## Description
This removes the support for the old schema in repository definitions, i.e., defining repos as:

```xml
<extension point="xbmc.addon.repository">
    <info>https://example.com/addons/addons.xml</info>
    <checksum>https://example.com/addons/addons.xml.md5</checksum>
    <datadir>https://example.com/addons/</datadir>
</extension>
```

Since gotham we have a more modern and flexible way of defining the repo dirs:

```xml
<extension point="xbmc.addon.repository">
  <dir>
    <info>https://example.com/addons/addons.xml</info>
    <checksum>https://example.com/addons/addons.xml.md5</checksum>
    <datadir>https://example.com/addons/</datadir>
    <hashes>sha256</hashes>
  </dir>
</extension>
```

## Motivation and context
See https://github.com/xbmc/xbmc/pull/21029 for context

## How has this been tested?
Runtime tested

## What is the effect on users?
Ancient repos without defining `dirs` no longer work. Our main repo was already adjusted and most (if not all) mainstream repos are already defined this way anyway. If not, they need to be updated.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
