### PR TITLE
[iOS/tvOS] initialise log and settings components to prevent app crash on launch

### DIFF
--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -353,6 +353,12 @@
 
     setlocale(LC_NUMERIC, "C");
 
+    // Create logging and settings
+    CServiceBroker::CreateLogging();
+    const auto settingsComponent = std::make_shared<CSettingsComponent>();
+    settingsComponent->Initialize(appParamParser);
+    CServiceBroker::RegisterSettingsComponent(settingsComponent);
+
     if (!g_application.Create(appParamParser))
     {
       readyToRun = false;
@@ -391,6 +397,13 @@
         ELOG(@"%sException caught on main loop. Exiting", __PRETTY_FUNCTION__);
       }
     }
+
+    // Destroy settings and logging
+    CServiceBroker::GetLogging().UnregisterFromSettings();
+    CServiceBroker::GetSettingsComponent()->Deinitialize();
+    CServiceBroker::UnregisterSettingsComponent();
+    CServiceBroker::GetLogging().Uninitialize();
+    CServiceBroker::DestroyLogging();
 
     // signal we are dead
     [myLock unlockWithCondition:TRUE];

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -380,7 +380,13 @@ int KODI_Run(bool renderGUI)
 {
   int status = -1;
 
+  // Create logging and settings
+  CServiceBroker::CreateLogging();
   CAppParamParser appParamParser; //! @todo : proper params
+  const auto settingsComponent = std::make_shared<CSettingsComponent>();
+  settingsComponent->Initialize(appParamParser);
+  CServiceBroker::RegisterSettingsComponent(settingsComponent);
+
   if (!g_application.Create(appParamParser))
   {
     CLog::Log(LOGERROR, "ERROR: Unable to create application. Exiting");
@@ -429,6 +435,13 @@ int KODI_Run(bool renderGUI)
     CLog::Log(LOGERROR, "ERROR: Exception caught on main loop. Exiting");
     status = -1;
   }
+
+  // Destroy settings and logging
+  CServiceBroker::GetLogging().UnregisterFromSettings();
+  CServiceBroker::GetSettingsComponent()->Deinitialize();
+  CServiceBroker::UnregisterSettingsComponent();
+  CServiceBroker::GetLogging().Uninitialize();
+  CServiceBroker::DestroyLogging();
 
   return status;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
#21174 changed the way log and settings components are initialised: they're now created in `XBMC_Run()`. iOS and tvOS don't call this function but rather re-implement the same logic internally. Since log component is no longer initialised on those platforms, the first attempt to log something results in a crash.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #21238

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Launched and exited app on iOS and tvOS ensuring there's no crash.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users are able to use the app on iOS/tvOS again.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
