### PR TITLE
[cleanup] fix warning: this statement may fall through [-Wimplicit-fa…

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -1046,10 +1046,12 @@ bool CAESinkALSA::OpenPCMDevice(const std::string &name, const std::string &para
       case 4:
         if (TryDeviceWithParams("surround40" + openName, params, pcmp, lconf))
           return true;
+        [[fallthrough]];
       case 5:
       case 6:
         if (TryDeviceWithParams("surround51" + openName, params, pcmp, lconf))
           return true;
+        [[fallthrough]];
       case 7:
       case 8:
         if (TryDeviceWithParams("surround71" + openName, params, pcmp, lconf))


### PR DESCRIPTION
…llthrough=]

```
AESinkALSA.cpp:1047:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
 1047 |         if (TryDeviceWithParams("surround40" + openName, params, pcmp, lconf))
      |         ^~
AESinkALSA.cpp:1049:7: note: here
 1049 |       case 5:
      |       ^~~~
AESinkALSA.cpp:1051:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
 1051 |         if (TryDeviceWithParams("surround51" + openName, params, pcmp, lconf))
      |         ^~
AESinkALSA.cpp:1053:7: note: here
 1053 |       case 7:
      |       ^~~~
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
