### PR TITLE
[GUI] Fix crash when resuming from contextmenu +  close contextmenu on playback started

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -81,6 +81,12 @@ bool CGUIDialogContextMenu::OnMessage(CGUIMessage &message)
     Close();
     return true;
   }
+  else if (message.GetMessage() == GUI_MSG_PLAYBACK_AVSTARTED)
+  {
+    // playback was just started from elsewhere - close the dialog
+    Close();
+    return true;
+  }
   return CGUIDialog::OnMessage(message);
 }
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -644,6 +644,10 @@ bool CGUIWindowVideoBase::OnSelect(int iItem)
 bool CGUIWindowVideoBase::OnFileAction(int iItem, int action, const std::string& player)
 {
   CFileItemPtr item = m_vecItems->Get(iItem);
+  if (!item)
+  {
+    return false;
+  }
 
   // Reset the current start offset. The actual resume
   // option is set in the switch, based on the action passed.


### PR DESCRIPTION
## Description
When clicking on a fileitem via the GUI which has a resume point the context menu with the option to resume or start from the beginning is shown. At that point in time if file is queued/sent for playback from elsewhere (e.g. json) the item to which the context menu referred to is no longer valid. Kodi crashes due to the missing nullptr check in `CGUIWindowVideoBase::OnFileAction`. This commit will need to be backported.

The PR goes a step further and ensures the dialog is also closed automatically when the playback is started as I don't think it will make much sense to leave the context menu opened on top of the video osd.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21127

## How has this been tested?
Runtime tested on Linux
