### PR TITLE
[Estuary] Show slider nib when player is paused

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -88,7 +88,7 @@
 				<textureslidernib colordiffuse="button_focus">osd/progress/nub_bar.png</textureslidernib>
 				<textureslidernibfocus colordiffuse="button_focus">colors/white.png</textureslidernibfocus>
 				<info>Player.Seekbar</info>
-				<visible>!VideoPlayer.Content(LiveTV) + [Player.Seeking | Player.DisplayAfterSeek]</visible>
+				<visible>!VideoPlayer.Content(LiveTV) + [Player.Seeking | Player.DisplayAfterSeek | Player.Paused]</visible>
 			</control>
 			<control type="group">
 				<visible>VideoPlayer.Content(LiveTV)</visible>


### PR DESCRIPTION
## Description
When the player is paused the top seekbar is shown in Estuary (for 5 secs). While it presents the "Paused" label and the correct playback time, the slider nib is not visible which makes it not clear where we are in the video timeline (the "seekbar" also includes the cache buffer).
This makes the nib visible if player is paused.

## Motivation and context
UX

## How has this been tested?
Runtime tested

## What is the effect on users?
The slider nib should be shown in the estuary top overlay when the player is paused.

