### PR TITLE
[MediaManager] Use libcdio for close tray in posix platforms

### DIFF
--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -46,10 +46,6 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
-#if defined(TARGET_POSIX) && !defined(TARGET_DARWIN) && !defined(TARGET_FREEBSD)
-#include <sys/ioctl.h>
-#include <linux/cdrom.h>
-#endif
 #include <string>
 #include <vector>
 
@@ -626,20 +622,25 @@ void CMediaManager::EjectTray( const bool bEject, const char cDriveLetter )
 void CMediaManager::CloseTray(const char cDriveLetter)
 {
 #ifdef HAS_DVD_DRIVE
-#if defined(TARGET_DARWIN)
-  // FIXME...
-#elif defined(TARGET_FREEBSD)
-  // NYI
-#elif defined(TARGET_POSIX)
-  char* dvdDevice = CLibcdio::GetInstance()->GetDeviceFileName();
-  if (strlen(dvdDevice) != 0)
+#if defined(TARGET_POSIX)
+  std::shared_ptr<CLibcdio> libCdio = CLibcdio::GetInstance();
+  if (!libCdio)
   {
-    int fd = open(dvdDevice, O_RDONLY | O_NONBLOCK);
-    if (fd >= 0)
-    {
-      ioctl(fd, CDROMCLOSETRAY, 0);
-      close(fd);
-    }
+    CLog::LogF(LOGERROR, "Failed to obtain cdio handler");
+    return;
+  }
+
+  char* dvdDevice = libCdio->GetDeviceFileName();
+  if (!dvdDevice)
+  {
+    CLog::LogF(LOGERROR, "Failed to obtain default disc device");
+  }
+
+  driver_return_code_t ret = libCdio->cdio_close_tray(dvdDevice, nullptr);
+  if (ret != DRIVER_OP_SUCCESS)
+  {
+    CLog::LogF(LOGERROR, "Closing tray failed for device {}: {}", dvdDevice,
+               libCdio->cdio_driver_errmsg(ret));
   }
 #elif defined(TARGET_WINDOWS)
   CWIN32Util::CloseTray(cDriveLetter);

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -178,6 +178,17 @@ driver_return_code_t CLibcdio::cdio_read_audio_sectors(
   return( ::cdio_read_audio_sectors(p_cdio, p_buf, i_lsn, i_blocks) );
 }
 
+driver_return_code_t CLibcdio::cdio_close_tray(const char* psz_source, driver_id_t* driver_id)
+{
+  std::unique_lock<CCriticalSection> lock(*this);
+  return (::cdio_close_tray(psz_source, driver_id));
+}
+
+const char* CLibcdio::cdio_driver_errmsg(driver_return_code_t drc)
+{
+  return (::cdio_driver_errmsg(drc));
+}
+
 char* CLibcdio::GetDeviceFileName()
 {
   std::unique_lock<CCriticalSection> lock(*this);

--- a/xbmc/storage/cdioSupport.h
+++ b/xbmc/storage/cdioSupport.h
@@ -257,6 +257,8 @@ public:
   lsn_t cdio_get_track_lsn(const CdIo_t *p_cdio, track_t i_track);
   lsn_t cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t i_track);
   driver_return_code_t cdio_read_audio_sectors(const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn, uint32_t i_blocks);
+  driver_return_code_t cdio_close_tray(const char* psz_source, driver_id_t* driver_id);
+  const char* cdio_driver_errmsg(driver_return_code_t drc);
 
   char* GetDeviceFileName();
 


### PR DESCRIPTION
## Description
Libcdio has drivers for linux, bsd (freebsd), osx among others and supports the `close_tray` operation in all of them. We can simplify the posix code to use the library instead of specific includes.
This makes it easier to split disc drive handling into platform code at some point in the future (which I've been slowly studying in https://github.com/enen92/xbmc/commit/41632ac7cc943b4b302a90f48d89c641ef4c41a7).

Btw, the linux driver code in libcdio uses the same path as the code removed here: https://github.com/Distrotech/libcdio/blob/806566a6fd894eb408b4cbcfe4eaa82ec8a81796/lib/driver/gnu_linux.c#L1563-L1566
