### PR TITLE
[Xbox] WASAPI: improves/fix 48000 Hz sample rate detection

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -385,6 +385,7 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
   CAEDeviceInfo        deviceInfo;
   CAEChannelInfo       deviceChannels;
   bool                 add192 = false;
+  bool add48 = false;
 
   WAVEFORMATEXTENSIBLE wfxex = {};
   HRESULT              hr;
@@ -536,6 +537,7 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
         deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
         deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
         deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+        add48 = true;
       }
 
       /* Test format Dolby AC3 */
@@ -551,6 +553,7 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
         }
 
         deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+        add48 = true;
       }
 
       /* Test format for PCM format iteration */
@@ -607,6 +610,12 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
         {
           deviceInfo.m_sampleRates.push_back(WASAPISampleRates[j]);
           CLog::LogF(LOGINFO, "sample rate 192khz on device \"{}\" seems to be not supported.",
+                     details.strDescription);
+        }
+        else if (wfxex.Format.nSamplesPerSec == 48000 && add48)
+        {
+          deviceInfo.m_sampleRates.push_back(WASAPISampleRates[j]);
+          CLog::LogF(LOGINFO, "sample rate 48khz on device \"{}\" seems to be not supported.",
                      details.strDescription);
         }
       }


### PR DESCRIPTION
## Description
WASAPI: improves/fix 48000 Hz sample rate detection.

Fixes DTS passthrough switch is not displayed in Xbox audio settings (still DTS works).

## Motivation and context
Samples rates detection is based on `KSDATAFORMAT_SUBTYPE_PCM` test. Since WASAPI on Xbox only supports passthrough, PCM test fails but 48000 is implicit supported if `KSDATAFORMAT_SUBTYPE_IEC61937_DTS` or `KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_DIGITAL` are supported.

The error was hidden because apart from the DTS switch not being displayed in GUI, the DTS audio PT was still working.

Although it has never been reported before (far as I know), the same could happen in Windows x64 if a device does not support 16 bit / PCM / 48 KHz specifically but instead supports the RAW format corresponding to DTS or AC3.
It seems strange but an HDMI device could only support 32/24 bits in PCM and fail because only 16 bits are tested.

## How has this been tested?
Runtime tested Xbox Series S.

Tested that DTS PT works same as before but also tested with DTS switch disabled and DTS is played as multichannel PCM.
Previously it was not possible to specifically disable the DTS format.

## What is the effect on users?
[Xbox] fixes DTS passthrough switch is not displayed in GUI audio settings.
[Xbox] fixes DTS passthrough format cannot be disabled.
[Xbox] probably on systems that only supports 48KHz and not 192KHz (ARC ?), fixes passthrough didn't work at all. (not tested)

## Screenshots (if appropriate):
**Before** (no DTS switch)
![screenshot00000 (2)](https://user-images.githubusercontent.com/58434170/159174505-511a2d51-0d12-46d2-a42f-3fbb77ac6320.png)

**After**
![screenshot00000](https://user-images.githubusercontent.com/58434170/159174497-34b96a58-25ab-45fc-8dbe-61d7805cd50d.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
