### PR TITLE
[Android] Fix startup crash on older Android version.

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -243,7 +243,7 @@ void CXBMCApp::onStart()
     m_activityManager =
         std::make_unique<CJNIActivityManager>(getSystemService(CJNIContext::ACTIVITY_SERVICE));
     m_inputHandler.setDPI(GetDPI());
-    RegisterDisplayListener();
+    runNativeOnUiThread(RegisterDisplayListenerCallback, nullptr);
   }
 }
 
@@ -385,13 +385,13 @@ void CXBMCApp::onLostFocus()
   m_hasFocus = false;
 }
 
-void CXBMCApp::RegisterDisplayListener()
+void CXBMCApp::RegisterDisplayListenerCallback(CVariant*)
 {
   CJNIDisplayManager displayManager(getSystemService("display"));
   if (displayManager)
   {
     android_printf("CXBMCApp: installing DisplayManager::DisplayListener");
-    displayManager.registerDisplayListener(m_displayListener.get_raw());
+    displayManager.registerDisplayListener(CXBMCApp::Get().getDisplayListener());
   }
 }
 

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -141,6 +141,7 @@ public:
   void onDisplayAdded(int displayId) override;
   void onDisplayChanged(int displayId) override;
   void onDisplayRemoved(int displayId) override;
+  jni::jhobject getDisplayListener() { return m_displayListener.get_raw(); }
 
   bool isValid() { return m_activity != NULL; }
 
@@ -258,7 +259,7 @@ private:
   static void SetRefreshRateCallback(CVariant *rate);
   static void SetDisplayModeCallback(CVariant *mode);
 
-  void RegisterDisplayListener();
+  static void RegisterDisplayListenerCallback(CVariant*);
   void UnregisterDisplayListener();
 
   ANativeActivity* m_activity{nullptr};


### PR DESCRIPTION
Fixes some fallout from #21146, which introduced a crash on Kodi startup, at least for Kodu running on older Android version.

Runtime-tested by @wsnipex @howie-f - see https://github.com/xbmc/xbmc/pull/21146#issuecomment-1085734567 ff.