### PR TITLE
[Stringutils] android Fix CreateUUID crash after #20982

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1694,7 +1694,12 @@ void StringUtils::WordToDigits(std::string &word)
 std::string StringUtils::CreateUUID()
 {
 #ifdef HAVE_NEW_CROSSGUID
+#ifdef TARGET_ANDROID
+  JNIEnv* env = xbmc_jnienv();
+  return xg::newGuid(env).str();
+#else
   return xg::newGuid().str();
+#endif /* TARGET_ANDROID */
 #else
   static GuidGenerator guidGenerator;
   auto guid = guidGenerator.newGuid();


### PR DESCRIPTION
## Description
newer releases of crossguid use an override of newGuid to handle multi threading
of crossguid lib. provide jnienv to newGUID for android only

## Motivation and context
Bump of crossguid lib causing startup failures in 20220325 [nightly](https://mirrors.kodi.tv/nightlies/android/arm64-v8a/master/kodi-20220325-4734091c-master-22176-arm64-v8a.apk)

@wsnipex if you can test artifact to confirm it works for you as well.

Any preferences in handling this another way, im all ears. Ive gone this way, because i think a rollback of the crossguid lib just pushes the issue down the road for someone else to be blindsided by.

## How has this been tested?
Android 12 on pixel 3a 

## What is the effect on users?
Working build

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
