### PR TITLE
[PVR] Various performance improvements

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10726,7 +10726,11 @@ msgctxt "#19238"
 msgid "Loading recordings from clients"
 msgstr ""
 
-#empty string with id 19239
+#. label for PVR client creation progress control
+#: xbmc/pvr/addons/PVRClients.cpp
+msgctxt "#19239"
+msgid "Creating PVR clients"
+msgstr ""
 
 #. label for pvr settings client priorities control and client priorities dialog heading.
 #: system/settings/settings.xml

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -193,6 +193,9 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag,
       SetArt("icon", "DefaultTVShows.png");
   }
 
+  // Speedup FillInDefaultIcon()
+  SetProperty("icon_never_overlay", true);
+
   FillMusicInfoTag(groupMember, tag);
   FillInMimeType(false);
 }
@@ -211,6 +214,9 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgSearchFilter>& filter)
     m_dateTime.SetFromUTCDateTime(lastExec);
 
   SetArt("icon", "DefaultPVRSearch.png");
+
+  // Speedup FillInDefaultIcon()
+  SetProperty("icon_never_overlay", true);
 
   FillInMimeType(false);
 }
@@ -239,6 +245,9 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
   SetProperty("channelid", channel->ChannelID());
   SetProperty("path", channelGroupMember->Path());
   SetArt("thumb", channel->IconPath());
+
+  // Speedup FillInDefaultIcon()
+  SetProperty("icon_never_overlay", true);
 
   FillMusicInfoTag(channelGroupMember, epgNow);
   FillInMimeType(false);
@@ -275,6 +284,9 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
   if (!record->FanartPath().empty())
     SetArt("fanart", record->FanartPath());
 
+  // Speedup FillInDefaultIcon()
+  SetProperty("icon_never_overlay", true);
+
   FillInMimeType(false);
 }
 
@@ -294,6 +306,9 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
     SetArt("icon", "DefaultMusicSongs.png");
   else
     SetArt("icon", "DefaultTVShows.png");
+
+  // Speedup FillInDefaultIcon()
+  SetProperty("icon_never_overlay", true);
 
   FillInMimeType(false);
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -226,7 +226,6 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
   Initialize();
 
   const std::shared_ptr<CPVRChannel> channel = channelGroupMember->Channel();
-  const std::shared_ptr<CPVREpgInfoTag> epgNow = channel->GetEPGNow();
 
   m_pvrChannelGroupMemberInfoTag = channelGroupMember;
 
@@ -249,7 +248,11 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
   // Speedup FillInDefaultIcon()
   SetProperty("icon_never_overlay", true);
 
-  FillMusicInfoTag(channelGroupMember, epgNow);
+  if (channel->IsRadio())
+  {
+    const std::shared_ptr<CPVREpgInfoTag> epgNow = channel->GetEPGNow();
+    FillMusicInfoTag(channelGroupMember, epgNow);
+  }
   FillInMimeType(false);
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -961,49 +961,6 @@ void CPVRChannelGroup::OnSettingChanged()
   m_events.Publish(bRenumbered ? PVREvent::ChannelGroupInvalidated : PVREvent::ChannelGroup);
 }
 
-CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
-{
-  CDateTime date;
-  std::shared_ptr<CPVREpg> epg;
-  std::shared_ptr<CPVRChannel> channel;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-
-  for (const auto& memberPair : m_members)
-  {
-    channel = memberPair.second->Channel();
-    if (!channel->IsHidden() && (epg = channel->GetEPG()))
-    {
-      CDateTime epgDate;
-      switch (epgDateType)
-      {
-        case EPG_FIRST_DATE:
-          epgDate = epg->GetFirstDate();
-          if (epgDate.IsValid() && (!date.IsValid() || epgDate < date))
-            date = epgDate;
-          break;
-
-        case EPG_LAST_DATE:
-          epgDate = epg->GetLastDate();
-          if (epgDate.IsValid() && (!date.IsValid() || epgDate > date))
-            date = epgDate;
-          break;
-      }
-    }
-  }
-
-  return date;
-}
-
-CDateTime CPVRChannelGroup::GetFirstEPGDate() const
-{
-  return GetEPGDate(EPG_FIRST_DATE);
-}
-
-CDateTime CPVRChannelGroup::GetLastEPGDate() const
-{
-  return GetEPGDate(EPG_LAST_DATE);
-}
-
 int CPVRChannelGroup::GroupID() const
 {
   return m_iGroupId;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -35,12 +35,6 @@ namespace PVR
   class CPVRClient;
   class CPVREpgInfoTag;
 
-  enum EpgDateType
-  {
-    EPG_FIRST_DATE = 0,
-    EPG_LAST_DATE = 1
-  };
-
   enum RenumberMode
   {
     NORMAL = 0,
@@ -368,18 +362,6 @@ namespace PVR
     virtual bool CreateChannelEpgs(bool bForce = false);
 
     /*!
-     * @brief Get the start time of the first entry.
-     * @return The start time.
-     */
-    CDateTime GetFirstEPGDate() const;
-
-    /*!
-     * @brief Get the end time of the last entry.
-     * @return The end time.
-     */
-    CDateTime GetLastEPGDate() const;
-
-    /*!
      * @brief Update a channel group member with given data.
      * @param storageId The storage id of the channel.
      * @param strChannelName The channel name to set.
@@ -549,8 +531,6 @@ namespace PVR
         const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
 
     void OnSettingChanged();
-
-    CDateTime GetEPGDate(EpgDateType epgDateType) const;
 
     std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
     CPVRChannelsPath m_path;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -334,22 +334,23 @@ void CGUIDialogPVRGuideSearch::Update()
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_IGNORE_FUTURE,
                        m_searchFilter->ShouldIgnoreFutureBroadcasts());
 
-  /* Set time fields */
+  // Set start/end datetime fields
   m_startDateTime = m_searchFilter->GetStartDateTime();
-  if (!m_startDateTime.IsValid())
+  m_endDateTime = m_searchFilter->GetEndDateTime();
+  if (!m_startDateTime.IsValid() || !m_endDateTime.IsValid())
   {
-    m_startDateTime = CServiceBroker::GetPVRManager().EpgContainer().GetFirstEPGDate();
+    const auto dates = CServiceBroker::GetPVRManager().EpgContainer().GetFirstAndLastEPGDate();
     if (!m_startDateTime.IsValid())
-      m_startDateTime = CDateTime::GetUTCDateTime();
+      m_startDateTime = dates.first;
+    if (!m_endDateTime.IsValid())
+      m_endDateTime = dates.second;
   }
 
-  m_endDateTime = m_searchFilter->GetEndDateTime();
+  if (!m_startDateTime.IsValid())
+    m_startDateTime = CDateTime::GetUTCDateTime();
+
   if (!m_endDateTime.IsValid())
-  {
-    m_endDateTime = CServiceBroker::GetPVRManager().EpgContainer().GetLastEPGDate();
-    if (!m_endDateTime.IsValid())
-      m_endDateTime = m_startDateTime + CDateTimeSpan(10, 0, 0, 0); // default to start + 10 days
-  }
+    m_endDateTime = m_startDateTime + CDateTimeSpan(10, 0, 0, 0); // default to start + 10 days
 
   CDateTime startLocal;
   startLocal.SetFromUTCDateTime(m_startDateTime);

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -377,18 +377,6 @@ bool CPVREpg::QueueDeleteQueries(const std::shared_ptr<CPVREpgDatabase>& databas
   return true;
 }
 
-CDateTime CPVREpg::GetFirstDate() const
-{
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  return m_tags.GetFirstStartTime();
-}
-
-CDateTime CPVREpg::GetLastDate() const
-{
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  return m_tags.GetLastEndTime();
-}
-
 std::pair<CDateTime, CDateTime> CPVREpg::GetFirstAndLastUncommitedEPGDate() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -389,6 +389,12 @@ CDateTime CPVREpg::GetLastDate() const
   return m_tags.GetLastEndTime();
 }
 
+std::pair<CDateTime, CDateTime> CPVREpg::GetFirstAndLastUncommitedEPGDate() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_tags.GetFirstAndLastUncommitedEPGDate();
+}
+
 bool CPVREpg::UpdateFromScraper(time_t start, time_t end, bool bForceUpdate)
 {
   if (m_strScraperName.empty())

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -237,6 +237,12 @@ namespace PVR
     CDateTime GetLastDate() const;
 
     /*!
+     * @brief Get the start and end time of the last not yet commited entry in this table.
+     * @return The times; first: start time, second: end time.
+     */
+    std::pair<CDateTime, CDateTime> GetFirstAndLastUncommitedEPGDate() const;
+
+    /*!
      * @brief Notify observers when the currently active tag changed.
      * @return True if the playing tag has changed, false otherwise.
      */

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -225,18 +225,6 @@ namespace PVR
     bool QueueDeleteQueries(const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
-     * @brief Get the start time of the first entry in this table.
-     * @return The first date in UTC.
-     */
-    CDateTime GetFirstDate() const;
-
-    /*!
-     * @brief Get the end time of the last entry in this table.
-     * @return The last date in UTC.
-     */
-    CDateTime GetLastDate() const;
-
-    /*!
      * @brief Get the start and end time of the last not yet commited entry in this table.
      * @return The times; first: start time, second: end time.
      */

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -147,8 +147,6 @@ void CPVREpgContainer::Start()
     std::unique_lock<CCriticalSection> lock(m_critSection);
     m_bIsInitialising = true;
 
-    CheckPlayingEvents();
-
     Create();
     SetPriority(ThreadPriority::BELOW_NORMAL);
 

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -810,42 +810,6 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   return !bInterrupted;
 }
 
-const CDateTime CPVREpgContainer::GetFirstEPGDate()
-{
-  CDateTime returnValue;
-
-  m_critSection.lock();
-  const auto epgs = m_epgIdToEpgMap;
-  m_critSection.unlock();
-
-  for (const auto& epgEntry : epgs)
-  {
-    CDateTime entry = epgEntry.second->GetFirstDate();
-    if (entry.IsValid() && (!returnValue.IsValid() || entry < returnValue))
-      returnValue = entry;
-  }
-
-  return returnValue;
-}
-
-const CDateTime CPVREpgContainer::GetLastEPGDate()
-{
-  CDateTime returnValue;
-
-  m_critSection.lock();
-  const auto epgs = m_epgIdToEpgMap;
-  m_critSection.unlock();
-
-  for (const auto& epgEntry : epgs)
-  {
-    CDateTime entry = epgEntry.second->GetLastDate();
-    if (entry.IsValid() && (!returnValue.IsValid() || entry > returnValue))
-      returnValue = entry;
-  }
-
-  return returnValue;
-}
-
 std::pair<CDateTime, CDateTime> CPVREpgContainer::GetFirstAndLastEPGDate() const
 {
   // Get values from db

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -942,8 +942,6 @@ int CPVREpgContainer::CleanupCachedImages()
 {
   int iCleanedImages = 0;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-
   const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
   if (!database)
   {
@@ -951,7 +949,12 @@ int CPVREpgContainer::CleanupCachedImages()
     return iCleanedImages;
   }
 
-  for (const auto& epg : m_epgIdToEpgMap)
+  // Processing can take some time. Do not block.
+  m_critSection.lock();
+  const std::map<int, std::shared_ptr<CPVREpg>> epgIdToEpgMap = m_epgIdToEpgMap;
+  m_critSection.unlock();
+
+  for (const auto& epg : epgIdToEpgMap)
   {
     iCleanedImages += epg.second->CleanupCachedImages(database);
   }

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -111,18 +111,6 @@ namespace PVR
     std::shared_ptr<CPVREpg> CreateChannelEpg(int iEpgId, const std::string& strScraperName, const std::shared_ptr<CPVREpgChannelData>& channelData);
 
     /*!
-     * @brief Get the start time of the first entry.
-     * @return The start time.
-     */
-    const CDateTime GetFirstEPGDate();
-
-    /*!
-     * @brief Get the end time of the last entry.
-     * @return The end time.
-     */
-    const CDateTime GetLastEPGDate();
-
-    /*!
      * @brief Get the start and end time across all EPGs.
      * @return The times; first: start time, second: end time.
      */

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -123,6 +123,12 @@ namespace PVR
     const CDateTime GetLastEPGDate();
 
     /*!
+     * @brief Get the start and end time across all EPGs.
+     * @return The times; first: start time, second: end time.
+     */
+    std::pair<CDateTime, CDateTime> GetFirstAndLastEPGDate() const;
+
+    /*!
      * @brief Get all EPGs.
      * @return The EPGs.
      */

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -459,6 +459,30 @@ CDateTime CPVREpgDatabase::GetLastEndTime(int iEpgID)
   return {};
 }
 
+std::pair<CDateTime, CDateTime> CPVREpgDatabase::GetFirstAndLastEPGDate()
+{
+  CDateTime first;
+  CDateTime last;
+
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  // 1st query: get min start time
+  std::string strQuery = PrepareSQL("SELECT MIN(iStartTime) FROM epgtags;");
+
+  std::string strValue = GetSingleValue(strQuery);
+  if (!strValue.empty())
+    first = CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
+
+  // 2nd query: get max end time
+  strQuery = PrepareSQL("SELECT MAX(iEndTime) FROM epgtags;");
+
+  strValue = GetSingleValue(strQuery);
+  if (!strValue.empty())
+    last = CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
+
+  return {first, last};
+}
+
 CDateTime CPVREpgDatabase::GetMinStartTime(int iEpgID, const CDateTime& minStart)
 {
   time_t t;

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -435,16 +435,13 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(
   return {};
 }
 
-CDateTime CPVREpgDatabase::GetFirstStartTime(int iEpgID)
+bool CPVREpgDatabase::HasTags(int iEpgID)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery =
-      PrepareSQL("SELECT MIN(iStartTime) FROM epgtags WHERE idEpg = %u;", iEpgID);
+      PrepareSQL("SELECT iStartTime FROM epgtags WHERE idEpg = %u LIMIT 1;", iEpgID);
   std::string strValue = GetSingleValue(strQuery);
-  if (!strValue.empty())
-    return CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
-
-  return {};
+  return !strValue.empty();
 }
 
 CDateTime CPVREpgDatabase::GetLastEndTime(int iEpgID)

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -132,6 +132,12 @@ namespace PVR
     CDateTime GetLastEndTime(int iEpgID);
 
     /*!
+     * @brief Get the start and end time across all EPGs.
+     * @return The times; first: start time, second: end time.
+     */
+    std::pair<CDateTime, CDateTime> GetFirstAndLastEPGDate();
+
+    /*!
      * @brief Get the start time of the first tag with a start time greater than the given min time.
      * @param iEpgID The ID of the EPG.
      * @param minStart The min start time.

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -118,11 +118,11 @@ namespace PVR
     std::vector<std::string> GetAllIconPaths(int iEpgID);
 
     /*!
-     * @brief Get the start time of the first tag in this EPG.
+     * @brief Check whether this EPG has any tags.
      * @param iEpgID The ID of the EPG.
-     * @return The time.
+     * @return True in case there are tags, false otherwise.
      */
-    CDateTime GetFirstStartTime(int iEpgID);
+    bool HasTags(int iEpgID);
 
     /*!
      * @brief Get the end time of the last tag in this EPG.

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -348,7 +348,7 @@ bool CPVREpgTagsContainer::IsEmpty() const
     return false;
 
   if (m_database)
-    return !m_database->GetFirstStartTime(m_iEpgID).IsValid();
+    return !m_database->HasTags(m_iEpgID);
 
   return true;
 }
@@ -583,7 +583,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetAllTags() 
   if (m_database)
   {
     std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
-    if (!m_changedTags.empty() && !m_database->GetFirstStartTime(m_iEpgID).IsValid())
+    if (!m_changedTags.empty() && !m_database->HasTags(m_iEpgID))
     {
       // nothing in the db yet. take what we have in memory.
       for (const auto& tag : m_changedTags)

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -645,6 +645,15 @@ CDateTime CPVREpgTagsContainer::GetLastEndTime() const
   return result;
 }
 
+std::pair<CDateTime, CDateTime> CPVREpgTagsContainer::GetFirstAndLastUncommitedEPGDate() const
+{
+  if (m_changedTags.empty())
+    return {};
+
+  return {(*m_changedTags.cbegin()).second->StartAsUTC(),
+          (*m_changedTags.crbegin()).second->EndAsUTC()};
+}
+
 bool CPVREpgTagsContainer::NeedsSave() const
 {
   return !m_changedTags.empty() || !m_deletedTags.empty();

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -611,40 +611,6 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetAllTags() 
   return {};
 }
 
-CDateTime CPVREpgTagsContainer::GetFirstStartTime() const
-{
-  CDateTime result;
-
-  if (!m_changedTags.empty())
-    result = (*m_changedTags.cbegin()).second->StartAsUTC();
-
-  if (m_database)
-  {
-    const CDateTime dbResult = m_database->GetFirstStartTime(m_iEpgID);
-    if (!result.IsValid() || (dbResult.IsValid() && dbResult < result))
-      result = dbResult;
-  }
-
-  return result;
-}
-
-CDateTime CPVREpgTagsContainer::GetLastEndTime() const
-{
-  CDateTime result;
-
-  if (!m_changedTags.empty())
-    result = (*m_changedTags.crbegin()).second->EndAsUTC();
-
-  if (m_database)
-  {
-    const CDateTime dbResult = m_database->GetLastEndTime(m_iEpgID);
-    if (!result.IsValid() || (dbResult.IsValid() && dbResult > result))
-      result = dbResult;
-  }
-
-  return result;
-}
-
 std::pair<CDateTime, CDateTime> CPVREpgTagsContainer::GetFirstAndLastUncommitedEPGDate() const
 {
   if (m_changedTags.empty())

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -153,18 +153,6 @@ public:
   std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllTags() const;
 
   /*!
-   * @brief Get the start time of the first tag in this EPG.
-   * @return The time.
-   */
-  CDateTime GetFirstStartTime() const;
-
-  /*!
-   * @brief Get the end time of the last tag in this EPG.
-   * @return The time.
-   */
-  CDateTime GetLastEndTime() const;
-
-  /*!
    * @brief Get the start and end time of the last not yet commited entry in this EPG.
    * @return The times; first: start time, second: end time.
    */

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -165,6 +165,12 @@ public:
   CDateTime GetLastEndTime() const;
 
   /*!
+   * @brief Get the start and end time of the last not yet commited entry in this EPG.
+   * @return The times; first: start time, second: end time.
+   */
+  std::pair<CDateTime, CDateTime> GetFirstAndLastUncommitedEPGDate() const;
+
+  /*!
    * @brief Check whether this container has unsaved data.
    * @return True if this container contains unsaved data, false otherwise.
    */

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.h
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.h
@@ -97,7 +97,6 @@ public:
   bool GetChannelsDirectory(CFileItemList& results) const;
 
 private:
-  bool FilterDirectory(CFileItemList& results) const;
   bool GetTimersDirectory(CFileItemList& results) const;
   bool GetRecordingsDirectory(CFileItemList& results) const;
   bool GetSavedSearchesDirectory(bool bRadio, CFileItemList& results) const;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1855,7 +1855,7 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
 
 std::unique_ptr<CFileItemList> CGUIEPGGridContainer::GetCurrentTimeLineItems() const
 {
-  return m_gridModel->GetCurrentTimeLineItems();
+  return m_gridModel->GetCurrentTimeLineItems(m_channelOffset, m_channelsPerPage);
 }
 
 void CGUIEPGGridContainer::GoToChannel(int channelIndex)

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -690,15 +690,19 @@ bool CGUIEPGGridContainerModel::IsEventMemberOfBlock(const std::shared_ptr<CPVRE
   return false;
 }
 
-std::unique_ptr<CFileItemList> CGUIEPGGridContainerModel::GetCurrentTimeLineItems() const
+std::unique_ptr<CFileItemList> CGUIEPGGridContainerModel::GetCurrentTimeLineItems(
+    int firstChannel, int numChannels) const
 {
   // Note: No need to keep this in a member. Gets generally not called multiple times for the
   //       same timeline, but content must be synced with m_epgItems, which changes quite often.
 
   std::unique_ptr<CFileItemList> items(new CFileItemList);
 
+  if (numChannels > ChannelItemsSize())
+    numChannels = ChannelItemsSize();
+
   int i = 0;
-  for (int channel = 0; channel < ChannelItemsSize(); ++channel)
+  for (int channel = firstChannel; channel < (firstChannel + numChannels); ++channel)
   {
     // m_epgItems is not sorted, fileitemlist must be sorted, so we have to 'find' the channel
     const auto itEpg = m_epgItems.find(channel);

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -109,7 +109,7 @@ namespace PVR
     int GetLastEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
     bool IsEventMemberOfBlock(const std::shared_ptr<CPVREpgInfoTag>& event, int iBlock) const;
 
-    std::unique_ptr<CFileItemList> GetCurrentTimeLineItems() const;
+    std::unique_ptr<CFileItemList> GetCurrentTimeLineItems(int firstChannel, int numChannels) const;
 
   private:
     GridItem* GetGridItemPtr(int iChannel, int iBlock) const;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -66,6 +66,8 @@ namespace PVR
     void SetInvalid() override;
     bool CanBeActivated() const override;
 
+    bool UseFileDirectories() override { return false; }
+
     /*!
      * @brief CEventStream callback for PVR events.
      * @param event The event.

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -693,17 +693,18 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       if (!group)
         return false;
 
-      CDateTime startDate(group->GetFirstEPGDate());
-      CDateTime endDate(group->GetLastEPGDate());
-      const CDateTime currentDate(CDateTime::GetCurrentDateTime().GetAsUTCDateTime());
+      CPVREpgContainer& epgContainer = CServiceBroker::GetPVRManager().EpgContainer();
+
+      const std::pair<CDateTime, CDateTime> dates = epgContainer.GetFirstAndLastEPGDate();
+      CDateTime startDate = dates.first;
+      CDateTime endDate = dates.second;
+      const CDateTime currentDate = CDateTime::GetUTCDateTime();
 
       if (!startDate.IsValid())
         startDate = currentDate;
 
       if (!endDate.IsValid() || endDate < startDate)
         endDate = startDate;
-
-      CPVREpgContainer& epgContainer = CServiceBroker::GetPVRManager().EpgContainer();
 
       // limit start to past days to display
       const int iPastDays = epgContainer.GetPastDaysToDisplay();


### PR DESCRIPTION
Performance improvements made as the result of stress tests with 100K TV channels. 

Kodi is able to handle this large number of channels, but is definitely not designed for this (rather artificial) use case, given Kodi has enough RAM and user has some patience to get all data loaded. ;-)

There could definitely done more to further improve loading and processing speed. I consider this only the low hanging fruits.

Runtime-tested on latest Kodi master, macOS and Android, with both 100K test scenario and a normal setup with 200 channels.

@phunkyfish your review is welcome.