### PR TITLE
[Cmake] Add autoconf vars to toolchain

### DIFF
--- a/cmake/modules/FindFstrcmp.cmake
+++ b/cmake/modules/FindFstrcmp.cmake
@@ -18,8 +18,10 @@ if(ENABLE_INTERNAL_FSTRCMP)
 
   SETUP_BUILD_VARS()
 
-  set(PATCH_COMMAND autoreconf -vif)
-  set(CONFIGURE_COMMAND ./configure --prefix ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
+  find_program(AUTORECONF autoreconf REQUIRED)
+
+  set(CONFIGURE_COMMAND ${AUTORECONF} -vif
+                COMMAND ./configure --prefix ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
   set(BUILD_COMMAND make lib/libfstrcmp.la)
   set(BUILD_IN_SOURCE 1)
   set(INSTALL_COMMAND make install-libdir install-include)

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -141,7 +141,22 @@ macro(BUILD_DEP_TARGET)
   endif()
 
   if(CONFIGURE_COMMAND)
-    set(CONFIGURE_COMMAND CONFIGURE_COMMAND ${CONFIGURE_COMMAND})
+    if(NOT CMAKE_ARGS AND DEP_BUILDENV)
+      # DEP_BUILDENV only used for non cmake externalproject_add builds
+      # iterate through CONFIGURE_COMMAND looking for multiple COMMAND, we need to
+      # add DEP_BUILDENV for each distinct COMMAND
+      set(tmp_config_command ${DEP_BUILDENV})
+      foreach(item ${CONFIGURE_COMMAND})
+        list(APPEND tmp_config_command ${item})
+        if(item STREQUAL "COMMAND")
+          list(APPEND tmp_config_command ${DEP_BUILDENV})
+        endif()
+      endforeach()
+      set(CONFIGURE_COMMAND CONFIGURE_COMMAND ${tmp_config_command})
+      unset(tmp_config_command)
+    else()
+      set(CONFIGURE_COMMAND CONFIGURE_COMMAND ${CONFIGURE_COMMAND})
+    endif()
   endif()
 
   if(BUILD_COMMAND)

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -62,6 +62,7 @@ set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_C_COMPILER @CC@)
 set(CMAKE_CXX_COMPILER @CXX@)
 set(CMAKE_AR @AR@ CACHE FILEPATH "Archiver")
+SET(CMAKE_AS @AS@ CACHE FILEPATH "Assembler")
 set(CMAKE_LINKER @LD@ CACHE FILEPATH "Linker")
 set(CMAKE_NM @NM@ CACHE FILEPATH "Nm")
 set(CMAKE_STRIP @STRIP@ CACHE PATH "strip binary" FORCE)
@@ -118,6 +119,93 @@ set(ENV{PKG_CONFIG_LIBDIR} @prefix@/@deps_dir@/lib/pkgconfig:@prefix@/@deps_dir@
 if(NOT CORE_SYSTEM_NAME STREQUAL linux)
   set(ADDONS_PREFER_STATIC_LIBS ON)
 endif()
+
+# common usage in autoconf to refer to host arch tool use
+set(CC_FOR_BUILD "@CC_FOR_BUILD@")
+set(CXX_FOR_BUILD "@CXX_FOR_BUILD@")
+set(LD_FOR_BUILD "@LD_FOR_BUILD@")
+set(CC_BINARY_FOR_BUILD "@CC_FOR_BUILD@")
+set(CXX_BINARY_FOR_BUILD "@CXX_FOR_BUILD@")
+set(AR_FOR_BUILD "@AR_FOR_BUILD@")
+set(RANLIB_FOR_BUILD "@RANLIB_FOR_BUILD@")
+set(AS_FOR_BUILD "@AS_FOR_BUILD@")
+set(NM_FOR_BUILD "@NM_FOR_BUILD@")
+set(STRIP_FOR_BUILD "@STRIP_FOR_BUILD@")
+set(READELF_FOR_BUILD "@READELF_FOR_BUILD@")
+set(OBJDUMP_FOR_BUILD "@OBJDUMP_FOR_BUILD@")
+
+# flags for host arch building
+set(CFLAGS_FOR_BUILD "@host_includes@ -I@prefix@/@tool_dir@/include")
+set(LDFLAGS_FOR_BUILD "@host_includes@ -L@prefix@/@tool_dir@/lib")
+
+# other build tools
+find_program(NASM nasm HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+
+# common autoconf build tools
+find_program(AUTOCONF autoconf HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(ACLOCAL aclocal HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(AUTOHEADER autoheader HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(AUTOMAKE automake HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(AUTOM4TE autom4te HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(AUTOPOINT autopoint HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(AUTORECONF autoreconf HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(LIBTOOL libtool HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+find_program(LIBTOOLIZE libtoolize HINTS "${NATIVEPREFIX}/bin" REQUIRED)
+
+set(ENV{ACLOCAL_PATH} "${DEPENDS_PATH}/share/aclocal:${NATIVEPREFIX}/share/aclocal")
+set(ENVPATH "${NATIVEPREFIX}/bin:$ENV{PATH}")
+
+# Dependency build tool config files
+find_file(MESON-CROSS "cross-file.meson" PATHS "${DEPENDS_PATH}/share" NO_CMAKE_FIND_ROOT_PATH REQUIRED)
+# autoconf config.site
+find_file(CONFIG_SITE "config.site" PATHS "${DEPENDS_PATH}/share" NO_CMAKE_FIND_ROOT_PATH REQUIRED)
+
+# Env variables for non cmake target environments
+set(PROJECT_TARGETENV "AS=${CMAKE_AS}"
+                      "AR=${CMAKE_AR}"
+                      "CC=${CMAKE_C_COMPILER}"
+                      "CXX=${CMAKE_CXX_COMPILER}"
+                      "NM=${CMAKE_NM}"
+                      "LD=${CMAKE_LINKER}"
+                      "STRIP=${CMAKE_STRIP}"
+                      "RANLIB=${CMAKE_RANLIB}"
+                      "OBJDUMP=${CMAKE_OBJDUMP}"
+                      "CFLAGS=${CMAKE_C_FLAGS}"
+                      "CPPFLAGS=${CMAKE_CPP_FLAGS}"
+                      "LDFLAGS=${CMAKE_EXE_LINKER_FLAGS}"
+                      "PKG_CONFIG_LIBDIR=$ENV{PKG_CONFIG_LIBDIR}"
+                      "AUTOM4TE=${AUTOM4TE}"
+                      "AUTOMAKE=${AUTOMAKE}"
+                      "AUTOCONF=${AUTOCONF}"
+                      "AUTORECONF=${AUTORECONF}"
+                      "ACLOCAL=${ACLOCAL}"
+                      "ACLOCAL_PATH=$ENV{ACLOCAL_PATH}"
+                      "AUTOPOINT=${AUTOPOINT}"
+                      "AUTOHEADER=${AUTOHEADER}"
+                      "LIBTOOL=${LIBTOOL}"
+                      "LIBTOOLIZE=${LIBTOOLIZE}"
+                      "CONFIG_SITE=${CONFIG_SITE}"
+                      )
+
+# Env variables for non cmake host environments
+set(PROJECT_BUILDENV CC_FOR_BUILD=${CC_FOR_BUILD}
+                     CXX_FOR_BUILD=${CXX_FOR_BUILD}
+                     LD_FOR_BUILD=${LD_FOR_BUILD}
+                     CC_BINARY_FOR_BUILD=${CC_FOR_BUILD}
+                     CXX_BINARY_FOR_BUILD=${CXX_FOR_BUILD}
+                     AR_FOR_BUILD=${AR_FOR_BUILD}
+                     RANLIB_FOR_BUILD=${RANLIB_FOR_BUILD}
+                     AS_FOR_BUILD=${AS_FOR_BUILD}
+                     NM_FOR_BUILD=${NM_FOR_BUILD}
+                     STRIP_FOR_BUILD=${STRIP_FOR_BUILD}
+                     READELF_FOR_BUILD=${READELF_FOR_BUILD}
+                     OBJDUMP_FOR_BUILD=${OBJDUMP_FOR_BUILD}
+                     CFLAGS_FOR_BUILD=${CFLAGS_FOR_BUILD}
+                     LDFLAGS_FOR_BUILD=${LDFLAGS_FOR_BUILD}
+                     )
+
+# variable to easily set host/target env for non cmake internal dep builds
+set(DEP_BUILDENV ${CMAKE_COMMAND} -E env ${PROJECT_TARGETENV} ${PROJECT_BUILDENV})
 
 set(KODI_DEPENDSBUILD 1)
 


### PR DESCRIPTION
## Description
Adds autoconf build system tools/vars to Toolchain file for cross compile of Apple/Android platforms

## Motivation and context
Enable the ability to cross compile autoconf based internal deps for Apple/Android platforms
Implementation of fstrcmp as an example of the usage.

Currently fstrcmp will build ok with host==target, however if cross compiling, it will fail.
Our cross compile platforms currently are Android/Apple, and they all use a Toolchain.cmake file.
My question is whether adding this into the Toolchain file is the best way to go, or if it should be moved into the core cmake to enable platforms that dont use a toolchain to potentially set the required variables?
Also open to alternative variable naming re the PROJECT_XXXENV variables and the ~~DEPBUILDENV~~ DEP_BUILDENV variable

~~Unfortunately the DEPBUILDENV may need to be added to each step (CONFIGURE, PATCH, BUILD) depending on whats done. I dont know of a way to easily insert automatically, as a single step may have multiple commands as demonstrated by the fstrcmp CONFIGURE_COMMAND. You can chain commands without using the COMMAND to break them, but i feel the separation the COMMAND usage gives makes things clear. In the fstrcmp example, the env vars are only required for the autoreconf and configure steps of the CONFIGURE_COMMAND.
May be able to do some crazy regex matches to insert, but before going down that route, i figure id see if this is acceptable in general first.~~

## How has this been tested?
Build fstrcmp using -DENABLE_INTERNAL_FSTRCMP=ON for ios/osx platforms

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
