### PR TITLE
[Discs] Move disc drive handling to platform code

### DIFF
--- a/cmake/treedata/freebsd/subdirs.txt
+++ b/cmake/treedata/freebsd/subdirs.txt
@@ -10,6 +10,7 @@ xbmc/platform/linux/storage         platform/linux/storage
 xbmc/platform/posix                 platform/posix
 xbmc/platform/posix/filesystem      platform/posix/filesystem
 xbmc/platform/posix/network         platform/posix/network
+xbmc/platform/posix/storage/discs   platform/posix/storage/discs
 xbmc/platform/posix/threads         platform/posix/threads
 xbmc/platform/posix/utils           platform/posix/utils
 xbmc/windowing/linux                windowing/linux

--- a/cmake/treedata/linux/subdirs.txt
+++ b/cmake/treedata/linux/subdirs.txt
@@ -10,6 +10,7 @@ xbmc/platform/linux/storage         platform/linux/storage
 xbmc/platform/posix                 platform/posix
 xbmc/platform/posix/filesystem      platform/posix/filesystem
 xbmc/platform/posix/network         platform/posix/network
+xbmc/platform/posix/storage/discs   platform/posix/storage/discs
 xbmc/platform/posix/threads         platform/posix/threads
 xbmc/platform/posix/utils           platform/posix/utils
 xbmc/windowing/linux                windowing/linux

--- a/cmake/treedata/osx/subdirs.txt
+++ b/cmake/treedata/osx/subdirs.txt
@@ -12,6 +12,7 @@ xbmc/platform/darwin/utils            platform/darwin/utils
 xbmc/platform/posix                   posix
 xbmc/platform/posix/filesystem        platform/posix/filesystem
 xbmc/platform/posix/network           platform/posix/network
+xbmc/platform/posix/storage/discs     platform/posix/storage/discs
 xbmc/platform/posix/threads           platform/posix/threads
 xbmc/platform/posix/utils             platform/posix/utils
 xbmc/windowing/osx                    windowing/osx

--- a/cmake/treedata/windows/subdirs.txt
+++ b/cmake/treedata/windows/subdirs.txt
@@ -12,6 +12,7 @@ xbmc/platform/win32/network            platform/win32/network
 xbmc/platform/win32/peripherals        platform/win32/peripherals
 xbmc/platform/win32/powermanagement    platform/win32/powermanagement
 xbmc/platform/win32/storage            platform/win32/storage
+xbmc/platform/win32/storage/discs      platform/win32/storage/discs
 xbmc/platform/win32/threads            platform/win32/threads
 xbmc/platform/win32/utils              platform/win32/utils
 xbmc/rendering/dx                      rendering/dx

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -31,6 +31,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "storage/discs/IDiscDriveHandler.h"
 #include "utils/AlarmClock.h"
 #include "utils/CPUInfo.h"
 #include "utils/HDRCapabilities.h"
@@ -546,10 +547,12 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       return true;
 #ifdef HAS_DVD_DRIVE
     case SYSTEM_DVDREADY:
-      value = CServiceBroker::GetMediaManager().GetDriveStatus() != DRIVE_NOT_READY;
+      value = CServiceBroker::GetMediaManager().GetDriveStatus() !=
+              static_cast<int>(DriveState::NOT_READY);
       return true;
     case SYSTEM_TRAYOPEN:
-      value = CServiceBroker::GetMediaManager().GetDriveStatus() == DRIVE_OPEN;
+      value =
+          CServiceBroker::GetMediaManager().GetDriveStatus() == static_cast<int>(DriveState::OPEN);
       return true;
 #endif
     case SYSTEM_CAN_POWERDOWN:

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -547,12 +547,10 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       return true;
 #ifdef HAS_DVD_DRIVE
     case SYSTEM_DVDREADY:
-      value = CServiceBroker::GetMediaManager().GetDriveStatus() !=
-              static_cast<int>(DriveState::NOT_READY);
+      value = CServiceBroker::GetMediaManager().GetDriveStatus() != DriveState::NOT_READY;
       return true;
     case SYSTEM_TRAYOPEN:
-      value =
-          CServiceBroker::GetMediaManager().GetDriveStatus() == static_cast<int>(DriveState::OPEN);
+      value = CServiceBroker::GetMediaManager().GetDriveStatus() == DriveState::OPEN;
       return true;
 #endif
     case SYSTEM_CAN_POWERDOWN:

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -240,7 +240,7 @@ namespace XBMCAddon
     long getDVDState()
     {
       XBMC_TRACE;
-      return CServiceBroker::GetMediaManager().GetDriveStatus();
+      return static_cast<long>(CServiceBroker::GetMediaManager().GetDriveStatus());
     }
 
     long getFreeMem()

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -33,6 +33,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "storage/discs/IDiscDriveHandler.h"
 #include "threads/SystemClock.h"
 #include "utils/Crc32.h"
 #include "utils/FileExtensionProvider.h"
@@ -553,10 +554,22 @@ namespace XBMCAddon
 
     int getPLAYLIST_MUSIC() { return PLAYLIST_MUSIC; }
     int getPLAYLIST_VIDEO() { return PLAYLIST_VIDEO; }
-    int getTRAY_OPEN() { return TRAY_OPEN; }
-    int getDRIVE_NOT_READY() { return DRIVE_NOT_READY; }
-    int getTRAY_CLOSED_NO_MEDIA() { return TRAY_CLOSED_NO_MEDIA; }
-    int getTRAY_CLOSED_MEDIA_PRESENT() { return TRAY_CLOSED_MEDIA_PRESENT; }
+    int getTRAY_OPEN()
+    {
+      return static_cast<int>(TrayState::OPEN);
+    }
+    int getDRIVE_NOT_READY()
+    {
+      return static_cast<int>(DriveState::NOT_READY);
+    }
+    int getTRAY_CLOSED_NO_MEDIA()
+    {
+      return static_cast<int>(TrayState::CLOSED_NO_MEDIA);
+    }
+    int getTRAY_CLOSED_MEDIA_PRESENT()
+    {
+      return static_cast<int>(TrayState::CLOSED_MEDIA_PRESENT);
+    }
     int getLOGDEBUG() { return LOGDEBUG; }
     int getLOGINFO() { return LOGINFO; }
     int getLOGWARNING() { return LOGWARNING; }

--- a/xbmc/platform/posix/storage/discs/CMakeLists.txt
+++ b/xbmc/platform/posix/storage/discs/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(ENABLE_OPTICAL)
+  set(SOURCES DiscDriveHandlerPosix.cpp)
+
+  set(HEADERS DiscDriveHandlerPosix.h)
+
+  core_add_library(platform_posix_storage_discs)
+endif()

--- a/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
+++ b/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DiscDriveHandlerPosix.h"
+
+#include "storage/cdioSupport.h"
+#include "utils/log.h"
+
+#include <memory>
+
+namespace
+{
+constexpr int MAX_OPEN_RETRIES = 3;
+}
+using namespace MEDIA_DETECT;
+
+std::shared_ptr<IDiscDriveHandler> IDiscDriveHandler::CreateInstance()
+{
+  return std::make_shared<CDiscDriveHandlerPosix>();
+}
+
+DriveState CDiscDriveHandlerPosix::GetDriveState(const std::string& devicePath)
+{
+  DriveState driveStatus = DriveState::NOT_READY;
+  const std::shared_ptr<CLibcdio> libCdio = CLibcdio::GetInstance();
+  if (!libCdio)
+  {
+    CLog::LogF(LOGERROR, "Failed to obtain libcdio handler");
+    return driveStatus;
+  }
+
+  CdIo_t* cdio = libCdio->cdio_open(devicePath.c_str(), DRIVER_UNKNOWN);
+  if (!cdio)
+  {
+    CLog::LogF(LOGERROR, "Failed to open device {} libcdio handler", devicePath);
+    return driveStatus;
+  }
+
+  CdioTrayStatus status = libCdio->mmc_get_tray_status(cdio);
+
+  switch (status)
+  {
+    case CdioTrayStatus::CLOSED:
+      driveStatus = DriveState::CLOSED_MEDIA_UNDEFINED;
+      break;
+
+    case CdioTrayStatus::OPEN:
+      driveStatus = DriveState::OPEN;
+      break;
+
+    case CdioTrayStatus::DRIVER_ERROR:
+      driveStatus = DriveState::NOT_READY;
+      break;
+
+    default:
+      CLog::LogF(LOGWARNING, "Unknown/unhandled drive state interpreted as DRIVE_NOT_READY");
+      break;
+  }
+  libCdio->cdio_destroy(cdio);
+
+  return driveStatus;
+}
+
+TrayState CDiscDriveHandlerPosix::GetTrayState(const std::string& devicePath)
+{
+  TrayState trayStatus = TrayState::UNDEFINED;
+  const std::shared_ptr<CLibcdio> libCdio = CLibcdio::GetInstance();
+  if (!libCdio)
+  {
+    CLog::LogF(LOGERROR, "Failed to obtain libcdio handler");
+    return trayStatus;
+  }
+
+  discmode_t discmode = CDIO_DISC_MODE_NO_INFO;
+  CdIo_t* cdio = libCdio->cdio_open(devicePath.c_str(), DRIVER_UNKNOWN);
+  if (!cdio)
+  {
+    CLog::LogF(LOGERROR, "Failed to open device {} libcdio handler", devicePath);
+    return trayStatus;
+  }
+
+  discmode = libCdio->cdio_get_discmode(cdio);
+
+  if (discmode == CDIO_DISC_MODE_NO_INFO)
+  {
+    trayStatus = TrayState::CLOSED_NO_MEDIA;
+  }
+  else if (discmode == CDIO_DISC_MODE_ERROR)
+  {
+    trayStatus = TrayState::UNDEFINED;
+  }
+  else
+  {
+    trayStatus = TrayState::CLOSED_MEDIA_PRESENT;
+  }
+  libCdio->cdio_destroy(cdio);
+
+  return trayStatus;
+}
+
+void CDiscDriveHandlerPosix::EjectDriveTray(const std::string& devicePath)
+{
+  const std::shared_ptr<CLibcdio> libCdio = CLibcdio::GetInstance();
+  if (!libCdio)
+  {
+    CLog::LogF(LOGERROR, "Failed to obtain libcdio handler");
+    return;
+  }
+
+  int retries = MAX_OPEN_RETRIES;
+  CdIo_t* cdio = libCdio->cdio_open(devicePath.c_str(), DRIVER_UNKNOWN);
+  while (cdio && retries-- > 0)
+  {
+    const driver_return_code_t ret = libCdio->cdio_eject_media(&cdio);
+    libCdio->cdio_destroy(cdio);
+    if (ret == DRIVER_OP_SUCCESS)
+      break;
+  }
+}
+
+void CDiscDriveHandlerPosix::CloseDriveTray(const std::string& devicePath)
+{
+  const std::shared_ptr<CLibcdio> libCdio = CLibcdio::GetInstance();
+  if (!libCdio)
+  {
+    CLog::LogF(LOGERROR, "Failed to obtain libcdio handler");
+    return;
+  }
+
+  const driver_return_code_t ret = libCdio->cdio_close_tray(devicePath.c_str(), nullptr);
+  if (ret != DRIVER_OP_SUCCESS)
+  {
+    CLog::LogF(LOGERROR, "Closing tray failed for device {}: {}", devicePath,
+               libCdio->cdio_driver_errmsg(ret));
+  }
+}
+
+void CDiscDriveHandlerPosix::ToggleDriveTray(const std::string& devicePath)
+{
+  if (GetDriveState(devicePath) == DriveState::OPEN)
+  {
+    CloseDriveTray(devicePath);
+  }
+  else
+  {
+    EjectDriveTray(devicePath);
+  }
+}

--- a/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.h
+++ b/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "storage/discs/IDiscDriveHandler.h"
+
+#include <string>
+
+class CDiscDriveHandlerPosix : public IDiscDriveHandler
+{
+public:
+  /*! \brief Posix DiscDriveHandler constructor
+  */
+  CDiscDriveHandlerPosix() = default;
+
+  /*! \brief Posix DiscDriveHandler default destructor
+  */
+  ~CDiscDriveHandlerPosix() override = default;
+
+  /*! \brief Get the optical drive state provided its device path
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  * \return The drive state
+  */
+  DriveState GetDriveState(const std::string& devicePath) override;
+
+  /*! \brief Get the optical drive tray state provided the drive device path
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  * \return The drive state
+  */
+  TrayState GetTrayState(const std::string& devicePath) override;
+
+  /*! \brief Eject the provided drive device
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  */
+  void EjectDriveTray(const std::string& devicePath) override;
+
+  /*! \brief Close the provided drive device
+  * \note Some drives support closing appart from opening/eject
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  */
+  void CloseDriveTray(const std::string& devicePath) override;
+
+  /*! \brief Toggle the state of a given drive device
+  *
+  * Will internally call EjectDriveTray or CloseDriveTray depending on
+  * the internal state of the drive (i.e. if open -> CloseDriveTray /
+  * if closed -> EjectDriveTray)
+  *
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  */
+  void ToggleDriveTray(const std::string& devicePath) override;
+};

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -41,7 +41,8 @@ void CWin32StorageProvider::Initialize()
 #ifdef HAS_DVD_DRIVE
   // Can be removed once the StorageHandler supports optical media
   for (const auto& it : vShare)
-    if (CServiceBroker::GetMediaManager().GetDriveStatus(it.strPath) == DRIVE_CLOSED_MEDIA_PRESENT)
+    if (CServiceBroker::GetMediaManager().GetDriveStatus(it.strPath) ==
+        DriveState::CLOSED_MEDIA_PRESENT)
       CServiceBroker::GetJobManager()->AddJob(new CDetectDisc(it.strPath, false), nullptr);
       // remove end
 #endif

--- a/xbmc/platform/win32/storage/discs/CMakeLists.txt
+++ b/xbmc/platform/win32/storage/discs/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(ENABLE_OPTICAL)
+  set(SOURCES Win32DiscDriveHandler.cpp)
+
+  set(HEADERS Win32DiscDriveHandler.h)
+
+  core_add_library(platform_win32_storage_discs)
+endif()

--- a/xbmc/platform/win32/storage/discs/Win32DiscDriveHandler.cpp
+++ b/xbmc/platform/win32/storage/discs/Win32DiscDriveHandler.cpp
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Win32DiscDriveHandler.h"
+
+#include "utils/log.h"
+
+#include "platform/win32/WIN32Util.h"
+
+#include <memory>
+
+namespace
+{
+/*! Abstraction for win32 return codes - state drive error */
+constexpr int WIN32_DISCDRIVESTATE_DRIVE_ERROR = -1;
+/*! Abstraction for win32 return codes - state no media in tray */
+constexpr int WIN32_DISCDRIVESTATE_NO_MEDIA = 0;
+/*! Abstraction for win32 return codes - state tray open */
+constexpr int WIN32_DISCDRIVESTATE_TRAY_OPEN = 1;
+/*! Abstraction for win32 return codes - state media accessible */
+constexpr int WIN32_DISCDRIVESTATE_MEDIA_ACCESSIBLE = 2;
+} // namespace
+
+std::shared_ptr<IDiscDriveHandler> IDiscDriveHandler::CreateInstance()
+{
+  return std::make_shared<CWin32DiscDriveHandler>();
+}
+
+DriveState CWin32DiscDriveHandler::GetDriveState(const std::string& devicePath)
+{
+  DriveState driveState = DriveState::NOT_READY;
+  int status = CWIN32Util::GetDriveStatus(devicePath);
+  switch (status)
+  {
+    case WIN32_DISCDRIVESTATE_DRIVE_ERROR:
+      driveState = DriveState::NOT_READY;
+      break;
+    case WIN32_DISCDRIVESTATE_NO_MEDIA:
+      driveState = DriveState::CLOSED_NO_MEDIA;
+      break;
+    case WIN32_DISCDRIVESTATE_TRAY_OPEN:
+      driveState = DriveState::OPEN;
+      break;
+    case WIN32_DISCDRIVESTATE_MEDIA_ACCESSIBLE:
+      driveState = DriveState::CLOSED_MEDIA_PRESENT;
+      break;
+    default:
+      CLog::LogF(LOGWARNING, "Unknown/unhandled drive state interpreted as NOT_READY");
+      break;
+  }
+  return driveState;
+}
+
+TrayState CWin32DiscDriveHandler::GetTrayState(const std::string& devicePath)
+{
+  TrayState trayState = TrayState::UNDEFINED;
+  DriveState driveState = GetDriveState(devicePath);
+  switch (driveState)
+  {
+    case DriveState::OPEN:
+      trayState = TrayState::OPEN;
+      break;
+    case DriveState::CLOSED_NO_MEDIA:
+      trayState = TrayState::CLOSED_NO_MEDIA;
+      break;
+    case DriveState::CLOSED_MEDIA_PRESENT:
+      trayState = TrayState::CLOSED_MEDIA_PRESENT;
+      break;
+    default:
+      CLog::LogF(LOGWARNING, "Unknown/unhandled tray state interpreted as TrayState::UNDEFINED");
+      break;
+  }
+  return trayState;
+}
+
+void CWin32DiscDriveHandler::EjectDriveTray(const std::string& devicePath)
+{
+  if (devicePath.empty())
+  {
+    CLog::LogF(LOGERROR, "Invalid/Empty devicePath provided");
+    return;
+  }
+  CWIN32Util::EjectTray(devicePath[0]);
+}
+
+void CWin32DiscDriveHandler::CloseDriveTray(const std::string& devicePath)
+{
+  if (devicePath.empty())
+  {
+    CLog::LogF(LOGERROR, "Invalid/Empty devicePath provided");
+    return;
+  }
+  CWIN32Util::CloseTray(devicePath[0]);
+}
+
+void CWin32DiscDriveHandler::ToggleDriveTray(const std::string& devicePath)
+{
+  if (devicePath.empty())
+  {
+    CLog::LogF(LOGERROR, "Invalid/Empty devicePath provided");
+    return;
+  }
+  CWIN32Util::ToggleTray(devicePath[0]);
+}

--- a/xbmc/platform/win32/storage/discs/Win32DiscDriveHandler.h
+++ b/xbmc/platform/win32/storage/discs/Win32DiscDriveHandler.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "storage/discs/IDiscDriveHandler.h"
+
+#include <string>
+
+class CWin32DiscDriveHandler : public IDiscDriveHandler
+{
+public:
+  /*! \brief Win32 DiscDriveHandler constructor
+  */
+  CWin32DiscDriveHandler() = default;
+
+  /*! \brief Win32 DiscDriveHandler destructor
+  */
+  ~CWin32DiscDriveHandler() override = default;
+
+  /*! \brief Get the optical drive state provided its device path
+  * \param devicePath the path for the device drive (e.g. D\://)
+  * \return The drive state
+  */
+  DriveState GetDriveState(const std::string& devicePath) override;
+
+  /*! \brief Get the optical drive tray state provided the drive device path
+  * \param devicePath the path for the device drive (e.g. D\://)
+  * \return The drive state
+  */
+  TrayState GetTrayState(const std::string& devicePath) override;
+
+  /*! \brief Eject the provided drive device
+  * \param devicePath the path for the device drive (e.g. D\://)
+  */
+  void EjectDriveTray(const std::string& devicePath) override;
+
+  /*! \brief Close the provided drive device
+  * \note Some drives support closing appart from opening/eject
+  * \param devicePath the path for the device drive (e.g. D\://)
+  */
+  void CloseDriveTray(const std::string& devicePath) override;
+
+  /*! \brief Toggle the state of a given drive device
+  *
+  * \param devicePath the path for the device drive (e.g. D\://)
+  */
+  void ToggleDriveTray(const std::string& devicePath) override;
+};

--- a/xbmc/storage/CMakeLists.txt
+++ b/xbmc/storage/CMakeLists.txt
@@ -9,7 +9,8 @@ if(ENABLE_OPTICAL)
   list(APPEND SOURCES cdioSupport.cpp
                       DetectDVDType.cpp)
   list(APPEND HEADERS cdioSupport.h
-                      DetectDVDType.h)
+                      DetectDVDType.h
+                      discs/IDiscDriveHandler.h)
 endif()
 
 core_add_library(storage)

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -390,9 +390,14 @@ void CDetectDVDMedia::WaitMediaReady()
 
 // Static function
 // Returns status of the DVD Drive
-int CDetectDVDMedia::DriveReady()
+bool CDetectDVDMedia::DriveReady()
 {
-  return static_cast<int>(m_DriveState);
+  return m_DriveState == DriveState::READY;
+}
+
+DriveState CDetectDVDMedia::GetDriveState()
+{
+  return m_DriveState;
 }
 
 // Static function

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -321,7 +321,7 @@ DWORD CDetectDVDMedia::GetTrayState()
   if (cdio)
   {
     static discmode_t discmode = CDIO_DISC_MODE_NO_INFO;
-    int status = m_cdio->mmc_get_tray_status(cdio);
+    int status = static_cast<int>(m_cdio->mmc_get_tray_status(cdio));
     static int laststatus = -1;
     // We only poll for new discmode when status has changed or there have been read errors (The last usually happens when new media is inserted)
     if (status == 0 && (laststatus != status || discmode == CDIO_DISC_MODE_ERROR))

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -15,14 +15,6 @@
 #include "utils/log.h"
 
 #include <mutex>
-#ifdef TARGET_POSIX
-#include <sys/types.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
-#if !defined(TARGET_DARWIN) && !defined(TARGET_FREEBSD)
-#include <linux/cdrom.h>
-#endif
-#endif
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "GUIUserMessages.h"
@@ -39,7 +31,7 @@ using namespace std::chrono_literals;
 
 CCriticalSection CDetectDVDMedia::m_muReadingMedia;
 CEvent CDetectDVDMedia::m_evAutorun;
-int CDetectDVDMedia::m_DriveState = DRIVE_CLOSED_NO_MEDIA;
+DriveState CDetectDVDMedia::m_DriveState{DriveState::CLOSED_NO_MEDIA};
 CCdInfo* CDetectDVDMedia::m_pCdInfo = NULL;
 time_t CDetectDVDMedia::m_LastPoll = 0;
 CDetectDVDMedia* CDetectDVDMedia::m_pInstance = NULL;
@@ -108,84 +100,85 @@ void CDetectDVDMedia::UpdateDvdrom()
   // newly inserted media.
   {
     std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
-    switch (GetTrayState())
+    switch (PollDriveState())
     {
-      case DRIVE_NONE:
+      case DriveState::NONE:
         //! @todo reduce / stop polling for drive updates
         break;
 
-      case DRIVE_OPEN:
+      case DriveState::OPEN:
+      {
+        // Send Message to GUI that disc been ejected
+        SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath), false,
+                          g_localizeStrings.Get(502));
+        CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REMOVED_MEDIA);
+        CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+        // Clear all stored info
+        Clear();
+        // Update drive state
+        waitLock.unlock();
+        m_DriveState = DriveState::OPEN;
+        return;
+      }
+      break;
+      case DriveState::NOT_READY:
+      {
+        // Drive is not ready (closing, opening)
+        SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath), false,
+                          g_localizeStrings.Get(503));
+        m_DriveState = DriveState::NOT_READY;
+        // DVD-ROM in undefined state
+        // Better delete old CD Information
+        if (m_pCdInfo != nullptr)
         {
-          // Send Message to GUI that disc been ejected
-          SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath),
-                            false, g_localizeStrings.Get(502));
-          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REMOVED_MEDIA);
-          CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
-          // Clear all stored info
-          Clear();
-          // Update drive state
-          waitLock.unlock();
-          m_DriveState = DRIVE_OPEN;
-          return;
+          delete m_pCdInfo;
+          m_pCdInfo = nullptr;
         }
-        break;
+        waitLock.unlock();
+        CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
+        CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+        // Do we really need sleep here? This will fix: [ 1530771 ] "Open tray" problem
+        // CThread::Sleep(6000ms);
+        return;
+      }
+      break;
 
-      case DRIVE_NOT_READY:
-        {
-          // Drive is not ready (closing, opening)
-          SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath),
-                            false, g_localizeStrings.Get(503));
-          m_DriveState = DRIVE_NOT_READY;
-          // DVD-ROM in undefined state
-          // Better delete old CD Information
-          if ( m_pCdInfo != NULL )
-          {
-            delete m_pCdInfo;
-            m_pCdInfo = NULL;
-          }
-          waitLock.unlock();
-          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-          CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
-          // Do we really need sleep here? This will fix: [ 1530771 ] "Open tray" problem
-          // CThread::Sleep(6000ms);
-          return ;
-        }
-        break;
-
-      case DRIVE_CLOSED_NO_MEDIA:
-        {
-          // Nothing in there...
-          SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath),
-                            false, g_localizeStrings.Get(504));
-          m_DriveState = DRIVE_CLOSED_NO_MEDIA;
-          // Send Message to GUI that disc has changed
-          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-          waitLock.unlock();
-          CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
-          return ;
-        }
-        break;
-      case DRIVE_READY:
+      case DriveState::CLOSED_NO_MEDIA:
+      {
+        // Nothing in there...
+        SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath), false,
+                          g_localizeStrings.Get(504));
+        m_DriveState = DriveState::CLOSED_NO_MEDIA;
+        // Send Message to GUI that disc has changed
+        CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
+        waitLock.unlock();
+        CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+        return;
+      }
+      break;
+      case DriveState::READY:
 #if !defined(TARGET_DARWIN)
         return ;
 #endif
-      case DRIVE_CLOSED_MEDIA_PRESENT:
+        break;
+      case DriveState::CLOSED_MEDIA_PRESENT:
+      {
+        if (m_DriveState != DriveState::CLOSED_MEDIA_PRESENT)
         {
-          if ( m_DriveState != DRIVE_CLOSED_MEDIA_PRESENT)
-          {
-            m_DriveState = DRIVE_CLOSED_MEDIA_PRESENT;
-            // Detect ISO9660(mode1/mode2) or CDDA filesystem
-            DetectMediaType();
-            CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-            waitLock.unlock();
-            CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
-            // Tell the application object that a new Cd is inserted
-            // So autorun can be started.
-            if ( !m_bStartup )
-              m_bAutorun = true;
-          }
-          return ;
+          m_DriveState = DriveState::CLOSED_MEDIA_PRESENT;
+          // Detect ISO9660(mode1/mode2) or CDDA filesystem
+          DetectMediaType();
+          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
+          waitLock.unlock();
+          CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+          // Tell the application object that a new Cd is inserted
+          // So autorun can be started.
+          if (!m_bStartup)
+            m_bAutorun = true;
         }
+        return;
+      }
+      default:
         break;
     }
 
@@ -302,97 +295,83 @@ void CDetectDVDMedia::SetNewDVDShareUrl( const std::string& strNewUrl, bool bCDD
   m_diskPath = strNewUrl;
 }
 
-DWORD CDetectDVDMedia::GetTrayState()
+DriveState CDetectDVDMedia::PollDriveState()
 {
-#ifdef TARGET_POSIX
-
-  char* dvdDevice = m_cdio->GetDeviceFileName();
-  if (strlen(dvdDevice) == 0)
-    return DRIVE_NONE;
-
-  // The following code works with libcdio >= 0.78
-  // To enable it, download and install the latest version from
-  // http://www.gnu.org/software/libcdio/
-  // -d4rk 06/27/07
-
-
-  m_dwTrayState = TRAY_CLOSED_MEDIA_PRESENT;
-  CdIo_t* cdio = m_cdio->cdio_open(dvdDevice, DRIVER_UNKNOWN);
-  if (cdio)
+  const std::shared_ptr<IDiscDriveHandler> platformDiscDriveHandler =
+      CServiceBroker::GetMediaManager().GetDiscDriveHandler();
+  if (!platformDiscDriveHandler)
   {
-    static discmode_t discmode = CDIO_DISC_MODE_NO_INFO;
-    int status = static_cast<int>(m_cdio->mmc_get_tray_status(cdio));
-    static int laststatus = -1;
-    // We only poll for new discmode when status has changed or there have been read errors (The last usually happens when new media is inserted)
-    if (status == 0 && (laststatus != status || discmode == CDIO_DISC_MODE_ERROR))
-      discmode = m_cdio->cdio_get_discmode(cdio);
+    return DriveState::NONE;
+  }
 
-    switch(status)
-    {
-    case 0: //closed
-      if (discmode==CDIO_DISC_MODE_NO_INFO || discmode==CDIO_DISC_MODE_ERROR)
-        m_dwTrayState = TRAY_CLOSED_NO_MEDIA;
-      else
-        m_dwTrayState = TRAY_CLOSED_MEDIA_PRESENT;
+  const std::string discPath = CServiceBroker::GetMediaManager().TranslateDevicePath("");
+  const DriveState driveState = platformDiscDriveHandler->GetDriveState(discPath);
+  switch (driveState)
+  {
+    case DriveState::CLOSED_MEDIA_UNDEFINED:
+      // We only poll for new traystatus when driveState has changed or if the last recorded
+      // tray state is undefined
+      if (driveState == DriveState::CLOSED_MEDIA_UNDEFINED &&
+          (m_LastTrayState == TrayState::UNDEFINED || driveState != m_LastDriveState))
+      {
+        m_TrayState = platformDiscDriveHandler->GetTrayState(discPath);
+      }
       break;
-
-    case 1: //open
-      m_dwTrayState = TRAY_OPEN;
+    case DriveState::OPEN:
+      m_TrayState = TrayState::OPEN;
       break;
-    }
-    laststatus = status;
-    m_cdio->cdio_destroy(cdio);
+    default:
+      m_TrayState = TrayState::UNDEFINED;
+      break;
   }
-  else
-    return DRIVE_NOT_READY;
+  m_LastDriveState = driveState;
 
-#endif // TARGET_POSIX
-
-  if (m_dwTrayState == TRAY_CLOSED_MEDIA_PRESENT)
+  if (m_TrayState == TrayState::CLOSED_MEDIA_PRESENT)
   {
-    if (m_dwLastTrayState != TRAY_CLOSED_MEDIA_PRESENT)
+    if (m_LastTrayState != TrayState::CLOSED_MEDIA_PRESENT)
     {
-      m_dwLastTrayState = m_dwTrayState;
-      return DRIVE_CLOSED_MEDIA_PRESENT;
+      m_LastTrayState = m_TrayState;
+      return DriveState::CLOSED_MEDIA_PRESENT;
     }
     else
     {
-      return DRIVE_READY;
+      return DriveState::READY;
     }
   }
-  else if (m_dwTrayState == TRAY_CLOSED_NO_MEDIA)
+  else if (m_TrayState == TrayState::CLOSED_NO_MEDIA)
   {
-    if ( (m_dwLastTrayState != TRAY_CLOSED_NO_MEDIA) && (m_dwLastTrayState != TRAY_CLOSED_MEDIA_PRESENT) )
+    if ((m_LastTrayState != TrayState::CLOSED_NO_MEDIA) &&
+        (m_LastTrayState != TrayState::CLOSED_MEDIA_PRESENT))
     {
-      m_dwLastTrayState = m_dwTrayState;
-      return DRIVE_CLOSED_NO_MEDIA;
+      m_LastTrayState = m_TrayState;
+      return DriveState::CLOSED_NO_MEDIA;
     }
     else
     {
-      return DRIVE_READY;
+      return DriveState::READY;
     }
   }
-  else if (m_dwTrayState == TRAY_OPEN)
+  else if (m_TrayState == TrayState::OPEN)
   {
-    if (m_dwLastTrayState != TRAY_OPEN)
+    if (m_LastTrayState != TrayState::OPEN)
     {
-      m_dwLastTrayState = m_dwTrayState;
-      return DRIVE_OPEN;
+      m_LastTrayState = m_TrayState;
+      return DriveState::OPEN;
     }
     else
     {
-      return DRIVE_READY;
+      return DriveState::READY;
     }
   }
   else
   {
-    m_dwLastTrayState = m_dwTrayState;
+    m_LastTrayState = m_TrayState;
   }
 
 #ifdef HAS_DVD_DRIVE
-  return DRIVE_NOT_READY;
+  return DriveState::NOT_READY;
 #else
-  return DRIVE_READY;
+  return DriveState::READY;
 #endif
 }
 
@@ -413,14 +392,14 @@ void CDetectDVDMedia::WaitMediaReady()
 // Returns status of the DVD Drive
 int CDetectDVDMedia::DriveReady()
 {
-  return m_DriveState;
+  return static_cast<int>(m_DriveState);
 }
 
 // Static function
 // Whether a disc is in drive
 bool CDetectDVDMedia::IsDiscInDrive()
 {
-  return m_DriveState == DRIVE_CLOSED_MEDIA_PRESENT;
+  return m_DriveState == DriveState::CLOSED_MEDIA_PRESENT;
 }
 
 // Static function

--- a/xbmc/storage/DetectDVDType.h
+++ b/xbmc/storage/DetectDVDType.h
@@ -42,7 +42,8 @@ public:
 
   static void WaitMediaReady();
   static bool IsDiscInDrive();
-  static int DriveReady();
+  static bool DriveReady();
+  static DriveState GetDriveState();
   static CCdInfo* GetCdInfo();
   static CEvent m_evAutorun;
 

--- a/xbmc/storage/DetectDVDType.h
+++ b/xbmc/storage/DetectDVDType.h
@@ -17,6 +17,7 @@
 
 #ifdef HAS_DVD_DRIVE
 
+#include "storage/discs/IDiscDriveHandler.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 #include "utils/DiscsUtils.h"
@@ -51,7 +52,7 @@ public:
   static void UpdateState();
 protected:
   void UpdateDvdrom();
-  DWORD GetTrayState();
+  DriveState PollDriveState();
 
 
   void DetectMediaType();
@@ -62,7 +63,7 @@ protected:
 private:
   static CCriticalSection m_muReadingMedia;
 
-  static int m_DriveState;
+  static DriveState m_DriveState;
   static time_t m_LastPoll;
   static CDetectDVDMedia* m_pInstance;
 
@@ -70,8 +71,9 @@ private:
 
   bool m_bStartup = true; // Do not autorun on startup
   bool m_bAutorun = false;
-  DWORD m_dwTrayState;
-  DWORD m_dwLastTrayState = 0;
+  TrayState m_TrayState{TrayState::UNDEFINED};
+  TrayState m_LastTrayState{TrayState::UNDEFINED};
+  DriveState m_LastDriveState{DriveState::NONE};
 
   static std::string m_diskLabel;
   static std::string m_diskPath;

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -57,7 +57,7 @@ public:
   bool IsAudio(const std::string& devicePath="");
   bool HasOpticalDrive();
   std::string TranslateDevicePath(const std::string& devicePath, bool bReturnAsDevice=false);
-  DWORD GetDriveStatus(const std::string& devicePath="");
+  DriveState GetDriveStatus(const std::string& devicePath = "");
 #ifdef HAS_DVD_DRIVE
   MEDIA_DETECT::CCdInfo* GetCdInfo(const std::string& devicePath="");
   bool RemoveCdInfo(const std::string& devicePath="");

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -10,6 +10,7 @@
 
 #include "IStorageProvider.h"
 #include "MediaSource.h" // for VECSOURCES
+#include "storage/discs/IDiscDriveHandler.h"
 #include "threads/CriticalSection.h"
 #include "utils/DiscsUtils.h"
 #include "utils/Job.h"
@@ -73,6 +74,13 @@ public:
   bool RemoveCdInfo(const std::string& devicePath="");
   std::string GetDiskLabel(const std::string& devicePath="");
   std::string GetDiskUniqueId(const std::string& devicePath="");
+
+  /*! \brief Gets the platform disc drive handler
+  * @todo this likely doesn't belong here but in some discsupport component owned by media manager
+  * let's keep it here for now
+  * \return The platform disc drive handler
+  */
+  std::shared_ptr<IDiscDriveHandler> GetDiscDriveHandler();
 #endif
   std::string GetDiscPath();
   void SetHasOpticalDrive(bool bstatus);
@@ -120,6 +128,9 @@ protected:
 
 private:
   std::unique_ptr<IStorageProvider> m_platformStorage;
+#ifdef HAS_DVD_DRIVE
+  std::shared_ptr<IDiscDriveHandler> m_platformDiscDriveHander;
+#endif
 
   UTILS::DISCS::DiscInfo GetDiscInfo(const std::string& mediaPath);
   void RemoveDiscInfo(const std::string& devicePath);

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -21,17 +21,6 @@
 
 #include "PlatformDefs.h"
 
-#define TRAY_OPEN     16
-#define TRAY_CLOSED_NO_MEDIA  64
-#define TRAY_CLOSED_MEDIA_PRESENT 96
-
-#define DRIVE_OPEN      0 // Open...
-#define DRIVE_NOT_READY     1 // Opening.. Closing...
-#define DRIVE_READY      2
-#define DRIVE_CLOSED_NO_MEDIA   3 // CLOSED...but no media in drive
-#define DRIVE_CLOSED_MEDIA_PRESENT  4 // Will be send once when the drive just have closed
-#define DRIVE_NONE  5 // system doesn't have an optical drive
-
 class CFileItem;
 
 class CNetworkLocation

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -19,6 +19,14 @@
 #include <cdio/mmc.h>
 #include <cdio/util.h>
 
+namespace
+{
+/* Helper constexpr to hide the 0 return code for tray closed. */
+constexpr int CDIO_TRAY_STATUS_CLOSED = 0;
+/* Helper constexpr to hide the 1 return code for tray open */
+constexpr int CDIO_TRAY_STATUS_OPEN = 1;
+} // namespace
+
 using namespace MEDIA_DETECT;
 
 std::shared_ptr<CLibcdio> CLibcdio::m_pInstance;
@@ -135,11 +143,21 @@ discmode_t CLibcdio::cdio_get_discmode(CdIo_t *p_cdio)
   return( ::cdio_get_discmode(p_cdio) );
 }
 
-int CLibcdio::mmc_get_tray_status(const CdIo_t *p_cdio)
+CdioTrayStatus CLibcdio::mmc_get_tray_status(const CdIo_t* p_cdio)
 {
   std::unique_lock<CCriticalSection> lock(*this);
 
-  return( ::mmc_get_tray_status(p_cdio) );
+  int status = ::mmc_get_tray_status(p_cdio);
+  switch (status)
+  {
+    case CDIO_TRAY_STATUS_CLOSED:
+      return CdioTrayStatus::CLOSED;
+    case CDIO_TRAY_STATUS_OPEN:
+      return CdioTrayStatus::OPEN;
+    default:
+      break;
+  }
+  return CdioTrayStatus::DRIVER_ERROR;
 }
 
 driver_return_code_t CLibcdio::cdio_eject_media(CdIo_t** p_cdio)

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -142,7 +142,7 @@ int CLibcdio::mmc_get_tray_status(const CdIo_t *p_cdio)
   return( ::mmc_get_tray_status(p_cdio) );
 }
 
-int CLibcdio::cdio_eject_media(CdIo_t **p_cdio)
+driver_return_code_t CLibcdio::cdio_eject_media(CdIo_t** p_cdio)
 {
   std::unique_lock<CCriticalSection> lock(*this);
 

--- a/xbmc/storage/cdioSupport.h
+++ b/xbmc/storage/cdioSupport.h
@@ -252,7 +252,7 @@ public:
   void cdio_destroy(CdIo_t *p_cdio);
   discmode_t cdio_get_discmode(CdIo_t *p_cdio);
   int mmc_get_tray_status(const CdIo_t *p_cdio);
-  int cdio_eject_media(CdIo_t **p_cdio);
+  driver_return_code_t cdio_eject_media(CdIo_t** p_cdio);
   track_t cdio_get_last_track_num(const CdIo_t *p_cdio);
   lsn_t cdio_get_track_lsn(const CdIo_t *p_cdio, track_t i_track);
   lsn_t cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t i_track);

--- a/xbmc/storage/cdioSupport.h
+++ b/xbmc/storage/cdioSupport.h
@@ -97,6 +97,17 @@ typedef struct TRACKINFO
 }
 trackinfo;
 
+/*! \brief Helper enum class for the MMC tray state
+*/
+enum class CdioTrayStatus
+{
+  /* The MMC tray state is reported closed */
+  CLOSED,
+  /* The MMC tray state is reported open */
+  OPEN,
+  /* Driver error */
+  DRIVER_ERROR
+};
 
 class CCdInfo
 {
@@ -251,7 +262,7 @@ public:
   CdIo_t* cdio_open_win32(const char *psz_source);
   void cdio_destroy(CdIo_t *p_cdio);
   discmode_t cdio_get_discmode(CdIo_t *p_cdio);
-  int mmc_get_tray_status(const CdIo_t *p_cdio);
+  CdioTrayStatus mmc_get_tray_status(const CdIo_t* p_cdio);
   driver_return_code_t cdio_eject_media(CdIo_t** p_cdio);
   track_t cdio_get_last_track_num(const CdIo_t *p_cdio);
   lsn_t cdio_get_track_lsn(const CdIo_t *p_cdio, track_t i_track);

--- a/xbmc/storage/discs/IDiscDriveHandler.h
+++ b/xbmc/storage/discs/IDiscDriveHandler.h
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+/*! \brief Represents the state of a disc (optical) drive */
+enum class DriveState
+{
+  /*! The drive is open */
+  OPEN,
+  /*! The drive is not ready (happens when openning or closing) */
+  NOT_READY,
+  /*! The drive is ready */
+  READY,
+  /*! The drive is closed but no media could be detected in the drive */
+  CLOSED_NO_MEDIA,
+  /*! The drive is closed and there is media in the drive */
+  CLOSED_MEDIA_PRESENT,
+  /*! The system does not have an optical drive */
+  NONE,
+  /*! The drive is closed but we don't know yet if there's media there */
+  CLOSED_MEDIA_UNDEFINED
+};
+
+/*! \brief Represents the state of the drive tray */
+enum class TrayState
+{
+  /*!  The tray is in an undefined state, we don't know yet */
+  UNDEFINED,
+  /*!  The tray is open */
+  OPEN,
+  /*! The tray is closed and doesn't have any optical media */
+  CLOSED_NO_MEDIA,
+  /*! The tray is closed and contains optical media */
+  CLOSED_MEDIA_PRESENT
+};
+
+/*! \brief Generic interface for platform disc drive handling
+*/
+class IDiscDriveHandler
+{
+public:
+  /*! \brief Get the optical drive state provided its device path
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  * \return The drive state
+  */
+  virtual DriveState GetDriveState(const std::string& devicePath) = 0;
+
+  /*! \brief Get the optical drive tray state provided the drive device path
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  * \return The drive state
+  */
+  virtual TrayState GetTrayState(const std::string& devicePath) = 0;
+
+  /*! \brief Eject the provided drive device
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  */
+  virtual void EjectDriveTray(const std::string& devicePath) = 0;
+
+  /*! \brief Close the provided drive device
+  * \note Some drives support closing appart from opening/eject
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  */
+  virtual void CloseDriveTray(const std::string& devicePath) = 0;
+
+  /*! \brief Toggle the state of a given drive device
+  *
+  * Will internally call EjectDriveTray or CloseDriveTray depending on
+  * the internal state of the drive (i.e. if open -> CloseDriveTray /
+  * if closed -> EjectDriveTray)
+  *
+  * \param devicePath the path for the device drive (e.g. /dev/sr0)
+  */
+  virtual void ToggleDriveTray(const std::string& devicePath) = 0;
+
+  /*! \brief Called to create platform-specific disc drive handler
+  *
+  * This method is used to create platform-specific disc drive handler
+  */
+  static std::shared_ptr<IDiscDriveHandler> CreateInstance();
+
+protected:
+  virtual ~IDiscDriveHandler() = default;
+  IDiscDriveHandler() = default;
+};


### PR DESCRIPTION
## Description
This is the first step into decoupling platform code related to disc drive handling (currently ifdefd in `MediaManager`) into platform code. By discdrive handling I refer to stuff like ejecttray, toggletray, closetray or get the status of either the drive or the tray.

- It introduces a generic `IDiscDriveHander` interface 
- ~~It includes an base `IDiscDriveHandler` (`CDiscDriveHandlerBase`) implementation which can be used to implement generic code (e.g toggle is pretty much the same of calling open/close depending on the state unless re-implemented by the specific platform code path)~~
- Implements the Posix code path (using libcdio)
- Implements the win32 code path (using win32 util)

Currently the old methods in `MediaManager` are still available. This has been done to ensure the diff is as small as possible and to allow incremental refactoring.
The methods in MediaManager likely don't belong there but rather in some DiscSupport component (with platform support) owned by the mediamanger itself.

The next step will most likely be the uniformization of DiscProbing which currently follows two completely different code paths/implementations in windows (`CDetectDisc`) and linux/posix (`DetectDVDMedia`) introducing stuff like a `DiscManager` (to hold probed disc cache and inform the parent - `MediaManager` - using auto sources) and a `DiscProbing` Interface that platforms can implement. Also note that currently in some platforms if there is no disc drive available (I don't mean the disc but the actual drive/optical support) we are still left with a thread running for the lifetime of the application for no reason...

Doing stuff like this incrementally and without a full rewrite is pretty hard to be honest and thinking about how the several pieces fit together is even harder. I appreciate constructive feedback considering the final "product" is still work in progress.

Cheers