### PR TITLE
[PVR] Fix crash on open of Guide window.

### DIFF
--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -512,7 +512,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetTimeline(
         }
 
         // Append missing tags
-        MergeTags(tags.back()->EndAsUTC(), maxEventStart, tags);
+        MergeTags(tags.empty() ? minEventEnd : tags.back()->EndAsUTC(), maxEventStart, tags);
       }
     }
 


### PR DESCRIPTION
Never call `back()` on an empty `std::vector`. behavior is undefined and actually leads to crashes. Can happen while PVR Guide window is updating.

Fixes fallout from #20966 

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish if you find some time for a review.