### PR TITLE
[video] select correct inputstream for satip protocol

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -110,20 +110,21 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
           || StringUtils::StartsWithNoCase(file, "bluray:"))
     return std::shared_ptr<CDVDInputStreamBluray>(new CDVDInputStreamBluray(pPlayer, fileitem));
 #endif
-  else if(StringUtils::StartsWithNoCase(file, "rtp://") ||
-          StringUtils::StartsWithNoCase(file, "rtsp://") ||
-          StringUtils::StartsWithNoCase(file, "rtsps://") ||
-          StringUtils::StartsWithNoCase(file, "sdp://") ||
-          StringUtils::StartsWithNoCase(file, "udp://") ||
-          StringUtils::StartsWithNoCase(file, "tcp://") ||
-          StringUtils::StartsWithNoCase(file, "mms://") ||
-          StringUtils::StartsWithNoCase(file, "mmst://") ||
-          StringUtils::StartsWithNoCase(file, "mmsh://") ||
-          StringUtils::StartsWithNoCase(file, "rtmp://") ||
-          StringUtils::StartsWithNoCase(file, "rtmpt://") ||
-          StringUtils::StartsWithNoCase(file, "rtmpe://") ||
-          StringUtils::StartsWithNoCase(file, "rtmpte://") ||
-          StringUtils::StartsWithNoCase(file, "rtmps://"))
+  else if (StringUtils::StartsWithNoCase(file, "rtp://") ||
+           StringUtils::StartsWithNoCase(file, "rtsp://") ||
+           StringUtils::StartsWithNoCase(file, "rtsps://") ||
+           StringUtils::StartsWithNoCase(file, "satip://") ||
+           StringUtils::StartsWithNoCase(file, "sdp://") ||
+           StringUtils::StartsWithNoCase(file, "udp://") ||
+           StringUtils::StartsWithNoCase(file, "tcp://") ||
+           StringUtils::StartsWithNoCase(file, "mms://") ||
+           StringUtils::StartsWithNoCase(file, "mmst://") ||
+           StringUtils::StartsWithNoCase(file, "mmsh://") ||
+           StringUtils::StartsWithNoCase(file, "rtmp://") ||
+           StringUtils::StartsWithNoCase(file, "rtmpt://") ||
+           StringUtils::StartsWithNoCase(file, "rtmpe://") ||
+           StringUtils::StartsWithNoCase(file, "rtmpte://") ||
+           StringUtils::StartsWithNoCase(file, "rtmps://"))
   {
     return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(fileitem));
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Support was added in ffmpeg for the `satip://` protocol and then added to kodi ([here](https://github.com/xbmc/xbmc/pull/19876)). However adding it to the inputstream selection was missed. Satip is very similar to rtsp with some minor differences.

Should be backported to Matrix once verified.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Incomplete feature addition.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Awaiting user testing

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
