### PR TITLE
[backport] CSysfsPath: add std::string specialization declaration in header

### DIFF
--- a/xbmc/platform/linux/SysfsPath.h
+++ b/xbmc/platform/linux/SysfsPath.h
@@ -43,3 +43,6 @@ public:
 private:
   std::string m_path;
 };
+
+template<>
+std::string CSysfsPath::Get<std::string>();


### PR DESCRIPTION
backport of #21170 