### PR TITLE
[cmake] declare directories of external libraries as system headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ endif()
 # Generate messages
 core_add_subdirs_from_filelist(${CMAKE_SOURCE_DIR}/cmake/messages/flatbuffers/*.txt)
 
-include_directories(${INCLUDES} ${SYSTEM_INCLUDES})
+include_directories(${INCLUDES} SYSTEM ${SYSTEM_INCLUDES})
 add_compile_options(${ARCH_DEFINES} "${SYSTEM_DEFINES}" ${DEP_DEFINES} ${PATH_DEFINES})
 
 set(core_DEPENDS "" CACHE STRING "" FORCE)

--- a/cmake/modules/FindFriBidi.cmake
+++ b/cmake/modules/FindFriBidi.cmake
@@ -33,15 +33,18 @@ find_package_handle_standard_args(FriBidi
 if(FRIBIDI_FOUND)
   set(FRIBIDI_LIBRARIES ${FRIBIDI_LIBRARY})
   set(FRIBIDI_INCLUDE_DIRS ${FRIBIDI_INCLUDE_DIR})
-  if(PC_FRIBIDI_CFLAGS)
-    set(FRIBIDI_DEFINITIONS ${PC_FRIBIDI_CFLAGS})
+  if(PC_FRIBIDI_INCLUDE_DIRS)
+    list(APPEND FRIBIDI_INCLUDE_DIRS ${PC_FRIBIDI_INCLUDE_DIRS})
+  endif()
+  if(PC_FRIBIDI_CFLAGS_OTHER)
+    set(FRIBIDI_DEFINITIONS ${PC_FRIBIDI_CFLAGS_OTHER})
   endif()
 
   if(NOT TARGET FriBidi::FriBidi)
     add_library(FriBidi::FriBidi UNKNOWN IMPORTED)
     set_target_properties(FriBidi::FriBidi PROPERTIES
                                            IMPORTED_LOCATION "${FRIBIDI_LIBRARY}"
-                                           INTERFACE_INCLUDE_DIRECTORIES "${FRIBIDI_INCLUDE_DIR}"
+                                           INTERFACE_INCLUDE_DIRECTORIES "${FRIBIDI_INCLUDE_DIRS}"
                                            INTERFACE_COMPILE_OPTIONS "${FRIBIDI_DEFINITIONS}")
   endif()
 endif()

--- a/cmake/modules/FindZip.cmake
+++ b/cmake/modules/FindZip.cmake
@@ -32,14 +32,12 @@ find_package_handle_standard_args(Zip
 if(ZIP_FOUND)
   set(ZIP_LIBRARIES ${ZIP_LIBRARY})
   set(ZIP_INCLUDE_DIRS ${ZIP_INCLUDE_DIR})
-  set(ZIP_DEFINITIONS "${PC_ZIP_CFLAGS}")
 
   if(NOT TARGET ZIP::ZIP)
     add_library(ZIP::ZIP UNKNOWN IMPORTED)
     set_target_properties(ZIP::ZIP PROPERTIES
                                    IMPORTED_LOCATION "${ZIP_LIBRARY}"
-                                   INTERFACE_INCLUDE_DIRECTORIES "${ZIP_INCLUDE_DIR}"
-                                   INTERFACE_COMPILE_DEFINITIONS "${PC_ZIP_CFLAGS}")
+                                   INTERFACE_INCLUDE_DIRECTORIES "${ZIP_INCLUDE_DIR}")
   endif()
 endif()
 

--- a/lib/libUPnP/CMakeLists.txt
+++ b/lib/libUPnP/CMakeLists.txt
@@ -109,14 +109,16 @@ if(CORE_SYSTEM_NAME STREQUAL "freebsd")
   target_compile_definitions(upnp PUBLIC -DNPT_CONFIG_HAVE_GETADDRINFO)
 endif()
 
-target_include_directories(upnp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                       Platinum/Source/Core
-                                       Platinum/Source/Platinum
-                                       Platinum/Source/Devices/MediaConnect
-                                       Platinum/Source/Devices/MediaRenderer
-                                       Platinum/Source/Devices/MediaServer
-                                       Neptune/Source/Core
-                                       Neptune/Source/System/Posix)
+set(INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
+                        Platinum/Source/Core
+                        Platinum/Source/Platinum
+                        Platinum/Source/Devices/MediaConnect
+                        Platinum/Source/Devices/MediaRenderer
+                        Platinum/Source/Devices/MediaServer
+                        Neptune/Source/Core
+                        Neptune/Source/System/Posix)
+target_include_directories(upnp SYSTEM INTERFACE ${INCLUDE_DIRECTORIES})
+target_include_directories(upnp PRIVATE ${INCLUDE_DIRECTORIES})
 if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
   target_include_directories(upnp PRIVATE Neptune/Source/System/Win32)
 endif()

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -332,7 +332,7 @@ case $host in
       esac
 
     platform_cxxflags="$platform_cflags -frtti"
-    platform_includes="-I$prefix/$deps_dir/include/android-$use_ndk_api"
+    platform_includes="-isystem $prefix/$deps_dir/include/android-$use_ndk_api"
     platform_os="android"
     meson_system="android"
     #android builds are always cross

--- a/xbmc/network/CMakeLists.txt
+++ b/xbmc/network/CMakeLists.txt
@@ -55,13 +55,6 @@ if(BLUETOOTH_FOUND)
   target_compile_definitions(${CORE_LIBRARY} PRIVATE -DHAVE_LIBBLUETOOTH=1)
 endif()
 
-if(ENABLE_UPNP)
-  target_include_directories(${CORE_LIBRARY} PRIVATE ${CMAKE_SOURCE_DIR}/lib/libUPnP
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Core
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Platinum
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Devices/MediaConnect
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Devices/MediaRenderer
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Devices/MediaServer
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Neptune/Source/System/Posix
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Neptune/Source/Core)
+if(ENABLE_STATIC_LIBS AND ENABLE_UPNP)
+  target_link_libraries(${CORE_LIBRARY} PRIVATE upnp)
 endif()

--- a/xbmc/platform/android/activity/CMakeLists.txt
+++ b/xbmc/platform/android/activity/CMakeLists.txt
@@ -48,6 +48,6 @@ set(HEADERS AndroidExtra.h
             XBMCApp.h)
 
 core_add_library(platform_android_activity)
-target_include_directories(${CORE_LIBRARY}
+target_include_directories(${CORE_LIBRARY} SYSTEM
                            PRIVATE ${NDKROOT}/sources/android/native_app_glue
                                    ${NDKROOT}/sources/android/cpufeatures)


### PR DESCRIPTION
## Motivation and context
This allows the compiler and checker tools to ignore warnings in the library headers.

## How has this been tested?
configured for Linux, Android, iOS, macOS and tvOS and checked `compile_commands.json` file

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
