### PR TITLE
[Win32] Fix portable_data [-p] command-line option

### DIFF
--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -365,6 +365,11 @@ std::string CWIN32Util::GetSystemPath()
 
 std::string CWIN32Util::GetProfilePath()
 {
+  return GetProfilePath(g_application.PlatformDirectoriesEnabled());
+}
+
+std::string CWIN32Util::GetProfilePath(bool bPlatformDirectories)
+{
   std::string strProfilePath;
 #ifdef TARGET_WINDOWS_STORE
   auto localFolder = ApplicationData::Current().LocalFolder();
@@ -372,10 +377,11 @@ std::string CWIN32Util::GetProfilePath()
 #else
   std::string strHomePath = CUtil::GetHomePath();
 
-  if(g_application.PlatformDirectoriesEnabled())
-    strProfilePath = URIUtils::AddFileToFolder(GetSpecialFolder(CSIDL_APPDATA|CSIDL_FLAG_CREATE), CCompileInfo::GetAppName());
+  if (bPlatformDirectories)
+    strProfilePath = URIUtils::AddFileToFolder(GetSpecialFolder(CSIDL_APPDATA | CSIDL_FLAG_CREATE),
+                                               CCompileInfo::GetAppName());
   else
-    strProfilePath = URIUtils::AddFileToFolder(strHomePath , "portable_data");
+    strProfilePath = URIUtils::AddFileToFolder(strHomePath, "portable_data");
 
   if (strProfilePath.length() == 0)
     strProfilePath = strHomePath;

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -45,7 +45,8 @@ public:
 
   static std::string GetSystemPath();
   static std::string GetProfilePath();
-  static std::string UncToSmb(const std::string &strPath);
+  static std::string GetProfilePath(bool bPlatformDirectories);
+  static std::string UncToSmb(const std::string& strPath);
   static std::string SmbToUnc(const std::string &strPath);
   static bool AddExtraLongPathPrefix(std::wstring& path);
   static bool RemoveExtraLongPathPrefix(std::wstring& path);

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -350,7 +350,7 @@ bool CSettingsComponent::InitDirectoriesWin32(bool bPlatformDirectories)
   CSpecialProtocol::SetXBMCPath(xbmcPath);
   CSpecialProtocol::SetXBMCBinAddonPath(xbmcPath + "/addons");
 
-  std::string strWin32UserFolder = CWIN32Util::GetProfilePath();
+  std::string strWin32UserFolder = CWIN32Util::GetProfilePath(bPlatformDirectories);
   CSpecialProtocol::SetLogPath(strWin32UserFolder);
   CSpecialProtocol::SetHomePath(strWin32UserFolder);
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));


### PR DESCRIPTION
## Description
Commit https://github.com/xbmc/xbmc/commit/c3d1bebc08ade14d423ac55d0185f75de0c27901 inadvertently caused a problem with the [-p] portable_data command-line option on the Win32 platform, causing the option to no longer work.

The Win32 platform initialization is a bit wonky compared to how the other platforms are initialized, and I originally worked out and intended to submit a much more complete PR for this, but felt the changes became over-scoped and fell back on this (much) simpler PR to instead just target the specific problem I am trying to address, as portable_data is an important feature for Kodi development work.

While I _hope_ this won't be rejected due to its quick-fix nature, this PR allows Win32 initialization to pass the **bPlatformDirectories** flag present in SettingsComponent to CWin32Util::GetProfilePath() and ignore the state of **g_application.PlatformDirectoriesEnabled()**. The parameter-less version of CWin32Util::GetProfilePath() was left in place for use by Win32Exception, and will obey **g_application.PlatformDirectoriesEnabled()** as it does in the as-is. No other Kodi modules access CWin32Util::GetProfilePath().

## Motivation and context
PR allows for the [-p] command line option to function on Win32 platforms after commit https://github.com/xbmc/xbmc/commit/c3d1bebc08ade14d423ac55d0185f75de0c27901

## How has this been tested?
Tested on Windows 11 x64 (Desktop) and Windows 11 x64 (UWP).  The [-p] option became functional again on Desktop and still had no effect on UWP, which was expected.  A lack of specifying the [-p] option on Desktop still created and used the %APPDATA%\Kodi directory as expected.  

The Win32Exception class was also tested, and the behavior appears identical to the as-is implementation; if an unhandled exception is thrown before Kodi has been initialized for the [-p] option the crash dump will be generated in the %APPDATA%\Kodi directory.  If the unhandled exception is thrown after the state of g_application is complete, the crash dump will be generated in the portable_data folder alongside the log files.

## What is the effect on users?
No end-user effects are anticipated.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
