### PR TITLE
DXVA2: use texture copy on AMD hardware < DirectX FL 12_1

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1114,7 +1114,8 @@ void DX::DeviceResources::CheckDXVA2SharedDecoderSurfaces()
   m_DXVA2SharedDecoderSurfaces =
       ad.VendorId == PCIV_Intel ||
       (ad.VendorId == PCIV_NVIDIA && driver.valid && driver.majorVersion >= 465) ||
-      (ad.VendorId == PCIV_AMD && driver.valid && driver.majorVersion >= 30);
+      (ad.VendorId == PCIV_AMD && driver.valid && driver.majorVersion >= 30 &&
+       m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_12_1);
 
   CLog::LogF(LOGINFO, "DXVA2 shared decoder surfaces is{}supported",
              m_DXVA2SharedDecoderSurfaces ? " " : " NOT ");


### PR DESCRIPTION
## Description
DXVA2: use texture copy on AMD hardware < DirectX FL 12_1

## Motivation and context
This is a follow-up of https://github.com/xbmc/xbmc/pull/20900

New method works fine on recent AMD hardware i.e. Vega (GCN 5.1, DirectX 12.1) / Ryzen 4650G and RX 6600 
but not in Polaris RX 550 (GCN 4.0, DirectX 12.0) even using latest drivers.

See: https://forum.kodi.tv/showthread.php?tid=366670&pid=3087866#pid3087866

Seems a HW limitation due GCN 4.0

I have consulted a database (https://www.techpowerup.com/gpu-specs/) and all AMD HW after Polaris is GCN 5.x and supports DirectX FL 12.1 on Windows 10. So an easy way to differentiate is using FL.

The only side effect is that is also disabled on recent AMD HW using Windows 8.1. But that doesn't matter, it will also work same as before (texture copy).




## What is the effect on users?
Fix not working DXVA2 decoding on "old" AMD hardware using new method after PR20900



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
