### PR TITLE
[Windows] Fix colour management ICC profile/3DLUT parameters are not applied

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -163,15 +163,11 @@ bool CWinShader::Execute(const std::vector<CD3DTexture*> &targets, unsigned int 
 
 void COutputShader::ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWidth, unsigned sourceHeight)
 {
-  if (m_useLut)
+  if (m_useLut && HasLUT())
   {
-    float lut_params[2] = { 0.0f, 0.0f };
-    if (HasLUT())
-    {
-      lut_params[0] = (m_lutSize - 1) / static_cast<float>(m_lutSize);
-      lut_params[1] = 0.5f / static_cast<float>(m_lutSize);
-    };
-    effect.SetResources("m_LUT", &m_pLUTView, 1);
+    float lut_params[2] = {(m_lutSize - 1) / static_cast<float>(m_lutSize),
+                           0.5f / static_cast<float>(m_lutSize)};
+    effect.SetResources("m_LUT", m_pLUTView.GetAddressOf(), 1);
     effect.SetFloatArray("m_LUTParams", lut_params, 2);
   }
   if (m_useDithering)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -354,7 +354,7 @@ bool CRendererBase::CreateIntermediateTarget(unsigned width, unsigned height, bo
 void CRendererBase::OnCMSConfigChanged(AVColorPrimaries srcPrimaries)
 {
   m_lutSize = 0;
-  m_clutLoaded = false;
+  m_lutIsLoading = true;
 
   auto loadLutTask = Concurrency::create_task([this, srcPrimaries] {
     // load 3DLUT data
@@ -383,7 +383,7 @@ void CRendererBase::OnCMSConfigChanged(AVColorPrimaries srcPrimaries)
     m_lutSize = lutSize;
     if (m_outputShader)
       m_outputShader->SetLUT(m_lutSize, m_pLUTView.Get());
-    m_clutLoaded = true;
+    m_lutIsLoading = false;
   });
 }
 
@@ -449,10 +449,12 @@ void CRendererBase::CheckVideoParameters()
     OnOutputReset();
   }
 
-  const AVColorPrimaries color_primaries = static_cast<AVColorPrimaries>(buf->primaries);
-  if (m_cmsOn && !m_colorManager->CheckConfiguration(m_cmsToken, color_primaries))
+  if (m_cmsOn && !m_lutIsLoading)
   {
-    OnCMSConfigChanged(color_primaries);
+    const AVColorPrimaries color_primaries = static_cast<AVColorPrimaries>(buf->primaries);
+
+    if (!m_colorManager->CheckConfiguration(m_cmsToken, color_primaries))
+      OnCMSConfigChanged(color_primaries);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -159,7 +159,7 @@ protected:
   bool m_toneMapping = false;
   bool m_useDithering = false;
   bool m_cmsOn = false;
-  bool m_clutLoaded = false;
+  bool m_lutIsLoading = false;
   bool m_useHLGtoPQ = false;
   int m_toneMapMethod = 0;
 


### PR DESCRIPTION
## Description
[Windows] Fix colour management ICC profile/3DLUT parameters are not applied

Fixes https://github.com/xbmc/xbmc/issues/20999

## Motivation and context
Seems fails due to use `Concurrency::create_task` . Removing and use sequential code fix the issue and everything seems to work fine.

NOTE: changes on WinVideoFilter they are not essential. They are just for consistency with other shaders.

## How has this been tested?
Runtime tested Windows x64
Tested with ICC profile provided in https://github.com/xbmc/xbmc/issues/20999

Tested enabled profile all the time and enable disable on the fly during payback / pause. 
Enabled / disabled also from contextual video settings menu to test all logic.

## What is the effect on users?
Fixes colour management ICC profile/3DLUT not working

## Screenshots (if appropriate):

Before - ICC off  or ICC on  (video output not changes)
![screenshot00001](https://user-images.githubusercontent.com/58434170/158057355-f893aa9b-3c3d-4499-9c96-4fed43d66c01.png)

After - ICC on
![screenshot00000](https://user-images.githubusercontent.com/58434170/158057392-57a4fd7c-dc20-41ba-8918-02c7147b309c.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
