### PR TITLE
[discs][dvdnav] - Fix external subs and remove old conversions

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -123,20 +123,6 @@ protected:
 
   int ProcessBlock(uint8_t* buffer, int* read);
 
-  /**
-   * XBMC     : the audio stream id we use in xbmc
-   * external : the audio stream id that is used in libdvdnav
-   */
-  int ConvertAudioStreamId_XBMCToExternal(int id);
-  int ConvertAudioStreamId_ExternalToXBMC(int id);
-
-  /**
-   * XBMC     : the subtitle stream id we use in xbmc
-   * external : the subtitle stream id that is used in libdvdnav
-   */
-  int ConvertSubtitleStreamId_XBMCToExternal(int id);
-  int ConvertSubtitleStreamId_ExternalToXBMC(int id);
-
   static void SetAudioStreamName(AudioStreamInfo &info, const audio_attr_t &audio_attributes);
   static void SetSubtitleStreamName(SubtitleStreamInfo &info, const subp_attr_t &subp_attributes);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5084,8 +5084,14 @@ void CVideoPlayer::UpdateContentState()
                                                             nav->GetActiveAngle());
     m_content.m_audioIndex = m_SelectionStreams.TypeIndexOf(STREAM_AUDIO, STREAM_SOURCE_NAV, -1,
                                                             nav->GetActiveAudioStream());
-    m_content.m_subtitleIndex = m_SelectionStreams.TypeIndexOf(STREAM_SUBTITLE, STREAM_SOURCE_NAV,
-                                                               -1, nav->GetActiveSubtitleStream());
+
+    // only update the subtitle index in libdvdnav if the subtitle is provided by the dvd itself,
+    // i.e. for external subtitles the index is always greater than the subtitlecount in dvdnav
+    if (m_content.m_subtitleIndex < nav->GetSubTitleStreamCount())
+    {
+      m_content.m_subtitleIndex = m_SelectionStreams.TypeIndexOf(
+          STREAM_SUBTITLE, STREAM_SOURCE_NAV, -1, nav->GetActiveSubtitleStream());
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This PR provides both a fix and a cleanup of the old xbmc->libdvdnav stream ids:

https://github.com/xbmc/xbmc/commit/fd13a826c44c491e22079710427715e3e41913d9 - Fixes an issue with external subtitles when using libdvdnav (physical dvds or dvd isos). When the stream is started the subtitle list from the dvd is populated. Afterwards, if you decide to add an external sub to the file being played it is added as external (at the bottom of the subtitle list). Lets say that if a dvd has 5 subtitle streams (index 0-4), the index of the external one you just downloaded in now 5.
However, when we set a subtitle stream we sync the state from videoplayer to the libdvdnav handler. At this point, the external subtitle index is greater than the list libdvdnav knows about ... which leads kodi to indicate the current enabled subtitle is the previous one that was enabled (and not the external one). Note this was not introduced with the recent changes nor is related to the cleanup, been an issue for a long time.

Now it shows correctly when an external sub is selected and the dialog is opened again:
![Screenshot from 2022-03-20 17-56-48](https://user-images.githubusercontent.com/7375276/159176663-d5c89159-8857-414b-b780-73275ee4db08.png)


https://github.com/xbmc/xbmc/commit/d508dd559c8ee37cdd2230fbd959fe55cd73343d - Removes the old xbmc->toexternal or external->xbmc methods. They date back to a time older than the VP was re-written. There is no chance an id that is not returned by libdvdnav itself to be used when setting subtitles or audio streams. Furthermore, the code pretty much only checks if the index is valid according to the maximum value dvds can provide (8 for audio, 32 for spu/subs). 


