### PR TITLE
Add new KODI_EXTRA_FILE_WHITELIST env var to allow access to more directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                                             -DAPP_SHARED_LIBRARY_SUFFIX="${APP_SHARED_LIBRARY_SUFFIX}"
                                             -DPYTHON_VERSION=${PYTHON_VERSION}
                                             -Dprefix=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
+                                            -DKODI_WEBSERVER_EXTRA_WHITELIST="${KODI_WEBSERVER_EXTRA_WHITELIST}"
                                             -P ${CMAKE_SOURCE_DIR}/cmake/scripts/common/GenerateVersionedFiles.cmake
                    DEPENDS ${CMAKE_SOURCE_DIR}/version.txt
                            export-files

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4842,6 +4842,11 @@ void CApplication::PrintStartupLog()
 #endif
   CSpecialProtocol::LogPaths();
 
+#ifdef HAS_WEB_SERVER
+  CLog::Log(LOGINFO, "Webserver extra whitelist paths: {}",
+            StringUtils::Join(CCompileInfo::GetWebserverExtraWhitelist(), ", "));
+#endif
+
   std::string executable = CUtil::ResolveExecutablePath();
   CLog::Log(LOGINFO, "The executable running is: {}", executable);
   std::string hostname("[unknown]");

--- a/xbmc/CompileInfo.cpp.in
+++ b/xbmc/CompileInfo.cpp.in
@@ -111,3 +111,8 @@ std::string CCompileInfo::GetPythonVersion()
 {
   return "@PYTHON_VERSION@";
 }
+
+const std::vector<std::string> CCompileInfo::GetWebserverExtraWhitelist()
+{
+  return StringUtils::Split("@KODI_WEBSERVER_EXTRA_WHITELIST@", ',');
+}

--- a/xbmc/CompileInfo.h
+++ b/xbmc/CompileInfo.h
@@ -33,4 +33,5 @@ public:
   static std::vector<std::string> GetAvailableWindowSystems();
   static std::vector<ADDON::RepoInfo> LoadOfficialRepoInfos();
   static std::string GetPythonVersion();
+  static const std::vector<std::string> GetWebserverExtraWhitelist();
 };

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -7,24 +7,26 @@
  */
 
 #include "FileUtils.h"
-#include "ServiceBroker.h"
-#include "guilib/GUIKeyboardFactory.h"
-#include "utils/log.h"
-#include "guilib/LocalizeStrings.h"
-#include "JobManager.h"
+
+#include "CompileInfo.h"
 #include "FileOperationJob.h"
+#include "JobManager.h"
+#include "ServiceBroker.h"
+#include "StringUtils.h"
 #include "URIUtils.h"
+#include "URL.h"
+#include "Util.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
+#include "guilib/GUIKeyboardFactory.h"
+#include "guilib/LocalizeStrings.h"
 #include "settings/MediaSourceSettings.h"
-#include "Util.h"
-#include "StringUtils.h"
-#include "URL.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 
 #if defined(TARGET_WINDOWS)
 #include "platform/win32/WIN32Util.h"
@@ -261,11 +263,14 @@ bool CFileUtils::CheckFileAccessAllowed(const std::string &filePath)
     "/.ssh/",
   };
   // ALLOW kodi paths
-  const std::vector<std::string> whitelist = {
-    CSpecialProtocol::TranslatePath("special://home"),
-    CSpecialProtocol::TranslatePath("special://xbmc"),
-    CSpecialProtocol::TranslatePath("special://musicartistsinfo")
+  std::vector<std::string> whitelist = {
+      CSpecialProtocol::TranslatePath("special://home"),
+      CSpecialProtocol::TranslatePath("special://xbmc"),
+      CSpecialProtocol::TranslatePath("special://musicartistsinfo"),
   };
+
+  auto kodiExtraWhitelist = CCompileInfo::GetWebserverExtraWhitelist();
+  whitelist.insert(whitelist.end(), kodiExtraWhitelist.begin(), kodiExtraWhitelist.end());
 
   // image urls come in the form of image://... sometimes with a / appended at the end
   // and can be embedded in a music or video file image://music@...


### PR DESCRIPTION
Add new KODI_WEBSERVER_EXTRA_WHITELIST cmake var to allow access to more directories

This is useful for NixOS, which often ends up creating a `KODI_HOME`
with symlinks to other files (including the chorus2 interface). Kodi's
webserver cautiously refuses to follow these symlinks, and you end up
getting 404s rather than the web page.

See https://forum.kodi.tv/showthread.php?tid=366338&pid=3079493 for a
discussion of this on the Kodi forum.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
