### PR TITLE
[discs][dvds] Make sure we populate playerstate when it's available f…

### DIFF
--- a/xbmc/video/Bookmark.cpp
+++ b/xbmc/video/Bookmark.cpp
@@ -32,3 +32,8 @@ bool CBookmark::IsPartWay() const
 {
   return totalTimeInSeconds > 0.0 && timeInSeconds > 0.0;
 }
+
+bool CBookmark::HasSavedPlayerState() const
+{
+  return !playerState.empty();
+}

--- a/xbmc/video/Bookmark.h
+++ b/xbmc/video/Bookmark.h
@@ -27,6 +27,11 @@ public:
    */
   bool IsPartWay() const;
 
+  /*! \brief returns true if this bookmark has a stored serialized player state
+   \return true if playerState is not empty.
+   */
+  bool HasSavedPlayerState() const;
+
   double timeInSeconds;
   double totalTimeInSeconds;
   long partNumber;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2334,7 +2334,9 @@ bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoIn
       details.m_lastPlayed.SetFromDBDateTime(m_pDS->fv("files.lastPlayed").get_asString());
     if (!details.m_dateAdded.IsValid())
       details.m_dateAdded.SetFromDBDateTime(m_pDS->fv("files.dateAdded").get_asString());
-    if (!details.GetResumePoint().IsSet())
+    if (!details.GetResumePoint().IsSet() ||
+        (!details.GetResumePoint().HasSavedPlayerState() &&
+         !m_pDS->fv("bookmark.playerState").get_asString().empty()))
     {
       details.SetResumePoint(m_pDS->fv("bookmark.timeInSeconds").get_asDouble(),
                              m_pDS->fv("bookmark.totalTimeInSeconds").get_asDouble(),


### PR DESCRIPTION
…rom db

## Description
Found while working on https://github.com/xbmc/xbmc/pull/21239. It seems we do not populate the videoinfotag with the playerstate member of the resumepoint even though we have it on the returned query when playing iso files (not from DB). We avoid defining the resume point if it is already partially filled (e.g. if it has the resume time from the resume point). However, this won't work without the companion serialized player state. 

The bug is easily reproducible if you attempt to resume from a dvd iso. Without this change you can only resume to the point if you don't leave the window. As soon as you leave and enter it again, the player state is lost. That behavior can be seen in the screencast below:

[![BUG](https://img.youtube.com/vi/7ELD4KXwpCc/0.jpg)](https://www.youtube.com/watch?v=7ELD4KXwpCc)


With this PR it should behave as expected:

[![FIX](https://img.youtube.com/vi/ympk-RLp_oo/0.jpg)](https://www.youtube.com/watch?v=ympk-RLp_oo)

Note that when resuming a playerstate there's currently a jump of ~9 seconds. That should be fixed with https://github.com/xbmc/xbmc/pull/21239.

## Motivation and context
Reproduceable resumes for dvd isos

## How has this been tested?
Runtime tested on linux

## What is the effect on users?
Users should now be able to resume dvd isos regardless of having the window they are in.

## Screenshots (if appropriate):

