### PR TITLE
Get rid of CFDEventMonitor static global instance.

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -222,6 +222,8 @@ void CServiceManager::DeinitStageThree()
   m_contextMenuManager->Deinit();
   m_gameServices.reset();
   m_peripherals->Clear();
+
+  m_Platform->DeinitStageThree();
 }
 
 void CServiceManager::DeinitStageTwo()
@@ -250,11 +252,12 @@ void CServiceManager::DeinitStageTwo()
   m_repositoryUpdater.reset();
   m_binaryAddonManager.reset();
   m_addonMgr.reset();
-  m_Platform.reset();
   m_databaseManager.reset();
 
   m_mediaManager->Stop();
   m_mediaManager.reset();
+
+  m_Platform->DeinitStageTwo();
 }
 
 void CServiceManager::DeinitStageOne()
@@ -267,6 +270,9 @@ void CServiceManager::DeinitStageOne()
   CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(m_XBPython.get());
   m_XBPython.reset();
 #endif
+
+  m_Platform->DeinitStageOne();
+  m_Platform.reset();
 }
 
 #if defined(HAS_FILESYSTEM_SMB)

--- a/xbmc/cores/AudioEngine/Sinks/alsa/ALSADeviceMonitor.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/alsa/ALSADeviceMonitor.cpp
@@ -61,10 +61,11 @@ void CALSADeviceMonitor::Start()
       goto err_unref_monitor;
     }
 
-    g_fdEventMonitor.AddFD(
-        CFDEventMonitor::MonitoredFD(udev_monitor_get_fd(m_udevMonitor),
-                                     POLLIN, FDEventCallback, m_udevMonitor),
-        m_fdMonitorId);
+    const auto eventMonitor = CServiceBroker::GetPlatform().GetService<CFDEventMonitor>();
+    if (eventMonitor)
+      eventMonitor->AddFD(CFDEventMonitor::MonitoredFD(udev_monitor_get_fd(m_udevMonitor), POLLIN,
+                                                       FDEventCallback, m_udevMonitor),
+                          m_fdMonitorId);
   }
 
   return;
@@ -81,7 +82,9 @@ void CALSADeviceMonitor::Stop()
 {
   if (m_udev)
   {
-    g_fdEventMonitor.RemoveFD(m_fdMonitorId);
+    const auto eventMonitor = CServiceBroker::GetPlatform().GetService<CFDEventMonitor>();
+    if (eventMonitor)
+      eventMonitor->RemoveFD(m_fdMonitorId);
 
     udev_monitor_unref(m_udevMonitor);
     m_udevMonitor = NULL;

--- a/xbmc/cores/AudioEngine/Sinks/alsa/ALSAHControlMonitor.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/alsa/ALSAHControlMonitor.cpp
@@ -85,13 +85,18 @@ void CALSAHControlMonitor::Start()
     }
   }
 
-  g_fdEventMonitor.AddFDs(monitoredFDs, m_fdMonitorIds);
+  const auto eventMonitor = CServiceBroker::GetPlatform().GetService<CFDEventMonitor>();
+  if (eventMonitor)
+    eventMonitor->AddFDs(monitoredFDs, m_fdMonitorIds);
 }
 
 
 void CALSAHControlMonitor::Stop()
 {
-  g_fdEventMonitor.RemoveFDs(m_fdMonitorIds);
+  const auto eventMonitor = CServiceBroker::GetPlatform().GetService<CFDEventMonitor>();
+  if (eventMonitor)
+    eventMonitor->RemoveFDs(m_fdMonitorIds);
+
   m_fdMonitorIds.clear();
 }
 

--- a/xbmc/platform/Platform.h
+++ b/xbmc/platform/Platform.h
@@ -8,6 +8,19 @@
 
 #pragma once
 
+#include "threads/CriticalSection.h"
+
+#include <memory>
+#include <typeindex>
+#include <unordered_map>
+
+//! \brief Base class for services.
+class IPlatformService
+{
+public:
+  virtual ~IPlatformService() = default;
+};
+
 /**\brief Class for the Platform object
  *
  * Contains methods to retrieve platform specific information
@@ -39,7 +52,6 @@ public:
    *
    * This method can be used for starting platform specific services that
    * do not depend on windowing/gui. (eg macos XBMCHelper)
-   *
    */
   virtual bool InitStageTwo() { return true; }
 
@@ -47,9 +59,26 @@ public:
    *
    * This method can be used for starting platform specific Window/GUI related
    * services/components. (eg , WS-Discovery Daemons)
-   *
    */
   virtual bool InitStageThree() { return true; }
+
+  /**\brief Called at a late stage of application shutdown
+   *
+   * This method should be used to cleanup resources allocated in InitStageOne
+   */
+  virtual void DeinitStageOne() {}
+
+  /**\brief Called at a middle stage of application shutdown
+   *
+   * This method should be used to cleanup resources allocated in InitStageTwo
+   */
+  virtual void DeinitStageTwo() {}
+
+  /**\brief Called at an early stage of application shutdown
+   *
+   * This method should be used to cleanup resources allocated in InitStageThree
+   */
+  virtual void DeinitStageThree() {}
 
   /**\brief Flag whether disabled add-ons - installed via packagemanager or manually - should be
    * offered for configuration and activation on kodi startup for this platform
@@ -65,4 +94,46 @@ public:
    * Logs platform specific system info during application creation startup
    */
   virtual void PlatformSyslog() {}
+
+  /**\brief Get a platform service instance.
+   */
+  template<class T>
+  std::shared_ptr<T> GetService()
+  {
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    const auto it = m_services.find(std::type_index(typeid(T)));
+    if (it != m_services.end())
+      return std::static_pointer_cast<T>((*it).second);
+
+    return nullptr;
+  }
+
+protected:
+  /**\brief Register a new platform service instance.
+   */
+  void RegisterService(const std::shared_ptr<IPlatformService>& service)
+  {
+    if (!service)
+      return;
+
+    // Note: Extra var needed to avoid clang warning
+    // "Expression with side effects will be evaluated despite being used as an operand to 'typeid'"
+    // https://stackoverflow.com/questions/46494928/clang-warning-on-expression-side-effects
+    const auto& serviceRef = *service;
+
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    m_services.insert({std::type_index(typeid(serviceRef)), service});
+  }
+
+  /**\brief Deregister a platform service instance.
+   */
+  void DeregisterService(const std::type_info& typeInfo)
+  {
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    m_services.erase(typeInfo);
+  }
+
+private:
+  CCriticalSection m_critSection;
+  std::unordered_map<std::type_index, std::shared_ptr<IPlatformService>> m_services;
 };

--- a/xbmc/platform/linux/FDEventMonitor.h
+++ b/xbmc/platform/linux/FDEventMonitor.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include "platform/Platform.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
-#include "utils/GlobalsHandling.h"
 
 #include <map>
 #include <vector>
@@ -20,7 +20,7 @@
 /**
  * Monitor a file descriptor with callback on poll() events.
  */
-class CFDEventMonitor : private CThread
+class CFDEventMonitor : public IPlatformService, private CThread
 {
 public:
 
@@ -72,6 +72,3 @@ private:
   CCriticalSection m_mutex;
   CCriticalSection m_pollMutex;
 };
-
-XBMC_GLOBAL_REF(CFDEventMonitor, g_fdEventMonitor);
-#define g_fdEventMonitor XBMC_GLOBAL_USE(CFDEventMonitor)

--- a/xbmc/platform/linux/PlatformLinux.cpp
+++ b/xbmc/platform/linux/PlatformLinux.cpp
@@ -10,6 +10,7 @@
 
 #include "utils/StringUtils.h"
 
+#include "platform/linux/FDEventMonitor.h"
 #include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 
 // clang-format off
@@ -119,5 +120,12 @@ bool CPlatformLinux::InitStageOne()
 
   m_lirc.reset(OPTIONALS::LircRegister());
 
+  RegisterService(std::make_shared<CFDEventMonitor>());
+
   return true;
+}
+
+void CPlatformLinux::DeinitStageOne()
+{
+  DeregisterService(typeid(CFDEventMonitor));
 }

--- a/xbmc/platform/linux/PlatformLinux.h
+++ b/xbmc/platform/linux/PlatformLinux.h
@@ -21,6 +21,8 @@ public:
   ~CPlatformLinux() override = default;
 
   bool InitStageOne() override;
+  void DeinitStageOne() override;
+
   bool IsConfigureAddonsAtStartupEnabled() override { return true; }
 
 private:


### PR DESCRIPTION
Fixes #21240

@lrusak Do you think the way I solved the new case of a platform dependent service by extending `CPlatform` is okay?
@mglae by any chance, could you do a runtime-test and report back here?
