### PR TITLE
GUIFontTTF: fix last character corruption on AMD RX 6000 series

### DIFF
--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -49,17 +49,22 @@ typedef std::vector<character_t> vecText;
  \brief
  */
 
+#ifdef HAS_DX
 struct SVertex
 {
   float x, y, z;
-#ifdef HAS_DX
   XMFLOAT4 col;
+  float u, v;
+  float u2, v2;
+};
 #else
+struct SVertex
+{
+  float x, y, z;
   unsigned char r, g, b, a;
-#endif
   float u, v;
 };
-
+#endif
 
 #include "GUIFontCache.h"
 


### PR DESCRIPTION
## Description
Partial backport of https://github.com/xbmc/xbmc/pull/21276


## What is the effect on users?
Fixes last character corruption on AMD RX 6000 series.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
