### PR TITLE
[PVR] Fix loading addon providers from database.

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -433,7 +433,7 @@ bool CPVRDatabase::Get(CPVRProviders& results,
   std::string strQuery = "SELECT * from providers ";
   const std::string clientIds = GetClientIdsSQL(clients);
   if (!clientIds.empty())
-    strQuery += "WHERE " + clientIds;
+    strQuery += "WHERE " + clientIds + " OR iType = 1"; // always load addon providers
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
   strQuery = PrepareSQL(strQuery);


### PR DESCRIPTION
Fixes fallout from #20898

Manifests itself as log spam on Kodi startup:

```
2022-03-16 20:17:50.633677+0100 kodi.bin[30842:6207481] 2022-03-16 20:17:50.632 T:6207481   ERROR <general>: SQL: [TV39.db] SQLite error SQLITE_CONSTRAINT_PRIMARYKEY (UNIQUE constraint failed: providers.idProvider)
2022-03-16 20:17:50.634420+0100 kodi.bin[30842:6207481] 2022-03-16 20:17:50.634 T:6207481   ERROR <general>: ExecuteQuery - failed to execute query 'INSERT INTO providers (idProvider, iUniqueId, iClientId, sName, iType, sIconPath, sCountries, sLanguages) VALUES (7, -1, 151949354, 'PVR Demo Client', 1, '', '', '');'
```

Runtime-tested on macOS, latest Kodi master.

@phunkyfish as discussed...