### PR TITLE
[Backport]Fix audio player to start playback at offset or percentage

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -327,7 +327,23 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
 
   StreamInfo *si = new StreamInfo();
   si->m_fileItem = file;
-  if (!si->m_decoder.Create(file, si->m_fileItem.m_lStartOffset))
+
+  // Start stream at zero offset
+  si->m_startOffset = 0;
+  //File item start offset defines where in song to resume
+  double starttime = CUtil::ConvertMilliSecsToSecs(si->m_fileItem.m_lStartOffset);
+
+  // Music from cuesheet => "item_start" and offset match
+  // Start offset defines where this song starts in file of multiple songs
+  if (si->m_fileItem.HasProperty("item_start") &&
+      (si->m_fileItem.GetProperty("item_start").asInteger() == si->m_fileItem.m_lStartOffset))
+  {
+    // Start stream at offset from cuesheet
+    si->m_startOffset = si->m_fileItem.m_lStartOffset;
+    starttime = 0; // No resume point
+  }
+
+  if (!si->m_decoder.Create(file, si->m_startOffset))
   {
     CLog::Log(LOGWARNING, "PAPlayer::QueueNextFileEx - Failed to create the decoder");
 
@@ -367,7 +383,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
 
   /* init the streaminfo struct */
   si->m_audioFormat = si->m_decoder.GetFormat();
-  si->m_startOffset = file.m_lStartOffset;
+  // si->m_startOffset already initialized
   si->m_endOffset = file.m_lEndOffset;
   si->m_bytesPerSample = CAEUtil::DataFormatToBits(si->m_audioFormat.m_dataFormat) >> 3;
   si->m_bytesPerFrame = si->m_bytesPerSample * si->m_audioFormat.m_channelLayout.Count();
@@ -375,10 +391,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
   si->m_finishing = false;
   si->m_framesSent = 0;
   si->m_seekNextAtFrame = 0;
-  if (si->m_fileItem.HasProperty("audiobook_bookmark"))
-    si->m_seekFrame = si->m_audioFormat.m_sampleRate * CUtil::ConvertMilliSecsToSecs(si->m_fileItem.GetProperty("audiobook_bookmark").asInteger());
-  else
-    si->m_seekFrame = -1;
+  si->m_seekFrame = -1;
   si->m_stream = NULL;
   si->m_volume = (fadeIn && m_upcomingCrossfadeMS) ? 0.0f : 1.0f;
   si->m_fadeOutTriggered = false;
@@ -388,6 +401,23 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
   int64_t streamTotalTime = si->m_decoderTotal;
   if (si->m_endOffset)
     streamTotalTime = si->m_endOffset - si->m_startOffset;
+
+  // Seek to a resume point
+  if (si->m_fileItem.HasProperty("StartPercent") &&
+      (si->m_fileItem.GetProperty("StartPercent").asDouble() > 0) &&
+      (si->m_fileItem.GetProperty("StartPercent").asDouble() <= 100))
+  {
+    si->m_seekFrame =
+        si->m_audioFormat.m_sampleRate *
+        CUtil::ConvertMilliSecsToSecs(static_cast<int>(static_cast<double>(
+            streamTotalTime * (si->m_fileItem.GetProperty("StartPercent").asDouble() / 100.0))));
+  }
+  else if (starttime > 0)
+    si->m_seekFrame = si->m_audioFormat.m_sampleRate * starttime;
+  else if (si->m_fileItem.HasProperty("audiobook_bookmark"))
+    si->m_seekFrame =
+        si->m_audioFormat.m_sampleRate *
+        CUtil::ConvertMilliSecsToSecs(si->m_fileItem.GetProperty("audiobook_bookmark").asInteger());
 
   si->m_prepareNextAtFrame = 0;
   // cd drives don't really like it to be crossfaded or prepared


### PR DESCRIPTION
Backport of #21175 

Fix audio player to correctly start playback at given offset or percentage of track duration.

Previously audio would start playback from the given offset but incorrect times would be displayed by the OSD, percentage didn't work at all. This is now fixes and has been tested with both single track and cue sheet (multiple songs in one music file).