### PR TITLE
changed: add a verbose flag for texturepacker

### DIFF
--- a/tools/depends/native/TexturePacker/src/DecoderManager.cpp
+++ b/tools/depends/native/TexturePacker/src/DecoderManager.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include "DecoderManager.h"
 
+bool DecoderManager::verbose;
 std::vector<IDecoder *> DecoderManager::m_decoders;
 
 // ADD new decoders here
@@ -72,7 +73,9 @@ bool DecoderManager::LoadFile(const std::string &filename, DecodedFrames &frames
   {
     if (m_decoders[i]->CanDecode(filename))
     {
-      fprintf(stdout, "This is a %s - lets load it via %s...\n", m_decoders[i]->GetImageFormatName(), m_decoders[i]->GetDecoderName());
+      if (verbose)
+        fprintf(stdout, "This is a %s - lets load it via %s...\n",
+                m_decoders[i]->GetImageFormatName(), m_decoders[i]->GetDecoderName());
       return m_decoders[i]->LoadFile(filename, frames);
     }
   }

--- a/tools/depends/native/TexturePacker/src/DecoderManager.h
+++ b/tools/depends/native/TexturePacker/src/DecoderManager.h
@@ -30,6 +30,8 @@ class DecoderManager
     static bool IsSupportedGraphicsFile(char *strFileName);
     static bool LoadFile(const std::string &filename, DecodedFrames &frames);
     static void FreeDecodedFrames(DecodedFrames &frames);
+    static bool verbose;
+
   private:
     static std::vector<IDecoder *> m_decoders;
 };

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -384,6 +384,10 @@ int main(int argc, char* argv[])
     {
       dupecheck = true;
     }
+    else if (!strcmp(args[i], "-verbose"))
+    {
+      DecoderManager::verbose = true;
+    }
     else if (!platform_stricmp(args[i], "-output") || !platform_stricmp(args[i], "-o"))
     {
       OutputFilename = args[++i];


### PR DESCRIPTION
and suppress the 'This is a XXX' message if not enabled

## Description
Prettier output.

## Motivation and context
This has annoyed me for a long time...

## How has this been tested?
Packed estuary textures and no output was given, added -verbose in macro and it was given.

## What is the effect on users?
None. Prettier output for (skin)devs when packing textures.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
