### PR TITLE
[Subtitles][subrip] Handle HTML color names

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.h
@@ -8,8 +8,11 @@
 
 #pragma once
 
+#include "utils/ColorUtils.h"
+
 #include <stdio.h>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define FLAG_BOLD 0
@@ -58,7 +61,11 @@ public:
   std::vector<SLangclass> m_Langclass;
 
 private:
+  void LoadColors();
+
   CRegExp* m_tags;
   CRegExp* m_tagOptions;
   bool m_flag[6];
+  bool m_CSSColorsLoaded{false};
+  std::vector<std::pair<std::string, UTILS::COLOR::ColorInfo>> m_CSSColors;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add the support to handle HTML colors names instead of hex values only as it should be for SubRip

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An user has reported problems with subtitle colors:
https://github.com/rbuehlma/pvr.zattoo/issues/140
investigating to possible causes i found that i forgot to implement colour handling by name which i should have done later after other implementations.
This is now needed because before (the full subtitle rework) was delegated to GUI now no longer involved

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually edited a srt sub

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Show the right color

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
