### PR TITLE
[subtitles] Improved align to video condition based on resolution ratio

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -94,6 +94,14 @@ namespace OVERLAY {
     float m_height;
     float m_source_width{0}; // Video source width resolution used to calculate aspect ratio
     float m_source_height{0}; // Video source height resolution used to calculate aspect ratio
+
+  protected:
+    /*!
+     * \brief Given the resolution ratio determines if it is a 4/3 resolution
+     * \param resRatio The resolution ratio (the results of width / height)
+     * \return True if the ratio refer to a 4/3 resolution, otherwise false
+     */
+    bool IsSquareResolution(float resRatio) { return resRatio > 1.22f && resRatio < 1.34f; }
   };
 
   class CRenderer : public Observer

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -25,6 +25,8 @@
 #define ASSERT(f) _ASSERTE((f))
 #endif
 
+#include <cmath>
+
 using namespace OVERLAY;
 using namespace DirectX;
 
@@ -219,14 +221,14 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o, CRect& rSource)
     m_x = (0.5f * o->width + o->x) / o->source_width;
     m_y = (0.5f * o->height + o->y) / o->source_height;
 
-    int videoSourceH{static_cast<int>(rSource.Height())};
-    int videoSourceW{static_cast<int>(rSource.Width())};
+    const float subRatio{static_cast<float>(o->source_width) / o->source_height};
+    const float vidRatio{rSource.Width() / rSource.Height()};
 
-    if ((o->source_height == videoSourceH || videoSourceH % o->source_height == 0) &&
-        (o->source_width == videoSourceW || videoSourceW % o->source_width == 0))
+    // We always consider aligning 4/3 subtitles to the video,
+    // for example SD DVB subtitles (4/3) must be stretched on fullhd video
+
+    if (std::fabs(subRatio - vidRatio) < 0.001f || IsSquareResolution(subRatio))
     {
-      // We check also for multiple of source_height/source_width
-      // because for example 1080P subtitles can be used on 4K videos
       m_align = ALIGN_VIDEO;
       m_width = static_cast<float>(o->width) / o->source_width;
       m_height = static_cast<float>(o->height) / o->source_height;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -28,6 +28,8 @@
 #include "utils/log.h"
 #include "utils/GLUtils.h"
 
+#include <cmath>
+
 #if HAS_GLES >= 2
 // GLES2.0 cant do CLAMP, but can do CLAMP_TO_EDGE.
 #define GL_CLAMP	GL_CLAMP_TO_EDGE
@@ -191,14 +193,14 @@ COverlayTextureGL::COverlayTextureGL(CDVDOverlayImage* o, CRect& rSource)
     m_x = (0.5f * o->width + o->x) / o->source_width;
     m_y = (0.5f * o->height + o->y) / o->source_height;
 
-    int videoSourceH{static_cast<int>(rSource.Height())};
-    int videoSourceW{static_cast<int>(rSource.Width())};
+    const float subRatio{static_cast<float>(o->source_width) / o->source_height};
+    const float vidRatio{rSource.Width() / rSource.Height()};
 
-    if ((o->source_height == videoSourceH || videoSourceH % o->source_height == 0) &&
-        (o->source_width == videoSourceW || videoSourceW % o->source_width == 0))
+    // We always consider aligning 4/3 subtitles to the video,
+    // for example SD DVB subtitles (4/3) must be stretched on fullhd video
+
+    if (std::fabs(subRatio - vidRatio) < 0.001f || IsSquareResolution(subRatio))
     {
-      // We check also for multiple of source_height/source_width
-      // because for example 1080P subtitles can be used on 4K videos
       m_align = ALIGN_VIDEO;
       m_width = static_cast<float>(o->width) / o->source_width;
       m_height = static_cast<float>(o->height) / o->source_height;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Improved the condition used to choose the "aligmnent to video"
with a more reliable condition that check the resolution ratios

added also a check to always align to video the 4/3 subtitles
this because the DVB subtitles at SD (4/3) resolution can be used on a fullhd video
(and fix the regression)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An user has reported a regression https://github.com/xbmc/xbmc/issues/20729#issuecomment-1086860869 on a DVB subtitle after PR #21162

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Again tested all samples from our FTP folder:
samples_new/subtitles/PGS/
(see FilesInfo.txt for each file info)

and

samples_new/subtitles/DVB/
where i have add the new test case file:
sample1080p_DVB.at.SD.4_3.ts (fullhd video with SD 4/3 DVB subtitle)

PS. no need to test BD 4k menu because the behaviour is the same of before

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
