### PR TITLE
GUIFontTTF: fix last character corruption on AMD RX 6000 series

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -80,7 +80,7 @@ public:
       FT_Init_FreeType(&m_library);
     if (!m_library)
     {
-      CLog::Log(LOGERROR, "CFreeTypeLibrary::{}: Unable to initialize freetype library", __func__);
+      CLog::LogF(LOGERROR, "Unable to initialize freetype library");
       return nullptr;
     }
 
@@ -789,15 +789,13 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyph
     End();
   if (!CacheCharacter(letter, style, m_char + low, glyphIndex))
   { // unable to cache character - try clearing them all out and starting over
-    CLog::Log(
-        LOGDEBUG,
-        "CGUIFontTTF::{}: Unable to cache character.  Clearing character cache of {} characters",
-        __func__, m_numChars);
+    CLog::LogF(LOGDEBUG, "Unable to cache character. Clearing character cache of {} characters",
+               m_numChars);
     ClearCharacterCache();
     low = 0;
     if (!CacheCharacter(letter, style, m_char + low, glyphIndex))
     {
-      CLog::Log(LOGERROR, "CGUIFontTTF::{}: Unable to cache character (out of memory?)", __func__);
+      CLog::LogF(LOGERROR, "Unable to cache character (out of memory?)");
       if (nestedBeginCount)
         Begin();
       m_nestedBeginCount = nestedBeginCount;
@@ -833,8 +831,7 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, 
   FT_Glyph glyph = nullptr;
   if (FT_Load_Glyph(m_face, glyphIndex, FT_LOAD_TARGET_LIGHT))
   {
-    CLog::Log(LOGDEBUG, "CGUIFontTTF::{}: Failed to load glyph {:x}", __func__,
-              static_cast<uint32_t>(letter));
+    CLog::LogF(LOGDEBUG, "Failed to load glyph {:x}", static_cast<uint32_t>(letter));
     return false;
   }
 
@@ -850,8 +847,7 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, 
   // grab the glyph
   if (FT_Get_Glyph(m_face->glyph, &glyph))
   {
-    CLog::Log(LOGDEBUG, "CGUIFontTTF::{}: Failed to get glyph {:x}", __func__,
-              static_cast<uint32_t>(letter));
+    CLog::LogF(LOGDEBUG, "Failed to get glyph {:x}", static_cast<uint32_t>(letter));
     return false;
   }
   if (m_stroker)
@@ -859,8 +855,7 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, 
   // render the glyph
   if (FT_Glyph_To_Bitmap(&glyph, FT_RENDER_MODE_NORMAL, nullptr, 1))
   {
-    CLog::Log(LOGDEBUG, "CGUIFontTTF::{}: Failed to render glyph {:x} to a bitmap", __func__,
-              static_cast<uint32_t>(letter));
+    CLog::LogF(LOGDEBUG, "Failed to render glyph {:x} to a bitmap", static_cast<uint32_t>(letter));
     return false;
   }
 
@@ -889,9 +884,8 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, 
         // check for max height
         if (newHeight > m_renderSystem->GetMaxTextureSize())
         {
-          CLog::Log(LOGDEBUG,
-                    "CGUIFontTTF::{}: New cache texture is too large ({} > {} pixels long)",
-                    __func__, newHeight, m_renderSystem->GetMaxTextureSize());
+          CLog::LogF(LOGDEBUG, "New cache texture is too large ({} > {} pixels long)", newHeight,
+                     m_renderSystem->GetMaxTextureSize());
           FT_Done_Glyph(glyph);
           return false;
         }
@@ -900,8 +894,7 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, 
         if (!newTexture)
         {
           FT_Done_Glyph(glyph);
-          CLog::Log(LOGDEBUG, "CGUIFontTTF::{}: Failed to allocate new texture of height {}",
-                    __func__, newHeight);
+          CLog::LogF(LOGDEBUG, "Failed to allocate new texture of height {}", newHeight);
           return false;
         }
         m_texture = std::move(newTexture);
@@ -911,7 +904,7 @@ bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, 
     if (!m_texture)
     {
       FT_Done_Glyph(glyph);
-      CLog::Log(LOGDEBUG, "CGUIFontTTF::{}: no texture to cache character to", __func__);
+      CLog::LogF(LOGDEBUG, "no texture to cache character to");
       return false;
     }
   }

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -52,17 +52,22 @@ typedef std::vector<character_t> vecText;
  \brief
  */
 
+#ifdef HAS_DX
 struct SVertex
 {
   float x, y, z;
-#ifdef HAS_DX
   XMFLOAT4 col;
+  float u, v;
+  float u2, v2;
+};
 #else
+struct SVertex
+{
+  float x, y, z;
   unsigned char r, g, b, a;
-#endif
   float u, v;
 };
-
+#endif
 
 #include "GUIFontCache.h"
 


### PR DESCRIPTION
## Description
GUIFontTTF: fix last character corruption on AMD RX 6000 series

Fixes: https://github.com/xbmc/xbmc/issues/20008

## Motivation and context
See https://forum.kodi.tv/showthread.php?tid=335005 and https://forum.kodi.tv/showthread.php?tid=359715 and https://forum.kodi.tv/showthread.php?tid=332826

Also https://github.com/xbmc/xbmc/issues/20008

This is very long-standing bug present at least in Kodi v16, v17, v18, v19....

Finally seems that true root cause is missing/corrupted vertex data due misaligned  `SVertex` structure. DirectX 11 needs 16 ~bit~ byte aligned data. ~as data type is `DXGI_FORMAT_R16_UINT`.~

`stride` is 36 before and 48 after here:
https://github.com/xbmc/xbmc/blob/d89c10711a535e572db1f093dbed9da0eed9fb6a/xbmc/guilib/GUIFontTTFDX.cpp#L91

Current Intel and Nvidia drivers seems are able to get around this ignoring missing/incorrect vertex data but RenderDoc displays that one vertex data is missing anyway (Nvidia).

## How has this been tested?
Runtime tested on AMD RX 6500 XT, Nvidia RTX 2060 and Intel NUC8i3BEK

Test build here: 
https://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20220417-ab616756-fix-font-AMD-x64.exe

Updated build with vertex struct size = 44 bytes and all other changes:
https://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20220418-c88e3449-fix-font-AMD-x64.exe


## What is the effect on users?
Fixes last character corruption on AMD RX 6000 series.

## Screenshots (if appropriate):
Before:
![Captura de pantalla-before](https://user-images.githubusercontent.com/58434170/163726215-99c6b3ec-39f1-4add-bb15-040a491819cf.png)

After:
![Captura de pantalla-after](https://user-images.githubusercontent.com/58434170/163726219-e2edc1d6-da52-48e7-9d04-fb55c15e9195.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
