### PR TITLE
[warnings] GUIFontTTF: fix Visual Studio warnings

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -543,7 +543,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
                                 scrolling, std::chrono::steady_clock::now(), dirtyCache);
       CVertexBuffer newVertexBuffer = CreateVertexBuffer(*tempVertices);
       vertexBuffer = newVertexBuffer;
-      m_vertexTrans.emplace_back(0, 0, 0, &vertexBuffer, context.GetClipRegion());
+      m_vertexTrans.emplace_back(.0f, .0f, .0f, &vertexBuffer, context.GetClipRegion());
     }
     else
     {


### PR DESCRIPTION
## Description
GUIFontTTF: fix Visual Studio warnings

## Motivation and context
```
1>GUIFontTTF.cpp
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\xmemory(680,68): warning C4244: 'argument': conversion from '_Ty' to 'float', possible loss of data
1>        with
1>        [
1>            _Ty=int
1>        ]
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\vector(602): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,int,int,int,CVertexBuffer*,CRectGen<float>>(_Alloc &,_Objty *const ,int &&,int &&,int &&,CVertexBuffer *&&,CRectGen<float> &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<CGUIFontTTF::CTranslatedVertices>,
1>            _Ty=CGUIFontTTF::CTranslatedVertices,
1>            _Objty=CGUIFontTTF::CTranslatedVertices
1>        ]
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\vector(607): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,int,int,int,CVertexBuffer*,CRectGen<float>>(_Alloc &,_Objty *const ,int &&,int &&,int &&,CVertexBuffer *&&,CRectGen<float> &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<CGUIFontTTF::CTranslatedVertices>,
1>            _Ty=CGUIFontTTF::CTranslatedVertices,
1>            _Objty=CGUIFontTTF::CTranslatedVertices
1>        ]
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\vector(620): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::_Emplace_back_with_unused_capacity<int,int,int,CVertexBuffer*,CRectGen<float>>(int &&,int &&,int &&,CVertexBuffer *&&,CRectGen<float> &&)' being compiled
1>        with
1>        [
1>            _Ty=CGUIFontTTF::CTranslatedVertices
1>        ]
1>T:\KODI\kodi\xbmc\guilib\GUIFontTTF.cpp(546): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::emplace_back<int,int,int,CVertexBuffer*,CRect>(int &&,int &&,int &&,CVertexBuffer *&&,CRect &&)' being compiled
1>        with
1>        [
1>            _Ty=CGUIFontTTF::CTranslatedVertices
1>        ]
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
