### PR TITLE
[discs][dvdnav] Cleanup event callbacks

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -412,24 +412,14 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
       {
         dvdnav_spu_stream_change_event_t* event = reinterpret_cast<dvdnav_spu_stream_change_event_t*>(buf);
 
-        //libdvdnav never sets logical, why.. don't know..
-        event->logical = GetActiveSubtitleStream();
-
-        /* correct stream ids for disabled subs if needed */
-        if(!IsSubtitleStreamEnabled())
+        // correct stream ids for disabled subs if needed
+        if (!IsSubtitleStreamEnabled())
         {
           event->physical_letterbox |= 0x80;
           event->physical_pan_scan |= 0x80;
           event->physical_wide |= 0x80;
         }
 
-        if(event->logical<0 && GetSubTitleStreamCount()>0)
-        {
-          /* this will not take effect in this event */
-          CLog::Log(LOGINFO, "{} - none or invalid subtitle stream selected, defaulting to first",
-                    __FUNCTION__);
-          SetActiveSubtitleStream(0);
-        }
         m_bCheckButtons = true;
         iNavresult = m_pVideoPlayer->OnDiscNavResult(buf, DVDNAV_SPU_STREAM_CHANGE);
       }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -410,16 +410,6 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
     case DVDNAV_SPU_STREAM_CHANGE:
       // Player applications should inform their SPU decoder to switch channels
       {
-        dvdnav_spu_stream_change_event_t* event = reinterpret_cast<dvdnav_spu_stream_change_event_t*>(buf);
-
-        // correct stream ids for disabled subs if needed
-        if (!IsSubtitleStreamEnabled())
-        {
-          event->physical_letterbox |= 0x80;
-          event->physical_pan_scan |= 0x80;
-          event->physical_wide |= 0x80;
-        }
-
         m_bCheckButtons = true;
         iNavresult = m_pVideoPlayer->OnDiscNavResult(buf, DVDNAV_SPU_STREAM_CHANGE);
       }
@@ -428,26 +418,6 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
     case DVDNAV_AUDIO_STREAM_CHANGE:
       // Player applications should inform their audio decoder to switch channels
       {
-
-        //dvdnav_get_audio_logical_stream actually does the opposite to the docs..
-        //taking a audiostream as given on dvd, it gives the physical stream that
-        //refers to in the mpeg file
-
-        dvdnav_audio_stream_change_event_t* event = reinterpret_cast<dvdnav_audio_stream_change_event_t*>(buf);
-
-        //wrong... stupid docs..
-        //event->logical = dvdnav_get_audio_logical_stream(m_dvdnav, event->physical);
-        //logical should actually be set to the (vm->state).AST_REG
-
-        event->logical = GetActiveAudioStream();
-        if(event->logical<0)
-        {
-          /* this will not take effect in this event */
-          CLog::Log(LOGINFO, "{} - none or invalid audio stream selected, defaulting to first",
-                    __FUNCTION__);
-          SetActiveAudioStream(0);
-        }
-
         iNavresult = m_pVideoPlayer->OnDiscNavResult(buf, DVDNAV_AUDIO_STREAM_CHANGE);
       }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4079,16 +4079,9 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
       break;
     case DVDNAV_AUDIO_STREAM_CHANGE:
       {
-        // This should be the correct way i think, however we don't have any streams right now
-        // since the demuxer hasn't started so it doesn't change. not sure how to do this.
         dvdnav_audio_stream_change_event_t* event = static_cast<dvdnav_audio_stream_change_event_t*>(pData);
-
         // Tell system what audiostream should be opened by default
-        if (event->logical >= 0)
-          m_dvd.iSelectedAudioStream = event->physical;
-        else
-          m_dvd.iSelectedAudioStream = -1;
-
+        m_dvd.iSelectedAudioStream = event->physical;
         m_CurrentAudio.stream = NULL;
       }
       break;


### PR DESCRIPTION
## Description

This further removes some code blocks that are currently doing nothing of use:

- For subtitles we are setting the logical id on the received event from libdvdnav which doesn't make any sense (logical stream ids are never used on the calls to libdvdnav - unless to translate the physical id - which comes in the event). Furthermore when setting a few breakpoints the logical stream id is set anyway in the event...

- Furthermore, for subtitles we are changing the event, taking decisions on data that doesn't come from the callback and then passing the original buffer to the player (so we change the event...for nothing)

- For audio the information in the comments is wrong and we should also not change the stream id that comes from the library. If for some unknown reason a wrong (negative) stream id is returned in the event it will pretty much do the same as the if/else that's currently there

Note this callbacks are sent from libdvdnav when we do some action (change subs, change audio stream, etc)