### PR TITLE
[Android] SDK 30 and All files access permission

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -7,9 +7,10 @@
 
     <uses-sdk
         android:minSdkVersion="21"
-        android:targetSdkVersion="29" />
+        android:targetSdkVersion="30" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.GET_TASKS" />

--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         applicationId "@APP_PACKAGE@"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode @APP_VERSION_CODE_ANDROID@
         versionName "@APP_VERSION@"
     }

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -1,5 +1,6 @@
 package @APP_PACKAGE@;
 
+import static android.content.pm.PackageManager.FEATURE_LEANBACK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 import android.Manifest;
@@ -21,6 +22,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Message;
+import android.provider.Settings;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
@@ -63,12 +65,14 @@ public class Splash extends Activity
   private static final int CheckingPermissionsDone = 10;
   private static final int CheckingPermissionsInfo = 11;
   private static final int CheckExternalStorage = 12;
+  private static final int RecordAudioPermission = 13;
   private static final int DownloadingObb = 90;
   private static final int DownloadObbDone = 91;
   private static final int StartingXBMC = 99;
 
   private static final String TAG = "@APP_NAME@";
 
+  private static final int RECORDAUDIO_RESULT_CODE = 8946;
   private static final int PERMISSION_RESULT_CODE = 8947;
 
   private String mCpuinfo = "";
@@ -125,17 +129,38 @@ public class Splash extends Activity
             @Override
             public void onClick(DialogInterface dialog, int which)
             {
-              mStateMachine.sendEmptyMessage(CheckingPermissions);
+              mStateMachine.sendEmptyMessage(RecordAudioPermission);
             }
           });
           dialog.show();
           break;
-        case CheckingPermissions:
+        case RecordAudioPermission:
           mSplash.mTextView.setText("Asking for permissions...");
           mSplash.mProgress.setVisibility(View.INVISIBLE);
 
-          requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.RECORD_AUDIO},
+          requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO},
+                    RECORDAUDIO_RESULT_CODE);
+          break;
+        case CheckingPermissions:
+          if ((Build.VERSION.SDK_INT >= 30) && !isAndroidTV())
+          {
+            try
+            {
+              Intent intent = new Intent();
+              intent.setAction(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+              intent.setData(Uri.parse(String.format("package:%s", getPackageName())));
+              startActivityForResult(intent, PERMISSION_RESULT_CODE);
+            }
+            catch (Exception e)
+            {
+              Log.d(TAG, "Exception asking for permissions: " + e.getMessage());
+            }
+          }
+          else
+          {
+            requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
                     PERMISSION_RESULT_CODE);
+          }
           break;
         case CheckingPermissionsDone:
           if (mPermissionOK)
@@ -734,7 +759,14 @@ public class Splash extends Activity
   private boolean CheckPermissions()
   {
     boolean retVal = false;
-    if (android.os.Build.VERSION.SDK_INT > 22)
+    if ((Build.VERSION.SDK_INT >= 30) && !isAndroidTV())
+    {
+      if (Environment.isExternalStorageManager())
+      {
+        retVal = true;
+      }
+    }
+    else if (Build.VERSION.SDK_INT > 22)
     {
       int permissionCheck;
       permissionCheck = checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
@@ -742,7 +774,7 @@ public class Splash extends Activity
         retVal = true;
     }
     else
-      retVal=  true;
+      retVal = true;
 
     return retVal;
   }
@@ -760,9 +792,28 @@ public class Splash extends Activity
         {
           mPermissionOK = true;
         }
+        mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+        break;
+      }
+      case RECORDAUDIO_RESULT_CODE:
+      {
+        mStateMachine.sendEmptyMessage(CheckingPermissions);
       }
     }
-    mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data)
+  {
+    super.onActivityResult(requestCode, resultCode, data);
+    if (requestCode == PERMISSION_RESULT_CODE)
+    {
+      if (Environment.isExternalStorageManager())
+      {
+        mPermissionOK = true;
+      }
+      mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+    }
   }
 
   void updateExternalStorageState()
@@ -960,6 +1011,20 @@ public class Splash extends Activity
         new FillCache(this).execute();
       else
         mStateMachine.sendEmptyMessage(CachingDone);
+    }
+  }
+
+  private boolean isAndroidTV()
+  {
+    if (getPackageManager().hasSystemFeature(FEATURE_LEANBACK))
+    {
+      Log.d(TAG, "Running on an Android TV Device");
+      return true;
+    }
+    else
+    {
+      Log.d(TAG, "Running on a non Android TV Device");
+      return false;
     }
   }
 


### PR DESCRIPTION
## Description
Android 11 and higher are greatly restricting access to external storage. Apps must make use of the more privacy-friendly APIs, such as Storage Access Framework (user sees a system picker) or the Media Store (only media files from well-defined collections).
 
Android provides a special app access called `All files access` for situations that have a core use case that requires broad access of files on a device. This permission is only allowed for few apps like antivirus, file manager, etc. We've to justify the reason while publishing the app to PlayStore.

Proposed changes:

- Target to `API level 30`.

- Declare the `MANAGE_EXTERNAL_STORAGE` permission in the manifest.

- Request and check the permission at startup, using the `ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION` intent action.

Additional testing may be required, please send feedback and any further issues. 

Also identify possible regressions due to the change in the target level.

## How has this been tested?
Tested on an AFTV with Android 9, I've made some tests with files and videos and it works as usual. As expected, this permissions change should only affect devices with API level >= 30.
 
Also tested on a device running Android 11 with several types of files on the external storage and the SD card.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
