### PR TITLE
[GUI][Discs] Fix System.DVDLabel

### DIFF
--- a/xbmc/storage/DetectDVDType.h
+++ b/xbmc/storage/DetectDVDType.h
@@ -18,8 +18,9 @@
 #ifdef HAS_DVD_DRIVE
 
 #include "threads/CriticalSection.h"
-
 #include "threads/Thread.h"
+#include "utils/DiscsUtils.h"
+
 #include <memory>
 #include <string>
 
@@ -56,6 +57,8 @@ protected:
   void DetectMediaType();
   void SetNewDVDShareUrl( const std::string& strNewUrl, bool bCDDA, const std::string& strDiscLabel );
 
+  void Clear();
+
 private:
   static CCriticalSection m_muReadingMedia;
 
@@ -74,6 +77,9 @@ private:
   static std::string m_diskPath;
 
   std::shared_ptr<CLibcdio> m_cdio;
+
+  /*! \brief Stores the DiscInfo of the current disk */
+  static UTILS::DISCS::DiscInfo m_discInfo;
 };
 }
 #endif

--- a/xbmc/utils/DiscsUtils.h
+++ b/xbmc/utils/DiscsUtils.h
@@ -39,6 +39,15 @@ struct DiscInfo
     \return true if the info is empty, false otherwise
   */
   bool empty() { return (type == DiscType::UNKNOWN && name.empty() && serial.empty()); }
+
+  /*! \brief Clears all the DiscInfo members
+  */
+  void clear()
+  {
+    type = DiscType::UNKNOWN;
+    name.clear();
+    serial.clear();
+  }
 };
 
 /*! \brief Try to obtain the disc info (type, name, serial) of a given media path


### PR DESCRIPTION
## Description
This PR fixes the `System.DVDLabel` which in Linux returns only "DVD" or "AUDIO-CD" when in fact (and according to the documentation) it should return the detected dvd label/name. In windows the behavior (and code path) is different and the label works correctly.
This should also put us a step closer at fixing https://github.com/xbmc/xbmc/issues/20935 or play optical disks without requiring mounting them.

**Notes:**
The DetectDVDType thread/component could well benefit from a huge refactor and platform code split. It has no ownership and abuses a lot of static vars. Something to be done incrementally.
The infolabel is a bit legacy and likely comes from the time Kodi only supported DVDs. New infolabels should be created and this one deprecated later.

## How has this been tested?
Runtime tested in Linux
Still missing a runtime test on windows (will let jenkins build a testbuild for this). Will remove the don't merge label if it behaves as expected.

## Screenshots (if appropriate):

**Before:**
![Screenshot from 2022-03-11 17-48-15](https://user-images.githubusercontent.com/7375276/157946475-cc21ee06-e53f-4363-a821-fb30ce99dd75.png)


**PR:**
![image](https://user-images.githubusercontent.com/7375276/157945799-eb298bff-d6f0-4814-bce5-2e26a3a9d6b4.png)
