### PR TITLE
Add HDR10+ HDR type

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1665,7 +1665,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           st->hdr_type = StreamHdrType::HDR_TYPE_HDR10PLUS;
         else if (st->colorPrimaries == AVCOL_PRI_BT2020)
         {
-          side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
+          side_data =
+              av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
           if (st->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084) // hdr10
             st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
           else if (st->colorTransferCharacteristic == AVCOL_TRC_ARIB_STD_B67) // hlg

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1657,6 +1657,19 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->colorRange = pStream->codecpar->color_range;
 
         int size = 0;
+        uint8_t* side_data = nullptr;
+
+        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
+        if (side_data && size)
+        {
+          st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
+              *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
+          // file could be SMPTE2086 which FFmpeg currently returns as unknown so use the presence
+          // of static metadata to detect it
+          if (st->masteringMetaData->has_primaries && st->masteringMetaData->has_luminance)
+            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
+        }
+
         uint8_t* dv_side_data = nullptr;
         uint8_t* hdr10plus_side_data = nullptr;
 
@@ -1672,17 +1685,6 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
             st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
           else if (st->colorTransferCharacteristic == AVCOL_TRC_ARIB_STD_B67) // hlg
             st->hdr_type = StreamHdrType::HDR_TYPE_HLG;
-        }
-
-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
-        if (side_data && size)
-        {
-          st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
-              *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
-          // file could be SMPTE2086 which FFmpeg currently returns as unknown so use the presence
-          // of static metadata to detect it
-          if (st->masteringMetaData->has_primaries && st->masteringMetaData->has_luminance)
-            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
         }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1674,7 +1674,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         uint8_t* hdr10plus_side_data = nullptr;
 
         dv_side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
-        hdr10plus_side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DYNAMIC_HDR10_PLUS, &size);
+        hdr10plus_side_data =
+            av_stream_get_side_data(pStream, AV_PKT_DATA_DYNAMIC_HDR10_PLUS, &size);
         if (dv_side_data && size)
           st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
         else if (hdr10plus_side_data && size)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1665,7 +1665,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         if (dv_side_data && size)
           st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
         else if (hdr10plus_side_data && size)
-          st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
+          st->hdr_type = StreamHdrType::HDR_TYPE_HDR10PLUS;
         else if (st->colorPrimaries == AVCOL_PRI_BT2020)
         {
           if (st->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084) // hdr10

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1657,10 +1657,14 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->colorRange = pStream->codecpar->color_range;
 
         int size = 0;
-        uint8_t* side_data = nullptr;
+        uint8_t* dv_side_data = nullptr;
+        uint8_t* hdr10plus_side_data = nullptr;
 
-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
-        if (side_data && size)
+        dv_side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+        hdr10plus_side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DYNAMIC_HDR10_PLUS, &size);
+        if (dv_side_data && size)
+          st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
+        else if (hdr10plus_side_data && size)
           st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
         else if (st->colorPrimaries == AVCOL_PRI_BT2020)
         {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1662,10 +1662,14 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         if (pStream->codecpar->codec_id == AV_CODEC_ID_HEVC)
         {
           // TODO: Error handling
-          AVPacket* pkt = &m_pkt.pkt; // <- TODO: How to get the first packet of the stream?
+          AVPacket pkt;
+          av_init_packet(&pkt); // <- TODO: Any non deprecated way to do this?
+          pkt.data = nullptr;
+          pkt.size = 0;
+          av_read_frame(m_pFormatContext, &pkt);
           AVFrame* frame = av_frame_alloc();
           AVCodecContext* coctx = pStream->codec; // <- TODO: Any non deprecated way to get this?
-          avcodec_send_packet(coctx, pkt);
+          avcodec_send_packet(coctx, &pkt);
           avcodec_receive_frame(coctx, frame);
           AVFrameSideData* frame_side_data =
               av_frame_get_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS);

--- a/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
+++ b/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
@@ -34,6 +34,7 @@ enum class StreamHdrType
 {
   HDR_TYPE_NONE, ///< <b>None</b>, returns an empty string when used in infolabels
   HDR_TYPE_HDR10, ///< <b>HDR10</b>, returns `hdr10` when used in infolabels
+  HDR_TYPE_HDR10PLUS, ///< <b>HDR10+</b>, returns `hdr10plus` when used in infolabels
   HDR_TYPE_DOLBYVISION, ///< <b>Dolby Vision</b>, returns `dolbyvision` when used in infolabels
   HDR_TYPE_HLG ///< <b>HLG</b>, returns `hlg` when used in infolabels
 };

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -663,6 +663,8 @@ std::string CStreamDetails::HdrTypeToString(StreamHdrType hdrType)
   {
     case StreamHdrType::HDR_TYPE_DOLBYVISION:
       return "dolbyvision";
+    case StreamHdrType::HDR_TYPE_HDR10PLUS:
+      return "hdr10plus";
     case StreamHdrType::HDR_TYPE_HDR10:
       return "hdr10";
     case StreamHdrType::HDR_TYPE_HLG:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
There are currently HDR flags for DV, HLG and HDR10

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #21031

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TBD

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users should be able to see an icon on HDR10+ (only) files.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
  - I think so, but unsure how to verify
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
