### PR TITLE
[discs][gui] Fix hasmenu boolean condition

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4775,7 +4775,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         if (!pMenu->CanSeek())
           state.time_offset = 0;
       }
-      state.hasMenu = true;
+      state.hasMenu = pMenu->HasMenu();
     }
 
     state.canpause = m_pInputStream->CanPause();


### PR DESCRIPTION
## Description
We can only move to the menu from a playing title if the bluray was started via `bd_play`:
https://github.com/xbmc/libbluray/blob/bdb37106453bb52d89f80263914a93f861994635/src/libbluray/bluray.c#L3310-L3312

If playback is started from the simplified menu without going through the main bluray menu any subsequent calls to the `PlayerControl(ShowVideoMenu)` builtin will result in noop. Instead of blindingly assume we can jump into the menu on the fact the current inputstream implements the `IMenus` interface just call the corresponding implementation to see if they are actually supported. For dvds this will always evaluate to true. For blurays it really depends on the state (if `m_navmode` is set or not):

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp#L1176-L1179

You can easily confirm this will not work by checking what happens when `OnMenu` is called:

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp#L1120-L1124

This PR makes sure `VideoPlayer.HasMenu` boolean condition is not set when menus are not supported. In estuary this will lead the "Menu" icon not to be shown in the video OSD in such cases.