### PR TITLE
[Xbox] Fix crash related to DXVA2 decoding of H264 SD interlaced videos

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -134,6 +134,11 @@ void DX::DeviceResources::GetAdapterDesc(DXGI_ADAPTER_DESC* desc) const
 {
   if (m_adapter)
     m_adapter->GetDesc(desc);
+
+  // GetDesc() returns VendorId == 0 in Xbox however, we need to know that
+  // GPU is AMD to apply workarounds in DXVA.cpp CheckCompatibility() same as desktop
+  if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::Xbox)
+    desc->VendorId = PCIV_AMD;
 }
 
 void DX::DeviceResources::GetDisplayMode(DXGI_MODE_DESC* mode) const


### PR DESCRIPTION
## Description
[Xbox] Fix crash related to DXVA2 decoding of H264 SD interlaced videos

Should fix https://github.com/xbmc/xbmc/issues/21072

## Motivation and context
There are some crash reports with PVR streams, seems especially H264 SD (interlaced) streams.

Xbox uses an AMD GPU (all models) and needs same DXVA2 workarounds that desktop AMD GPUs. This is also related to https://github.com/xbmc/xbmc/pull/21044

I found that existent workarounds are not applied in Xbox because `VendorId` returns zero.

The fix consists in force `VendorId = PCIV_AMD` on Xbox and use same DXVA2 workarounds that desktop, especially for H264 SD interlaced or H264 HD encodes that exceeds level 4.1.


## How has this been tested?
Runtime tested in Xbox Series S using same sample stream used in https://github.com/xbmc/xbmc/pull/21044 (PVR recording)

Xbox crash (restart) without PR and works fine (with ffmpeg decoding for H264 SD) after PR

NOTE: also tested other Blu-Ray interlaced sources:  1080i AVC / 1080i VC1 / 1080i MPEG2  25.0 fps and 29.97 fps and does NOT trigger the crash at least on Series S.
 

## What is the effect on users?
[Xbox] Fix crash related to DXVA2 decoding of H264 SD interlaced videos


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
