### PR TITLE
[dvdnav] reimplement dvdstateserializer logic

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2022 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -13,6 +13,7 @@
 #include "DVDDemuxers/DVDDemux.h"
 #include "DVDInputStream.h"
 #include "DVDInputStreamFile.h"
+#include "DVDStateSerializer.h"
 #include "DllDvdNav.h"
 #include "utils/Geometry.h"
 
@@ -129,6 +130,12 @@ protected:
   int GetAngleCount();
   void GetVideoResolution(uint32_t * width, uint32_t * height);
 
+  /*! \brief Provided a pod DVDState struct, fill it with the current dvdnav state
+  * \param[in,out] dvdstate the DVD state struct to be filled
+  * \return true if it was possible to fill the state struct based on the current dvdnav state, false otherwise
+  */
+  bool FillDVDState(DVDState& dvdstate);
+
   DllDvdNav m_dll;
   bool m_bCheckButtons;
   bool m_bEOF;
@@ -161,5 +168,8 @@ protected:
   int m_lastevent;
 
   std::map<int, std::map<int, int64_t>> m_mapTitleChapters;
+
+  /*! DVD state serializer handler */
+  CDVDStateSerializer m_dvdStateSerializer;
 };
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2022 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,16 +8,60 @@
 
 #pragma once
 
-#include "DllDvdNav.h"
-
 #include <string>
 
+class TiXmlElement;
+
+/*! \brief Pod structure which represents the current dvd state with respect to dvdnav properties */
+struct DVDState
+{
+  /*! The current title being played */
+  int32_t title = -1;
+  /*! Program number */
+  int32_t pgn = -1;
+  /*! Program cell number */
+  int32_t pgcn = -1;
+  /*! Current playing angle */
+  int32_t current_angle = -1;
+  /*! Physical subtitle id set in dvdnav  */
+  int8_t subp_num = -1;
+  /*! Physical audio stream id set in dvdnav  */
+  int8_t audio_num = -1;
+  /*! If subtitles are enabled or disabled  */
+  bool sub_enabled = false;
+};
+
+/*! \brief Auxiliar class to serialize/deserialize the dvd state (into/from XML)
+*/
 class CDVDStateSerializer
 {
 public:
-  static bool DVDToXMLState( std::string &xmlstate, const dvd_state_t *state );
-  static bool XMLToDVDState( dvd_state_t *state, const std::string &xmlstate );
+  /*! \brief Default constructor */
+  CDVDStateSerializer() = default;
 
-  static bool test( const dvd_state_t *state );
+  /*! \brief Default destructor */
+  ~CDVDStateSerializer() = default;
+
+  /*! \brief Provided the state in xml format, fills a DVDState struct representing the DVD state and returns the
+  * success status of the operation
+  * \param[in,out] state the DVD state struct to be filled
+  * \param xmlstate a string describing the dvd state (XML)
+  * \return true if it was possible to fill the state struct based on the XML content, false otherwise
+  */
+  bool XMLToDVDState(DVDState& state, const std::string& xmlstate);
+
+  /*! \brief Provided the DVDState struct of the current playing dvd, serializes the struct to XML
+  * \param[in,out] xmlstate a string describing the dvd state (XML)
+  * \param state the DVD state struct
+  * \return true if it was possible to serialize the struct into XML, false otherwise
+  */
+  bool DVDStateToXML(std::string& xmlstate, const DVDState& state);
+
+private:
+  /*! \brief Appends a new element with the given name and value to a provided root XML element
+  * \param[in,out] root the root xml element to append the new element
+  * \param name the new element name
+  * \param value the new element value
+  */
+  void AddXMLElement(TiXmlElement& root, const std::string& name, const std::string& value);
 };
-

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
@@ -101,6 +101,14 @@ public:
   virtual int64_t dvdnav_get_current_time(dvdnav_t* self) = 0;
   virtual void dvdnav_free(void* pdata) = 0;
   virtual int dvdnav_get_video_resolution(dvdnav_t* self, uint32_t* width, uint32_t* height)=0;
+  virtual dvdnav_status_t dvdnav_program_play(dvdnav_t* self,
+                                              int32_t title,
+                                              int32_t pgcn,
+                                              int32_t pgn) = 0;
+  virtual dvdnav_status_t dvdnav_current_title_program(dvdnav_t* self,
+                                                       int32_t* title,
+                                                       int32_t* pgcn,
+                                                       int32_t* pgn) = 0;
 };
 
 class DllDvdNav : public DllDynamic, DllDvdNavInterface
@@ -169,6 +177,12 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_title_string, (dvdnav_t *p1, const char **p2))
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_serial_string, (dvdnav_t *p1, const char **p2))
   DEFINE_METHOD4(uint32_t, dvdnav_describe_title_chapters, (dvdnav_t* p1, uint32_t p2, uint64_t** p3, uint64_t* p4))
+  DEFINE_METHOD4(dvdnav_status_t,
+                 dvdnav_program_play,
+                 (dvdnav_t * p1, int32_t p2, int32_t p3, int32_t p4))
+  DEFINE_METHOD4(dvdnav_status_t,
+                 dvdnav_current_title_program,
+                 (dvdnav_t * p1, int32_t* p2, int32_t* p3, int32_t* p4))
   DEFINE_METHOD1(int64_t, dvdnav_get_current_time, (dvdnav_t* p1))
   DEFINE_METHOD1(void, dvdnav_free, (void *p1))
   DEFINE_METHOD3(int, dvdnav_get_video_resolution, (dvdnav_t* p1, uint32_t* p2, uint32_t* p3))
@@ -209,6 +223,8 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
     RESOLVE_METHOD(dvdnav_next_pg_search)
     RESOLVE_METHOD(dvdnav_get_highlight_area)
     RESOLVE_METHOD(dvdnav_go_up)
+    RESOLVE_METHOD(dvdnav_program_play)
+    RESOLVE_METHOD(dvdnav_current_title_program)
     RESOLVE_METHOD(dvdnav_get_active_audio_stream)
     RESOLVE_METHOD(dvdnav_audio_stream_to_lang)
     RESOLVE_METHOD(dvdnav_get_vm)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1223,13 +1223,15 @@ void CVideoPlayer::Prepare()
   if (std::shared_ptr<CDVDInputStream::IMenus> ptr = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream))
   {
     CLog::Log(LOGINFO, "VideoPlayer: playing a file with menu's");
-    if(std::dynamic_pointer_cast<CDVDInputStreamNavigator>(m_pInputStream))
-      m_playerOptions.starttime = 0;
 
     if (!m_playerOptions.state.empty())
+    {
       discStateRestored = ptr->SetState(m_playerOptions.state);
+    }
     else if(std::shared_ptr<CDVDInputStreamNavigator> nav = std::dynamic_pointer_cast<CDVDInputStreamNavigator>(m_pInputStream))
+    {
       nav->EnableSubtitleStream(m_processInfo->GetVideoSettings().m_SubtitleOn);
+    }
   }
 
   if (!OpenDemuxStream())


### PR DESCRIPTION
## Description
Currently to save and restore save states in dvdnav (for optical discs or dvd isos) Kodi uses a private member of libdvdnav (`dvd_state_t`). We patch our version of libdvdnav with setters and getters for this state. Furthermore the `dvd_state_t` holds the values for pretty much any register value which makes the serializing/deserializing logic really verbose. Since there is no chance something like this will ever be accepted upstream, this PR provides an alternative.

When resuming an already played disc or ISO we want to:
- move to the title, program, cell and angle we were before
- change the audio stream to the one previously enabled
- change the subtitle stream to the previously enabled one
- enable/disable subtitles

This allow us to have the same functionality without abusing the library interface. Furthermore it has the side effect of greatly simplifying the serialization logic.

## Motivation and context
Get rid of patches (and maybe dll wrapping) on VP/libdvdnav

## How has this been tested?
Runtime tested on linux with physical dvds and isos

## What is the effect on users?
Hopefully none :) if any, something is wrong

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
