### PR TITLE
[Android] Refactor CXBMCAapp

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2499,7 +2499,7 @@ bool CApplication::Stop(int exitCode)
 #if defined(TARGET_ANDROID)
   // Note: On Android, the app must be stopped asynchronously, once Android has
   // signalled that the app shall be destroyed. See android_main() implementation.
-  if (!CXBMCApp::get()->Stop(exitCode))
+  if (!CXBMCApp::Get().Stop(exitCode))
     return false;
 #endif
 
@@ -4229,7 +4229,7 @@ void CApplication::ProcessSlow()
 
 #ifdef TARGET_ANDROID
   // Pass the slow loop to droid
-  CXBMCApp::get()->ProcessSlow();
+  CXBMCApp::Get().ProcessSlow();
 #endif
 
   // check for any idle curl connections

--- a/xbmc/addons/interfaces/platform/android/System.cpp
+++ b/xbmc/addons/interfaces/platform/android/System.cpp
@@ -44,7 +44,7 @@ void* Interface_Android::get_jni_env()
 
 int Interface_Android::get_sdk_version()
 {
-  return CXBMCApp::Get().getActivity()->sdkVersion;
+  return CXBMCApp::Get().GetSDKVersion();
 }
 
 const char *Interface_Android::get_class_name()

--- a/xbmc/addons/interfaces/platform/android/System.cpp
+++ b/xbmc/addons/interfaces/platform/android/System.cpp
@@ -44,7 +44,7 @@ void* Interface_Android::get_jni_env()
 
 int Interface_Android::get_sdk_version()
 {
-  return CXBMCApp::get()->getActivity()->sdkVersion;
+  return CXBMCApp::Get().getActivity()->sdkVersion;
 }
 
 const char *Interface_Android::get_class_name()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -238,7 +238,7 @@ void CMediaCodecVideoBuffer::RenderUpdate(const CRect &DestRect, int64_t display
   CRect surfRect = m_videoview->getSurfaceRect();
   if (DestRect != surfRect)
   {
-    CRect adjRect = CXBMCApp::MapRenderToDroid(DestRect);
+    CRect adjRect = CXBMCApp::Get().MapRenderToDroid(DestRect);
     if (adjRect != surfRect)
     {
       m_videoview->setSurfaceRect(adjRect);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -101,7 +101,7 @@ void CRendererMediaCodecSurface::ReleaseVideoBuffer(int idx, bool render)
     if (mcvb)
     {
       if (render && m_bConfigured)
-        mcvb->RenderUpdate(m_surfDestRect, CXBMCApp::GetNextFrameTime());
+        mcvb->RenderUpdate(m_surfDestRect, CXBMCApp::Get().GetNextFrameTime());
       else
         mcvb->ReleaseOutputBuffer(render, 0);
     }

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -602,7 +602,8 @@ void CGUIDialogKeyboardGeneric::OnVoiceRecognition()
   CJNIIntent intent = CJNIIntent(CJNIRecognizerIntent::ACTION_RECOGNIZE_SPEECH);
   intent.putExtra(CJNIRecognizerIntent::EXTRA_LANGUAGE_MODEL, CJNIRecognizerIntent::LANGUAGE_MODEL_FREE_FORM);
   CJNIIntent result;
-  if (CXBMCApp::WaitForActivityResult(intent, ACTION_RECOGNIZE_SPEECH_REQID, result) == CJNIBase::RESULT_OK)
+  if (CXBMCApp::Get().WaitForActivityResult(intent, ACTION_RECOGNIZE_SPEECH_REQID, result) ==
+      CJNIBase::RESULT_OK)
   {
     CJNIArrayList<std::string> guesses = result.getStringArrayListExtra(CJNIRecognizerIntent::EXTRA_RESULTS);
     if (guesses.size())

--- a/xbmc/platform/android/MemUtils.cpp
+++ b/xbmc/platform/android/MemUtils.cpp
@@ -38,7 +38,7 @@ void GetMemoryStatus(MemoryStatus* buffer)
   long availMem = 0;
   long totalMem = 0;
 
-  if (CXBMCApp::get()->GetMemoryInfo(availMem, totalMem))
+  if (CXBMCApp::Get().GetMemoryInfo(availMem, totalMem))
   {
     *buffer = {};
     buffer->totalPhys = static_cast<unsigned long>(totalMem);

--- a/xbmc/platform/android/activity/AndroidJoyStick.cpp
+++ b/xbmc/platform/android/activity/AndroidJoyStick.cpp
@@ -18,7 +18,7 @@ bool CAndroidJoyStick::onJoyStickEvent(AInputEvent* event)
 
   // only handle input events from a gamepad or joystick
   if ((source & (AINPUT_SOURCE_GAMEPAD | AINPUT_SOURCE_JOYSTICK)) != 0)
-    return CXBMCApp::onInputDeviceEvent(event);
+    return CXBMCApp::Get().onInputDeviceEvent(event);
 
   CXBMCApp::android_printf("CAndroidJoyStick::onJoyStickEvent(type = %d, keycode = %d, source = %d): ignoring non-joystick input event",
                            AInputEvent_getType(event), AKeyEvent_getKeyCode(event), source);

--- a/xbmc/platform/android/activity/EventLoop.cpp
+++ b/xbmc/platform/android/activity/EventLoop.cpp
@@ -70,7 +70,7 @@ void CEventLoop::processActivity(int32_t command)
       m_activityHandler->onCreateWindow(m_application->window);
 
       // set the proper DPI value
-      m_inputHandler->setDPI(CXBMCApp::GetDPI());
+      m_inputHandler->setDPI(CXBMCApp::Get().GetDPI());
       break;
 
     case APP_CMD_WINDOW_RESIZED:

--- a/xbmc/platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.cpp
@@ -63,6 +63,5 @@ void CJNIXBMCAudioManagerOnAudioFocusChangeListener::_onAudioFocusChange(JNIEnv 
 
 void CJNIXBMCAudioManagerOnAudioFocusChangeListener::onAudioFocusChange(int focusChange)
 {
-  if(CXBMCApp::get())
-    CXBMCApp::get()->onAudioFocusChange(focusChange);
+  CXBMCApp::Get().onAudioFocusChange(focusChange);
 }

--- a/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
@@ -46,7 +46,7 @@ void CJNIXBMCDisplayManagerDisplayListener::_onDisplayAdded(JNIEnv *env, jobject
   static_cast<void>(env);
   static_cast<void>(context);
 
-  CXBMCApp::get()->onDisplayAdded(displayId);
+  CXBMCApp::Get().onDisplayAdded(displayId);
 }
 
 void CJNIXBMCDisplayManagerDisplayListener::_onDisplayChanged(JNIEnv *env, jobject context, jint displayId)
@@ -54,7 +54,7 @@ void CJNIXBMCDisplayManagerDisplayListener::_onDisplayChanged(JNIEnv *env, jobje
   static_cast<void>(env);
   static_cast<void>(context);
 
-  CXBMCApp::get()->onDisplayChanged(displayId);
+  CXBMCApp::Get().onDisplayChanged(displayId);
 }
 
 void CJNIXBMCDisplayManagerDisplayListener::_onDisplayRemoved(JNIEnv *env, jobject context, jint displayId)
@@ -62,5 +62,5 @@ void CJNIXBMCDisplayManagerDisplayListener::_onDisplayRemoved(JNIEnv *env, jobje
   static_cast<void>(env);
   static_cast<void>(context);
 
-  CXBMCApp::get()->onDisplayRemoved(displayId);
+  CXBMCApp::Get().onDisplayRemoved(displayId);
 }

--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
@@ -160,7 +160,7 @@ bool CJNIXBMCMediaSession::OnMediaButtonEvent(const CJNIIntent& intent)
 {
   if (CXBMCApp::HasFocus())
   {
-    CXBMCApp::get()->onReceive(intent);
+    CXBMCApp::Get().onReceive(intent);
     return true;
   }
   return false;

--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
@@ -158,7 +158,7 @@ void CJNIXBMCMediaSession::OnSeekRequested(int64_t pos)
 
 bool CJNIXBMCMediaSession::OnMediaButtonEvent(const CJNIIntent& intent)
 {
-  if (CXBMCApp::HasFocus())
+  if (CXBMCApp::Get().HasFocus())
   {
     CXBMCApp::Get().onReceive(intent);
     return true;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -663,7 +663,7 @@ CRect CXBMCApp::MapRenderToDroid(const CRect& srcRect)
   float scaleX = 1.0;
   float scaleY = 1.0;
 
-  CJNIRect r = CXBMCApp::Get().getDisplayRect();
+  CJNIRect r = getDisplayRect();
   if (r.width() && r.height())
   {
     RESOLUTION_INFO renderRes = CDisplaySettings::GetInstance().GetResolutionInfo(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -113,7 +113,6 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
-CJNIWakeLock *CXBMCApp::m_wakeLock = NULL;
 bool CXBMCApp::m_hasFocus = false;
 bool CXBMCApp::m_headsetPlugged = false;
 bool CXBMCApp::m_hdmiPlugged = true;
@@ -154,8 +153,6 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
 
 CXBMCApp::~CXBMCApp()
 {
-  delete m_wakeLock;
-
   if (m_window)
     ANativeWindow_release(m_window);
 }
@@ -443,11 +440,12 @@ bool CXBMCApp::EnableWakeLock(bool on)
     StringUtils::ToLower(appName);
     std::string className = CCompileInfo::GetPackage();
     // SCREEN_BRIGHT_WAKE_LOCK is marked as deprecated but there is no real alternatives for now
-    m_wakeLock = new CJNIWakeLock(CJNIPowerManager(getSystemService("power")).newWakeLock(CJNIPowerManager::SCREEN_BRIGHT_WAKE_LOCK | CJNIPowerManager::ON_AFTER_RELEASE, className.c_str()));
-    if (m_wakeLock)
-      m_wakeLock->setReferenceCounted(false);
-    else
-      return false;
+    m_wakeLock =
+        std::make_unique<CJNIWakeLock>(CJNIPowerManager(getSystemService("power"))
+                                           .newWakeLock(CJNIPowerManager::SCREEN_BRIGHT_WAKE_LOCK |
+                                                            CJNIPowerManager::ON_AFTER_RELEASE,
+                                                        className.c_str()));
+    m_wakeLock->setReferenceCounted(false);
   }
 
   if (on)

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -112,8 +112,6 @@ using namespace std::chrono_literals;
 std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
-IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
-IInputDeviceEventHandler* CXBMCApp::m_inputDeviceEventHandler = nullptr;
 bool CXBMCApp::m_hasReqVisible = false;
 CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
 CEvent CXBMCApp::m_vsyncEvent;
@@ -1440,10 +1438,8 @@ ANativeWindow* CXBMCApp::GetNativeWindow(int timeout)
 
 void CXBMCApp::RegisterInputDeviceCallbacks(IInputDeviceCallbacks* handler)
 {
-  if (handler == nullptr)
-    return;
-
-  m_inputDeviceCallbacks = handler;
+  if (handler != nullptr)
+    m_inputDeviceCallbacks = handler;
 }
 
 void CXBMCApp::UnregisterInputDeviceCallbacks()
@@ -1453,7 +1449,7 @@ void CXBMCApp::UnregisterInputDeviceCallbacks()
 
 void CXBMCApp::onInputDeviceAdded(int deviceId)
 {
-  CXBMCApp::android_printf("Input device added: %d", deviceId);
+  android_printf("Input device added: %d", deviceId);
 
   if (m_inputDeviceCallbacks != nullptr)
     m_inputDeviceCallbacks->OnInputDeviceAdded(deviceId);
@@ -1461,7 +1457,7 @@ void CXBMCApp::onInputDeviceAdded(int deviceId)
 
 void CXBMCApp::onInputDeviceChanged(int deviceId)
 {
-  CXBMCApp::android_printf("Input device changed: %d", deviceId);
+  android_printf("Input device changed: %d", deviceId);
 
   if (m_inputDeviceCallbacks != nullptr)
     m_inputDeviceCallbacks->OnInputDeviceChanged(deviceId);
@@ -1469,7 +1465,7 @@ void CXBMCApp::onInputDeviceChanged(int deviceId)
 
 void CXBMCApp::onInputDeviceRemoved(int deviceId)
 {
-  CXBMCApp::android_printf("Input device removed: %d", deviceId);
+  android_printf("Input device removed: %d", deviceId);
 
   if (m_inputDeviceCallbacks != nullptr)
     m_inputDeviceCallbacks->OnInputDeviceRemoved(deviceId);
@@ -1477,10 +1473,8 @@ void CXBMCApp::onInputDeviceRemoved(int deviceId)
 
 void CXBMCApp::RegisterInputDeviceEventHandler(IInputDeviceEventHandler* handler)
 {
-  if (handler == nullptr)
-    return;
-
-  m_inputDeviceEventHandler = handler;
+  if (handler != nullptr)
+    m_inputDeviceEventHandler = handler;
 }
 
 void CXBMCApp::UnregisterInputDeviceEventHandler()

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -112,7 +112,6 @@ using namespace std::chrono_literals;
 std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
-ANativeActivity *CXBMCApp::m_activity = NULL;
 IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
 IInputDeviceEventHandler* CXBMCApp::m_inputDeviceEventHandler = nullptr;
 bool CXBMCApp::m_hasReqVisible = false;
@@ -129,7 +128,7 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
     m_inputHandler(inputHandler)
 {
   m_activity = nativeActivity;
-  if (m_activity == NULL)
+  if (m_activity == nullptr)
   {
     android_printf("CXBMCApp: invalid ANativeActivity instance");
     exit(1);
@@ -644,9 +643,9 @@ int CXBMCApp::android_printf(const char *format, ...)
   return result;
 }
 
-int CXBMCApp::GetDPI()
+int CXBMCApp::GetDPI() const
 {
-  if (m_activity == NULL || m_activity->assetManager == NULL)
+  if (m_activity->assetManager == nullptr)
     return 0;
 
   // grab DPI from the current configuration - this is approximate

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -115,10 +115,8 @@ std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
 IInputDeviceEventHandler* CXBMCApp::m_inputDeviceEventHandler = nullptr;
 bool CXBMCApp::m_hasReqVisible = false;
-CCriticalSection CXBMCApp::m_activityResultMutex;
 CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
 CEvent CXBMCApp::m_vsyncEvent;
-std::vector<CActivityResultEvent*> CXBMCApp::m_activityResultEvents;
 
 uint32_t CXBMCApp::m_playback_state = PLAYBACK_STATE_STOPPED;
 
@@ -1241,7 +1239,7 @@ int CXBMCApp::WaitForActivityResult(const CJNIIntent &intent, int requestCode, C
   CActivityResultEvent* event = new CActivityResultEvent(requestCode);
   {
     std::unique_lock<CCriticalSection> lock(m_activityResultMutex);
-    m_activityResultEvents.push_back(event);
+    m_activityResultEvents.emplace_back(event);
   }
   startActivityForResult(intent, requestCode);
   if (event->Wait())

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -167,7 +167,6 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
     return;
   }
   m_mainView.reset(new CJNIXBMCMainView(this));
-  m_firstrun = true;
   m_hdmiSource = CJNISystemProperties::get("ro.hdmi.device_type", "") == "4";
   android_printf("CXBMCApp: Created");
 }
@@ -529,7 +528,7 @@ void CXBMCApp::run()
   if (!GetNativeWindow(30000))
     return;
 
-  m_firstrun=false;
+  m_firstrun = false;
   android_printf(" => running XBMC_Run...");
 
   CAppParamParser appParamParser;
@@ -1553,10 +1552,10 @@ void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
     android_printf(" => invalid ANativeWindow object");
     return;
   }
-  if(!m_firstrun)
-  {
+
+  if (!m_firstrun)
     XBMC_SetupDisplay();
-  }
+
   g_application.SetRenderGUI(true);
 }
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -829,11 +829,6 @@ std::vector<androidPackage> CXBMCApp::GetApplications() const
   return m_applications;
 }
 
-bool CXBMCApp::HasLaunchIntent(const std::string &package)
-{
-  return GetPackageManager().getLaunchIntentForPackage(package) != NULL;
-}
-
 // Note intent, dataType, dataURI all default to ""
 bool CXBMCApp::StartActivity(const std::string &package, const std::string &intent, const std::string &dataType, const std::string &dataURI)
 {

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -111,8 +111,6 @@ using namespace std::chrono_literals;
 
 std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
-uint32_t CXBMCApp::m_playback_state = PLAYBACK_STATE_STOPPED;
-
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
   : CJNIMainActivity(nativeActivity),
     CJNIBroadcastReceiver(CJNIContext::getPackageName() + ".XBMCBroadcastReceiver"),

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -111,9 +111,6 @@ using namespace std::chrono_literals;
 
 std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
-CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
-CEvent CXBMCApp::m_vsyncEvent;
-
 uint32_t CXBMCApp::m_playback_state = PLAYBACK_STATE_STOPPED;
 
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
@@ -1288,7 +1285,7 @@ void CXBMCApp::InitFrameCallback(CVideoSyncAndroid* syncImpl)
 
 void CXBMCApp::DeinitFrameCallback()
 {
-  m_syncImpl = NULL;
+  m_syncImpl = nullptr;
 }
 
 void CXBMCApp::doFrame(int64_t frameTimeNanos)

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -145,8 +145,7 @@ uint32_t CXBMCApp::m_playback_state = PLAYBACK_STATE_STOPPED;
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
   : CJNIMainActivity(nativeActivity),
     CJNIBroadcastReceiver(CJNIContext::getPackageName() + ".XBMCBroadcastReceiver"),
-    m_inputHandler(inputHandler),
-    m_videosurfaceInUse(false)
+    m_inputHandler(inputHandler)
 {
   m_xbmcappinstance = this;
   m_activity = nativeActivity;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -113,7 +113,6 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
-bool CXBMCApp::m_headsetPlugged = false;
 bool CXBMCApp::m_hdmiPlugged = true;
 bool CXBMCApp::m_hdmiSource = false;
 IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
@@ -501,11 +500,6 @@ void CXBMCApp::RequestVisibleBehind(bool requested)
 
   m_hasReqVisible = requestVisibleBehind(requested);
   CLog::Log(LOGDEBUG, "Visible Behind request: {}", m_hasReqVisible ? "true" : "false");
-}
-
-bool CXBMCApp::IsHeadsetPlugged()
-{
-  return m_headsetPlugged;
 }
 
 bool CXBMCApp::IsHDMIPlugged()

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -111,7 +111,6 @@ using namespace std::chrono_literals;
 
 std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
-std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
 CEvent CXBMCApp::m_vsyncEvent;
 
@@ -1426,10 +1425,7 @@ std::string CXBMCApp::GetFilenameFromIntent(const CJNIIntent &intent)
 
 ANativeWindow* CXBMCApp::GetNativeWindow(int timeout)
 {
-  if (m_window)
-    return m_window;
-
-  if (m_mainView)
+  if (!m_window)
     m_mainView->waitForSurface(timeout);
 
   return m_window;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -109,14 +109,8 @@ using namespace ANNOUNCEMENT;
 using namespace jni;
 using namespace std::chrono_literals;
 
-template<class T, void(T::*fn)()>
-void* thread_run(void* obj)
-{
-  (static_cast<T*>(obj)->*fn)();
-  return NULL;
-}
+std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
-CXBMCApp* CXBMCApp::m_xbmcappinstance = NULL;
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
 CJNIWakeLock *CXBMCApp::m_wakeLock = NULL;
@@ -147,7 +141,6 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
     CJNIBroadcastReceiver(CJNIContext::getPackageName() + ".XBMCBroadcastReceiver"),
     m_inputHandler(inputHandler)
 {
-  m_xbmcappinstance = this;
   m_activity = nativeActivity;
   if (m_activity == NULL)
   {
@@ -163,7 +156,6 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
 
 CXBMCApp::~CXBMCApp()
 {
-  m_xbmcappinstance = NULL;
   delete m_wakeLock;
 
   if (m_window)
@@ -376,13 +368,13 @@ void CXBMCApp::RegisterDisplayListener(CVariant* variant)
   if (displayManager)
   {
     android_printf("CXBMCApp: installing DisplayManager::DisplayListener");
-    displayManager.registerDisplayListener(CXBMCApp::get()->getDisplayListener());
+    displayManager.registerDisplayListener(CXBMCApp::Get().getDisplayListener());
   }
 }
 
 void CXBMCApp::Initialize()
 {
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(CXBMCApp::get());
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
   runNativeOnUiThread(RegisterDisplayListener, nullptr);
   m_activityManager.reset(new CJNIActivityManager(getSystemService(CJNIContext::ACTIVITY_SERVICE)));
   m_inputHandler.setDPI(GetDPI());
@@ -476,9 +468,6 @@ bool CXBMCApp::EnableWakeLock(bool on)
 
 bool CXBMCApp::AcquireAudioFocus()
 {
-  if (!m_xbmcappinstance)
-    return false;
-
   CJNIAudioManager audioManager(getSystemService("audio"));
 
   // Request audio focus for playback
@@ -498,9 +487,6 @@ bool CXBMCApp::AcquireAudioFocus()
 
 bool CXBMCApp::ReleaseAudioFocus()
 {
-  if (!m_xbmcappinstance)
-    return false;
-
   CJNIAudioManager audioManager(getSystemService("audio"));
 
   // Release audio focus after playback
@@ -702,7 +688,7 @@ CRect CXBMCApp::MapRenderToDroid(const CRect& srcRect)
   float scaleX = 1.0;
   float scaleY = 1.0;
 
-  CJNIRect r = m_xbmcappinstance->getDisplayRect();
+  CJNIRect r = CXBMCApp::Get().getDisplayRect();
   if (r.width() && r.height())
   {
     RESOLUTION_INFO renderRes = CDisplaySettings::GetInstance().GetResolutionInfo(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
@@ -805,7 +791,7 @@ void CXBMCApp::OnPlayBackStarted()
   CJNIIntent intent(ACTION_XBMC_RESUME, CJNIURI::EMPTY, *this, get_class(CJNIContext::get_raw()));
   m_mediaSession->updateIntent(intent);
 
-  m_xbmcappinstance->AcquireAudioFocus();
+  AcquireAudioFocus();
   CAndroidKey::SetHandleMediaKeys(false);
 
   RequestVisibleBehind(true);
@@ -819,7 +805,7 @@ void CXBMCApp::OnPlayBackPaused()
   UpdateSessionState();
 
   RequestVisibleBehind(false);
-  m_xbmcappinstance->ReleaseAudioFocus();
+  ReleaseAudioFocus();
 }
 
 void CXBMCApp::OnPlayBackStopped()
@@ -832,7 +818,7 @@ void CXBMCApp::OnPlayBackStopped()
 
   RequestVisibleBehind(false);
   CAndroidKey::SetHandleMediaKeys(true);
-  m_xbmcappinstance->ReleaseAudioFocus();
+  ReleaseAudioFocus();
 }
 
 const CJNIViewInputDevice CXBMCApp::GetInputDevice(int deviceId)

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -113,7 +113,6 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
-bool CXBMCApp::m_hdmiPlugged = true;
 bool CXBMCApp::m_hdmiSource = false;
 IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
 IInputDeviceEventHandler* CXBMCApp::m_inputDeviceEventHandler = nullptr;
@@ -500,11 +499,6 @@ void CXBMCApp::RequestVisibleBehind(bool requested)
 
   m_hasReqVisible = requestVisibleBehind(requested);
   CLog::Log(LOGDEBUG, "Visible Behind request: {}", m_hasReqVisible ? "true" : "false");
-}
-
-bool CXBMCApp::IsHDMIPlugged()
-{
-  return m_hdmiPlugged;
 }
 
 void CXBMCApp::run()
@@ -1072,13 +1066,13 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   }
   else if (action == "android.media.action.HDMI_AUDIO_PLUG")
   {
-    m_hdmiPlugged = (intent.getIntExtra("android.media.extra.AUDIO_PLUG_STATE", 0) != 0);
-    CLog::Log(LOGDEBUG, "-- HDMI state: {}", m_hdmiPlugged ? "on" : "off");
+    const bool hdmiPlugged = (intent.getIntExtra("android.media.extra.AUDIO_PLUG_STATE", 0) != 0);
+    CLog::Log(LOGDEBUG, "-- HDMI is plugged in: {}", hdmiPlugged);
     if (m_hdmiSource && g_application.IsInitialized())
     {
       CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
       if (winSystem && dynamic_cast<CWinSystemAndroid*>(winSystem))
-        dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHdmiState(m_hdmiPlugged);
+        dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHdmiState(hdmiPlugged);
     }
   }
   else if (action == "android.intent.action.SCREEN_ON")

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -113,18 +113,13 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
-bool CXBMCApp::m_hdmiSource = false;
 IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
 IInputDeviceEventHandler* CXBMCApp::m_inputDeviceEventHandler = nullptr;
 bool CXBMCApp::m_hasReqVisible = false;
 CCriticalSection CXBMCApp::m_activityResultMutex;
 CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
 CEvent CXBMCApp::m_vsyncEvent;
-CEvent CXBMCApp::m_displayChangeEvent;
 std::vector<CActivityResultEvent*> CXBMCApp::m_activityResultEvents;
-
-int64_t CXBMCApp::m_frameTimeNanos = 0;
-float CXBMCApp::m_refreshRate = 0.0f;
 
 uint32_t CXBMCApp::m_playback_state = PLAYBACK_STATE_STOPPED;
 
@@ -561,7 +556,7 @@ void CXBMCApp::SetRefreshRateCallback(CVariant* rateVariant)
       }
     }
   }
-  m_displayChangeEvent.Set();
+  CXBMCApp::Get().m_displayChangeEvent.Set();
 }
 
 void CXBMCApp::SetDisplayModeCallback(CVariant* variant)
@@ -582,7 +577,7 @@ void CXBMCApp::SetDisplayModeCallback(CVariant* variant)
       return;
     }
   }
-  m_displayChangeEvent.Set();
+  CXBMCApp::Get().m_displayChangeEvent.Set();
 }
 
 void CXBMCApp::SetRefreshRate(float rate)
@@ -1314,7 +1309,7 @@ void CXBMCApp::doFrame(int64_t frameTimeNanos)
   m_vsyncEvent.Set();
 }
 
-int64_t CXBMCApp::GetNextFrameTime()
+int64_t CXBMCApp::GetNextFrameTime() const
 {
   if (m_refreshRate > 0.0001f)
     return m_frameTimeNanos + static_cast<int64_t>(1500000000ll / m_refreshRate);
@@ -1322,7 +1317,7 @@ int64_t CXBMCApp::GetNextFrameTime()
     return m_frameTimeNanos;
 }
 
-float CXBMCApp::GetFrameLatencyMs()
+float CXBMCApp::GetFrameLatencyMs() const
 {
   return (CurrentHostCounter() - m_frameTimeNanos) * 0.000001;
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -117,9 +117,7 @@ bool CXBMCApp::m_hdmiSource = false;
 IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
 IInputDeviceEventHandler* CXBMCApp::m_inputDeviceEventHandler = nullptr;
 bool CXBMCApp::m_hasReqVisible = false;
-CCriticalSection CXBMCApp::m_applicationsMutex;
 CCriticalSection CXBMCApp::m_activityResultMutex;
-std::vector<androidPackage> CXBMCApp::m_applications;
 CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
 CEvent CXBMCApp::m_vsyncEvent;
 CEvent CXBMCApp::m_displayChangeEvent;
@@ -822,7 +820,7 @@ void CXBMCApp::ProcessSlow()
     UpdateSessionState();
 }
 
-std::vector<androidPackage> CXBMCApp::GetApplications()
+std::vector<androidPackage> CXBMCApp::GetApplications() const
 {
   std::unique_lock<CCriticalSection> lock(m_applicationsMutex);
   if (m_applications.empty())
@@ -841,7 +839,7 @@ std::vector<androidPackage> CXBMCApp::GetApplications()
       newPackage.packageName = packageList.get(i).packageName;
       newPackage.packageLabel = GetPackageManager().getApplicationLabel(packageList.get(i)).toString();
       newPackage.icon = packageList.get(i).icon;
-      m_applications.push_back(newPackage);
+      m_applications.emplace_back(newPackage);
     }
   }
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -113,7 +113,6 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
-bool CXBMCApp::m_hasFocus = false;
 bool CXBMCApp::m_headsetPlugged = false;
 bool CXBMCApp::m_hdmiPlugged = true;
 bool CXBMCApp::m_hdmiSource = false;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -114,7 +114,6 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
 CJNIWakeLock *CXBMCApp::m_wakeLock = NULL;
-ANativeWindow* CXBMCApp::m_window = NULL;
 int CXBMCApp::m_batteryLevel = 0;
 bool CXBMCApp::m_hasFocus = false;
 bool CXBMCApp::m_headsetPlugged = false;
@@ -525,7 +524,7 @@ void CXBMCApp::run()
   SetupEnv();
 
   // Wait for main window
-  ANativeWindow* nativeWindow = CXBMCApp::GetNativeWindow(30000);
+  ANativeWindow* nativeWindow = GetNativeWindow(30000);
   if (!nativeWindow)
     return;
 
@@ -1560,7 +1559,7 @@ void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
     ANativeWindow_release(m_window);
 
   m_window = ANativeWindow_fromSurface(xbmc_jnienv(), holder.getSurface().get_raw());
-  if (m_window == NULL)
+  if (m_window == nullptr)
   {
     android_printf(" => invalid ANativeWindow object");
     return;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -166,6 +166,9 @@ CXBMCApp::~CXBMCApp()
 {
   m_xbmcappinstance = NULL;
   delete m_wakeLock;
+
+  if (m_window)
+    ANativeWindow_release(m_window);
 }
 
 void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
@@ -342,7 +345,11 @@ void CXBMCApp::onCreateWindow(ANativeWindow* window)
 void CXBMCApp::onResizeWindow()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
-  m_window = NULL;
+  if (m_window)
+  {
+    ANativeWindow_release(m_window);
+    m_window = nullptr;
+  }
   // no need to do anything because we are fixed in fullscreen landscape mode
 }
 
@@ -1563,6 +1570,10 @@ void CXBMCApp::surfaceChanged(CJNISurfaceHolder holder, int format, int width, i
 void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
+
+  if (m_window)
+    ANativeWindow_release(m_window);
+
   m_window = ANativeWindow_fromSurface(xbmc_jnienv(), holder.getSurface().get_raw());
   if (m_window == NULL)
   {
@@ -1582,8 +1593,11 @@ void CXBMCApp::surfaceDestroyed(CJNISurfaceHolder holder)
   // If we have exited XBMC, it no longer exists.
   g_application.SetRenderGUI(false);
   if (!m_exiting)
-  {
     XBMC_DestroyDisplay();
-    m_window = NULL;
+
+  if (m_window)
+  {
+    ANativeWindow_release(m_window);
+    m_window = nullptr;
   }
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -114,7 +114,6 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
 CJNIWakeLock *CXBMCApp::m_wakeLock = NULL;
-int CXBMCApp::m_batteryLevel = 0;
 bool CXBMCApp::m_hasFocus = false;
 bool CXBMCApp::m_headsetPlugged = false;
 bool CXBMCApp::m_hdmiPlugged = true;
@@ -903,7 +902,7 @@ bool CXBMCApp::StartActivity(const std::string &package, const std::string &inte
   return true;
 }
 
-int CXBMCApp::GetBatteryLevel()
+int CXBMCApp::GetBatteryLevel() const
 {
   return m_batteryLevel;
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -109,6 +109,49 @@ using namespace ANNOUNCEMENT;
 using namespace jni;
 using namespace std::chrono_literals;
 
+std::shared_ptr<CNativeWindow> CNativeWindow::CreateFromSurface(CJNISurfaceHolder holder)
+{
+  ANativeWindow* window = ANativeWindow_fromSurface(xbmc_jnienv(), holder.getSurface().get_raw());
+  if (window)
+    return std::shared_ptr<CNativeWindow>(new CNativeWindow(window));
+
+  return {};
+}
+
+CNativeWindow::CNativeWindow(ANativeWindow* window) : m_window(window)
+{
+}
+
+CNativeWindow::~CNativeWindow()
+{
+  if (m_window)
+    ANativeWindow_release(m_window);
+}
+
+bool CNativeWindow::SetBuffersGeometry(int width, int height, int format)
+{
+  if (m_window)
+    return (ANativeWindow_setBuffersGeometry(m_window, width, height, format) == 0);
+
+  return false;
+}
+
+int32_t CNativeWindow::GetWidth() const
+{
+  if (m_window)
+    return ANativeWindow_getWidth(m_window);
+
+  return -1;
+}
+
+int32_t CNativeWindow::GetHeight() const
+{
+  if (m_window)
+    return ANativeWindow_getHeight(m_window);
+
+  return -1;
+}
+
 std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
@@ -131,8 +174,6 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
 
 CXBMCApp::~CXBMCApp()
 {
-  if (m_window)
-    ANativeWindow_release(m_window);
 }
 
 void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
@@ -309,11 +350,7 @@ void CXBMCApp::onCreateWindow(ANativeWindow* window)
 void CXBMCApp::onResizeWindow()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
-  if (m_window)
-  {
-    ANativeWindow_release(m_window);
-    m_window = nullptr;
-  }
+  m_window.reset();
   // no need to do anything because we are fixed in fullscreen landscape mode
 }
 
@@ -489,8 +526,7 @@ void CXBMCApp::run()
   SetupEnv();
 
   // Wait for main window
-  ANativeWindow* nativeWindow = GetNativeWindow(30000);
-  if (!nativeWindow)
+  if (!GetNativeWindow(30000))
     return;
 
   m_firstrun=false;
@@ -517,9 +553,12 @@ bool CXBMCApp::XBMC_DestroyDisplay()
   return result;
 }
 
-int CXBMCApp::SetBuffersGeometry(int width, int height, int format)
+bool CXBMCApp::SetBuffersGeometry(int width, int height, int format)
 {
-  return ANativeWindow_setBuffersGeometry(m_window, width, height, format);
+  if (m_window)
+    return m_window->SetBuffersGeometry(width, height, format);
+
+  return false;
 }
 
 #include "threads/Event.h"
@@ -1413,7 +1452,7 @@ std::string CXBMCApp::GetFilenameFromIntent(const CJNIIntent &intent)
   return ret;
 }
 
-ANativeWindow* CXBMCApp::GetNativeWindow(int timeout)
+std::shared_ptr<CNativeWindow> CXBMCApp::GetNativeWindow(int timeout) const
 {
   if (!m_window)
     m_mainView->waitForSurface(timeout);
@@ -1508,10 +1547,7 @@ void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
 
-  if (m_window)
-    ANativeWindow_release(m_window);
-
-  m_window = ANativeWindow_fromSurface(xbmc_jnienv(), holder.getSurface().get_raw());
+  m_window = CNativeWindow::CreateFromSurface(holder);
   if (m_window == nullptr)
   {
     android_printf(" => invalid ANativeWindow object");
@@ -1532,9 +1568,5 @@ void CXBMCApp::surfaceDestroyed(CJNISurfaceHolder holder)
   if (!m_exiting)
     XBMC_DestroyDisplay();
 
-  if (m_window)
-  {
-    ANativeWindow_release(m_window);
-    m_window = nullptr;
-  }
+  m_window.reset();
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -112,7 +112,6 @@ using namespace std::chrono_literals;
 std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 
 std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
-bool CXBMCApp::m_hasReqVisible = false;
 CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
 CEvent CXBMCApp::m_vsyncEvent;
 

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -268,7 +268,7 @@ private:
   bool XBMC_DestroyDisplay();
   bool XBMC_SetupDisplay();
 
-  static uint32_t m_playback_state;
+  uint32_t m_playback_state{0};
   int64_t m_frameTimeNanos{0};
   float m_refreshRate{0.0f};
 

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -85,9 +85,16 @@ class CXBMCApp
     , public CJNISurfaceHolderCallback
 {
 public:
-  explicit CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputhandler);
+  static CXBMCApp& Create(ANativeActivity* nativeActivity, IInputHandler& inputhandler)
+  {
+    m_appinstance.reset(new CXBMCApp(nativeActivity, inputhandler));
+    return *m_appinstance;
+  }
+  static CXBMCApp& Get() { return *m_appinstance; }
+  static void Destroy() { m_appinstance.reset(); }
+
+  CXBMCApp() = delete;
   ~CXBMCApp() override;
-  static CXBMCApp* get() { return m_xbmcappinstance; }
 
   // IAnnouncer IF
   void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
@@ -214,7 +221,10 @@ protected:
   static void RequestVisibleBehind(bool requested);
 
 private:
-  static CXBMCApp* m_xbmcappinstance;
+  static std::unique_ptr<CXBMCApp> m_appinstance;
+
+  CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputhandler);
+
   CJNIXBMCAudioManagerOnAudioFocusChangeListener m_audioFocusListener;
   CJNIXBMCDisplayManagerDisplayListener m_displayListener;
   static std::unique_ptr<CJNIXBMCMainView> m_mainView;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -150,7 +150,7 @@ public:
   int SetBuffersGeometry(int width, int height, int format);
   static int android_printf(const char *format, ...);
 
-  static int GetBatteryLevel();
+  int GetBatteryLevel() const;
   static bool EnableWakeLock(bool on);
   static bool HasFocus() { return m_hasFocus; }
   static bool IsHeadsetPlugged();
@@ -242,7 +242,7 @@ private:
   static ANativeActivity *m_activity;
   IInputHandler& m_inputHandler;
   static CJNIWakeLock *m_wakeLock;
-  static int m_batteryLevel;
+  int m_batteryLevel{0};
   static bool m_hasFocus;
   static bool m_headsetPlugged;
   static bool m_hdmiPlugged;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -241,7 +241,6 @@ private:
   static IInputDeviceCallbacks* m_inputDeviceCallbacks;
   static IInputDeviceEventHandler* m_inputDeviceEventHandler;
   static bool m_hasReqVisible;
-  bool m_videosurfaceInUse;
   bool m_firstrun;
   std::atomic<bool> m_exiting{false};
   int m_exitCode{0};

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -153,7 +153,6 @@ public:
   int GetBatteryLevel() const;
   bool EnableWakeLock(bool on);
   bool HasFocus() const { return m_hasFocus; }
-  static bool IsHeadsetPlugged();
   static bool IsHDMIPlugged();
 
   static bool StartActivity(const std::string &package, const std::string &intent = std::string(), const std::string &dataType = std::string(), const std::string &dataURI = std::string());
@@ -244,7 +243,7 @@ private:
   std::unique_ptr<CJNIWakeLock> m_wakeLock;
   int m_batteryLevel{0};
   bool m_hasFocus{false};
-  static bool m_headsetPlugged;
+  bool m_headsetPlugged{false};
   static bool m_hdmiPlugged;
   static bool m_hdmiReportedState;
   static bool m_hdmiSource;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -216,7 +216,7 @@ protected:
   static int GetMaxSystemVolume(JNIEnv *env);
   bool AcquireAudioFocus();
   bool ReleaseAudioFocus();
-  static void RequestVisibleBehind(bool requested);
+  void RequestVisibleBehind(bool requested);
 
 private:
   static std::unique_ptr<CXBMCApp> m_appinstance;
@@ -246,7 +246,7 @@ private:
   bool m_hdmiSource{false};
   IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
   IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
-  static bool m_hasReqVisible;
+  bool m_hasReqVisible{false};
   bool m_firstrun;
   std::atomic<bool> m_exiting{false};
   int m_exitCode{0};

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -186,14 +186,14 @@ public:
   void UpdateSessionState();
 
   // input device methods
-  static void RegisterInputDeviceCallbacks(IInputDeviceCallbacks* handler);
-  static void UnregisterInputDeviceCallbacks();
+  void RegisterInputDeviceCallbacks(IInputDeviceCallbacks* handler);
+  void UnregisterInputDeviceCallbacks();
   static const CJNIViewInputDevice GetInputDevice(int deviceId);
   static std::vector<int> GetInputDeviceIds();
 
-  static void RegisterInputDeviceEventHandler(IInputDeviceEventHandler* handler);
-  static void UnregisterInputDeviceEventHandler();
-  static bool onInputDeviceEvent(const AInputEvent* event);
+  void RegisterInputDeviceEventHandler(IInputDeviceEventHandler* handler);
+  void UnregisterInputDeviceEventHandler();
+  bool onInputDeviceEvent(const AInputEvent* event);
 
   static void InitFrameCallback(CVideoSyncAndroid *syncImpl);
   static void DeinitFrameCallback();
@@ -244,8 +244,8 @@ private:
   bool m_hasFocus{false};
   bool m_headsetPlugged{false};
   bool m_hdmiSource{false};
-  static IInputDeviceCallbacks* m_inputDeviceCallbacks;
-  static IInputDeviceEventHandler* m_inputDeviceEventHandler;
+  IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
+  IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
   static bool m_hasReqVisible;
   bool m_firstrun;
   std::atomic<bool> m_exiting{false};

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -270,10 +270,10 @@ private:
   IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
   IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
   bool m_hasReqVisible{false};
-  bool m_firstrun;
+  bool m_firstrun{true};
   std::atomic<bool> m_exiting{false};
   int m_exitCode{0};
-  bool m_bResumePlayback = false;
+  bool m_bResumePlayback{false};
   std::thread m_thread;
   mutable CCriticalSection m_applicationsMutex;
   mutable std::vector<androidPackage> m_applications;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -174,7 +174,7 @@ public:
   int GetDPI() const;
 
   CRect MapRenderToDroid(const CRect& srcRect);
-  static int WaitForActivityResult(const CJNIIntent &intent, int requestCode, CJNIIntent& result);
+  int WaitForActivityResult(const CJNIIntent& intent, int requestCode, CJNIIntent& result);
 
   // Playback callbacks
   void OnPlayBackStarted();
@@ -253,9 +253,9 @@ private:
   bool m_bResumePlayback = false;
   std::thread m_thread;
   mutable CCriticalSection m_applicationsMutex;
-  static CCriticalSection m_activityResultMutex;
   mutable std::vector<androidPackage> m_applications;
-  static std::vector<CActivityResultEvent*> m_activityResultEvents;
+  CCriticalSection m_activityResultMutex;
+  std::vector<CActivityResultEvent*> m_activityResultEvents;
 
   ANativeWindow* m_window{nullptr};
 

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -151,7 +151,7 @@ public:
   static int android_printf(const char *format, ...);
 
   int GetBatteryLevel() const;
-  static bool EnableWakeLock(bool on);
+  bool EnableWakeLock(bool on);
   static bool HasFocus() { return m_hasFocus; }
   static bool IsHeadsetPlugged();
   static bool IsHDMIPlugged();
@@ -241,7 +241,7 @@ private:
 
   static ANativeActivity *m_activity;
   IInputHandler& m_inputHandler;
-  static CJNIWakeLock *m_wakeLock;
+  std::unique_ptr<CJNIWakeLock> m_wakeLock;
   int m_batteryLevel{0};
   static bool m_hasFocus;
   static bool m_headsetPlugged;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -227,7 +227,6 @@ private:
   CJNIXBMCDisplayManagerDisplayListener m_displayListener;
   std::unique_ptr<CJNIXBMCMainView> m_mainView;
   std::unique_ptr<jni::CJNIXBMCMediaSession> m_mediaSession;
-  static bool HasLaunchIntent(const std::string &package);
   std::string GetFilenameFromIntent(const CJNIIntent &intent);
 
   void run();

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -155,7 +155,7 @@ public:
   bool HasFocus() const { return m_hasFocus; }
 
   static bool StartActivity(const std::string &package, const std::string &intent = std::string(), const std::string &dataType = std::string(), const std::string &dataURI = std::string());
-  static std::vector <androidPackage> GetApplications();
+  std::vector<androidPackage> GetApplications() const;
 
   /*!
    * \brief If external storage is available, it returns the path for the external storage (for the specified type)
@@ -253,9 +253,9 @@ private:
   int m_exitCode{0};
   bool m_bResumePlayback = false;
   std::thread m_thread;
-  static CCriticalSection m_applicationsMutex;
+  mutable CCriticalSection m_applicationsMutex;
   static CCriticalSection m_activityResultMutex;
-  static std::vector<androidPackage> m_applications;
+  mutable std::vector<androidPackage> m_applications;
   static std::vector<CActivityResultEvent*> m_activityResultEvents;
 
   ANativeWindow* m_window{nullptr};

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -152,7 +152,7 @@ public:
 
   int GetBatteryLevel() const;
   bool EnableWakeLock(bool on);
-  static bool HasFocus() { return m_hasFocus; }
+  bool HasFocus() const { return m_hasFocus; }
   static bool IsHeadsetPlugged();
   static bool IsHDMIPlugged();
 
@@ -243,7 +243,7 @@ private:
   IInputHandler& m_inputHandler;
   std::unique_ptr<CJNIWakeLock> m_wakeLock;
   int m_batteryLevel{0};
-  static bool m_hasFocus;
+  bool m_hasFocus{false};
   static bool m_headsetPlugged;
   static bool m_hdmiPlugged;
   static bool m_hdmiReportedState;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -122,7 +122,8 @@ public:
   jni::jhobject getDisplayListener() { return m_displayListener.get_raw(); }
 
   bool isValid() { return m_activity != NULL; }
-  const ANativeActivity *getActivity() const { return m_activity; }
+
+  int32_t GetSDKVersion() const { return m_activity->sdkVersion; }
 
   void onStart() override;
   void onResume() override;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -169,8 +169,8 @@ public:
   static float GetSystemVolume();
   static void SetSystemVolume(float percent);
 
-  static void SetRefreshRate(float rate);
-  static void SetDisplayMode(int mode, float rate);
+  void SetRefreshRate(float rate);
+  void SetDisplayMode(int mode, float rate);
   static int GetDPI();
 
   static CRect MapRenderToDroid(const CRect& srcRect);
@@ -202,8 +202,8 @@ public:
   void ProcessSlow();
 
   static bool WaitVSync(unsigned int milliSeconds);
-  static int64_t GetNextFrameTime();
-  static float GetFrameLatencyMs();
+  int64_t GetNextFrameTime() const;
+  float GetFrameLatencyMs() const;
 
   bool getVideosurfaceInUse();
   void setVideosurfaceInUse(bool videosurfaceInUse);
@@ -243,8 +243,7 @@ private:
   int m_batteryLevel{0};
   bool m_hasFocus{false};
   bool m_headsetPlugged{false};
-  static bool m_hdmiReportedState;
-  static bool m_hdmiSource;
+  bool m_hdmiSource{false};
   static IInputDeviceCallbacks* m_inputDeviceCallbacks;
   static IInputDeviceEventHandler* m_inputDeviceEventHandler;
   static bool m_hasReqVisible;
@@ -262,7 +261,7 @@ private:
 
   static CVideoSyncAndroid* m_syncImpl;
   static CEvent m_vsyncEvent;
-  static CEvent m_displayChangeEvent;
+  CEvent m_displayChangeEvent;
 
   std::unique_ptr<CJNIActivityManager> m_activityManager;
 
@@ -270,8 +269,8 @@ private:
   bool XBMC_SetupDisplay();
 
   static uint32_t m_playback_state;
-  static int64_t m_frameTimeNanos;
-  static float m_refreshRate;
+  int64_t m_frameTimeNanos{0};
+  float m_refreshRate{0.0f};
 
 public:
   // CJNISurfaceHolderCallback interface

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -59,6 +59,28 @@ struct androidPackage
   int icon;
 };
 
+class CNativeWindow
+{
+  friend class CWinSystemAndroidGLESContext; // meh
+
+public:
+  static std::shared_ptr<CNativeWindow> CreateFromSurface(CJNISurfaceHolder holder);
+  ~CNativeWindow();
+
+  bool SetBuffersGeometry(int width, int height, int format);
+  int32_t GetWidth() const;
+  int32_t GetHeight() const;
+
+private:
+  explicit CNativeWindow(ANativeWindow* window);
+
+  CNativeWindow() = delete;
+  CNativeWindow(const CNativeWindow&) = delete;
+  CNativeWindow& operator=(const CNativeWindow&) = delete;
+
+  ANativeWindow* m_window{nullptr};
+};
+
 class CActivityResultEvent : public CEvent
 {
 public:
@@ -147,8 +169,9 @@ public:
   bool Stop(int exitCode);
   void Quit();
 
-  ANativeWindow* GetNativeWindow(int timeout);
-  int SetBuffersGeometry(int width, int height, int format);
+  std::shared_ptr<CNativeWindow> GetNativeWindow(int timeout) const;
+
+  bool SetBuffersGeometry(int width, int height, int format);
   static int android_printf(const char *format, ...);
 
   int GetBatteryLevel() const;
@@ -257,7 +280,7 @@ private:
   CCriticalSection m_activityResultMutex;
   std::vector<CActivityResultEvent*> m_activityResultEvents;
 
-  ANativeWindow* m_window{nullptr};
+  std::shared_ptr<CNativeWindow> m_window;
 
   CVideoSyncAndroid* m_syncImpl{nullptr};
   CEvent m_vsyncEvent;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -173,7 +173,7 @@ public:
   void SetDisplayMode(int mode, float rate);
   int GetDPI() const;
 
-  static CRect MapRenderToDroid(const CRect& srcRect);
+  CRect MapRenderToDroid(const CRect& srcRect);
   static int WaitForActivityResult(const CJNIIntent &intent, int requestCode, CJNIIntent& result);
 
   // Playback callbacks

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -171,7 +171,7 @@ public:
 
   void SetRefreshRate(float rate);
   void SetDisplayMode(int mode, float rate);
-  static int GetDPI();
+  int GetDPI() const;
 
   static CRect MapRenderToDroid(const CRect& srcRect);
   static int WaitForActivityResult(const CJNIIntent &intent, int requestCode, CJNIIntent& result);
@@ -237,7 +237,7 @@ private:
   static void SetDisplayModeCallback(CVariant *mode);
   static void RegisterDisplayListener(CVariant*);
 
-  static ANativeActivity *m_activity;
+  ANativeActivity* m_activity{nullptr};
   IInputHandler& m_inputHandler;
   std::unique_ptr<CJNIWakeLock> m_wakeLock;
   int m_batteryLevel{0};

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -153,7 +153,6 @@ public:
   int GetBatteryLevel() const;
   bool EnableWakeLock(bool on);
   bool HasFocus() const { return m_hasFocus; }
-  static bool IsHDMIPlugged();
 
   static bool StartActivity(const std::string &package, const std::string &intent = std::string(), const std::string &dataType = std::string(), const std::string &dataURI = std::string());
   static std::vector <androidPackage> GetApplications();
@@ -244,7 +243,6 @@ private:
   int m_batteryLevel{0};
   bool m_hasFocus{false};
   bool m_headsetPlugged{false};
-  static bool m_hdmiPlugged;
   static bool m_hdmiReportedState;
   static bool m_hdmiSource;
   static IInputDeviceCallbacks* m_inputDeviceCallbacks;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -146,8 +146,8 @@ public:
   bool Stop(int exitCode);
   void Quit();
 
-  static ANativeWindow* GetNativeWindow(int timeout);
-  static int SetBuffersGeometry(int width, int height, int format);
+  ANativeWindow* GetNativeWindow(int timeout);
+  int SetBuffersGeometry(int width, int height, int format);
   static int android_printf(const char *format, ...);
 
   static int GetBatteryLevel();
@@ -261,7 +261,7 @@ private:
   static std::vector<androidPackage> m_applications;
   static std::vector<CActivityResultEvent*> m_activityResultEvents;
 
-  static ANativeWindow* m_window;
+  ANativeWindow* m_window{nullptr};
 
   static CVideoSyncAndroid* m_syncImpl;
   static CEvent m_vsyncEvent;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -225,7 +225,7 @@ private:
 
   CJNIXBMCAudioManagerOnAudioFocusChangeListener m_audioFocusListener;
   CJNIXBMCDisplayManagerDisplayListener m_displayListener;
-  static std::unique_ptr<CJNIXBMCMainView> m_mainView;
+  std::unique_ptr<CJNIXBMCMainView> m_mainView;
   std::unique_ptr<jni::CJNIXBMCMediaSession> m_mediaSession;
   static bool HasLaunchIntent(const std::string &package);
   std::string GetFilenameFromIntent(const CJNIIntent &intent);

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -195,13 +195,13 @@ public:
   void UnregisterInputDeviceEventHandler();
   bool onInputDeviceEvent(const AInputEvent* event);
 
-  static void InitFrameCallback(CVideoSyncAndroid *syncImpl);
-  static void DeinitFrameCallback();
+  void InitFrameCallback(CVideoSyncAndroid* syncImpl);
+  void DeinitFrameCallback();
 
   // Application slow ping
   void ProcessSlow();
 
-  static bool WaitVSync(unsigned int milliSeconds);
+  bool WaitVSync(unsigned int milliSeconds);
   int64_t GetNextFrameTime() const;
   float GetFrameLatencyMs() const;
 
@@ -259,8 +259,8 @@ private:
 
   ANativeWindow* m_window{nullptr};
 
-  static CVideoSyncAndroid* m_syncImpl;
-  static CEvent m_vsyncEvent;
+  CVideoSyncAndroid* m_syncImpl{nullptr};
+  CEvent m_vsyncEvent;
   CEvent m_displayChangeEvent;
 
   std::unique_ptr<CJNIActivityManager> m_activityManager;

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -102,23 +102,25 @@ extern void android_main(struct android_app* state)
 
     CEventLoop eventLoop(state);
     IInputHandler inputHandler;
-    CXBMCApp xbmcApp(state->activity, inputHandler);
-    if (xbmcApp.isValid())
+    CXBMCApp& theApp = CXBMCApp::Create(state->activity, inputHandler);
+    if (theApp.isValid())
     {
       start_logger("Kodi");
-      eventLoop.run(xbmcApp, inputHandler);
-      xbmcApp.Quit();
+      eventLoop.run(theApp, inputHandler);
+      theApp.Quit();
     }
     else
       CXBMCApp::android_printf("android_main: setup failed");
 
     CXBMCApp::android_printf("android_main: Exiting");
-    // We need to call exit() so that all loaded libraries are properly unloaded
-    // otherwise on the next start of the Activity android will simple re-use
-    // those loaded libs in the state they were in when we quit XBMC last time
-    // which will lead to crashes because of global/static classes that haven't
-    // been properly uninitialized
+
+    CXBMCApp::Destroy();
   }
+  // We need to call exit() so that all loaded libraries are properly unloaded
+  // otherwise on the next start of the Activity android will simply re-use
+  // those loaded libs in the state they were in when we quit Kodi last time
+  // which will lead to crashes because of global/static classes that haven't
+  // been properly uninitialized
   exit(0);
 }
 

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
@@ -33,7 +33,7 @@ bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   if (dirname == "apps")
   {
-    std::vector<androidPackage> applications = CXBMCApp::GetApplications();
+    const std::vector<androidPackage> applications = CXBMCApp::Get().GetApplications();
     if (applications.empty())
     {
       CLog::Log(LOGERROR, "CAndroidAppDirectory::GetDirectory Application lookup listing failed");

--- a/xbmc/platform/android/filesystem/AndroidAppFile.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppFile.cpp
@@ -45,7 +45,7 @@ bool CFileAndroidApp::Open(const CURL& url)
   m_packageName =  URIUtils::GetFileName(url.Get());
   m_packageName = m_packageName.substr(0, m_packageName.size() - 4);
 
-  std::vector<androidPackage> applications = CXBMCApp::GetApplications();
+  const std::vector<androidPackage> applications = CXBMCApp::Get().GetApplications();
   for (const auto& i : applications)
   {
     if (i.packageName == m_packageName)
@@ -64,7 +64,7 @@ bool CFileAndroidApp::Exists(const CURL& url)
   std::string appname =  URIUtils::GetFileName(url.Get());
   appname = appname.substr(0, appname.size() - 4);
 
-  std::vector<androidPackage> applications = CXBMCApp::GetApplications();
+  const std::vector<androidPackage> applications = CXBMCApp::Get().GetApplications();
   for (const auto& i : applications)
   {
     if (i.packageName == appname)

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -42,10 +42,10 @@ CPeripheralBusAndroid::CPeripheralBusAndroid(CPeripherals& manager) :
   m_bNeedsPolling = false;
 
   // register for input device callbacks
-  CXBMCApp::RegisterInputDeviceCallbacks(this);
+  CXBMCApp::Get().RegisterInputDeviceCallbacks(this);
 
   // register for input device events
-  CXBMCApp::RegisterInputDeviceEventHandler(this);
+  CXBMCApp::Get().RegisterInputDeviceEventHandler(this);
 
   // get all currently connected input devices
   m_scanResults = GetInputDevices();
@@ -54,10 +54,10 @@ CPeripheralBusAndroid::CPeripheralBusAndroid(CPeripherals& manager) :
 CPeripheralBusAndroid::~CPeripheralBusAndroid()
 {
   // unregister from input device events
-  CXBMCApp::UnregisterInputDeviceEventHandler();
+  CXBMCApp::Get().UnregisterInputDeviceEventHandler();
 
   // unregister from input device callbacks
-  CXBMCApp::UnregisterInputDeviceCallbacks();
+  CXBMCApp::Get().UnregisterInputDeviceCallbacks();
 }
 
 bool CPeripheralBusAndroid::InitializeProperties(CPeripheral& peripheral)

--- a/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
+++ b/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
@@ -22,9 +22,9 @@ void CAndroidPowerSyscall::Register()
   IPowerSyscall::RegisterPowerSyscall(CAndroidPowerSyscall::CreateInstance);
 }
 
-int CAndroidPowerSyscall::BatteryLevel(void)
+int CAndroidPowerSyscall::BatteryLevel()
 {
-  return CXBMCApp::GetBatteryLevel();
+  return CXBMCApp::Get().GetBatteryLevel();
 }
 
 bool CAndroidPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -33,7 +33,7 @@ extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params)
   }
 
 #if defined(TARGET_ANDROID)
-  CXBMCApp::get()->Initialize();
+  CXBMCApp::Get().Initialize();
 #endif
 
   if (renderGUI && !g_application.CreateGUI())
@@ -75,7 +75,7 @@ extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params)
 #endif
 
 #if defined(TARGET_ANDROID)
-  CXBMCApp::get()->Deinitialize();
+  CXBMCApp::Get().Deinitialize();
 #endif
 
   return status;

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -219,7 +219,8 @@ CAndroidUtils::CAndroidUtils()
 
 bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO* res) const
 {
-  EGLNativeWindowType nativeWindow = (EGLNativeWindowType)CXBMCApp::GetNativeWindow(30000);
+  EGLNativeWindowType nativeWindow =
+      static_cast<EGLNativeWindowType>(CXBMCApp::Get().GetNativeWindow(30000));
   if (!nativeWindow)
     return false;
 
@@ -271,7 +272,8 @@ bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO& res)
   }
   else
     CXBMCApp::SetRefreshRate(res.fRefreshRate);
-  CXBMCApp::SetBuffersGeometry(res.iWidth, res.iHeight, 0);
+
+  CXBMCApp::Get().SetBuffersGeometry(res.iWidth, res.iHeight, 0);
 
   return true;
 }

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -267,11 +267,11 @@ bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO& res)
 
   if (s_hasModeApi)
   {
-    CXBMCApp::SetDisplayMode(atoi(res.strId.c_str()), res.fRefreshRate);
+    CXBMCApp::Get().SetDisplayMode(std::atoi(res.strId.c_str()), res.fRefreshRate);
     s_res_cur_displayMode = res;
   }
   else
-    CXBMCApp::SetRefreshRate(res.fRefreshRate);
+    CXBMCApp::Get().SetRefreshRate(res.fRefreshRate);
 
   CXBMCApp::Get().SetBuffersGeometry(res.iWidth, res.iHeight, 0);
 

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -219,17 +219,14 @@ CAndroidUtils::CAndroidUtils()
 
 bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO* res) const
 {
-  EGLNativeWindowType nativeWindow =
-      static_cast<EGLNativeWindowType>(CXBMCApp::Get().GetNativeWindow(30000));
+  const std::shared_ptr<CNativeWindow> nativeWindow = CXBMCApp::Get().GetNativeWindow(30000);
   if (!nativeWindow)
     return false;
 
   if (!m_width || !m_height)
   {
-    ANativeWindow_acquire(nativeWindow);
-    m_width = ANativeWindow_getWidth(nativeWindow);
-    m_height= ANativeWindow_getHeight(nativeWindow);
-    ANativeWindow_release(nativeWindow);
+    m_width = nativeWindow->GetWidth();
+    m_height = nativeWindow->GetHeight();
     CLog::Log(LOGINFO, "CAndroidUtils: window resolution: {}x{}", m_width, m_height);
   }
 

--- a/xbmc/windowing/android/OSScreenSaverAndroid.cpp
+++ b/xbmc/windowing/android/OSScreenSaverAndroid.cpp
@@ -12,10 +12,10 @@
 
 void COSScreenSaverAndroid::Inhibit()
 {
-  CXBMCApp::get()->EnableWakeLock(true);
+  CXBMCApp::Get().EnableWakeLock(true);
 }
 
 void COSScreenSaverAndroid::Uninhibit()
 {
-  CXBMCApp::get()->EnableWakeLock(false);
+  CXBMCApp::Get().EnableWakeLock(false);
 }

--- a/xbmc/windowing/android/VideoSyncAndroid.cpp
+++ b/xbmc/windowing/android/VideoSyncAndroid.cpp
@@ -29,7 +29,7 @@ bool CVideoSyncAndroid::Setup(PUPDATECLOCK func)
   UpdateClock = func;
   m_abortEvent.Reset();
 
-  CXBMCApp::InitFrameCallback(this);
+  CXBMCApp::Get().InitFrameCallback(this);
   CServiceBroker::GetWinSystem()->Register(this);
 
   return true;
@@ -44,7 +44,7 @@ void CVideoSyncAndroid::Run(CEvent& stopEvent)
 void CVideoSyncAndroid::Cleanup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncAndroid::{} cleaning up", __FUNCTION__);
-  CXBMCApp::DeinitFrameCallback();
+  CXBMCApp::Get().DeinitFrameCallback();
   CServiceBroker::GetWinSystem()->Unregister(this);
 }
 

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -142,7 +142,7 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
   if (m_nativeWindow)
     ANativeWindow_release(m_nativeWindow);
 
-  m_nativeWindow = CXBMCApp::GetNativeWindow(2000);
+  m_nativeWindow = CXBMCApp::Get().GetNativeWindow(2000);
   if (!m_nativeWindow)
   {
     CLog::Log(LOGERROR, "CWinSystemAndroid::CreateNewWindow: failed");

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -62,8 +62,10 @@ CWinSystemAndroid::CWinSystemAndroid()
 
 CWinSystemAndroid::~CWinSystemAndroid()
 {
-  m_nativeWindow = nullptr;
-  delete m_dispResetTimer, m_dispResetTimer = nullptr;
+  if (m_nativeWindow)
+    ANativeWindow_release(m_nativeWindow);
+
+  delete m_dispResetTimer;
 }
 
 bool CWinSystemAndroid::InitWindowSystem()
@@ -137,12 +139,16 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
   m_stereo_mode = stereo_mode;
   m_bFullScreen = fullScreen;
 
+  if (m_nativeWindow)
+    ANativeWindow_release(m_nativeWindow);
+
   m_nativeWindow = CXBMCApp::GetNativeWindow(2000);
   if (!m_nativeWindow)
   {
     CLog::Log(LOGERROR, "CWinSystemAndroid::CreateNewWindow: failed");
     return false;
   }
+  ANativeWindow_acquire(m_nativeWindow);
   m_android->SetNativeResolution(res);
 
   return true;
@@ -151,7 +157,11 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
 bool CWinSystemAndroid::DestroyWindow()
 {
   CLog::Log(LOGINFO, "CWinSystemAndroid::{}", __FUNCTION__);
-  m_nativeWindow = nullptr;
+  if (m_nativeWindow)
+  {
+    ANativeWindow_release(m_nativeWindow);
+    m_nativeWindow = nullptr;
+  }
   m_bWindowCreated = false;
   return true;
 }

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -46,7 +46,6 @@ using namespace std::chrono_literals;
 CWinSystemAndroid::CWinSystemAndroid()
 {
   m_nativeDisplay = EGL_NO_DISPLAY;
-  m_nativeWindow = nullptr;
 
   m_displayWidth = 0;
   m_displayHeight = 0;
@@ -62,9 +61,6 @@ CWinSystemAndroid::CWinSystemAndroid()
 
 CWinSystemAndroid::~CWinSystemAndroid()
 {
-  if (m_nativeWindow)
-    ANativeWindow_release(m_nativeWindow);
-
   delete m_dispResetTimer;
 }
 
@@ -139,16 +135,13 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
   m_stereo_mode = stereo_mode;
   m_bFullScreen = fullScreen;
 
-  if (m_nativeWindow)
-    ANativeWindow_release(m_nativeWindow);
-
   m_nativeWindow = CXBMCApp::Get().GetNativeWindow(2000);
   if (!m_nativeWindow)
   {
     CLog::Log(LOGERROR, "CWinSystemAndroid::CreateNewWindow: failed");
     return false;
   }
-  ANativeWindow_acquire(m_nativeWindow);
+
   m_android->SetNativeResolution(res);
 
   return true;
@@ -157,11 +150,7 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
 bool CWinSystemAndroid::DestroyWindow()
 {
   CLog::Log(LOGINFO, "CWinSystemAndroid::{}", __FUNCTION__);
-  if (m_nativeWindow)
-  {
-    ANativeWindow_release(m_nativeWindow);
-    m_nativeWindow = nullptr;
-  }
+  m_nativeWindow.reset();
   m_bWindowCreated = false;
   return true;
 }

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -16,8 +16,11 @@
 #include "utils/HDRCapabilities.h"
 #include "windowing/WinSystem.h"
 
+#include <memory>
+
 class CDecoderFilterManager;
 class IDispResource;
+class CNativeWindow;
 
 class CWinSystemAndroid : public CWinSystemBase, public ITimerCallback
 {
@@ -63,7 +66,7 @@ protected:
   CAndroidUtils *m_android;
 
   EGLDisplay m_nativeDisplay;
-  EGLNativeWindowType m_nativeWindow;
+  std::shared_ptr<CNativeWindow> m_nativeWindow;
 
   int m_displayWidth;
   int m_displayHeight;

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -173,14 +173,15 @@ std::unique_ptr<CVideoSync> CWinSystemAndroidGLESContext::GetVideoSync(void *clo
 
 bool CWinSystemAndroidGLESContext::CreateSurface()
 {
-  if (!m_pGLContext.CreateSurface(m_nativeWindow, m_HDRColorSpace))
+  if (!m_pGLContext.CreateSurface(static_cast<EGLNativeWindowType>(m_nativeWindow->m_window),
+                                  m_HDRColorSpace))
   {
     if (m_HDRColorSpace != EGL_NONE)
     {
       m_HDRColorSpace = EGL_NONE;
       m_displayMetadata = nullptr;
       m_lightMetadata = nullptr;
-      if (!m_pGLContext.CreateSurface(m_nativeWindow))
+      if (!m_pGLContext.CreateSurface(static_cast<EGLNativeWindowType>(m_nativeWindow->m_window)))
         return false;
     }
     else

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -136,7 +136,8 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
   // we can't actually do anything about it
   if (rendered && !m_pGLContext.TrySwapBuffers())
     CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-  CXBMCApp::get()->WaitVSync(1000);
+
+  CXBMCApp::Get().WaitVSync(1000);
 }
 
 float CWinSystemAndroidGLESContext::GetFrameLatencyAdjustment()

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -142,7 +142,7 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
 
 float CWinSystemAndroidGLESContext::GetFrameLatencyAdjustment()
 {
-  return CXBMCApp::GetFrameLatencyMs();
+  return CXBMCApp::Get().GetFrameLatencyMs();
 }
 
 EGLDisplay CWinSystemAndroidGLESContext::GetEGLDisplay() const


### PR DESCRIPTION
I felt like `CXBMCApp`could profit from a larger refactoring. No functional changes, just reshuffling of code here (except fix of leaked native window instances). Not saying there is nothing more that could be improved, but that's for another day.

* get rid of static member variables (well, there were a lot of these)
* encapsulate native data types
* remove dead code
* NULL vs nullptr
* push_back vs emplace_back
* member init in ctor body/init list vs member init header
* raw pointers vs smart pointers
* xbmcapp singleton lifecycle management
* ...