### PR TITLE
[discs][dvdnav] Simplify IsSubtitleStreamEnabled/remove private vm

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1329,15 +1329,7 @@ bool CDVDInputStreamNavigator::IsSubtitleStreamEnabled()
   if (!m_dvdnav)
     return false;
 
-  vm_t* vm = m_dll.dvdnav_get_vm(m_dvdnav);
-  if (!vm)
-    return false;
-
-
-  if(vm->state.SPST_REG & 0x40)
-    return true;
-  else
-    return false;
+  return m_dll.dvdnav_get_active_spu_stream(m_dvdnav) >= 0;
 }
 
 bool CDVDInputStreamNavigator::GetState(std::string &xmlstate)


### PR DESCRIPTION
## Description
Another one that can be simplified without requiring access to the private VM. To check if the VM has enabled subtitles we can simply get the logical subtitle stream and check if it is valid  (i.e. has an index >= 0).
Runtime tested with enabled and disabled subtitles.