### PR TITLE
[PVR] Allow backend to change channel hidden flag after creation if user hasn't via the GUI

### DIFF
--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -64,7 +64,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 39; }
+    int GetSchemaVersion() const override { return 40; }
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -202,11 +202,13 @@ bool CPVRChannel::UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel)
 
   UpdateEncryptionName();
 
-  // only update the channel name and icon if the user hasn't changed them manually
+  // only update the channel name, icon, and hidden flag if the user hasn't changed them manually
   if (m_strChannelName.empty() || !IsUserSetName())
     SetChannelName(channel->ClientChannelName());
   if (IconPath().empty() || !IsUserSetIcon())
     SetIconPath(channel->ClientIconPath());
+  if (!IsUserSetHidden())
+    SetHidden(channel->IsHidden());
 
   return m_bChanged;
 }
@@ -253,13 +255,14 @@ bool CPVRChannel::SetChannelID(int iChannelId)
   return false;
 }
 
-bool CPVRChannel::SetHidden(bool bIsHidden)
+bool CPVRChannel::SetHidden(bool bIsHidden, bool bIsUserSetHidden /*= false*/)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (m_bIsHidden != bIsHidden)
   {
     m_bIsHidden = bIsHidden;
+    m_bIsUserSetHidden = bIsUserSetHidden;
 
     if (m_epg)
       m_epg->GetChannelData()->SetHidden(m_bIsHidden);
@@ -704,6 +707,12 @@ bool CPVRChannel::IsUserSetName() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bIsUserSetName;
+}
+
+bool CPVRChannel::IsUserSetHidden() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_bIsUserSetHidden;
 }
 
 std::string CPVRChannel::ChannelName() const

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -106,9 +106,10 @@ namespace PVR
      * Set to true to hide this channel. Set to false to unhide it.
      * The EPG of hidden channels won't be updated.
      * @param bIsHidden The new setting.
+     * @param bIsUserSetIcon true if user changed the hidden flag via GUI, false otherwise.
      * @return True if the something changed, false otherwise.
      */
-    bool SetHidden(bool bIsHidden);
+    bool SetHidden(bool bIsHidden, bool bIsUserSetHidden = false);
 
     /*!
      * @return True if this channel is locked. False if not.
@@ -168,6 +169,11 @@ namespace PVR
      * @return whether the user has changed the channel name through the GUI
      */
     bool IsUserSetName() const;
+
+    /*!
+     * @return True if user changed the hidden flag via GUI, False if not
+     */
+    bool IsUserSetHidden() const;
 
     /*!
      * @brief Set the path to the icon for this channel.
@@ -494,6 +500,7 @@ namespace PVR
     bool m_bIsHidden = false; /*!< true if this channel is hidden, false if not */
     bool m_bIsUserSetName = false; /*!< true if user set the channel name via GUI, false if not */
     bool m_bIsUserSetIcon = false; /*!< true if user set the icon via GUI, false if not */
+    bool m_bIsUserSetHidden = false; /*!< true if user set the hidden flag via GUI, false if not */
     bool m_bIsLocked = false; /*!< true if channel is locked, false if not */
     CPVRCachedImage m_iconPath; /*!< the path to the icon for this channel */
     std::string m_strChannelName; /*!< the name for this channel used by XBMC */

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1102,7 +1102,8 @@ bool CPVRChannelGroup::UpdateChannel(const std::pair<int, int>& storageId,
                                      bool bHidden,
                                      bool bEPGEnabled,
                                      bool bParentalLocked,
-                                     bool bUserSetIcon)
+                                     bool bUserSetIcon,
+                                     bool bUserSetHidden)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -1112,7 +1113,7 @@ bool CPVRChannelGroup::UpdateChannel(const std::pair<int, int>& storageId,
     return false;
 
   channel->SetChannelName(strChannelName, true);
-  channel->SetHidden(bHidden);
+  channel->SetHidden(bHidden, bUserSetHidden);
   channel->SetLocked(bParentalLocked);
   channel->SetIconPath(strIconPath, bUserSetIcon);
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -390,6 +390,7 @@ namespace PVR
      * @param bEPGEnabled Set/Remove EPG enabled flag for the channel group member identified by storage id.
      * @param bParentalLocked Set/Remove parental locked flag for the channel group member identified by storage id.
      * @param bUserSetIcon Set/Remove user set icon flag for the channel group member identified by storage id.
+     * @param bUserSetHidden Set/Remove user set hidden flag for the channel group member identified by storage id.
      * @return True on success, false otherwise.
      */
     bool UpdateChannel(const std::pair<int, int>& storageId,
@@ -400,7 +401,8 @@ namespace PVR
                        bool bHidden,
                        bool bEPGEnabled,
                        bool bParentalLocked,
-                       bool bUserSetIcon);
+                       bool bUserSetIcon,
+                       bool bUserSetHidden);
 
     /*!
      * @brief Get a channel given the channel number on the client.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -191,7 +191,7 @@ bool CPVRChannelGroupInternal::AppendToGroup(const std::shared_ptr<CPVRChannel>&
   if (!groupMember)
     return false;
 
-  channel->SetHidden(false);
+  channel->SetHidden(false, true);
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -210,7 +210,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const std::shared_ptr<CPVRChannel
   if (!IsGroupMember(channel))
     return false;
 
-  channel->SetHidden(true);
+  channel->SetHidden(true, true);
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -69,6 +69,7 @@ constexpr const char* LABEL_CHANNEL_DISABLED = "0";
 // Note: strings must not be changed; they are part of the public skinning API for this dialog.
 constexpr const char* PROPERTY_CHANNEL_NUMBER = "Number";
 constexpr const char* PROPERTY_CHANNEL_ENABLED = "ActiveChannel";
+constexpr const char* PROPERTY_CHANNEL_USER_SET_HIDDEN = "UserSetHidden";
 constexpr const char* PROPERTY_CHANNEL_LOCKED = "ParentalLocked";
 constexpr const char* PROPERTY_CHANNEL_ICON = "Icon";
 constexpr const char* PROPERTY_CHANNEL_CUSTOM_ICON = "UserSetIcon";
@@ -317,6 +318,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioActive(CGUIMessage& message)
       if (pItem->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean() != selected)
       {
         pItem->SetProperty(PROPERTY_CHANNEL_ENABLED, selected);
+        pItem->SetProperty(PROPERTY_CHANNEL_USER_SET_HIDDEN, true);
         SetItemChanged(pItem);
         Renumber();
       }
@@ -817,6 +819,7 @@ void CGUIDialogPVRChannelManager::Update()
     const std::shared_ptr<CPVRChannel> channel(channelFile->GetPVRChannelInfoTag());
 
     channelFile->SetProperty(PROPERTY_CHANNEL_ENABLED, !channel->IsHidden());
+    channelFile->SetProperty(PROPERTY_CHANNEL_USER_SET_HIDDEN, channel->IsUserSetHidden());
     channelFile->SetProperty(PROPERTY_CHANNEL_NAME, channel->ChannelName());
     channelFile->SetProperty(PROPERTY_CHANNEL_EPG_ENABLED, channel->EPGEnabled());
     channelFile->SetProperty(PROPERTY_CHANNEL_ICON, channel->ClientIconPath());
@@ -938,7 +941,8 @@ bool CGUIDialogPVRChannelManager::PersistChannel(const CFileItemPtr& pItem,
       !pItem->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean(), // hidden
       pItem->GetProperty(PROPERTY_CHANNEL_EPG_ENABLED).asBoolean(),
       pItem->GetProperty(PROPERTY_CHANNEL_LOCKED).asBoolean(),
-      pItem->GetProperty(PROPERTY_CHANNEL_CUSTOM_ICON).asBoolean());
+      pItem->GetProperty(PROPERTY_CHANNEL_CUSTOM_ICON).asBoolean(),
+      pItem->GetProperty(PROPERTY_CHANNEL_USER_SET_HIDDEN).asBoolean());
 }
 
 void CGUIDialogPVRChannelManager::PromptAndSaveList()
@@ -1028,6 +1032,8 @@ bool IsItemChanged(const std::shared_ptr<CFileItem>& item)
   const std::shared_ptr<CPVRChannel> channel = member->Channel();
 
   return item->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean() == channel->IsHidden() ||
+         item->GetProperty(PROPERTY_CHANNEL_USER_SET_HIDDEN).asBoolean() !=
+             channel->IsUserSetHidden() ||
          item->GetProperty(PROPERTY_CHANNEL_NAME).asString() != channel->ChannelName() ||
          item->GetProperty(PROPERTY_CHANNEL_EPG_ENABLED).asBoolean() != channel->EPGEnabled() ||
          item->GetProperty(PROPERTY_CHANNEL_ICON).asString() != channel->ClientIconPath() ||


### PR DESCRIPTION
## Description
Attempts to address Issue https://github.com/xbmc/xbmc/issues/21039 ([PVR] Channel hidden attribute changes from backend not obeyed/persisted)

This PR adds a database field to track if the user has changed the Hidden flag of a PVR channel via the PVR Channel Manager or PVR Group Manager or if the associated PVR backend has requested this change, giving priority to any existing user changes that may have been made.  Prior to the PR, Kodi would only track/persist the initial Hidden flag of the channel imported from the backend when the channel was created and ignore any subsequent requested changes by the backend.

**NOTE:** In testing I found an unrelated concern with channels that were originally flagged as Hidden by the backend when they were first imported; if the user subsequently enables such a channel, that channel will have no EPG data unless they also go into the PVR Channel Manager and toggle "Active Guide".  This is an unintuitive behavior to me, but I feel should be treated as a separate concern and is not trying to be addressed here.  This PR cannot be backported to Matrix baseline due to the database, but a future PR to deal with this could probably be backported.

## Motivation and context
I ran into a problem with my PVR addon/backend [pvr.hdhomerundvr](https://github.com/djp952/pvr.hdhomerundvr) that was caused by trying to exclude channels from the lineup via a setting. I thought marking these channels as Hidden in Kodi instead of excluding them might be a better way forward and would simplify the required code but noted Issue https://github.com/xbmc/xbmc/issues/21039 while going down that path.

## How has this been tested?
I performed as much testing as I could think of here, including root cause analysis of the aforementioned unrelated concern on Windows 11 x64 (Desktop).  More specifically:

> In-place upgrade of a TV39 database to TV40 as well as a new TV40 database (pass)
> Test that all channels previous marked as Hidden remain that way during an upgrade (pass)
> Test that the PVR backend can successfully change the Hidden status of an otherwise untouched channel (pass)
> Test that if the user has altered the Hidden flag of a channel, nothing the PVR backend tries to do changes this flag (pass)

During testing, I noted that an assumption should be made that the user was responsible for marking any given channel as hidden as opposed to assuming the backend marked it as such.  Only a few (official) PVR backends may ever set this flag to true, I felt that erring on the side of the user with the **"UPDATE channels SET bIsUserSetHidden = bIsHidden"** was the best way forward here.  If the channel was Hidden, and the PVR backend can't change that flag; it seems pretty safe to assume the user did it; yes?

## What is the effect on users?
I don't anticipate any direct effect on users as the PR errs on the side of caution to obey anything they may have already set in favor of anything the PVR backend is trying to change.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
