### PR TITLE
CVideoSettings: use ETONEMAPMETHOD instead of int

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1559,9 +1559,11 @@ bool CApplication::OnAction(const CAction &action)
     if (m_appPlayer.IsPlayingVideo())
     {
       CVideoSettings vs = m_appPlayer.GetVideoSettings();
-      vs.m_ToneMapMethod++;
+      vs.m_ToneMapMethod = static_cast<ETONEMAPMETHOD>(static_cast<int>(vs.m_ToneMapMethod) + 1);
       if (vs.m_ToneMapMethod >= VS_TONEMAPMETHOD_MAX)
-        vs.m_ToneMapMethod = VS_TONEMAPMETHOD_OFF + 1;
+        vs.m_ToneMapMethod =
+            static_cast<ETONEMAPMETHOD>(static_cast<int>(VS_TONEMAPMETHOD_OFF) + 1);
+
       m_appPlayer.SetVideoSettings(vs);
 
       int code = 0;
@@ -1576,6 +1578,8 @@ bool CApplication::OnAction(const CAction &action)
         case VS_TONEMAPMETHOD_HABLE:
           code = 36558;
           break;
+        default:
+          throw std::logic_error("Tonemapping method not found. Did you forget to add a mapping?");
       }
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(34224),
                                             g_localizeStrings.Get(code), 1000, false, 500);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -2718,7 +2718,7 @@ void CLinuxRendererGL::DeleteCLUT()
 void CLinuxRendererGL::CheckVideoParameters(int index)
 {
   CPictureBuffer &buf = m_buffers[index];
-  int method = m_videoSettings.m_ToneMapMethod;
+  ETONEMAPMETHOD method = m_videoSettings.m_ToneMapMethod;
 
   AVColorPrimaries srcPrim = GetSrcPrimaries(buf.m_srcPrimaries, buf.image.width, buf.image.height);
   if (srcPrim != m_srcPrimaries)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -216,7 +216,7 @@ protected:
   bool m_fullRange;
   AVColorPrimaries m_srcPrimaries;
   bool m_toneMap = false;
-  int m_toneMapMethod = 0;
+  ETONEMAPMETHOD m_toneMapMethod = VS_TONEMAPMETHOD_OFF;
   float m_clearColour = 0.0f;
   bool m_pboSupported = true;
   bool m_pboUsed = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -850,7 +850,7 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
   }
 
   bool toneMap = false;
-  int toneMapMethod = m_videoSettings.m_ToneMapMethod;
+  ETONEMAPMETHOD toneMapMethod = m_videoSettings.m_ToneMapMethod;
 
   if (!m_passthroughHDR && toneMapMethod != VS_TONEMAPMETHOD_OFF)
   {
@@ -985,7 +985,7 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field)
   }
 
   bool toneMap = false;
-  int toneMapMethod = m_videoSettings.m_ToneMapMethod;
+  ETONEMAPMETHOD toneMapMethod = m_videoSettings.m_ToneMapMethod;
 
   if (toneMapMethod != VS_TONEMAPMETHOD_OFF)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -202,7 +202,7 @@ protected:
   bool m_fullRange;
   AVColorPrimaries m_srcPrimaries;
   bool m_toneMap = false;
-  int m_toneMapMethod = 0;
+  ETONEMAPMETHOD m_toneMapMethod = VS_TONEMAPMETHOD_OFF;
   bool m_passthroughHDR = false;
   unsigned char* m_planeBuffer = nullptr;
   size_t m_planeBufferSize = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -285,8 +285,12 @@ void COutputShader::GetDefines(DefinesMap& map) const
   }
 }
 
-bool COutputShader::Create(
-    bool useLUT, bool useDithering, int ditherDepth, bool toneMapping, int toneMethod, bool HLGtoPQ)
+bool COutputShader::Create(bool useLUT,
+                           bool useDithering,
+                           int ditherDepth,
+                           bool toneMapping,
+                           ETONEMAPMETHOD toneMethod,
+                           bool HLGtoPQ)
 {
   m_useLut = useLUT;
   m_ditherDepth = ditherDepth;
@@ -355,7 +359,7 @@ void COutputShader::SetDisplayMetadata(bool hasDisplayMetadata, AVMasteringDispl
   m_lightMetadata = lightMetadata;
 }
 
-void COutputShader::SetToneMapParam(int method, float param)
+void COutputShader::SetToneMapParam(ETONEMAPMETHOD method, float param)
 {
   m_toneMappingMethod = method;
   m_toneMappingParam = param;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -62,7 +62,12 @@ public:
 
   void ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWidth, unsigned sourceHeight);
   void GetDefines(DefinesMap &map) const;
-  bool Create(bool useLUT, bool useDithering, int ditherDepth, bool toneMapping, int toneMethod, bool HLGtoPQ);
+  bool Create(bool useLUT,
+              bool useDithering,
+              int ditherDepth,
+              bool toneMapping,
+              ETONEMAPMETHOD toneMethod,
+              bool HLGtoPQ);
   void Render(CD3DTexture& sourceTexture, CRect sourceRect, const CPoint points[4]
             , CD3DTexture& target, unsigned range = 0, float contrast = 0.5f, float brightness = 0.5f);
   void Render(CD3DTexture& sourceTexture, CRect sourceRect, CRect destRect
@@ -70,7 +75,7 @@ public:
   void SetLUT(int lutSize, ID3D11ShaderResourceView *pLUTView);
   void SetDisplayMetadata(bool hasDisplayMetadata, AVMasteringDisplayMetadata displayMetadata,
                           bool hasLightMetadata, AVContentLightMetadata lightMetadata);
-  void SetToneMapParam(int method, float param);
+  void SetToneMapParam(ETONEMAPMETHOD method, float param);
   std::string GetDebugInfo();
 
   static bool CreateLUTView(int lutSize, uint16_t* lutData, bool isRGB, ID3D11ShaderResourceView** ppLUTView);
@@ -99,7 +104,7 @@ private:
   unsigned m_sourceHeight = 0;
   int m_lutSize = 0;
   int m_ditherDepth = 0;
-  int m_toneMappingMethod = 0;
+  ETONEMAPMETHOD m_toneMappingMethod = VS_TONEMAPMETHOD_OFF;
   float m_toneMappingParam = 1.0f;
   float m_toneMappingDebug = .0f;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -27,10 +27,13 @@ using namespace Shaders::GL;
 // BaseYUV2RGBGLSLShader - base class for GLSL YUV2RGB shaders
 //////////////////////////////////////////////////////////////////////
 
-BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect, EShaderFormat format, bool stretch,
-                                             AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries,
+BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect,
+                                             EShaderFormat format,
+                                             bool stretch,
+                                             AVColorPrimaries dstPrimaries,
+                                             AVColorPrimaries srcPrimaries,
                                              bool toneMap,
-                                             int toneMapMethod,
+                                             ETONEMAPMETHOD toneMapMethod,
                                              std::shared_ptr<GLSLOutput> output)
 {
   m_width = 1;
@@ -244,7 +247,7 @@ void BaseYUV2RGBGLSLShader::SetDisplayMetadata(bool hasDisplayMetadata, AVMaster
 }
 
 
-void BaseYUV2RGBGLSLShader::SetToneMapParam(int method, float param)
+void BaseYUV2RGBGLSLShader::SetToneMapParam(ETONEMAPMETHOD method, float param)
 {
   m_toneMappingMethod = method;
   m_toneMappingParam = param;
@@ -293,10 +296,16 @@ YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(bool rect,
                                                    AVColorPrimaries dstPrimaries,
                                                    AVColorPrimaries srcPrimaries,
                                                    bool toneMap,
-                                                   int toneMapMethod,
+                                                   ETONEMAPMETHOD toneMapMethod,
                                                    std::shared_ptr<GLSLOutput> output)
-  : BaseYUV2RGBGLSLShader(
-        rect, format, stretch, dstPrimaries, srcPrimaries, toneMap, toneMapMethod, std::move(output))
+  : BaseYUV2RGBGLSLShader(rect,
+                          format,
+                          stretch,
+                          dstPrimaries,
+                          srcPrimaries,
+                          toneMap,
+                          toneMapMethod,
+                          std::move(output))
 {
   PixelShader()->LoadSource("gl_yuv2rgb_basic.glsl", m_defines);
   PixelShader()->AppendSource("gl_output.glsl");
@@ -314,11 +323,17 @@ YUV2RGBFilterShader4::YUV2RGBFilterShader4(bool rect,
                                            AVColorPrimaries dstPrimaries,
                                            AVColorPrimaries srcPrimaries,
                                            bool toneMap,
-                                           int toneMapMethod,
+                                           ETONEMAPMETHOD toneMapMethod,
                                            ESCALINGMETHOD method,
                                            std::shared_ptr<GLSLOutput> output)
-  : BaseYUV2RGBGLSLShader(
-        rect, format, stretch, dstPrimaries, srcPrimaries, toneMap, toneMapMethod, std::move(output))
+  : BaseYUV2RGBGLSLShader(rect,
+                          format,
+                          stretch,
+                          dstPrimaries,
+                          srcPrimaries,
+                          toneMap,
+                          toneMapMethod,
+                          std::move(output))
 {
   m_scaling = method;
   PixelShader()->LoadSource("gl_yuv2rgb_filter4.glsl", m_defines);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -31,10 +31,13 @@ namespace GL
 class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
 {
 public:
-  BaseYUV2RGBGLSLShader(bool rect, EShaderFormat format, bool stretch,
-                        AVColorPrimaries dst, AVColorPrimaries src,
+  BaseYUV2RGBGLSLShader(bool rect,
+                        EShaderFormat format,
+                        bool stretch,
+                        AVColorPrimaries dst,
+                        AVColorPrimaries src,
                         bool toneMap,
-                        int toneMapMethod,
+                        ETONEMAPMETHOD toneMapMethod,
                         std::shared_ptr<GLSLOutput> output);
   ~BaseYUV2RGBGLSLShader() override;
 
@@ -48,7 +51,7 @@ public:
   void SetNonLinStretch(float stretch) { m_stretch = stretch; }
   void SetDisplayMetadata(bool hasDisplayMetadata, AVMasteringDisplayMetadata displayMetadata,
                           bool hasLightMetadata, AVContentLightMetadata lightMetadata);
-  void SetToneMapParam(int method, float param);
+  void SetToneMapParam(ETONEMAPMETHOD method, float param);
   float GetLuminanceValue() const;
 
   void SetConvertFullColorRange(bool convertFullRange) { m_convertFullRange = convertFullRange; }
@@ -78,7 +81,7 @@ protected:
   bool m_hasLightMetadata = false;
   AVContentLightMetadata m_lightMetadata;
   bool m_toneMapping = false;
-  int m_toneMappingMethod = VS_TONEMAPMETHOD_REINHARD;
+  ETONEMAPMETHOD m_toneMappingMethod = VS_TONEMAPMETHOD_REINHARD;
   float m_toneMappingParam = 1.0;
 
   bool m_colorConversion{false};
@@ -126,9 +129,10 @@ public:
   YUV2RGBProgressiveShader(bool rect,
                            EShaderFormat format,
                            bool stretch,
-                           AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries,
+                           AVColorPrimaries dstPrimaries,
+                           AVColorPrimaries srcPrimaries,
                            bool toneMap,
-                           int toneMapMethod,
+                           ETONEMAPMETHOD toneMapMethod,
                            std::shared_ptr<GLSLOutput> output);
 };
 
@@ -138,9 +142,10 @@ public:
   YUV2RGBFilterShader4(bool rect,
                        EShaderFormat format,
                        bool stretch,
-                       AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries,
+                       AVColorPrimaries dstPrimaries,
+                       AVColorPrimaries srcPrimaries,
                        bool toneMap,
-                       int toneMapMethod,
+                       ETONEMAPMETHOD toneMapMethod,
                        ESCALINGMETHOD method,
                        std::shared_ptr<GLSLOutput> output);
   ~YUV2RGBFilterShader4() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -27,7 +27,7 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
                                              AVColorPrimaries dstPrimaries,
                                              AVColorPrimaries srcPrimaries,
                                              bool toneMap,
-                                             int toneMapMethod)
+                                             ETONEMAPMETHOD toneMapMethod)
 {
   m_width = 1;
   m_height = 1;
@@ -249,7 +249,7 @@ YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(EShaderFormat format,
                                                    AVColorPrimaries dstPrimaries,
                                                    AVColorPrimaries srcPrimaries,
                                                    bool toneMap,
-                                                   int toneMapMethod)
+                                                   ETONEMAPMETHOD toneMapMethod)
   : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod)
 {
   PixelShader()->LoadSource("gles_yuv2rgb_basic.frag", m_defines);
@@ -265,7 +265,7 @@ YUV2RGBBobShader::YUV2RGBBobShader(EShaderFormat format,
                                    AVColorPrimaries dstPrimaries,
                                    AVColorPrimaries srcPrimaries,
                                    bool toneMap,
-                                   int toneMapMethod)
+                                   ETONEMAPMETHOD toneMapMethod)
   : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod)
 {
   m_hStepX = -1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -30,7 +30,7 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                           AVColorPrimaries dst,
                           AVColorPrimaries src,
                           bool toneMap,
-                          int toneMapMethod);
+                          ETONEMAPMETHOD toneMapMethod);
     ~BaseYUV2RGBGLSLShader() override;
     void SetField(int field) { m_field = field; }
     void SetWidth(int w) { m_width = w; }
@@ -68,7 +68,7 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
     bool m_hasLightMetadata{false};
     AVContentLightMetadata m_lightMetadata;
     bool m_toneMapping{false};
-    int m_toneMappingMethod{VS_TONEMAPMETHOD_REINHARD};
+    ETONEMAPMETHOD m_toneMappingMethod{VS_TONEMAPMETHOD_REINHARD};
     float m_toneMappingParam{1.0};
 
     bool m_colorConversion{false};
@@ -115,7 +115,7 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                              AVColorPrimaries dstPrimaries,
                              AVColorPrimaries srcPrimaries,
                              bool toneMap,
-                             int toneMapMethod);
+                             ETONEMAPMETHOD toneMapMethod);
   };
 
   class YUV2RGBBobShader : public BaseYUV2RGBGLSLShader
@@ -125,7 +125,7 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                      AVColorPrimaries dstPrimaries,
                      AVColorPrimaries srcPrimaries,
                      bool toneMap,
-                     int toneMapMethod);
+                     ETONEMAPMETHOD toneMapMethod);
     void OnCompiledAndLinked() override;
     bool OnEnabled() override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -210,8 +210,13 @@ void CRendererBase::AddVideoPicture(const VideoPicture& picture, int index)
   }
 }
 
-void CRendererBase::Render(int index, int index2, CD3DTexture& target, const CRect& sourceRect, 
-                           const CRect& destRect, const CRect& viewRect, unsigned flags)
+void CRendererBase::Render(int index,
+                           int index2,
+                           CD3DTexture& target,
+                           const CRect& sourceRect,
+                           const CRect& destRect,
+                           const CRect& viewRect,
+                           unsigned flags)
 {
   m_iBufferIndex = index;
   ManageTextures();
@@ -429,7 +434,7 @@ void CRendererBase::UpdateVideoFilters()
 void CRendererBase::CheckVideoParameters()
 {
   CRenderBuffer* buf = m_renderBuffers[m_iBufferIndex];
-  int method = m_videoSettings.m_ToneMapMethod;
+  ETONEMAPMETHOD method = m_videoSettings.m_ToneMapMethod;
 
   bool isHDRPQ = (buf->color_transfer == AVCOL_TRC_SMPTE2084 && buf->primaries == AVCOL_PRI_BT2020);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -161,7 +161,7 @@ protected:
   bool m_cmsOn = false;
   bool m_clutLoaded = false;
   bool m_useHLGtoPQ = false;
-  int m_toneMapMethod = 0;
+  ETONEMAPMETHOD m_toneMapMethod = VS_TONEMAPMETHOD_OFF;
 
   int m_iBufferIndex = 0;
   int m_iNumBuffers = 0;

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -112,7 +112,7 @@ public:
   int m_StereoMode;
   bool m_StereoInvert;
   int m_VideoStream;
-  int m_ToneMapMethod;
+  ETONEMAPMETHOD m_ToneMapMethod;
   float m_ToneMapParam;
   int m_Orientation;
   int m_CenterMixLevel; // relative to metadata or default

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -115,8 +115,13 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
       m_defaultVideoSettings.m_StereoMode = 0;
     if (!XMLUtils::GetInt(pElement, "centermixlevel", m_defaultVideoSettings.m_CenterMixLevel))
       m_defaultVideoSettings.m_CenterMixLevel = 0;
-    if (!XMLUtils::GetInt(pElement, "tonemapmethod", m_defaultVideoSettings.m_ToneMapMethod))
-      m_defaultVideoSettings.m_ToneMapMethod = VS_TONEMAPMETHOD_REINHARD;
+
+    int toneMapMethod;
+    if (!XMLUtils::GetInt(pElement, "tonemapmethod", toneMapMethod, VS_TONEMAPMETHOD_OFF,
+                          VS_TONEMAPMETHOD_MAX))
+      toneMapMethod = VS_TONEMAPMETHOD_REINHARD;
+    m_defaultVideoSettings.m_ToneMapMethod = static_cast<ETONEMAPMETHOD>(toneMapMethod);
+
     if (!XMLUtils::GetFloat(pElement, "tonemapparam", m_defaultVideoSettings.m_ToneMapParam, 0.1f, 5.0f))
       m_defaultVideoSettings.m_ToneMapParam = 1.0f;
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4452,7 +4452,8 @@ bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
       settings.m_StereoMode = m_pDS->fv("StereoMode").get_asInt();
       settings.m_StereoInvert = m_pDS->fv("StereoInvert").get_asBool();
       settings.m_VideoStream = m_pDS->fv("VideoStream").get_asInt();
-      settings.m_ToneMapMethod = m_pDS->fv("TonemapMethod").get_asInt();
+      settings.m_ToneMapMethod =
+          static_cast<ETONEMAPMETHOD>(m_pDS->fv("TonemapMethod").get_asInt());
       settings.m_ToneMapParam = m_pDS->fv("TonemapParam").get_asFloat();
       settings.m_Orientation = m_pDS->fv("Orientation").get_asInt();
       settings.m_CenterMixLevel = m_pDS->fv("CenterMixLevel").get_asInt();

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -174,7 +174,8 @@ void CGUIDialogVideoSettings::OnSettingChanged(const std::shared_ptr<const CSett
   else if (settingId == SETTING_VIDEO_TONEMAP_METHOD)
   {
     CVideoSettings vs = g_application.GetAppPlayer().GetVideoSettings();
-    vs.m_ToneMapMethod = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
+    vs.m_ToneMapMethod = static_cast<ETONEMAPMETHOD>(
+        std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
     g_application.GetAppPlayer().SetVideoSettings(vs);
   }
   else if (settingId == SETTING_VIDEO_TONEMAP_PARAM)


### PR DESCRIPTION
We use the enum type for `ESCALINGMETHOD` and `EINTERLACEMETHOD`, we should do the same for `ETONEMAPMETHOD`.

This is pretty straightforward and will felicitate the conversion to enum class in the future.

This is also needed for some future `fmt::formatter` work to allow deducing the formatted value from the type. see: https://github.com/xbmc/xbmc/commit/0f55469a7f6bec75e6319fec481d6d36b1df2917