### PR TITLE
[GUI] Always respect sortattributes in tvshow sort methods

### DIFF
--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -130,12 +130,19 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         AddSortMethod(SortByOriginalTitle, sortAttributes, 20376,
                       LABEL_MASKS("%T", "%M", "%T", "%M")); // Title, #Episodes | Title, #Episodes
 
-        AddSortMethod(SortByNumberOfEpisodes, 20360, LABEL_MASKS("%L", "%M", "%L", "%M"));  // Label, #Episodes | Label, #Episodes
-        AddSortMethod(SortByLastPlayed, 568, LABEL_MASKS("%T", "%p", "%T", "%p"));  // Title, #Last played | Title, #Last played
-        AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%T", "%a", "%T", "%a"));  // Title, DateAdded | Title, DateAdded
-        AddSortMethod(SortByYear, 562, LABEL_MASKS("%L","%Y","%L","%Y")); // Label, Year | Label, Year
-        AddSortMethod(SortByRating, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-        AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T", "%r", "%T", "%r"));  // Title, Userrating | Title, Userrating
+        AddSortMethod(SortByNumberOfEpisodes, sortAttributes, 20360,
+                      LABEL_MASKS("%L", "%M", "%L", "%M")); // Label, #Episodes | Label, #Episodes
+        AddSortMethod(
+            SortByLastPlayed, sortAttributes, 568,
+            LABEL_MASKS("%T", "%p", "%T", "%p")); // Title, #Last played | Title, #Last played
+        AddSortMethod(SortByDateAdded, sortAttributes, 570,
+                      LABEL_MASKS("%T", "%a", "%T", "%a")); // Title, DateAdded | Title, DateAdded
+        AddSortMethod(SortByYear, sortAttributes, 562,
+                      LABEL_MASKS("%L", "%Y", "%L", "%Y")); // Label, Year | Label, Year
+        AddSortMethod(SortByRating, sortAttributes, 563,
+                      LABEL_MASKS("%T", "%R", "%T", "%R")); // Title, Rating | Title, Rating
+        AddSortMethod(SortByUserRating, sortAttributes, 38018,
+                      LABEL_MASKS("%T", "%r", "%T", "%r")); // Title, Userrating | Title, Userrating
         SetSortMethod(SortByLabel);
 
         const CViewState *viewState = CViewStateSettings::GetInstance().Get("videonavtvshows");
@@ -523,14 +530,23 @@ void CGUIViewStateVideoMusicVideos::SaveViewState()
 
 CGUIViewStateVideoTVShows::CGUIViewStateVideoTVShows(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
-  AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%T", "%M", "%T", "%M"),  // Title, #Episodes | Title, #Episodes
-    CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+  SortAttribute sortAttributes = SortAttributeNone;
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  if (settings->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
+    sortAttributes = SortAttributeIgnoreArticle;
 
-  AddSortMethod(SortByNumberOfEpisodes, 20360, LABEL_MASKS("%L", "%M", "%L", "%M"));  // Label, #Episodes | Label, #Episodes
-  AddSortMethod(SortByLastPlayed, 568, LABEL_MASKS("%T", "%p", "%T", "%p"));  // Title, #Last played | Title, #Last played
-  AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%T", "%a", "%T", "%a"));  // Title, DateAdded | Title, DateAdded
-  AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
-  AddSortMethod(SortByUserRating, 38018, LABEL_MASKS("%T", "%r", "%T", "%r"));  // Title, Userrating | Title, Userrating
+  AddSortMethod(SortBySortTitle, sortAttributes, 556,
+                LABEL_MASKS("%T", "%M", "%T", "%M")); // Title, #Episodes | Title, #Episodes
+  AddSortMethod(SortByNumberOfEpisodes, sortAttributes, 20360,
+                LABEL_MASKS("%L", "%M", "%L", "%M")); // Label, #Episodes | Label, #Episodes
+  AddSortMethod(SortByLastPlayed, sortAttributes, 568,
+                LABEL_MASKS("%T", "%p", "%T", "%p")); // Title, #Last played | Title, #Last played
+  AddSortMethod(SortByDateAdded, sortAttributes, 570,
+                LABEL_MASKS("%T", "%a", "%T", "%a")); // Title, DateAdded | Title, DateAdded
+  AddSortMethod(SortByYear, sortAttributes, 562,
+                LABEL_MASKS("%T", "%Y", "%T", "%Y")); // Title, Year | Title, Year
+  AddSortMethod(SortByUserRating, sortAttributes, 38018,
+                LABEL_MASKS("%T", "%r", "%T", "%r")); // Title, Userrating | Title, Userrating
 
   const CViewState *viewState = CViewStateSettings::GetInstance().Get("videonavtvshows");
   if (items.IsSmartPlayList() || items.IsLibraryFolder())


### PR DESCRIPTION
## Description
Kodi was not respecting the sortattributes (which might contain `SortAttributeIgnoreArticle`) for any sort method rather than title. This PR makes sure it is correctly applied to any sortmethod in the tvshow scope.
Other nodes (e.g. musicvideos) might need a similar implementation. I decided to fix only what I could see.

Fixes https://github.com/xbmc/xbmc/issues/21252

A runtime test is appreciated to confirm the fix.

![image](https://user-images.githubusercontent.com/7375276/162741230-faeeb4c5-d595-49fe-a492-09dfaeea12b2.png)
