### PR TITLE
[discs][win32] Only probe drives after initialization

### DIFF
--- a/xbmc/platform/win32/storage/Win32StorageProvider.h
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.h
@@ -47,6 +47,9 @@ public:
 private:
   static void GetDrivesByType(VECSOURCES &localDrives, Drive_Types eDriveType=ALL_DRIVES, bool bonlywithmedia=false);
   static DEVINST GetDrivesDevInstByDiskNumber(long DiskNumber);
+#ifdef HAS_DVD_DRIVE
+  std::vector<std::string> m_OpticalDrivesNeedProbing;
+#endif
 };
 
 class CDetectDisc : public CJob


### PR DESCRIPTION
## Description
I wonder how this was not found earlier (guess no one uses discs anymore :) ). 
If Kodi is started with a disc in the drive it may result in a crash right away. This happens because if there is a disc present (and the drive status is flagged as `DRIVE_CLOSED_MEDIA_PRESENT`) the platform storageprovider will start a probe task/job for the drive right away scheduling jobs to the (yet to be born) `Jobmanager`. 
Storage/Filesystem is initialized on `App::Create` whereas `Jobmanager` is constructed afterwards (in InitStageTwo).

This PR stores the drives path so that on `PumpDriveChangeEvents` (called in MediaManager::Process()) the jobs can actually be scheduled. Process tasks are only executed after app initialization.
Not sure if there's a better way to do this in windows, pretty much leave this to your consideration.