### PR TITLE
[discs] Remove unecessary log error lines

### DIFF
--- a/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
+++ b/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
@@ -37,7 +37,6 @@ DriveState CDiscDriveHandlerPosix::GetDriveState(const std::string& devicePath)
   CdIo_t* cdio = libCdio->cdio_open(devicePath.c_str(), DRIVER_UNKNOWN);
   if (!cdio)
   {
-    CLog::LogF(LOGERROR, "Failed to open device {} libcdio handler", devicePath);
     return driveStatus;
   }
 
@@ -80,7 +79,6 @@ TrayState CDiscDriveHandlerPosix::GetTrayState(const std::string& devicePath)
   CdIo_t* cdio = libCdio->cdio_open(devicePath.c_str(), DRIVER_UNKNOWN);
   if (!cdio)
   {
-    CLog::LogF(LOGERROR, "Failed to open device {} libcdio handler", devicePath);
     return trayStatus;
   }
 


### PR DESCRIPTION
## Description
In libcdio, MacOS only successfully opens the device when a disc is present and will fail otherwise. Since we are constantly polling the drive state in DetectDVDMedia it will result in log flooding for no reason. Those messages were added recently in https://github.com/xbmc/xbmc/pull/21143 and were not part of the original implementation.
