### PR TITLE
Fix clang formatting for RetroPlayer, Games, Input, Peripherals

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -18,12 +18,8 @@
 
 using namespace KODI;
 
-
-CServiceBroker::CServiceBroker() :
-    m_pGUI(nullptr),
-    m_pWinSystem(nullptr),
-    m_pActiveAE(nullptr),
-    m_decoderFilterManager(nullptr)
+CServiceBroker::CServiceBroker()
+  : m_pGUI(nullptr), m_pWinSystem(nullptr), m_pActiveAE(nullptr), m_decoderFilterManager(nullptr)
 {
 }
 
@@ -51,7 +47,8 @@ std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> CServiceBroker::GetAnnouncem
 {
   return g_serviceBroker.m_pAnnouncementManager;
 }
-void CServiceBroker::RegisterAnnouncementManager(std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> port)
+void CServiceBroker::RegisterAnnouncementManager(
+    std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> port)
 {
   g_serviceBroker.m_pAnnouncementManager = std::move(port);
 }
@@ -61,17 +58,17 @@ void CServiceBroker::UnregisterAnnouncementManager()
   g_serviceBroker.m_pAnnouncementManager.reset();
 }
 
-ADDON::CAddonMgr &CServiceBroker::GetAddonMgr()
+ADDON::CAddonMgr& CServiceBroker::GetAddonMgr()
 {
   return g_application.m_ServiceManager->GetAddonMgr();
 }
 
-ADDON::CBinaryAddonManager &CServiceBroker::GetBinaryAddonManager()
+ADDON::CBinaryAddonManager& CServiceBroker::GetBinaryAddonManager()
 {
   return g_application.m_ServiceManager->GetBinaryAddonManager();
 }
 
-ADDON::CBinaryAddonCache &CServiceBroker::GetBinaryAddonCache()
+ADDON::CBinaryAddonCache& CServiceBroker::GetBinaryAddonCache()
 {
   return g_application.m_ServiceManager->GetBinaryAddonCache();
 }
@@ -81,7 +78,7 @@ ADDONS::CExtsMimeSupportList& CServiceBroker::GetExtsMimeSupportList()
   return g_application.m_ServiceManager->GetExtsMimeSupportList();
 }
 
-ADDON::CVFSAddonCache &CServiceBroker::GetVFSAddonCache()
+ADDON::CVFSAddonCache& CServiceBroker::GetVFSAddonCache()
 {
   return g_application.m_ServiceManager->GetVFSAddonCache();
 }
@@ -107,7 +104,7 @@ MEDIA_DETECT::CDetectDVDMedia& CServiceBroker::GetDetectDVDMedia()
 }
 #endif
 
-PVR::CPVRManager &CServiceBroker::GetPVRManager()
+PVR::CPVRManager& CServiceBroker::GetPVRManager()
 {
   return g_application.m_ServiceManager->GetPVRManager();
 }
@@ -117,7 +114,7 @@ CContextMenuManager& CServiceBroker::GetContextMenuManager()
   return g_application.m_ServiceManager->GetContextMenuManager();
 }
 
-CDataCacheCore &CServiceBroker::GetDataCacheCore()
+CDataCacheCore& CServiceBroker::GetDataCacheCore()
 {
   return g_application.m_ServiceManager->GetDataCacheCore();
 }
@@ -127,7 +124,7 @@ CPlatform& CServiceBroker::GetPlatform()
   return g_application.m_ServiceManager->GetPlatform();
 }
 
-PLAYLIST::CPlayListPlayer &CServiceBroker::GetPlaylistPlayer()
+PLAYLIST::CPlayListPlayer& CServiceBroker::GetPlaylistPlayer()
 {
   return g_application.m_ServiceManager->GetPlaylistPlayer();
 }
@@ -199,14 +196,12 @@ CNetworkBase& CServiceBroker::GetNetwork()
 
 bool CServiceBroker::IsBinaryAddonCacheUp()
 {
-  return g_application.m_ServiceManager &&
-         g_application.m_ServiceManager->init_level > 1;
+  return g_application.m_ServiceManager && g_application.m_ServiceManager->init_level > 1;
 }
 
 bool CServiceBroker::IsServiceManagerUp()
 {
-  return g_application.m_ServiceManager &&
-         g_application.m_ServiceManager->init_level == 3;
+  return g_application.m_ServiceManager && g_application.m_ServiceManager->init_level == 3;
 }
 
 CWinSystemBase* CServiceBroker::GetWinSystem()
@@ -214,7 +209,7 @@ CWinSystemBase* CServiceBroker::GetWinSystem()
   return g_serviceBroker.m_pWinSystem;
 }
 
-void CServiceBroker::RegisterWinSystem(CWinSystemBase *winsystem)
+void CServiceBroker::RegisterWinSystem(CWinSystemBase* winsystem)
 {
   g_serviceBroker.m_pWinSystem = winsystem;
 }
@@ -274,7 +269,7 @@ CGUIComponent* CServiceBroker::GetGUI()
   return g_serviceBroker.m_pGUI;
 }
 
-void CServiceBroker::RegisterGUI(CGUIComponent *gui)
+void CServiceBroker::RegisterGUI(CGUIComponent* gui)
 {
   g_serviceBroker.m_pGUI = gui;
 }
@@ -289,7 +284,7 @@ IAE* CServiceBroker::GetActiveAE()
 {
   return g_serviceBroker.m_pActiveAE;
 }
-void CServiceBroker::RegisterAE(IAE *ae)
+void CServiceBroker::RegisterAE(IAE* ae)
 {
   g_serviceBroker.m_pActiveAE = ae;
 }

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -12,18 +12,19 @@
 
 #include <memory>
 
-namespace ADDON {
+namespace ADDON
+{
 class CAddonMgr;
 class CBinaryAddonManager;
 class CBinaryAddonCache;
 class CVFSAddonCache;
 class CServiceAddonManager;
 class CRepositoryUpdater;
-}
+} // namespace ADDON
 
 namespace ANNOUNCEMENT
 {
-  class CAnnouncementManager;
+class CAnnouncementManager;
 }
 
 namespace MEDIA_DETECT
@@ -33,12 +34,12 @@ class CDetectDVDMedia;
 
 namespace PVR
 {
-  class CPVRManager;
+class CPVRManager;
 }
 
 namespace PLAYLIST
 {
-  class CPlayListPlayer;
+class CPlayListPlayer;
 }
 
 namespace KODI
@@ -90,19 +91,19 @@ class CExtsMimeSupportList;
 
 namespace GAME
 {
-  class CControllerManager;
-  class CGameServices;
-}
+class CControllerManager;
+class CGameServices;
+} // namespace GAME
 
 namespace RETRO
 {
-  class CGUIGameRenderManager;
+class CGUIGameRenderManager;
 }
-}
+} // namespace KODI
 
 namespace PERIPHERALS
 {
-  class CPeripherals;
+class CPeripherals;
 }
 
 class CServiceBroker
@@ -116,18 +117,19 @@ public:
   static void DestroyLogging();
 
   static std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> GetAnnouncementManager();
-  static void RegisterAnnouncementManager(std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> announcementManager);
+  static void RegisterAnnouncementManager(
+      std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> announcementManager);
   static void UnregisterAnnouncementManager();
 
-  static ADDON::CAddonMgr &GetAddonMgr();
-  static ADDON::CBinaryAddonManager &GetBinaryAddonManager();
-  static ADDON::CBinaryAddonCache &GetBinaryAddonCache();
+  static ADDON::CAddonMgr& GetAddonMgr();
+  static ADDON::CBinaryAddonManager& GetBinaryAddonManager();
+  static ADDON::CBinaryAddonCache& GetBinaryAddonCache();
   static KODI::ADDONS::CExtsMimeSupportList& GetExtsMimeSupportList();
-  static ADDON::CVFSAddonCache &GetVFSAddonCache();
-  static XBPython &GetXBPython();
+  static ADDON::CVFSAddonCache& GetVFSAddonCache();
+  static XBPython& GetXBPython();
   static WSDiscovery::IWSDiscovery& GetWSDiscovery();
   static MEDIA_DETECT::CDetectDVDMedia& GetDetectDVDMedia();
-  static PVR::CPVRManager &GetPVRManager();
+  static PVR::CPVRManager& GetPVRManager();
   static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();
   static CPlatform& GetPlatform();
@@ -140,32 +142,32 @@ public:
   static ADDON::CServiceAddonManager& GetServiceAddons();
   static ADDON::CRepositoryUpdater& GetRepositoryUpdater();
   static CInputManager& GetInputManager();
-  static CFileExtensionProvider &GetFileExtensionProvider();
+  static CFileExtensionProvider& GetFileExtensionProvider();
   static bool IsBinaryAddonCacheUp();
   static bool IsServiceManagerUp();
   static CNetworkBase& GetNetwork();
   static CPowerManager& GetPowerManager();
   static CWeatherManager& GetWeatherManager();
-  static CPlayerCoreFactory &GetPlayerCoreFactory();
-  static CDatabaseManager &GetDatabaseManager();
+  static CPlayerCoreFactory& GetPlayerCoreFactory();
+  static CDatabaseManager& GetDatabaseManager();
   static CEventLog* GetEventLog();
   static CMediaManager& GetMediaManager();
 
   static CGUIComponent* GetGUI();
-  static void RegisterGUI(CGUIComponent *gui);
+  static void RegisterGUI(CGUIComponent* gui);
   static void UnregisterGUI();
 
   static void RegisterSettingsComponent(const std::shared_ptr<CSettingsComponent>& settings);
   static void UnregisterSettingsComponent();
   static std::shared_ptr<CSettingsComponent> GetSettingsComponent();
 
-  static void RegisterWinSystem(CWinSystemBase *winsystem);
+  static void RegisterWinSystem(CWinSystemBase* winsystem);
   static void UnregisterWinSystem();
   static CWinSystemBase* GetWinSystem();
   static CRenderSystemBase* GetRenderSystem();
 
   static IAE* GetActiveAE();
-  static void RegisterAE(IAE *ae);
+  static void RegisterAE(IAE* ae);
   static void UnregisterAE();
 
   static std::shared_ptr<CAppInboundProtocol> GetAppPort();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -101,7 +101,8 @@ bool CServiceManager::InitStageOne()
 
 #ifdef HAS_PYTHON
   m_XBPython.reset(new XBPython());
-  CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(m_XBPython.get(), ".py");
+  CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(m_XBPython.get(),
+                                                                            ".py");
 #endif
 
   m_playlistPlayer.reset(new PLAYLIST::CPlayListPlayer());
@@ -112,12 +113,15 @@ bool CServiceManager::InitStageOne()
   return true;
 }
 
-bool CServiceManager::InitStageTwo(const CAppParamParser &params, const std::string& profilesUserDataFolder)
+bool CServiceManager::InitStageTwo(const CAppParamParser& params,
+                                   const std::string& profilesUserDataFolder)
 {
   // Initialize the addon database (must be before the addon manager is init'd)
   m_databaseManager.reset(new CDatabaseManager);
 
-  m_binaryAddonManager.reset(new ADDON::CBinaryAddonManager()); /* Need to constructed before, GetRunningInstance() of binary CAddonDll need to call them */
+  m_binaryAddonManager.reset(
+      new ADDON::
+          CBinaryAddonManager()); /* Need to constructed before, GetRunningInstance() of binary CAddonDll need to call them */
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
@@ -136,7 +140,7 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params, const std::str
 
   m_dataCacheCore.reset(new CDataCacheCore());
 
-  m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
+  m_binaryAddonCache.reset(new ADDON::CBinaryAddonCache());
   m_binaryAddonCache->Init();
 
   m_favouritesService.reset(new CFavouritesService(profilesUserDataFolder));
@@ -149,8 +153,7 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params, const std::str
   m_inputManager.reset(new CInputManager(params));
   m_inputManager->InitializeInputs();
 
-  m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_inputManager,
-                                                    *m_gameControllerManager));
+  m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_inputManager, *m_gameControllerManager));
 
   m_gameRenderManager.reset(new RETRO::CGUIGameRenderManager);
 
@@ -189,10 +192,8 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
   // Peripherals depends on strings being loaded before stage 3
   m_peripherals->Initialise();
 
-  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager,
-    *m_gameRenderManager,
-    *m_peripherals,
-    *profileManager));
+  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager, *m_gameRenderManager,
+                                               *m_peripherals, *profileManager));
 
   m_contextMenuManager->Init();
 
@@ -275,7 +276,7 @@ WSDiscovery::IWSDiscovery& CServiceManager::GetWSDiscovery()
 }
 #endif
 
-ADDON::CAddonMgr &CServiceManager::GetAddonMgr()
+ADDON::CAddonMgr& CServiceManager::GetAddonMgr()
 {
   return *m_addonMgr;
 }
@@ -285,27 +286,27 @@ ADDONS::CExtsMimeSupportList& CServiceManager::GetExtsMimeSupportList()
   return *m_extsMimeSupportList;
 }
 
-ADDON::CBinaryAddonCache &CServiceManager::GetBinaryAddonCache()
+ADDON::CBinaryAddonCache& CServiceManager::GetBinaryAddonCache()
 {
   return *m_binaryAddonCache;
 }
 
-ADDON::CBinaryAddonManager &CServiceManager::GetBinaryAddonManager()
+ADDON::CBinaryAddonManager& CServiceManager::GetBinaryAddonManager()
 {
   return *m_binaryAddonManager;
 }
 
-ADDON::CVFSAddonCache &CServiceManager::GetVFSAddonCache()
+ADDON::CVFSAddonCache& CServiceManager::GetVFSAddonCache()
 {
   return *m_vfsAddonCache;
 }
 
-ADDON::CServiceAddonManager &CServiceManager::GetServiceAddons()
+ADDON::CServiceAddonManager& CServiceManager::GetServiceAddons()
 {
   return *m_serviceAddons;
 }
 
-ADDON::CRepositoryUpdater &CServiceManager::GetRepositoryUpdater()
+ADDON::CRepositoryUpdater& CServiceManager::GetRepositoryUpdater()
 {
   return *m_repositoryUpdater;
 }
@@ -384,23 +385,23 @@ CFileExtensionProvider& CServiceManager::GetFileExtensionProvider()
   return *m_fileExtensionProvider;
 }
 
-CPowerManager &CServiceManager::GetPowerManager()
+CPowerManager& CServiceManager::GetPowerManager()
 {
   return *m_powerManager;
 }
 
 // deleters for unique_ptr
-void CServiceManager::delete_dataCacheCore::operator()(CDataCacheCore *p) const
+void CServiceManager::delete_dataCacheCore::operator()(CDataCacheCore* p) const
 {
   delete p;
 }
 
-void CServiceManager::delete_contextMenuManager::operator()(CContextMenuManager *p) const
+void CServiceManager::delete_contextMenuManager::operator()(CContextMenuManager* p) const
 {
   delete p;
 }
 
-void CServiceManager::delete_favouritesService::operator()(CFavouritesService *p) const
+void CServiceManager::delete_favouritesService::operator()(CFavouritesService* p) const
 {
   delete p;
 }
@@ -415,12 +416,12 @@ CWeatherManager& CServiceManager::GetWeatherManager()
   return *m_weatherManager;
 }
 
-CPlayerCoreFactory &CServiceManager::GetPlayerCoreFactory()
+CPlayerCoreFactory& CServiceManager::GetPlayerCoreFactory()
 {
   return *m_playerCoreFactory;
 }
 
-CDatabaseManager &CServiceManager::GetDatabaseManager()
+CDatabaseManager& CServiceManager::GetDatabaseManager()
 {
   return *m_databaseManager;
 }

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -16,22 +16,22 @@ class CAppParamParser;
 
 namespace ADDON
 {
-  class CAddonMgr;
-  class CBinaryAddonManager;
-  class CBinaryAddonCache;
-  class CVFSAddonCache;
-  class CServiceAddonManager;
-  class CRepositoryUpdater;
-}
+class CAddonMgr;
+class CBinaryAddonManager;
+class CBinaryAddonCache;
+class CVFSAddonCache;
+class CServiceAddonManager;
+class CRepositoryUpdater;
+} // namespace ADDON
 
 namespace PVR
 {
-  class CPVRManager;
+class CPVRManager;
 }
 
 namespace PLAYLIST
 {
-  class CPlayListPlayer;
+class CPlayListPlayer;
 }
 
 class CContextMenuManager;
@@ -60,15 +60,15 @@ class CExtsMimeSupportList;
 
 namespace GAME
 {
-  class CControllerManager;
-  class CGameServices;
-}
+class CControllerManager;
+class CGameServices;
+} // namespace GAME
 
 namespace RETRO
 {
-  class CGUIGameRenderManager;
+class CGUIGameRenderManager;
 }
-}
+} // namespace KODI
 
 namespace MEDIA_DETECT
 {
@@ -77,7 +77,7 @@ class CDetectDVDMedia;
 
 namespace PERIPHERALS
 {
-  class CPeripherals;
+class CPeripherals;
 }
 
 class CInputManager;
@@ -96,7 +96,7 @@ public:
 
   bool InitForTesting();
   bool InitStageOne();
-  bool InitStageTwo(const CAppParamParser &params, const std::string& profilesUserDataFolder);
+  bool InitStageTwo(const CAppParamParser& params, const std::string& profilesUserDataFolder);
   bool InitStageThree(const std::shared_ptr<CProfileManager>& profileManager);
   void DeinitTesting();
   void DeinitStageThree();
@@ -132,16 +132,16 @@ public:
   int init_level = 0;
 
   CFavouritesService& GetFavouritesService();
-  CInputManager &GetInputManager();
-  CFileExtensionProvider &GetFileExtensionProvider();
+  CInputManager& GetInputManager();
+  CFileExtensionProvider& GetFileExtensionProvider();
 
-  CPowerManager &GetPowerManager();
+  CPowerManager& GetPowerManager();
 
-  CWeatherManager &GetWeatherManager();
+  CWeatherManager& GetWeatherManager();
 
-  CPlayerCoreFactory &GetPlayerCoreFactory();
+  CPlayerCoreFactory& GetPlayerCoreFactory();
 
-  CDatabaseManager &GetDatabaseManager();
+  CDatabaseManager& GetDatabaseManager();
 
   CMediaManager& GetMediaManager();
 
@@ -152,17 +152,17 @@ public:
 protected:
   struct delete_dataCacheCore
   {
-    void operator()(CDataCacheCore *p) const;
+    void operator()(CDataCacheCore* p) const;
   };
 
   struct delete_contextMenuManager
   {
-    void operator()(CContextMenuManager *p) const;
+    void operator()(CContextMenuManager* p) const;
   };
 
   struct delete_favouritesService
   {
-    void operator()(CFavouritesService *p) const;
+    void operator()(CFavouritesService* p) const;
   };
 
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
@@ -13,7 +13,6 @@
 using namespace KODI;
 using namespace RETRO;
 
-
 CRenderBufferOpenGL::CRenderBufferOpenGL(GLuint pixeltype,
                                          GLuint internalformat,
                                          GLuint pixelformat,

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.cpp
@@ -28,7 +28,6 @@ bool CRenderBufferPoolDMA::IsCompatible(const CRenderVideoSettings& renderSettin
   return true;
 }
 
-
 IRenderBuffer* CRenderBufferPoolDMA::CreateRenderBuffer(void* header /* = nullptr */)
 {
   return new CRenderBufferDMA(m_context, m_fourcc);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -275,7 +275,6 @@ void CRPRenderManager::CheckFlush()
 
     m_processInfo.GetBufferManager().FlushPools();
 
-
     m_bFlush = false;
   }
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -76,7 +76,6 @@ bool CRetroPlayerAudio::OpenStream(const StreamProperties& properties)
   if (m_pAudioStream != nullptr)
     CloseStream();
 
-
   IAE* audioEngine = CServiceBroker::GetActiveAE();
   if (audioEngine == nullptr)
     return false;

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -587,7 +587,6 @@ void CGameClient::LogException(const char* strFunctionName) const
   CLog::Log(LOGERROR, "Please contact the developer of this add-on: {}", Author());
 }
 
-
 void CGameClient::cb_close_game(KODI_HANDLE kodiInstance)
 {
   using namespace MESSAGING;

--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -89,7 +89,6 @@ bool CGameClientJoystick::OnButtonMotion(const std::string& feature,
   event.feature_name = feature.c_str();
   event.analog_button.magnitude = magnitude;
 
-
   return m_gameClient.Input().InputEvent(event);
 }
 

--- a/xbmc/games/addons/input/GameClientMouse.cpp
+++ b/xbmc/games/addons/input/GameClientMouse.cpp
@@ -58,7 +58,6 @@ bool CGameClientMouse::OnMotion(const std::string& relpointer, int dx, int dy)
   event.rel_pointer.x = dx;
   event.rel_pointer.y = dy;
 
-
   return m_gameClient.Input().InputEvent(event);
 }
 
@@ -79,7 +78,6 @@ bool CGameClientMouse::OnButtonPress(const std::string& button)
   event.feature_name = button.c_str();
   event.digital_button.pressed = true;
 
-
   return m_gameClient.Input().InputEvent(event);
 }
 
@@ -93,7 +91,6 @@ void CGameClientMouse::OnButtonRelease(const std::string& button)
   event.port_address = ""; // Not used
   event.feature_name = button.c_str();
   event.digital_button.pressed = false;
-
 
   m_gameClient.Input().InputEvent(event);
 }

--- a/xbmc/input/InertialScrollingHandler.cpp
+++ b/xbmc/input/InertialScrollingHandler.cpp
@@ -6,7 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-
 #include "InertialScrollingHandler.h"
 
 #include "Application.h"

--- a/xbmc/input/Key.cpp
+++ b/xbmc/input/Key.cpp
@@ -133,7 +133,6 @@ float CKey::GetLeftThumbY() const
   return m_leftThumbY;
 }
 
-
 float CKey::GetRightThumbX() const
 {
   return m_rightThumbX;

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -185,7 +185,6 @@ static const std::vector<FallbackWindowMapping> FallbackWindows = {
 };
 } // anonymous namespace
 
-
 bool CWindowTranslator::WindowNameCompare::operator()(const WindowMapItem& lhs,
                                                       const WindowMapItem& rhs) const
 {

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -185,7 +185,6 @@ static const XBMCKEYTABLE XBMCKeyTable[] = {
     {XBMCK_FASTFORWARD, 0, 0, XBMCVK_MEDIA_FASTFORWARD, "fastforward"},
     {XBMCK_RECORD, 0, 0, XBMCVK_MEDIA_RECORD, "record"}
 
-
     // Function keys
     ,
     {XBMCK_F1, 0, 0, XBMCVK_F1, "f1"},

--- a/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
@@ -46,7 +46,6 @@ float CGenericTouchInputHandler::AdjustPointerSize(float size)
     return m_dpi / 8.0f;
 }
 
-
 bool CGenericTouchInputHandler::HandleTouchInput(TouchInput event,
                                                  float x,
                                                  float y,

--- a/xbmc/peripherals/addons/AddonInputHandling.cpp
+++ b/xbmc/peripherals/addons/AddonInputHandling.cpp
@@ -160,7 +160,6 @@ void CAddonInputHandling::OnKeyRelease(const CKey& key)
     m_keyboardHandler->OnKeyRelease(key);
 }
 
-
 bool CAddonInputHandling::OnPosition(int x, int y)
 {
   if (m_mouseHandler)

--- a/xbmc/peripherals/devices/PeripheralImon.cpp
+++ b/xbmc/peripherals/devices/PeripheralImon.cpp
@@ -16,7 +16,6 @@ using namespace PERIPHERALS;
 
 std::atomic<long> CPeripheralImon::m_lCountOfImonsConflictWithDInput(0L);
 
-
 CPeripheralImon::CPeripheralImon(CPeripherals& manager,
                                  const PeripheralScanResult& scanResult,
                                  CPeripheralBus* bus)


### PR DESCRIPTION
## Description

As title says, this fixes clang-formatting for some of my codeowner code. Formatting needed updating after https://github.com/xbmc/xbmc/pull/21152 applied a rule limiting consecutive newlines to 1.

EDIT: I also formatted ServiceMonitor/Broker because I touch those a lot when adding new stuff to Kodi.

## Motivation and context

Caused https://github.com/xbmc/xbmc/pull/21182 and https://github.com/xbmc/xbmc/pull/21183 to fail the clang-format check.

## How has this been tested?

Compile-tested. We'll see if Jenkins reports back on and formatting changes needed.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
