### PR TITLE
[discs] Fix resume in blurays (and br isos)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -140,6 +140,7 @@ bool CDVDInputStreamBluray::Open()
 
   bool openStream = false;
   bool openDisc = false;
+  bool resumable = true;
 
   // The item was selected via the simple menu
   if (URIUtils::IsProtocol(strPath, "bluray"))
@@ -161,6 +162,7 @@ bool CDVDInputStreamBluray::Open()
       const std::string& root2 = url2.GetHostName();
       CURL url(root2);
       CFileItem item(url, false);
+      resumable = false;
 
       // Check whether disc is AACS protected
       if (!openDisc)
@@ -325,7 +327,8 @@ bool CDVDInputStreamBluray::Open()
     m_navmode = false;
     m_titleInfo = GetTitleFile(filename);
   }
-  else if (mode == BD_PLAYBACK_MAIN_TITLE)
+  else if (mode == BD_PLAYBACK_MAIN_TITLE ||
+           (resumable && m_item.m_lStartOffset == STARTOFFSET_RESUME))
   {
     m_navmode = false;
     m_titleInfo = GetTitleLongest();


### PR DESCRIPTION
## Description
Currently resuming bluray discs (or bluray isos) may fail to correctly show the file position on the video timeline. This happens because in those cases `m_titleInfo` is not populated with the proper bluray track. The BR is initated using `bd_play(m_bd)` (just like we were playing menus) and a seek is performed afterwards.

The following videos ilustrates the issue.

**Master:**
[![IMASTER](https://img.youtube.com/vi/6geGSzWqDZA/0.jpg)](https://www.youtube.com/watch?v=6geGSzWqDZA)

**PR**
[![IMASTER](https://img.youtube.com/vi/Yi_h9YI2myU/0.jpg)](https://www.youtube.com/watch?v=Yi_h9YI2myU)

This PR makes sure if we are resuming the bluray and the playback can actually be resumed (i.e. not playing menus) we set the current title to the main BR track (the only one that can be resumable).
Tested with a physical bluray and an iso.