### PR TITLE
[Application] Clean uninit of logging component; Extend logging and settings lifetime

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -325,6 +325,8 @@ extern "C" void __stdcall cleanup_emu_environ();
 
 bool CApplication::Create(const CAppParamParser &params)
 {
+  m_bStop = false;
+
   // Grab a handle to our thread to be used later in identifying the render thread.
   m_threadID = CThread::GetCurrentThreadId();
 
@@ -2501,6 +2503,8 @@ bool CApplication::Cleanup()
 
     CServiceBroker::UnregisterJobManager();
     CServiceBroker::UnregisterCPUInfo();
+
+    m_bInitializing = true;
 
     return true;
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2503,11 +2503,13 @@ bool CApplication::Cleanup()
     m_pAnnouncementManager.reset();
 
     CServiceBroker::UnregisterJobManager();
+    CServiceBroker::UnregisterCPUInfo();
 
+    CServiceBroker::GetLogging().UnregisterFromSettings();
     m_pSettingsComponent->Deinit();
     m_pSettingsComponent.reset();
-
-    CServiceBroker::UnregisterCPUInfo();
+    CServiceBroker::GetLogging().Uninitialize();
+    CServiceBroker::DestroyLogging();
 
     return true;
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -334,12 +334,7 @@ bool CApplication::Create(const CAppParamParser &params)
   m_windowing = params.GetWindowing();
   m_logTarget = params.GetLogTarget();
 
-  CServiceBroker::CreateLogging();
-
   CServiceBroker::RegisterCPUInfo(CCPUInfo::GetCPUInfo());
-
-  m_pSettingsComponent.reset(new CSettingsComponent());
-  m_pSettingsComponent->Init(params);
 
   // Register JobManager service
   CServiceBroker::RegisterJobManager(std::make_shared<CJobManager>());
@@ -395,12 +390,13 @@ bool CApplication::Create(const CAppParamParser &params)
   av_log_set_callback(ff_avutil_log);
 
   CLog::Log(LOGINFO, "loading settings");
-  if (!m_pSettingsComponent->Load())
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent->Load())
     return false;
 
   CLog::Log(LOGINFO, "creating subdirectories");
-  const std::shared_ptr<CProfileManager> profileManager = m_pSettingsComponent->GetProfileManager();
-  const std::shared_ptr<CSettings> settings = m_pSettingsComponent->GetSettings();
+  const std::shared_ptr<CProfileManager> profileManager = settingsComponent->GetProfileManager();
+  const std::shared_ptr<CSettings> settings = settingsComponent->GetSettings();
   CLog::Log(LOGINFO, "userdata folder: {}",
             CURL::GetRedacted(profileManager->GetProfileUserDataFolder()));
   CLog::Log(LOGINFO, "recording folder: {}",
@@ -417,7 +413,8 @@ bool CApplication::Create(const CAppParamParser &params)
   m_pAppPort = std::make_shared<CAppInboundProtocol>(*this);
   CServiceBroker::RegisterAppPort(m_pAppPort);
 
-  if (!m_ServiceManager->InitStageTwo(params, m_pSettingsComponent->GetProfileManager()->GetProfileUserDataFolder()))
+  if (!m_ServiceManager->InitStageTwo(
+          params, settingsComponent->GetProfileManager()->GetProfileUserDataFolder()))
   {
     return false;
   }
@@ -445,7 +442,7 @@ bool CApplication::Create(const CAppParamParser &params)
 
   // set user defined CA trust bundle
   std::string caCert =
-      CSpecialProtocol::TranslatePath(m_pSettingsComponent->GetAdvancedSettings()->m_caTrustFile);
+      CSpecialProtocol::TranslatePath(settingsComponent->GetAdvancedSettings()->m_caTrustFile);
   if (!caCert.empty())
   {
     if (XFILE::CFile::Exists(caCert))
@@ -529,7 +526,7 @@ bool CApplication::CreateGUI()
   }
 
   // update the window resolution
-  const std::shared_ptr<CSettings> settings = m_pSettingsComponent->GetSettings();
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   CServiceBroker::GetWinSystem()->SetWindowResolution(settings->GetInt(CSettings::SETTING_WINDOW_WIDTH), settings->GetInt(CSettings::SETTING_WINDOW_HEIGHT));
 
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_startFullScreen && CDisplaySettings::GetInstance().GetCurrentResolution() == RES_WINDOW)
@@ -2504,12 +2501,6 @@ bool CApplication::Cleanup()
 
     CServiceBroker::UnregisterJobManager();
     CServiceBroker::UnregisterCPUInfo();
-
-    CServiceBroker::GetLogging().UnregisterFromSettings();
-    m_pSettingsComponent->Deinit();
-    m_pSettingsComponent.reset();
-    CServiceBroker::GetLogging().Uninitialize();
-    CServiceBroker::DestroyLogging();
 
     return true;
   }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -325,7 +325,6 @@ protected:
   bool NotifyActionListeners(const CAction &action) const;
 
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
-  std::unique_ptr<CSettingsComponent> m_pSettingsComponent;
   std::unique_ptr<CGUIComponent> m_pGUI;
   std::unique_ptr<CWinSystemBase> m_pWinSystem;
   std::unique_ptr<ActiveAE::CActiveAE> m_pActiveAE;

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -42,6 +42,11 @@ void CServiceBroker::CreateLogging()
   g_serviceBroker.m_logging = std::make_unique<CLog>();
 }
 
+void CServiceBroker::DestroyLogging()
+{
+  g_serviceBroker.m_logging.reset();
+}
+
 // announcement
 std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> CServiceBroker::GetAnnouncementManager()
 {

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -23,7 +23,6 @@ CServiceBroker::CServiceBroker() :
     m_pGUI(nullptr),
     m_pWinSystem(nullptr),
     m_pActiveAE(nullptr),
-    m_pSettingsComponent(nullptr),
     m_decoderFilterManager(nullptr)
 {
 }
@@ -133,17 +132,17 @@ PLAYLIST::CPlayListPlayer &CServiceBroker::GetPlaylistPlayer()
   return g_application.m_ServiceManager->GetPlaylistPlayer();
 }
 
-void CServiceBroker::RegisterSettingsComponent(CSettingsComponent *settings)
+void CServiceBroker::RegisterSettingsComponent(const std::shared_ptr<CSettingsComponent>& settings)
 {
   g_serviceBroker.m_pSettingsComponent = settings;
 }
 
 void CServiceBroker::UnregisterSettingsComponent()
 {
-  g_serviceBroker.m_pSettingsComponent = nullptr;
+  g_serviceBroker.m_pSettingsComponent.reset();
 }
 
-CSettingsComponent* CServiceBroker::GetSettingsComponent()
+std::shared_ptr<CSettingsComponent> CServiceBroker::GetSettingsComponent()
 {
   return g_serviceBroker.m_pSettingsComponent;
 }

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -155,9 +155,9 @@ public:
   static void RegisterGUI(CGUIComponent *gui);
   static void UnregisterGUI();
 
-  static void RegisterSettingsComponent(CSettingsComponent *settings);
+  static void RegisterSettingsComponent(const std::shared_ptr<CSettingsComponent>& settings);
   static void UnregisterSettingsComponent();
-  static CSettingsComponent* GetSettingsComponent();
+  static std::shared_ptr<CSettingsComponent> GetSettingsComponent();
 
   static void RegisterWinSystem(CWinSystemBase *winsystem);
   static void UnregisterWinSystem();
@@ -204,7 +204,7 @@ private:
   CWinSystemBase* m_pWinSystem;
   IAE* m_pActiveAE;
   std::shared_ptr<CAppInboundProtocol> m_pAppPort;
-  CSettingsComponent* m_pSettingsComponent;
+  std::shared_ptr<CSettingsComponent> m_pSettingsComponent;
   CDecoderFilterManager* m_decoderFilterManager;
   std::shared_ptr<CCPUInfo> m_cpuInfo;
   std::shared_ptr<CTextureCache> m_textureCache;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -113,6 +113,7 @@ public:
 
   static CLog& GetLogging();
   static void CreateLogging();
+  static void DestroyLogging();
 
   static std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> GetAnnouncementManager();
   static void RegisterAnnouncementManager(std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> announcementManager);

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -463,7 +463,8 @@ void CXBMCApp::Quit()
   // wait for the run thread to finish
   m_thread.join();
 
-  CLog::Log(LOGINFO, "XBMCApp: Application stopped!");
+  // Note: CLog no longer available here.
+  android_printf("%s: Application stopped!", __PRETTY_FUNCTION__);
 }
 
 bool CXBMCApp::EnableWakeLock(bool on)

--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -34,7 +34,7 @@ namespace
 CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
   m_libInputHandler(handler)
 {
-  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
   if (!settingsComponent)
     return;
 
@@ -134,7 +134,7 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
 
 CLibInputSettings::~CLibInputSettings()
 {
-  CSettingsComponent *settingsComponent = CServiceBroker::GetSettingsComponent();
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
   if (!settingsComponent)
     return;
 

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -39,10 +39,9 @@ CSettingsComponent::CSettingsComponent()
 
 CSettingsComponent::~CSettingsComponent()
 {
-  Deinit();
 }
 
-void CSettingsComponent::Init(const CAppParamParser &params)
+void CSettingsComponent::Initialize(const CAppParamParser& params)
 {
   if (m_state == State::DEINITED)
   {
@@ -59,8 +58,6 @@ void CSettingsComponent::Init(const CAppParamParser &params)
     URIUtils::RegisterAdvancedSettings(*m_advancedSettings);
 
     m_profileManager->Initialize(m_settings);
-
-    CServiceBroker::RegisterSettingsComponent(this);
 
     m_state = State::INITED;
   }
@@ -100,12 +97,10 @@ bool CSettingsComponent::Load()
   }
 }
 
-void CSettingsComponent::Deinit()
+void CSettingsComponent::Deinitialize()
 {
   if (m_state >= State::INITED)
   {
-    CServiceBroker::UnregisterSettingsComponent();
-
     if (m_state == State::LOADED)
     {
       m_settings->Unload();

--- a/xbmc/settings/SettingsComponent.h
+++ b/xbmc/settings/SettingsComponent.h
@@ -25,7 +25,7 @@ public:
    * @brief Initialize all subcomponents with system default values (loaded from code, system settings files, ...).
    * @param params The command line params passed to the app.
    */
-  void Init(const CAppParamParser &params);
+  void Initialize(const CAppParamParser& params);
 
   /*!
    * @brief Initialize all subcomponents with user values (loaded from user settings files, according to active profile).
@@ -36,7 +36,7 @@ public:
   /*!
    * @brief Deinitialize all subcomponents.
    */
-  void Deinit();
+  void Deinitialize();
 
   /*!
    * @brief Get access to the settings subcomponent.

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -44,8 +44,9 @@ void TestBasicEnvironment::SetUp()
 
   CServiceBroker::CreateLogging();
 
-  m_pSettingsComponent.reset(new CSettingsComponent());
-  m_pSettingsComponent->Init(params);
+  const auto settingsComponent = std::make_shared<CSettingsComponent>();
+  settingsComponent->Initialize(params);
+  CServiceBroker::RegisterSettingsComponent(settingsComponent);
 
   CServiceBroker::RegisterAppMessenger(std::make_shared<KODI::MESSAGING::CApplicationMessenger>());
 
@@ -100,8 +101,8 @@ void TestBasicEnvironment::SetUp()
   }
 
   const CProfile profile("special://temp");
-  m_pSettingsComponent->GetProfileManager()->AddProfile(profile);
-  m_pSettingsComponent->GetProfileManager()->CreateProfileFolders();
+  CServiceBroker::GetSettingsComponent()->GetProfileManager()->AddProfile(profile);
+  CServiceBroker::GetSettingsComponent()->GetProfileManager()->CreateProfileFolders();
 
   if (!g_application.m_ServiceManager->InitForTesting())
     exit(1);
@@ -116,8 +117,8 @@ void TestBasicEnvironment::TearDown()
   CServiceBroker::UnregisterAppMessenger();
 
   CServiceBroker::GetLogging().UnregisterFromSettings();
-  m_pSettingsComponent->Deinit();
-  m_pSettingsComponent.reset();
+  CServiceBroker::GetSettingsComponent()->Deinitialize();
+  CServiceBroker::UnregisterSettingsComponent();
   CServiceBroker::GetLogging().Uninitialize();
   CServiceBroker::DestroyLogging();
 }

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -21,6 +21,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/log.h"
 #include "windowing/WinSystem.h"
 
 #ifdef TARGET_DARWIN
@@ -112,10 +113,13 @@ void TestBasicEnvironment::TearDown()
 
   g_application.m_ServiceManager->DeinitTesting();
 
+  CServiceBroker::UnregisterAppMessenger();
+
+  CServiceBroker::GetLogging().UnregisterFromSettings();
   m_pSettingsComponent->Deinit();
   m_pSettingsComponent.reset();
-
-  CServiceBroker::UnregisterAppMessenger();
+  CServiceBroker::GetLogging().Uninitialize();
+  CServiceBroker::DestroyLogging();
 }
 
 void TestBasicEnvironment::SetUpError()

--- a/xbmc/test/TestBasicEnvironment.h
+++ b/xbmc/test/TestBasicEnvironment.h
@@ -8,13 +8,9 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include <gtest/gtest.h>
-
-class CSettings;
-class CSettingsComponent;
 
 class TestBasicEnvironment : public testing::Environment
 {
@@ -26,5 +22,4 @@ public:
 private:
   void SetUpError();
   std::string m_tempPath;
-  std::unique_ptr<CSettingsComponent> m_pSettingsComponent;
 };

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -37,7 +37,7 @@ public:
 AdvancedSettingsResetBase::AdvancedSettingsResetBase()
 {
   // Force all advanced settings to be reset to defaults
-  CSettingsComponent* settings = CServiceBroker::GetSettingsComponent();
+  const auto settings = CServiceBroker::GetSettingsComponent();
   CSettingsManager* settingsMgr = settings->GetSettings()->GetSettingsManager();
   settings->GetAdvancedSettings()->Uninitialize(*settingsMgr);
   settings->GetAdvancedSettings()->Initialize(CAppParamParser(), *settingsMgr);

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -57,6 +57,11 @@ CLog::CLog()
   SetLogLevel(m_logLevel);
 }
 
+CLog::~CLog()
+{
+  spdlog::drop("general");
+}
+
 void CLog::OnSettingsLoaded()
 {
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -127,17 +132,20 @@ void CLog::Initialize(const std::string& path)
   m_sinks->add_sink(m_fileSink);
 }
 
-void CLog::Uninitialize()
+void CLog::UnregisterFromSettings()
 {
-  if (m_fileSink == nullptr)
-    return;
-
   // unregister setting callbacks
   auto settingsManager =
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetSettingsManager();
   settingsManager->UnregisterSettingOptionsFiller("loggingcomponents");
   settingsManager->UnregisterSettingsHandler(this);
   settingsManager->UnregisterCallback(this);
+}
+
+void CLog::Uninitialize()
+{
+  if (m_fileSink == nullptr)
+    return;
 
   // flush all loggers
   spdlog::apply_all([](const std::shared_ptr<spdlog::logger>& logger) { logger->flush(); });

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -51,7 +51,7 @@ class CLog : public ISettingsHandler, public ISettingCallback
 {
 public:
   CLog();
-  ~CLog() = default;
+  ~CLog();
 
   // implementation of ISettingsHandler
   void OnSettingsLoaded() override;
@@ -60,6 +60,7 @@ public:
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
   void Initialize(const std::string& path);
+  void UnregisterFromSettings();
   void Uninitialize();
 
   void SetLogLevel(int level);

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -39,7 +39,7 @@ CWeatherManager::CWeatherManager(void) : CInfoLoader(30 * 60 * 1000) // 30 minut
 
 CWeatherManager::~CWeatherManager(void)
 {
-  CSettingsComponent *settingsComponent = CServiceBroker::GetSettingsComponent();
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
   if (!settingsComponent)
     return;
 

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -39,7 +39,7 @@ CGLContextEGL::CGLContextEGL(Display *dpy, EGLint renderingApi) : CGLContext(dpy
 
   m_eglGetPlatformDisplayEXT = (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
 
-  CSettingsComponent *settings = CServiceBroker::GetSettingsComponent();
+  const auto settings = CServiceBroker::GetSettingsComponent();
   if (settings)
   {
     m_omlSync = settings->GetAdvancedSettings()->m_omlSync;


### PR DESCRIPTION
I'm currently working on getting rid of this one line of Android specific code: https://github.com/xbmc/xbmc/blob/master/xbmc/platform/android/activity/android_main.cpp#L122-L127, enabling libkodi.so to be reused by Android on subsequent starts of the Kodi Activity, finally having a clean shutdown of the Kodi Activity, without any crash or other strange side effects (currently logcat is full of crashes and warnings - all kind of bad stuff wrt. Kodi). 

```
  // We need to call exit() so that all loaded libraries are properly unloaded
  // otherwise on the next start of the Activity android will simply re-use
  // those loaded libs in the state they were in when we quit Kodi last time
  // which will lead to crashes because of global/static classes that haven't
  // been properly uninitialized
  exit(0);
 ```
 
 To achieve this, Kodi needs to uninit its globals and services properly on exit of the app. 
 
 We're always there as I already brought in couple of PRs heading into this direction; I have it already running for quite some time here and there are now only view code changes to master needed for this, which I will bring in step by step.
 
 This PR adds 
 * clean uninit of the logging component
 * extended lifetime of the settings and logging component (logging needs settings).
 * proper init/reinit of the two relevent status members of the `CApplication` global singleton (`m_bInitializing`and `m_bStop`).
  
 BTW: Although the final goal is an improvement for Kodi on Android, nearly all required code changes are platform-agnostic, making Kodi init/uninit sequence cleaner for all platforms.
 
 I carefully tested this on Android and macOS, no regressions found so far.