### PR TITLE
[Subtitle] Fix missing subtitle position reset on flush

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2506,6 +2506,7 @@ void CVideoPlayer::OnExit()
   });
 
   // destroy objects
+  m_renderManager.Flush(false, false);
   m_pDemuxer.reset();
   m_pSubtitleDemuxer.reset();
   m_subtitleDemuxerMap.clear();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -95,6 +95,14 @@ void CRenderer::Flush()
     Release(buffer);
 
   ReleaseCache();
+  Reset();
+}
+
+void CRenderer::Reset()
+{
+  m_subtitlePosition = 0;
+  m_subtitlePosResInfo = -1;
+  m_subtitleVerticalMargin = 0;
 }
 
 void CRenderer::Release(int idx)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -116,6 +116,12 @@ namespace OVERLAY {
     void AddOverlay(CDVDOverlay* o, double pts, int index);
     virtual void Render(int idx);
     void Flush();
+
+    /*!
+     * \brief Reset to default values
+     */
+    void Reset();
+
     void Release(int idx);
     bool HasOverlay(int idx);
     void SetVideoRect(CRect &source, CRect &dest, CRect &view);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Was missing resetting the subtitle resolution position on flush

i have add renderManager flush on `CVideoPlayer::OnExit()`
currenlty never flushed when played is stopped/cleared,
use case:
- "play from here" to add all files in playlist
- Play the first video and wait until playback end and start automatically the second one
- Flush not exists but renderManager is always the same used, then OverlayRenderer.cpp -> Flush() is not called and variables not resetted to defaults

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Problem report: https://github.com/xbmc/xbmc/pull/21026#issuecomment-1105506512
"At first subtitles are in correct place (bottom of screen) but after finishing first episode and second episode starts subtitles jumps to top of screen"

Bug introduced with #21026

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Having multiple video files with relative external SRT subtitles files
then choose "play from here" to add all files in playlist
see subtitles position from first file and the other

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Subtitle in right position

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
