### PR TITLE
[Windows] Fix portable mode

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -268,7 +268,6 @@ public:
 
   int GlobalIdleTime();
 
-  bool PlatformDirectoriesEnabled() { return m_bPlatformDirectories; }
   bool IsStandAlone() { return m_bStandalone; }
   bool IsEnableTestMode() { return m_bTestMode; }
 

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -8,7 +8,6 @@
 
 #include "WIN32Util.h"
 
-#include "Application.h"
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
 #include "Util.h"
@@ -363,7 +362,7 @@ std::string CWIN32Util::GetSystemPath()
 #endif
 }
 
-std::string CWIN32Util::GetProfilePath()
+std::string CWIN32Util::GetProfilePath(const bool platformDirectories)
 {
   std::string strProfilePath;
 #ifdef TARGET_WINDOWS_STORE
@@ -372,7 +371,7 @@ std::string CWIN32Util::GetProfilePath()
 #else
   std::string strHomePath = CUtil::GetHomePath();
 
-  if(g_application.PlatformDirectoriesEnabled())
+  if (platformDirectories)
     strProfilePath = URIUtils::AddFileToFolder(GetSpecialFolder(CSIDL_APPDATA|CSIDL_FLAG_CREATE), CCompileInfo::GetAppName());
   else
     strProfilePath = URIUtils::AddFileToFolder(strHomePath , "portable_data");

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -44,7 +44,7 @@ public:
   static size_t GetSystemMemorySize();
 
   static std::string GetSystemPath();
-  static std::string GetProfilePath();
+  static std::string GetProfilePath(const bool platformDirectories);
   static std::string UncToSmb(const std::string &strPath);
   static std::string SmbToUnc(const std::string &strPath);
   static bool AddExtraLongPathPrefix(std::wstring& path);

--- a/xbmc/platform/win32/threads/Win32Exception.cpp
+++ b/xbmc/platform/win32/threads/Win32Exception.cpp
@@ -58,6 +58,7 @@ typedef DWORD (__stdcall *tSSO)( IN DWORD SymOptions );
 typedef LONG (__stdcall *GCPFN)(UINT32*, PWSTR);
 
 std::string win32_exception::mVersion;
+bool win32_exception::m_platformDir;
 
 bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
 {
@@ -72,7 +73,8 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
                                      mVersion, stLocalTime.year, stLocalTime.month, stLocalTime.day,
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
-  dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
+  dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(
+      CWIN32Util::GetProfilePath(m_platformDir), CUtil::MakeLegalFileName(dumpFileName)));
 
   dumpFileNameW = KODI::PLATFORM::WINDOWS::ToW(dumpFileName);
   HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
@@ -187,7 +189,8 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
                                      mVersion, stLocalTime.year, stLocalTime.month, stLocalTime.day,
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
-  dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
+  dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(
+      CWIN32Util::GetProfilePath(m_platformDir), CUtil::MakeLegalFileName(dumpFileName)));
 
   dumpFileNameW = KODI::PLATFORM::WINDOWS::ToW(dumpFileName);
   hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);

--- a/xbmc/platform/win32/threads/Win32Exception.h
+++ b/xbmc/platform/win32/threads/Win32Exception.h
@@ -16,9 +16,11 @@ public:
     typedef const void* Address; // OK on Win32 platform
 
     static void set_version(std::string version) { mVersion = version; }
+    static void set_platformDirectories(const bool platformDir) { m_platformDir = platformDir; }
     static bool write_minidump(EXCEPTION_POINTERS* pEp);
     static bool write_stacktrace(EXCEPTION_POINTERS* pEp);
     static bool ShouldHook();
 private:
     static std::string mVersion;
+    static bool m_platformDir;
 };

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -350,7 +350,7 @@ bool CSettingsComponent::InitDirectoriesWin32(bool bPlatformDirectories)
   CSpecialProtocol::SetXBMCPath(xbmcPath);
   CSpecialProtocol::SetXBMCBinAddonPath(xbmcPath + "/addons");
 
-  std::string strWin32UserFolder = CWIN32Util::GetProfilePath();
+  std::string strWin32UserFolder = CWIN32Util::GetProfilePath(bPlatformDirectories);
   CSpecialProtocol::SetLogPath(strWin32UserFolder);
   CSpecialProtocol::SetHomePath(strWin32UserFolder);
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));


### PR DESCRIPTION
## Description
- Fix portable mode.
- Removes global `g_application` from WIN32Util.cpp

## Motivation and context
Due recent changes in components initialization order like https://github.com/xbmc/xbmc/commit/c3d1bebc08ade14d423ac55d0185f75de0c27901, portable mode is broken in Windows. Although it is also because the initialization was already different than in the other platforms and quite fragile depending on the exact order in which other components are initialized.

Basically parameter `bPlatformDirectories` are not used here:

https://github.com/xbmc/xbmc/blob/71fb3d3a63992c270b1cdac953020eb8848f6b1f/xbmc/settings/SettingsComponent.cpp#L344-L353

And instead is used:
https://github.com/xbmc/xbmc/blob/71fb3d3a63992c270b1cdac953020eb8848f6b1f/xbmc/platform/win32/WIN32Util.cpp#L375

in `CWIN32Util::GetProfilePath()`

`g_application.PlatformDirectoriesEnabled()` is false at this point because application component is not yet configured.

The fix consists in propagate `bPlatformDirectories` parameter to `CWIN32Util::GetProfilePath()` and get rid of dependence from `g_application`.

Also some changes are need in `Win32Exception` because this component is also initialized before application and it needs to know for itself that it is in portable mode. This also fixes an existing long term issue where crash dump files could end up in the roaming (non-portable) folder if the crash occurred too soon before the application was fully initialized.

This way, things unique to Windows are handled internally, and initialization of common components can be done the same way as on other platforms.


## How has this been tested?
Runtime tested Windows x64


## What is the effect on users?
Fixes portable mode broken recently. 
Fixes long term bug that causes crash dump files written in roaming (non portable) folder even in portable mode if crash occurs very soon.



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
