### PR TITLE
[clang-format] Keep number of empty lines to 1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,7 +59,7 @@ JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 2
+MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false


### PR DESCRIPTION
## Description
Background is provided in https://github.com/xbmc/xbmc/pull/21143#discussion_r830453379
Since there's always a trend to add additional blank lines by mistake it's likely better that clang-format removes them automatically to lower the effort on reviews.
