### PR TITLE
[PVR] CPVRGUITimesInfo: Fix updating the playing EPG tag.

### DIFF
--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
@@ -65,9 +65,12 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
 
     std::unique_lock<CCriticalSection> lock(m_critSection);
 
-    const std::shared_ptr<CPVRChannel> playingChannel = m_playingEpgTag ? groups->GetChannelForEpgTag(m_playingEpgTag) : nullptr;
-    if (!m_playingEpgTag || !m_playingEpgTag->IsActive() ||
-        !playingChannel || !currentChannel || *playingChannel != *currentChannel)
+    const std::shared_ptr<CPVRChannel> playingChannel =
+        m_playingEpgTag ? groups->GetChannelForEpgTag(m_playingEpgTag) : nullptr;
+
+    if (!m_playingEpgTag || !currentTag || !playingChannel || !currentChannel ||
+        m_playingEpgTag->StartAsUTC() != currentTag->StartAsUTC() ||
+        m_playingEpgTag->EndAsUTC() != currentTag->EndAsUTC() || *playingChannel != *currentChannel)
     {
       if (currentTag)
       {


### PR DESCRIPTION
Fix `CPVRGUITimesInfo::UpdatePlayingTag` not handling invalid tags properly.

`tag->IsActive()`only checks whether the tag covers current playback time, but not if there is another newer tag that covers this time as well and therefore is the tag to use.

Happens if EPG gets updated while watching a channel, with for example a special news program getting inserted in between two other events.

Example:

Old EPG:
20:00 - 20:15: News 
20:15 - 21:30: Movie
...

New EPG:
20:00 - 20:15: News
20:15 - 20:30: Special News 
20:30 - 21:45: Movie
..

If playbacktime is between 20:15 and 20:30, the tag for "Special News" must be used by `CPVRGUITimesInfo`, not the tag for "News". This is what this PR fixes.

Runtime-tested on Android and macOS, latest Kodi master.

@phunkyfish when you find some time for a review. 