### PR TITLE
[MediaManager] Use smart ptr for platformStorage

### DIFF
--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -75,9 +75,9 @@ constexpr std::array<const char*, 4> deviceWL = {
 
 } // namespace
 
-IStorageProvider* IStorageProvider::CreateInstance()
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 {
-  return new CAndroidStorageProvider();
+  return std::make_unique<CAndroidStorageProvider>();
 }
 
 CAndroidStorageProvider::CAndroidStorageProvider()

--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
@@ -13,9 +13,9 @@
 
 #import <Foundation/Foundation.h>
 
-IStorageProvider* IStorageProvider::CreateInstance()
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 {
-  return new CIOSStorageProvider();
+  return std::make_unique<CIOSStorageProvider>();
 }
 
 void CIOSStorageProvider::GetLocalDrives(VECSOURCES& localDrives)

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
@@ -21,9 +21,9 @@
 std::vector<std::pair<std::string, std::string>> COSXStorageProvider::m_mountsToNotify;
 std::vector<std::pair<std::string, std::string>> COSXStorageProvider::m_unmountsToNotify;
 
-IStorageProvider* IStorageProvider::CreateInstance()
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 {
-  return new COSXStorageProvider();
+  return std::make_unique<COSXStorageProvider>();
 }
 
 COSXStorageProvider::COSXStorageProvider()

--- a/xbmc/platform/linux/storage/LinuxStorageProvider.cpp
+++ b/xbmc/platform/linux/storage/LinuxStorageProvider.cpp
@@ -15,9 +15,9 @@
 #endif
 #include "platform/posix/PosixMountProvider.h"
 
-IStorageProvider* IStorageProvider::CreateInstance()
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 {
-  return new CLinuxStorageProvider();
+  return std::make_unique<CLinuxStorageProvider>();
 }
 
 CLinuxStorageProvider::CLinuxStorageProvider()

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -29,11 +29,10 @@ namespace winrt
 }
 using namespace winrt::Windows::Devices::Enumeration;
 using namespace winrt::Windows::Foundation::Collections;
-using namespace winrt::Windows::Storage;
 
-::IStorageProvider* ::IStorageProvider::CreateInstance()
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 {
-  return new CStorageProvider();
+  return std::make_unique<CStorageProvider>();
 }
 
 CStorageProvider::~CStorageProvider()
@@ -149,7 +148,7 @@ std::vector<std::string> CStorageProvider::GetDiskUsage()
   ULARGE_INTEGER ULTotalFree = { { 0 } };
   std::string strRet;
 
-  auto localfolder = ApplicationData::Current().LocalFolder().Path();
+  auto localfolder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder().Path();
   GetDiskFreeSpaceExW(localfolder.c_str(), nullptr, &ULTotal, &ULTotalFree);
   strRet = StringUtils::Format("{}: {} MB {}", g_localizeStrings.Get(21440),
                                (ULTotalFree.QuadPart / (1024 * 1024)), g_localizeStrings.Get(160));

--- a/xbmc/platform/win10/storage/Win10StorageProvider.h
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <vector>
 
-class CStorageProvider : public ::IStorageProvider
+class CStorageProvider : public IStorageProvider
 {
 public:
   virtual ~CStorageProvider();

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -23,9 +23,9 @@
 
 bool CWin32StorageProvider::xbevent = false;
 
-IStorageProvider* IStorageProvider::CreateInstance()
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 {
-  return new CWin32StorageProvider();
+  return std::make_unique<CWin32StorageProvider>();
 }
 
 void CWin32StorageProvider::Initialize()

--- a/xbmc/storage/IStorageProvider.h
+++ b/xbmc/storage/IStorageProvider.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
+#include "MediaSource.h"
+
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "MediaSource.h"
 #ifdef HAS_DVD_DRIVE
 #include "cdioSupport.h"
 #endif
@@ -90,5 +91,5 @@ public:
   *
   * This method used to create platform specified storage provider
   */
-  static IStorageProvider* CreateInstance();
+  static std::unique_ptr<IStorageProvider> CreateInstance();
 };

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -78,7 +78,7 @@ void CMediaManager::Initialize()
 {
   if (!m_platformStorage)
   {
-    m_platformStorage.reset(IStorageProvider::CreateInstance());
+    m_platformStorage = IStorageProvider::CreateInstance();
   }
 #ifdef HAS_DVD_DRIVE
   m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -64,7 +64,6 @@ const char MEDIA_SOURCES_XML[] = { "special://profile/mediasources.xml" };
 CMediaManager::CMediaManager()
 {
   m_bhasoptical = false;
-  m_platformStorage = nullptr;
 }
 
 void CMediaManager::Stop()
@@ -72,15 +71,14 @@ void CMediaManager::Stop()
   if (m_platformStorage)
     m_platformStorage->Stop();
 
-  delete m_platformStorage;
-  m_platformStorage = nullptr;
+  m_platformStorage.reset();
 }
 
 void CMediaManager::Initialize()
 {
   if (!m_platformStorage)
   {
-    m_platformStorage = IStorageProvider::CreateInstance();
+    m_platformStorage.reset(IStorageProvider::CreateInstance());
   }
 #ifdef HAS_DVD_DRIVE
   m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -15,6 +15,7 @@
 #include "utils/Job.h"
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "PlatformDefs.h"
@@ -118,7 +119,7 @@ protected:
   std::string m_strFirstAvailDrive;
 
 private:
-  IStorageProvider *m_platformStorage;
+  std::unique_ptr<IStorageProvider> m_platformStorage;
 
   UTILS::DISCS::DiscInfo GetDiscInfo(const std::string& mediaPath);
   void RemoveDiscInfo(const std::string& devicePath);


### PR DESCRIPTION
## Description

Trivial improvement, this makes MediaManager use a `unique_ptr` for the platform storage member instead of a raw pointer.