### PR TITLE
[Estuary] Show Menu help label when menu button is focused

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -266,6 +266,7 @@
 		<value condition="Control.HasFocus(87) + [Player.Paused + Window.IsVisible(videoosd)]">$LOCALIZE[31055]</value>
 		<value condition="Control.HasFocus(608)+ PVR.IsRecordingPlayingChannel">$LOCALIZE[19059]</value>
 		<value condition="Control.HasFocus(608)">$LOCALIZE[264]</value>
+		<value condition="Control.HasFocus(804)">$LOCALIZE[33061]</value>
 		<value condition="Control.HasFocus(70040)">$LOCALIZE[19019]</value>
 		<value condition="Control.HasFocus(70041)">$LOCALIZE[19069]</value>
 		<value condition="Control.HasFocus(70042)">$LOCALIZE[31065]</value>


### PR DESCRIPTION
## Description
Daily estuary PR - this shows the menu "help" label when the menu button is focused in the video OSD. Somehow this was the only button that didn't show anything on the OSD, when I started investigating the optical disk implementation I wondered what the "home button" would do :)

Usually it's a good practice to change the strings.po file with actual string uses but since this is used only by the skin I don't think we need to add anything there (not used within the core).

![Screenshot from 2022-03-03 20-59-46](https://user-images.githubusercontent.com/7375276/156652139-c2bd6eb3-bcef-4b72-a82d-fb6ac8ad2396.png)

