### PR TITLE
[android] fix building kodi for android on osx host due to ffmpeg linker issues

### DIFF
--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -19,6 +19,7 @@ if(CROSSCOMPILING)
                           --enable-cross-compile
                           --enable-pic
                           --ar=${CMAKE_AR}
+                          --ranlib=${CMAKE_RANLIB}
                           --strip=${CMAKE_STRIP}
               )
 

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -23,6 +23,9 @@ endif
 ifeq ($(CROSS_COMPILING), yes)
   CMAKE_ARGS+= -DPKG_CONFIG_EXECUTABLE=$(NATIVEPREFIX)/bin/pkg-config \
                -DCROSSCOMPILING=$(CROSS_COMPILING)
+               -DCMAKE_AR=$(AR) \
+               -DCMAKE_RANLIB=$(RANLIB) \
+               -DCMAKE_STRIP=$(STRIP)
 endif
 
 ifeq ($(OS), android)


### PR DESCRIPTION
## Description
Fix building android kodi on osx host.
Issue was caused by https://github.com/xbmc/xbmc/pull/21077

## Motivation and context
ffmpeg build was using osx native tools for AR/RANLIB/STRIP via tools/depends build
internal build was missing RANLIB, and therefore getting the following warnings

warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib:
archive library: /Users/Shared/xbmc-depends/aarch64-linux-android-31-debug/lib/libswscale.a the table of
contents is empty (no object file members in the library define global symbols)

This would then cause linker failures for libkodi.so with the inability to find ffmpeg symbols
when built on osx host.

## How has this been tested?
Built ffmpeg as both tools/depends system and ENABLE_INTERNAL_FFMPEG
build and link kodi successfully

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
