### PR TITLE
[GUI][Discs][MediaManager] Access CDInfo in a lazy way

### DIFF
--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -535,7 +535,8 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     #ifdef HAS_DVD_DRIVE
       if (CServiceBroker::GetMediaManager().IsDiscInDrive())
       {
-        MEDIA_DETECT::CCdInfo* pCdInfo = CServiceBroker::GetMediaManager().GetCdInfo();
+        MEDIA_DETECT::CCdInfo* pCdInfo =
+            CServiceBroker::GetMediaManager().GetCdInfo("", WaitMode::LAZY);
         value = pCdInfo && (pCdInfo->IsAudio(1) || pCdInfo->IsCDExtra(1) || pCdInfo->IsMixedMode(1));
       }
       else

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -434,6 +434,17 @@ CCdInfo* CDetectDVDMedia::GetCdInfo()
   return pCdInfo;
 }
 
+CCdInfo* CDetectDVDMedia::LazyGetCdInfo()
+{
+  std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia, std::try_to_lock);
+  if (waitLock.owns_lock())
+  {
+    CCdInfo* pCdInfo = m_pCdInfo;
+    return pCdInfo;
+  }
+  return nullptr;
+}
+
 const std::string &CDetectDVDMedia::GetDVDLabel()
 {
   if (!m_discInfo.empty())

--- a/xbmc/storage/DetectDVDType.h
+++ b/xbmc/storage/DetectDVDType.h
@@ -42,7 +42,20 @@ public:
   static void WaitMediaReady();
   static bool IsDiscInDrive();
   static int DriveReady();
+
+  /*! \brief Gets the CDInfo of the current inserted optical disc
+    \note This is a blocking operation, the caller will be blocked if
+    some other resource is trying to obtain the CDInfo at the same time
+    \return a pointer to the CCdInfo of nullptr if it doesn't exist
+  */
   static CCdInfo* GetCdInfo();
+
+  /*! \brief Gets the CDInfo of the current inserted optical disc in a lazy way
+    \note This will return nullptr if some other thread is accessing the same resource.
+    \return a pointer to the CCdInfo of nullptr if it doesn't exist (or if some other thread is accessing the drive)
+  */
+  static CCdInfo* LazyGetCdInfo();
+
   static CEvent m_evAutorun;
 
   static const std::string &GetDVDLabel();

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -430,7 +430,7 @@ DWORD CMediaManager::GetDriveStatus(const std::string& devicePath)
 }
 
 #ifdef HAS_DVD_DRIVE
-CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath)
+CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath, WaitMode waitMode)
 {
 #ifdef TARGET_WINDOWS
   if(!m_bhasoptical)
@@ -456,7 +456,14 @@ CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath)
 
   return pCdInfo;
 #else
-  return MEDIA_DETECT::CDetectDVDMedia::GetCdInfo();
+  if (waitMode == WaitMode::WAIT)
+  {
+    return MEDIA_DETECT::CDetectDVDMedia::GetCdInfo();
+  }
+  else
+  {
+    return MEDIA_DETECT::CDetectDVDMedia::LazyGetCdInfo();
+  }
 #endif
 }
 

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -30,6 +30,14 @@
 #define DRIVE_CLOSED_MEDIA_PRESENT  4 // Will be send once when the drive just have closed
 #define DRIVE_NONE  5 // system doesn't have an optical drive
 
+
+/*! \brief Wait modes for acessing MediaManager info */
+enum class WaitMode
+{
+  WAIT, /*!< When this mode is specified the caller is blocked if some other component is trying to access the same info, and the info is returned */
+  LAZY /*!< When this mode is specified the caller is not blocked when some other component is trying to access the same info and the info might not be returned  */
+};
+
 class CFileItem;
 
 class CNetworkLocation
@@ -68,7 +76,16 @@ public:
   std::string TranslateDevicePath(const std::string& devicePath, bool bReturnAsDevice=false);
   DWORD GetDriveStatus(const std::string& devicePath="");
 #ifdef HAS_DVD_DRIVE
-  MEDIA_DETECT::CCdInfo* GetCdInfo(const std::string& devicePath="");
+  /*! \brief Gets the CDInfo of the current inserted optical disc
+    \param devicePath The disc mediapath (e.g. /dev/cdrom, D\://, etc), default empty
+    \param waitMode Getting the cd info is a blocking operation. waitMode specifies if the
+    caller must wait for the result (WaitMode::WAIT) or get the info in a lazy/best effort way (WaitMode::LAZY).
+    If WaitMode::WAIT is specified nullptr will be returned if the drive is currently being accessed
+    by some other resource.
+    \return a pointer to the CCdInfo of nullptr if it doesn't exist
+*/
+  MEDIA_DETECT::CCdInfo* GetCdInfo(const std::string& devicePath = "",
+                                   WaitMode waitMode = WaitMode::WAIT);
   bool RemoveCdInfo(const std::string& devicePath="");
   std::string GetDiskLabel(const std::string& devicePath="");
   std::string GetDiskUniqueId(const std::string& devicePath="");


### PR DESCRIPTION
## Description
Currently when a physical disc in inserted in the drive Kodi will start to probe the disc and store info about it such as the CDInfo (which allows to know if it's an audio cd, number of audio/data tracks, etc). While probing happens on its own thread (DetectDVDType) the GUI needs access to some of this information to display infolabels or process infobools. While most of the stuff doesn't block the renderthread (as the example of the recently added DiscInfo struct) this is not the case for CDInfo. The main thread will be blocked for the time it takes to the access lock to be unlocked. Accessing the physical optical drive is a really slow operation which renders the GUI completely blocked for a few seconds. While this is not a problem if you're actively inserting and ejecting disks ...  this also happens on kodi startup if a disc is inserted in the drive blocking Kodi usage even if you're not planing to play the disc.
Since the info is not ready yet, just take a lazy approach for the GUIInfos, returning early/empty if some other resource is still accessing the disk to store the info we need.

## How has this been tested?
Runtime tested

## What is the effect on users?
Should be able to freely use the GUI and the input subsystem while discs are being probed
