### PR TITLE
[VideoPlayer] OpenDefaultStreams: dont close non-CC subtitle streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -315,6 +315,7 @@ void CDVDDemuxCC::Handler(int service, void *userdata)
   if (idx >= ctx->m_streamdata.size())
   {
     CDemuxStreamSubtitle stream;
+    stream.source = STREAM_SOURCE_VIDEOMUX;
     stream.language = "cc";
     stream.flags = FLAG_HEARING_IMPAIRED;
     stream.codec = AV_CODEC_ID_EIA_608;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -933,7 +933,10 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
                                 m_processInfo->GetVideoSettings().m_SubtitleStream,
                                 m_processInfo->GetVideoSettings().m_SubtitleOn);
   valid = false;
-  CloseStream(m_CurrentSubtitle, false);
+  // We need to close CC subtitles to avoid conflicts with external sub stream
+  if (m_CurrentSubtitle.source == STREAM_SOURCE_VIDEOMUX)
+    CloseStream(m_CurrentSubtitle, false);
+
   for (const auto &stream : m_SelectionStreams.Get(STREAM_SUBTITLE, psp))
   {
     if (OpenStream(m_CurrentSubtitle, stream.demuxerId, stream.id, stream.source))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change allow us when we send `DEMUX_SPECIALID_STREAMCHANGE` to keep the same subtitle opened stream, and avoid that subtitle parser/renderer (libass) instance to be resetted

That otherwise the reinitialization of subtitle parser and the renderer (Libass) will cause side effects like:
- Stored parsed data in libass will be lost, at every reinit will force the re-download(from ISAdaptive)/re-init libass renderer/re-parsing full file while in playback
- In case of too many fonts to load for subtitles will cause a delay in the display of subtitles, therefore nothing will be displayed during (re-)loading
- In case of big subtitle file the parsing could take time on slower cpu, therefore nothing will be displayed during (re-)parsing

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When we play a DASH/HLS adaptive video streams, InputStream Adaptive send to kodi `DEMUX_SPECIALID_STREAMCHANGE` packet to let know the VP of changed audio/video quality during the playback (some factors determine the change in video quality such as bandwidth), which lead to a forced processing of each component with all side effets of the case

Fix #20404 related to https://github.com/xbmc/inputstream.adaptive/issues/836#issuecomment-977739259
Superseeds #20579 where there is all the discussions/info on this problem

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with PVR/channel switching to check regressions, comment: https://github.com/xbmc/xbmc/pull/20579#issuecomment-1105094583

tested with ISAdaptive with a dash stream with Webvtt like "file" stream, by forcing adaptive stream change

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Have subtitle working when playing DASH/HLS with adaptive video stream technology

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
