### PR TITLE
[clang-tidy] fix performance-* warnings

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -54,7 +54,7 @@ bool CDialogGameSaves::OnMessage(CGUIMessage& message)
           if (selectedItem >= 0 && selectedItem < m_vecList->Size())
           {
             CFileItemPtr item = m_vecList->Get(selectedItem);
-            OnPopupMenu(std::move(item));
+            OnPopupMenu(item);
             return true;
           }
         }
@@ -79,7 +79,7 @@ void CDialogGameSaves::FrameMove()
       if (selectedItem >= 0 && selectedItem < m_vecList->Size())
       {
         CFileItemPtr item = m_vecList->Get(selectedItem);
-        OnFocus(std::move(item));
+        OnFocus(item);
       }
     }
     else
@@ -99,7 +99,7 @@ std::string CDialogGameSaves::GetSelectedItemPath()
   return "";
 }
 
-void CDialogGameSaves::OnFocus(CFileItemPtr item)
+void CDialogGameSaves::OnFocus(const CFileItemPtr& item)
 {
   const std::string caption = item->GetProperty(SAVESTATE_CAPTION).asString();
 
@@ -111,7 +111,7 @@ void CDialogGameSaves::OnFocusLost()
   HandleCaption("");
 }
 
-void CDialogGameSaves::OnPopupMenu(CFileItemPtr item)
+void CDialogGameSaves::OnPopupMenu(const CFileItemPtr& item)
 {
   const std::string& savePath = item->GetPath();
 

--- a/xbmc/games/dialogs/osd/DialogGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.h
@@ -36,7 +36,7 @@ private:
   /*!
    * \brief Called every frame with the item being focused
    */
-  void OnFocus(CFileItemPtr item);
+  void OnFocus(const CFileItemPtr& item);
 
   /*!
    * \brief Called every frame if no item is focused
@@ -46,7 +46,7 @@ private:
   /*!
    * \brief Called when a popup menu is opened for an item
    */
-  void OnPopupMenu(CFileItemPtr item);
+  void OnPopupMenu(const CFileItemPtr& item);
 
   /*!
    * \brief Called every frame with the caption to set

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -46,7 +46,7 @@ void CDialogInGameSaves::PreInit()
   item->SetProperty(SAVESTATE_CAPTION,
                     g_localizeStrings.Get(15315)); // "Save progress to new save file"
 
-  m_items.AddFront(std::move(item), 0);
+  m_items.AddFront(item, 0);
 }
 
 void CDialogInGameSaves::InitSavedGames()

--- a/xbmc/interfaces/json-rpc/SettingsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.cpp
@@ -817,7 +817,7 @@ JSONRPC_STATUS CSettingsOperations::GetSkinSettings(const std::string& method,
   const std::set<ADDON::CSkinSettingPtr> settings = CSkinSettings::GetInstance().GetSettings();
   CVariant varSettings(CVariant::VariantTypeArray);
 
-  for (auto setting : settings)
+  for (const auto& setting : settings)
   {
     CVariant varSetting(CVariant::VariantTypeObject);
     varSetting["id"] = setting->name;


### PR DESCRIPTION
## Description
fix performance-* clang-tidy warnings

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
