### PR TITLE
[Discs][DvdNav] Fix audio stream id

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -996,12 +996,26 @@ int CDVDInputStreamNavigator::GetSubTitleStreamCount()
 
 int CDVDInputStreamNavigator::GetActiveAudioStream()
 {
-  int activeStream = -1;
-
-  if (m_dvdnav)
+  if (!m_dvdnav)
   {
-    int audioN = m_dll.dvdnav_get_active_audio_stream(m_dvdnav);
-    activeStream = ConvertAudioStreamId_ExternalToXBMC(audioN);
+    return -1;
+  }
+
+  const int8_t logicalAudioStreamId = m_dll.dvdnav_get_active_audio_stream(m_dvdnav);
+  if (logicalAudioStreamId < 0)
+  {
+    return -1;
+  }
+
+  int activeStream = -1;
+  int audioStreamCount = GetAudioStreamCount();
+  for (int audioN = 0; audioN < audioStreamCount; audioN++)
+  {
+    if (m_dll.dvdnav_get_audio_logical_stream(m_dvdnav, audioN) == logicalAudioStreamId)
+    {
+      activeStream = ConvertAudioStreamId_ExternalToXBMC(audioN);
+      break;
+    }
   }
 
   return activeStream;


### PR DESCRIPTION
## Description
Similar to https://github.com/xbmc/xbmc/pull/21101 and fixing something i did not take into account in https://github.com/xbmc/xbmc/pull/21078.
`dvdnav_get_active_audio_stream` returns a logical stream id which may not be the same as the index the player uses (in some of my dvds most of the times physical index = logical index) - see https://code.videolan.org/videolan/libdvdnav/-/blob/master/src/vm/vmget.c#L109-111.
We need to iterate over the available audio streams to find the matching id provided the logical one