### PR TITLE
[Application] On app cleanup, unregister announcement manager from service broker

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2498,6 +2498,7 @@ bool CApplication::Cleanup()
 
     CServiceBroker::UnregisterAppMessenger();
 
+    CServiceBroker::UnregisterAnnouncementManager();
     m_pAnnouncementManager->Deinitialize();
     m_pAnnouncementManager.reset();
 


### PR DESCRIPTION
Announcement Manager was registered, but never unregistered from Service Broker.

Runtime-tested on macOS and Android, latest master.

@howie-f  could you review, please. It's a no-brainer.