### PR TITLE
add new constexpr map class

### DIFF
--- a/xbmc/platform/linux/threads/ThreadImplLinux.cpp
+++ b/xbmc/platform/linux/threads/ThreadImplLinux.cpp
@@ -8,6 +8,7 @@
 
 #include "ThreadImplLinux.h"
 
+#include "utils/Map.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -26,23 +27,20 @@
 namespace
 {
 
-constexpr std::array<ThreadPriorityStruct, 5> nativeThreadPriorityMap = {{
+constexpr auto nativeThreadPriorityMap = make_map<ThreadPriority, int>({
     {ThreadPriority::LOWEST, -1},
     {ThreadPriority::BELOW_NORMAL, -1},
     {ThreadPriority::NORMAL, 0},
     {ThreadPriority::ABOVE_NORMAL, 1},
     {ThreadPriority::HIGHEST, 1},
-}};
+});
 
-//! @todo: c++20 has constexpr std::find_if
-int ThreadPriorityToNativePriority(const ThreadPriority& priority)
+constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
 {
-  auto it = std::find_if(nativeThreadPriorityMap.cbegin(), nativeThreadPriorityMap.cend(),
-                         [&priority](const auto& map) { return map.priority == priority; });
-
+  const auto it = nativeThreadPriorityMap.find(priority);
   if (it != nativeThreadPriorityMap.cend())
   {
-    return it->nativePriority;
+    return it->second;
   }
 
   throw std::runtime_error("priority not implemented");

--- a/xbmc/platform/linux/threads/ThreadImplLinux.cpp
+++ b/xbmc/platform/linux/threads/ThreadImplLinux.cpp
@@ -35,6 +35,10 @@ constexpr auto nativeThreadPriorityMap = make_map<ThreadPriority, int>({
     {ThreadPriority::HIGHEST, 1},
 });
 
+static_assert(static_cast<size_t>(ThreadPriority::PRIORITY_COUNT) == nativeThreadPriorityMap.size(),
+              "nativeThreadPriorityMap doesn't match the size of ThreadPriority, did you forget to "
+              "add/remove a mapping?");
+
 constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
 {
   const auto it = nativeThreadPriorityMap.find(priority);

--- a/xbmc/platform/linux/threads/ThreadImplLinux.cpp
+++ b/xbmc/platform/linux/threads/ThreadImplLinux.cpp
@@ -46,8 +46,10 @@ constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
   {
     return it->second;
   }
-
-  throw std::runtime_error("priority not implemented");
+  else
+  {
+    throw std::range_error("Priority not found");
+  }
 }
 
 #if !defined(TARGET_ANDROID) && (defined(__GLIBC__) || defined(__UCLIBC__))

--- a/xbmc/platform/win32/threads/ThreadImplWin.cpp
+++ b/xbmc/platform/win32/threads/ThreadImplWin.cpp
@@ -8,6 +8,7 @@
 
 #include "ThreadImplWin.h"
 
+#include "utils/Map.h"
 #include "utils/log.h"
 
 #include "platform/win32/WIN32Util.h"
@@ -21,23 +22,20 @@
 namespace
 {
 
-constexpr std::array<ThreadPriorityStruct, 5> nativeThreadPriorityMap = {{
+constexpr auto nativeThreadPriorityMap = make_map<ThreadPriority, int>({
     {ThreadPriority::LOWEST, THREAD_PRIORITY_IDLE},
     {ThreadPriority::BELOW_NORMAL, THREAD_PRIORITY_BELOW_NORMAL},
     {ThreadPriority::NORMAL, THREAD_PRIORITY_NORMAL},
     {ThreadPriority::ABOVE_NORMAL, THREAD_PRIORITY_ABOVE_NORMAL},
     {ThreadPriority::HIGHEST, THREAD_PRIORITY_HIGHEST},
-}};
+});
 
-//! @todo: c++20 has constexpr std::find_if
-int ThreadPriorityToNativePriority(const ThreadPriority& priority)
+constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
 {
-  auto it = std::find_if(nativeThreadPriorityMap.cbegin(), nativeThreadPriorityMap.cend(),
-                         [&priority](const auto& map) { return map.priority == priority; });
-
+  const auto it = nativeThreadPriorityMap.find(priority);
   if (it != nativeThreadPriorityMap.cend())
   {
-    return it->nativePriority;
+    return it->second;
   }
 
   throw std::runtime_error("priority not implemented");

--- a/xbmc/platform/win32/threads/ThreadImplWin.cpp
+++ b/xbmc/platform/win32/threads/ThreadImplWin.cpp
@@ -30,6 +30,10 @@ constexpr auto nativeThreadPriorityMap = make_map<ThreadPriority, int>({
     {ThreadPriority::HIGHEST, THREAD_PRIORITY_HIGHEST},
 });
 
+static_assert(static_cast<size_t>(ThreadPriority::PRIORITY_COUNT) == nativeThreadPriorityMap.size(),
+              "nativeThreadPriorityMap doesn't match the size of ThreadPriority, did you forget to "
+              "add/remove a mapping?");
+
 constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
 {
   const auto it = nativeThreadPriorityMap.find(priority);

--- a/xbmc/platform/win32/threads/ThreadImplWin.cpp
+++ b/xbmc/platform/win32/threads/ThreadImplWin.cpp
@@ -41,8 +41,10 @@ constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
   {
     return it->second;
   }
-
-  throw std::runtime_error("priority not implemented");
+  else
+  {
+    throw std::range_error("Priority not found");
+  }
 }
 
 } // namespace

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -30,6 +30,13 @@ enum class ThreadPriority
   NORMAL,
   ABOVE_NORMAL,
   HIGHEST,
+
+  /*!
+   * \brief Do not use this for priority. It is only needed to count the
+   *        amount of values in the ThreadPriority enum.
+   *
+   */
+  PRIORITY_COUNT,
 };
 
 class IRunnable;

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -32,12 +32,6 @@ enum class ThreadPriority
   HIGHEST,
 };
 
-struct ThreadPriorityStruct
-{
-  ThreadPriority priority;
-  int nativePriority;
-};
-
 class IRunnable;
 class IThreadImpl;
 class CThread

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -134,6 +134,7 @@ set(HEADERS ActorProtocol.h
             Locale.h
             log.h
             logtypes.h
+            Map.h
             MathUtils.h
             MemUtils.h
             Mime.h

--- a/xbmc/utils/Map.h
+++ b/xbmc/utils/Map.h
@@ -1,0 +1,102 @@
+
+/*
+ *  Copyright (C) 2005-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+
+/*!
+ * \brief This class is designed to implement a constexpr version of std::map.
+ *        The standard library std::map doesn't allow constexpr (and it
+ *        doesn't look like it will be implemented in the future). This class
+ *        utilizes std::array and std::pair as they allow constexpr.
+ *
+ *        When using this class you should use the helper make_map instead of
+ *        constructing this class directly. For example:
+ *        constexpr auto myMap = make_map<int, std::string_view>({{1, "one"}});
+ *
+ *        This class is useful for mapping enum values to strings that can be
+ *        compile time checked. This also helps with heap usage.
+ *
+ *        Lookups have linear complexity, so should not be used for "big" maps.
+ */
+template<typename Key, typename Value, size_t Size>
+class CMap
+{
+public:
+  template<typename Iterable>
+  constexpr CMap(Iterable begin, Iterable end)
+  {
+    size_t index = 0;
+    while (begin != end)
+    {
+      // c++17 doesn't have constexpr assignment operator for std::pair
+      auto& first = m_map[index].first;
+      auto& second = m_map[index].second;
+      ++index;
+
+      first = std::move(begin->first);
+      second = std::move(begin->second);
+      ++begin;
+
+      //! @todo: c++20 can use constexpr assignment operator instead
+      // auto& p = data[index];
+      // ++index;
+
+      // p = std::move(*begin);
+      // ++begin;
+      //
+    }
+  }
+
+  ~CMap() = default;
+
+  constexpr const Value& at(const Key& key) const
+  {
+    const auto it = find(key);
+    if (it != m_map.cend())
+    {
+      return it->second;
+    }
+    else
+    {
+      throw std::range_error("Not Found");
+    }
+  }
+
+  constexpr auto find(const Key& key) const
+  {
+    return std::find_if(m_map.cbegin(), m_map.cend(),
+                        [&key](const auto& pair) { return pair.first == key; });
+  }
+
+  constexpr size_t size() const { return Size; }
+
+  constexpr auto cbegin() const { return m_map.cbegin(); }
+  constexpr auto cend() const { return m_map.cend(); }
+
+private:
+  CMap() = delete;
+
+  std::array<std::pair<Key, Value>, Size> m_map;
+};
+
+/*!
+ * \brief Use this helper when wanting to use CMap. This is needed to allow
+ *        deducing the size of the map from the initializer list without
+ *        needing to explicitly give the size of the map (similar to std::map).
+ *
+ */
+template<typename Key, typename Value, std::size_t Size>
+constexpr auto make_map(std::pair<Key, Value>(&&m)[Size]) -> CMap<Key, Value, Size>
+{
+  return CMap<Key, Value, Size>(std::begin(m), std::end(m));
+}


### PR DESCRIPTION
I've been working on this for a bit as a solution for mapping enum values to std::string_view.

There is no such thing as a `constexpr std::map` see [std::map](https://en.cppreference.com/w/cpp/container/map/map).

This PR adds a custom `CMap` class that can be used as a constexpr mapping. This is desired because it allows us to do compile time checks (and reduces heap usage AFAIK). With this we can compare the size of an enum and the size of the map at compile time and fail to build if it doesn't match. This is desired to avoid missing mappings when adding enum values in the future. This will also in the future allow for constexpr std::format checks (TBD).

Compile time check example:
```
xbmc/platform/posix/threads/ThreadImplPosix.cpp:42:67: error: static assertion failed: nativeThreadPriorityMap doesn't match the size of ThreadPriority, did you forget to add/remove a mapping?
   42 | static_assert(static_cast<size_t>(ThreadPriority::PRIORITY_COUNT) == nativeThreadPriorityMap.size(),
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The new `CMap` class generally isn't used directly but instead used via the `make_map<T1, T2>` helper. This is used to automatically determine the map size from the initializer list (similar to how `std::map` can be initialized). For example:
```
constexpr auto myMap = make_map<MyEnum, std::string_view>({
  {MyEnum::One, "one"},
  {MyEnum::Two, "two"},
});
```
I really like this pattern and am PRing it because I would like to use it for quite a few things (mainly mapping enums to strings for the purpose of human readable logging). I typically don't like adding custom classes that have stl alternatives but in this case I think this class is the best option.

I've added some doxygen for the new class to help understand it's usage further. I have also included a few commits to help show it's usage (along with some other minor commits).

Some things I would like some opinions on.
 - Is this a good pattern?
 - should I namespace the new class, if so what should it be?
   - `kodi::`
   - `utils::`
   - `custom::`
 - When adding an enum count, what naming convention should be used, I've used `_COUNT` but am open to opinions.
   - `NUMBER_OF_ITEMS`
   - `NUM_ITEMS`
   - `COUNT`
   - `MAX`

There is some further implementation here -> https://github.com/xbmc/xbmc/compare/xbmc:master...lrusak:enum-formatter