### PR TITLE
[subtitles] Align to screen image based subtitles when video source is cropped

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -76,6 +76,7 @@ namespace OVERLAY {
     enum EAlign
     {
       ALIGN_SCREEN,
+      ALIGN_SCREEN_AR,
       ALIGN_VIDEO,
       ALIGN_SUBTITLE
     } m_align;
@@ -91,6 +92,8 @@ namespace OVERLAY {
     float m_y;
     float m_width;
     float m_height;
+    float m_source_width{0}; // Video source width resolution used to calculate aspect ratio
+    float m_source_height{0}; // Video source height resolution used to calculate aspect ratio
   };
 
   class CRenderer : public Observer

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -197,7 +197,7 @@ COverlayImageDX::~COverlayImageDX()
 {
 }
 
-COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
+COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o, CRect& rSource)
 {
   if (o->palette.empty())
   {
@@ -213,17 +213,35 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
     Load(rgba.data(), o->width, o->height, o->width * 4);
   }
 
-  if (o->source_width && o->source_height)
+  if (o->source_width > 0 && o->source_height > 0)
   {
-    float center_x = (0.5f * o->width + o->x) / o->source_width;
-    float center_y = (0.5f * o->height + o->y) / o->source_height;
-
-    m_align = ALIGN_VIDEO;
     m_pos = POSITION_RELATIVE;
-    m_x = center_x;
-    m_y = center_y;
-    m_width = static_cast<float>(o->width) / o->source_width;
-    m_height = static_cast<float>(o->height) / o->source_height;
+    m_x = (0.5f * o->width + o->x) / o->source_width;
+    m_y = (0.5f * o->height + o->y) / o->source_height;
+
+    int videoSourceH{static_cast<int>(rSource.Height())};
+    int videoSourceW{static_cast<int>(rSource.Width())};
+
+    if ((o->source_height == videoSourceH || videoSourceH % o->source_height == 0) &&
+        (o->source_width == videoSourceW || videoSourceW % o->source_width == 0))
+    {
+      // We check also for multiple of source_height/source_width
+      // because for example 1080P subtitles can be used on 4K videos
+      m_align = ALIGN_VIDEO;
+      m_width = static_cast<float>(o->width) / o->source_width;
+      m_height = static_cast<float>(o->height) / o->source_height;
+    }
+    else
+    {
+      // We should have a re-encoded/cropped (removed black bars) video source.
+      // Then we cannot align to video otherwise the subtitles will be deformed
+      // better align to screen by keeping the aspect-ratio.
+      m_align = ALIGN_SCREEN_AR;
+      m_width = static_cast<float>(o->width);
+      m_height = static_cast<float>(o->height);
+      m_source_width = static_cast<float>(o->source_width);
+      m_source_height = static_cast<float>(o->source_height);
+    }
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
@@ -37,7 +37,11 @@ namespace OVERLAY {
     : public COverlay
   {
   public:
-    explicit COverlayImageDX(CDVDOverlayImage* o);
+    /*! \brief Create the overlay for rendering
+     *  \param o The overlay image
+     *  \param rSource The video source rect size
+     */
+    explicit COverlayImageDX(CDVDOverlayImage* o, CRect& rSource);
     explicit COverlayImageDX(CDVDOverlaySpu*   o);
     virtual ~COverlayImageDX();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
@@ -24,8 +24,12 @@ namespace OVERLAY {
   class COverlayTextureGL : public COverlay
   {
   public:
-     explicit COverlayTextureGL(CDVDOverlayImage* o);
-     explicit COverlayTextureGL(CDVDOverlaySpu* o);
+    /*! \brief Create the overlay for rendering
+     *  \param o The overlay image
+     *  \param rSource The video source rect size
+     */
+    explicit COverlayTextureGL(CDVDOverlayImage* o, CRect& rSource);
+    explicit COverlayTextureGL(CDVDOverlaySpu* o);
     ~COverlayTextureGL() override;
 
     void Render(SRenderState& state) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This introduce a different behaviour for scaling/stretching for image based subtitles, that concern cropped video cases only.

Now if a video has been cropped and the subtitles have been created for non-cropped video,
subtitles will be aligned to the screen by keeping the aspect-ratio, instead of align to video that cause to show subtitles distorted/squashed.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Time ago merged PR #20204 (with some revert with #20794) to fix issue #14866,
mainly i have changed the alignment from `ALIGN_SCREEN` to `ALIGN_VIDEO`.
This change allow to show the PGS/Vobsub correctly as happens on VLC/MPV players, respecting the correct positioning and appearance (even when the window is resized).

But (as happens on all other players) this cause a side effect with the videos that has been remuxed and cropped (removed black bars).

When a video is cropped have less height than the original source, if the subtitle images are scaled to the cropped video source (ALIGN_VIDEO) the subtitles will be displayed distorted/squashed, as i example in this issue #21141.

Then instead add another setting i have add a check to compare the subtitle size param to the video source, in this way we can understand if the video has been cropped, and align the subtitles to screen by keeping the aspect ratio `ALIGN_SCREEN_AR`.

This fix #21141 i have tested with the provided video and all my PGS/Vobsub/SUP with success

This partially re-add the code of #20204 to keep aspect ratio, but should not affect bluray menu, because use full resolution for menu. I have tested with a my bluray sample but it do not have a java menu and kodi do not handle it in good way, in any case i do not see regression for this case.

@thexai please can you try with your "Viuda negra" bluray that have java menu?

i will prepare an artifact to allow testing

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
From our FTP folder: samples_new/subtitles/PGS/

**La.dolce.vita.1960.1080p.Criterion.Bluray.DTS.x264.mkv** (cropped video with cropped subtitles resolution, subtitles must be shown inside video not in the black bars and _aligned to the video_)

**PGS_StretchingTest.mkv** (4/3 video and same thing for subtitles, subtitles must be shown with right aspect ratio and _aligned to the video_)

**A Global Journey_cropped.mkv** (this is a cropped video with full 1080p subtitle. With the first sub track : original english, subtitles must be appears with right aspect ratio, _aligned to the screen_)

**Bohemian.Rhapsody.2018.4K.PGS.at.1080.mkv** (this is a full 4K video resolution with full 1080p subtitle, subtitles must be appears _aligned with the video_)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Have a better aspect ratio of subtitles when used with cropped videos,
and so allow to see subtitles with right aspect ratio on ultrawide monitor's

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
