### PR TITLE
[cmake] FindFFMPEG correctly handdle FFMPEG_URL provided

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -39,10 +39,18 @@ macro(buildFFMPEG)
 
   set(MODULE_LC ffmpeg)
 
+  # We require this due to the odd nature of github URL's compared to our other tarball
+  # mirror system. If User sets FFMPEG_URL, allow get_filename_component in SETUP_BUILD_VARS
+  if(FFMPEG_URL)
+    set(FFMPEG_URL_PROVIDED TRUE)
+  endif()
+
   SETUP_BUILD_VARS()
 
-  # override FFMPEG_URL due to tar naming when retrieved from github release for ffmpeg
-  set(FFMPEG_URL ${FFMPEG_BASE_URL}/archive/${FFMPEG_VER}.tar.gz)
+  if(NOT FFMPEG_URL_PROVIDED)
+    # override FFMPEG_URL due to tar naming when retrieved from github release for ffmpeg
+    set(FFMPEG_URL ${FFMPEG_BASE_URL}/archive/${FFMPEG_VER}.tar.gz)
+  endif()
 
   if(NOT DAV1D_FOUND)
     message(STATUS "dav1d not found, internal ffmpeg build will be missing AV1 support!")


### PR DESCRIPTION
## Description
Fixup for PPA build providing FFMPEG_URL

## Motivation and context
PPA build failure

## How has this been tested?
FFMPEG_URL provided is passed through.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
