### PR TITLE
[cmake] Update FindFFMPEG module and FFMPEG cmake build

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -32,15 +32,110 @@
 # --------
 #
 
-# required ffmpeg library versions
-set(REQUIRED_FFMPEG_VERSION 4.4.1)
-set(_avcodec_ver ">=58.134.100")
-set(_avfilter_ver ">=7.110.100")
-set(_avformat_ver ">=58.76.100")
-set(_avutil_ver ">=56.70.100")
-set(_swscale_ver ">=5.9.100")
-set(_swresample_ver ">=3.9.100")
-set(_postproc_ver ">=55.9.100")
+# Macro to build internal FFmpeg
+# Refactoring to a macro allows simple fallthrough callback if system ffmpeg failure
+macro(buildFFMPEG)
+  include(ExternalProject)
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  get_archive_name(ffmpeg)
+
+  # allow user to override the download URL with a local tarball
+  # needed for offline build envs
+  if(FFMPEG_URL)
+    get_filename_component(FFMPEG_URL "${FFMPEG_URL}" ABSOLUTE)
+  else()
+    # github tarball format is tagname.tar.gz (eg 4.4-N-Alpha1.tar.gz)
+    # tagname is our FFMPEG_VER from VERSION file.
+    set(FFMPEG_URL ${FFMPEG_BASE_URL}/archive/${FFMPEG_VER}.tar.gz)
+  endif()
+  if(VERBOSE)
+    message(STATUS "FFMPEG_URL: ${FFMPEG_URL}")
+  endif()
+
+  if (NOT DAV1D_FOUND)
+    message(STATUS "dav1d not found, internal ffmpeg build will be missing AV1 support!")
+  endif()
+
+  set(FFMPEG_OPTIONS -DENABLE_CCACHE=${ENABLE_CCACHE}
+                     -DCCACHE_PROGRAM=${CCACHE_PROGRAM}
+                     -DENABLE_VAAPI=${ENABLE_VAAPI}
+                     -DENABLE_VDPAU=${ENABLE_VDPAU}
+                     -DENABLE_DAV1D=${DAV1D_FOUND}
+                     -DEXTRA_FLAGS=${FFMPEG_EXTRA_FLAGS})
+
+  if(KODI_DEPENDSBUILD)
+    set(CROSS_ARGS -DDEPENDS_PATH=${DEPENDS_PATH}
+                   -DPKG_CONFIG_EXECUTABLE=${PKG_CONFIG_EXECUTABLE}
+                   -DCROSSCOMPILING=${CMAKE_CROSSCOMPILING}
+                   -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                   -DOS=${OS}
+                   -DCMAKE_AR=${CMAKE_AR})
+  endif()
+  set(LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+  list(APPEND LINKER_FLAGS ${SYSTEM_LDFLAGS})
+
+  externalproject_add(ffmpeg
+                      URL ${FFMPEG_URL}
+                      URL_HASH ${FFMPEG_HASH}
+                      DOWNLOAD_NAME ${FFMPEG_ARCHIVE}
+                      DOWNLOAD_DIR ${TARBALL_DIR}
+                      PREFIX ${CORE_BUILD_DIR}/ffmpeg
+                      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
+                                 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                                 -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+                                 -DFFMPEG_VER=${FFMPEG_VER}
+                                 -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
+                                 -DCORE_PLATFORM_NAME=${CORE_PLATFORM_NAME_LC}
+                                 -DCPU=${CPU}
+                                 -DENABLE_NEON=${ENABLE_NEON}
+                                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                                 -DENABLE_CCACHE=${ENABLE_CCACHE}
+                                 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                                 -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                                 -DCMAKE_EXE_LINKER_FLAGS=${LINKER_FLAGS}
+                                 ${CROSS_ARGS}
+                                 ${FFMPEG_OPTIONS}
+                                 -DPKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig
+                      PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+                                    ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/CMakeLists.txt
+                                    <SOURCE_DIR>)
+
+  if (ENABLE_INTERNAL_DAV1D)
+    add_dependencies(ffmpeg dav1d)
+  endif()
+
+  find_program(BASH_COMMAND bash)
+  if(NOT BASH_COMMAND)
+    message(FATAL_ERROR "Internal FFmpeg requires bash.")
+  endif()
+  file(WRITE ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg/ffmpeg-link-wrapper
+"#!${BASH_COMMAND}
+if [[ $@ == *${APP_NAME_LC}.bin* || $@ == *${APP_NAME_LC}${APP_BINARY_SUFFIX}* || $@ == *${APP_NAME_LC}.so* || $@ == *${APP_NAME_LC}-test* ]]
+then
+  avformat=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavcodec`
+  avcodec=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavformat`
+  avfilter=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavfilter`
+  avutil=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavutil`
+  swscale=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libswscale`
+  swresample=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libswresample`
+  gnutls=`PKG_CONFIG_PATH=${DEPENDS_PATH}/lib/pkgconfig/ ${PKG_CONFIG_EXECUTABLE}  --libs-only-l --static --silence-errors gnutls`
+  $@ $avcodec $avformat $avcodec $avfilter $swscale $swresample -lpostproc $gnutls
+else
+  $@
+fi")
+  file(COPY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg/ffmpeg-link-wrapper
+       DESTINATION ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
+       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
+  set(FFMPEG_LINK_EXECUTABLE "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg-link-wrapper <CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" PARENT_SCOPE)
+  set(FFMPEG_CREATE_SHARED_LIBRARY "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg-link-wrapper <CMAKE_CXX_COMPILER> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>" PARENT_SCOPE)
+  set(FFMPEG_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+  set(FFMPEG_DEFINITIONS -DUSE_STATIC_FFMPEG=1)
+  set(FFMPEG_FOUND 1)
+  set_target_properties(ffmpeg PROPERTIES FOLDER "External Projects")
+endmacro()
+
 
 # Allows building with external ffmpeg not found in system paths,
 # without library version checks
@@ -48,13 +143,16 @@ if(WITH_FFMPEG)
   set(FFMPEG_PATH ${WITH_FFMPEG})
   message(STATUS "Warning: FFmpeg version checking disabled")
   set(REQUIRED_FFMPEG_VERSION undef)
-  unset(_avcodec_ver)
-  unset(_avfilter_ver)
-  unset(_avformat_ver)
-  unset(_avutil_ver)
-  unset(_swscale_ver)
-  unset(_swresample_ver)
-  unset(_postproc_ver)
+else()
+  # required ffmpeg library versions
+  set(REQUIRED_FFMPEG_VERSION 4.4.1)
+  set(_avcodec_ver ">=58.134.100")
+  set(_avfilter_ver ">=7.110.100")
+  set(_avformat_ver ">=58.76.100")
+  set(_avutil_ver ">=56.70.100")
+  set(_postproc_ver ">=55.9.100")
+  set(_swresample_ver ">=3.9.100")
+  set(_swscale_ver ">=5.9.100")
 endif()
 
 # Allows building with external ffmpeg not found in system paths,
@@ -63,8 +161,10 @@ if(FFMPEG_PATH)
   set(ENABLE_INTERNAL_FFMPEG OFF)
 endif()
 
-# external FFMPEG
-if(NOT ENABLE_INTERNAL_FFMPEG OR KODI_DEPENDSBUILD)
+if(ENABLE_INTERNAL_FFMPEG)
+  buildFFMPEG()
+else()
+  # external FFMPEG
   if(FFMPEG_PATH)
     list(APPEND CMAKE_PREFIX_PATH ${FFMPEG_PATH})
   endif()
@@ -165,153 +265,49 @@ if(NOT ENABLE_INTERNAL_FFMPEG OR KODI_DEPENDSBUILD)
                                                     FFMPEG_VERSION
                                       FAIL_MESSAGE "FFmpeg ${REQUIRED_FFMPEG_VERSION} not found, please consider using -DENABLE_INTERNAL_FFMPEG=ON")
 
+    if(FFMPEG_FOUND)
+      set(FFMPEG_LDFLAGS ${PC_FFMPEG_LDFLAGS} CACHE STRING "ffmpeg linker flags")
+
+      set(FFMPEG_LIBRARIES ${FFMPEG_LIBAVCODEC} ${FFMPEG_LIBAVFILTER}
+                           ${FFMPEG_LIBAVFORMAT} ${FFMPEG_LIBAVUTIL}
+                           ${FFMPEG_LIBSWSCALE} ${FFMPEG_LIBSWRESAMPLE}
+                           ${FFMPEG_LIBPOSTPROC} ${FFMPEG_LDFLAGS})
+
+      # check if ffmpeg libs are statically linked
+      set(FFMPEG_LIB_TYPE SHARED)
+      foreach(_fflib IN LISTS FFMPEG_LIBRARIES)
+        if(${_fflib} MATCHES ".+\.a$" AND PC_FFMPEG_STATIC_LDFLAGS)
+          set(FFMPEG_LDFLAGS ${PC_FFMPEG_STATIC_LDFLAGS} CACHE STRING "ffmpeg linker flags" FORCE)
+          set(FFMPEG_LIB_TYPE STATIC)
+          break()
+        endif()
+      endforeach()
+    endif()
   else()
-    message(STATUS "FFmpeg ${REQUIRED_FFMPEG_VERSION} not found, falling back to internal build")
-    unset(FFMPEG_INCLUDE_DIRS)
-    unset(FFMPEG_INCLUDE_DIRS CACHE)
-    unset(FFMPEG_LIBRARIES)
-    unset(FFMPEG_LIBRARIES CACHE)
-    unset(FFMPEG_DEFINITIONS)
-    unset(FFMPEG_DEFINITIONS CACHE)
-  endif()
-
-  if(FFMPEG_FOUND)
-    set(FFMPEG_LDFLAGS ${PC_FFMPEG_LDFLAGS} CACHE STRING "ffmpeg linker flags")
-
-    # check if ffmpeg libs are statically linked
-    set(FFMPEG_LIB_TYPE SHARED)
-    foreach(_fflib IN LISTS FFMPEG_LIBRARIES)
-      if(${_fflib} MATCHES ".+\.a$" AND PC_FFMPEG_STATIC_LDFLAGS)
-        set(FFMPEG_LDFLAGS ${PC_FFMPEG_STATIC_LDFLAGS} CACHE STRING "ffmpeg linker flags" FORCE)
-        set(FFMPEG_LIB_TYPE STATIC)
-        break()
-      endif()
-    endforeach()
-
-    set(FFMPEG_LIBRARIES ${FFMPEG_LIBAVCODEC} ${FFMPEG_LIBAVFILTER}
-                         ${FFMPEG_LIBAVFORMAT} ${FFMPEG_LIBAVUTIL}
-                         ${FFMPEG_LIBSWSCALE} ${FFMPEG_LIBSWRESAMPLE}
-                         ${FFMPEG_LIBPOSTPROC} ${FFMPEG_LDFLAGS})
-    list(APPEND FFMPEG_DEFINITIONS -DFFMPEG_VER_SHA=\"${FFMPEG_VERSION}\")
-
-    if(NOT TARGET ffmpeg)
-      add_library(ffmpeg ${FFMPEG_LIB_TYPE} IMPORTED)
-      set_target_properties(ffmpeg PROPERTIES
-                                   FOLDER "External Projects"
-                                   IMPORTED_LOCATION "${FFMPEG_LIBRARIES}"
-                                   INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}"
-                                   INTERFACE_LINK_LIBRARIES "${FFMPEG_LDFLAGS}"
-                                   INTERFACE_COMPILE_DEFINITIONS "${FFMPEG_DEFINITIONS}")
+    if(FFMPEG_PATH)
+      message(FATAL_ERROR "FFmpeg not found, please consider using -DENABLE_INTERNAL_FFMPEG=ON")
+    else()
+      message(STATUS "FFmpeg ${REQUIRED_FFMPEG_VERSION} not found, falling back to internal build")
+      buildFFMPEG()
     endif()
   endif()
 endif()
 
-# Internal FFMPEG
-if(NOT FFMPEG_FOUND)
-  include(ExternalProject)
-  include(cmake/scripts/common/ModuleHelpers.cmake)
+if(FFMPEG_FOUND)
 
-  get_archive_name(ffmpeg)
+  list(APPEND FFMPEG_DEFINITIONS -DFFMPEG_VER_SHA=\"${FFMPEG_VERSION}\")
 
-  # allow user to override the download URL with a local tarball
-  # needed for offline build envs
-  if(FFMPEG_URL)
-    get_filename_component(FFMPEG_URL "${FFMPEG_URL}" ABSOLUTE)
-  else()
-    # github tarball format is tagname.tar.gz (eg 4.4-N-Alpha1.tar.gz)
-    # tagname is our FFMPEG_VER from VERSION file.
-    set(FFMPEG_URL ${FFMPEG_BASE_URL}/archive/${FFMPEG_VER}.tar.gz)
-  endif()
-  if(VERBOSE)
-    message(STATUS "FFMPEG_URL: ${FFMPEG_URL}")
+  if(NOT TARGET ffmpeg)
+    add_library(ffmpeg ${FFMPEG_LIB_TYPE} IMPORTED)
+    set_target_properties(ffmpeg PROPERTIES
+                                 FOLDER "External Projects"
+                                 IMPORTED_LOCATION "${FFMPEG_LIBRARIES}"
+                                 INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}"
+                                 INTERFACE_LINK_LIBRARIES "${FFMPEG_LDFLAGS}"
+                                 INTERFACE_COMPILE_DEFINITIONS "${FFMPEG_DEFINITIONS}")
   endif()
 
-  if (NOT DAV1D_FOUND)
-    message(STATUS "dav1d not found, internal ffmpeg build will be missing AV1 support!")
-  endif()
-
-  set(FFMPEG_OPTIONS -DENABLE_CCACHE=${ENABLE_CCACHE}
-                     -DCCACHE_PROGRAM=${CCACHE_PROGRAM}
-                     -DENABLE_VAAPI=${ENABLE_VAAPI}
-                     -DENABLE_VDPAU=${ENABLE_VDPAU}
-                     -DENABLE_DAV1D=${DAV1D_FOUND}
-                     -DEXTRA_FLAGS=${FFMPEG_EXTRA_FLAGS})
-
-  if(KODI_DEPENDSBUILD)
-    set(CROSS_ARGS -DDEPENDS_PATH=${DEPENDS_PATH}
-                   -DPKG_CONFIG_EXECUTABLE=${PKG_CONFIG_EXECUTABLE}
-                   -DCROSSCOMPILING=${CMAKE_CROSSCOMPILING}
-                   -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-                   -DOS=${OS}
-                   -DCMAKE_AR=${CMAKE_AR})
-  endif()
-  set(LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
-  list(APPEND LINKER_FLAGS ${SYSTEM_LDFLAGS})
-
-  externalproject_add(ffmpeg
-                      URL ${FFMPEG_URL}
-                      URL_HASH ${FFMPEG_HASH}
-                      DOWNLOAD_NAME ${FFMPEG_ARCHIVE}
-                      DOWNLOAD_DIR ${TARBALL_DIR}
-                      PREFIX ${CORE_BUILD_DIR}/ffmpeg
-                      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
-                                 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                                 -DFFMPEG_VER=${FFMPEG_VER}
-                                 -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
-                                 -DCORE_PLATFORM_NAME=${CORE_PLATFORM_NAME_LC}
-                                 -DCPU=${CPU}
-                                 -DENABLE_NEON=${ENABLE_NEON}
-                                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                                 -DENABLE_CCACHE=${ENABLE_CCACHE}
-                                 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-                                 -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-                                 -DCMAKE_EXE_LINKER_FLAGS=${LINKER_FLAGS}
-                                 ${CROSS_ARGS}
-                                 ${FFMPEG_OPTIONS}
-                                 -DPKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig
-                      PATCH_COMMAND ${CMAKE_COMMAND} -E copy
-                                    ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/CMakeLists.txt
-                                    <SOURCE_DIR> &&
-                                    ${CMAKE_COMMAND} -E copy
-                                    ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/FindGnuTls.cmake
-                                    <SOURCE_DIR>)
-
-  if (ENABLE_INTERNAL_DAV1D)
-    add_dependencies(ffmpeg dav1d)
-  endif()
-
-  find_program(BASH_COMMAND bash)
-  if(NOT BASH_COMMAND)
-    message(FATAL_ERROR "Internal FFmpeg requires bash.")
-  endif()
-  file(WRITE ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg/ffmpeg-link-wrapper
-"#!${BASH_COMMAND}
-if [[ $@ == *${APP_NAME_LC}.bin* || $@ == *${APP_NAME_LC}${APP_BINARY_SUFFIX}* || $@ == *${APP_NAME_LC}.so* || $@ == *${APP_NAME_LC}-test* ]]
-then
-  avformat=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavcodec`
-  avcodec=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavformat`
-  avfilter=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavfilter`
-  avutil=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libavutil`
-  swscale=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libswscale`
-  swresample=`PKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libswresample`
-  gnutls=`PKG_CONFIG_PATH=${DEPENDS_PATH}/lib/pkgconfig/ ${PKG_CONFIG_EXECUTABLE}  --libs-only-l --static --silence-errors gnutls`
-  $@ $avcodec $avformat $avcodec $avfilter $swscale $swresample -lpostproc $gnutls
-else
-  $@
-fi")
-  file(COPY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg/ffmpeg-link-wrapper
-       DESTINATION ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
-       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
-  set(FFMPEG_LINK_EXECUTABLE "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg-link-wrapper <CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" PARENT_SCOPE)
-  set(FFMPEG_CREATE_SHARED_LIBRARY "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ffmpeg-link-wrapper <CMAKE_CXX_COMPILER> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>" PARENT_SCOPE)
-  set(FFMPEG_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
-  list(APPEND FFMPEG_DEFINITIONS -DFFMPEG_VER_SHA=\"${FFMPEG_VER}\"
-                                 -DUSE_STATIC_FFMPEG=1)
-  set(FFMPEG_FOUND 1)
-  set_target_properties(ffmpeg PROPERTIES FOLDER "External Projects")
+  set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP ffmpeg)
 endif()
-
-set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP ffmpeg)
 
 mark_as_advanced(FFMPEG_INCLUDE_DIRS FFMPEG_LIBRARIES FFMPEG_LDFLAGS FFMPEG_DEFINITIONS FFMPEG_FOUND)

--- a/cmake/modules/FindGnuTLS.cmake
+++ b/cmake/modules/FindGnuTLS.cmake
@@ -18,7 +18,7 @@ if(NOT GNUTLS_FOUND)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GnuTls DEFAULT_MSG GNUTLS_INCLUDE_DIRS GNUTLS_LIBRARIES)
+find_package_handle_standard_args(GnuTLS DEFAULT_MSG GNUTLS_INCLUDE_DIRS GNUTLS_LIBRARIES)
 
 if(GNUTLS_FOUND)
   list(APPEND GNUTLS_DEFINITIONS -DHAVE_GNUTLS=1)

--- a/cmake/modules/FindNASM.cmake
+++ b/cmake/modules/FindNASM.cmake
@@ -1,0 +1,30 @@
+#.rst:
+# FindNASM
+# ----------
+# Finds nasm executable
+#
+# This will define the following variables::
+#
+# NASM_EXECUTABLE - nasm executable
+
+include(FindPackageHandleStandardArgs)
+
+find_program(NASM_EXECUTABLE nasm)
+
+if(NASM_EXECUTABLE)
+  execute_process(COMMAND ${NASM_EXECUTABLE} -version
+                  OUTPUT_VARIABLE nasm_version
+                  ERROR_QUIET
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  )
+  if(nasm_version MATCHES "^NASM version ([0-9\\.]*)")
+    set(NASM_VERSION_STRING "${CMAKE_MATCH_1}")
+  endif()
+endif()
+
+# Provide standardized success/failure messages
+find_package_handle_standard_args(NASM
+                                  REQUIRED_VARS NASM_EXECUTABLE
+                                  VERSION_VAR NASM_VERSION_STRING)
+
+mark_as_advanced(NASM_EXECUTABLE)

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -2,21 +2,40 @@ project(ffmpeg)
 
 cmake_minimum_required(VERSION 2.8)
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
-
 if(ENABLE_CCACHE AND CCACHE_PROGRAM)
-  set(ffmpeg_conf "--cc=${CCACHE_PROGRAM} ${CMAKE_C_COMPILER}" "--cxx=${CCACHE_PROGRAM} ${CMAKE_CXX_COMPILER}")
+  set(ffmpeg_conf "--cc=${CCACHE_PROGRAM} ${CMAKE_C_COMPILER}"
+                  "--cxx=${CCACHE_PROGRAM} ${CMAKE_CXX_COMPILER}"
+                )
 else()
-  set(ffmpeg_conf --cc=${CMAKE_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER})
+  set(ffmpeg_conf --cc=${CMAKE_C_COMPILER}
+                  --cxx=${CMAKE_CXX_COMPILER}
+                )
 endif()
 
 if(CROSSCOMPILING)
   set(pkgconf "PKG_CONFIG_LIBDIR=${DEPENDS_PATH}/lib/pkgconfig")
-  list(APPEND ffmpeg_conf --pkg-config=${PKG_CONFIG_EXECUTABLE} --pkg-config-flags=--static)
-  list(APPEND ffmpeg_conf --enable-cross-compile --cpu=${CPU} --arch=${CPU} --target-os=${OS})
-  list(APPEND ffmpeg_conf --ar=${CMAKE_AR} --strip=${CMAKE_STRIP})
+  list(APPEND ffmpeg_conf --pkg-config=${PKG_CONFIG_EXECUTABLE}
+                          --pkg-config-flags=--static
+                          --enable-cross-compile
+                          --enable-pic
+                          --ar=${CMAKE_AR}
+                          --strip=${CMAKE_STRIP}
+              )
+
   message(STATUS "CROSS: ${ffmpeg_conf}")
 endif()
+
+set(CONFIGARCH --arch=${CPU})
+
+list(APPEND ffmpeg_conf --disable-doc
+                        --disable-devices
+                        --disable-programs
+                        --disable-sdl2
+                        --enable-gpl
+                        --enable-postproc
+                        --enable-runtime-cpudetect
+                        --enable-pthreads
+            )
 
 if(CMAKE_C_FLAGS)
   list(APPEND ffmpeg_conf --extra-cflags=${CMAKE_C_FLAGS})
@@ -39,7 +58,9 @@ if(CMAKE_BUILD_TYPE STREQUAL Release)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd)
-  list(APPEND ffmpeg_conf --enable-pic)
+  list(APPEND ffmpeg_conf --enable-pic
+                          --target-os=linux
+              )
   if(ENABLE_VAAPI)
     list(APPEND ffmpeg_conf --enable-vaapi)
   else()
@@ -51,34 +72,47 @@ if(CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd)
     list(APPEND ffmpeg_conf --disable-vdpau)
   endif()
 elseif(CORE_SYSTEM_NAME STREQUAL android)
+  list(APPEND ffmpeg_conf --target-os=android
+                          --extra-libs=-liconv
+                          --disable-linux-perf
+              )
   if(CPU MATCHES arm64)
-    list(APPEND ffmpeg_conf --cpu=cortex-a53 --arch=aarch64)
+    set(CONFIGARCH --arch=aarch64)
+    list(APPEND ffmpeg_conf --cpu=cortex-a53)
   elseif(CPU MATCHES arm)
     list(APPEND ffmpeg_conf --cpu=cortex-a9)
   elseif(CPU MATCHES x86_64)
-    list(APPEND ffmpeg_conf --cpu=x86_64 --enable-pic)
+    list(APPEND ffmpeg_conf --cpu=x86_64)
   else()
     list(APPEND ffmpeg_conf --cpu=i686 --disable-mmx)
   endif()
-  list(APPEND ffmpeg_conf --target-os=linux --extra-libs=-liconv --disable-linux-perf)
 elseif(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
-  list(APPEND ffmpeg_conf --disable-crystalhd --enable-videotoolbox 
-                          --target-os=darwin)
-elseif(CORE_SYSTEM_NAME STREQUAL osx)
-  list(APPEND ffmpeg_conf --disable-crystalhd --enable-videotoolbox
+  list(APPEND ffmpeg_conf --disable-crystalhd
+                          --enable-videotoolbox
                           --target-os=darwin
-                          --disable-securetransport)
+                          --disable-securetransport
+              )
+elseif(CORE_SYSTEM_NAME STREQUAL osx)
+  list(APPEND ffmpeg_conf --disable-crystalhd
+                          --enable-videotoolbox
+                          --target-os=darwin
+              )
 endif()
 
 if(CPU MATCHES arm)
-  list(APPEND ffmpeg_conf --enable-pic --disable-armv5te --disable-armv6t2)
+  list(APPEND ffmpeg_conf --disable-armv5te --disable-armv6t2)
 elseif(CPU MATCHES mips)
   list(APPEND ffmpeg_conf --disable-mips32r2 --disable-mipsdsp --disable-mipsdspr2)
 endif()
 
-find_package(GnuTls)
+find_package(GnuTLS)
 if(GNUTLS_FOUND)
   list(APPEND ffmpeg_conf --enable-gnutls)
+endif()
+
+if(CPU MATCHES x86 OR CPU MATCHES x86_64)
+  find_package(NASM REQUIRED)
+  list(APPEND ffmpeg_conf --x86asmexe=${NASM_EXECUTABLE})
 endif()
 
 if(ENABLE_DAV1D)
@@ -91,6 +125,8 @@ endif()
 if(EXTRA_FLAGS)
   list(APPEND ffmpeg_conf ${EXTRA_FLAGS})
 endif()
+
+list(APPEND ffmpeg_conf ${CONFIGARCH})
 
 message(STATUS "FFMPEG_CONF: ${ffmpeg_conf}")
 
@@ -110,13 +146,6 @@ externalproject_add(ffmpeg
                     CONFIGURE_COMMAND ${pkgconf} ${pkgconf_path} <SOURCE_DIR>/configure
                       --prefix=${CMAKE_INSTALL_PREFIX}
                       --extra-version="kodi-${FFMPEG_VER}"
-                      --disable-devices
-                      --disable-doc
-                      --disable-programs
-                      --enable-gpl
-                      --enable-runtime-cpudetect
-                      --enable-postproc
-                      --enable-pthreads
                       ${ffmpeg_conf}
                     BUILD_COMMAND ${MAKE_COMMAND})
 


### PR DESCRIPTION
## Description
Bit of a refresher of the FindFFMPEG module.
Refresh of the actual Cmake build script as well to enable usage on osx (tested crosscompile x86_64 target from aarch64 host) at least. Should function fine for android/darwinembedded

## Motivation and context
Brings FFMPEG inline with other findmodules with the format

```
if (ENABLE_INTERNAL_MODULE)
   <do internal setup>
else ()
  <find package calls>
endif()

find_package_handle_standard_args

if (MODULE_FOUND)
  <set include/libs>
endif()
```

Cleanup some superfluous unsetting of version vars
Fixup an unushed block regarding FFMPEG_LIBRARIES where it wasnt set before a foreach loop acting on it.

~~Of note, one thing that is different is there is no longer a fallback to internal ffmpeg if the find libs calls fail.
I think this is acceptable for now, as what im envisioning is to pull the internal build segments out into their own function/build file, which would then allow us to call on failure again if needed.~~

Fallback is handled

## How has this been tested?
Linux system ffmpeg, enable_internal_ffmpeg
osx configure and build enable_internal_ffmpeg 

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
