### PR TITLE
[application] Fix and simplify application parameters handling.

### DIFF
--- a/xbmc/AppEnvironment.cpp
+++ b/xbmc/AppEnvironment.cpp
@@ -26,7 +26,7 @@ void CAppEnvironment::TearDown()
   CServiceBroker::GetLogging().UnregisterFromSettings();
   CServiceBroker::GetSettingsComponent()->Deinitialize();
   CServiceBroker::UnregisterSettingsComponent();
-  CServiceBroker::GetLogging().Uninitialize();
+  CServiceBroker::GetLogging().Deinitialize();
   CServiceBroker::DestroyLogging();
   CServiceBroker::UnregisterAppParams();
 }

--- a/xbmc/AppEnvironment.cpp
+++ b/xbmc/AppEnvironment.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2005-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AppEnvironment.h"
+
+#include "ServiceBroker.h"
+#include "settings/SettingsComponent.h"
+#include "utils/log.h"
+
+void CAppEnvironment::SetUp(const std::shared_ptr<CAppParams>& appParams)
+{
+  CServiceBroker::RegisterAppParams(appParams);
+  CServiceBroker::CreateLogging();
+  const auto settingsComponent = std::make_shared<CSettingsComponent>();
+  settingsComponent->Initialize();
+  CServiceBroker::RegisterSettingsComponent(settingsComponent);
+}
+
+void CAppEnvironment::TearDown()
+{
+  CServiceBroker::GetLogging().UnregisterFromSettings();
+  CServiceBroker::GetSettingsComponent()->Deinitialize();
+  CServiceBroker::UnregisterSettingsComponent();
+  CServiceBroker::GetLogging().Uninitialize();
+  CServiceBroker::DestroyLogging();
+  CServiceBroker::UnregisterAppParams();
+}

--- a/xbmc/AppEnvironment.h
+++ b/xbmc/AppEnvironment.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2022 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,4 +12,9 @@
 
 class CAppParams;
 
-extern "C" int XBMC_Run(bool renderGUI, const std::shared_ptr<CAppParams>& params);
+class CAppEnvironment
+{
+public:
+  static void SetUp(const std::shared_ptr<CAppParams>& appParams);
+  static void TearDown();
+};

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -8,55 +8,27 @@
 
 #pragma once
 
-#include "commons/ilog.h"
-
 #include <memory>
 #include <string>
 
-class CAdvancedSettings;
-class CFileItemList;
+class CAppParams;
 
 class CAppParamParser
 {
 public:
   CAppParamParser();
-  virtual ~CAppParamParser();
+  virtual ~CAppParamParser() = default;
 
   void Parse(const char* const* argv, int nArgs);
-  void SetAdvancedSettings(CAdvancedSettings& advancedSettings) const;
 
-  const CFileItemList& GetPlaylist() const;
-
-  void SetLogLevel(int logLevel) { m_logLevel = logLevel; }
-  void SetStartFullScreen(bool startFullScreen) { m_startFullScreen = startFullScreen; }
-  void SetPlatformDirectories(bool platformDirectories)
-  {
-    m_platformDirectories = platformDirectories;
-  }
-  void SetStandAlone(bool standAlone) { m_standAlone = standAlone; }
-
-  bool HasPlatformDirectories() const { return m_platformDirectories; }
-  bool IsTestMode() const { return m_testmode; }
-  bool IsStandAlone() const { return m_standAlone; }
-  const std::string& GetWindowing() const { return m_windowing; }
-  const std::string& GetLogTarget() const { return m_logTarget; }
+  std::shared_ptr<CAppParams> GetAppParams() const { return m_params; }
 
 protected:
   virtual void ParseArg(const std::string& arg);
   virtual void DisplayHelp();
 
-  std::string m_windowing;
-  std::string m_logTarget;
-
 private:
   void DisplayVersion();
 
-  int m_logLevel = LOG_LEVEL_NORMAL;
-  bool m_startFullScreen = false;
-  bool m_platformDirectories = true;
-  bool m_testmode = false;
-  bool m_standAlone = false;
-
-  std::string m_settingsFile;
-  std::unique_ptr<CFileItemList> m_playlist;
+  std::shared_ptr<CAppParams> m_params;
 };

--- a/xbmc/AppParams.cpp
+++ b/xbmc/AppParams.cpp
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (C) 2005-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AppParams.h"
+
+#include "FileItem.h"
+
+CAppParams::CAppParams() : m_playlist(std::make_unique<CFileItemList>())
+{
+}

--- a/xbmc/AppParams.h
+++ b/xbmc/AppParams.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2005-202 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "commons/ilog.h"
+
+#include <memory>
+#include <string>
+
+class CFileItemList;
+
+class CAppParams
+{
+public:
+  CAppParams();
+  virtual ~CAppParams() = default;
+
+  int GetLogLevel() const { return m_logLevel; }
+  void SetLogLevel(int logLevel) { m_logLevel = logLevel; }
+
+  bool IsStartFullScreen() const { return m_startFullScreen; }
+  void SetStartFullScreen(bool startFullScreen) { m_startFullScreen = startFullScreen; }
+
+  bool IsStandAlone() const { return m_standAlone; }
+  void SetStandAlone(bool standAlone) { m_standAlone = standAlone; }
+
+  bool HasPlatformDirectories() const { return m_platformDirectories; }
+  void SetPlatformDirectories(bool platformDirectories)
+  {
+    m_platformDirectories = platformDirectories;
+  }
+
+  bool IsTestMode() const { return m_testmode; }
+  void SetTestMode(bool testMode) { m_testmode = testMode; }
+
+  const std::string& GetSettingsFile() const { return m_settingsFile; }
+  void SetSettingsFile(const std::string& settingsFile) { m_settingsFile = settingsFile; }
+
+  const std::string& GetWindowing() const { return m_windowing; }
+  void SetWindowing(const std::string& windowing) { m_windowing = windowing; }
+
+  const std::string& GetLogTarget() const { return m_logTarget; }
+  void SetLogTarget(const std::string& logTarget) { m_logTarget = logTarget; }
+
+  CFileItemList& GetPlaylist() const { return *m_playlist; }
+
+private:
+  int m_logLevel{LOG_LEVEL_NORMAL};
+
+  bool m_startFullScreen{false};
+  bool m_standAlone{false};
+  bool m_platformDirectories{true};
+  bool m_testmode{false};
+
+  std::string m_settingsFile;
+  std::string m_windowing;
+  std::string m_logTarget;
+
+  std::unique_ptr<CFileItemList> m_playlist;
+};

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -138,9 +138,9 @@ public:
   CApplication(void);
   ~CApplication(void) override;
 
-  bool Create(const CAppParamParser& params);
+  bool Create();
   bool Initialize();
-  int Run(const CAppParamParser& params);
+  int Run();
   bool Cleanup();
 
   void FrameMove(bool processEvents, bool processGUI = true) override;
@@ -268,11 +268,6 @@ public:
 
   int GlobalIdleTime();
 
-  bool IsStandAlone() { return m_bStandalone; }
-  bool IsEnableTestMode() { return m_bTestMode; }
-
-  const std::string& GetLogTarget() const { return m_logTarget; }
-
   bool IsAppFocused() const { return m_AppFocused; }
 
   bool ToggleDPMS(bool manual);
@@ -394,16 +389,12 @@ protected:
   std::string m_prevMedia;
   std::thread::id m_threadID;       // application thread ID.  Used in applicationMessenger to know where we are firing a thread with delay from.
   bool m_bInitializing = true;
-  bool m_bPlatformDirectories = true;
 
   int m_nextPlaylistItem = -1;
 
   std::chrono::time_point<std::chrono::steady_clock> m_lastRenderTime;
   bool m_skipGuiRender = false;
 
-  std::string m_logTarget;
-  bool m_bStandalone = false;
-  bool m_bTestMode = false;
   bool m_bSystemScreenSaverEnable = false;
 
   std::unique_ptr<MUSIC_INFO::CMusicInfoScanner> m_musicInfoScanner;
@@ -452,7 +443,6 @@ private:
   CApplicationPlayer m_appPlayer;
   CEvent m_playerEvent;
   CApplicationStackHelper m_stackHelper;
-  std::string m_windowing;
   int m_ExitCode{EXITCODE_QUIT};
 };
 

--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -2,7 +2,9 @@ set(SOURCES Application.cpp
             AppInboundProtocol.cpp
             ApplicationPlayer.cpp
             ApplicationStackHelper.cpp
+            AppEnvironment.cpp
             AppParamParser.cpp
+            AppParams.cpp
             AutoSwitch.cpp
             BackgroundInfoLoader.cpp
             ContextMenuItem.cpp
@@ -37,7 +39,9 @@ set(SOURCES Application.cpp
             Util.cpp
             XBDateTime.cpp)
 
-set(HEADERS AppParamParser.h
+set(HEADERS AppEnvironment.h
+            AppParamParser.h
+            AppParams.h
             Application.h
             AppInboundProtocol.h
             ApplicationPlayer.h

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -14,6 +14,7 @@
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
+#include <stdexcept>
 #include <utility>
 
 using namespace KODI;
@@ -25,6 +26,24 @@ CServiceBroker::CServiceBroker()
 
 CServiceBroker::~CServiceBroker()
 {
+}
+
+std::shared_ptr<CAppParams> CServiceBroker::GetAppParams()
+{
+  if (!g_serviceBroker.m_appParams)
+    throw std::logic_error("AppParams not yet available / not available anymore.");
+
+  return g_serviceBroker.m_appParams;
+}
+
+void CServiceBroker::RegisterAppParams(const std::shared_ptr<CAppParams>& appParams)
+{
+  g_serviceBroker.m_appParams = appParams;
+}
+
+void CServiceBroker::UnregisterAppParams()
+{
+  g_serviceBroker.m_appParams.reset();
 }
 
 CLog& CServiceBroker::GetLogging()

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -50,6 +50,7 @@ class CApplicationMessenger;
 }
 } // namespace KODI
 
+class CAppParams;
 class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
@@ -111,6 +112,10 @@ class CServiceBroker
 public:
   CServiceBroker();
   ~CServiceBroker();
+
+  static std::shared_ptr<CAppParams> GetAppParams();
+  static void RegisterAppParams(const std::shared_ptr<CAppParams>& appParams);
+  static void UnregisterAppParams();
 
   static CLog& GetLogging();
   static void CreateLogging();
@@ -200,6 +205,7 @@ public:
   static std::shared_ptr<CKeyboardLayoutManager> GetKeyboardLayoutManager();
 
 private:
+  std::shared_ptr<CAppParams> m_appParams;
   std::unique_ptr<CLog> m_logging;
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
   CGUIComponent* m_pGUI;

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -113,8 +113,7 @@ bool CServiceManager::InitStageOne()
   return true;
 }
 
-bool CServiceManager::InitStageTwo(const CAppParamParser& params,
-                                   const std::string& profilesUserDataFolder)
+bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
 {
   // Initialize the addon database (must be before the addon manager is init'd)
   m_databaseManager.reset(new CDatabaseManager);
@@ -150,7 +149,7 @@ bool CServiceManager::InitStageTwo(const CAppParamParser& params,
   m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr));
 
   m_gameControllerManager.reset(new GAME::CControllerManager);
-  m_inputManager.reset(new CInputManager(params));
+  m_inputManager.reset(new CInputManager());
   m_inputManager->InitializeInputs();
 
   m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_inputManager, *m_gameControllerManager));

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -12,8 +12,6 @@
 
 #include <memory>
 
-class CAppParamParser;
-
 namespace ADDON
 {
 class CAddonMgr;
@@ -96,7 +94,7 @@ public:
 
   bool InitForTesting();
   bool InitStageOne();
-  bool InitStageTwo(const CAppParamParser& params, const std::string& profilesUserDataFolder);
+  bool InitStageTwo(const std::string& profilesUserDataFolder);
   bool InitStageThree(const std::shared_ptr<CProfileManager>& profileManager);
   void DeinitTesting();
   void DeinitStageThree();

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "guilib/guiinfo/SystemGUIInfo.h"
 
+#include "AppParams.h"
 #include "Application.h"
 #include "GUIPassword.h"
 #include "LangInfo.h"
@@ -597,7 +598,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = CServiceBroker::GetWinSystem()->IsFullScreen();
       return true;
     case SYSTEM_ISSTANDALONE:
-      value = g_application.IsStandAlone();
+      value = CServiceBroker::GetAppParams()->IsStandAlone();
       return true;
     case SYSTEM_IDLE_SHUTDOWN_INHIBITED:
       value = g_application.IsIdleShutdownInhibited();

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -51,7 +51,7 @@ using namespace KODI;
 
 const std::string CInputManager::SETTING_INPUT_ENABLE_CONTROLLER = "input.enablejoystick";
 
-CInputManager::CInputManager(const CAppParamParser& params)
+CInputManager::CInputManager()
   : m_keymapEnvironment(new CKeymapEnvironment),
     m_buttonTranslator(new CButtonTranslator),
     m_customControllerTranslator(new CCustomControllerTranslator),

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -24,7 +24,6 @@
 #include <string>
 #include <vector>
 
-class CAppParamParser;
 class CButtonTranslator;
 class CCustomControllerTranslator;
 class CJoystickMapper;
@@ -64,7 +63,7 @@ class IMouseDriverHandler;
 class CInputManager : public ISettingCallback, public IActionListener, public Observable
 {
 public:
-  explicit CInputManager(const CAppParamParser& params);
+  CInputManager();
   CInputManager(const CInputManager&) = delete;
   CInputManager const& operator=(CInputManager const&) = delete;
   ~CInputManager() override;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -9,7 +9,7 @@
 #include "XBMCApp.h"
 
 #include "AndroidKey.h"
-#include "AppParamParser.h"
+#include "AppParams.h"
 #include "Application.h"
 #include "CompileInfo.h"
 #include "guilib/GUIWindowManager.h"
@@ -553,8 +553,7 @@ void CXBMCApp::run()
   m_firstrun = false;
   android_printf(" => running XBMC_Run...");
 
-  CAppParamParser appParamParser;
-  status = XBMC_Run(true, appParamParser);
+  status = XBMC_Run(true, std::make_shared<CAppParams>());
   android_printf(" => XBMC_Run finished with %d", status);
 }
 

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -120,7 +120,7 @@ static NSMenu* setupWindowMenu()
   CAppParamParser appParamParser;
   appParamParser.Parse((const char**)gArgv, (int)gArgc);
 
-  XBMC_Run(true, appParamParser);
+  XBMC_Run(true, appParamParser.GetAppParams());
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -8,7 +8,8 @@
 
 #import "platform/darwin/tvos/XBMCController.h"
 
-#include "AppParamParser.h"
+#include "AppEnvironment.h"
+#include "AppParams.h"
 #include "Application.h"
 #include "CompileInfo.h"
 #include "FileItem.h"
@@ -380,14 +381,9 @@ int KODI_Run(bool renderGUI)
 {
   int status = -1;
 
-  // Create logging and settings
-  CServiceBroker::CreateLogging();
-  CAppParamParser appParamParser; //! @todo : proper params
-  const auto settingsComponent = std::make_shared<CSettingsComponent>();
-  settingsComponent->Initialize(appParamParser);
-  CServiceBroker::RegisterSettingsComponent(settingsComponent);
+  CAppEnvironment::SetUp(std::make_shared<CAppParams>()); //! @todo : proper params
 
-  if (!g_application.Create(appParamParser))
+  if (!g_application.Create())
   {
     CLog::Log(LOGERROR, "ERROR: Unable to create application. Exiting");
     return status;
@@ -428,7 +424,7 @@ int KODI_Run(bool renderGUI)
 
   try
   {
-    status = g_application.Run(appParamParser);
+    status = g_application.Run();
   }
   catch (...)
   {
@@ -436,12 +432,7 @@ int KODI_Run(bool renderGUI)
     status = -1;
   }
 
-  // Destroy settings and logging
-  CServiceBroker::GetLogging().UnregisterFromSettings();
-  CServiceBroker::GetSettingsComponent()->Deinitialize();
-  CServiceBroker::UnregisterSettingsComponent();
-  CServiceBroker::GetLogging().Uninitialize();
-  CServiceBroker::DestroyLogging();
+  CAppEnvironment::TearDown();
 
   return status;
 }

--- a/xbmc/platform/linux/AppParamParserLinux.cpp
+++ b/xbmc/platform/linux/AppParamParserLinux.cpp
@@ -8,6 +8,7 @@
 
 #include "AppParamParserLinux.h"
 
+#include "AppParams.h"
 #include "CompileInfo.h"
 #include "utils/StringUtils.h"
 
@@ -59,7 +60,7 @@ void CAppParamParserLinux::ParseArg(const std::string& arg)
   {
     if (std::find(availableWindowSystems.begin(), availableWindowSystems.end(), arg.substr(12)) !=
         availableWindowSystems.end())
-      m_windowing = arg.substr(12);
+      GetAppParams()->SetWindowing(arg.substr(12));
     else
     {
       std::cout << StringUtils::Format(windowingText, arg.substr(12),
@@ -72,7 +73,7 @@ void CAppParamParserLinux::ParseArg(const std::string& arg)
     if (std::find(availableLogTargets.begin(), availableLogTargets.end(), arg.substr(10)) !=
         availableLogTargets.end())
     {
-      m_logTarget = arg.substr(10);
+      GetAppParams()->SetLogTarget(arg.substr(10));
     }
     else
     {

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -66,5 +66,5 @@ int main(int argc, char* argv[])
 #endif
   appParamParser.Parse(argv, argc);
 
-  return XBMC_Run(true, appParamParser);
+  return XBMC_Run(true, appParamParser.GetAppParams());
 }

--- a/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
+++ b/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
@@ -8,7 +8,8 @@
 
 #include "PosixInterfaceForCLog.h"
 
-#include "Application.h"
+#include "AppParams.h"
+#include "ServiceBroker.h"
 
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -23,6 +24,6 @@ std::unique_ptr<IPlatformLog> IPlatformLog::CreatePlatformLog()
 void CPosixInterfaceForCLog::AddSinks(
     std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> distributionSink) const
 {
-  if (g_application.GetLogTarget() == "console")
+  if (CServiceBroker::GetAppParams()->GetLogTarget() == "console")
     distributionSink->add_sink(std::make_shared<spdlog::sinks::stdout_color_sink_st>());
 }

--- a/xbmc/platform/win10/Win10App.cpp
+++ b/xbmc/platform/win10/Win10App.cpp
@@ -9,6 +9,7 @@
 #include "Win10App.h"
 
 #include "AppParamParser.h"
+#include "AppParams.h"
 #include "Application.h"
 #include "pch.h"
 #include "platform/Environment.h"
@@ -83,13 +84,15 @@ void App::Run()
 
     CAppParamParser appParamParser;
     appParamParser.Parse(m_argv.data(), m_argv.size());
-    appParamParser.SetStartFullScreen(fullscreen);
+
+    const auto params = appParamParser.GetAppParams();
+    params->SetStartFullScreen(fullscreen);
 
     if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::Xbox)
-      appParamParser.SetStandAlone(true);
+      params->SetStandAlone(true);
 
     // Create and run the app
-    XBMC_Run(true, appParamParser);
+    XBMC_Run(true, params);
   }
 
   WSACleanup();

--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "AppParamParser.h"
+#include "AppParams.h"
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
 #include "platform/Environment.h"
@@ -57,6 +58,8 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT)
   CAppParamParser appParamParser;
   appParamParser.Parse(argv, argc);
 
+  const auto params = appParamParser.GetAppParams();
+
   // this fixes crash if OPENSSL_CONF is set to existed openssl.cfg
   // need to set it as soon as possible
   CEnvironment::unsetenv("OPENSSL_CONF");
@@ -73,7 +76,7 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT)
   if (win32_exception::ShouldHook())
   {
     win32_exception::set_version(std::string(ver));
-    win32_exception::set_platformDirectories(appParamParser.HasPlatformDirectories());
+    win32_exception::set_platformDirectories(params->HasPlatformDirectories());
     SetUnhandledExceptionFilter(CreateMiniDump);
   }
 
@@ -111,7 +114,7 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT)
 #endif
 
   // Create and run the app
-  int status = XBMC_Run(true, appParamParser);
+  int status = XBMC_Run(true, params);
 
   for (int i = 0; i < argc; ++i)
     delete[] argv[i];

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -8,6 +8,7 @@
 
 #include "PowerManager.h"
 
+#include "AppParams.h"
 #include "Application.h"
 #include "PowerTypes.h"
 #include "ServiceBroker.h"
@@ -67,7 +68,7 @@ void CPowerManager::SetDefaults()
     case POWERSTATE_QUIT:
     case POWERSTATE_MINIMIZE:
       // assume we can shutdown if --standalone is passed
-      if (g_application.IsStandAlone())
+      if (CServiceBroker::GetAppParams()->IsStandAlone())
         defaultShutdown = POWERSTATE_SHUTDOWN;
     break;
     case POWERSTATE_HIBERNATE:
@@ -286,7 +287,7 @@ void CPowerManager::SettingOptionsShutdownStatesFiller(const SettingConstPtr& se
     list.emplace_back(g_localizeStrings.Get(13010), POWERSTATE_HIBERNATE);
   if (CServiceBroker::GetPowerManager().CanSuspend())
     list.emplace_back(g_localizeStrings.Get(13011), POWERSTATE_SUSPEND);
-  if (!g_application.IsStandAlone())
+  if (!CServiceBroker::GetAppParams()->IsStandAlone())
   {
     list.emplace_back(g_localizeStrings.Get(13009), POWERSTATE_QUIT);
 #if !defined(TARGET_DARWIN_EMBEDDED)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -8,8 +8,7 @@
 
 #include "AdvancedSettings.h"
 
-#include "AppParamParser.h"
-#include "Application.h"
+#include "AppParams.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
@@ -86,11 +85,28 @@ void CAdvancedSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& 
     SetDebugMode(std::static_pointer_cast<const CSettingBool>(setting)->GetValue());
 }
 
-void CAdvancedSettings::Initialize(const CAppParamParser &params, CSettingsManager& settingsMgr)
+void CAdvancedSettings::Initialize(CSettingsManager& settingsMgr)
 {
   Initialize();
 
-  params.SetAdvancedSettings(*this);
+  const auto params = CServiceBroker::GetAppParams();
+
+  if (params->GetLogLevel() == LOG_LEVEL_DEBUG)
+  {
+    m_logLevel = LOG_LEVEL_DEBUG;
+    m_logLevelHint = LOG_LEVEL_DEBUG;
+    CServiceBroker::GetLogging().SetLogLevel(LOG_LEVEL_DEBUG);
+  }
+
+  const std::string& settingsFile = params->GetSettingsFile();
+  if (!settingsFile.empty())
+    AddSettingsFile(settingsFile);
+
+  if (params->IsStartFullScreen())
+    m_startFullScreen = true;
+
+  if (params->IsStandAlone())
+    m_handleMounting = true;
 
   settingsMgr.RegisterSettingsHandler(this, true);
   std::set<std::string> settingSet;
@@ -177,7 +193,7 @@ void CAdvancedSettings::Initialize()
   m_cddbAddress = "gnudb.gnudb.org";
   m_addSourceOnTop = false;
 
-  m_handleMounting = g_application.IsStandAlone();
+  m_handleMounting = CServiceBroker::GetAppParams()->IsStandAlone();
 
   m_fullScreenOnMovieStart = true;
   m_cachePath = "special://temp/";

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -24,7 +24,6 @@
 #define CACHE_BUFFER_MODE_NONE 3
 #define CACHE_BUFFER_MODE_NETWORK 4
 
-class CAppParamParser;
 class CProfileManager;
 class CSettingsManager;
 class CVariant;
@@ -115,7 +114,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
-    void Initialize(const CAppParamParser &params, CSettingsManager& settingsMgr);
+    void Initialize(CSettingsManager& settingsMgr);
     void Uninitialize(CSettingsManager& settingsMgr);
     bool Initialized() const { return m_initialized; }
     void AddSettingsFile(const std::string &filename);

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "SettingConditions.h"
+
+#include "AppParams.h"
 #include "Application.h"
 #include "LockType.h"
 #include "Util.h"
@@ -420,7 +422,7 @@ void CSettingConditions::Initialize()
 #ifdef TARGET_ANDROID
   m_simpleConditions.insert("isstandalone");
 #else
-  if (g_application.IsStandAlone())
+  if (CServiceBroker::GetAppParams()->IsStandAlone())
     m_simpleConditions.insert("isstandalone");
 #endif
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -8,6 +8,7 @@
 
 #include "Settings.h"
 
+#include "AppParams.h"
 #include "Application.h"
 #include "Autorun.h"
 #include "GUIPassword.h"
@@ -759,7 +760,7 @@ void CSettings::InitializeDefaults()
   }
 #endif
 
-  if (g_application.IsStandAlone())
+  if (CServiceBroker::GetAppParams()->IsStandAlone())
   {
     auto setting =
         GetSettingsManager()->GetSetting(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE);

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -9,7 +9,7 @@
 #include "SettingsComponent.h"
 
 #include "AdvancedSettings.h"
-#include "AppParamParser.h"
+#include "AppParams.h"
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
 #include "Settings.h"
@@ -41,20 +41,22 @@ CSettingsComponent::~CSettingsComponent()
 {
 }
 
-void CSettingsComponent::Initialize(const CAppParamParser& params)
+void CSettingsComponent::Initialize()
 {
   if (m_state == State::DEINITED)
   {
+    const auto params = CServiceBroker::GetAppParams();
+
     // only the InitDirectories* for the current platform should return true
-    bool inited = InitDirectoriesLinux(params.HasPlatformDirectories());
+    bool inited = InitDirectoriesLinux(params->HasPlatformDirectories());
     if (!inited)
-      inited = InitDirectoriesOSX(params.HasPlatformDirectories());
+      inited = InitDirectoriesOSX(params->HasPlatformDirectories());
     if (!inited)
-      inited = InitDirectoriesWin32(params.HasPlatformDirectories());
+      inited = InitDirectoriesWin32(params->HasPlatformDirectories());
 
     m_settings->Initialize();
 
-    m_advancedSettings->Initialize(params, *m_settings->GetSettingsManager());
+    m_advancedSettings->Initialize(*m_settings->GetSettingsManager());
     URIUtils::RegisterAdvancedSettings(*m_advancedSettings);
 
     m_profileManager->Initialize(m_settings);

--- a/xbmc/settings/SettingsComponent.h
+++ b/xbmc/settings/SettingsComponent.h
@@ -10,7 +10,6 @@
 
 #include <memory>
 
-class CAppParamParser;
 class CAdvancedSettings;
 class CProfileManager;
 class CSettings;
@@ -23,9 +22,8 @@ public:
 
   /*!
    * @brief Initialize all subcomponents with system default values (loaded from code, system settings files, ...).
-   * @param params The command line params passed to the app.
    */
-  void Initialize(const CAppParamParser& params);
+  void Initialize();
 
   /*!
    * @brief Initialize all subcomponents with user values (loaded from user settings files, according to active profile).

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -8,7 +8,8 @@
 
 #include "TestBasicEnvironment.h"
 
-#include "AppParamParser.h"
+#include "AppEnvironment.h"
+#include "AppParams.h"
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "TestUtils.h"
@@ -18,10 +19,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "platform/Filesystem.h"
 #include "profiles/ProfileManager.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/log.h"
 #include "windowing/WinSystem.h"
 
 #ifdef TARGET_DARWIN
@@ -39,14 +37,10 @@ TestBasicEnvironment::TestBasicEnvironment() = default;
 
 void TestBasicEnvironment::SetUp()
 {
-  CAppParamParser params;
-  params.SetPlatformDirectories(false);
+  const auto params = std::make_shared<CAppParams>();
+  params->SetPlatformDirectories(false);
 
-  CServiceBroker::CreateLogging();
-
-  const auto settingsComponent = std::make_shared<CSettingsComponent>();
-  settingsComponent->Initialize(params);
-  CServiceBroker::RegisterSettingsComponent(settingsComponent);
+  CAppEnvironment::SetUp(params);
 
   CServiceBroker::RegisterAppMessenger(std::make_shared<KODI::MESSAGING::CApplicationMessenger>());
 
@@ -116,11 +110,7 @@ void TestBasicEnvironment::TearDown()
 
   CServiceBroker::UnregisterAppMessenger();
 
-  CServiceBroker::GetLogging().UnregisterFromSettings();
-  CServiceBroker::GetSettingsComponent()->Deinitialize();
-  CServiceBroker::UnregisterSettingsComponent();
-  CServiceBroker::GetLogging().Uninitialize();
-  CServiceBroker::DestroyLogging();
+  CAppEnvironment::TearDown();
 }
 
 void TestBasicEnvironment::SetUpError()

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -6,7 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "AppParamParser.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -40,7 +39,7 @@ AdvancedSettingsResetBase::AdvancedSettingsResetBase()
   const auto settings = CServiceBroker::GetSettingsComponent();
   CSettingsManager* settingsMgr = settings->GetSettings()->GetSettingsManager();
   settings->GetAdvancedSettings()->Uninitialize(*settingsMgr);
-  settings->GetAdvancedSettings()->Initialize(CAppParamParser(), *settingsMgr);
+  settings->GetAdvancedSettings()->Initialize(*settingsMgr);
 }
 
 class TestFileItemSpecifiedArtJpg : public AdvancedSettingsResetBase,

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -142,7 +142,7 @@ void CLog::UnregisterFromSettings()
   settingsManager->UnregisterCallback(this);
 }
 
-void CLog::Uninitialize()
+void CLog::Deinitialize()
 {
   if (m_fileSink == nullptr)
     return;

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -61,7 +61,7 @@ public:
 
   void Initialize(const std::string& path);
   void UnregisterFromSettings();
-  void Uninitialize();
+  void Deinitialize();
 
   void SetLogLevel(int level);
   int GetLogLevel() { return m_logLevel; }

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -127,7 +127,7 @@ class TestRegExpLog : public testing::Test
 {
 protected:
   TestRegExpLog() = default;
-  ~TestRegExpLog() override { CServiceBroker::GetLogging().Uninitialize(); }
+  ~TestRegExpLog() override { CServiceBroker::GetLogging().Deinitialize(); }
 };
 
 TEST_F(TestRegExpLog, DumpOvector)
@@ -148,7 +148,7 @@ TEST_F(TestRegExpLog, DumpOvector)
   EXPECT_TRUE(regex.RegComp("^(?<first>Test)\\s*(?<second>.*)\\."));
   EXPECT_EQ(0, regex.RegFind("Test string."));
   regex.DumpOvector(LOGDEBUG);
-  CServiceBroker::GetLogging().Uninitialize();
+  CServiceBroker::GetLogging().Deinitialize();
 
   EXPECT_TRUE(file.Open(logfile));
   while ((bytesread = file.Read(buf, sizeof(buf) - 1)) > 0)

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -23,7 +23,7 @@ class Testlog : public testing::Test
 {
 protected:
   Testlog() = default;
-  ~Testlog() override { CServiceBroker::GetLogging().Uninitialize(); }
+  ~Testlog() override { CServiceBroker::GetLogging().Deinitialize(); }
 };
 
 TEST_F(Testlog, Log)
@@ -47,7 +47,7 @@ TEST_F(Testlog, Log)
   CLog::Log(LOGERROR, "error log message");
   CLog::Log(LOGFATAL, "fatal log message");
   CLog::Log(LOGNONE, "none type log message");
-  CServiceBroker::GetLogging().Uninitialize();
+  CServiceBroker::GetLogging().Deinitialize();
 
   EXPECT_TRUE(file.Open(logfile));
   while ((bytesread = file.Read(buf, sizeof(buf) - 1)) > 0)
@@ -91,6 +91,6 @@ TEST_F(Testlog, SetLogLevel)
   CServiceBroker::GetLogging().SetLogLevel(LOG_LEVEL_MAX);
   EXPECT_EQ(LOG_LEVEL_MAX, CServiceBroker::GetLogging().GetLogLevel());
 
-  CServiceBroker::GetLogging().Uninitialize();
+  CServiceBroker::GetLogging().Deinitialize();
   EXPECT_TRUE(XFILE::CFile::Delete(logfile));
 }


### PR DESCRIPTION
Fixes #21284 

Application parameters (for example passed by command line) are very very basic application data. Other very basic services like logging, settings, advanced settings etc. are dependent on app params.

In this PR, I factored out `CAppParams` from `CAppParamParser`, then made `CAppParams` the very first component registered at `CServiceBroker`so that the app params are available from the very beginning to other components. Furthermore I removed the app params "shadowed" at `CApplication` (members `m_standAlone` and others) which fixes some circular dependencies between `CApplication`and low level components like advanced settings. Last not least I factored the init/deinit of very basic app services (app params, settings, logging) into a new class `CAppEnvironment` which is now used at all the places which before worked with copied code (`BasicTestEnvironment`, `XMBC_Run`, tvOS main and iOS main).

I carefully runtime-tested on macOS and ensured Jenkins (including test suite) is green. 

@howie-f, @Portisch  maybe you could do a runtime-test on Linux?

@lrusak , @garbear anybody else, any comments regarding the general approach and the code changes?