### PR TITLE
Fix slideshow image scaling in SlideShowPicture.cpp

### DIFF
--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -475,12 +475,12 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
   // work out if we should be compensating the zoom to minimize blackbars
   // we should compute this based on the % of black bars on screen perhaps??
   //! @todo change m_displayEffect != EFFECT_NO_TIMEOUT to whether we're running the slideshow
-  if (m_displayEffect != EFFECT_NO_TIMEOUT && fScreenRatio < fSourceAR * fComp && fSourceAR < fScreenRatio * fComp)
+  if (m_displayEffect != EFFECT_NO_TIMEOUT && m_displayEffect != EFFECT_NONE && fScreenRatio < fSourceAR * fComp && fSourceAR < fScreenRatio * fComp)
     bFillScreen = true;
   if ((!bFillScreen && fScreenWidth*fPixelRatio > fScreenHeight*fSourceAR) || (bFillScreen && fScreenWidth*fPixelRatio < fScreenHeight*fSourceAR))
     fScaleNorm = fScreenHeight / (m_fHeight * fPixelRatio);
   bFillScreen = false;
-  if (m_displayEffect != EFFECT_NO_TIMEOUT && fScreenRatio < fSourceInvAR * fComp && fSourceInvAR < fScreenRatio * fComp)
+  if (m_displayEffect != EFFECT_NO_TIMEOUT && m_displayEffect != EFFECT_NONE && fScreenRatio < fSourceInvAR * fComp && fSourceInvAR < fScreenRatio * fComp)
     bFillScreen = true;
   if ((!bFillScreen && fScreenWidth*fPixelRatio > fScreenHeight*fSourceInvAR) || (bFillScreen && fScreenWidth*fPixelRatio < fScreenHeight*fSourceInvAR))
     fScaleInv = fScreenHeight / (m_fWidth * fPixelRatio);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
I added an additional boolean condition in front of each of the two calculations which involve the value of the advanced settings parameter \<blackbarcompensation\>, which occur in a sequence of calculations that arrive at an image scaling factor for the current image in a slideshow in pictures/SlideShowPicture.cpp.

The new conditions (m_displayEffect != EFFECT_NONE) have the effect of skipping the two steps when the image is being displayed within an active (not paused) slideshow and the user setting "Use pan and zoom effects" is OFF. Performing these steps in this case leads to the incorrect scaling factors described in issue 21117.

By reading the code, I determined that (m_displayEffect == EFFECT_NONE) during the scale factor calculations if and only if the "pan and zoom" setting is OFF within an active slideshow, which is exactly the case when the calculations with \<blackbarcompensation\> are erroneously applied. Therefore these changes are almost assuredly the textually minimal effective fix.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes xbmc/xbmc#21117

Issue 21117 contains a detailed description of the problem with sample images.

Following is a summary with some new analysis, now that the cause of the problem is known.

When boolean user setting "Use pan and zoom effects" (Player -> Pictures) is OFF, individual images shown within an active full-screen slideshow should be displayed scaled to fit on the screen, the same way as the image is shown when viewed full-screen outside an active slideshow.

Current behavior applies the wrong scaling factor to some images: images with aspect ratios differing from the screen aspect ratio less than 20% are incorrectly upscaled by an amount sufficient to eliminate the display of black bars, cropping up to 25% of the image pixels in the other dimension as a consequence. The advanced setting \<blackbarcompensation\>, which defaults to 20, determines the threshold and the maximum pixel loss. The default value of 20 means the aspect ratio threshold is 20%, and the 25% cropping is derived from 20% like this: 100% is 1**25%** larger than 80% [i.e., 100% - 20%]).

The tunable parameter \<blackbarcompensation\> should influence the image scaling factor *only* when user setting "Use pan and zoom effects" is ON. This commit eliminates the improper influence of <blackbarcompensation> when the setting is OFF. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with a build (Windows x64) against upstream MASTER of about 3/18/2022. Kodi now correctly renders all test images in a slideshow when "Use pan and zoom effects" is OFF, without changing the value of \<blackbarcompensation\>, which correctly continues to apply to slideshows when "pan and zoom" is ON.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
End users will be happy the bug is fixed :)
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X ] I have added tests to cover my change
- [ ] All new and existing tests passed

Notes:

The "Tests to cover my change" are the images attached to issue 21117. I have a couple more cases now that I can and will add, which exercise all the logic in the code (my initial test cases did not include images that require downscaling to fit on the screen). If there's a better way to package and submit these images as part of a test suite, please let me know. The question implies Kodi has a regression test suite, but I don't know anything about it. 

While my changes themselves don't require a change in documentation, the wiki documentation of advanced slideshow settings deserves a few clarifications (they apply only to "pan and zoom" effects , and \<blackbarcompensation\> doesn't always crop the "longer length"). I will submit recommended changes after understanding whether this pull request will be accepted, which will affect documentation (e.g., "prior to version 20, blackbarcompensation was also applied ...".)