### PR TITLE
[Android] CXBMCApp: Listener cleanup

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -322,6 +322,9 @@ void CXBMCApp::onDestroy()
 
   unregisterReceiver(*this);
 
+  UnregisterDisplayListener();
+  CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
+
   m_mediaSession.release();
 }
 
@@ -380,6 +383,16 @@ void CXBMCApp::RegisterDisplayListener(CVariant* variant)
   {
     android_printf("CXBMCApp: installing DisplayManager::DisplayListener");
     displayManager.registerDisplayListener(CXBMCApp::Get().getDisplayListener());
+  }
+}
+
+void CXBMCApp::UnregisterDisplayListener()
+{
+  CJNIDisplayManager displayManager(getSystemService("display"));
+  if (displayManager)
+  {
+    android_printf("CXBMCApp: removing DisplayManager::DisplayListener");
+    displayManager.unregisterDisplayListener(getDisplayListener());
   }
 }
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -234,7 +234,11 @@ void CXBMCApp::onStart()
     intentFilter.addAction("android.intent.action.SCREEN_OFF");
     intentFilter.addAction("android.net.conn.CONNECTIVITY_CHANGE");
     registerReceiver(*this, intentFilter);
-    m_mediaSession.reset(new CJNIXBMCMediaSession());
+    m_mediaSession = std::make_unique<CJNIXBMCMediaSession>();
+    m_activityManager =
+        std::make_unique<CJNIActivityManager>(getSystemService(CJNIContext::ACTIVITY_SERVICE));
+    m_inputHandler.setDPI(GetDPI());
+    RegisterDisplayListener();
   }
 }
 
@@ -376,13 +380,13 @@ void CXBMCApp::onLostFocus()
   m_hasFocus = false;
 }
 
-void CXBMCApp::RegisterDisplayListener(CVariant* variant)
+void CXBMCApp::RegisterDisplayListener()
 {
   CJNIDisplayManager displayManager(getSystemService("display"));
   if (displayManager)
   {
     android_printf("CXBMCApp: installing DisplayManager::DisplayListener");
-    displayManager.registerDisplayListener(CXBMCApp::Get().getDisplayListener());
+    displayManager.registerDisplayListener(m_displayListener.get_raw());
   }
 }
 
@@ -392,16 +396,13 @@ void CXBMCApp::UnregisterDisplayListener()
   if (displayManager)
   {
     android_printf("CXBMCApp: removing DisplayManager::DisplayListener");
-    displayManager.unregisterDisplayListener(getDisplayListener());
+    displayManager.unregisterDisplayListener(m_displayListener.get_raw());
   }
 }
 
 void CXBMCApp::Initialize()
 {
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
-  runNativeOnUiThread(RegisterDisplayListener, nullptr);
-  m_activityManager.reset(new CJNIActivityManager(getSystemService(CJNIContext::ACTIVITY_SERVICE)));
-  m_inputHandler.setDPI(GetDPI());
 }
 
 void CXBMCApp::Deinitialize()

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -258,7 +258,9 @@ private:
   void SetupEnv();
   static void SetRefreshRateCallback(CVariant *rate);
   static void SetDisplayModeCallback(CVariant *mode);
+
   static void RegisterDisplayListener(CVariant*);
+  void UnregisterDisplayListener();
 
   ANativeActivity* m_activity{nullptr};
   IInputHandler& m_inputHandler;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -141,7 +141,6 @@ public:
   void onDisplayAdded(int displayId) override;
   void onDisplayChanged(int displayId) override;
   void onDisplayRemoved(int displayId) override;
-  jni::jhobject getDisplayListener() { return m_displayListener.get_raw(); }
 
   bool isValid() { return m_activity != NULL; }
 
@@ -259,7 +258,7 @@ private:
   static void SetRefreshRateCallback(CVariant *rate);
   static void SetDisplayModeCallback(CVariant *mode);
 
-  static void RegisterDisplayListener(CVariant*);
+  void RegisterDisplayListener();
   void UnregisterDisplayListener();
 
   ANativeActivity* m_activity{nullptr};


### PR DESCRIPTION
* Fix resource leaks: Unregister display listener and announcer on Kodi exit.
* Cleanup: Register display listener, create activity manager in CXBMCApp::onStart(). Now matches the reverse operations in CXBMCApp::onDestroy().

Due to lack of a Kodi Android maintainer I have no idea who could review this, thus will merge this PR after a couple of days of inactivity. 