### PR TITLE
DXVA2: workaround for AMD H264 SD interlaced issues

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -1079,6 +1079,19 @@ static bool HasATIMP2Bug(AVCodecContext* avctx)
       && avctx->color_trc == AVCOL_TRC_GAMMA28;
 }
 
+static bool HasAMDH264SDiBug(AVCodecContext* avctx)
+{
+  DXGI_ADAPTER_DESC AIdentifier = {};
+  DX::DeviceResources::Get()->GetAdapterDesc(&AIdentifier);
+
+  if (AIdentifier.VendorId != PCIV_AMD)
+    return false;
+
+  // AMD card has issues with SD H264 interlaced content
+  return (avctx->height <= 576 && avctx->codec_id == AV_CODEC_ID_H264 &&
+          avctx->field_order != AV_FIELD_PROGRESSIVE);
+}
+
 static bool CheckCompatibility(AVCodecContext* avctx)
 {
   if (avctx->codec_id == AV_CODEC_ID_MPEG2VIDEO && HasATIMP2Bug(avctx))
@@ -1094,6 +1107,15 @@ static bool CheckCompatibility(AVCodecContext* avctx)
     CLog::Log(LOGWARNING,
               "DXVA: width {} is not supported with nVidia VP3 hardware. DXVA will not be used.",
               avctx->coded_width);
+    return false;
+  }
+
+  // AMD H264 SD interlaced incompatibility
+  if (HasAMDH264SDiBug(avctx))
+  {
+    CLog::Log(
+        LOGWARNING,
+        "DXVA: H264 SD interlaced has issues on AMD graphics hardware. DXVA will not be used.");
     return false;
   }
 


### PR DESCRIPTION
## Description
DXVA2: workaround for AMD H264 SD interlaced issues.

## Motivation and context
Users of AMD graphics cards has issues (video flickering) with H264 SD interlaced content.
See: https://forum.kodi.tv/showthread.php?tid=366235

The issue seems very consistent in different AMD HW:  RX 570, RX 6600...  and different AMD drivers 22.2.2 and 21.x

NOTE: this is unrelated to recent DXVA2 improvements (true sharing textures) on master branch. This issue is also present in Matrix.

## How has this been tested?
Runtime tested Windows x64 simulating ID of AMD card.

Also confirmed with a test build.
See: https://forum.kodi.tv/showthread.php?tid=366235&pid=3088238#pid3088238

## What is the effect on users?
Fix H264 SD video flickering on AMD graphics cards. 



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
