### PR TITLE
[Subtitles][Libass] Check if folders exists

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -103,14 +103,19 @@ void CDVDSubtitlesLibass::Configure()
   // Load additional fonts into Libass memory
   CFileItemList items;
   // Get fonts from system directory
-  XFILE::CDirectory::GetDirectory(UTILS::FONT::FONTPATH::SYSTEM, items,
-                                  UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
-                                  XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  if (XFILE::CDirectory::Exists(UTILS::FONT::FONTPATH::SYSTEM))
+  {
+    XFILE::CDirectory::GetDirectory(UTILS::FONT::FONTPATH::SYSTEM, items,
+                                    UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+                                    XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  }
   // Get temporary fonts
-  XFILE::CDirectory::GetDirectory(
-      UTILS::FONT::FONTPATH::TEMP, items, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
-      XFILE::DIR_FLAG_BYPASS_CACHE | XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
-
+  if (XFILE::CDirectory::Exists(UTILS::FONT::FONTPATH::SYSTEM, false))
+  {
+    XFILE::CDirectory::GetDirectory(
+        UTILS::FONT::FONTPATH::TEMP, items, UTILS::FONT::SUPPORTED_EXTENSIONS_MASK,
+        XFILE::DIR_FLAG_BYPASS_CACHE | XFILE::DIR_FLAG_NO_FILE_DIRS | XFILE::DIR_FLAG_NO_FILE_INFO);
+  }
   for (const auto& item : items)
   {
     if (item->m_bIsFolder)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Check if folders exists before call `GetDirectory` to avoid print misleading errors in log

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Errors like these are printed when a folder not exists and users always think of a Kodi bug
```
2022-02-28 19:48:18.103 T:3112    ERROR <general>: XFILE::CDirectory::GetDirectory - Error getting D:\KodiPortable_Builded_20\portable_data\cache\fonts\
2022-02-28 19:48:18.103 T:3112    ERROR <general>: XFILE::CDirectory::GetDirectory - Error getting special://temp/fonts/
```
(intended that these folders are optional)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
