### PR TITLE
[Discs] Use free instead of dvdnav_free when using dvdnav_describe_ti…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -532,7 +532,7 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
             {
               m_mapTitleChapters[m_iTitle][i + 2] = times[i] / 90000;
             }
-            m_dll.dvdnav_free(times);
+            free(times);
           }
         }
         CLog::Log(LOGDEBUG, "{} - Cell change: Title {}, Chapter {}", __FUNCTION__, m_iTitle,


### PR DESCRIPTION
…tle_chapters

## Description
In our patched version of libdvdnav we are exposing `libdvdnav_free`. Searching for its use it comes down to a single usage: a call to `dvdnav_describe_title_chapters`. Libdvdnav docs states the following:

```
/*
 * Stores in *times an array (that the application *must* free) of
 * dvdtimes corresponding to the chapter times for the chosen title.
 * *duration will have the duration of the title
 * The number of entries in *times is the result of the function.
 * On error *times is NULL and the output is 0
 */
```
the times array should be freed by the application after use.

dvdnav already frees the temporary copy of times (see https://code.videolan.org/videolan/libdvdnav/-/blob/master/src/searching.c#L758-759) and times is a simple array. There's no need to call `dvdnav_free` which is not even exposed outside. Just use C library `free` instead. This allows us to remove the patch in the future. 