### PR TITLE
[cleanup] cppcheck warnings "constVariable" / a move operation in AddonDatabase

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2042,7 +2042,7 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
   if (!m_cueDocument)
     return false;
 
-  CMusicInfoTag& tag = *GetMusicInfoTag();
+  const CMusicInfoTag& tag = *GetMusicInfoTag();
 
   VECSONGS tracks;
   m_cueDocument->GetSongs(tracks);

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -180,7 +180,7 @@ int CPlayListPlayer::GetNextSong()
 bool CPlayListPlayer::PlayNext(int offset, bool bAutoPlay)
 {
   int iSong = GetNextSong(offset);
-  CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
+  const CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
 
   if ((iSong < 0) || (iSong >= playlist.size()) || (playlist.GetPlayable() <= 0))
   {
@@ -202,7 +202,7 @@ bool CPlayListPlayer::PlayPrevious()
   if (m_iCurrentPlayList == PLAYLIST_NONE)
     return false;
 
-  CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
+  const CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
   int iSong = m_iCurrentSong;
 
   if (!RepeatedOne(m_iCurrentPlayList))
@@ -231,7 +231,7 @@ bool CPlayListPlayer::Play()
   if (m_iCurrentPlayList == PLAYLIST_NONE)
     return false;
 
-  CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
+  const CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
   if (playlist.size() <= 0)
     return false;
 

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -188,7 +188,7 @@ int CSeekHandler::GetSeekSize() const
 
 void CSeekHandler::SetSeekSize(double seekSize)
 {
-  CApplicationPlayer& player = g_application.GetAppPlayer();
+  const CApplicationPlayer& player = g_application.GetAppPlayer();
   int64_t playTime = player.GetTime();
   double minSeekSize = (player.GetMinTime() - playTime) / 1000.0;
   double maxSeekSize = (player.GetMaxTime() - playTime) / 1000.0;

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -813,7 +813,7 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
       auto addon = CAddonBuilder::Generate(builder.get(), ADDON_UNKNOWN);
       if (addon)
       {
-        result.emplace_back(addon);
+        result.emplace_back(std::move(addon));
       }
       else
         CLog::Log(LOGWARNING, "CAddonDatabase: failed to build {}", addonId);

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -158,7 +158,7 @@ CAEChannelInfo& CAEChannelInfo::operator=(const enum AEStdChLayout rhs)
 {
   assert(rhs > AE_CH_LAYOUT_INVALID && rhs < AE_CH_LAYOUT_MAX);
 
-  static const enum AEChannel layouts[AE_CH_LAYOUT_MAX][9] = {
+  static constexpr enum AEChannel layouts[AE_CH_LAYOUT_MAX][9] = {
       {AE_CH_FC, AE_CH_NULL},
       {AE_CH_FL, AE_CH_FR, AE_CH_NULL},
       {AE_CH_FL, AE_CH_FR, AE_CH_LFE, AE_CH_NULL},

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -158,19 +158,19 @@ CAEChannelInfo& CAEChannelInfo::operator=(const enum AEStdChLayout rhs)
 {
   assert(rhs > AE_CH_LAYOUT_INVALID && rhs < AE_CH_LAYOUT_MAX);
 
-  static enum AEChannel layouts[AE_CH_LAYOUT_MAX][9] = {
-    {AE_CH_FC, AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_LFE, AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_FC , AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_FC , AE_CH_LFE, AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_BL , AE_CH_BR , AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_BL , AE_CH_BR , AE_CH_LFE, AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_FC , AE_CH_BL , AE_CH_BR , AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_FC , AE_CH_LFE,  AE_CH_BL , AE_CH_BR , AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_FC , AE_CH_BL , AE_CH_BR , AE_CH_SL , AE_CH_SR, AE_CH_NULL},
-    {AE_CH_FL, AE_CH_FR, AE_CH_FC , AE_CH_LFE, AE_CH_BL , AE_CH_BR , AE_CH_SL , AE_CH_SR, AE_CH_NULL}
-  };
+  static const enum AEChannel layouts[AE_CH_LAYOUT_MAX][9] = {
+      {AE_CH_FC, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_LFE, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_BL, AE_CH_BR, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_BL, AE_CH_BR, AE_CH_LFE, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_BL, AE_CH_BR, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BL, AE_CH_BR, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_BL, AE_CH_BR, AE_CH_SL, AE_CH_SR, AE_CH_NULL},
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BL, AE_CH_BR, AE_CH_SL, AE_CH_SR,
+       AE_CH_NULL}};
 
   *this = layouts[rhs];
   return *this;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -232,7 +232,7 @@ bool CRendererVAAPIGL::UploadTexture(int index)
 
   m_vaapiTextures[index]->Map(pic);
 
-  YuvImage &im = buf.image;
+  const YuvImage& im = buf.image;
   CYuvPlane (&planes)[3] = buf.fields[0];
 
   auto size = m_vaapiTextures[index]->GetTextureSize();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -161,7 +161,7 @@ bool CLinuxRendererGL::ValidateRenderer()
     return false;
 
   int index = m_iYV12RenderBuffer;
-  CPictureBuffer& buf = m_buffers[index];
+  const CPictureBuffer& buf = m_buffers[index];
 
   if (!buf.fields[FIELD_FULL][0].id)
     return false;
@@ -2717,7 +2717,7 @@ void CLinuxRendererGL::DeleteCLUT()
 
 void CLinuxRendererGL::CheckVideoParameters(int index)
 {
-  CPictureBuffer &buf = m_buffers[index];
+  const CPictureBuffer& buf = m_buffers[index];
   ETONEMAPMETHOD method = m_videoSettings.m_ToneMapMethod;
 
   AVColorPrimaries srcPrim = GetSrcPrimaries(buf.m_srcPrimaries, buf.image.width, buf.image.height);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -771,8 +771,7 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
     }
   }
 
-
-  SPresent& m = m_Queue[m_presentsource];
+  const SPresent& m = m_Queue[m_presentsource];
 
   {
     std::unique_lock<CCriticalSection> lock(m_presentlock);
@@ -832,7 +831,7 @@ bool CRenderManager::IsVideoLayer()
 /* simple present method */
 void CRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
 {
-  SPresent& m = m_Queue[m_presentsource];
+  const SPresent& m = m_Queue[m_presentsource];
 
   if (m.presentfield == FS_BOT)
     m_pRenderer->RenderUpdate(m_presentsource, m_presentsourcePast, clear, flags | RENDER_FLAG_BOT, alpha);
@@ -846,7 +845,7 @@ void CRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
  * we just render the two fields right after eachother */
 void CRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
 {
-  SPresent& m = m_Queue[m_presentsource];
+  const SPresent& m = m_Queue[m_presentsource];
 
   if(m_presentstep == PRESENT_FRAME)
   {
@@ -866,7 +865,7 @@ void CRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
 
 void CRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
 {
-  SPresent& m = m_Queue[m_presentsource];
+  const SPresent& m = m_Queue[m_presentsource];
 
   if( m.presentfield == FS_BOT )
   {

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -73,7 +73,7 @@ void CGUIDialogSeekBar::FrameMove()
 
 int CGUIDialogSeekBar::GetProgress() const
 {
-  CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
+  const CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
 
   int progress = 0;
 
@@ -113,7 +113,7 @@ int CGUIDialogSeekBar::GetEpgEventProgress() const
 
 int CGUIDialogSeekBar::GetTimeshiftProgress() const
 {
-  CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
+  const CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
 
   int progress = 0;
   infoMgr.GetInt(progress, PVR_TIMESHIFT_SEEKBAR);

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -30,7 +30,7 @@ bool CPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if (playlistTyp==PLAYLIST_NONE)
     return false;
 
-  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlistTyp);
+  const CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlistTyp);
   items.Reserve(playlist.size());
 
   for (int i = 0; i < playlist.size(); ++i)

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -391,8 +391,7 @@ void CGUISliderControl::SetPercentage(float percent, RangeSelector selector /* =
 
   float percentLower = selector == RangeSelectorLower ? percent : m_percentValues[0];
   float percentUpper = selector == RangeSelectorUpper ? percent : m_percentValues[1];
-  float oldValues[2] = { m_percentValues[0],m_percentValues[1] };
-
+  const float oldValues[2] = {m_percentValues[0], m_percentValues[1]};
 
   if (!m_rangeSelection || percentLower <= percentUpper)
   {

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -162,7 +162,7 @@ bool CTextureBundleXBT::LoadTexture(const std::string& filename,
   if (file.GetFrames().empty())
     return false;
 
-  CXBTFFrame& frame = file.GetFrames().at(0);
+  const CXBTFFrame& frame = file.GetFrames().at(0);
   if (!ConvertFrameToTexture(filename, frame, texture))
   {
     return false;

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -90,7 +90,7 @@ bool CheckWindowCondition(CGUIWindow *window, int condition)
 
 CGUIWindow* GetWindowWithCondition(int contextWindow, int condition)
 {
-  CGUIWindowManager& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
+  const CGUIWindowManager& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
 
   CGUIWindow *window = windowMgr.GetWindow(contextWindow);
   if (CheckWindowCondition(window, condition))

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -529,7 +529,8 @@ bool CMusicGUIInfo::GetPartyModeLabel(std::string& value, const CGUIInfo &info) 
 
 bool CMusicGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo &info) const
 {
-  PLAYLIST::CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC);
+  const PLAYLIST::CPlayList& playlist =
+      CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC);
   if (playlist.size() < 1)
     return false;
 

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -602,7 +602,8 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
 
 bool CVideoGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo& info) const
 {
-  PLAYLIST::CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_VIDEO);
+  const PLAYLIST::CPlayList& playlist =
+      CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_VIDEO);
   if (playlist.size() < 1)
     return false;
 

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -104,7 +104,7 @@ void CIRTranslator::MapRemote(TiXmlNode* pRemote, const std::string& szDevice)
   if (it == m_irRemotesMap.end())
     m_irRemotesMap[szDevice].reset(new IRButtonMap);
 
-  std::shared_ptr<IRButtonMap>& buttons = m_irRemotesMap[szDevice];
+  const std::shared_ptr<IRButtonMap>& buttons = m_irRemotesMap[szDevice];
 
   TiXmlElement* pButton = pRemote->FirstChildElement();
   while (pButton != nullptr)

--- a/xbmc/input/touch/generic/GenericTouchPinchDetector.cpp
+++ b/xbmc/input/touch/generic/GenericTouchPinchDetector.cpp
@@ -55,8 +55,8 @@ bool CGenericTouchPinchDetector::OnTouchMove(unsigned int index, const Pointer& 
   // update the internal pointers
   m_pointers[index] = pointer;
 
-  Pointer& primaryPointer = m_pointers[0];
-  Pointer& secondaryPointer = m_pointers[1];
+  const Pointer& primaryPointer = m_pointers[0];
+  const Pointer& secondaryPointer = m_pointers[1];
 
   if (!primaryPointer.valid() || !secondaryPointer.valid() ||
       (!primaryPointer.moving && !secondaryPointer.moving))

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -71,7 +71,7 @@ static const std::string getListOfAddonClassesAsString(
 {
   std::string message;
   std::unique_lock<CCriticalSection> l(*(languageHook.get()));
-  std::set<XBMCAddon::AddonClass*>& acs = languageHook->GetRegisteredAddonClasses();
+  const std::set<XBMCAddon::AddonClass*>& acs = languageHook->GetRegisteredAddonClasses();
   bool firstTime = true;
   for (const auto& iter : acs)
   {

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -110,7 +110,7 @@ namespace MUSIC_UTILS
       loaded when the playlist is shown.
       */
       bool clearcache(false);
-      CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC);
+      const CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC);
       for (int i = 0; i < playlist.size(); ++i)
       {
         CFileItemPtr songitem = playlist[i];
@@ -235,7 +235,7 @@ namespace MUSIC_UTILS
 
   bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist)
   {
-    CMusicInfoTag &tag = *musicitem.GetMusicInfoTag();
+    const CMusicInfoTag& tag = *musicitem.GetMusicInfoTag();
     if (tag.GetDatabaseId() < 1 || tag.GetType().empty())
       return false;
     if (tag.GetType() != MediaTypeArtist && tag.GetType() != MediaTypeAlbum && tag.GetType() != MediaTypeSong)

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -198,7 +198,7 @@ bool CNetworkBase::HasInterfaceForIP(unsigned long address)
 
 bool CNetworkBase::IsAvailable(void)
 {
-  std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
+  const std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
   return (ifaces.size() != 0);
 }
 

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -215,7 +215,7 @@ bool CMACDiscoveryJob::DoWork()
     return false;
   }
 
-  std::vector<CNetworkInterface*>& ifaces = CServiceBroker::GetNetwork().GetInterfaceList();
+  const std::vector<CNetworkInterface*>& ifaces = CServiceBroker::GetNetwork().GetInterfaceList();
   for (const auto& it : ifaces)
   {
     if (it->GetHostMacAddress(ipAddress, m_macAddress))

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -77,7 +77,7 @@ private:
 
 void CEpgTagStateChange::Deliver()
 {
-  CPVREpgContainer& epgContainer = CServiceBroker::GetPVRManager().EpgContainer();
+  const CPVREpgContainer& epgContainer = CServiceBroker::GetPVRManager().EpgContainer();
 
   const std::shared_ptr<CPVREpg> epg = epgContainer.GetByChannelUid(m_epgtag->ClientID(), m_epgtag->UniqueChannelID());
   if (!epg)

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -2740,7 +2740,7 @@ namespace PVR
 
   void CPVRChannelSwitchingInputHandler::GetChannelNumbers(std::vector<std::string>& channelNumbers)
   {
-    CPVRManager& pvrMgr = CServiceBroker::GetPVRManager();
+    const CPVRManager& pvrMgr = CServiceBroker::GetPVRManager();
     const std::shared_ptr<CPVRChannel> playingChannel = pvrMgr.PlaybackState()->GetPlayingChannel();
     if (playingChannel)
     {

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -252,7 +252,7 @@ void CPVRGUIInfo::UpdateDescrambleData()
 
 void CPVRGUIInfo::UpdateMisc()
 {
-  CPVRManager& mgr = CServiceBroker::GetPVRManager();
+  const CPVRManager& mgr = CServiceBroker::GetPVRManager();
   bool bStarted = mgr.IsStarted();
   const std::shared_ptr<CPVRPlaybackState> state = mgr.PlaybackState();
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -756,7 +756,7 @@ bool CGUIWindowPVRGuideBase::GotoEnd()
 
 bool CGUIWindowPVRGuideBase::GotoCurrentProgramme()
 {
-  CPVRManager& mgr = CServiceBroker::GetPVRManager();
+  const CPVRManager& mgr = CServiceBroker::GetPVRManager();
   std::shared_ptr<CPVRChannel> channel = mgr.PlaybackState()->GetPlayingChannel();
 
   if (!channel)
@@ -823,7 +823,7 @@ bool CGUIWindowPVRGuideBase::GotoLastChannel()
 
 bool CGUIWindowPVRGuideBase::GotoPlayingChannel()
 {
-  CPVRManager& mgr = CServiceBroker::GetPVRManager();
+  const CPVRManager& mgr = CServiceBroker::GetPVRManager();
   std::shared_ptr<CPVRChannel> channel = mgr.PlaybackState()->GetPlayingChannel();
 
   if (!channel)

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -101,7 +101,7 @@ protected:
                                         std::chrono::milliseconds(-1) /* indicates wait forever*/)
   {
     XbmcThreads::CEventGroup group{&event, &m_StopEvent};
-    CEvent* result =
+    const CEvent* result =
         duration < std::chrono::milliseconds::zero() ? group.wait() : group.wait(duration);
     return  result == &event ? WAIT_SIGNALED :
       (result == NULL ? WAIT_TIMEDOUT : WAIT_INTERRUPTED);

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -79,7 +79,7 @@ bool CStreamDetailVideo::IsWorseThan(const CStreamDetail &that) const
     return true;
 
   // Best video stream is that with the most pixels
-  auto &sdv = static_cast<const CStreamDetailVideo &>(that);
+  const auto& sdv = static_cast<const CStreamDetailVideo&>(that);
   return (sdv.m_iWidth * sdv.m_iHeight) > (m_iWidth * m_iHeight);
 }
 
@@ -123,7 +123,7 @@ bool CStreamDetailAudio::IsWorseThan(const CStreamDetail &that) const
   if (that.m_eType != CStreamDetail::AUDIO)
     return true;
 
-  auto &sda = static_cast<const CStreamDetailAudio &>(that);
+  const auto& sda = static_cast<const CStreamDetailAudio&>(that);
   // First choice is the thing with the most channels
   if (sda.m_iChannels > m_iChannels)
     return true;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1511,7 +1511,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
 
   int heading = -1;
   VIDEODB_CONTENT_TYPE type = static_cast<VIDEODB_CONTENT_TYPE>(item->GetVideoContentType());
-  std::string& subtype = item->GetVideoInfoTag()->m_type;
+  const std::string& subtype = item->GetVideoInfoTag()->m_type;
   if (subtype != "tag")
   {
     switch (type)

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -613,7 +613,7 @@ bool CWinSystemWayland::ResizeWindow(int, int, int, int)
   // CGraphicContext is "smart" and calls ResizeWindow or SetFullScreen depending
   // on some state like whether we were already fullscreen. But actually the processing
   // here is always identical, so we are using a common function to handle both.
-  auto& res = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);
+  const auto& res = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);
   // The newWidth/newHeight parameters are taken from RES_WINDOW anyway, so we can just
   // ignore them
   return SetResolutionExternal(false, res);
@@ -922,7 +922,7 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
 
 void CWinSystemWayland::FinishModeChange(RESOLUTION res)
 {
-  auto& resInfo = CDisplaySettings::GetInstance().GetResolutionInfo(res);
+  const auto& resInfo = CDisplaySettings::GetInstance().GetResolutionInfo(res);
 
   ApplyNextState();
 

--- a/xbmc/windowing/wayland/WindowDecorator.cpp
+++ b/xbmc/windowing/wayland/WindowDecorator.cpp
@@ -508,7 +508,7 @@ void CWindowDecorator::OnPointerButton(CSeat* seat, std::uint32_t serial, std::u
   {
     return;
   }
-  auto& seatState = seatStateI->second;
+  const auto& seatState = seatStateI->second;
   if (seatState.currentSurface != SURFACE_COUNT && state == wayland::pointer_button_state::pressed)
   {
     HandleSeatClick(seatState, seatState.currentSurface, serial, button, seatState.pointerPosition);


### PR DESCRIPTION
## Description
nothing exciting. just get rid of a few cppcheck warnings.
the move in addondb should save some atomic reference counting.

## How has this been tested?
a few weeks on the sofa :)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

