### PR TITLE
[Discs] Move disc probing to utils

### DIFF
--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -30,7 +30,6 @@
 #include "AutorunMediaJob.h"
 #include "GUIUserMessages.h"
 #include "addons/VFSEntry.h"
-#include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogPlayEject.h"
 #include "filesystem/File.h"
@@ -51,10 +50,6 @@
 #endif
 #include <string>
 #include <vector>
-
-#ifdef HAVE_LIBBLURAY
-#include "filesystem/BlurayDirectory.h"
-#endif
 
 using namespace XFILE;
 
@@ -503,7 +498,7 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
   if (CServiceBroker::GetMediaManager().GetDriveStatus(drivePath) != DRIVE_CLOSED_MEDIA_PRESENT)
     return "";
 
-  DiscInfo info;
+  UTILS::DISCS::DiscInfo info;
   info = GetDiscInfo(mediaPath);
   if (!info.name.empty())
   {
@@ -554,7 +549,7 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
   }
 #endif
 
-  DiscInfo info = GetDiscInfo(mediaPath);
+  UTILS::DISCS::DiscInfo info = GetDiscInfo(mediaPath);
   if (info.empty())
   {
     CLog::Log(LOGDEBUG, "GetDiskUniqueId: Retrieving ID for path {} failed, ID is empty.",
@@ -735,9 +730,9 @@ void CMediaManager::OnStorageUnsafelyRemoved(const MEDIA_DETECT::STORAGE::Storag
                                         device.label);
 }
 
-CMediaManager::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
+UTILS::DISCS::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
 {
-  DiscInfo info;
+  UTILS::DISCS::DiscInfo info;
 
   if (mediaPath.empty())
     return info;
@@ -751,32 +746,18 @@ CMediaManager::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
     pathVideoTS = TranslateDevicePath("");
   }
 
+  // check for DVD discs
   if (XFILE::CFile::Exists(pathVideoTS))
   {
-    CFileItem item(pathVideoTS, false);
-    CDVDInputStreamNavigator dvdNavigator(nullptr, item);
-    if (dvdNavigator.Open())
-    {
-      info.type = "DVD";
-      info.name = dvdNavigator.GetDVDTitleString();
-      info.serial = dvdNavigator.GetDVDSerialString();
+    info = UTILS::DISCS::ProbeDVDDiscInfo(pathVideoTS);
+    if (!info.empty())
       return info;
-    }
   }
-#ifdef HAVE_LIBBLURAY
   // check for Blu-ray discs
   if (XFILE::CFile::Exists(URIUtils::AddFileToFolder(mediaPath, "BDMV", "index.bdmv")))
   {
-    info.type = "Blu-ray";
-    CBlurayDirectory bdDir;
-
-    if (!bdDir.InitializeBluray(mediaPath))
-      return info;
-
-    info.name = bdDir.GetBlurayTitle();
-    info.serial = bdDir.GetBlurayID();
+    info = UTILS::DISCS::ProbeBlurayDiscInfo(mediaPath);
   }
-#endif
 
   return info;
 }

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -11,6 +11,7 @@
 #include "IStorageProvider.h"
 #include "MediaSource.h" // for VECSOURCES
 #include "threads/CriticalSection.h"
+#include "utils/DiscsUtils.h"
 #include "utils/Job.h"
 
 #include <map>
@@ -119,19 +120,7 @@ protected:
 private:
   IStorageProvider *m_platformStorage;
 
-  struct DiscInfo
-  {
-    std::string name;
-    std::string serial;
-    std::string type;
-
-    bool empty()
-    {
-      return (name.empty() && serial.empty());
-    }
-  };
-
-  DiscInfo GetDiscInfo(const std::string& mediaPath);
+  UTILS::DISCS::DiscInfo GetDiscInfo(const std::string& mediaPath);
   void RemoveDiscInfo(const std::string& devicePath);
-  std::map<std::string, DiscInfo> m_mapDiscInfo;
+  std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
 };

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES ActorProtocol.cpp
             CSSUtils.cpp
             DatabaseUtils.cpp
             Digest.cpp
+            DiscsUtils.cpp
             EndianSwap.cpp
             EmbeddedArt.cpp
             FileExtensionProvider.cpp
@@ -93,6 +94,7 @@ set(HEADERS ActorProtocol.h
             CSSUtils.h
             DatabaseUtils.h
             Digest.h
+            DiscsUtils.h
             EndianSwap.h
             EventStream.h
             EventStreamDetail.h

--- a/xbmc/utils/DiscsUtils.cpp
+++ b/xbmc/utils/DiscsUtils.cpp
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DiscsUtils.h"
+
+#include "FileItem.h"
+//! @todo it's wrong to include videoplayer scoped files, refactor
+// dvd inputstream so they can be used by other components. Or just use libdvdnav directly.
+#include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h"
+#ifdef HAVE_LIBBLURAY
+//! @todo it's wrong to include vfs scoped files in a utils class, refactor
+// to use libbluray directly.
+#include "filesystem/BlurayDirectory.h"
+#endif
+
+bool UTILS::DISCS::GetDiscInfo(UTILS::DISCS::DiscInfo& info, const std::string& mediaPath)
+{
+  // try to probe as a DVD
+  info = ProbeDVDDiscInfo(mediaPath);
+  if (!info.empty())
+    return true;
+
+  // try to probe as Blu-ray
+  info = ProbeBlurayDiscInfo(mediaPath);
+  if (!info.empty())
+    return true;
+
+  return false;
+}
+
+UTILS::DISCS::DiscInfo UTILS::DISCS::ProbeDVDDiscInfo(const std::string& mediaPath)
+{
+  DiscInfo info;
+  CFileItem item{mediaPath, false};
+  CDVDInputStreamNavigator dvdNavigator{nullptr, item};
+  if (dvdNavigator.Open())
+  {
+    info.type = DiscType::DVD;
+    info.name = dvdNavigator.GetDVDTitleString();
+    info.serial = dvdNavigator.GetDVDSerialString();
+  }
+  return info;
+}
+
+UTILS::DISCS::DiscInfo UTILS::DISCS::ProbeBlurayDiscInfo(const std::string& mediaPath)
+{
+  DiscInfo info;
+#ifdef HAVE_LIBBLURAY
+  XFILE::CBlurayDirectory bdDir;
+  if (!bdDir.InitializeBluray(mediaPath))
+    return info;
+
+  info.type = DiscType::BLURAY;
+  info.name = bdDir.GetBlurayTitle();
+  info.serial = bdDir.GetBlurayID();
+#endif
+  return info;
+}

--- a/xbmc/utils/DiscsUtils.h
+++ b/xbmc/utils/DiscsUtils.h
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace UTILS
+{
+namespace DISCS
+{
+
+/*! \brief Abstracts a disc type
+*/
+enum class DiscType
+{
+  UNKNOWN, ///< the default value, the application doesn't know what the device is
+  DVD, ///< dvd disc
+  BLURAY ///< blu-ray disc
+};
+
+/*! \brief Abstracts the info the app knows about a disc (type, name, serial)
+*/
+struct DiscInfo
+{
+  /*! \brief The disc type, \sa DiscType */
+  DiscType type{DiscType::UNKNOWN};
+  /*! \brief The disc serial number */
+  std::string serial;
+  /*! \brief The disc label (equivalent to the mount point label) */
+  std::string name;
+
+  /*! \brief Check if the info is empty (e.g. after probing)
+    \return true if the info is empty, false otherwise
+  */
+  bool empty() { return (type == DiscType::UNKNOWN && name.empty() && serial.empty()); }
+};
+
+/*! \brief Try to obtain the disc info (type, name, serial) of a given media path
+    \param[in, out] info The disc info struct
+    \param mediaPath The disc mediapath (e.g. /dev/cdrom, D\://, etc)
+    \return true if getting the disc info was successfull
+*/
+bool GetDiscInfo(DiscInfo& info, const std::string& mediaPath);
+
+/*! \brief Try to probe the provided media path as a DVD
+    \param mediaPath The disc mediapath (e.g. /dev/cdrom, D\://, etc)
+    \return the DiscInfo for the given media path (might be an empty struct)
+*/
+DiscInfo ProbeDVDDiscInfo(const std::string& mediaPath);
+
+/*! \brief Try to probe the provided media path as a Bluray
+    \param mediaPath The disc mediapath (e.g. /dev/cdrom, D\://, etc)
+    \return the DiscInfo for the given media path (might be an empty struct)
+*/
+DiscInfo ProbeBlurayDiscInfo(const std::string& mediaPath);
+
+} // namespace DISCS
+} // namespace UTILS


### PR DESCRIPTION
## Description
This PR moves optical disc probing (currently done via libdbdnav and libbluray) to a new utils class `DiscsUtils`. The reason of the PR is to have a way to reuse probing from different components (e.g. to solve https://github.com/xbmc/xbmc/issues/20935 we need to probe discs in DetectDVDMedia so that the DiscInfo is stored and used as a fallback if no data tracks are found in libcdio).
Also adds documentation for all methods in utils.

## Motivation and context
Improve discs subsystems, fix linux discs handling.

## How has this been tested?
Runtime tested

## What is the effect on users?
None, it's a simple move of functionality

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

