### PR TITLE
[Docs][Python] Fix Doxygen for xbmc python module

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -218,6 +218,7 @@ namespace XBMCAddon
       int m_order;
       String m_thumbnail;
     };
+    /// @}
 
     ///
     /// \defgroup python_xbmc_videostreamdetail VideoStreamDetail
@@ -246,7 +247,7 @@ namespace XBMCAddon
     public:
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
-      /// \ingroup python_xbmc_videostreamdetail VideoStreamDetail
+      /// \ingroup python_xbmc_videostreamdetail
       /// @brief \python_func{ xbmc.VideoStreamDetail([width, height, aspect, duration, codec, stereoMode, language, hdrType]) }
       /// Creates a single video stream details class for a video item wrapped by InfoTagVideo.
       ///
@@ -571,6 +572,7 @@ namespace XBMCAddon
       String m_language;
       String m_hdrType;
     };
+    /// @}
 
     ///
     /// \defgroup python_xbmc_audiostreamdetail AudioStreamDetail
@@ -736,6 +738,7 @@ namespace XBMCAddon
       String m_codec;
       String m_language;
     };
+    /// @}
 
     ///
     /// \defgroup python_xbmc_subtitlestreamdetail SubtitleStreamDetail
@@ -827,6 +830,7 @@ namespace XBMCAddon
     private:
       String m_language;
     };
+    /// @}
 
     ///
     /// \defgroup python_InfoTagVideo InfoTagVideo
@@ -2681,6 +2685,7 @@ namespace XBMCAddon
         bool isgz = false,
         int season = -1);
 #endif
+      /// @}
 
 #ifndef SWIG
       static void setDbIdRaw(CVideoInfoTag* infoTag, int dbId);


### PR DESCRIPTION
## Description
Doxygen docs are currently broken for the xbmc python module as the groups for Actor, InfotagVideo, SubtitleStreamDetails, AudioStreamDetails are not being closed. As a result, the tree/ownership of groups are placed on the wrong location (currently all childrens of Actor):

**Current docs.kodi.tv:**
![image](https://user-images.githubusercontent.com/7375276/158014884-1c4dcd1d-7ace-4427-862f-2eccc04b4954.png)

**PR:**
![image](https://user-images.githubusercontent.com/7375276/158014909-dd2dee07-737b-4d17-830a-b1b36923ee25.png)
