### PR TITLE
[PVR] Fix EPG search genre matching.

### DIFF
--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -696,9 +696,18 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
 
   if (searchData.m_iGenreType != EPG_SEARCH_UNSET)
   {
-    filter.AppendWhere(PrepareSQL("(iGenreType < %u) OR (iGenreType > %u) OR (iGenreType = %u)",
-                                  EPG_EVENT_CONTENTMASK_MOVIEDRAMA,
-                                  EPG_EVENT_CONTENTMASK_USERDEFINED, searchData.m_iGenreType));
+    if (searchData.m_bIncludeUnknownGenres)
+    {
+      // match the exact genre and everything with unknown genre
+      filter.AppendWhere(PrepareSQL("(iGenreType == %u) OR (iGenreType < %u) OR (iGenreType > %u)",
+                                    searchData.m_iGenreType, EPG_EVENT_CONTENTMASK_MOVIEDRAMA,
+                                    EPG_EVENT_CONTENTMASK_USERDEFINED));
+    }
+    else
+    {
+      // match only the exact genre
+      filter.AppendWhere(PrepareSQL("iGenreType == %u", searchData.m_iGenreType));
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////

--- a/xbmc/pvr/epg/EpgSearchData.h
+++ b/xbmc/pvr/epg/EpgSearchData.h
@@ -21,6 +21,7 @@ struct PVREpgSearchData
 {
   std::string m_strSearchTerm; /*!< The term to search for */
   bool m_bSearchInDescription = false; /*!< Search for strSearchTerm in the description too */
+  bool m_bIncludeUnknownGenres = false; /*!< Whether to include unknown genres */
   int m_iGenreType = EPG_SEARCH_UNSET; /*!< The genre type for an entry */
   bool m_bIgnoreFinishedBroadcasts; /*!< True to ignore finished broadcasts, false if not */
   bool m_bIgnoreFutureBroadcasts; /*!< True to ignore future broadcasts, false if not */
@@ -31,6 +32,7 @@ struct PVREpgSearchData
   {
     m_strSearchTerm.clear();
     m_bSearchInDescription = false;
+    m_bIncludeUnknownGenres = false;
     m_iGenreType = EPG_SEARCH_UNSET;
     m_bIgnoreFinishedBroadcasts = true;
     m_bIgnoreFutureBroadcasts = false;

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -39,7 +39,6 @@ void CPVREpgSearchFilter::Reset()
   m_bIsCaseSensitive = false;
   m_iMinimumDuration = EPG_SEARCH_UNSET;
   m_iMaximumDuration = EPG_SEARCH_UNSET;
-  m_bIncludeUnknownGenres = false;
   m_bRemoveDuplicates = false;
 
   /* pvr specific filters */
@@ -157,9 +156,9 @@ void CPVREpgSearchFilter::SetEndDateTime(const CDateTime& endDateTime)
 
 void CPVREpgSearchFilter::SetIncludeUnknownGenres(bool bIncludeUnknownGenres)
 {
-  if (m_bIncludeUnknownGenres != bIncludeUnknownGenres)
+  if (m_searchData.m_bIncludeUnknownGenres != bIncludeUnknownGenres)
   {
-    m_bIncludeUnknownGenres = bIncludeUnknownGenres;
+    m_searchData.m_bIncludeUnknownGenres = bIncludeUnknownGenres;
     m_bChanged = true;
   }
 }
@@ -244,17 +243,27 @@ void CPVREpgSearchFilter::SetLastExecutedDateTime(const CDateTime& lastExecutedD
 
 bool CPVREpgSearchFilter::MatchGenre(const std::shared_ptr<CPVREpgInfoTag>& tag) const
 {
-  bool bReturn(true);
+  if (m_bEpgSearchDataFiltered)
+    return true;
 
   if (m_searchData.m_iGenreType != EPG_SEARCH_UNSET)
   {
-    bool bIsUnknownGenre(tag->GenreType() > EPG_EVENT_CONTENTMASK_USERDEFINED ||
-                         tag->GenreType() < EPG_EVENT_CONTENTMASK_MOVIEDRAMA);
-    bReturn = ((m_bIncludeUnknownGenres && bIsUnknownGenre) || m_bEpgSearchDataFiltered ||
-               tag->GenreType() == m_searchData.m_iGenreType);
+    if (m_searchData.m_bIncludeUnknownGenres)
+    {
+      // match the exact genre and everything with unknown genre
+      return (tag->GenreType() == m_searchData.m_iGenreType ||
+              tag->GenreType() < EPG_EVENT_CONTENTMASK_MOVIEDRAMA ||
+              tag->GenreType() > EPG_EVENT_CONTENTMASK_USERDEFINED);
+    }
+    else
+    {
+      // match only the exact genre
+      return (tag->GenreType() == m_searchData.m_iGenreType);
+    }
   }
 
-  return bReturn;
+  // match any genre
+  return true;
 }
 
 bool CPVREpgSearchFilter::MatchDuration(const std::shared_ptr<CPVREpgInfoTag>& tag) const

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -92,7 +92,7 @@ namespace PVR
     const CDateTime& GetEndDateTime() const { return m_searchData.m_endDateTime; }
     void SetEndDateTime(const CDateTime& endDateTime);
 
-    bool ShouldIncludeUnknownGenres() const { return m_bIncludeUnknownGenres; }
+    bool ShouldIncludeUnknownGenres() const { return m_searchData.m_bIncludeUnknownGenres; }
     void SetIncludeUnknownGenres(bool bIncludeUnknownGenres);
 
     bool ShouldRemoveDuplicates() const { return m_bRemoveDuplicates; }
@@ -146,7 +146,6 @@ namespace PVR
     bool m_bIsCaseSensitive; /*!< Do a case sensitive search */
     int m_iMinimumDuration; /*!< The minimum duration for an entry */
     int m_iMaximumDuration; /*!< The maximum duration for an entry */
-    bool m_bIncludeUnknownGenres; /*!< Include unknown genres or not */
     bool m_bRemoveDuplicates; /*!< True to remove duplicate events, false if not */
 
     // PVR specific filters


### PR DESCRIPTION
Fixes a problem reported in the forum: https://forum.kodi.tv/showthread.php?tid=367720&pid=3094103#pid3094103 

"Search results include the Other / Unknown genre even when it was excluded from the search configuration."

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish mind taking a look at the code changes?

