### PR TITLE
[cleanup] removes two unreferenced/undefined methods

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -277,8 +277,6 @@ public:
 
   bool ToggleDPMS(bool manual);
 
-  bool SwitchToFullScreen(bool force = false);
-
   bool GetRenderGUI() const override { return m_renderGUI; }
 
   bool SetLanguage(const std::string &strLanguage);
@@ -443,7 +441,6 @@ public:
 
 private:
   void PrintStartupLog();
-  void Preflight();
   void ResetCurrentItem();
 
   mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */


### PR DESCRIPTION
## Description
Removes two unreferenced/undefined methods in Application.h

## Motivation and context
Found by VS 2022

## How has this been tested?
Compile Windows x64

## What is the effect on users?
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
