### PR TITLE
[GUI][SpinControlEx] Limit max width for long text cases

### DIFF
--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -502,29 +502,6 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
 
 void CGUISpinControl::Render()
 {
-  if ( HasFocus() )
-  {
-    if (m_iSelect == SPIN_BUTTON_UP)
-      m_imgspinUpFocus->Render();
-    else
-      m_imgspinUp->Render();
-
-    if (m_iSelect == SPIN_BUTTON_DOWN)
-      m_imgspinDownFocus->Render();
-    else
-      m_imgspinDown->Render();
-  }
-  else if ( !HasFocus() && !IsDisabled() )
-  {
-    m_imgspinUp->Render();
-    m_imgspinDown->Render();
-  }
-  else
-  {
-    m_imgspinUpDisabled->Render();
-    m_imgspinDownDisabled->Render();
-  }
-
   if (m_label.GetLabelInfo().font)
   {
     const float space = 5;
@@ -541,6 +518,30 @@ void CGUISpinControl::Render()
     // set our hit rectangle for MouseOver events
     m_hitRect = m_label.GetRenderRect();
   }
+
+  if (HasFocus())
+  {
+    if (m_iSelect == SPIN_BUTTON_UP)
+      m_imgspinUpFocus->Render();
+    else
+      m_imgspinUp->Render();
+
+    if (m_iSelect == SPIN_BUTTON_DOWN)
+      m_imgspinDownFocus->Render();
+    else
+      m_imgspinDown->Render();
+  }
+  else if (!HasFocus() && !IsDisabled())
+  {
+    m_imgspinUp->Render();
+    m_imgspinDown->Render();
+  }
+  else
+  {
+    m_imgspinUpDisabled->Render();
+    m_imgspinDownDisabled->Render();
+  }
+
   CGUIControl::Render();
 }
 

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -17,6 +17,12 @@
 #define SPIN_BUTTON_DOWN 1
 #define SPIN_BUTTON_UP   2
 
+namespace
+{
+// Additional space between text and spin buttons
+constexpr float TEXT_SPACE = 5.0f;
+} // unnamed namespace
+
 CGUISpinControl::CGUISpinControl(int parentID,
                                  int controlID,
                                  float posX,
@@ -474,16 +480,15 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
   bool arrowsOnRight(0 != (m_label.GetLabelInfo().align & (XBFONT_RIGHT | XBFONT_CENTER_X)));
   if (!arrowsOnRight)
   {
-    const float space = 5;
-    changed |= m_imgspinDownFocus->SetPosition(m_posX + textWidth + space, m_posY);
-    changed |= m_imgspinDown->SetPosition(m_posX + textWidth + space, m_posY);
-    changed |= m_imgspinDownDisabled->SetPosition(m_posX + textWidth + space, m_posY);
-    changed |= m_imgspinUpFocus->SetPosition(m_posX + textWidth + space + m_imgspinDown->GetWidth(),
-                                             m_posY);
-    changed |=
-        m_imgspinUp->SetPosition(m_posX + textWidth + space + m_imgspinDown->GetWidth(), m_posY);
+    changed |= m_imgspinDownFocus->SetPosition(m_posX + textWidth + TEXT_SPACE, m_posY);
+    changed |= m_imgspinDown->SetPosition(m_posX + textWidth + TEXT_SPACE, m_posY);
+    changed |= m_imgspinDownDisabled->SetPosition(m_posX + textWidth + TEXT_SPACE, m_posY);
+    changed |= m_imgspinUpFocus->SetPosition(
+        m_posX + textWidth + TEXT_SPACE + m_imgspinDown->GetWidth(), m_posY);
+    changed |= m_imgspinUp->SetPosition(m_posX + textWidth + TEXT_SPACE + m_imgspinDown->GetWidth(),
+                                        m_posY);
     changed |= m_imgspinUpDisabled->SetPosition(
-        m_posX + textWidth + space + m_imgspinDownDisabled->GetWidth(), m_posY);
+        m_posX + textWidth + TEXT_SPACE + m_imgspinDownDisabled->GetWidth(), m_posY);
   }
 
   changed |= m_imgspinDownFocus->Process(currentTime);
@@ -504,15 +509,14 @@ void CGUISpinControl::Render()
 {
   if (m_label.GetLabelInfo().font)
   {
-    const float space = 5;
     float textWidth = m_label.GetTextWidth() + 2 * m_label.GetLabelInfo().offsetX;
     // Position the arrows
     bool arrowsOnRight(0 != (m_label.GetLabelInfo().align & (XBFONT_RIGHT | XBFONT_CENTER_X)));
 
     if (arrowsOnRight)
-      RenderText(m_posX - space - textWidth, m_posY, textWidth, m_height);
+      RenderText(m_posX - TEXT_SPACE - textWidth, m_posY, textWidth, m_height);
     else
-      RenderText(m_posX + m_imgspinDown->GetWidth() + m_imgspinUp->GetWidth() + space, m_posY,
+      RenderText(m_posX + m_imgspinDown->GetWidth() + m_imgspinUp->GetWidth() + TEXT_SPACE, m_posY,
                  textWidth, m_height);
 
     // set our hit rectangle for MouseOver events

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -67,7 +67,6 @@ void CGUISpinControlEx::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
 void CGUISpinControlEx::Render()
 {
-  m_buttonControl.Render();
   CGUISpinControl::Render();
 }
 
@@ -136,9 +135,27 @@ void CGUISpinControlEx::SetSpinPosition(float spinPosX)
 
 void CGUISpinControlEx::RenderText(float posX, float posY, float width, float height)
 {
-  const float spaceWidth = 10;
-  // check our limits from the button control
-  float x = std::max(m_buttonControl.m_label.GetRenderRect().x2 + spaceWidth, posX);
+  const float freeSpaceWidth{m_buttonControl.GetWidth() - GetSpinWidth() * 2};
+
+  // Limit right label text width to max 50% of free space
+  // (will be slightly shifted due to offsetX padding)
+  const float rightTextMaxWidth{freeSpaceWidth * 0.5f};
+
+  float rightTextWidth{width};
+  if (rightTextWidth > rightTextMaxWidth)
+  {
+    rightTextWidth = rightTextMaxWidth - m_label.GetLabelInfo().offsetX;
+  }
+
   m_label.SetScrolling(HasFocus());
-  CGUISpinControl::RenderText(x, m_buttonControl.GetYPosition(), width + posX - x, m_buttonControl.GetHeight());
+  // Replace posX by using our button position
+  posX = m_buttonControl.GetXPosition() + freeSpaceWidth - rightTextWidth -
+         m_label.GetLabelInfo().offsetX;
+
+  // Limit the max width for the left label to avoid text overlapping
+  m_buttonControl.SetMaxWidth(posX + m_label.GetLabelInfo().offsetX);
+  m_buttonControl.Render();
+
+  CGUISpinControl::RenderText(posX, m_buttonControl.GetYPosition(), rightTextWidth,
+                              m_buttonControl.GetHeight());
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Limit the max text width for the left (description) and right (value) labels to avoid overlapping

the idea is to automatically handle the free space for the text, depending on the length of the text, also when the right text change by clicking in the spin up/down buttons

as in set now the right (value) label can expand until to max 50% of free space,
see screenshots of use cases:

* LEFT LABEL **LONG**, RIGHT LABEL **LONG** selected/scrolling
![immagine](https://user-images.githubusercontent.com/3257156/162395940-822ef825-f138-41ea-be1d-f871ec707ced.png)
* LEFT LABEL **LONG**, RIGHT LABEL **LONG** not selected
![immagine](https://user-images.githubusercontent.com/3257156/162396098-6b93f4cb-0e3c-4a6b-b303-dffafa5f00d2.png)
* LEFT LABEL **LONG**, RIGHT LABEL **SHORT**
![immagine](https://user-images.githubusercontent.com/3257156/162396196-c5306ef2-fc1a-4b90-9d76-3e6c2e3599f2.png)
* LEFT LABEL **SHORT**, RIGHT LABEL **LONG**
![immagine](https://user-images.githubusercontent.com/3257156/162396235-b150fb4a-c43e-405b-80d5-4e96782e5e0a.png)


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In spinner ex control was not handled long text cases with the result of overlapping text as in #21184
causing it to be impossible to read the value to the right label

the intention is to have a GUI rendering fix, without relying on specific changes in the skins as in PR #21216

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
custom python addon settings with long text for spin control

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
