### PR TITLE
[Subtitles][libass] Fix wrong rendering due to ass_set_storage_size and wrong PAR

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -279,7 +279,8 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(
 
   ass_set_frame_size(m_renderer, static_cast<int>(opts.frameWidth),
                      static_cast<int>(opts.frameHeight));
-
+  ass_set_storage_size(m_renderer, static_cast<int>(opts.sourceWidth),
+                       static_cast<int>(opts.sourceHeight));
   if (m_drawWithinBlackBars)
   {
     int marginTop = static_cast<int>((opts.frameHeight - opts.videoHeight) / 2);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -274,8 +274,8 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(
     m_drawWithinBlackBars = subStyle->drawWithinBlackBars;
   }
 
-  double sar = static_cast<double>(opts.sourceWidth / opts.sourceHeight);
-  double dar = static_cast<double>(opts.videoWidth / opts.videoHeight);
+  double sar = static_cast<double>(opts.sourceWidth) / static_cast<double>(opts.sourceHeight);
+  double dar = static_cast<double>(opts.videoWidth) / static_cast<double>(opts.videoHeight);
 
   ass_set_frame_size(m_renderer, static_cast<int>(opts.frameWidth),
                      static_cast<int>(opts.frameHeight));
@@ -292,7 +292,7 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(
   // Vertical text position in percent (if 0 do nothing)
   ass_set_line_position(m_renderer, opts.position);
 
-  ass_set_pixel_aspect(m_renderer, sar / dar);
+  ass_set_pixel_aspect(m_renderer, dar / sar);
 
   // For posterity ass_render_frame have an inconsistent rendering for overlapped subtitles cases,
   // if the playback occurs in sequence (without seeks) the overlapped subtitles lines will be rendered in right order


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
set missing ass_set_storage_size values to render correctly graphics effects
and fix wrong PAR calculation cause of wrong rendering

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/libass/libass/issues/591
Fix #21027

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With provided test files from libass
~the 16/9 video works, but the anamorphic is not rendered well, i suspect the problem is similar to #21027 that i am not able find the bug~

Differences:
16/9 BEFORE:
![before](https://user-images.githubusercontent.com/3257156/155771704-d03a23ac-70c2-4bc4-934a-745c431369a9.jpg)
16/9 AFTER:
![after](https://user-images.githubusercontent.com/3257156/155771750-17688309-bd30-433c-827a-b99cc627c998.jpg)
anamorphic BEFORE:
![before2](https://user-images.githubusercontent.com/3257156/155771803-f43f862d-0944-410e-85b4-97b5b26e822f.jpg)
anamorphic AFTER:
![dopo2](https://user-images.githubusercontent.com/3257156/155837553-712eeaa4-1704-4590-bdef-f11cbe1c8d7f.jpg)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
