### PR TITLE
[tools/depends][target] Use CMakeLists.txt for ffmpeg

### DIFF
--- a/cmake/modules/FindGnuTLS.cmake
+++ b/cmake/modules/FindGnuTLS.cmake
@@ -5,11 +5,14 @@
 # GNUTLS_INCLUDE_DIRS - the gnutls include directory
 # GNUTLS_LIBRARIES - The gnutls libraries
 
+# Suppress PkgConfig Mismatch warning, see https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html
+set(FPHSA_NAME_MISMATCHED 1)
 include(FindPkgConfig)
-find_package(PkgConfig)
+find_package(PkgConfig QUIET)
+unset(FPHSA_NAME_MISMATCHED)
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules (GNUTLS gnutls)
+  pkg_check_modules(GNUTLS gnutls QUIET)
 endif()
 
 if(NOT GNUTLS_FOUND)

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -83,19 +83,21 @@ elseif(CORE_SYSTEM_NAME STREQUAL android)
     list(APPEND ffmpeg_conf --cpu=cortex-a9)
   elseif(CPU MATCHES x86_64)
     list(APPEND ffmpeg_conf --cpu=x86_64)
+    list(APPEND ffmpeg_conf --extra-cflags=-mno-stackrealign)
   else()
     list(APPEND ffmpeg_conf --cpu=i686 --disable-mmx)
+    list(APPEND ffmpeg_conf --extra-cflags=-mno-stackrealign)
   endif()
 elseif(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
   list(APPEND ffmpeg_conf --disable-crystalhd
                           --enable-videotoolbox
                           --target-os=darwin
-                          --disable-securetransport
               )
 elseif(CORE_SYSTEM_NAME STREQUAL osx)
   list(APPEND ffmpeg_conf --disable-crystalhd
                           --enable-videotoolbox
                           --target-os=darwin
+                          --disable-securetransport
               )
 endif()
 
@@ -123,6 +125,7 @@ else()
 endif()
 
 if(EXTRA_FLAGS)
+  string(REPLACE " " ";" EXTRA_FLAGS ${EXTRA_FLAGS})
   list(APPEND ffmpeg_conf ${EXTRA_FLAGS})
 endif()
 

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -2,81 +2,34 @@ include ../../Makefile.include
 include FFMPEG-VERSION ../../download-files.include
 DEPS = ../../Makefile.include FFMPEG-VERSION Makefile ../../download-files.include
 
-export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
+BUILD_TYPE = Release
+ifeq ($(DEBUG_BUILD),yes)
+  BUILD_TYPE = Debug
+endif
 
-# configuration settings
-ffmpg_config = --prefix=$(PREFIX) --extra-version="kodi-$(VERSION)"
-ffmpg_config += --cc="$(CC)" --cxx="$(CXX)" --ar=$(AR) --ranlib=$(RANLIB) --strip=$(STRIP)
-ffmpg_config += --extra-cflags="$(CFLAGS)"
-ffmpg_config += --extra-cxxflags="$(CXXFLAGS)"
-ffmpg_config += --extra-ldflags="$(LDFLAGS)"
-ffmpg_config += --pkg-config=$(NATIVEPREFIX)/bin/pkg-config
+CMAKE_ARGS=-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+           -DCMAKE_MODULE_PATH=$(CMAKE_SOURCE_DIR)/cmake/modules \
+           -DPKG_CONFIG_PATH=$(PREFIX)/lib/pkgconfig \
+           -DCMAKE_INSTALL_PREFIX=$(PREFIX) \
+           -DFFMPEG_VER=$(VERSION) \
+           -DENABLE_DAV1D=ON \
+           -DEXTRA_FLAGS="$(FFMPEG_CONFIGURE_OPTIONS)"
 
-ffmpg_config += --disable-doc
-ffmpg_config += --disable-devices
-ffmpg_config += --disable-programs
-ffmpg_config += --disable-sdl2
-ffmpg_config += --enable-gpl
-ffmpg_config += --enable-postproc
-ffmpg_config += --enable-runtime-cpudetect
-ffmpg_config += --enable-pthreads
-ffmpg_config += --enable-gnutls
-ffmpg_config += --enable-libdav1d
-ffmpg_config += $(FFMPEG_CONFIGURE_OPTIONS)
-
-CONFIGARCH= --arch=$(CPU)
+ifeq ($(USE_CCACHE), yes)
+  CMAKE_ARGS+= -DENABLE_CCACHE=$(USE_CCACHE) \
+               -DCCACHE_PROGRAM=$(CCACHE)
+endif
 
 ifeq ($(CROSS_COMPILING), yes)
-  ffmpg_config += --enable-cross-compile
-  ffmpg_config += --pkg-config-flags=--static
-  ffmpg_config += --enable-pic
-endif
-ifeq ($(OS), linux)
-  ffmpg_config += --target-os=$(OS)
-endif
-ifeq ($(OS), android)
-  ifeq ($(findstring arm64, $(CPU)), arm64)
-    ffmpg_config += --cpu=cortex-a53
-    CONFIGARCH= --arch=aarch64
-  else
-    ifeq ($(findstring arm, $(CPU)), arm)
-      ffmpg_config += --cpu=cortex-a9
-    else
-      ifeq ($(CPU), x86_64)
-        ffmpg_config += --cpu=$(CPU)
-      else
-        ffmpg_config += --cpu=i686 --disable-mmx
-      endif
-      ffmpg_config += --extra-cflags='-mno-stackrealign'
-    endif
-  endif
-  ffmpg_config += --target-os=$(OS) --extra-libs=-liconv
-endif
-ifeq ($(OS), darwin_embedded)
-  ffmpg_config += --disable-crystalhd --enable-videotoolbox
-  ffmpg_config += --target-os=darwin
-endif
-ifeq ($(OS), osx)
-  ffmpg_config += --disable-crystalhd --enable-videotoolbox
-  ffmpg_config += --target-os=darwin
-  ffmpg_config += --disable-securetransport
-endif
-ifeq ($(findstring arm, $(CPU)), arm)
-  ffmpg_config += --disable-armv5te --disable-armv6t2
-endif
-ifeq ($(findstring mips, $(CPU)), mips)
-  ffmpg_config += --disable-mips32r2 --disable-mipsdsp --disable-mipsdspr2
-endif
-ifeq ($(CPU),x86)
-  ffmpg_config += --x86asmexe=$(NATIVEPREFIX)/bin/nasm
-else ifeq ($(CPU),x86_64)
-  ffmpg_config += --x86asmexe=$(NATIVEPREFIX)/bin/nasm
-endif
-ifeq ($(Configuration), Release)
-  ffmpg_config += --disable-debug
+  CMAKE_ARGS+= -DPKG_CONFIG_EXECUTABLE=$(NATIVEPREFIX)/bin/pkg-config \
+               -DCROSSCOMPILING=$(CROSS_COMPILING)
 endif
 
-ffmpg_config +=$(CONFIGARCH)
+ifeq ($(OS), android)
+  ifeq ($(findstring arm64, $(CPU)), arm64)
+  CMAKE_ARGS+= -DENABLE_NEON=YES
+  endif
+endif
 
 all: .installed-$(PLATFORM)
 
@@ -85,15 +38,17 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
+	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)/build
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM);	./configure $(ffmpg_config)
+	cd $(PLATFORM); cp ../CMakeLists.txt ./
+	cd $(PLATFORM)/build; $(CMAKE) $(CMAKE_ARGS) ..
 
 .build-$(PLATFORM): $(PLATFORM)
-	$(MAKE) -C $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/build
 	touch $@
 
 .installed-$(PLATFORM): .build-$(PLATFORM)
-	$(MAKE) -C $(PLATFORM) install
+	$(MAKE) -C $(PLATFORM)/build install
 	touch $@
 
 clean:


### PR DESCRIPTION
## Description
Use CMakelists.txt for ffmpeg build for tools/depends system. This is the same script when ENABLE_INTERNAL_FFMPEG is used in kodi cmake system

## Motivation and context
One less duplicated location for ffmpeg build.
More extensive testing via CI of the ffmpeg cmake script (prior only freebsd, now Apple/android/linux/freebsd)

## How has this been tested?
Build ios/osx ffmpeg. compare libs to previous tools/depends output

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
