### PR TITLE
[cmake] Fix internal crossguid on lib64 Linux platforms

### DIFF
--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -42,6 +42,7 @@ if(ENABLE_INTERNAL_CROSSGUID)
   # Force release build type. crossguid forces a debug postfix -dgb. may want to patch this
   # if we enable adaptive build type for the library.
   set(CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
+                 -DCMAKE_INSTALL_LIBDIR=lib
                  -DCROSSGUID_TESTS=OFF
                  -DDISABLE_WALL=ON
                  -DCMAKE_BUILD_TYPE=Release)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

On Linux systems that use a `<prefix>/lib64` libdir for 64-bit libraries
(e.g. Fedora x86_64), CMake installs libraries to that directory by
default unless overridden.

We use CMake to build internal crossguid and the code in
ModuleHelpers.cmake assumes <prefix>/lib as the library directory.

This discrepancy causes a build failure on affected systems:

```
make[2]: *** No rule to make target 'build/lib/libcrossguid.a', needed by 'kodi.bin'.  Stop.
```

Fix that by specifying `-DCMAKE_INSTALL_LIBDIR=lib` which is the method
used in the CMake scripting of our various other bundled libraries as
well.

These types of options should probably be centralized in
`ModuleHelpers.cmake` at some point in the future, though.

## How has this been tested?

Build now succeeds on Fedora 35 x86_64 with internal crossguid (which is the default).

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
