### PR TITLE
[Android] Main activity: onDestroy: Cancel all scheduled jobs.

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -290,6 +290,8 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   @Override
   public void onDestroy()
   {
+    TvUtil.cancelAllScheduledJobs(this);
+
     // unregister the InputDeviceListener implementation
     InputManager manager = (InputManager) getSystemService(INPUT_SERVICE);
     manager.unregisterInputDeviceListener(mInputDeviceListener);

--- a/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
@@ -181,6 +181,18 @@ public class TvUtil
   }
 
   /**
+   * Cancel all jobs scheduled by this app via a {@link JobScheduler}.
+   *
+   * @param context for accessing the {@link JobScheduler}.
+   */
+  public static void cancelAllScheduledJobs(Context context)
+  {
+    JobScheduler scheduler =
+            (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+    scheduler.cancelAll();
+  }
+
+  /**
    * Schedules syncing channels via a {@link JobScheduler}.
    *
    * @param context for accessing the {@link JobScheduler}.


### PR DESCRIPTION
Kodi's Main activity must cancel any jobs it might have scheduled in `onDestroy`, as those jobs make native calls into libkodi.so, which might be already deinitialized/unloaded then.

Fixes crashes on Kodi exit.

(Hmm, I thought I would have saved some real stack traces documenting those crashes. Seems, I already threw them away, sorry.)

Like always, I runtime-tested this change on Android.

No idea who could review this PR due to lack of an Android maintainer. If nobody steps up I will merge this in the next days.