### PR TITLE
Fix fix user-after-free

### DIFF
--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -20,10 +20,6 @@ using namespace KODI::GUILIB;
 CGUIListItemLayout::CGUIListItemLayout()
 : m_group(0, 0, 0, 0, 0, 0)
 {
-  m_width = 0;
-  m_height = 0;
-  m_focused = false;
-  m_invalidated = true;
   m_group.SetPushUpdates(true);
 }
 
@@ -37,7 +33,6 @@ CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout& from, CGUIContr
     m_width(from.m_width),
     m_height(from.m_height),
     m_focused(from.m_focused),
-    m_invalidated(from.m_invalidated),
     m_condition(from.m_condition),
     m_isPlaying(from.m_isPlaying),
     m_infoUpdateMillis(from.m_infoUpdateMillis)

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -54,10 +54,10 @@ protected:
 
   CGUIListGroup m_group;
 
-  float m_width;
-  float m_height;
-  bool m_focused;
-  bool m_invalidated;
+  float m_width{0};
+  float m_height{0};
+  bool m_focused{false};
+  bool m_invalidated{true};
 
   INFO::InfoPtr m_condition;
   KODI::GUILIB::GUIINFO::CGUIInfoBool m_isPlaying;


### PR DESCRIPTION
## Description

This PR fixes the fix for the user-after-free bug when embedding a static list inside another list. The bug manifests by listitems not always refreshing.

Original PR is https://github.com/xbmc/xbmc/pull/20852. That PR didn't introduce the bug, it was an issue in the existing code, the PR just uncovered the bug by adding a code path that calls into the problematic code. So in this PR, we fix the underlying issue.

## Motivation and context

Thanks to @ksooo who noticed the bug in the original PR.

## How has this been tested?

I've just compile-tested this one.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
