### PR TITLE
Refactor HDR type detection

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1662,30 +1662,16 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->colorSpace = pStream->codecpar->color_space;
         st->colorTransferCharacteristic = pStream->codecpar->color_trc;
         st->colorRange = pStream->codecpar->color_range;
+        st->hdr_type = DetermineHdrType(pStream);
 
         int size = 0;
         uint8_t* side_data = nullptr;
-
-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
-        if (side_data && size)
-          st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
-        else if (st->colorPrimaries == AVCOL_PRI_BT2020)
-        {
-          if (st->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084) // hdr10
-            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
-          else if (st->colorTransferCharacteristic == AVCOL_TRC_ARIB_STD_B67) // hlg
-            st->hdr_type = StreamHdrType::HDR_TYPE_HLG;
-        }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
         if (side_data && size)
         {
           st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
               *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
-          // file could be SMPTE2086 which FFmpeg currently returns as unknown so use the presence
-          // of static metadata to detect it
-          if (st->masteringMetaData->has_primaries && st->masteringMetaData->has_luminance)
-            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
         }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);
@@ -2496,4 +2482,22 @@ void CDVDDemuxFFmpeg::GetL16Parameters(int &channels, int &samplerate)
       }
     }
   }
+}
+
+StreamHdrType CDVDDemuxFFmpeg::DetermineHdrType(AVStream* pStream)
+{
+  StreamHdrType hdrType = StreamHdrType::HDR_TYPE_NONE;
+
+  if (av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, nullptr)) // DoVi
+    hdrType = StreamHdrType::HDR_TYPE_DOLBYVISION;
+  else if (pStream->codecpar->color_trc == AVCOL_TRC_SMPTE2084) // HDR10
+    hdrType = StreamHdrType::HDR_TYPE_HDR10;
+  else if (pStream->codecpar->color_trc == AVCOL_TRC_ARIB_STD_B67) // HLG
+    hdrType = StreamHdrType::HDR_TYPE_HLG;
+  // file could be SMPTE2086 which FFmpeg currently returns as unknown
+  // so use the presence of static metadata to detect it
+  else if (av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, nullptr))
+    hdrType = StreamHdrType::HDR_TYPE_HDR10;
+
+  return hdrType;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -140,6 +140,8 @@ protected:
   void GetL16Parameters(int& channels, int& samplerate);
   double SelectAspect(AVStream* st, bool& forced);
 
+  StreamHdrType DetermineHdrType(AVStream* pStream);
+
   CCriticalSection m_critSection;
   std::map<int, CDemuxStream*> m_streams;
   std::map<int, std::unique_ptr<CDemuxParserFFmpeg>> m_parsers;


### PR DESCRIPTION
## Description
Refactor HDR type detection.

Fixes https://github.com/xbmc/xbmc/issues/21116
Supersedes https://github.com/xbmc/xbmc/pull/21123

## Motivation and context
Separates HDR type detection code for database (media flags) from side data code used for video rendering.

This code was introduced initially for formats that does not include side data on every frame but only on video header/container as HDR VP9 media files. This metadata is used for video rendering and now is used also for HDR type detection:

```c++
        int size = 0;
        uint8_t* side_data = nullptr;

        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
        if (side_data && size)
        {
          st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
              *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
        }

        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);
        if (side_data && size)
        {
          st->contentLightMetaData = std::make_shared<AVContentLightMetadata>(
              *reinterpret_cast<AVContentLightMetadata*>(side_data));
        }
```

This is not bad, but if more types of HDR such as HDR10+ need to be added and the priorities are modified by adding new conditions, the code becomes much more complicated and bugs may be introduced in the video rendering part.

Now in this PR it is separated in such a way that modifications to one thing do not influence the other and it will be much easier to expand or modify in the future.

Note that side data for video rendering code also we need to expand soon to support Dolby Vision in MKV container.


## How has this been tested?
Runtime tested Windows x64


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
