### PR TITLE
Do not return plain const from `CCompileInfo::GetWebserverExtraWhitelist()`

### DIFF
--- a/xbmc/CompileInfo.cpp.in
+++ b/xbmc/CompileInfo.cpp.in
@@ -112,7 +112,7 @@ std::string CCompileInfo::GetPythonVersion()
   return "@PYTHON_VERSION@";
 }
 
-const std::vector<std::string> CCompileInfo::GetWebserverExtraWhitelist()
+std::vector<std::string> CCompileInfo::GetWebserverExtraWhitelist()
 {
   return StringUtils::Split("@KODI_WEBSERVER_EXTRA_WHITELIST@", ',');
 }

--- a/xbmc/CompileInfo.h
+++ b/xbmc/CompileInfo.h
@@ -33,5 +33,5 @@ public:
   static std::vector<std::string> GetAvailableWindowSystems();
   static std::vector<ADDON::RepoInfo> LoadOfficialRepoInfos();
   static std::string GetPythonVersion();
-  static const std::vector<std::string> GetWebserverExtraWhitelist();
+  static std::vector<std::string> GetWebserverExtraWhitelist();
 };


### PR DESCRIPTION
This is in response to this PR feedback: https://github.com/xbmc/xbmc/pull/21113#discussion_r835767499

## Motivation and context

Followup from this PR feedback: https://github.com/xbmc/xbmc/pull/21113#discussion_r835767499

## How has this been tested?

I've confirmed that the code still compiles.

## What is the effect on users?

No effect

## Screenshots (if appropriate):

N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
