### PR TITLE
[Estuary][PVR] Show nib when paused in PVR

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -125,7 +125,7 @@
 				<textureslidernib colordiffuse="button_focus">osd/progress/nub_bar.png</textureslidernib>
 				<textureslidernibfocus colordiffuse="button_focus">colors/white.png</textureslidernibfocus>
 				<info>PVR.TimeShiftSeekbar</info>
-				<visible>VideoPlayer.Content(LiveTV) + [Player.Seeking | Player.DisplayAfterSeek] + !Player.ChannelPreviewActive</visible>
+				<visible>VideoPlayer.Content(LiveTV) + [Player.Seeking | Player.DisplayAfterSeek | Player.Paused] + !Player.ChannelPreviewActive</visible>
 			</control>
 			<control type="ranges">
 				<left>0</left>


### PR DESCRIPTION
## Description
Identical to https://github.com/xbmc/xbmc/pull/21053 this PR makes the nib visible in the topoverlay when the player is paused in Live TV/PVR.
Requested by @ksooo 