### PR TITLE
[Discs] Get rid of get_vm hacks when getting active audio stream

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1000,24 +1000,8 @@ int CDVDInputStreamNavigator::GetActiveAudioStream()
 
   if (m_dvdnav)
   {
-    vm_t* vm = m_dll.dvdnav_get_vm(m_dvdnav);
-    if (vm && vm->state.pgc)
-    {
-      // get the current selected audiostream, for non VTS_DOMAIN it is always stream 0
-      int audioN = 0;
-      if (vm->state.domain == VTS_DOMAIN)
-      {
-        audioN = vm->state.AST_REG;
-
-        /* make sure stream is valid, if not don't allow it */
-        if (audioN < 0 || audioN >= 8)
-          audioN = -1;
-        else if ( !(vm->state.pgc->audio_control[audioN] & (1<<15)) )
-          audioN = -1;
-      }
-
-      activeStream = ConvertAudioStreamId_ExternalToXBMC(audioN);
-    }
+    int audioN = m_dll.dvdnav_get_active_audio_stream(m_dvdnav);
+    activeStream = ConvertAudioStreamId_ExternalToXBMC(audioN);
   }
 
   return activeStream;


### PR DESCRIPTION
## Description
We currently expose the internal dvd virtual machine in our patched version of libdvdnav [1] which is totally wrong and definitely won't ever be accepted upstream. We seem to do this to access some functionality that is not exposed from dvdnav (e.g. get subtitles count, get audio stream count, etc) - they might be exposed in dvdread or accessed via other hacks. I've been trying to slowly understand why we need some of the patches and figuring out alternatives for them while submitting what we miss/need upstream when we can't do it in another way (see [2]).

Not sure why we were using the vm in this case, most likely the implementation is too old and dvdnav didn't include a way of getting the active audio stream index in the past but this is no longer the case (`dvdnav_get_active_audio_stream` is available so just use that instead). 
Runtime tested, confirmed the returned values are exactly equal regardless of the position (menu, main title, etc).

Refs
[1]: https://github.com/xbmc/libdvdnav/commit/8305696be79fe650d3d9eee29b2a88e020d7c58f
[2]: https://code.videolan.org/videolan/libdvdnav/-/merge_requests/32

## Motivation and context
Cleanup/remove dvd/discs hacks