### PR TITLE
[Matrix][PVR] Fix crash on open of Guide window.

### DIFF
--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -493,7 +493,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetTimeline(
         }
 
         // Append missing tags
-        MergeTags(tags.back()->EndAsUTC(), maxEventStart, tags);
+        MergeTags(tags.empty() ? minEventEnd : tags.back()->EndAsUTC(), maxEventStart, tags);
       }
     }
 


### PR DESCRIPTION
Never call `back()` on an empty `std::vector`. Behavior is undefined and actually leads to crashes. Can happen while PVR Guide window is updating.

Fixes fallout from #20969

Runtime-tested on macOS, latest Kodi Matrix.

@phunkyfish if you find some time for a review.