### PR TITLE
[Android] Fix show storage usage in system info

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -968,16 +968,26 @@ bool CXBMCApp::GetExternalStorage(std::string &path, const std::string &type /* 
 
 bool CXBMCApp::GetStorageUsage(const std::string &path, std::string &usage)
 {
-#define PATH_MAXLEN 50
+#define PATH_MAXLEN 38
 
   if (path.empty())
   {
     std::ostringstream fmt;
-    fmt.width(PATH_MAXLEN);  fmt << std::left  << "Filesystem";
-    fmt.width(12);  fmt << std::right << "Size";
-    fmt.width(12);  fmt << "Used";
-    fmt.width(12);  fmt << "Avail";
-    fmt.width(12);  fmt << "Use %";
+
+    fmt.width(PATH_MAXLEN);
+    fmt << std::left << "Filesystem";
+
+    fmt.width(12);
+    fmt << std::right << "Size";
+
+    fmt.width(12);
+    fmt << "Used";
+
+    fmt.width(12);
+    fmt << "Avail";
+
+    fmt.width(12);
+    fmt << "Use %";
 
     usage = fmt.str();
     return false;
@@ -997,14 +1007,26 @@ bool CXBMCApp::GetStorageUsage(const std::string &path, std::string &usage)
   float usedPercentage = usedSize / totalSize * 100;
 
   std::ostringstream fmt;
+
   fmt << std::fixed;
   fmt.precision(1);
-  fmt.width(PATH_MAXLEN);  fmt << std::left  << (path.size() < PATH_MAXLEN-1 ? path : StringUtils::Left(path, PATH_MAXLEN-4) + "...");
-  fmt.width(12);  fmt << std::right << totalSize << "G"; // size in GB
-  fmt.width(12);  fmt << usedSize << "G"; // used in GB
-  fmt.width(12);  fmt << freeSize << "G"; // free
+
+  fmt.width(PATH_MAXLEN);
+  fmt << std::left
+      << (path.size() < PATH_MAXLEN - 1 ? path : StringUtils::Left(path, PATH_MAXLEN - 4) + "...");
+
+  fmt.width(11);
+  fmt << std::right << totalSize << "G";
+
+  fmt.width(11);
+  fmt << usedSize << "G";
+
+  fmt.width(11);
+  fmt << freeSize << "G";
+
   fmt.precision(0);
-  fmt.width(12);  fmt << usedPercentage << "%"; // percentage used
+  fmt.width(11);
+  fmt << usedPercentage << "%";
 
   usage = fmt.str();
   return true;


### PR DESCRIPTION
## Description
Android is not displaying storage usage information correctly in System info.

## Screenshots:
Before:
![before](https://user-images.githubusercontent.com/76552691/160788394-09939d70-42e8-4944-94c9-8c7d8a0e8908.png)

After:
![after](https://user-images.githubusercontent.com/76552691/160788448-b2bdeb04-4729-4bcd-9c1d-cf6625e0376e.png)

## How has this been tested?
Tested in Android 9 and 11.
## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
