### PR TITLE
[TextureCache][JobMananger][KeyboardLayoutManager][ApplicationMessenger] Kill some more static global singletons.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -349,6 +349,9 @@ bool CApplication::Create(const CAppParamParser &params)
   const auto appMessenger = std::make_shared<CApplicationMessenger>();
   CServiceBroker::RegisterAppMessenger(appMessenger);
 
+  const auto keyboardLayoutManager = std::make_shared<CKeyboardLayoutManager>();
+  CServiceBroker::RegisterKeyboardLayoutManager(keyboardLayoutManager);
+
   m_ServiceManager.reset(new CServiceManager());
 
   if (!m_ServiceManager->InitStageOne())
@@ -431,7 +434,7 @@ bool CApplication::Create(const CAppParamParser &params)
   m_replayGainSettings.bAvoidClipping = settings->GetBool(CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING);
 
   // load the keyboard layouts
-  if (!CKeyboardLayoutManager::GetInstance().Load())
+  if (!keyboardLayoutManager->Load())
   {
     CLog::Log(LOGFATAL, "CApplication::Create: Unable to load keyboard layouts");
     return false;
@@ -2485,6 +2488,8 @@ bool CApplication::Cleanup()
       m_ServiceManager->DeinitStageOne();
       m_ServiceManager.reset();
     }
+
+    CServiceBroker::UnregisterKeyboardLayoutManager();
 
     CServiceBroker::UnregisterAppMessenger();
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -727,6 +727,8 @@ bool CApplication::Initialize()
       return false;
     }
 
+    CServiceBroker::RegisterTextureCache(std::make_shared<CTextureCache>());
+
     std::string defaultSkin = std::static_pointer_cast<const CSettingString>(setting)->GetDefault();
     if (!LoadSkin(settings->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN)))
     {
@@ -1183,9 +1185,9 @@ bool CApplication::LoadSkin(const std::string& skinID)
   CServiceBroker::GetGUI()->GetWindowManager().SetCallback(*this);
   //@todo should be done by GUIComponents
   CServiceBroker::GetGUI()->GetWindowManager().Initialize();
-  CTextureCache::GetInstance().Initialize();
   CServiceBroker::GetGUI()->GetAudioManager().Enable(true);
   CServiceBroker::GetGUI()->GetAudioManager().Load();
+  CServiceBroker::GetTextureCache()->Initialize();
 
   if (g_SkinInfo->HasSkinFile("DialogFullScreenInfo.xml"))
     CServiceBroker::GetGUI()->GetWindowManager().Add(new CGUIDialogFullScreenInfo);
@@ -1245,7 +1247,7 @@ void CApplication::UnloadSkin()
     gui->GetAudioManager().Enable(false);
 
     gui->GetWindowManager().DeInitialize();
-    CTextureCache::GetInstance().Deinitialize();
+    CServiceBroker::GetTextureCache()->Deinitialize();
 
     // remove the skin-dependent window
     gui->GetWindowManager().Delete(WINDOW_DIALOG_FULLSCREEN_INFO);
@@ -2403,6 +2405,8 @@ bool CApplication::Cleanup()
 
     CLog::Log(LOGINFO, "unload skin");
     UnloadSkin();
+
+    CServiceBroker::UnregisterTextureCache();
 
     // stop all remaining scripts; must be done after skin has been unloaded,
     // not before some windows still need it when deinitializing during skin

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -57,7 +57,7 @@ CGUIInfoManager::~CGUIInfoManager(void)
 
 void CGUIInfoManager::Initialize()
 {
-  KODI::MESSAGING::CApplicationMessenger::GetInstance().RegisterReceiver(this);
+  CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
 }
 
 /// \brief Translates a string as given by the skin into an int that we use for more

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -43,7 +43,7 @@ bool CImageLoader::DoWork()
     return false;
 
   if (m_use_cache)
-    loadPath = CTextureCache::GetInstance().CheckCachedImage(texturePath, needsChecking);
+    loadPath = CServiceBroker::GetTextureCache()->CheckCachedImage(texturePath, needsChecking);
   else
     loadPath = texturePath;
 
@@ -64,7 +64,7 @@ bool CImageLoader::DoWork()
     if (m_texture)
     {
       if (needsChecking)
-        CTextureCache::GetInstance().BackgroundCacheImage(texturePath);
+        CServiceBroker::GetTextureCache()->BackgroundCacheImage(texturePath);
 
       return true;
     }
@@ -77,7 +77,7 @@ bool CImageLoader::DoWork()
     return false; // We're done
 
   // not in our texture cache or it failed to load from it, so try and load directly and then cache the result
-  CTextureCache::GetInstance().CacheImage(texturePath, &m_texture);
+  CServiceBroker::GetTextureCache()->CacheImage(texturePath, &m_texture);
   return (m_texture != NULL);
 }
 

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -197,7 +197,7 @@ void CGUILargeTextureManager::ReleaseImage(const std::string &path, bool immedia
     if (image->GetPath() == path && image->DecrRef(true))
     {
       // cancel this job
-      CJobManager::GetInstance().CancelJob(id);
+      CServiceBroker::GetJobManager()->CancelJob(id);
       m_queued.erase(it);
       return;
     }
@@ -223,7 +223,8 @@ void CGUILargeTextureManager::QueueImage(const std::string &path, bool useCache)
 
   // queue the item
   CLargeTexture *image = new CLargeTexture(path);
-  unsigned int jobID = CJobManager::GetInstance().AddJob(new CImageLoader(path, useCache), this, CJob::PRIORITY_NORMAL);
+  unsigned int jobID = CServiceBroker::GetJobManager()->AddJob(new CImageLoader(path, useCache),
+                                                               this, CJob::PRIORITY_NORMAL);
   m_queued.emplace_back(jobID, image);
 }
 

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -184,7 +184,7 @@ bool CGUIPassword::CheckStartUpLock()
   }
   else
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN); // Turn off the box
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SHUTDOWN); // Turn off the box
     return false;
   }
 }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -35,7 +35,6 @@
 #include <stdexcept>
 
 using namespace PVR;
-using namespace KODI::MESSAGING;
 
 static std::string shortDateFormats[] = {
   // short date formats using "/"
@@ -741,7 +740,8 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
     // also tell our weather and skin to reload as these are localized
     CServiceBroker::GetWeatherManager().Refresh();
     CServiceBroker::GetPVRManager().LocalizationChanged();
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               "ReloadSkin");
   }
 
   return true;

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -944,7 +944,7 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
       if (GetCurrentPlaylist() != pMsg->param1)
         SetCurrentPlaylist(pMsg->param1);
 
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, pMsg->param2);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_PLAY, pMsg->param2);
     }
   }
   break;

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -347,3 +347,18 @@ std::shared_ptr<CTextureCache> CServiceBroker::GetTextureCache()
 {
   return g_serviceBroker.m_textureCache;
 }
+
+void CServiceBroker::RegisterJobManager(const std::shared_ptr<CJobManager>& jobManager)
+{
+  g_serviceBroker.m_jobManager = jobManager;
+}
+
+void CServiceBroker::UnregisterJobManager()
+{
+  g_serviceBroker.m_jobManager.reset();
+}
+
+std::shared_ptr<CJobManager> CServiceBroker::GetJobManager()
+{
+  return g_serviceBroker.m_jobManager;
+}

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -362,3 +362,19 @@ std::shared_ptr<CJobManager> CServiceBroker::GetJobManager()
 {
   return g_serviceBroker.m_jobManager;
 }
+
+void CServiceBroker::RegisterAppMessenger(
+    const std::shared_ptr<KODI::MESSAGING::CApplicationMessenger>& appMessenger)
+{
+  g_serviceBroker.m_appMessenger = appMessenger;
+}
+
+void CServiceBroker::UnregisterAppMessenger()
+{
+  g_serviceBroker.m_appMessenger.reset();
+}
+
+std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> CServiceBroker::GetAppMessenger()
+{
+  return g_serviceBroker.m_appMessenger;
+}

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -378,3 +378,19 @@ std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> CServiceBroker::GetAppMe
 {
   return g_serviceBroker.m_appMessenger;
 }
+
+void CServiceBroker::RegisterKeyboardLayoutManager(
+    const std::shared_ptr<CKeyboardLayoutManager>& keyboardLayoutManager)
+{
+  g_serviceBroker.m_keyboardLayoutManager = keyboardLayoutManager;
+}
+
+void CServiceBroker::UnregisterKeyboardLayoutManager()
+{
+  g_serviceBroker.m_keyboardLayoutManager.reset();
+}
+
+std::shared_ptr<CKeyboardLayoutManager> CServiceBroker::GetKeyboardLayoutManager()
+{
+  return g_serviceBroker.m_keyboardLayoutManager;
+}

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -332,3 +332,18 @@ void CServiceBroker::UnregisterCPUInfo()
 {
   g_serviceBroker.m_cpuInfo.reset();
 }
+
+void CServiceBroker::RegisterTextureCache(const std::shared_ptr<CTextureCache>& cache)
+{
+  g_serviceBroker.m_textureCache = cache;
+}
+
+void CServiceBroker::UnregisterTextureCache()
+{
+  g_serviceBroker.m_textureCache.reset();
+}
+
+std::shared_ptr<CTextureCache> CServiceBroker::GetTextureCache()
+{
+  return g_serviceBroker.m_textureCache;
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -64,6 +64,7 @@ class CMediaManager;
 class CCPUInfo;
 class CLog;
 class CPlatform;
+class CTextureCache;
 
 namespace WSDiscovery
 {
@@ -167,6 +168,10 @@ public:
   static void RegisterCPUInfo(std::shared_ptr<CCPUInfo> cpuInfo);
   static void UnregisterCPUInfo();
 
+  static void RegisterTextureCache(const std::shared_ptr<CTextureCache>& cache);
+  static void UnregisterTextureCache();
+  static std::shared_ptr<CTextureCache> GetTextureCache();
+
 private:
   std::unique_ptr<CLog> m_logging;
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
@@ -177,6 +182,7 @@ private:
   CSettingsComponent* m_pSettingsComponent;
   CDecoderFilterManager* m_decoderFilterManager;
   std::shared_ptr<CCPUInfo> m_cpuInfo;
+  std::shared_ptr<CTextureCache> m_textureCache;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -65,6 +65,7 @@ class CCPUInfo;
 class CLog;
 class CPlatform;
 class CTextureCache;
+class CJobManager;
 
 namespace WSDiscovery
 {
@@ -172,6 +173,10 @@ public:
   static void UnregisterTextureCache();
   static std::shared_ptr<CTextureCache> GetTextureCache();
 
+  static void RegisterJobManager(const std::shared_ptr<CJobManager>& jobManager);
+  static void UnregisterJobManager();
+  static std::shared_ptr<CJobManager> GetJobManager();
+
 private:
   std::unique_ptr<CLog> m_logging;
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
@@ -183,6 +188,7 @@ private:
   CDecoderFilterManager* m_decoderFilterManager;
   std::shared_ptr<CCPUInfo> m_cpuInfo;
   std::shared_ptr<CTextureCache> m_textureCache;
+  std::shared_ptr<CJobManager> m_jobManager;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -41,6 +41,14 @@ namespace PLAYLIST
   class CPlayListPlayer;
 }
 
+namespace KODI
+{
+namespace MESSAGING
+{
+class CApplicationMessenger;
+}
+} // namespace KODI
+
 class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
@@ -177,6 +185,11 @@ public:
   static void UnregisterJobManager();
   static std::shared_ptr<CJobManager> GetJobManager();
 
+  static void RegisterAppMessenger(
+      const std::shared_ptr<KODI::MESSAGING::CApplicationMessenger>& appMessenger);
+  static void UnregisterAppMessenger();
+  static std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> GetAppMessenger();
+
 private:
   std::unique_ptr<CLog> m_logging;
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
@@ -189,6 +202,7 @@ private:
   std::shared_ptr<CCPUInfo> m_cpuInfo;
   std::shared_ptr<CTextureCache> m_textureCache;
   std::shared_ptr<CJobManager> m_jobManager;
+  std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> m_appMessenger;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -74,6 +74,7 @@ class CLog;
 class CPlatform;
 class CTextureCache;
 class CJobManager;
+class CKeyboardLayoutManager;
 
 namespace WSDiscovery
 {
@@ -190,6 +191,11 @@ public:
   static void UnregisterAppMessenger();
   static std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> GetAppMessenger();
 
+  static void RegisterKeyboardLayoutManager(
+      const std::shared_ptr<CKeyboardLayoutManager>& keyboardLayoutManager);
+  static void UnregisterKeyboardLayoutManager();
+  static std::shared_ptr<CKeyboardLayoutManager> GetKeyboardLayoutManager();
+
 private:
   std::unique_ptr<CLog> m_logging;
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
@@ -203,6 +209,7 @@ private:
   std::shared_ptr<CTextureCache> m_textureCache;
   std::shared_ptr<CJobManager> m_jobManager;
   std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> m_appMessenger;
+  std::shared_ptr<CKeyboardLayoutManager> m_keyboardLayoutManager;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -31,12 +31,6 @@
 using namespace XFILE;
 using namespace std::chrono_literals;
 
-CTextureCache &CTextureCache::GetInstance()
-{
-  static CTextureCache s_cache;
-  return s_cache;
-}
-
 CTextureCache::CTextureCache() : CJobQueue(false, 1, CJob::PRIORITY_LOW_PAUSABLE)
 {
 }
@@ -53,6 +47,7 @@ void CTextureCache::Initialize()
 void CTextureCache::Deinitialize()
 {
   CancelJobs();
+
   std::unique_lock<CCriticalSection> lock(m_databaseSection);
   m_database.Close();
 }

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -36,11 +36,8 @@ class CTexture;
 class CTextureCache : public CJobQueue
 {
 public:
-  /*!
-   \brief The only way through which the global instance of the CTextureCache should be accessed.
-   \return the global instance.
-   */
-  static CTextureCache &GetInstance();
+  CTextureCache();
+  ~CTextureCache() override;
 
   /*! \brief Initialize the texture cache
    */
@@ -152,10 +149,8 @@ public:
   bool Export(const std::string &image, const std::string &destination); //! @todo BACKWARD COMPATIBILITY FOR MUSIC THUMBS
 private:
   // private construction, and no assignments; use the provided singleton methods
-  CTextureCache();
   CTextureCache(const CTextureCache&) = delete;
   CTextureCache const& operator=(CTextureCache const&) = delete;
-  ~CTextureCache() override;
 
   /*! \brief Check if the given image is a cached image
    \param image url of the image

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -63,7 +63,7 @@ bool CTextureCacheJob::DoWork()
 
   // check whether we need cache the job anyway
   bool needsRecaching = false;
-  std::string path(CTextureCache::GetInstance().CheckCachedImage(m_url, needsRecaching));
+  std::string path(CServiceBroker::GetTextureCache()->CheckCachedImage(m_url, needsRecaching));
   if (!path.empty() && !needsRecaching)
     return false;
   return CacheTexture();

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -9,6 +9,7 @@
 #include "ThumbLoader.h"
 
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "filesystem/File.h"
 
@@ -98,7 +99,7 @@ bool CProgramThumbLoader::FillThumb(CFileItem &item)
 
   if (!thumb.empty())
   {
-    CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+    CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);
     item.SetArt("thumb", thumb);
   }
   return true;

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -11,6 +11,7 @@
 #include "AppParamParser.h"
 #include "FileItem.h"
 #include "PlayListPlayer.h"
+#include "ServiceBroker.h"
 #include "commons/Exception.h"
 #include "messaging/ApplicationMessenger.h"
 #include "utils/XTimeUtils.h"
@@ -48,7 +49,7 @@ int CXBApplicationEx::Run(const CAppParamParser &params)
   {
     CServiceBroker::GetPlaylistPlayer().Add(0, params.GetPlaylist());
     CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(0);
-    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
 
   // Run xbmc

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -145,7 +145,7 @@ bool CAddonInstaller::Cancel(const std::string &addonID)
   JobMap::iterator i = m_downloadJobs.find(addonID);
   if (i != m_downloadJobs.end())
   {
-    CJobManager::GetInstance().CancelJob(i->second.jobID);
+    CServiceBroker::GetJobManager()->CancelJob(i->second.jobID);
     m_downloadJobs.erase(i);
     if (m_downloadJobs.empty())
       m_idle.Set();
@@ -288,7 +288,8 @@ bool CAddonInstaller::DoInstall(const AddonPtr& addon,
   {
     // Workaround: because CAddonInstallJob is blocking waiting for other jobs, it needs to be run
     // with priority dedicated.
-    unsigned int jobID = CJobManager::GetInstance().AddJob(installJob, this, CJob::PRIORITY_DEDICATED);
+    unsigned int jobID =
+        CServiceBroker::GetJobManager()->AddJob(installJob, this, CJob::PRIORITY_DEDICATED);
     m_downloadJobs.insert(make_pair(addon->ID(), CDownloadJob(jobID)));
     m_idle.Reset();
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -793,7 +793,7 @@ void CAddonMgr::OnPostUnInstall(const std::string& id)
 void CAddonMgr::UpdateLastUsed(const std::string& id)
 {
   auto time = CDateTime::GetCurrentDateTime();
-  CJobManager::GetInstance().Submit([this, id, time](){
+  CServiceBroker::GetJobManager()->Submit([this, id, time]() {
     {
       std::unique_lock<CCriticalSection> lock(m_critSection);
       m_database.SetLastUsed(id, time);

--- a/xbmc/addons/FontResource.cpp
+++ b/xbmc/addons/FontResource.cpp
@@ -18,8 +18,6 @@
 #include "settings/SettingsComponent.h"
 
 using namespace XFILE;
-using namespace KODI::MESSAGING;
-
 
 namespace ADDON
 {
@@ -31,7 +29,8 @@ void CFontResource::OnPostInstall(bool update, bool modal)
       CServiceBroker::GetAddonMgr().GetDepsRecursive(skin, OnlyEnabledRootAddon::CHOICE_YES);
   for (const auto& it : deps)
     if (it.id == ID())
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                                 "ReloadSkin");
 }
 
 bool CFontResource::GetFont(const std::string& file, std::string& path) const

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -149,7 +149,7 @@ void CRepositoryUpdater::CheckForUpdates(const ADDON::RepositoryPtr& repo, bool 
     m_doneEvent.Reset();
     if (showProgress)
       SetProgressIndicator(job);
-    CJobManager::GetInstance().AddJob(job, this, CJob::PRIORITY_LOW);
+    CServiceBroker::GetJobManager()->AddJob(job, this, CJob::PRIORITY_LOW);
   }
   else
   {

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -372,7 +372,8 @@ void CSkinInfo::OnPreInstall()
 {
   bool skinLoaded = g_SkinInfo != nullptr;
   if (IsInUse() && skinLoaded)
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "UnloadSkin");
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               "UnloadSkin");
 }
 
 void CSkinInfo::OnPostInstall(bool update, bool modal)
@@ -391,7 +392,8 @@ void CSkinInfo::OnPostInstall(bool update, bool modal)
       toast->Close(true);
     }
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN) == ID())
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                                 "ReloadSkin");
     else
       CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(CSettings::SETTING_LOOKANDFEEL_SKIN, ID());
   }

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -590,8 +590,8 @@ void CGUIDialogAddonInfo::OnUninstall()
   if (CDirectory::Exists("special://profile/addon_data/" + m_localAddon->ID()))
     removeData = CGUIDialogYesNo::ShowAndGetInput(CVariant{24037}, CVariant{39014});
 
-  CJobManager::GetInstance().AddJob(new CAddonUnInstallJob(m_localAddon, removeData),
-                                    &CAddonInstaller::GetInstance());
+  CServiceBroker::GetJobManager()->AddJob(new CAddonUnInstallJob(m_localAddon, removeData),
+                                          &CAddonInstaller::GetInstance());
   Close();
 }
 

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -399,7 +399,7 @@ bool Interface_General::get_keyboard_layout(void* kodiBase, char** layout_name, 
   std::string activeLayout = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT);
 
   CKeyboardLayout layout;
-  if (!CKeyboardLayoutManager::GetInstance().GetLayout(activeLayout, layout))
+  if (!CServiceBroker::GetKeyboardLayoutManager()->GetLayout(activeLayout, layout))
     return false;
 
   *layout_name = strdup(layout.GetName().c_str());
@@ -435,7 +435,7 @@ bool Interface_General::change_keyboard_layout(void* kodiBase, char** layout_nam
   std::vector<CKeyboardLayout> layouts;
   unsigned int currentLayout = 0;
 
-  const KeyboardLayouts& keyboardLayouts = CKeyboardLayoutManager::GetInstance().GetLayouts();
+  const KeyboardLayouts& keyboardLayouts = CServiceBroker::GetKeyboardLayoutManager()->GetLayouts();
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   std::vector<CVariant> layoutNames = settings->GetList(CSettings::SETTING_LOCALE_KEYBOARDLAYOUTS);
   std::string activeLayout = settings->GetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT);

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -29,9 +29,6 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
-using namespace ADDON;
-using namespace KODI::MESSAGING;
-
 namespace ADDON
 {
 
@@ -1456,13 +1453,13 @@ void CGUIAddonWindowDialog::Show(bool show /* = true */, bool modal /* = true*/)
   if (modal)
   {
     unsigned int count = CServiceBroker::GetWinSystem()->GetGfxContext().exit();
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ADDON_DIALOG, 0, show ? 1 : 0,
-                                                 static_cast<void*>(this));
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ADDON_DIALOG, 0, show ? 1 : 0,
+                                               static_cast<void*>(this));
     CServiceBroker::GetWinSystem()->GetGfxContext().restore(count);
   }
   else
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ADDON_DIALOG, 0, show ? 1 : 0,
-                                                 static_cast<void*>(this));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ADDON_DIALOG, 0, show ? 1 : 0,
+                                               static_cast<void*>(this));
 }
 
 void CGUIAddonWindowDialog::Show_Internal(bool show /* = true */)

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -197,7 +197,7 @@ void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   if (closeDialog)
     CGUIDialogAddonSettings::SaveAndClose();
 
-  KODI::MESSAGING::CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, actionData);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, actionData);
 }
 
 bool CAddonSettings::Initialize(const CXBMCTinyXML& doc, bool allowEmpty /* = false */)

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -174,7 +174,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   if (bSuccess)
   {
     // Switch to fullscreen
-    MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_SWITCHTOFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SWITCHTOFULLSCREEN);
 
     // Initialize gameplay
     CreatePlayback(m_gameServices.GameSettings().AutosaveEnabled());

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -499,14 +499,14 @@ void CRetroPlayer::SetPlaybackSpeed(double speed)
       if (speed == 1.0)
       {
         IPlayerCallback* callback = &m_callback;
-        CJobManager::GetInstance().Submit([callback]() { callback->OnPlayBackResumed(); },
-                                          CJob::PRIORITY_NORMAL);
+        CServiceBroker::GetJobManager()->Submit([callback]() { callback->OnPlayBackResumed(); },
+                                                CJob::PRIORITY_NORMAL);
       }
       else if (speed == 0.0)
       {
         IPlayerCallback* callback = &m_callback;
-        CJobManager::GetInstance().Submit([callback]() { callback->OnPlayBackPaused(); },
-                                          CJob::PRIORITY_NORMAL);
+        CServiceBroker::GetJobManager()->Submit([callback]() { callback->OnPlayBackPaused(); },
+                                                CJob::PRIORITY_NORMAL);
       }
     }
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1653,7 +1653,8 @@ void CDVDVideoCodecAndroidMediaCodec::InitSurfaceTexture(void)
     callbackData.userptr  = (void*)this;
 
     // wait for it.
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_CALLBACK, -1, -1, static_cast<void*>(&callbackData));
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_CALLBACK, -1, -1,
+                                               static_cast<void*>(&callbackData));
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -69,7 +69,6 @@
 #include <iterator>
 #include <utility>
 
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 //------------------------------------------------------------------------------
@@ -2032,7 +2031,7 @@ void CVideoPlayer::HandlePlaySpeed()
       {
         if (m_playerOptions.fullscreen)
         {
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_SWITCHTOFULLSCREEN);
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SWITCHTOFULLSCREEN);
         }
 
         IPlayerCallback *cb = &m_callback;
@@ -4351,7 +4350,9 @@ bool CVideoPlayer::OnAction(const CAction &action)
               return true;
             else
             {
-              CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_TRIGGER_OSD)));
+              CServiceBroker::GetAppMessenger()->PostMsg(
+                  TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                  static_cast<void*>(new CAction(ACTION_TRIGGER_OSD)));
               return false;
             }
           }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -33,7 +33,6 @@
 #include "../VideoPlayer/DVDClock.h"
 #include "../VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 void CRenderManager::CClockSync::Reset()
@@ -360,7 +359,7 @@ void CRenderManager::PreInit()
   if (!g_application.IsCurrentThread())
   {
     m_initEvent.Reset();
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_PREINIT);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RENDERER_PREINIT);
     if (!m_initEvent.Wait(2000ms))
     {
       CLog::Log(LOGERROR, "{} - timed out waiting for renderer to preinit", __FUNCTION__);
@@ -389,7 +388,7 @@ void CRenderManager::UnInit()
   if (!g_application.IsCurrentThread())
   {
     m_initEvent.Reset();
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_UNINIT);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RENDERER_UNINIT);
     if (!m_initEvent.Wait(2000ms))
     {
       CLog::Log(LOGERROR, "{} - timed out waiting for renderer to uninit", __FUNCTION__);
@@ -453,7 +452,7 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
   else
   {
     m_flushEvent.Reset();
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_RENDERER_FLUSH);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RENDERER_FLUSH);
     if (wait)
     {
       if (!m_flushEvent.Wait(1000ms))

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -224,11 +224,8 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     std::unique_lock<CCriticalSection> lock(m_streamsLock);
     m_jobCounter++;
   }
-  CJobManager::GetInstance().Submit(
-    [=]() { QueueNextFileEx(file, false); },
-    this,
-    CJob::PRIORITY_NORMAL
-  );
+  CServiceBroker::GetJobManager()->Submit([=]() { QueueNextFileEx(file, false); }, this,
+                                          CJob::PRIORITY_NORMAL);
 
   std::unique_lock<CCriticalSection> lock(m_streamsLock);
   if (m_streams.size() == 2)
@@ -288,9 +285,8 @@ bool PAPlayer::QueueNextFile(const CFileItem &file)
     std::unique_lock<CCriticalSection> lock(m_streamsLock);
     m_jobCounter++;
   }
-  CJobManager::GetInstance().Submit([this, file]() {
-    QueueNextFileEx(file, true);
-  }, this, CJob::PRIORITY_NORMAL);
+  CServiceBroker::GetJobManager()->Submit([this, file]() { QueueNextFileEx(file, true); }, this,
+                                          CJob::PRIORITY_NORMAL);
 
   return true;
 }
@@ -1141,9 +1137,8 @@ void PAPlayer::CloseFileCB(StreamInfo &si)
   bookmark.timeInSeconds -= si.m_stream->GetDelay();
   bookmark.player = m_name;
   bookmark.playerState = GetPlayerState();
-  CJobManager::GetInstance().Submit([=]() {
-    cb->OnPlayerCloseFile(fileItem, bookmark);
-  }, CJob::PRIORITY_NORMAL);
+  CServiceBroker::GetJobManager()->Submit([=]() { cb->OnPlayerCloseFile(fileItem, bookmark); },
+                                          CJob::PRIORITY_NORMAL);
 }
 
 void PAPlayer::AdvancePlaylistOnError(CFileItem &fileItem)

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -29,7 +29,6 @@
 
 #include <mutex>
 
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 #define TIME_TO_CACHE_NEXT_FILE 5000 /* 5 seconds before end of song, start caching the next song */
@@ -710,7 +709,7 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
     m_signalStarted = true;
     if (m_fullScreen)
     {
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_SWITCHTOFULLSCREEN);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SWITCHTOFULLSCREEN);
       m_fullScreen = false;
     }
     m_callback.OnAVStarted(si->m_fileItem);

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -20,8 +20,6 @@
 
 #include <mutex>
 
-
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 CGUIDialogCache::CGUIDialogCache(std::chrono::milliseconds delay,
@@ -55,7 +53,8 @@ void CGUIDialogCache::Close(bool bForceClose)
   // we cannot wait for the app thread to process the close message
   // as this might happen during player startup which leads to a deadlock
   if (m_pDlg && m_pDlg->IsDialogRunning())
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_WINDOW_CLOSE, -1, bForceClose ? 1 : 0, static_cast<void*>(m_pDlg));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_WINDOW_CLOSE, -1, bForceClose ? 1 : 0,
+                                               static_cast<void*>(m_pDlg));
 
   //Set stop, this will kill this object, when thread stops
   CThread::m_bStop = true;

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -131,7 +131,7 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   // fill in the keyboard layouts
   m_currentLayout = 0;
   m_layouts.clear();
-  const KeyboardLayouts& keyboardLayouts = CKeyboardLayoutManager::GetInstance().GetLayouts();
+  const KeyboardLayouts& keyboardLayouts = CServiceBroker::GetKeyboardLayoutManager()->GetLayouts();
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   std::vector<CVariant> layoutNames = settings->GetList(CSettings::SETTING_LOCALE_KEYBOARDLAYOUTS);
   std::string activeLayout = settings->GetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT);

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -71,19 +71,15 @@ public:
   CGetDirectory(std::shared_ptr<IDirectory>& imp, const CURL& dir, const CURL& listDir)
     : m_result(new CResult(dir, listDir))
   {
-    m_id = CJobManager::GetInstance().AddJob(new CGetJob(imp, m_result)
-                                           , NULL
-                                           , CJob::PRIORITY_HIGH);
+    m_id = CServiceBroker::GetJobManager()->AddJob(new CGetJob(imp, m_result), nullptr,
+                                                   CJob::PRIORITY_HIGH);
     if (m_id == 0)
     {
       CGetJob job(imp, m_result);
       job.DoWork();
     }
   }
- ~CGetDirectory()
-  {
-    CJobManager::GetInstance().CancelJob(m_id);
-  }
+  ~CGetDirectory() { CServiceBroker::GetJobManager()->CancelJob(m_id); }
 
   CEvent& GetEvent()
   {

--- a/xbmc/filesystem/ImageFile.cpp
+++ b/xbmc/filesystem/ImageFile.cpp
@@ -8,6 +8,7 @@
 
 #include "ImageFile.h"
 
+#include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "URL.h"
 
@@ -24,10 +25,11 @@ bool CImageFile::Open(const CURL& url)
 {
   std::string file = url.Get();
   bool needsRecaching = false;
-  std::string cachedFile = CTextureCache::GetInstance().CheckCachedImage(file, needsRecaching);
+  std::string cachedFile =
+      CServiceBroker::GetTextureCache()->CheckCachedImage(file, needsRecaching);
   if (cachedFile.empty())
   { // not in the cache, so cache it
-    cachedFile = CTextureCache::GetInstance().CacheImage(file);
+    cachedFile = CServiceBroker::GetTextureCache()->CacheImage(file);
   }
   if (!cachedFile.empty())
   { // in the cache, return what we have
@@ -40,7 +42,8 @@ bool CImageFile::Open(const CURL& url)
 bool CImageFile::Exists(const CURL& url)
 {
   bool needsRecaching = false;
-  std::string cachedFile = CTextureCache::GetInstance().CheckCachedImage(url.Get(), needsRecaching);
+  std::string cachedFile =
+      CServiceBroker::GetTextureCache()->CheckCachedImage(url.Get(), needsRecaching);
   if (!cachedFile.empty())
     return CFile::Exists(cachedFile, false);
 
@@ -54,7 +57,8 @@ bool CImageFile::Exists(const CURL& url)
 int CImageFile::Stat(const CURL& url, struct __stat64* buffer)
 {
   bool needsRecaching = false;
-  std::string cachedFile = CTextureCache::GetInstance().CheckCachedImage(url.Get(), needsRecaching);
+  std::string cachedFile =
+      CServiceBroker::GetTextureCache()->CheckCachedImage(url.Get(), needsRecaching);
   if (!cachedFile.empty())
     return CFile::Stat(cachedFile, buffer);
 

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -35,7 +35,6 @@
 
 using namespace XFILE;
 using namespace MUSIC_INFO;
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 CShoutcastFile::CShoutcastFile() :
@@ -354,8 +353,8 @@ void CShoutcastFile::Process()
         {
           CFileItem* item = new CFileItem(*front.second); // will be deleted by msg receiver
           m_tags.pop();
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
-                                                       static_cast<void*>(item));
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
+                                                     static_cast<void*>(item));
         }
       }
     }

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -591,8 +591,8 @@ void CGameClient::cb_close_game(KODI_HANDLE kodiInstance)
 {
   using namespace MESSAGING;
 
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
-                                               static_cast<void*>(new CAction(ACTION_STOP)));
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                             static_cast<void*>(new CAction(ACTION_STOP)));
 }
 
 KODI_GAME_STREAM_HANDLE CGameClient::cb_open_stream(KODI_HANDLE kodiInstance,

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIFeatureButton.h"
 
+#include "ServiceBroker.h"
 #include "games/controllers/windows/GUIControllerDefines.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/WindowIDs.h"
@@ -50,7 +51,7 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
   if (!HasFocus())
   {
     CGUIMessage msgFocus(GUI_MSG_SETFOCUS, GetID(), GetID());
-    CApplicationMessenger::GetInstance().SendGUIMessage(msgFocus, WINDOW_INVALID, false);
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msgFocus, WINDOW_INVALID, false);
   }
 
   CGUIMessage msgLabel(GUI_MSG_LABEL_SET, GetID(), GetID());
@@ -70,7 +71,7 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
       strLabel = StringUtils::Format(strPrompt, strFeature, secondsRemaining);
 
     msgLabel.SetLabel(strLabel);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msgLabel, WINDOW_INVALID, false);
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msgLabel, WINDOW_INVALID, false);
 
     waitEvent.Reset();
     bInterrupted = waitEvent.Wait(1000ms); // Wait 1 second
@@ -81,7 +82,7 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
 
   // Reset label
   msgLabel.SetLabel(m_feature.Label());
-  CApplicationMessenger::GetInstance().SendGUIMessage(msgLabel, WINDOW_INVALID, false);
+  CServiceBroker::GetAppMessenger()->SendGUIMessage(msgLabel, WINDOW_INVALID, false);
 
   return bInterrupted;
 }

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -177,7 +177,7 @@ void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
         typeid(event) == typeid(ADDON::AddonEvents::ReInstalled))
       msg.SetStringParam(event.id);
 
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, m_guiWindow->GetID());
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow->GetID());
   }
 }
 

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -156,7 +156,7 @@ void CGUIPortList::ResetPorts()
     // Refresh the GUI
     using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, m_guiWindow.GetID());
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }
 }
 
@@ -170,7 +170,7 @@ void CGUIPortList::OnEvent(const ADDON::AddonEvent& event)
     using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
     msg.SetStringParam(event.id);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, m_guiWindow.GetID());
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }
 }
 
@@ -297,7 +297,7 @@ void CGUIPortList::OnControllerSelected(const CPortNode& port, const ControllerP
     // Send a GUI message to reload the port list
     using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, m_guiWindow.GetID());
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }
 }
 

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -19,8 +19,6 @@
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 
-using namespace KODI::MESSAGING;
-
 CGUIDialog::CGUIDialog(int id, const std::string &xmlFile, DialogModalityType modalityType /* = DialogModalityType::MODAL */)
     : CGUIWindow(id, xmlFile)
 {
@@ -197,8 +195,8 @@ void CGUIDialog::Open(bool bProcessRenderLoop, const std::string& param /* = "" 
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OPEN, -1, bProcessRenderLoop,
-                                                 static_cast<void*>(this), param);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_DIALOG_OPEN, -1, bProcessRenderLoop,
+                                               static_cast<void*>(this), param);
   }
   else
     Open_Internal(bProcessRenderLoop, param);

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -49,12 +49,13 @@ void CGUIKeyboardFactory::keyTypedCB(CGUIKeyboard *ref, const std::string &typed
       case FILTERING_SEARCH:
         message.SetParam1(GUI_MSG_SEARCH_UPDATE);
         message.SetStringParam(typedString);
-        CApplicationMessenger::GetInstance().SendGUIMessage(message, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow());
+        CServiceBroker::GetAppMessenger()->SendGUIMessage(
+            message, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow());
         break;
       case FILTERING_CURRENT:
         message.SetParam1(GUI_MSG_FILTER_ITEMS);
         message.SetStringParam(typedString);
-        CApplicationMessenger::GetInstance().SendGUIMessage(message);
+        CServiceBroker::GetAppMessenger()->SendGUIMessage(message);
         break;
       case FILTERING_NONE:
         break;

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -238,7 +238,8 @@ void CGUIMultiImage::LoadDirectory()
   // slow(er) checks necessary - do them in the background
   std::unique_lock<CCriticalSection> lock(m_section);
   m_directoryStatus = LOADING;
-  m_jobID = CJobManager::GetInstance().AddJob(new CMultiImageJob(m_currentPath), this, CJob::PRIORITY_NORMAL);
+  m_jobID = CServiceBroker::GetJobManager()->AddJob(new CMultiImageJob(m_currentPath), this,
+                                                    CJob::PRIORITY_NORMAL);
 }
 
 void CGUIMultiImage::OnDirectoryLoaded()
@@ -260,7 +261,7 @@ void CGUIMultiImage::CancelLoading()
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   if (m_directoryStatus == LOADING)
-    CJobManager::GetInstance().CancelJob(m_jobID);
+    CServiceBroker::GetJobManager()->CancelJob(m_jobID);
   m_directoryStatus = UNLOADED;
 }
 

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -225,7 +225,7 @@ void CGUIMultiImage::LoadDirectory()
    3. Bundled folder
    */
   CFileItem item(m_currentPath, false);
-  if (item.IsPicture() || CTextureCache::GetInstance().HasCachedImage(m_currentPath))
+  if (item.IsPicture() || CServiceBroker::GetTextureCache()->HasCachedImage(m_currentPath))
     m_files.push_back(m_currentPath);
   else // bundled folder?
     m_files =

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -33,8 +33,6 @@
 
 #include <mutex>
 
-using namespace KODI::MESSAGING;
-
 bool CGUIWindow::icompare::operator()(const std::string &s1, const std::string &s2) const
 {
   return StringUtils::CompareNoCase(s1, s2) < 0;
@@ -407,9 +405,11 @@ void CGUIWindow::Close(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bo
     CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());
     int param2 = (forceClose ? 0x01 : 0) | (enableSound ? 0x02 : 0);
     if (bWait)
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_WINDOW_CLOSE, nextWindowID, param2, static_cast<void*>(this));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_WINDOW_CLOSE, nextWindowID, param2,
+                                                 static_cast<void*>(this));
     else
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_WINDOW_CLOSE, nextWindowID, param2, static_cast<void*>(this));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_WINDOW_CLOSE, nextWindowID, param2,
+                                                 static_cast<void*>(this));
   }
   else
     Close_Internal(forceClose, nextWindowID, enableSound);
@@ -827,7 +827,7 @@ bool CGUIWindow::Initialize()
     // if not app thread, send gui msg via app messenger
     // and wait for results, so windowLoaded flag would be updated
     CGUIMessage msg(GUI_MSG_WINDOW_LOAD, 0, 0);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, GetID(), true);
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, GetID(), true);
   }
   return m_windowLoaded;
 }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -14,6 +14,7 @@
 #include "GUIInfoManager.h"
 #include "GUIPassword.h"
 #include "GUITexture.h"
+#include "ServiceBroker.h"
 #include "WindowIDs.h"
 #include "addons/Skin.h"
 #include "addons/gui/GUIWindowAddonBrowser.h"
@@ -151,7 +152,6 @@
 using namespace KODI;
 using namespace PVR;
 using namespace PERIPHERALS;
-using namespace MESSAGING;
 
 CGUIWindowManager::CGUIWindowManager()
 {
@@ -170,7 +170,7 @@ void CGUIWindowManager::Initialize()
 
   LoadNotOnDemandWindows();
 
-  CApplicationMessenger::GetInstance().RegisterReceiver(this);
+  CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
 }
 
 void CGUIWindowManager::CreateWindows()
@@ -763,7 +763,8 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const std::vector<std::str
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTIVATE_WINDOW, iWindowID, swappingWindows ? 1 : 0, nullptr, "", params);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTIVATE_WINDOW, iWindowID,
+                                               swappingWindows ? 1 : 0, nullptr, "", params);
   }
   else
   {

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -38,8 +38,6 @@
 
 #include <stdlib.h>
 
-using namespace KODI::MESSAGING;
-
 struct StereoModeMap
 {
   const char*          name;
@@ -571,7 +569,7 @@ void CStereoscopicsManager::OnStreamChange()
   {
   case STEREOSCOPIC_PLAYBACK_MODE_ASK: // Ask
     {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
 
       CGUIDialogSelect* pDlgSelect = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
       pDlgSelect->Reset();
@@ -608,7 +606,7 @@ void CStereoscopicsManager::OnStreamChange()
         SetStereoModeByUser(mode);
       }
 
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_UNPAUSE);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_UNPAUSE);
     }
     break;
   case STEREOSCOPIC_PLAYBACK_MODE_PREFERRED: // Stereoscopic

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -48,7 +48,6 @@
 using EVENTSERVER::CEventServer;
 
 using namespace KODI;
-using namespace MESSAGING;
 
 const std::string CInputManager::SETTING_INPUT_ENABLE_CONTROLLER = "input.enablejoystick";
 
@@ -421,18 +420,18 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
         auto action =
             new CAction(actionId, 0, newEvent.touch.x, newEvent.touch.y, newEvent.touch.x2,
                         newEvent.touch.y2, newEvent.touch.x3, newEvent.touch.y3);
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
-                                                     static_cast<void*>(action));
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                   static_cast<void*>(action));
       }
       else
       {
         if (actionId == ACTION_BUILT_IN_FUNCTION && !actionString.empty())
-          CApplicationMessenger::GetInstance().PostMsg(
+          CServiceBroker::GetAppMessenger()->PostMsg(
               TMSG_GUI_ACTION, WINDOW_INVALID, -1,
               static_cast<void*>(new CAction(actionId, actionString)));
         else
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
-                                                       static_cast<void*>(new CAction(actionId)));
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                     static_cast<void*>(new CAction(actionId)));
       }
 
       break;
@@ -531,14 +530,14 @@ bool CInputManager::HandleKey(const CKey& key)
       CLog::LogF(LOGDEBUG, "action {} [{}], toggling state of playing device", action.GetName(),
                  action.GetID());
       bool result;
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_CECTOGGLESTATE, 0, 0,
-                                                   static_cast<void*>(&result));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_CECTOGGLESTATE, 0, 0,
+                                                 static_cast<void*>(&result));
       if (!result)
         return true;
     }
     else
     {
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_CECSTANDBY);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_CECSTANDBY);
       return true;
     }
   }

--- a/xbmc/input/KeyboardLayoutManager.cpp
+++ b/xbmc/input/KeyboardLayoutManager.cpp
@@ -9,6 +9,7 @@
 #include "KeyboardLayoutManager.h"
 
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/Directory.h"
 #include "settings/lib/Setting.h"
@@ -23,12 +24,6 @@
 CKeyboardLayoutManager::~CKeyboardLayoutManager()
 {
   Unload();
-}
-
-CKeyboardLayoutManager& CKeyboardLayoutManager::GetInstance()
-{
-  static CKeyboardLayoutManager s_instance;
-  return s_instance;
 }
 
 bool CKeyboardLayoutManager::Load(const std::string& path /* = "" */)
@@ -143,7 +138,7 @@ void CKeyboardLayoutManager::SettingOptionsKeyboardLayoutsFiller(
     std::string& current,
     void* data)
 {
-  for (const auto& it : CKeyboardLayoutManager::GetInstance().m_layouts)
+  for (const auto& it : CServiceBroker::GetKeyboardLayoutManager()->m_layouts)
   {
     std::string name = it.second.GetName();
     list.emplace_back(name, name);

--- a/xbmc/input/KeyboardLayoutManager.h
+++ b/xbmc/input/KeyboardLayoutManager.h
@@ -23,9 +23,8 @@ typedef std::map<std::string, CKeyboardLayout> KeyboardLayouts;
 class CKeyboardLayoutManager
 {
 public:
+  CKeyboardLayoutManager() = default;
   virtual ~CKeyboardLayoutManager();
-
-  static CKeyboardLayoutManager& GetInstance();
 
   bool Load(const std::string& path = "");
   void Unload();
@@ -39,7 +38,6 @@ public:
                                                   void* data);
 
 private:
-  CKeyboardLayoutManager() = default;
   CKeyboardLayoutManager(const CKeyboardLayoutManager&) = delete;
   CKeyboardLayoutManager const& operator=(CKeyboardLayoutManager const&) = delete;
 

--- a/xbmc/interfaces/builtins/AndroidBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AndroidBuiltins.cpp
@@ -8,6 +8,7 @@
 
 #include "AndroidBuiltins.h"
 
+#include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 
 /*! \brief Launch an android system activity.
@@ -19,8 +20,8 @@
  */
 static int LaunchAndroidActivity(const std::vector<std::string>& params)
 {
-  KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(
-    TMSG_START_ANDROID_ACTIVITY, -1, -1, nullptr, "", params);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_START_ANDROID_ACTIVITY, -1, -1, nullptr, "",
+                                             params);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -26,8 +26,6 @@
 
 #include <stdlib.h>
 
-using namespace KODI::MESSAGING;
-
 /*! \brief Extract an archive.
  *  \param params The parameters
  *  \details params[0] = The archive URL.
@@ -101,7 +99,8 @@ static int SetVolume(const std::vector<std::string>& params)
   {
     if(params.size() > 1 && StringUtils::EqualsNoCase(params[1], "showVolumeBar"))
     {
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_VOLUME_SHOW, oldVolume < volume ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN);
+      CServiceBroker::GetAppMessenger()->PostMsg(
+          TMSG_VOLUME_SHOW, oldVolume < volume ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN);
     }
   }
 

--- a/xbmc/interfaces/builtins/CECBuiltins.cpp
+++ b/xbmc/interfaces/builtins/CECBuiltins.cpp
@@ -8,16 +8,15 @@
 
 #include "CECBuiltins.h"
 
+#include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
-
-using namespace KODI::MESSAGING;
 
 /*! \brief Wake up device through CEC.
  *  \param params (ignored)
  */
 static int ActivateSource(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_CECACTIVATESOURCE);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_CECACTIVATESOURCE);
 
   return 0;
 }
@@ -27,7 +26,7 @@ static int ActivateSource(const std::vector<std::string>& params)
  */
 static int Standby(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_CECSTANDBY);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_CECSTANDBY);
 
   return 0;
 }
@@ -38,7 +37,8 @@ static int Standby(const std::vector<std::string>& params)
 static int ToggleState(const std::vector<std::string>& params)
 {
   bool result;
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_CECTOGGLESTATE, 0, 0, static_cast<void*>(&result));
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_CECTOGGLESTATE, 0, 0,
+                                             static_cast<void*>(&result));
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -32,8 +32,6 @@
 #include "utils/log.h"
 #include "windows/GUIMediaWindow.h"
 
-using namespace KODI::MESSAGING;
-
 /*! \brief Execute a GUI action.
  *  \param params The parameters.
  *  \details params[0] = Action to execute.
@@ -46,7 +44,8 @@ static int Action(const std::vector<std::string>& params)
   if (CActionTranslator::TranslateString(params[0], actionID))
   {
     int windowID = params.size() == 2 ? CWindowTranslator::TranslateWindow(params[1]) : WINDOW_INVALID;
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, windowID, -1, static_cast<void*>(new CAction(actionID)));
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, windowID, -1,
+                                               static_cast<void*>(new CAction(actionID)));
   }
 
   return 0;
@@ -334,7 +333,7 @@ static int Screenshot(const std::vector<std::string>& params)
  */
 static int SetLanguage(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_SETLANGUAGE, -1, -1, nullptr, params[0]);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SETLANGUAGE, -1, -1, nullptr, params[0]);
 
   return 0;
 }
@@ -362,7 +361,8 @@ static int SetStereoMode(const std::vector<std::string>& params)
 {
   CAction action = CStereoscopicsManager::ConvertActionCommandToAction("SetStereoMode", params[0]);
   if (action.GetID() != ACTION_NONE)
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(action)));
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(action)));
   else
   {
     CLog::Log(LOGERROR, "Builtin 'SetStereoMode' called with unknown parameter: {}", params[0]);

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -23,8 +23,6 @@
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 
-using namespace KODI::MESSAGING;
-
 /*! \brief Load a profile.
  *  \param params The parameters.
  *  \details params[0] = The profile name.
@@ -41,7 +39,7 @@ static int LoadProfile(const std::vector<std::string>& params)
       && (profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
         || g_passwordManager.IsProfileLockUnlocked(index,bCanceled,prompt)))
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_LOADPROFILE, index);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_LOADPROFILE, index);
   }
 
   return 0;

--- a/xbmc/interfaces/builtins/SystemBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SystemBuiltins.cpp
@@ -8,10 +8,9 @@
 
 #include "SystemBuiltins.h"
 
+#include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 #include "utils/StringUtils.h"
-
-using namespace KODI::MESSAGING;
 
 /*! \brief Execute a system executable.
  *  \param params The parameters.
@@ -22,8 +21,8 @@ using namespace KODI::MESSAGING;
   template<int Wait=0>
 static int Exec(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_MINIMIZE);
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_OS, Wait, -1, nullptr, params[0]);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MINIMIZE);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_OS, Wait, -1, nullptr, params[0]);
 
   return 0;
 }
@@ -33,7 +32,7 @@ static int Exec(const std::vector<std::string>& params)
  */
 static int Hibernate(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_HIBERNATE);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_HIBERNATE);
 
   return 0;
 }
@@ -45,7 +44,7 @@ static int Hibernate(const std::vector<std::string>& params)
 static int InhibitIdle(const std::vector<std::string>& params)
 {
   bool inhibit = (params.size() == 1 && StringUtils::EqualsNoCase(params[0], "true"));
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_INHIBITIDLESHUTDOWN, inhibit);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_INHIBITIDLESHUTDOWN, inhibit);
 
   return 0;
 }
@@ -55,7 +54,7 @@ static int InhibitIdle(const std::vector<std::string>& params)
  */
 static int Minimize(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_MINIMIZE);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MINIMIZE);
 
   return 0;
 }
@@ -65,7 +64,7 @@ static int Minimize(const std::vector<std::string>& params)
  */
 static int Powerdown(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_POWERDOWN);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_POWERDOWN);
 
   return 0;
 }
@@ -75,7 +74,7 @@ static int Powerdown(const std::vector<std::string>& params)
  */
 static int Quit(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
 
   return 0;
 }
@@ -85,7 +84,7 @@ static int Quit(const std::vector<std::string>& params)
  */
 static int Reboot(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTART);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RESTART);
 
   return 0;
 }
@@ -95,7 +94,7 @@ static int Reboot(const std::vector<std::string>& params)
  */
 static int RestartApp(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTARTAPP);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RESTARTAPP);
 
   return 0;
 }
@@ -105,7 +104,7 @@ static int RestartApp(const std::vector<std::string>& params)
  */
 static int ActivateScreensaver(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_ACTIVATESCREENSAVER);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_ACTIVATESCREENSAVER);
 
   return 0;
 }
@@ -115,7 +114,7 @@ static int ActivateScreensaver(const std::vector<std::string>& params)
  */
 static int ResetScreensaver(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_RESETSCREENSAVER);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RESETSCREENSAVER);
 
   return 0;
 }
@@ -127,7 +126,7 @@ static int ResetScreensaver(const std::vector<std::string>& params)
 static int InhibitScreenSaver(const std::vector<std::string>& params)
 {
   bool inhibit = (params.size() == 1 && StringUtils::EqualsNoCase(params[0], "true"));
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_INHIBITSCREENSAVER, inhibit);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_INHIBITSCREENSAVER, inhibit);
 
   return 0;
 }
@@ -137,7 +136,7 @@ static int InhibitScreenSaver(const std::vector<std::string>& params)
  */
 static int Shutdown(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SHUTDOWN);
 
   return 0;
 }
@@ -147,7 +146,7 @@ static int Shutdown(const std::vector<std::string>& params)
  */
 static int Suspend(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_SUSPEND);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SUSPEND);
 
   return 0;
 }

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -22,7 +22,6 @@
 using namespace JSONRPC;
 using namespace ADDON;
 using namespace XFILE;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CAddonsOperations::GetAddons(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -214,9 +213,9 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITrans
     cmd = StringUtils::Format("RunAddon({}, {})", id, argv);
 
   if (params["wait"].asBoolean())
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   else
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
 
   return ACK;
 }

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -301,7 +301,7 @@ void CAddonsOperations::FillDetails(const AddonPtr& addon,
       // We need to check the existence of fanart and thumbnails as the addon simply
       // holds where the art will be, not whether it exists.
       bool needsRecaching;
-      std::string image = CTextureCache::GetInstance().CheckCachedImage(url, needsRecaching);
+      std::string image = CServiceBroker::GetTextureCache()->CheckCachedImage(url, needsRecaching);
       if (!image.empty() || CFile::Exists(url))
         object[field] = CTextureUtils::GetWrappedImageURL(url);
       else

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -13,6 +13,7 @@
 #include "GUIInfoManager.h"
 #include "InputOperations.h"
 #include "LangInfo.h"
+#include "ServiceBroker.h"
 #include "Util.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
@@ -24,7 +25,6 @@
 #include <string.h>
 
 using namespace JSONRPC;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CApplicationOperations::GetProperties(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -80,7 +80,8 @@ JSONRPC_STATUS CApplicationOperations::SetVolume(const std::string &method, ITra
   else
     return InvalidParams;
 
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_VOLUME_SHOW, up ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_VOLUME_SHOW,
+                                             up ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN);
 
   return GetPropertyValue("volume", result);
 }
@@ -89,7 +90,8 @@ JSONRPC_STATUS CApplicationOperations::SetMute(const std::string &method, ITrans
 {
   if ((parameterObject["mute"].isString() && parameterObject["mute"].asString().compare("toggle") == 0) ||
       (parameterObject["mute"].isBoolean() && parameterObject["mute"].asBoolean() != g_application.IsMuted()))
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_MUTE)));
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(ACTION_MUTE)));
   else if (!parameterObject["mute"].isBoolean() && !parameterObject["mute"].isString())
     return InvalidParams;
 
@@ -98,7 +100,7 @@ JSONRPC_STATUS CApplicationOperations::SetMute(const std::string &method, ITrans
 
 JSONRPC_STATUS CApplicationOperations::Quit(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -31,7 +31,6 @@
 using namespace MUSIC_INFO;
 using namespace JSONRPC;
 using namespace XFILE;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CAudioLibrary::GetProperties(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -1032,7 +1031,7 @@ JSONRPC_STATUS CAudioLibrary::Scan(const std::string &method, ITransportLayer *t
       StringUtils::Format("updatelibrary(music, {}, {})", StringUtils::Paramify(directory),
                           parameterObject["showdialogs"].asBoolean() ? "true" : "false");
 
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
 }
 
@@ -1053,7 +1052,7 @@ JSONRPC_STATUS CAudioLibrary::Export(const std::string &method, ITransportLayer 
       cmd += ", overwrite";
     cmd += ")";
   }
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
 }
 
@@ -1061,7 +1060,7 @@ JSONRPC_STATUS CAudioLibrary::Clean(const std::string &method, ITransportLayer *
 {
   std::string cmd = StringUtils::Format(
       "cleanlibrary(music, {})", parameterObject["showdialogs"].asBoolean() ? "true" : "false");
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -26,7 +26,6 @@
 
 using namespace JSONRPC;
 using namespace ADDON;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CGUIOperations::GetProperties(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -58,7 +57,8 @@ JSONRPC_STATUS CGUIOperations::ActivateWindow(const std::string &method, ITransp
       if (param->isString() && !param->empty())
         params.push_back(param->asString());
     }
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTIVATE_WINDOW, iWindow, 0, nullptr, "", params);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTIVATE_WINDOW, iWindow, 0, nullptr, "",
+                                               params);
     return ACK;
   }
 
@@ -91,7 +91,8 @@ JSONRPC_STATUS CGUIOperations::SetFullscreen(const std::string &method, ITranspo
       (parameterObject["fullscreen"].isBoolean() &&
        parameterObject["fullscreen"].asBoolean() != g_application.IsFullScreen()))
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_SHOW_GUI)));
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(ACTION_SHOW_GUI)));
   }
   else if (!parameterObject["fullscreen"].isBoolean() && !parameterObject["fullscreen"].isString())
     return InvalidParams;
@@ -104,7 +105,8 @@ JSONRPC_STATUS CGUIOperations::SetStereoscopicMode(const std::string &method, IT
   CAction action = CStereoscopicsManager::ConvertActionCommandToAction("SetStereoMode", parameterObject["mode"].asString());
   if (action.GetID() != ACTION_NONE)
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(action)));
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(action)));
     return ACK;
   }
 

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -9,6 +9,7 @@
 #include "InputOperations.h"
 
 #include "Application.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindow.h"
@@ -20,7 +21,6 @@
 #include "utils/Variant.h"
 
 using namespace JSONRPC;
-using namespace KODI::MESSAGING;
 
 //! @todo the breakage of the screensaver should be refactored
 //! to one central super duper place for getting rid of
@@ -44,9 +44,11 @@ JSONRPC_STATUS CInputOperations::SendAction(int actionID, bool wakeScreensaver /
       gui->GetAudioManager().PlayActionSound(actionID);
 
     if (waitResult)
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(actionID)));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(actionID)));
     else
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(actionID)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(actionID)));
   }
   return ACK;
 }
@@ -54,7 +56,7 @@ JSONRPC_STATUS CInputOperations::SendAction(int actionID, bool wakeScreensaver /
 JSONRPC_STATUS CInputOperations::activateWindow(int windowID)
 {
   if(!handleScreenSaver())
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTIVATE_WINDOW, windowID, 0);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTIVATE_WINDOW, windowID, 0);
 
   return ACK;
 }
@@ -71,7 +73,7 @@ JSONRPC_STATUS CInputOperations::SendText(const std::string &method, ITransportL
   CGUIMessage msg(GUI_MSG_SET_TEXT, 0, window->GetFocusedControlID());
   msg.SetLabel(parameterObject["text"].asString());
   msg.SetParam1(parameterObject["done"].asBoolean() ? 1 : 0);
-  CApplicationMessenger::GetInstance().SendGUIMessage(msg, window->GetID());
+  CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, window->GetID());
 
   return ACK;
 }
@@ -110,7 +112,7 @@ JSONRPC_STATUS CInputOperations::ButtonEvent(const std::string& method,
   newEvent->keybutton.button = keycode;
   newEvent->keybutton.holdtime = holdtime;
 
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_EVENT, -1, -1, static_cast<void*>(newEvent));
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EVENT, -1, -1, static_cast<void*>(newEvent));
 
   return ACK;
 }

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -10,6 +10,7 @@
 
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
@@ -19,7 +20,6 @@
 
 using namespace JSONRPC;
 using namespace PLAYLIST;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CPlaylistOperations::GetPlaylists(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -68,7 +68,8 @@ JSONRPC_STATUS CPlaylistOperations::GetItems(const std::string &method, ITranspo
   {
     case PLAYLIST_VIDEO:
     case PLAYLIST_MUSIC:
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_GET_ITEMS, playlist, -1, static_cast<void*>(&list));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_GET_ITEMS, playlist, -1,
+                                                 static_cast<void*>(&list));
       break;
 
     case PLAYLIST_PICTURE:
@@ -120,7 +121,8 @@ JSONRPC_STATUS CPlaylistOperations::Add(const std::string &method, ITransportLay
     {
       auto tmpList = new CFileItemList();
       tmpList->Copy(list);
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_ADD, playlist, -1, static_cast<void*>(tmpList));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_ADD, playlist, -1,
+                                                 static_cast<void*>(tmpList));
       break;
     }
     case PLAYLIST_PICTURE:
@@ -154,8 +156,9 @@ JSONRPC_STATUS CPlaylistOperations::Insert(const std::string &method, ITransport
 
   auto tmpList = new CFileItemList();
   tmpList->Copy(list);
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_INSERT, playlist,
-    static_cast<int>(parameterObject["position"].asInteger()), static_cast<void*>(tmpList));
+  CServiceBroker::GetAppMessenger()->PostMsg(
+      TMSG_PLAYLISTPLAYER_INSERT, playlist,
+      static_cast<int>(parameterObject["position"].asInteger()), static_cast<void*>(tmpList));
 
   return ACK;
 }
@@ -170,7 +173,7 @@ JSONRPC_STATUS CPlaylistOperations::Remove(const std::string &method, ITransport
   if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist && CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == position)
     return InvalidParams;
 
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_REMOVE, playlist, position);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_REMOVE, playlist, position);
 
   return ACK;
 }
@@ -183,14 +186,15 @@ JSONRPC_STATUS CPlaylistOperations::Clear(const std::string &method, ITransportL
   {
     case PLAYLIST_MUSIC:
     case PLAYLIST_VIDEO:
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_CLEAR, playlist);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_CLEAR, playlist);
       break;
 
     case PLAYLIST_PICTURE:
       slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
       if (!slideshow)
         return FailedToExecute;
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1, static_cast<void*>(new CAction(ACTION_STOP)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1,
+                                                 static_cast<void*>(new CAction(ACTION_STOP)));
       slideshow->Reset();
       break;
   }
@@ -207,7 +211,8 @@ JSONRPC_STATUS CPlaylistOperations::Swap(const std::string &method, ITransportLa
   auto tmpVec = new std::vector<int>();
   tmpVec->push_back(static_cast<int>(parameterObject["position1"].asInteger()));
   tmpVec->push_back(static_cast<int>(parameterObject["position2"].asInteger()));
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_SWAP, playlist, -1, static_cast<void*>(tmpVec));
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_SWAP, playlist, -1,
+                                             static_cast<void*>(tmpVec));
 
   return ACK;
 }
@@ -252,7 +257,8 @@ JSONRPC_STATUS CPlaylistOperations::GetPropertyValue(int playlist, const std::st
     {
       case PLAYLIST_MUSIC:
       case PLAYLIST_VIDEO:
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_GET_ITEMS, playlist, -1, static_cast<void*>(&list));
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_GET_ITEMS, playlist, -1,
+                                                   static_cast<void*>(&list));
         result = list.Size();
         break;
 

--- a/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
@@ -18,7 +18,6 @@
 #include "utils/Variant.h"
 
 using namespace JSONRPC;
-using namespace KODI::MESSAGING;
 using KODI::UTILITY::CDigest;
 
 JSONRPC_STATUS CProfilesOperations::GetProfiles(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
@@ -129,7 +128,7 @@ JSONRPC_STATUS CProfilesOperations::LoadProfile(const std::string &method, ITran
 
   if (bLoadProfile)
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_LOADPROFILE, index);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_LOADPROFILE, index);
     return ACK;
   }
   return InvalidParams;

--- a/xbmc/interfaces/json-rpc/SystemOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SystemOperations.cpp
@@ -15,7 +15,6 @@
 #include "utils/Variant.h"
 
 using namespace JSONRPC;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CSystemOperations::GetProperties(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -45,7 +44,7 @@ JSONRPC_STATUS CSystemOperations::Shutdown(const std::string &method, ITransport
 {
   if (CServiceBroker::GetPowerManager().CanPowerdown())
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_POWERDOWN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_POWERDOWN);
     return ACK;
   }
   else
@@ -56,7 +55,7 @@ JSONRPC_STATUS CSystemOperations::Suspend(const std::string &method, ITransportL
 {
   if (CServiceBroker::GetPowerManager().CanSuspend())
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_SUSPEND);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SUSPEND);
     return ACK;
   }
   else
@@ -67,7 +66,7 @@ JSONRPC_STATUS CSystemOperations::Hibernate(const std::string &method, ITranspor
 {
   if (CServiceBroker::GetPowerManager().CanHibernate())
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_HIBERNATE);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_HIBERNATE);
     return ACK;
   }
   else
@@ -78,7 +77,7 @@ JSONRPC_STATUS CSystemOperations::Reboot(const std::string &method, ITransportLa
 {
   if (CServiceBroker::GetPowerManager().CanReboot())
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTART);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RESTART);
     return ACK;
   }
   else

--- a/xbmc/interfaces/json-rpc/TextureOperations.cpp
+++ b/xbmc/interfaces/json-rpc/TextureOperations.cpp
@@ -8,6 +8,7 @@
 
 #include "TextureOperations.h"
 
+#include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "TextureDatabase.h"
 #include "utils/Variant.h"
@@ -86,7 +87,7 @@ JSONRPC_STATUS CTextureOperations::RemoveTexture(const std::string &method, ITra
 {
   int id = (int)parameterObject["textureid"].asInteger();
 
-  if (!CTextureCache::GetInstance().ClearCachedImage(id))
+  if (!CServiceBroker::GetTextureCache()->ClearCachedImage(id))
     return InvalidParams;
 
   return ACK;

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -9,6 +9,7 @@
 #include "VideoLibrary.h"
 
 #include "PVROperations.h"
+#include "ServiceBroker.h"
 #include "TextureDatabase.h"
 #include "Util.h"
 #include "messaging/ApplicationMessenger.h"
@@ -20,7 +21,6 @@
 #include "video/VideoLibraryQueue.h"
 
 using namespace JSONRPC;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CVideoLibrary::GetMovies(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -958,7 +958,7 @@ JSONRPC_STATUS CVideoLibrary::Scan(const std::string &method, ITransportLayer *t
       StringUtils::Format("updatelibrary(video, {}, {})", StringUtils::Paramify(directory),
                           parameterObject["showdialogs"].asBoolean() ? "true" : "false");
 
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
 }
 
@@ -983,7 +983,7 @@ JSONRPC_STATUS CVideoLibrary::Export(const std::string &method, ITransportLayer 
     cmd += ")";
   }
 
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
 }
 
@@ -1000,7 +1000,7 @@ JSONRPC_STATUS CVideoLibrary::Clean(const std::string &method, ITransportLayer *
                               parameterObject["showdialogs"].asBoolean() ? "true" : "false",
                               StringUtils::Paramify(directory));
 
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/XBMCOperations.cpp
+++ b/xbmc/interfaces/json-rpc/XBMCOperations.cpp
@@ -14,7 +14,6 @@
 #include "utils/Variant.h"
 
 using namespace JSONRPC;
-using namespace KODI::MESSAGING;
 
 JSONRPC_STATUS CXBMCOperations::GetInfoLabels(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -31,7 +30,8 @@ JSONRPC_STATUS CXBMCOperations::GetInfoLabels(const std::string &method, ITransp
   if (!info.empty())
   {
     std::vector<std::string> infoLabels;
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_INFOLABEL, -1, -1, static_cast<void*>(&infoLabels), "", info);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_INFOLABEL, -1, -1,
+                                               static_cast<void*>(&infoLabels), "", info);
 
     for (unsigned int i = 0; i < info.size(); i++)
     {
@@ -74,7 +74,8 @@ JSONRPC_STATUS CXBMCOperations::GetInfoBooleans(const std::string &method, ITran
   if (!info.empty())
   {
     std::vector<bool> infoLabels;
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_INFOBOOL, -1, -1, static_cast<void*>(&infoLabels), "", info);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_INFOBOOL, -1, -1,
+                                               static_cast<void*>(&infoLabels), "", info);
     for (unsigned int i = 0; i < info.size(); i++)
     {
       if (i >= infoLabels.size())

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -46,7 +46,6 @@
 #include <vector>
 
 using namespace KODI;
-using namespace KODI::MESSAGING;
 
 namespace XBMCAddon
 {
@@ -67,13 +66,13 @@ namespace XBMCAddon
     void shutdown()
     {
       XBMC_TRACE;
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SHUTDOWN);
     }
 
     void restart()
     {
       XBMC_TRACE;
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTART);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RESTART);
     }
 
     void executescript(const char* script)
@@ -82,7 +81,7 @@ namespace XBMCAddon
       if (! script)
         return;
 
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_SCRIPT, -1, -1, nullptr, script);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_SCRIPT, -1, -1, nullptr, script);
     }
 
     void executebuiltin(const char* function, bool wait /* = false*/)
@@ -110,9 +109,11 @@ namespace XBMCAddon
       }
 
       if (wait)
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, function);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                                   function);
       else
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, function);
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                                   function);
     }
 
     String executeJSONRPC(const char* jsonrpccommand)

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -23,8 +23,6 @@
 #include "settings/MediaSettings.h"
 #include "utils/log.h"
 
-using namespace KODI::MESSAGING;
-
 namespace XBMCAddon
 {
   namespace xbmc
@@ -83,13 +81,15 @@ namespace XBMCAddon
         {
           // set m_strPath to the passed url
           listitem->item->SetPath(item.c_str());
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(new CFileItem(*listitem->item)));
+          CServiceBroker::GetAppMessenger()->PostMsg(
+              TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(new CFileItem(*listitem->item)));
         }
         else
         {
           CFileItemList *l = new CFileItemList; //don't delete,
           l->Add(std::make_shared<CFileItem>(item, false));
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, -1, -1,
+                                                     static_cast<void*>(l));
         }
       }
       else
@@ -106,7 +106,8 @@ namespace XBMCAddon
       // play current file in playlist
       if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != iPlayList)
         CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, CServiceBroker::GetPlaylistPlayer().GetCurrentSong());
+      CServiceBroker::GetAppMessenger()->SendMsg(
+          TMSG_PLAYLISTPLAYER_PLAY, CServiceBroker::GetPlaylistPlayer().GetCurrentSong());
     }
 
     void Player::playPlaylist(const PlayList* playlist, bool windowed, int startpos)
@@ -123,7 +124,7 @@ namespace XBMCAddon
         CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
         if (startpos > -1)
           CServiceBroker::GetPlaylistPlayer().SetCurrentSong(startpos);
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, startpos);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_PLAY, startpos);
       }
       else
         playCurrent(windowed);
@@ -132,13 +133,13 @@ namespace XBMCAddon
     void Player::stop()
     {
       XBMC_TRACE;
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
     }
 
     void Player::pause()
     {
       XBMC_TRACE;
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
     }
 
     void Player::playnext()
@@ -146,7 +147,7 @@ namespace XBMCAddon
       XBMC_TRACE;
       DelayedCallGuard dc(languageHook);
 
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_NEXT);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_NEXT);
     }
 
     void Player::playprevious()
@@ -154,7 +155,7 @@ namespace XBMCAddon
       XBMC_TRACE;
       DelayedCallGuard dc(languageHook);
 
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PREV);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_PREV);
     }
 
     void Player::playselected(int selected)
@@ -168,7 +169,7 @@ namespace XBMCAddon
       }
       CServiceBroker::GetPlaylistPlayer().SetCurrentSong(selected);
 
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, selected);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_PLAY, selected);
       //CServiceBroker::GetPlaylistPlayer().Play(selected);
       //CLog::Log(LOGINFO, "Current Song After Play: {}", CServiceBroker::GetPlaylistPlayer().GetCurrentSong());
     }

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -20,10 +20,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "utils/Variant.h"
 
-using namespace KODI::MESSAGING;
-
 #define ACTIVE_WINDOW CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow()
-
 
 namespace XBMCAddon
 {
@@ -490,7 +487,7 @@ namespace XBMCAddon
       DelayedCallGuard dcguard(languageHook);
       popActiveWindowId();
 
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTIVATE_WINDOW, iWindowId, 0);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTIVATE_WINDOW, iWindowId, 0);
     }
 
     void Window::setFocus(Control* pControl)
@@ -565,7 +562,7 @@ namespace XBMCAddon
 
       CGUIMessage msg(GUI_MSG_REMOVE_CONTROL, 0, 0);
       msg.SetPointer(pControl->pGUIControl);
-      CApplicationMessenger::GetInstance().SendGUIMessage(msg, iWindowId, wait);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, iWindowId, wait);
 
       // initialize control to zero
       pControl->pGUIControl = NULL;
@@ -646,7 +643,7 @@ namespace XBMCAddon
 
       {
         DelayedCallGuard dcguard(languageHook);
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_PREVIOUS_WINDOW, iOldWindowId, 0);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_PREVIOUS_WINDOW, iOldWindowId, 0);
       }
 
       iOldWindowId = 0;
@@ -735,7 +732,7 @@ namespace XBMCAddon
       // This calls the CGUIWindow parent class to do the final add
       CGUIMessage msg(GUI_MSG_ADD_CONTROL, 0, 0);
       msg.SetPointer(pControl->pGUIControl);
-      CApplicationMessenger::GetInstance().SendGUIMessage(msg, iWindowId, wait);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, iWindowId, wait);
     }
 
     void Window::addControls(std::vector<Control*> pControls)

--- a/xbmc/interfaces/legacy/WindowDialogMixin.cpp
+++ b/xbmc/interfaces/legacy/WindowDialogMixin.cpp
@@ -14,8 +14,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "messaging/ApplicationMessenger.h"
 
-using namespace KODI::MESSAGING;
-
 namespace XBMCAddon
 {
   namespace xbmcgui
@@ -23,7 +21,8 @@ namespace XBMCAddon
     void WindowDialogMixin::show()
     {
       XBMC_TRACE;
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_PYTHON_DIALOG, HACK_CUSTOM_ACTION_OPENING, 0, static_cast<void*>(w->window->get()));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_PYTHON_DIALOG, HACK_CUSTOM_ACTION_OPENING,
+                                                 0, static_cast<void*>(w->window->get()));
     }
 
     void WindowDialogMixin::close()
@@ -32,7 +31,8 @@ namespace XBMCAddon
       w->bModal = false;
       w->PulseActionEvent();
 
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_PYTHON_DIALOG, HACK_CUSTOM_ACTION_CLOSING, 0, static_cast<void*>(w->window->get()));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_PYTHON_DIALOG, HACK_CUSTOM_ACTION_CLOSING,
+                                                 0, static_cast<void*>(w->window->get()));
 
       w->iOldWindowId = 0;
     }

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -60,7 +60,6 @@ extern "C" FILE* fopen_utf8(const char* _Filename, const char* _Mode);
 #define PYTHON_SCRIPT_TIMEOUT 5000ms // ms
 
 using namespace XFILE;
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 #define PythonModulesSize sizeof(PythonModules) / sizeof(PythonModule)
@@ -513,7 +512,7 @@ bool CPythonInvoker::stop(bool abort)
       // on TMSG_GUI_PYTHON_DIALOG messages, so pump the message loop.
       if (g_application.IsCurrentThread())
       {
-        CApplicationMessenger::GetInstance().ProcessMessages();
+        CServiceBroker::GetAppMessenger()->ProcessMessages();
       }
     }
 

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -231,8 +231,9 @@ bool CDirectoryProvider::Update(bool forceRefresh)
   {
     CLog::Log(LOGDEBUG, "CDirectoryProvider[{}]: refreshing..", m_currentUrl);
     if (m_jobID)
-      CJobManager::GetInstance().CancelJob(m_jobID);
-    m_jobID = CJobManager::GetInstance().AddJob(new CDirectoryJob(m_currentUrl, m_currentSort, m_currentLimit, m_parentID), this);
+      CServiceBroker::GetJobManager()->CancelJob(m_jobID);
+    m_jobID = CServiceBroker::GetJobManager()->AddJob(
+        new CDirectoryJob(m_currentUrl, m_currentSort, m_currentLimit, m_parentID), this);
   }
 
   if (!changed)
@@ -349,7 +350,7 @@ void CDirectoryProvider::Reset()
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   if (m_jobID)
-    CJobManager::GetInstance().CancelJob(m_jobID);
+    CServiceBroker::GetJobManager()->CancelJob(m_jobID);
   m_jobID = 0;
   m_items.clear();
   m_currentTarget.clear();

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -47,14 +47,8 @@ void CDelayedMessage::Process()
   CThread::Sleep(std::chrono::milliseconds(m_delay));
 
   if (!m_bStop)
-    CApplicationMessenger::GetInstance().PostMsg(m_msg.dwMessage, m_msg.param1, m_msg.param1, m_msg.lpVoid, m_msg.strParam, m_msg.params);
-}
-
-
-CApplicationMessenger& CApplicationMessenger::GetInstance()
-{
-  static CApplicationMessenger appMessenger;
-  return appMessenger;
+    CServiceBroker::GetAppMessenger()->PostMsg(m_msg.dwMessage, m_msg.param1, m_msg.param1,
+                                               m_msg.lpVoid, m_msg.strParam, m_msg.params);
 }
 
 CApplicationMessenger::CApplicationMessenger() = default;

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -226,11 +226,8 @@ struct ThreadMessageCallback
 class CApplicationMessenger
 {
 public:
-  /*!
-   \brief The only way through which the global instance of the CApplicationMessenger should be accessed.
-   \return the global instance.
-   */
-  static CApplicationMessenger& GetInstance();
+  CApplicationMessenger();
+  ~CApplicationMessenger();
 
   void Cleanup();
   // if a message has to be send to the gui, use MSG_TYPE_WINDOW instead
@@ -410,11 +407,8 @@ public:
   void Stop() { m_bStop = true; }
 
 private:
-  // private construction, and no assignments; use the provided singleton methods
-  CApplicationMessenger();
   CApplicationMessenger(const CApplicationMessenger&) = delete;
   CApplicationMessenger const& operator=(CApplicationMessenger const&) = delete;
-  ~CApplicationMessenger();
 
   int SendMsg(ThreadMessage&& msg, bool wait);
   void ProcessMessage(ThreadMessage *pMsg);

--- a/xbmc/messaging/helpers/DialogHelper.cpp
+++ b/xbmc/messaging/helpers/DialogHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "DialogHelper.h"
 
+#include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 
 #include <cassert>
@@ -35,7 +36,8 @@ DialogResponse ShowYesNoCustomDialog(CVariant heading, CVariant text, CVariant n
   options.customLabel = std::move(customLabel);
   options.autoclose = autoCloseTimeout;
 
-  switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
+  switch (CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1,
+                                                     static_cast<void*>(&options)))
   {
   case -1:
     return DialogResponse::CHOICE_CANCELLED;
@@ -67,7 +69,8 @@ DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant l
   options.customLabel = "";
   options.autoclose = autoCloseTimeout;
 
-  switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
+  switch (CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1,
+                                                     static_cast<void*>(&options)))
   {
   case -1:
     return DialogResponse::CHOICE_CANCELLED;

--- a/xbmc/messaging/helpers/DialogOKHelper.cpp
+++ b/xbmc/messaging/helpers/DialogOKHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "DialogOKHelper.h"
 
+#include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 
 namespace KODI
@@ -22,7 +23,8 @@ bool ShowOKDialogText(CVariant heading, CVariant text)
   options.heading = std::move(heading);
   options.text = std::move(text);
 
-  if (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OK, -1, -1, static_cast<void*>(&options)) > 0)
+  if (CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_DIALOG_OK, -1, -1,
+                                                 static_cast<void*>(&options)) > 0)
     return true;
   return false;
 }
@@ -34,7 +36,8 @@ void UpdateOKDialogText(CVariant heading, CVariant text)
   options.text = std::move(text);
   options.show = false;
 
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OK, -1, -1, static_cast<void*>(&options));
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_DIALOG_OK, -1, -1,
+                                             static_cast<void*>(&options));
 }
 
 bool ShowOKDialogLines(CVariant heading, CVariant line0, CVariant line1, CVariant line2)
@@ -45,7 +48,8 @@ bool ShowOKDialogLines(CVariant heading, CVariant line0, CVariant line1, CVarian
   options.lines[1] = std::move(line1);
   options.lines[2] = std::move(line2);
 
-  if (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OK, -1, -1, static_cast<void*>(&options)) > 0)
+  if (CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_DIALOG_OK, -1, -1,
+                                                 static_cast<void*>(&options)) > 0)
     return true;
   return false;
 }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -11910,8 +11910,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                     savedArtfile = URIUtils::AddFileToFolder(strPath, "folder");
                   else
                     savedArtfile = URIUtils::AddFileToFolder(strPath, art.first);
-                  CTextureCache::GetInstance().Export(art.second, savedArtfile,
-                                                      settings.m_overwrite);
+                  CServiceBroker::GetTextureCache()->Export(art.second, savedArtfile,
+                                                            settings.m_overwrite);
                 }
               }
             }
@@ -12051,8 +12051,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                       savedArtfile = URIUtils::AddFileToFolder(strPath, "folder");
                     else
                       savedArtfile = URIUtils::AddFileToFolder(strPath, art.first);
-                    CTextureCache::GetInstance().Export(art.second, savedArtfile,
-                                                        settings.m_overwrite);
+                    CServiceBroker::GetTextureCache()->Export(art.second, savedArtfile,
+                                                              settings.m_overwrite);
                   }
                 }
               }

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -183,7 +183,7 @@ namespace MUSIC_UTILS
   {
     // Asynchronously update that type of art in the database
     CSetArtJob *job = new CSetArtJob(pItem, strType, strArt);
-    CJobManager::GetInstance().AddJob(job, NULL);
+    CServiceBroker::GetJobManager()->AddJob(job, nullptr);
   }
 
   // Add art types required in Kodi and configured by the user
@@ -343,7 +343,7 @@ namespace MUSIC_UTILS
       job = new CSetSongRatingJob(tag->GetDatabaseId(), userrating);
     else
       job = new CSetSongRatingJob(pItem->GetPath(), userrating);
-    CJobManager::GetInstance().AddJob(job, NULL);
+    CServiceBroker::GetJobManager()->AddJob(job, nullptr);
   }
 
   std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType)

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -340,7 +340,7 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
         // Asynchronously update song userrating in library
         CSetUserratingJob *job = new CSetUserratingJob(m_item->GetMusicInfoTag()->GetAlbumId(),
                                                        m_item->GetMusicInfoTag()->GetUserrating());
-        CJobManager::GetInstance().AddJob(job, NULL);
+        CServiceBroker::GetJobManager()->AddJob(job, nullptr);
       }
       if (m_hasRefreshed || m_hasUpdatedUserrating)
       {
@@ -444,13 +444,14 @@ bool CGUIDialogMusicInfo::SetItem(CFileItem* item)
   m_cancelled = false;  // Happens before win_init
 
   // In a separate job fetch info and fill list of art types.
-  int jobid = CJobManager::GetInstance().AddJob(new CGetInfoJob(), nullptr, CJob::PRIORITY_LOW);
+  int jobid =
+      CServiceBroker::GetJobManager()->AddJob(new CGetInfoJob(), nullptr, CJob::PRIORITY_LOW);
 
   // Wait to get all data before show, allowing user to cancel if fetch is slow
   if (!CGUIDialogBusy::WaitOnEvent(m_event, TIME_TO_BUSY_DIALOG))
   {
     // Cancel job still waiting in queue (unlikely)
-    CJobManager::GetInstance().CancelJob(jobid);
+    CServiceBroker::GetJobManager()->CancelJob(jobid);
     // Flag to stop job already in progress
     m_cancelled = true;
     return false;
@@ -606,7 +607,8 @@ void CGUIDialogMusicInfo::RefreshInfo()
 
   SetScrapedInfo(false);
   // Start separate job to scrape info and fill list of art types.
-  CJobManager::GetInstance().AddJob(new CRefreshInfoJob(dlgProgress), nullptr, CJob::PRIORITY_HIGH);
+  CServiceBroker::GetJobManager()->AddJob(new CRefreshInfoJob(dlgProgress), nullptr,
+                                          CJob::PRIORITY_HIGH);
 
   // Wait for refresh to complete or be canceled, but render every 10ms so that the
   // pointer movements works on dialog even when job is reporting progress infrequently

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -860,10 +860,10 @@ void CGUIDialogMusicInfo::OnGetArt()
     // Skip images from remote sources (current thumb could be remote)
     if (url.IsProtocol("http") || url.IsProtocol("https"))
       continue;
-    CTextureCache::GetInstance().ClearCachedImage(thumb);
+    CServiceBroker::GetTextureCache()->ClearCachedImage(thumb);
     // Remove any thumbnail of local image too (created when browsing files)
     std::string thumbthumb(CTextureUtils::GetWrappedThumbURL(thumb));
-    CTextureCache::GetInstance().ClearCachedImage(thumbthumb);
+    CServiceBroker::GetTextureCache()->ClearCachedImage(thumbthumb);
   }
 
   // Show list of possible art for user selection

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -388,10 +388,10 @@ void CGUIDialogSongInfo::OnGetArt()
     std::string thumb(item->GetArt("thumb"));
     if (thumb.empty())
       continue;
-    CTextureCache::GetInstance().ClearCachedImage(thumb);
+    CServiceBroker::GetTextureCache()->ClearCachedImage(thumb);
     // Remove any thumbnail of local image too (created when browsing files)
     std::string thumbthumb(CTextureUtils::GetWrappedThumbURL(thumb));
-    CTextureCache::GetInstance().ClearCachedImage(thumbthumb);
+    CServiceBroker::GetTextureCache()->ClearCachedImage(thumbthumb);
   }
 
   if (bHasArt && !bFallback)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -281,13 +281,14 @@ bool CGUIDialogSongInfo::SetSong(CFileItem* item)
   m_event.Reset();
   m_cancelled = false;  // SetSong happens before win_init
   // In a separate job fetch song info and fill list of art types.
-  int jobid = CJobManager::GetInstance().AddJob(new CGetSongInfoJob(), nullptr, CJob::PRIORITY_LOW);
+  int jobid =
+      CServiceBroker::GetJobManager()->AddJob(new CGetSongInfoJob(), nullptr, CJob::PRIORITY_LOW);
 
   // Wait to get all data before show, allowing user to cancel if fetch is slow
   if (!CGUIDialogBusy::WaitOnEvent(m_event, TIME_TO_BUSY_DIALOG))
   {
     // Cancel job still waiting in queue (unlikely)
-    CJobManager::GetInstance().CancelJob(jobid);
+    CServiceBroker::GetJobManager()->CancelJob(jobid);
     // Flag to stop job already in progress
     m_cancelled = true;
     return false;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1998,7 +1998,7 @@ bool CMusicInfoScanner::AddArtistArtwork(CArtist& artist, const std::string& art
     // (other art types will be cached when first displayed)
     if (iArtLevel != CSettings::MUSICLIBRARY_ARTWORK_LEVEL_ALL || it.first == "thumb" ||
         it.first == "fanart")
-      CTextureCache::GetInstance().BackgroundCacheImage(it.second);
+      CServiceBroker::GetTextureCache()->BackgroundCacheImage(it.second);
     auto ret = artist.art.insert(it);
     if (ret.second)
       m_musicDatabase.SetArtForItem(artist.idArtist, MediaTypeArtist, it.first, it.second);
@@ -2119,7 +2119,7 @@ bool CMusicInfoScanner::AddAlbumArtwork(CAlbum& album)
     // (other art types will be cached when first displayed)
     if (iArtLevel != CSettings::MUSICLIBRARY_ARTWORK_LEVEL_ALL || it.first == "thumb" ||
         it.first == "fanart")
-      CTextureCache::GetInstance().BackgroundCacheImage(it.second);
+      CServiceBroker::GetTextureCache()->BackgroundCacheImage(it.second);
 
     auto ret = album.art.insert(it);
     if (ret.second)

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -767,7 +767,8 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       database.Open();
       CVideoInfoTag details;
       database.GetMusicVideoInfo("", details, database.GetMatchingMusicVideo(item->GetMusicInfoTag()->GetArtistString(), item->GetMusicInfoTag()->GetAlbum(), item->GetMusicInfoTag()->GetTitle()));
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(new CFileItem(details)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0,
+                                                 static_cast<void*>(new CFileItem(details)));
       return true;
     }
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -562,7 +562,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         MEDIA_DETECT::CCdInfo* pCdInfo = CServiceBroker::GetMediaManager().GetCdInfo();
         if (pCdInfo->IsAudio(1) || pCdInfo->IsCDExtra(1) || pCdInfo->IsMixedMode(1))
         {
-          if (CJobManager::GetInstance().IsProcessing("cdrip"))
+          if (CServiceBroker::GetJobManager()->IsProcessing("cdrip"))
             buttons.Add(CONTEXT_BUTTON_CANCEL_RIP_CD, 14100);
           else
             buttons.Add(CONTEXT_BUTTON_RIP_CD, 600);

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -43,7 +43,6 @@
 
 #include <plist/plist.h>
 
-using namespace KODI::MESSAGING;
 using KODI::UTILITY::CDigest;
 using namespace std::chrono_literals;
 
@@ -817,14 +816,14 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
       {
         if (g_application.GetAppPlayer().IsPlaying() && !g_application.GetAppPlayer().IsPaused())
         {
-          CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+          CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
         }
       }
       else
       {
         if (g_application.GetAppPlayer().IsPausedPlayback())
         {
-          CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+          CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
         }
       }
   }
@@ -852,7 +851,8 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
         {
           backupVolume();
           g_application.SetVolume(volume);
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_VOLUME_SHOW, oldVolume < volume ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN);
+          CServiceBroker::GetAppMessenger()->PostMsg(
+              TMSG_VOLUME_SHOW, oldVolume < volume ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN);
         }
       }
   }
@@ -971,12 +971,12 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
 
       CFileItemList *l = new CFileItemList; //don't delete,
       l->Add(std::make_shared<CFileItem>(fileToPlay));
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
 
       // allow starting the player paused in ios8 mode (needed by camera roll app)
       if (!startPlayback)
       {
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
         g_application.GetAppPlayer().SeekPercentage(position * 100.0f);
       }
     }
@@ -1031,12 +1031,13 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
     {
       if (IsPlaying()) //only stop player if we started him
       {
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
         CAirPlayServer::m_isPlaying--;
       }
       else //if we are not playing and get the stop request - we just wanna stop picture streaming
       {
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1, static_cast<void*>(new CAction(ACTION_STOP)));
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1,
+                                                   static_cast<void*>(new CAction(ACTION_STOP)));
       }
     }
     ClearPhotoAssetCache();
@@ -1107,7 +1108,8 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
               CLog::Log(LOGWARNING, "AIRPLAY: Asset {} not found in our cache.", photoCacheId);
           }
           else
-            CApplicationMessenger::GetInstance().PostMsg(TMSG_PICTURE_SHOW, -1, -1, nullptr, tmpFileName);
+            CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PICTURE_SHOW, -1, -1, nullptr,
+                                                       tmpFileName);
         }
         else
         {

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -57,7 +57,6 @@
 #define ZEROCONF_DACP_SERVICE "_dacp._tcp"
 
 using namespace XFILE;
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 CAirTunesServer *CAirTunesServer::ServerInstance = NULL;
@@ -127,7 +126,8 @@ void CAirTunesServer::RefreshMetadata()
   if (m_metadata[2].length())
     tag.SetArtist(m_metadata[2]);//artist
 
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1, static_cast<void*>(new CFileItem(tag)));
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
+                                             static_cast<void*>(new CFileItem(tag)));
 }
 
 void CAirTunesServer::RefreshCoverArt(const char *outputFilename/* = NULL*/)
@@ -376,7 +376,7 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
   if (pipe->Write(&header, sizeof(header)) == 0)
     return 0;
 
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
 
   CFileItem *item = new CFileItem();
   item->SetPath(pipe->GetName());
@@ -384,7 +384,7 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
   m_streamStarted = true;
   m_sampleRate = samplerate;
 
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
 
   // Not all airplay streams will provide metadata (e.g. if using mirroring,
   // no metadata will be sent).  If there *is* metadata, it will be received
@@ -521,7 +521,7 @@ void  CAirTunesServer::AudioOutputFunctions::audio_destroy(void *cls, void *sess
   if (!CAirPlayServer::IsPlaying())
 #endif
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
     CLog::Log(LOGDEBUG, "AIRTUNES: AirPlay not running - stopping player");
   }
 

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -25,8 +25,6 @@
 #include "utils/StringUtils.h"
 #include "utils/XTimeUtils.h"
 
-using namespace KODI::MESSAGING;
-
 /* slightly modified in_ether taken from the etherboot project (http://sourceforge.net/projects/etherboot) */
 bool in_ether (const char *bufp, unsigned char *addr)
 {
@@ -87,12 +85,12 @@ bool in_ether (const char *bufp, unsigned char *addr)
 CNetworkBase::CNetworkBase() :
   m_services(new CNetworkServices())
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_NETWORKMESSAGE, SERVICES_UP, 0);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_NETWORKMESSAGE, SERVICES_UP, 0);
 }
 
 CNetworkBase::~CNetworkBase()
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_NETWORKMESSAGE, SERVICES_DOWN, 0);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_NETWORKMESSAGE, SERVICES_DOWN, 0);
 }
 
 int CNetworkBase::ParseHex(char *str, unsigned char *addr)

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -510,7 +510,7 @@ void CNetworkServices::OnSettingChanged(const std::shared_ptr<const CSetting>& s
         DialogResponse::CHOICE_YES)
     {
       m_settings->Save();
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTARTAPP);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RESTARTAPP);
     }
   }
 }

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -371,13 +371,10 @@ public:
     if (async)
     {
       CJob* job = new CHostProberJob(server);
-      m_jobId = CJobManager::GetInstance().AddJob(job, this);
+      m_jobId = CServiceBroker::GetJobManager()->AddJob(job, this);
     }
   }
-  ~PingResponseWaiter() override
-  {
-    CJobManager::GetInstance().CancelJob(m_jobId);
-  }
+  ~PingResponseWaiter() override { CServiceBroker::GetJobManager()->CancelJob(m_jobId); }
   bool SuccessWaiting () const override
   {
     return m_jobId ? m_hostOnline : Ping(m_server);
@@ -644,7 +641,7 @@ void CWakeOnAccess::QueueMACDiscoveryForHost(const std::string& host)
   if (IsEnabled())
   {
     if (URIUtils::IsHostOnLAN(host, true))
-      CJobManager::GetInstance().AddJob(new CMACDiscoveryJob(host), this);
+      CServiceBroker::GetJobManager()->AddJob(new CMACDiscoveryJob(host), this);
     else
       CLog::Log(LOGINFO, "{} - skip Mac discovery for non-local host '{}'", __FUNCTION__, host);
   }

--- a/xbmc/network/Zeroconf.cpp
+++ b/xbmc/network/Zeroconf.cpp
@@ -71,7 +71,7 @@ bool CZeroconf::PublishService(const std::string& fcr_identifier,
   if(!ret.second) //identifier exists
     return false;
   if(m_started)
-    CJobManager::GetInstance().AddJob(new CPublish(fcr_identifier, info), NULL);
+    CServiceBroker::GetJobManager()->AddJob(new CPublish(fcr_identifier, info), nullptr);
 
   //not yet started, so its just queued
   return true;
@@ -119,7 +119,7 @@ bool CZeroconf::Start()
     return true;
   m_started = true;
 
-  CJobManager::GetInstance().AddJob(new CPublish(m_service_map), NULL);
+  CServiceBroker::GetJobManager()->AddJob(new CPublish(m_service_map), nullptr);
   return true;
 }
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -536,7 +536,8 @@ void CUPnPPlayer::DoAudioWork()
       m_current_meta = (const char*)meta;
       CFileItemPtr item = GetFileItem(uri, meta);
       g_application.CurrentFileItem() = *item;
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_UPDATE_CURRENT_ITEM, 0, -1, static_cast<void*>(new CFileItem(*item)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 0, -1,
+                                                 static_cast<void*>(new CFileItem(*item)));
     }
 
     NPT_CHECK_LABEL(m_delegate->m_transport->GetStateVariableValue("TransportState", data), failed);

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -40,8 +40,6 @@
 
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.renderer")
 
-using namespace KODI::MESSAGING;
-
 namespace UPNP
 {
 
@@ -459,9 +457,11 @@ NPT_Result
 CUPnPRenderer::OnNext(PLT_ActionReference& action)
 {
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1, static_cast<void*>(new CAction(ACTION_NEXT_PICTURE)));
+      CServiceBroker::GetAppMessenger()->SendMsg(
+          TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1,
+          static_cast<void*>(new CAction(ACTION_NEXT_PICTURE)));
     } else {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_NEXT);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_NEXT);
     }
     return NPT_SUCCESS;
 }
@@ -473,9 +473,11 @@ NPT_Result
 CUPnPRenderer::OnPause(PLT_ActionReference& action)
 {
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1, static_cast<void*>(new CAction(ACTION_NEXT_PICTURE)));
+      CServiceBroker::GetAppMessenger()->SendMsg(
+          TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1,
+          static_cast<void*>(new CAction(ACTION_NEXT_PICTURE)));
     } else if (!g_application.GetAppPlayer().IsPausedPlayback())
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
     return NPT_SUCCESS;
 }
 
@@ -488,7 +490,7 @@ CUPnPRenderer::OnPlay(PLT_ActionReference& action)
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) {
         return NPT_SUCCESS;
     } else if (g_application.GetAppPlayer().IsPausedPlayback()) {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
     } else if (!g_application.GetAppPlayer().IsPlaying()) {
         NPT_String uri, meta;
         PLT_Service* service;
@@ -510,9 +512,11 @@ NPT_Result
 CUPnPRenderer::OnPrevious(PLT_ActionReference& action)
 {
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1, static_cast<void*>(new CAction(ACTION_PREV_PICTURE)));
+      CServiceBroker::GetAppMessenger()->SendMsg(
+          TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1,
+          static_cast<void*>(new CAction(ACTION_PREV_PICTURE)));
     } else {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PREV);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_PLAYLISTPLAYER_PREV);
     }
     return NPT_SUCCESS;
 }
@@ -524,9 +528,11 @@ NPT_Result
 CUPnPRenderer::OnStop(PLT_ActionReference& action)
 {
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1, static_cast<void*>(new CAction(ACTION_NEXT_PICTURE)));
+      CServiceBroker::GetAppMessenger()->SendMsg(
+          TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1,
+          static_cast<void*>(new CAction(ACTION_NEXT_PICTURE)));
     } else {
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
     }
     return NPT_SUCCESS;
 }
@@ -633,11 +639,12 @@ CUPnPRenderer::PlayMedia(const NPT_String& uri, const NPT_String& meta, PLT_Acti
     }
 
     if (item->IsPicture()) {
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_PICTURE_SHOW, -1, -1, nullptr, item->GetPath());
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PICTURE_SHOW, -1, -1, nullptr,
+                                                 item->GetPath());
     } else {
       CFileItemList *l = new CFileItemList; //don't delete,
       l->Add(std::make_shared<CFileItem>(*item));
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
     }
 
     // just return success because the play actions are asynchronous

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -70,7 +70,6 @@ using namespace KODI;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 using namespace XFILE;
-using namespace KODI::MESSAGING;
 
 CPeripherals::CPeripherals(CInputManager& inputManager,
                            GAME::CControllerManager& controllerProfiles)
@@ -132,7 +131,7 @@ void CPeripherals::Initialise()
 
   m_eventScanner->Start();
 
-  MESSAGING::CApplicationMessenger::GetInstance().RegisterReceiver(this);
+  CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
 }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -27,8 +27,6 @@
 
 #include <libcec/cec.h>
 
-using namespace KODI;
-using namespace MESSAGING;
 using namespace PERIPHERALS;
 using namespace CEC;
 using namespace ANNOUNCEMENT;
@@ -604,7 +602,7 @@ void CPeripheralCecAdapter::SetMenuLanguage(const char* strLanguage)
   if (!strGuiLanguage.empty())
   {
     strGuiLanguage = "resource.language." + strGuiLanguage;
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_SETLANGUAGE, -1, -1, nullptr, strGuiLanguage);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SETLANGUAGE, -1, -1, nullptr, strGuiLanguage);
     CLog::Log(LOGDEBUG, "{} - language set to '{}'", __FUNCTION__, strGuiLanguage);
   }
   else
@@ -619,29 +617,26 @@ void CPeripheralCecAdapter::OnTvStandby(void)
   {
     case LOCALISED_ID_POWEROFF:
       m_bStarted = false;
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_SYSTEM_POWERDOWN,
-                                                                    TMSG_SHUTDOWN);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SYSTEM_POWERDOWN, TMSG_SHUTDOWN);
       break;
     case LOCALISED_ID_SUSPEND:
       m_bStarted = false;
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_SYSTEM_POWERDOWN,
-                                                                    TMSG_SUSPEND);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SYSTEM_POWERDOWN, TMSG_SUSPEND);
       break;
     case LOCALISED_ID_HIBERNATE:
       m_bStarted = false;
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_SYSTEM_POWERDOWN,
-                                                                    TMSG_HIBERNATE);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SYSTEM_POWERDOWN, TMSG_HIBERNATE);
       break;
     case LOCALISED_ID_QUIT:
       m_bStarted = false;
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
       break;
     case LOCALISED_ID_PAUSE:
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
       break;
     case LOCALISED_ID_STOP:
       if (g_application.GetAppPlayer().IsPlaying())
-        KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_STOP);
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_STOP);
       break;
     case LOCALISED_ID_IGNORE:
       break;
@@ -1226,7 +1221,7 @@ void CPeripheralCecAdapter::CecSourceActivated(void* cbParam,
         pSlideShow->OnAction(CAction(ACTION_PAUSE));
       else
         // pause/resume player
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE);
     }
     else if (bPlayingAndDeactivated &&
              adapter->GetSettingInt("pause_or_stop_playback_on_deactivate") == LOCALISED_ID_STOP)
@@ -1234,7 +1229,7 @@ void CPeripheralCecAdapter::CecSourceActivated(void* cbParam,
       if (pSlideShow)
         pSlideShow->OnAction(CAction(ACTION_STOP));
       else
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
     }
   }
 }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1737,8 +1737,8 @@ bool CPeripheralCecAdapter::ReopenConnection(bool bAsync /* = false */)
 {
   if (bAsync)
   {
-    CJobManager::GetInstance().AddJob(new CPeripheralCecAdapterReopenJob(this), nullptr,
-                                      CJob::PRIORITY_NORMAL);
+    CServiceBroker::GetJobManager()->AddJob(new CPeripheralCecAdapterReopenJob(this), nullptr,
+                                            CJob::PRIORITY_NORMAL);
     return true;
   }
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -156,7 +156,7 @@ void CGUIDialogPeripherals::Notify(const Observable& obs, const ObservableMessag
 void CGUIDialogPeripherals::UpdatePeripheralsAsync()
 {
   CGUIMessage msg(GUI_MSG_REFRESH_LIST, GetID(), -1);
-  MESSAGING::CApplicationMessenger::GetInstance().SendGUIMessage(msg);
+  CServiceBroker::GetAppMessenger()->SendGUIMessage(msg);
 }
 
 void CGUIDialogPeripherals::UpdatePeripheralsSync()

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -60,7 +60,7 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
 
   if (pItem->HasArt("thumb") && m_regenerateThumbs)
   {
-    CTextureCache::GetInstance().ClearCachedImage(pItem->GetArt("thumb"));
+    CServiceBroker::GetTextureCache()->ClearCachedImage(pItem->GetArt("thumb"));
     if (m_textureDatabase->Open())
     {
       m_textureDatabase->ClearTextureForPath(pItem->GetPath(), "thumb");
@@ -80,7 +80,7 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
     if (!loader.FillThumb(*pItem))
     {
       std::string thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
-      if (CTextureCache::GetInstance().HasCachedImage(thumbURL))
+      if (CServiceBroker::GetTextureCache()->HasCachedImage(thumbURL))
       {
         thumb = thumbURL;
       }
@@ -99,7 +99,7 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
   }
   if (!thumb.empty())
   {
-    CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+    CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);
     pItem->SetArt("thumb", thumb);
   }
   pItem->FillInDefaultIcon();
@@ -137,7 +137,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     if (CFile::Exists(strTBN))
     {
       db.SetTextureForPath(pItem->GetPath(), "thumb", strTBN);
-      CTextureCache::GetInstance().BackgroundCacheImage(strTBN);
+      CServiceBroker::GetTextureCache()->BackgroundCacheImage(strTBN);
       pItem->SetArt("thumb", strTBN);
       return;
     }
@@ -164,7 +164,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     if (CFile::Exists(thumb))
     {
       db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
-      CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+      CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);
       pItem->SetArt("thumb", thumb);
       return;
     }
@@ -218,7 +218,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         items.Sort(SortByLabel, SortOrderAscending);
         std::string thumb = CTextureUtils::GetWrappedThumbURL(items[0]->GetPath());
         db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
-        CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+        CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);
         pItem->SetArt("thumb", thumb);
       }
       else
@@ -237,7 +237,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
           details.file = relativeCacheFile;
           details.width = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes;
           details.height = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes;
-          CTextureCache::GetInstance().AddCachedTexture(thumb, details);
+          CServiceBroker::GetTextureCache()->AddCachedTexture(thumb, details);
           db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
           pItem->SetArt("thumb", CTextureCache::GetCachedPath(relativeCacheFile));
         }

--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
@@ -11,6 +11,7 @@
 #include "AndroidKey.h"
 #include "Application.h"
 #include "CompileInfo.h"
+#include "ServiceBroker.h"
 #include "XBMCApp.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
@@ -102,7 +103,8 @@ void CJNIXBMCMediaSession::OnPlayRequested()
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (g_application.GetAppPlayer().IsPaused())
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(ACTION_PAUSE)));
   }
 }
 
@@ -111,20 +113,23 @@ void CJNIXBMCMediaSession::OnPauseRequested()
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (!g_application.GetAppPlayer().IsPaused())
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(ACTION_PAUSE)));
   }
 }
 
 void CJNIXBMCMediaSession::OnNextRequested()
 {
   if (g_application.GetAppPlayer().IsPlaying())
-    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_NEXT_ITEM)));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(ACTION_NEXT_ITEM)));
 }
 
 void CJNIXBMCMediaSession::OnPreviousRequested()
 {
   if (g_application.GetAppPlayer().IsPlaying())
-    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PREV_ITEM)));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(ACTION_PREV_ITEM)));
 }
 
 void CJNIXBMCMediaSession::OnForwardRequested()
@@ -132,7 +137,9 @@ void CJNIXBMCMediaSession::OnForwardRequested()
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (!g_application.GetAppPlayer().IsPaused())
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_FORWARD)));
+      CServiceBroker::GetAppMessenger()->PostMsg(
+          TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+          static_cast<void*>(new CAction(ACTION_PLAYER_FORWARD)));
   }
 }
 
@@ -141,14 +148,17 @@ void CJNIXBMCMediaSession::OnRewindRequested()
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (!g_application.GetAppPlayer().IsPaused())
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_REWIND)));
+      CServiceBroker::GetAppMessenger()->PostMsg(
+          TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+          static_cast<void*>(new CAction(ACTION_PLAYER_REWIND)));
   }
 }
 
 void CJNIXBMCMediaSession::OnStopRequested()
 {
   if (g_application.GetAppPlayer().IsPlaying())
-    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(ACTION_STOP)));
 }
 
 void CJNIXBMCMediaSession::OnSeekRequested(int64_t pos)

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -104,7 +104,6 @@
 #define PLAYBACK_STATE_AUDIO    0x0200
 #define PLAYBACK_STATE_CANNOT_PAUSE 0x0400
 
-using namespace KODI::MESSAGING;
 using namespace ANNOUNCEMENT;
 using namespace jni;
 using namespace std::chrono_literals;
@@ -253,7 +252,7 @@ void CXBMCApp::onResume()
     if (g_application.GetAppPlayer().HasVideo())
     {
       if (g_application.GetAppPlayer().IsPaused())
-        CApplicationMessenger::GetInstance().SendMsg(
+        CServiceBroker::GetAppMessenger()->SendMsg(
             TMSG_GUI_ACTION, WINDOW_INVALID, -1,
             static_cast<void*>(new CAction(ACTION_PLAYER_PLAY)));
     }
@@ -275,7 +274,8 @@ void CXBMCApp::onPause()
     {
       if (!g_application.GetAppPlayer().IsPaused() && !m_hasReqVisible)
       {
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                   static_cast<void*>(new CAction(ACTION_PAUSE)));
         m_bResumePlayback = true;
       }
     }
@@ -301,9 +301,11 @@ void CXBMCApp::onStop()
   if ((m_playback_state & PLAYBACK_STATE_PLAYING) && !m_hasReqVisible)
   {
     if (m_playback_state & PLAYBACK_STATE_CANNOT_PAUSE)
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(ACTION_STOP)));
     else if (m_playback_state & PLAYBACK_STATE_VIDEO)
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(ACTION_PAUSE)));
   }
 }
 
@@ -430,7 +432,7 @@ void CXBMCApp::Quit()
   }
 
   m_exiting = true; // enter stage two: android activity has finished. go on with stopping Kodi
-  CApplicationMessenger::GetInstance().PostMsg(msgId);
+  CServiceBroker::GetAppMessenger()->PostMsg(msgId);
 
   // wait for the run thread to finish
   m_thread.join();
@@ -549,7 +551,8 @@ bool CXBMCApp::XBMC_SetupDisplay()
 {
   android_printf("XBMC_SetupDisplay()");
   bool result;
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_DISPLAY_SETUP, -1, -1, static_cast<void*>(&result));
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_DISPLAY_SETUP, -1, -1,
+                                             static_cast<void*>(&result));
   return result;
 }
 
@@ -557,7 +560,8 @@ bool CXBMCApp::XBMC_DestroyDisplay()
 {
   android_printf("XBMC_DestroyDisplay()");
   bool result;
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_DISPLAY_DESTROY, -1, -1, static_cast<void*>(&result));
+  CServiceBroker::GetAppMessenger()->SendMsg(TMSG_DISPLAY_DESTROY, -1, -1,
+                                             static_cast<void*>(&result));
   return result;
 }
 
@@ -1068,13 +1072,13 @@ void CXBMCApp::onReceive(CJNIIntent intent)
       {
         if (g_application.GetAppPlayer().CanPause())
         {
-          CApplicationMessenger::GetInstance().PostMsg(
-              TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                     static_cast<void*>(new CAction(ACTION_PAUSE)));
         }
         else
         {
-          CApplicationMessenger::GetInstance().PostMsg(
-              TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                     static_cast<void*>(new CAction(ACTION_STOP)));
         }
       }
     }
@@ -1203,7 +1207,8 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
         std::vector<std::string> params;
         params.push_back(targeturl.Get());
         params.emplace_back("return");
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTIVATE_WINDOW, WINDOW_VIDEO_NAV, 0, nullptr, "", params);
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTIVATE_WINDOW, WINDOW_VIDEO_NAV, 0,
+                                                   nullptr, "", params);
       }
       else if (targeturl.IsProtocol("musicdb")
                || (targeturl.IsProtocol("special") && targetFile.find("playlists/music") != std::string::npos))
@@ -1211,7 +1216,8 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
         std::vector<std::string> params;
         params.push_back(targeturl.Get());
         params.emplace_back("return");
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTIVATE_WINDOW, WINDOW_MUSIC_NAV, 0, nullptr, "", params);
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTIVATE_WINDOW, WINDOW_MUSIC_NAV, 0,
+                                                   nullptr, "", params);
       }
     }
     else
@@ -1222,7 +1228,7 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
         *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item->GetPath()));
         item->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
       }
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
     }
   }
   else if (action == ACTION_XBMC_RESUME)
@@ -1232,7 +1238,8 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
       if (m_playback_state & PLAYBACK_STATE_VIDEO)
         RequestVisibleBehind(true);
       if (!(m_playback_state & PLAYBACK_STATE_PLAYING))
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                   static_cast<void*>(new CAction(ACTION_PAUSE)));
     }
   }
 }
@@ -1262,9 +1269,11 @@ void CXBMCApp::onVisibleBehindCanceled()
   if ((m_playback_state & PLAYBACK_STATE_PLAYING))
   {
     if (m_playback_state & PLAYBACK_STATE_CANNOT_PAUSE)
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(ACTION_STOP)));
     else if (m_playback_state & PLAYBACK_STATE_VIDEO)
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                 static_cast<void*>(new CAction(ACTION_PAUSE)));
   }
 }
 
@@ -1313,9 +1322,11 @@ void CXBMCApp::onAudioFocusChange(int focusChange)
     if ((m_playback_state & PLAYBACK_STATE_PLAYING))
     {
       if (m_playback_state & PLAYBACK_STATE_CANNOT_PAUSE)
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                   static_cast<void*>(new CAction(ACTION_STOP)));
       else
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                                   static_cast<void*>(new CAction(ACTION_PAUSE)));
     }
   }
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -738,7 +738,7 @@ void CXBMCApp::UpdateSessionMetadata()
     thumb = infoMgr.GetImage(MUSICPLAYER_COVER, -1);
   }
   bool needrecaching = false;
-  std::string cachefile = CTextureCache::GetInstance().CheckCachedImage(thumb, needrecaching);
+  std::string cachefile = CServiceBroker::GetTextureCache()->CheckCachedImage(thumb, needrecaching);
   if (!cachefile.empty())
   {
     std::string actualfile = CSpecialProtocol::TranslatePath(cachefile);

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -190,10 +190,11 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
 
     // Thumb cache process
     bool needsRecaching;
-    std::string cachedIcon(CTextureCache::GetInstance().CheckCachedImage(thumb, needsRecaching));
+    std::string cachedIcon(
+        CServiceBroker::GetTextureCache()->CheckCachedImage(thumb, needsRecaching));
     if (cachedIcon.empty())
     {
-      cachedIcon = CTextureCache::GetInstance().CacheImage(thumb);
+      cachedIcon = CServiceBroker::GetTextureCache()->CacheImage(thumb);
     }
     std::string iconRealPath = CSpecialProtocol::TranslatePath(cachedIcon);
     item[@"thumb"] = @(iconRealPath.c_str());

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -33,8 +33,6 @@
 #import <QuartzCore/QuartzCore.h>
 #include <sys/resource.h>
 
-using namespace KODI::MESSAGING;
-
 //--------------------------------------------------------------
 @interface IOSEAGLView (PrivateMethods)
 - (void) setContext:(EAGLContext *)newContext;
@@ -315,7 +313,7 @@ using namespace KODI::MESSAGING;
     xbmcAlive = FALSE;
     if (!g_application.m_bStop)
     {
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
     }
 
     CAnnounceReceiver::GetInstance()->DeInitialize();

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -51,8 +51,6 @@
 #import <AVFoundation/AVAudioSession.h>
 #include <sys/resource.h>
 
-using namespace KODI::MESSAGING;
-
 #ifndef M_PI
 #define M_PI 3.1415926535897932384626433832795028842
 #endif
@@ -879,36 +877,52 @@ public:
     switch (receivedEvent.subtype)
     {
       case UIEventSubtypeRemoteControlTogglePlayPause:
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_PLAYPAUSE)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+            static_cast<void*>(new CAction(ACTION_PLAYER_PLAYPAUSE)));
         break;
       case UIEventSubtypeRemoteControlPlay:
-	    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_PLAY)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+            static_cast<void*>(new CAction(ACTION_PLAYER_PLAY)));
         break;
       case UIEventSubtypeRemoteControlPause:
         // ACTION_PAUSE sometimes cause unpause, use MediaPauseIfPlaying to make sure pause only
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
         break;
       case UIEventSubtypeRemoteControlNextTrack:
-	    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_NEXT_ITEM)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_NEXT_ITEM)));
         break;
       case UIEventSubtypeRemoteControlPreviousTrack:
-	    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PREV_ITEM)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PREV_ITEM)));
         break;
       case UIEventSubtypeRemoteControlBeginSeekingForward:
         // use 4X speed forward.
-		CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_FORWARD)));
-		CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_FORWARD)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+            static_cast<void*>(new CAction(ACTION_PLAYER_FORWARD)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+            static_cast<void*>(new CAction(ACTION_PLAYER_FORWARD)));
         break;
       case UIEventSubtypeRemoteControlBeginSeekingBackward:
         // use 4X speed rewind.
-		CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_REWIND)));
-		CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_REWIND)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+            static_cast<void*>(new CAction(ACTION_PLAYER_REWIND)));
+        CServiceBroker::GetAppMessenger()->SendMsg(
+            TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+            static_cast<void*>(new CAction(ACTION_PLAYER_REWIND)));
         break;
       case UIEventSubtypeRemoteControlEndSeekingForward:
       case UIEventSubtypeRemoteControlEndSeekingBackward:
         // restore to normal playback speed.
         if (g_application.GetAppPlayer().IsPlaying() && !g_application.GetAppPlayer().IsPaused())
-		  CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PLAYER_PLAY)));
+          CServiceBroker::GetAppMessenger()->SendMsg(
+              TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+              static_cast<void*>(new CAction(ACTION_PLAYER_PLAY)));
         break;
       default:
         LOG(@"unhandled subtype: %zd", receivedEvent.subtype);
@@ -924,7 +938,7 @@ public:
   if (g_application.GetAppPlayer().IsPlaying() && !g_application.GetAppPlayer().IsPaused())
   {
     m_isPlayingBeforeInactive = YES;
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
   }
   CWinSystemIOS* winSystem = dynamic_cast<CWinSystemIOS*>(CServiceBroker::GetWinSystem());
   winSystem->OnAppFocusChange(false);
@@ -939,7 +953,7 @@ public:
   // when we come back, restore playing if we were.
   if (m_isPlayingBeforeInactive)
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_UNPAUSE);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_UNPAUSE);
     m_isPlayingBeforeInactive = NO;
   }
 }
@@ -951,7 +965,7 @@ public:
   if (g_application.GetAppPlayer().IsPlayingVideo() && !g_application.GetAppPlayer().IsPaused())
   {
     m_isPlayingBeforeInactive = YES;
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
   }
   // check whether we need disable network auto suspend.
   [self rescheduleNetworkAutoSuspend];

--- a/xbmc/platform/darwin/osx/OSXTextInputResponder.mm
+++ b/xbmc/platform/darwin/osx/OSXTextInputResponder.mm
@@ -9,12 +9,11 @@
 #import "OSXTextInputResponder.h"
 
 #include "GUIUserMessages.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
 #include "utils/log.h"
-
-using namespace KODI::MESSAGING;
 
 void SendKeyboardText(const char *text)
 {
@@ -26,7 +25,8 @@ void SendKeyboardText(const char *text)
 
   CAction *action = new CAction(ACTION_INPUT_TEXT);
   action->SetText(text);
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(action));
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                             static_cast<void*>(action));
 }
 
 void SendEditingText(const char *text, unsigned int location, unsigned int length)

--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
@@ -12,6 +12,7 @@
 #include "Application.h"
 #include "DatabaseManager.h"
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "filesystem/File.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -213,8 +214,7 @@ void CTVOSTopShelf::RunTopShelf()
 
   // its a bit ugly, but only way to get resume window to show
   std::string cmd = StringUtils::Format("PlayMedia({})", StringUtils::Paramify(url));
-  KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1,
-                                                                nullptr, cmd);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
 }
 
 void CTVOSTopShelf::HandleTopShelfUrl(const std::string& url, const bool run)

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -42,8 +42,6 @@
 #import <AVKit/AVDisplayManager.h>
 #import <AVKit/UIWindow.h>
 
-using namespace KODI::MESSAGING;
-
 XBMCController* g_xbmcController;
 
 #pragma mark - XBMCController implementation
@@ -319,7 +317,7 @@ XBMCController* g_xbmcController;
     m_animating = NO;
     if (!g_application.m_bStop)
     {
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
     }
 
     CAnnounceReceiver::GetInstance()->DeInitialize();

--- a/xbmc/platform/darwin/tvos/input/LibInputRemote.mm
+++ b/xbmc/platform/darwin/tvos/input/LibInputRemote.mm
@@ -117,7 +117,7 @@ NSTimeInterval REPEATED_KEYPRESS_PAUSE_S = 0.05;
   switch (receivedEvent.subtype)
   {
     case UIEventSubtypeRemoteControlTogglePlayPause:
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(
+      CServiceBroker::GetAppMessenger()->PostMsg(
           TMSG_GUI_ACTION, WINDOW_INVALID, -1,
           static_cast<void*>(new CAction(ACTION_PLAYER_PLAYPAUSE)));
       break;
@@ -146,7 +146,7 @@ NSTimeInterval REPEATED_KEYPRESS_PAUSE_S = 0.05;
     case UIEventSubtypeRemoteControlEndSeekingBackward:
       // restore to normal playback speed.
       if (g_application.GetAppPlayer().IsPlaying() && !g_application.GetAppPlayer().IsPaused())
-        KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(
+        CServiceBroker::GetAppMessenger()->PostMsg(
             TMSG_GUI_ACTION, WINDOW_INVALID, -1,
             static_cast<void*>(new CAction(ACTION_PLAYER_PLAY)));
       break;

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -42,7 +42,7 @@ void CWin32StorageProvider::Initialize()
   // Can be removed once the StorageHandler supports optical media
   for (const auto& it : vShare)
     if (CServiceBroker::GetMediaManager().GetDriveStatus(it.strPath) == DRIVE_CLOSED_MEDIA_PRESENT)
-      CJobManager::GetInstance().AddJob(new CDetectDisc(it.strPath, false), NULL);
+      CServiceBroker::GetJobManager()->AddJob(new CDetectDisc(it.strPath, false), nullptr);
       // remove end
 #endif
 }

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -27,7 +27,6 @@
 #include "utils/Variant.h"
 #include "windows/GUIWindowFileManager.h"
 
-using namespace KODI;
 using namespace XFILE;
 
 #define CONTROL_PROFILES 2
@@ -70,7 +69,7 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
   if (choice == 1)
   {
-    MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_LOADPROFILE, iItem);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_LOADPROFILE, iItem);
     return;
   }
 

--- a/xbmc/pvr/PVRCachedImages.cpp
+++ b/xbmc/pvr/PVRCachedImages.cpp
@@ -8,6 +8,7 @@
 
 #include "PVRCachedImages.h"
 
+#include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "TextureDatabase.h"
 #include "URL.h"
@@ -82,7 +83,7 @@ int CPVRCachedImages::Cleanup(const std::vector<PVRImagePattern>& urlPatterns,
     if (!bFound)
     {
       CLog::LogFC(LOGDEBUG, LOGPVR, "Removing stale cached image: '{}'", textureURL);
-      CTextureCache::GetInstance().ClearCachedImage(items[i]["textureid"].asInteger());
+      CServiceBroker::GetTextureCache()->ClearCachedImage(items[i]["textureid"].asInteger());
 
       if (clearTextureForPath)
         db.ClearTextureForPath(textureURL, "thumb");

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -46,7 +46,6 @@
 #include <vector>
 
 using namespace PVR;
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 namespace
@@ -410,7 +409,7 @@ void CPVRManager::Stop(bool bRestart /* = false */)
   if (!bRestart && m_playbackState->IsPlaying())
   {
     CLog::LogFC(LOGDEBUG, LOGPVR, "Stopping PVR playback");
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
   }
 
   CLog::Log(LOGINFO, "PVR Manager: Stopping");

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -367,7 +367,7 @@ void CPVRManager::Init()
 {
   // initial check for enabled addons
   // if at least one pvr addon is enabled, PVRManager start up
-  CJobManager::GetInstance().Submit([this] {
+  CServiceBroker::GetJobManager()->Submit([this] {
     Clients()->Start();
     return true;
   });
@@ -792,9 +792,8 @@ void CPVRManager::TriggerPlayChannelOnStartup()
 {
   if (IsStarted())
   {
-    CJobManager::GetInstance().Submit([this] {
-      return GUIActions()->PlayChannelOnStartup();
-    });
+    CServiceBroker::GetJobManager()->Submit(
+        [this] { return GUIActions()->PlayChannelOnStartup(); });
   }
 }
 
@@ -1009,7 +1008,7 @@ void CPVRManager::ConnectionStateChange(CPVRClient* client,
                                         PVR_CONNECTION_STATE state,
                                         const std::string& message)
 {
-  CJobManager::GetInstance().Submit([this, client, connectString, state, message] {
+  CServiceBroker::GetJobManager()->Submit([this, client, connectString, state, message] {
     Clients()->ConnectionStateChange(client, connectString, state, message);
     return true;
   });

--- a/xbmc/pvr/PVRThumbLoader.cpp
+++ b/xbmc/pvr/PVRThumbLoader.cpp
@@ -58,7 +58,7 @@ void CPVRThumbLoader::ClearCachedImage(CFileItem& item)
   const std::string thumb = item.GetArt("thumb");
   if (!thumb.empty())
   {
-    CTextureCache::GetInstance().ClearCachedImage(thumb);
+    CServiceBroker::GetTextureCache()->ClearCachedImage(thumb);
     if (m_textureDatabase->Open())
     {
       m_textureDatabase->ClearTextureForPath(item.GetPath(), "thumb");
@@ -127,7 +127,7 @@ std::string CPVRThumbLoader::CreateChannelGroupThumb(const CFileItem& channelGro
       details.file = relativeCacheFile;
       details.width = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes;
       details.height = details.width;
-      CTextureCache::GetInstance().AddCachedTexture(thumb, details);
+      CServiceBroker::GetTextureCache()->AddCachedTexture(thumb, details);
       return thumb;
     }
   }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -28,7 +28,6 @@
 
 using namespace ADDON;
 using namespace PVR;
-using namespace KODI::MESSAGING;
 
 namespace
 {
@@ -209,7 +208,7 @@ bool CPVRClients::StopClient(const std::string& id, bool bRestart)
 {
   // stop playback if needed
   if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlaying())
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -163,7 +163,10 @@ void CPVRClients::UpdateAddons(const std::string& changedAddonId /*= ""*/)
         {
           CServiceBroker::GetAddonMgr().DisableAddon(addon.first->ID(),
                                                      AddonDisabledReason::PERMANENT_FAILURE);
-          CJobManager::GetInstance().AddJob(new CPVREventLogJob(true, true, addon.first->Name(), g_localizeStrings.Get(24070), addon.first->Icon()), nullptr);
+          CServiceBroker::GetJobManager()->AddJob(
+              new CPVREventLogJob(true, true, addon.first->Name(), g_localizeStrings.Get(24070),
+                                  addon.first->Icon()),
+              nullptr);
         }
       }
     }
@@ -243,7 +246,7 @@ void CPVRClients::OnAddonEvent(const AddonEvent& event)
     const std::string id = event.id;
     if (CServiceBroker::GetAddonMgr().HasType(id, ADDON_PVRDLL))
     {
-      CJobManager::GetInstance().Submit([this, id] {
+      CServiceBroker::GetJobManager()->Submit([this, id] {
         UpdateAddons(id);
         return true;
       });
@@ -814,7 +817,8 @@ void CPVRClients::ConnectionStateChange(CPVRClient* client,
     strMsg = g_localizeStrings.Get(iMsg);
 
   // Notify user.
-  CJobManager::GetInstance().AddJob(new CPVREventLogJob(bNotify, bError, client->Name(), strMsg, client->Icon()), nullptr);
+  CServiceBroker::GetJobManager()->AddJob(
+      new CPVREventLogJob(bNotify, bError, client->Name(), strMsg, client->Icon()), nullptr);
 }
 
 namespace

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -572,7 +572,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRefreshChannelLogos()
     if (!thumb.empty())
     {
       // clear current cached image
-      CTextureCache::GetInstance().ClearCachedImage(thumb);
+      CServiceBroker::GetTextureCache()->ClearCachedImage(thumb);
       item->SetArt("thumb", "");
     }
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -32,7 +32,6 @@
 #include <vector>
 
 using namespace PVR;
-using namespace KODI::MESSAGING;
 
 using namespace std::chrono_literals;
 
@@ -244,7 +243,7 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
 void CGUIDialogPVRChannelsOSD::Notify(const PVREvent& event)
 {
   const CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, static_cast<int>(event));
-  CApplicationMessenger::GetInstance().SendGUIMessage(m);
+  CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
 }
 
 void CGUIDialogPVRChannelsOSD::SaveSelectedItemPath(int iGroupID)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -9,6 +9,7 @@
 #include "GUIEPGGridContainer.h"
 
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "guilib/DirtyRegion.h"
 #include "guilib/GUIAction.h"
 #include "guilib/GUIMessage.h"
@@ -2408,7 +2409,7 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
       // announce changed viewport
       const CGUIMessage msg(
           GUI_MSG_REFRESH_LIST, GetParentID(), GetID(), static_cast<int>(PVREvent::Epg));
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().SendGUIMessage(msg);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(msg);
     }
   }
 

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -76,7 +76,7 @@ void CPVRGUIActionListener::OnPVRManagerEvent(const PVREvent& event)
     if (g_application.IsInitialized())
     {
       // if GUI is ready, dispatch to GUI thread and handle the action there
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(
+      CServiceBroker::GetAppMessenger()->PostMsg(
           TMSG_GUI_ACTION, WINDOW_INVALID, -1,
           static_cast<void*>(new CAction(ACTION_PVR_ANNOUNCE_REMINDERS)));
     }

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1286,7 +1286,7 @@ namespace PVR
       }
     }
 
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
     CheckAndSwitchToFullscreen(bFullscreen);
   }
 
@@ -1932,7 +1932,7 @@ namespace PVR
     {
       CLog::Log(LOGINFO, "PVR is stopping playback for {} database reset",
                 bResetEPGOnly ? "EPG" : "PVR and EPG");
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+      CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
     }
 
     const std::shared_ptr<CPVRDatabase> pvrDatabase(CServiceBroker::GetPVRManager().GetTVDatabase());
@@ -2514,7 +2514,7 @@ namespace PVR
           // no epg; jump to end of buffer
           seekTime = CServiceBroker::GetDataCacheCore().GetMaxTime();
         }
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_SEEK_TIME, seekTime);
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_SEEK_TIME, seekTime);
       }
     }
   }
@@ -2555,7 +2555,7 @@ namespace PVR
           // no epg; jump to begin of buffer
           seekTime = CServiceBroker::GetDataCacheCore().GetMinTime();
         }
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_SEEK_TIME, seekTime);
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_SEEK_TIME, seekTime);
       }
     }
   }
@@ -2792,11 +2792,11 @@ namespace PVR
 
           if (groupMember)
           {
-            CApplicationMessenger::GetInstance().PostMsg(
-              TMSG_GUI_ACTION, WINDOW_INVALID, -1,
-              static_cast<void*>(new CAction(ACTION_CHANNEL_SWITCH,
-                                             static_cast<float>(channelNumber.GetChannelNumber()),
-                                             static_cast<float>(channelNumber.GetSubChannelNumber()))));
+            CServiceBroker::GetAppMessenger()->PostMsg(
+                TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                static_cast<void*>(new CAction(
+                    ACTION_CHANNEL_SWITCH, static_cast<float>(channelNumber.GetChannelNumber()),
+                    static_cast<float>(channelNumber.GetSubChannelNumber()))));
           }
         }
       }
@@ -2817,7 +2817,7 @@ namespace PVR
         if (groupMember)
         {
           const CPVRChannelNumber channelNumber = groupMember->ChannelNumber();
-          CApplicationMessenger::GetInstance().SendMsg(
+          CServiceBroker::GetAppMessenger()->SendMsg(
               TMSG_GUI_ACTION, WINDOW_INVALID, -1,
               static_cast<void*>(new CAction(
                   ACTION_CHANNEL_SWITCH, static_cast<float>(channelNumber.GetChannelNumber()),

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -2276,7 +2276,7 @@ namespace PVR
                     name,
                     GetAnnouncerText(timer, idEpg, idNoEpg),
                     icon);
-      CJobManager::GetInstance().AddJob(job, nullptr);
+      CServiceBroker::GetJobManager()->AddJob(job, nullptr);
     }
   } // unnamed namespace
 

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -161,10 +161,11 @@ namespace PVR
       {
         // delayed switch
         if (m_iChannelEntryJobId >= 0)
-          CJobManager::GetInstance().CancelJob(m_iChannelEntryJobId);
+          CServiceBroker::GetJobManager()->CancelJob(m_iChannelEntryJobId);
 
         CPVRChannelEntryTimeoutJob* job = new CPVRChannelEntryTimeoutJob(*this, timeout);
-        m_iChannelEntryJobId = CJobManager::GetInstance().AddJob(job, dynamic_cast<IJobCallback*>(job));
+        m_iChannelEntryJobId =
+            CServiceBroker::GetJobManager()->AddJob(job, dynamic_cast<IJobCallback*>(job));
       }
       else
       {
@@ -183,7 +184,7 @@ namespace PVR
 
       if (m_iChannelEntryJobId >= 0)
       {
-        CJobManager::GetInstance().CancelJob(m_iChannelEntryJobId);
+        CServiceBroker::GetJobManager()->CancelJob(m_iChannelEntryJobId);
         m_iChannelEntryJobId = -1;
       }
 
@@ -224,14 +225,15 @@ namespace PVR
 
       if (m_iChannelInfoJobId >= 0)
       {
-        CJobManager::GetInstance().CancelJob(m_iChannelInfoJobId);
+        CServiceBroker::GetJobManager()->CancelJob(m_iChannelInfoJobId);
         m_iChannelInfoJobId = -1;
       }
 
       if (!bForce && timeout > 0s)
       {
         CPVRChannelInfoTimeoutJob* job = new CPVRChannelInfoTimeoutJob(*this, timeout);
-        m_iChannelInfoJobId = CJobManager::GetInstance().AddJob(job, dynamic_cast<IJobCallback*>(job));
+        m_iChannelInfoJobId =
+            CServiceBroker::GetJobManager()->AddJob(job, dynamic_cast<IJobCallback*>(job));
       }
     }
   }
@@ -247,7 +249,7 @@ namespace PVR
 
       if (m_iChannelInfoJobId >= 0)
       {
-        CJobManager::GetInstance().CancelJob(m_iChannelInfoJobId);
+        CServiceBroker::GetJobManager()->CancelJob(m_iChannelInfoJobId);
         m_iChannelInfoJobId = -1;
       }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -393,7 +393,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer& timers, const std::vec
         }
       }
 
-      CJobManager::GetInstance().AddJob(job, nullptr);
+      CServiceBroker::GetJobManager()->AddJob(job, nullptr);
     }
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -183,17 +183,17 @@ void CGUIWindowPVRBase::NotifyEvent(const PVREvent& event)
     if (event == PVREvent::SystemSleep)
     {
       CGUIMessage m(GUI_MSG_SYSTEM_SLEEP, GetID(), 0, static_cast<int>(event));
-      CApplicationMessenger::GetInstance().SendGUIMessage(m);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
     }
     else if (event == PVREvent::SystemWake)
     {
       CGUIMessage m(GUI_MSG_SYSTEM_WAKE, GetID(), 0, static_cast<int>(event));
-      CApplicationMessenger::GetInstance().SendGUIMessage(m);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
     }
     else
     {
       CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, static_cast<int>(event));
-      CApplicationMessenger::GetInstance().SendGUIMessage(m);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
     }
   }
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -903,7 +903,7 @@ void CPVRRefreshTimelineItemsThread::Process()
     if (m_pGuideWindow->RefreshTimelineItems() && !m_bStop)
     {
       CGUIMessage m(GUI_MSG_REFRESH_LIST, m_pGuideWindow->GetID(), 0, static_cast<int>(PVREvent::Epg));
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().SendGUIMessage(m);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
     }
 
     if (m_bStop)

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -912,7 +912,8 @@ void DX::DeviceResources::HandleDeviceLost(bool removed)
   OnDeviceRestored();
 
   if (removed)
-    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               "ReloadSkin");
 }
 
 bool DX::DeviceResources::Begin()

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -694,8 +694,8 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
   {
     if (settings->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) == AUTOCD_RIP)
     {
-      CJobManager::GetInstance().AddJob(new CAutorunMediaJob(device.label, device.path), this,
-                                        CJob::PRIORITY_LOW);
+      CServiceBroker::GetJobManager()->AddJob(new CAutorunMediaJob(device.label, device.path), this,
+                                              CJob::PRIORITY_LOW);
     }
     else
     {
@@ -708,8 +708,8 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
         CLog::Log(LOGDEBUG, "{}: Could not execute autorun for optical disc with path {}",
                   __FUNCTION__, device.path);
       }
-      CJobManager::GetInstance().AddJob(new CAutorunMediaJob(device.label, device.path), this,
-                                        CJob::PRIORITY_HIGH);
+      CServiceBroker::GetJobManager()->AddJob(new CAutorunMediaJob(device.label, device.path), this,
+                                              CJob::PRIORITY_HIGH);
     }
   }
   else

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -7,19 +7,21 @@
  */
 
 #include "TestBasicEnvironment.h"
-#include "TestUtils.h"
+
+#include "AppParamParser.h"
+#include "Application.h"
 #include "ServiceBroker.h"
+#include "TestUtils.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
+#include "messaging/ApplicationMessenger.h"
+#include "platform/Filesystem.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "Application.h"
-#include "AppParamParser.h"
 #include "windowing/WinSystem.h"
-#include "platform/Filesystem.h"
 
 #ifdef TARGET_DARWIN
 #include "Util.h"
@@ -43,6 +45,8 @@ void TestBasicEnvironment::SetUp()
 
   m_pSettingsComponent.reset(new CSettingsComponent());
   m_pSettingsComponent->Init(params);
+
+  CServiceBroker::RegisterAppMessenger(std::make_shared<KODI::MESSAGING::CApplicationMessenger>());
 
   XFILE::CFile *f;
 
@@ -110,6 +114,8 @@ void TestBasicEnvironment::TearDown()
 
   m_pSettingsComponent->Deinit();
   m_pSettingsComponent.reset();
+
+  CServiceBroker::UnregisterAppMessenger();
 }
 
 void TestBasicEnvironment::SetUpError()

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -20,7 +20,6 @@
 #include <mutex>
 #include <utility>
 
-using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
 CAlarmClock::CAlarmClock() : CThread("AlarmClock")
@@ -125,7 +124,8 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
   }
   else
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, iter->second.m_strCommand);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               iter->second.m_strCommand);
     if (iter->second.m_loop)
     {
       iter->second.watch.Reset();

--- a/xbmc/utils/InfoLoader.cpp
+++ b/xbmc/utils/InfoLoader.cpp
@@ -9,6 +9,7 @@
 #include "InfoLoader.h"
 
 #include "JobManager.h"
+#include "ServiceBroker.h"
 #include "TimeUtils.h"
 #include "guilib/LocalizeStrings.h"
 
@@ -33,7 +34,7 @@ std::string CInfoLoader::GetInfo(int info)
   if (m_refreshTime < CTimeUtils::GetFrameTime() && !m_busy)
   { // queue up the job
     m_busy = true;
-    CJobManager::GetInstance().AddJob(GetJob(), this);
+    CServiceBroker::GetJobManager()->AddJob(GetJob(), this);
   }
   if (m_busy && CTimeUtils::GetFrameTime() - m_refreshTime > 1000)
   {

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -8,6 +8,7 @@
 
 #include "JobManager.h"
 
+#include "ServiceBroker.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
@@ -66,7 +67,7 @@ void CJobWorker::Process()
 
 void CJobQueue::CJobPointer::CancelJob()
 {
-  CJobManager::GetInstance().CancelJob(m_id);
+  CServiceBroker::GetJobManager()->CancelJob(m_id);
   m_id = 0;
 }
 
@@ -146,7 +147,7 @@ void CJobQueue::QueueNextJob()
   while (m_jobQueue.size() && m_processing.size() < m_jobsAtOnce)
   {
     CJobPointer &job = m_jobQueue.back();
-    job.m_id = CJobManager::GetInstance().AddJob(job.m_job, this, m_priority);
+    job.m_id = CServiceBroker::GetJobManager()->AddJob(job.m_job, this, m_priority);
     if (job.m_id > 0)
     {
       m_processing.emplace_back(job);
@@ -168,19 +169,14 @@ void CJobQueue::CancelJobs()
 
 bool CJobQueue::IsProcessing() const
 {
-  return CJobManager::GetInstance().m_running && (!m_processing.empty() || !m_jobQueue.empty());
+  return CServiceBroker::GetJobManager()->m_running &&
+         (!m_processing.empty() || !m_jobQueue.empty());
 }
 
 bool CJobQueue::QueueEmpty() const
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   return m_jobQueue.empty();
-}
-
-CJobManager &CJobManager::GetInstance()
-{
-  static CJobManager sJobManager;
-  return sJobManager;
 }
 
 CJobManager::CJobManager()

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -196,8 +196,8 @@ private:
  \brief Job Manager class for scheduling asynchronous jobs.
 
  Controls asynchronous job execution, by allowing clients to add and cancel jobs.
- Should be accessed via CJobManager::GetInstance().  Jobs are allocated based on
- priority levels.  Lower priority jobs are executed only if there are sufficient
+ Should be accessed via CServiceBroker::GetJobManager().  Jobs are allocated based
+ on priority levels.  Lower priority jobs are executed only if there are sufficient
  spare worker threads free to allow for higher priority jobs that may arise.
 
  \sa CJob and IJobCallback
@@ -238,11 +238,7 @@ class CJobManager final
   };
 
 public:
-  /*!
-   \brief The only way through which the global instance of the CJobManager should be accessed.
-   \return the global instance.
-   */
-  static CJobManager &GetInstance();
+  CJobManager();
 
   /*!
    \brief Add a job to the threaded job manager.
@@ -357,8 +353,6 @@ protected:
   bool  OnJobProgress(unsigned int progress, unsigned int total, const CJob *job) const;
 
 private:
-  // private construction, and no assignments; use the provided singleton methods
-  CJobManager();
   CJobManager(const CJobManager&) = delete;
   CJobManager const& operator=(CJobManager const&) = delete;
 

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -79,7 +79,7 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
     //write .png file asynchronous with CThumbnailWriter, prevents stalling of the render thread
     //buffer is deleted from CThumbnailWriter
     CThumbnailWriter* thumbnailwriter = new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename);
-    CJobManager::GetInstance().AddJob(thumbnailwriter, NULL);
+    CServiceBroker::GetJobManager()->AddJob(thumbnailwriter, nullptr);
   }
 }
 

--- a/xbmc/utils/test/TestJobManager.cpp
+++ b/xbmc/utils/test/TestJobManager.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "ServiceBroker.h"
 #include "test/MtTestUtils.h"
 #include "utils/Job.h"
 #include "utils/JobManager.h"
@@ -64,13 +65,14 @@ public:
 class TestJobManager : public testing::Test
 {
 protected:
-  TestJobManager() = default;
+  TestJobManager() { CServiceBroker::RegisterJobManager(std::make_shared<CJobManager>()); }
 
   ~TestJobManager() override
   {
     /* Always cancel jobs test completion */
-    CJobManager::GetInstance().CancelJobs();
-    CJobManager::GetInstance().Restart();
+    CServiceBroker::GetJobManager()->CancelJobs();
+    CServiceBroker::GetJobManager()->Restart();
+    CServiceBroker::UnregisterJobManager();
   }
 };
 
@@ -78,7 +80,7 @@ TEST_F(TestJobManager, AddJob)
 {
   Flags* flags = new Flags();
   ReallyDumbJob* job = new ReallyDumbJob(flags);
-  CJobManager::GetInstance().AddJob(job, NULL);
+  CServiceBroker::GetJobManager()->AddJob(job, nullptr);
   ASSERT_TRUE(poll([flags]() -> bool { return flags->finished; }));
   delete flags;
 }
@@ -88,13 +90,13 @@ TEST_F(TestJobManager, CancelJob)
   unsigned int id;
   Flags* flags = new Flags();
   DummyJob* job = new DummyJob(flags);
-  id = CJobManager::GetInstance().AddJob(job, NULL);
+  id = CServiceBroker::GetJobManager()->AddJob(job, nullptr);
 
   // wait for the worker thread to be entered
   ASSERT_TRUE(poll([flags]() -> bool { return flags->started; }));
 
   // cancel the job
-  CJobManager::GetInstance().CancelJob(id);
+  CServiceBroker::GetJobManager()->CancelJob(id);
 
   // let the worker thread continue
   flags->lingerAtWork = false;
@@ -181,7 +183,7 @@ BroadcastingJob *
 WaitForJobToStartProcessing(CJob::PRIORITY priority, JobControlPackage &package)
 {
   BroadcastingJob* job = new BroadcastingJob(package);
-  CJobManager::GetInstance().AddJob(job, NULL, priority);
+  CServiceBroker::GetJobManager()->AddJob(job, nullptr, priority);
 
   // We're now ready to wait, wait and then unblock once ready
   while (!package.ready)
@@ -196,11 +198,11 @@ TEST_F(TestJobManager, PauseLowPriorityJob)
   JobControlPackage package;
   BroadcastingJob *job (WaitForJobToStartProcessing(CJob::PRIORITY_LOW_PAUSABLE, package));
 
-  EXPECT_TRUE(CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW_PAUSABLE));
-  CJobManager::GetInstance().PauseJobs();
-  EXPECT_FALSE(CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW_PAUSABLE));
-  CJobManager::GetInstance().UnPauseJobs();
-  EXPECT_TRUE(CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW_PAUSABLE));
+  EXPECT_TRUE(CServiceBroker::GetJobManager()->IsProcessing(CJob::PRIORITY_LOW_PAUSABLE));
+  CServiceBroker::GetJobManager()->PauseJobs();
+  EXPECT_FALSE(CServiceBroker::GetJobManager()->IsProcessing(CJob::PRIORITY_LOW_PAUSABLE));
+  CServiceBroker::GetJobManager()->UnPauseJobs();
+  EXPECT_TRUE(CServiceBroker::GetJobManager()->IsProcessing(CJob::PRIORITY_LOW_PAUSABLE));
 
   job->FinishAndStopBlocking();
 }
@@ -210,7 +212,7 @@ TEST_F(TestJobManager, IsProcessing)
   JobControlPackage package;
   BroadcastingJob *job (WaitForJobToStartProcessing(CJob::PRIORITY_LOW_PAUSABLE, package));
 
-  EXPECT_EQ(0, CJobManager::GetInstance().IsProcessing(""));
+  EXPECT_EQ(0, CServiceBroker::GetJobManager()->IsProcessing(""));
 
   job->FinishAndStopBlocking();
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9931,7 +9931,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         for (const auto &i : artwork)
         {
           std::string savedThumb = item.GetLocalArt(i.first, false);
-          CTextureCache::GetInstance().Export(i.second, savedThumb, overwrite);
+          CServiceBroker::GetTextureCache()->Export(i.second, savedThumb, overwrite);
         }
         if (actorThumbs)
           ExportActorThumbs(actorsDir, movie, !singleFile, overwrite);
@@ -9980,7 +9980,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           for (const auto& art : artwork)
           {
             std::string savedThumb = URIUtils::AddFileToFolder(itemPath, art.first);
-            CTextureCache::GetInstance().Export(art.second, savedThumb, overwrite);
+            CServiceBroker::GetTextureCache()->Export(art.second, savedThumb, overwrite);
           }
         }
         else
@@ -10075,7 +10075,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         for (const auto &i : artwork)
         {
           std::string savedThumb = item.GetLocalArt(i.first, false);
-          CTextureCache::GetInstance().Export(i.second, savedThumb, overwrite);
+          CServiceBroker::GetTextureCache()->Export(i.second, savedThumb, overwrite);
         }
       }
       m_pDS->next();
@@ -10171,7 +10171,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         for (const auto &i : artwork)
         {
           std::string savedThumb = item.GetLocalArt(i.first, true);
-          CTextureCache::GetInstance().Export(i.second, savedThumb, overwrite);
+          CServiceBroker::GetTextureCache()->Export(i.second, savedThumb, overwrite);
         }
 
         if (actorThumbs)
@@ -10191,7 +10191,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           {
             std::string savedThumb(item.GetLocalArt(seasonThumb + "-" + j.first, true));
             if (!i.second.empty())
-              CTextureCache::GetInstance().Export(j.second, savedThumb, overwrite);
+              CServiceBroker::GetTextureCache()->Export(j.second, savedThumb, overwrite);
           }
         }
       }
@@ -10271,7 +10271,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           for (const auto &i : artwork)
           {
             std::string savedThumb = item.GetLocalArt(i.first, false);
-            CTextureCache::GetInstance().Export(i.second, savedThumb, overwrite);
+            CServiceBroker::GetTextureCache()->Export(i.second, savedThumb, overwrite);
           }
           if (actorThumbs)
             ExportActorThumbs(actorsDir, episode, !singleFile, overwrite);
@@ -10359,7 +10359,7 @@ void CVideoDatabase::ExportActorThumbs(const std::string &strDir, const CVideoIn
     if (!i.thumb.empty())
     {
       std::string thumbFile(GetSafeFile(strPath, i.strName));
-      CTextureCache::GetInstance().Export(i.thumb, thumbFile, overwrite);
+      CServiceBroker::GetTextureCache()->Export(i.thumb, thumbFile, overwrite);
     }
   }
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1551,7 +1551,7 @@ namespace VIDEO
       {
         // cache the image to determine sizing
         CTextureDetails details;
-        if (CTextureCache::GetInstance().CacheImage(artFile->GetPath(), details))
+        if (CServiceBroker::GetTextureCache()->CacheImage(artFile->GetPath(), details))
         {
           candidate = GetArtTypeFromSize(details.width, details.height);
           if (itemArt.find(candidate) != itemArt.end())
@@ -1669,7 +1669,7 @@ namespace VIDEO
     for (const auto& artType : artTypes)
     {
       if (art.find(artType) != art.end())
-        CTextureCache::GetInstance().BackgroundCacheImage(art[artType]);
+        CServiceBroker::GetTextureCache()->BackgroundCacheImage(art[artType]);
     }
 
     pItem->SetArt(art);
@@ -2182,7 +2182,7 @@ namespace VIDEO
         if (i->thumb.empty() && !i->thumbUrl.GetFirstUrlByType().m_url.empty())
           i->thumb = CScraperUrl::GetThumbUrl(i->thumbUrl.GetFirstUrlByType());
         if (!i->thumb.empty())
-          CTextureCache::GetInstance().BackgroundCacheImage(i->thumb);
+          CServiceBroker::GetTextureCache()->BackgroundCacheImage(i->thumb);
       }
     }
   }

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -113,7 +113,7 @@ bool CThumbExtractor::DoWork()
     result = CDVDFileInfo::ExtractThumb(m_item, details, m_fillStreamDetails ? &m_item.GetVideoInfoTag()->m_streamDetails : nullptr, m_pos);
     if (result)
     {
-      CTextureCache::GetInstance().AddCachedTexture(m_target, details);
+      CServiceBroker::GetTextureCache()->AddCachedTexture(m_target, details);
       m_item.SetProperty("HasAutoThumb", true);
       m_item.SetProperty("AutoThumbImage", m_target);
       m_item.SetArt("thumb", m_target);
@@ -417,7 +417,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
       if (!art.empty()) // cache it
       {
         SetCachedImage(*pItem, type, art);
-        CTextureCache::GetInstance().BackgroundCacheImage(art);
+        CServiceBroker::GetTextureCache()->BackgroundCacheImage(art);
         artwork.insert(std::make_pair(type, art));
       }
       else
@@ -444,7 +444,8 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
   {
     // An auto-generated thumb may have been cached on a different device - check we have it here
     std::string url = pItem->GetArt("thumb");
-    if (StringUtils::StartsWith(url, "image://video@") && !CTextureCache::GetInstance().HasCachedImage(url))
+    if (StringUtils::StartsWith(url, "image://video@") &&
+        !CServiceBroker::GetTextureCache()->HasCachedImage(url))
       pItem->SetArt("thumb", "");
 
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -452,9 +453,9 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
     {
       // create unique thumb for auto generated thumbs
       std::string thumbURL = GetEmbeddedThumbURL(*pItem);
-      if (CTextureCache::GetInstance().HasCachedImage(thumbURL))
+      if (CServiceBroker::GetTextureCache()->HasCachedImage(thumbURL))
       {
-        CTextureCache::GetInstance().BackgroundCacheImage(thumbURL);
+        CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumbURL);
         pItem->SetProperty("HasAutoThumb", true);
         pItem->SetProperty("AutoThumbImage", thumbURL);
         pItem->SetArt("thumb", thumbURL);

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -39,8 +39,6 @@
 #include <string>
 #include <vector>
 
-using namespace KODI::MESSAGING;
-
 #define BOOKMARK_THUMB_WIDTH CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes
 
 #define CONTROL_ADD_BOOKMARK           2
@@ -572,7 +570,7 @@ void CGUIDialogVideoBookmarks::OnJobComplete(unsigned int jobID,
     {
       unsigned int chapterIdx = (*iter).second;
       CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, 1, chapterIdx);
-      CApplicationMessenger::GetInstance().SendGUIMessage(m);
+      CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
       m_mapJobsChapter.erase(iter);
     }
   }

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -214,7 +214,8 @@ void CGUIDialogVideoBookmarks::UpdateItem(unsigned int chapterIdx)
   if (itemPos < m_vecItems->Size())
   {
     std::string time = StringUtils::Format("chapter://{}/{}", m_filePath, chapterIdx);
-    std::string cachefile = CTextureCache::GetInstance().GetCachedPath(CTextureCache::GetInstance().GetCacheFile(time) + ".jpg");
+    std::string cachefile = CServiceBroker::GetTextureCache()->GetCachedPath(
+        CServiceBroker::GetTextureCache()->GetCacheFile(time) + ".jpg");
     if (XFILE::CFile::Exists(cachefile))
     {
       (*m_vecItems)[itemPos]->SetArt("thumb", cachefile);
@@ -280,7 +281,8 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
     item->SetLabel2(time);
 
     std::string chapterPath = StringUtils::Format("chapter://{}/{}", m_filePath, i);
-    std::string cachefile = CTextureCache::GetInstance().GetCachedPath(CTextureCache::GetInstance().GetCacheFile(chapterPath)+".jpg");
+    std::string cachefile = CServiceBroker::GetTextureCache()->GetCachedPath(
+        CServiceBroker::GetTextureCache()->GetCacheFile(chapterPath) + ".jpg");
     if (XFILE::CFile::Exists(cachefile))
       item->SetArt("thumb", cachefile);
     else if (i > m_jobsStarted && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTCHAPTERTHUMBS))

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1190,10 +1190,11 @@ void CGUIDialogVideoInfo::PlayTrailer()
   {
     CFileItemList *l = new CFileItemList; //don't delete,
     l->Add(std::make_shared<CFileItem>(item));
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
   }
   else
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(new CFileItem(item)));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0,
+                                               static_cast<void*>(new CFileItem(item)));
 }
 
 void CGUIDialogVideoInfo::SetLabel(int iControl, const std::string &strLabel)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -363,7 +363,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
           if (!thumb.empty())
           {
             item->SetArt("thumb", thumb);
-            CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+            CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);
           }
         }
         item->SetArt("icon", "DefaultActor.png");
@@ -404,7 +404,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
           if (!thumb.empty())
           {
             item->SetArt("thumb", thumb);
-            CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+            CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);
           }
         }
       }
@@ -932,7 +932,7 @@ void CGUIDialogVideoInfo::OnGetArt()
       item->SetLabel(g_localizeStrings.Get(13513));
 
       //! @todo Do we need to clear the cached image?
-      //    CTextureCache::GetInstance().ClearCachedImage(thumb);
+      //    CServiceBroker::GetTextureCache()->ClearCachedImage(thumb);
       items.Add(item);
     }
 
@@ -1054,7 +1054,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
     item->SetLabel(g_localizeStrings.Get(20441));
 
     //! @todo Do we need to clear the cached image?
-//    CTextureCache::GetInstance().ClearCachedImage(thumb);
+    //    CServiceBroker::GetTextureCache()->ClearCachedImage(thumb);
     items.Add(item);
   }
 
@@ -1068,7 +1068,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
     itemLocal->SetLabel(g_localizeStrings.Get(20438));
 
     //! @todo Do we need to clear the cached image?
-    CTextureCache::GetInstance().ClearCachedImage(strLocal);
+    CServiceBroker::GetTextureCache()->ClearCachedImage(strLocal);
     items.Add(itemLocal);
   }
   else
@@ -2115,7 +2115,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
       items.Add(item);
 
       //! @todo Do we need to clear the cached image?
-      //    CTextureCache::GetInstance().ClearCachedImage(thumbs[i]);
+      //    CServiceBroker::GetTextureCache()->ClearCachedImage(thumbs[i]);
     }
 
     if (type == "actor")

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1069,7 +1069,8 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
                                                                         m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strTitle),
                                                                         song))
       {
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(new CFileItem(song)));
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0,
+                                                   static_cast<void*>(new CFileItem(song)));
       }
       return true;
     }

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -28,10 +28,8 @@
 #include <cassert>
 #include <mutex>
 
-using namespace KODI::MESSAGING;
-
-CGraphicContext::CGraphicContext(void) = default;
-CGraphicContext::~CGraphicContext(void) = default;
+CGraphicContext::CGraphicContext() = default;
+CGraphicContext::~CGraphicContext() = default;
 
 void CGraphicContext::SetOrigin(float x, float y)
 {
@@ -390,7 +388,7 @@ void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate)
   }
   else
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_SETVIDEORESOLUTION, res, forceUpdate ? 1 : 0);
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_SETVIDEORESOLUTION, res, forceUpdate ? 1 : 0);
   }
 }
 

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -27,7 +27,6 @@
 #include <X11/extensions/Xrandr.h>
 #include <X11/keysymdef.h>
 
-using namespace KODI::MESSAGING;
 using namespace KODI::WINDOWING::X11;
 
 static uint32_t SymMappingsX11[][2] =
@@ -394,7 +393,8 @@ bool CWinEventsX11::MessagePump()
       case ClientMessage:
       {
         if ((unsigned int)xevent.xclient.data.l[0] == m_wmDeleteMessage)
-          if (!g_application.m_bStop) CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+          if (!g_application.m_bStop)
+            CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
         break;
       }
 

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -33,7 +33,6 @@
 #include <X11/Xatom.h>
 #include <X11/extensions/Xrandr.h>
 
-using namespace KODI::MESSAGING;
 using namespace KODI::WINDOWING::X11;
 
 using namespace std::chrono_literals;
@@ -509,7 +508,7 @@ void CWinSystemX11::NotifyAppActiveChange(bool bActivated)
 {
   if (bActivated && m_bWasFullScreenBeforeMinimize && !m_bFullScreen)
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
 
     m_bWasFullScreenBeforeMinimize = false;
   }
@@ -522,7 +521,7 @@ void CWinSystemX11::NotifyAppFocusChange(bool bGaining)
       !m_bFullScreen)
   {
     m_bWasFullScreenBeforeMinimize = false;
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
     m_minimized = false;
   }
   if (!bGaining)
@@ -535,7 +534,7 @@ bool CWinSystemX11::Minimize()
   if (m_bWasFullScreenBeforeMinimize)
   {
     m_bIgnoreNextFocusMessage = true;
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
   }
 
   XIconifyWindow(m_dpy, m_mainWindow, m_screen);

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -8,6 +8,7 @@
 
 #include "WinSystemIOS.h"
 
+#include "ServiceBroker.h"
 #include "VideoSyncIos.h"
 #include "WinEventsIOS.h"
 #include "cores/AudioEngine/Sinks/AESinkDARWINIOS.h"
@@ -438,14 +439,14 @@ bool CWinSystemIOS::HasCursor()
 void CWinSystemIOS::NotifyAppActiveChange(bool bActivated)
 {
   if (bActivated && m_bWasFullScreenBeforeMinimize && !CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot())
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
 }
 
 bool CWinSystemIOS::Minimize()
 {
   m_bWasFullScreenBeforeMinimize = CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot();
   if (m_bWasFullScreenBeforeMinimize)
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
 
   return true;
 }

--- a/xbmc/windowing/osx/SDL/WinEventsSDL.cpp
+++ b/xbmc/windowing/osx/SDL/WinEventsSDL.cpp
@@ -23,8 +23,6 @@
 
 #include "platform/darwin/osx/CocoaInterface.h"
 
-using namespace KODI::MESSAGING;
-
 bool CWinEventsOSX::MessagePump()
 {
   SDL_Event event;
@@ -36,7 +34,7 @@ bool CWinEventsOSX::MessagePump()
     {
       case SDL_QUIT:
         if (!g_application.m_bStop)
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
         break;
 
       case SDL_ACTIVEEVENT:
@@ -214,7 +212,7 @@ bool CWinEventsOSX::ProcessOSXShortcuts(SDL_Event& event)
     {
     case SDLK_q:  // CMD-q to quit
       if (!g_application.m_bStop)
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
       return true;
 
     case SDLK_f: // CMD-Ctrl-f to toggle fullscreen
@@ -232,7 +230,7 @@ bool CWinEventsOSX::ProcessOSXShortcuts(SDL_Event& event)
       return true;
 
     case SDLK_m: // CMD-m to minimize
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_MINIMIZE);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MINIMIZE);
       return true;
 
     default:

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -57,7 +57,6 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 using namespace KODI;
-using namespace MESSAGING;
 using namespace WINDOWING;
 using namespace std::chrono_literals;
 
@@ -1660,7 +1659,7 @@ void CWinSystemOSX::HandlePossibleRefreshrateChange()
     oldRefreshRate = m_refreshRate;
     // send a message so that videoresolution (and refreshrate)
     // is changed
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_VIDEORESIZE, m_SDLSurface->w, m_SDLSurface->h);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_VIDEORESIZE, m_SDLSurface->w, m_SDLSurface->h);
   }
 }
 

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -8,6 +8,7 @@
 
 #include "WinSystemTVOS.h"
 
+#include "ServiceBroker.h"
 #import "cores/AudioEngine/Sinks/AESinkDARWINTVOS.h"
 #include "cores/RetroPlayer/process/ios/RPProcessInfoIOS.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
@@ -404,7 +405,7 @@ void CWinSystemTVOS::NotifyAppActiveChange(bool bActivated)
 {
   if (bActivated && m_bWasFullScreenBeforeMinimize &&
       !CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot())
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
 }
 
 bool CWinSystemTVOS::Minimize()
@@ -412,7 +413,7 @@ bool CWinSystemTVOS::Minimize()
   m_bWasFullScreenBeforeMinimize =
       CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot();
   if (m_bWasFullScreenBeforeMinimize)
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
 
   return true;
 }

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -1534,7 +1534,7 @@ void CWinSystemWayland::OnWindowShowContextMenu(const wayland::seat_t& seat, std
 
 void CWinSystemWayland::OnWindowClose()
 {
-  KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
 }
 
 void CWinSystemWayland::OnWindowMinimize()
@@ -1556,7 +1556,7 @@ void CWinSystemWayland::OnWindowMaximize()
 
 void CWinSystemWayland::OnClose()
 {
-  KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
 }
 
 bool CWinSystemWayland::MessagePump()

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -47,7 +47,6 @@ using namespace winrt::Windows::UI::Input;
 using namespace winrt::Windows::UI::ViewManagement;
 
 using namespace PERIPHERALS;
-using namespace KODI::MESSAGING;
 
 static winrt::Point GetScreenPoint(winrt::Point point)
 {
@@ -549,7 +548,8 @@ void CWinEventsWin10::OnBackRequested(const winrt::IInspectable&, const BackRequ
   // handle this only on windows mobile
   if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Mobile)
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_NAV_BACK)));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(ACTION_NAV_BACK)));
   }
   args.Handled(true);
 }
@@ -592,7 +592,8 @@ void CWinEventsWin10::OnSystemMediaButtonPressed(const SystemMediaTransportContr
   }
   if (action != ACTION_NONE)
   {
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(action)));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                               static_cast<void*>(new CAction(action)));
   }
 }
 

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -43,8 +43,6 @@
 
 #include <array>
 
-using namespace KODI::MESSAGING;
-
 HWND g_hWnd = nullptr;
 
 #ifndef LODWORD
@@ -363,7 +361,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           return(DefWindowProc(hWnd, uMsg, wParam, lParam));
         case VK_RETURN: //alt-return
           if ((lParam & REPEATED_KEYMASK) == 0)
-            CApplicationMessenger::GetInstance().PostMsg(TMSG_TOGGLEFULLSCREEN);
+            CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
           return 0;
         default:;
       }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -775,7 +775,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 if(wParam == DBT_DEVICEARRIVAL)
                 {
                   CLog::LogF(LOGDEBUG, "Drive {} Media has arrived.", strdrive);
-                  CJobManager::GetInstance().AddJob(new CDetectDisc(strdrive, true), NULL);
+                  CServiceBroker::GetJobManager()->AddJob(new CDetectDisc(strdrive, true), nullptr);
                 }
                 else
                 {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -2264,10 +2264,12 @@ bool CGUIMediaWindow::WaitGetDirectoryItems(CGetDirectoryItems &items)
   {
     m_updateJobActive = true;
     m_updateEvent.Reset();
-    CJobManager::GetInstance().Submit([&]() {
-      items.Run();
-      m_updateEvent.Set();
-    }, nullptr, CJob::PRIORITY_NORMAL);
+    CServiceBroker::GetJobManager()->Submit(
+        [&]() {
+          items.Run();
+          m_updateEvent.Set();
+        },
+        nullptr, CJob::PRIORITY_NORMAL);
 
     while (!m_updateEvent.Wait(1ms))
     {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1784,7 +1784,7 @@ bool CGUIMediaWindow::OnPopupMenu(int itemIdx)
   {
     bool saveVal = m_backgroundLoad;
     m_backgroundLoad = false;
-    CApplicationMessenger::GetInstance().SendMsg(
+    CServiceBroker::GetAppMessenger()->SendMsg(
         TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
         item->GetProperty(StringUtils::Format("contextmenuaction({})", idx - pluginMenuRange.first))
             .asString());

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1067,7 +1067,7 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
   if (item >= 0 && pItem->m_bIsFolder && !pItem->IsParentFolder())
     choices.Add(CONTROL_BTNCALCSIZE, 13393);
   choices.Add(CONTROL_BTNSWITCHMEDIA, 523);
-  if (CJobManager::GetInstance().IsProcessing("filemanager"))
+  if (CServiceBroker::GetJobManager()->IsProcessing("filemanager"))
     choices.Add(CONTROL_BTNCANCELJOB, 167);
 
   if (!pItem->m_bIsFolder)

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1209,7 +1209,7 @@ void CGUIWindowFileManager::OnJobComplete(unsigned int jobID, bool success, CJob
   if (IsActive())
   {
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_UPDATE);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, GetID(), false);
+    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, GetID(), false);
   }
 
   CJobQueue::OnJobComplete(jobID, success, job);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -130,7 +130,7 @@ void CGUIWindowHome::AddRecentlyAddedJobs(int flag)
   }
 
   if (flag && getAJob)
-    CJobManager::GetInstance().AddJob(new CRecentlyAddedJob(flag), this);
+    CServiceBroker::GetJobManager()->AddJob(new CRecentlyAddedJob(flag), this);
 
   m_updateRA = 0;
 }

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -92,7 +92,7 @@ bool CGUIWindowLoginScreen::OnMessage(CGUIMessage& message)
           if (bOkay)
           {
             if (iItem >= 0)
-              CApplicationMessenger::GetInstance().PostMsg(TMSG_LOADPROFILE, iItem);
+              CServiceBroker::GetAppMessenger()->PostMsg(TMSG_LOADPROFILE, iItem);
           }
           else
           {
@@ -242,7 +242,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
     if (g_passwordManager.CheckLock(profileManager->GetMasterProfile().getLockMode(), profileManager->GetMasterProfile().getLockCode(), 20075))
       g_passwordManager.iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
     else // be inconvenient
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN);
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SHUTDOWN);
 
     return true;
   }


### PR DESCRIPTION
Kill more of those global singletons, access via Service Broker instead, construct and destruct in a controlled way.

* CJobManager::GetInstance
* CKeyboardLayoutManager::GetInstance
* CApplicationMessenger::GetInstance
* CTextureCache::GetInstance

Runtime-tested on Android and macOS, latest Kodi master