### PR TITLE
[cmake] FindCrossguid fixes

### DIFF
--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -20,7 +20,7 @@ if(ENABLE_INTERNAL_CROSSGUID)
 
   # Temp: We force CMAKE_BUILD_TYPE to release, and makefile builds respect this
   # Multi config generators (eg VS, Xcode) dont, so handle debug postfix build/link for them only
-  if(NOT CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+  if(NOT CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR NOT CMAKE_GENERATOR STREQUAL "Ninja")
     set(CROSSGUID_DEBUG_POSTFIX "-dgb")
   endif()
 
@@ -50,18 +50,23 @@ if(ENABLE_INTERNAL_CROSSGUID)
 
 else()
   if(PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_CROSSGUID crossguid REQUIRED QUIET)
+    pkg_check_modules(PC_CROSSGUID crossguid QUIET)
     set(CROSSGUID_VERSION ${PC_CROSSGUID_VERSION})
   endif()
 
-  find_path(CROSSGUID_INCLUDE_DIR NAMES crossguid/guid.hpp guid.h
-                                  PATHS ${PC_CROSSGUID_INCLUDEDIR})
+  if(CROSSGUID_FOUND)
+    find_path(CROSSGUID_INCLUDE_DIR NAMES crossguid/guid.hpp guid.h
+    PATHS ${PC_CROSSGUID_INCLUDEDIR})
 
-  find_library(CROSSGUID_LIBRARY_RELEASE NAMES crossguid
-                                         PATHS ${PC_CROSSGUID_LIBDIR})
-  find_library(CROSSGUID_LIBRARY_DEBUG NAMES crossguidd crossguid-dgb
-                                       PATHS ${PC_CROSSGUID_LIBDIR})
-
+    find_library(CROSSGUID_LIBRARY_RELEASE NAMES crossguid
+            PATHS ${PC_CROSSGUID_LIBDIR})
+    find_library(CROSSGUID_LIBRARY_DEBUG NAMES crossguidd crossguid-dgb
+          PATHS ${PC_CROSSGUID_LIBDIR})
+  else()
+    find_path(CROSSGUID_INCLUDE_DIR NAMES crossguid/guid.hpp guid.h)
+    find_library(CROSSGUID_LIBRARY_RELEASE NAMES crossguid)
+    find_library(CROSSGUID_LIBRARY_DEBUG NAMES crossguidd)
+  endif()
 endif()
 
 # Select relevant lib build type (ie CROSSGUID_LIBRARY_RELEASE or CROSSGUID_LIBRARY_DEBUG)

--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -20,7 +20,7 @@ if(ENABLE_INTERNAL_CROSSGUID)
 
   # Temp: We force CMAKE_BUILD_TYPE to release, and makefile builds respect this
   # Multi config generators (eg VS, Xcode) dont, so handle debug postfix build/link for them only
-  if(NOT CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR NOT CMAKE_GENERATOR STREQUAL "Ninja")
+  if(NOT (CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL "Ninja"))
     set(CROSSGUID_DEBUG_POSTFIX "-dgb")
   endif()
 


### PR DESCRIPTION
## Description
Some fallout after #20982 

## Motivation and context
Fix some issues raised

## How has this been tested?
-DENABLE_INTERNAL_CROSSGUID=OFF on a fedora 34 with crossguid-devel package installed

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
