### PR TITLE
[macOS] fix window origin in multiscreen setup

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
+++ b/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
@@ -78,8 +78,10 @@ typedef std::map<eATVClientEvent, CPacketBUTTON*> tEventMap;
 typedef std::map<XBMCClientEventSequence, CPacketBUTTON*> tSequenceMap;
 typedef std::map<std::pair<int, eATVClientEvent>, CPacketBUTTON*> tMultiRemoteMap;
 
-class  XBMCClientWrapperImpl{
-	tEventMap m_event_map;
+struct XBMCClientWrapperImpl
+{
+private:
+  tEventMap m_event_map;
   tSequenceMap m_sequence_map;
   tMultiRemoteMap m_multiremote_map;
   eRemoteMode m_mode;

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -1025,7 +1025,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       {
         if (w == windowedFullScreenwindow)
           continue;
-        [w setFrameOrigin:NSZeroPoint];
+        [w setFrameOrigin:w.screen.frame.origin];
         break;
       }
     });


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- Fixes mouse interaction with Kodi when it's displayed on another screen
- Fixes a warning in code

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#20540 didn't take multiple screens into account, this PR fixes that.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested personally on macOS Big Sur with two screens
- @pkscout tested same change to 19.4 on macOS Monterey with a single screen

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users can interact with Kodi running on another screen using mouse again.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
