### PR TITLE
[GUI][SKIN] ContextWindow propagation for nested skin variables

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4077,7 +4077,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPt
   if (item)
     actionStr = GUILIB::GUIINFO::CGUIInfoLabel::GetItemLabel(actionStr, item.get());
   else
-    actionStr = GUILIB::GUIINFO::CGUIInfoLabel::GetLabel(actionStr);
+    actionStr = GUILIB::GUIINFO::CGUIInfoLabel::GetLabel(actionStr, INFO::DEFAULT_CONTEXT);
 
   // user has asked for something to be executed
   if (CBuiltins::GetInstance().HasCommand(actionStr))

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -20,7 +20,6 @@
 #include "ServiceBroker.h"
 #include "utils/StringUtils.h"
 
-
 bool CContextMenuItem::IsVisible(const CFileItem& item) const
 {
   if (!m_infoBoolRegistered)
@@ -28,7 +27,7 @@ bool CContextMenuItem::IsVisible(const CFileItem& item) const
     m_infoBool = CServiceBroker::GetGUI()->GetInfoManager().Register(m_visibilityCondition, 0);
     m_infoBoolRegistered = true;
   }
-  return IsGroup() || (m_infoBool && m_infoBool->Get(&item));
+  return IsGroup() || (m_infoBool && m_infoBool->Get(INFO::DEFAULT_CONTEXT, &item));
 }
 
 bool CContextMenuItem::IsParentOf(const CContextMenuItem& other) const

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10409,7 +10409,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
   {
-    return GetSkinVariableString(info, false);
+    return GetSkinVariableString(info, contextWindow, false);
   }
   else if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
@@ -10717,7 +10717,7 @@ std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string *
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
   {
-    return GetSkinVariableString(info, true);
+    return GetSkinVariableString(info, contextWindow, true);
   }
   else if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
@@ -10872,7 +10872,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
 
   if (info.m_info >= CONDITIONAL_LABEL_START && info.m_info <= CONDITIONAL_LABEL_END)
   {
-    return GetSkinVariableString(info.m_info, false, item);
+    return GetSkinVariableString(info.m_info, contextWindow, false, item);
   }
   else if (info.m_info >= MULTI_INFO_START && info.m_info <= MULTI_INFO_END)
   {
@@ -10996,7 +10996,7 @@ std::string CGUIInfoManager::GetMultiInfoItemImage(const CFileItem *item, int co
 {
   if (info.m_info >= CONDITIONAL_LABEL_START && info.m_info <= CONDITIONAL_LABEL_END)
   {
-    return GetSkinVariableString(info.m_info, true, item);
+    return GetSkinVariableString(info.m_info, contextWindow, true, item);
   }
   else if (info.m_info >= MULTI_INFO_START && info.m_info <= MULTI_INFO_END)
   {
@@ -11093,12 +11093,13 @@ int CGUIInfoManager::TranslateSkinVariableString(const std::string& name, int co
 }
 
 std::string CGUIInfoManager::GetSkinVariableString(int info,
+                                                   int contextWindow,
                                                    bool preferImage /*= false*/,
-                                                   const CGUIListItem *item /*= nullptr*/) const
+                                                   const CGUIListItem* item /*= nullptr*/) const
 {
   info -= CONDITIONAL_LABEL_START;
   if (info >= 0 && info < static_cast<int>(m_skinVariableStrings.size()))
-    return m_skinVariableStrings[info].GetValue(preferImage, item);
+    return m_skinVariableStrings[info].GetValue(contextWindow, preferImage, item);
 
   return "";
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9734,7 +9734,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           {
             int data1 = TranslateSingleString(prop.param(0), listItemDependent);
             // pipe our original string through the localize parsing then make it lowercase (picks up $LBRACKET etc.)
-            std::string label = CGUIInfoLabel::GetLabel(prop.param(1));
+            std::string label = CGUIInfoLabel::GetLabel(prop.param(1), INFO::DEFAULT_CONTEXT);
             StringUtils::ToLower(label);
             // 'true', 'false', 'yes', 'no' are valid strings, do not resolve them to SYSTEM_ALWAYS_TRUE or SYSTEM_ALWAYS_FALSE
             if (label != "true" && label != "false" && label != "yes" && label != "no")
@@ -9853,7 +9853,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           int infoLabel = TranslateSingleString(param, listItemDependent);
           if (infoLabel > 0)
             return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_TITLE, infoLabel, 0));
-          std::string label = CGUIInfoLabel::GetLabel(param);
+          std::string label = CGUIInfoLabel::GetLabel(param, INFO::DEFAULT_CONTEXT);
           StringUtils::ToLower(label);
           return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_TITLE, label, 1));
         }
@@ -9862,7 +9862,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           int infoLabel = TranslateSingleString(param, listItemDependent);
           if (infoLabel > 0)
             return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_ICON, infoLabel, 0));
-          std::string label = CGUIInfoLabel::GetLabel(param);
+          std::string label = CGUIInfoLabel::GetLabel(param, INFO::DEFAULT_CONTEXT);
           StringUtils::ToLower(label);
           return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_ICON, label, 1));
         }
@@ -9871,7 +9871,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           int infoLabel = TranslateSingleString(param, listItemDependent);
           if (infoLabel > 0)
             return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_VERSION, infoLabel, 0));
-          std::string label = CGUIInfoLabel::GetLabel(param);
+          std::string label = CGUIInfoLabel::GetLabel(param, INFO::DEFAULT_CONTEXT);
           StringUtils::ToLower(label);
           return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_VERSION, label, 1));
         }
@@ -10474,7 +10474,7 @@ bool CGUIInfoManager::EvaluateBool(const std::string &expression, int contextWin
 {
   INFO::InfoPtr info = Register(expression, contextWindow);
   if (info)
-    return info->Get(item.get());
+    return info->Get(contextWindow, item.get());
   return false;
 }
 
@@ -10501,7 +10501,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   {
     // default: use integer value different from 0 as true
     int val;
-    bReturn = GetInt(val, condition) && val != 0;
+    bReturn = GetInt(val, condition, DEFAULT_CONTEXT) && val != 0;
   }
 
   return (condition1 < 0) ? !bReturn : bReturn;
@@ -11108,7 +11108,7 @@ bool CGUIInfoManager::ConditionsChangedValues(const std::map<INFO::InfoPtr, bool
 {
   for (std::map<INFO::InfoPtr, bool>::const_iterator it = map.begin() ; it != map.end() ; ++it)
   {
-    if (it->first->Get() != it->second)
+    if (it->first->Get(INFO::DEFAULT_CONTEXT) != it->second)
       return true;
   }
   return false;
@@ -11129,7 +11129,7 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
     {
       auto infoLabels = static_cast<std::vector<std::string>*>(pMsg->lpVoid);
       for (auto& param : pMsg->params)
-        infoLabels->emplace_back(GetLabel(TranslateString(param)));
+        infoLabels->emplace_back(GetLabel(TranslateString(param), DEFAULT_CONTEXT));
     }
   }
   break;
@@ -11140,7 +11140,7 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
     {
       auto infoLabels = static_cast<std::vector<bool>*>(pMsg->lpVoid);
       for (auto& param : pMsg->params)
-        infoLabels->push_back(EvaluateBool(param));
+        infoLabels->push_back(EvaluateBool(param, DEFAULT_CONTEXT));
     }
   }
   break;

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -184,7 +184,10 @@ private:
   std::string GetMultiInfoItemLabel(const CFileItem *item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo &info, std::string *fallback = nullptr) const;
   std::string GetMultiInfoItemImage(const CFileItem *item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo &info, std::string *fallback = nullptr) const;
 
-  std::string GetSkinVariableString(int info, bool preferImage = false, const CGUIListItem *item = nullptr) const;
+  std::string GetSkinVariableString(int info,
+                                    int contextWindow,
+                                    bool preferImage = false,
+                                    const CGUIListItem* item = nullptr) const;
 
   int AddMultiInfo(const KODI::GUILIB::GUIINFO::CGUIInfo &info);
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -86,15 +86,17 @@ public:
    \return the value of the evaluated expression.
    \sa Register
    */
-  bool EvaluateBool(const std::string &expression, int context = 0, const CGUIListItemPtr &item = nullptr);
+  bool EvaluateBool(const std::string& expression,
+                    int context,
+                    const CGUIListItemPtr& item = nullptr);
 
   int TranslateString(const std::string &strCondition);
   int TranslateSingleString(const std::string &strCondition, bool &listItemDependent);
 
-  std::string GetLabel(int info, int contextWindow = 0, std::string *fallback = nullptr) const;
+  std::string GetLabel(int info, int contextWindow, std::string* fallback = nullptr) const;
   std::string GetImage(int info, int contextWindow, std::string *fallback = nullptr);
-  bool GetInt(int &value, int info, int contextWindow = 0, const CGUIListItem *item = nullptr) const;
-  bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item = nullptr);
+  bool GetInt(int& value, int info, int contextWindow, const CGUIListItem* item = nullptr) const;
+  bool GetBool(int condition, int contextWindow, const CGUIListItem* item = nullptr);
 
   std::string GetItemLabel(const CFileItem *item, int contextWindow, int info, std::string *fallback = nullptr) const;
   std::string GetItemImage(const CGUIListItem *item, int contextWindow, int info, std::string *fallback = nullptr) const;

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -48,7 +48,7 @@ bool InfoBool(const std::string& condition,
               const SettingConstPtr& setting,
               void* data)
 {
-  return CServiceBroker::GetGUI()->GetInfoManager().EvaluateBool(value);
+  return CServiceBroker::GetGUI()->GetInfoManager().EvaluateBool(value, INFO::DEFAULT_CONTEXT);
 }
 
 template<class TSetting>

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -78,9 +78,9 @@ int CGUIDialogSeekBar::GetProgress() const
   int progress = 0;
 
   if (g_application.GetAppPlayer().GetSeekHandler().GetSeekSize() != 0)
-    infoMgr.GetInt(progress, PLAYER_SEEKBAR);
+    infoMgr.GetInt(progress, PLAYER_SEEKBAR, INFO::DEFAULT_CONTEXT);
   else
-    infoMgr.GetInt(progress, PLAYER_PROGRESS);
+    infoMgr.GetInt(progress, PLAYER_PROGRESS, INFO::DEFAULT_CONTEXT);
 
   return progress;
 }
@@ -90,13 +90,13 @@ int CGUIDialogSeekBar::GetEpgEventProgress() const
   CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
 
   int progress = 0;
-  infoMgr.GetInt(progress, PVR_EPG_EVENT_PROGRESS);
+  infoMgr.GetInt(progress, PVR_EPG_EVENT_PROGRESS, INFO::DEFAULT_CONTEXT);
 
   int seekSize = g_application.GetAppPlayer().GetSeekHandler().GetSeekSize();
   if (seekSize != 0)
   {
     int total = 0;
-    infoMgr.GetInt(total, PVR_EPG_EVENT_DURATION);
+    infoMgr.GetInt(total, PVR_EPG_EVENT_DURATION, INFO::DEFAULT_CONTEXT);
 
     float totalTime = static_cast<float>(total);
     if (totalTime == 0.0f)
@@ -116,7 +116,7 @@ int CGUIDialogSeekBar::GetTimeshiftProgress() const
   const CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
 
   int progress = 0;
-  infoMgr.GetInt(progress, PVR_TIMESHIFT_SEEKBAR);
+  infoMgr.GetInt(progress, PVR_TIMESHIFT_SEEKBAR, INFO::DEFAULT_CONTEXT);
 
   return progress;
 }

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -147,7 +147,8 @@ TiXmlElement *CLibraryDirectory::LoadXML(const std::string &xmlFile)
   // check the condition
   std::string condition = XMLUtils::GetAttribute(xml, "visible");
   CGUIComponent* gui = CServiceBroker::GetGUI();
-  if (condition.empty() || (gui && gui->GetInfoManager().EvaluateBool(condition)))
+  if (condition.empty() ||
+      (gui && gui->GetInfoManager().EvaluateBool(condition, INFO::DEFAULT_CONTEXT)))
     return xml;
 
   return nullptr;

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -57,7 +57,7 @@ int CGUIAction::GetNavigation() const
   {
     if (StringUtils::IsInteger(i.action))
     {
-      if (i.condition.empty() || infoMgr.EvaluateBool(i.condition))
+      if (i.condition.empty() || infoMgr.EvaluateBool(i.condition, INFO::DEFAULT_CONTEXT))
         return atoi(i.action.c_str());
     }
   }
@@ -87,7 +87,7 @@ bool CGUIAction::HasActionsMeetingCondition() const
   CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
   for (const auto &i : m_actions)
   {
-    if (i.condition.empty() || infoMgr.EvaluateBool(i.condition))
+    if (i.condition.empty() || infoMgr.EvaluateBool(i.condition, INFO::DEFAULT_CONTEXT))
       return true;
   }
   return false;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1187,7 +1187,7 @@ void CGUIBaseContainer::ResetAutoScrolling()
 
 void CGUIBaseContainer::UpdateAutoScrolling(unsigned int currentTime)
 {
-  if (m_autoScrollCondition && m_autoScrollCondition->Get())
+  if (m_autoScrollCondition && m_autoScrollCondition->Get(INFO::DEFAULT_CONTEXT))
   {
     if (m_lastRenderTime)
       m_autoScrollDelayTime += currentTime - m_lastRenderTime;

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -528,7 +528,7 @@ void CGUIControl::SetVisible(bool bVisible, bool setVisState)
      //!       otherwise we just set m_forceHidden
     GUIVISIBLE visible;
     if (m_visibleCondition)
-      visible = m_visibleCondition->Get() ? VISIBLE : HIDDEN;
+      visible = m_visibleCondition->Get(INFO::DEFAULT_CONTEXT) ? VISIBLE : HIDDEN;
     else
       visible = VISIBLE;
     if (visible != m_visible)
@@ -593,7 +593,7 @@ void CGUIControl::UpdateVisibility(const CGUIListItem *item)
   if (m_visibleCondition)
   {
     bool bWasVisible = m_visibleFromSkinCondition;
-    m_visibleFromSkinCondition = m_visibleCondition->Get(item);
+    m_visibleFromSkinCondition = m_visibleCondition->Get(INFO::DEFAULT_CONTEXT, item);
     if (!bWasVisible && m_visibleFromSkinCondition)
     { // automatic change of visibility - queue the in effect
       //    CLog::Log(LOGDEBUG, "Visibility changed to visible for control id {}", m_controlID);
@@ -616,12 +616,12 @@ void CGUIControl::UpdateVisibility(const CGUIListItem *item)
   // this may need to be reviewed at a later date
   bool enabled = m_enabled;
   if (m_enableCondition)
-    m_enabled = m_enableCondition->Get(item);
+    m_enabled = m_enableCondition->Get(INFO::DEFAULT_CONTEXT, item);
 
   if (m_enabled != enabled)
     MarkDirtyRegion();
 
-  m_allowHiddenFocus.Update(item);
+  m_allowHiddenFocus.Update(INFO::DEFAULT_CONTEXT, item);
   if (UpdateColors(item))
     MarkDirtyRegion();
   // and finally, update our control information (if not pushed)
@@ -638,7 +638,7 @@ void CGUIControl::SetInitialVisibility()
 {
   if (m_visibleCondition)
   {
-    m_visibleFromSkinCondition = m_visibleCondition->Get();
+    m_visibleFromSkinCondition = m_visibleCondition->Get(INFO::DEFAULT_CONTEXT);
     m_visible = m_visibleFromSkinCondition ? VISIBLE : HIDDEN;
     //  CLog::Log(LOGDEBUG, "Set initial visibility for control {}: {}", m_controlID, m_visible == VISIBLE ? "visible" : "hidden");
   }
@@ -654,8 +654,8 @@ void CGUIControl::SetInitialVisibility()
   // and check for conditional enabling - note this overrides SetEnabled() from the code currently
   // this may need to be reviewed at a later date
   if (m_enableCondition)
-    m_enabled = m_enableCondition->Get();
-  m_allowHiddenFocus.Update();
+    m_enabled = m_enableCondition->Get(INFO::DEFAULT_CONTEXT);
+  m_allowHiddenFocus.Update(INFO::DEFAULT_CONTEXT);
   UpdateColors(nullptr);
 
   MarkDirtyRegion();

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1073,7 +1073,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       viewType = VIEW_TYPE_BIG_INFO;
     const char *label = itemElement->Attribute("label");
     if (label)
-      viewLabel = GUIINFO::CGUIInfoLabel::GetLabel(FilterLabel(label));
+      viewLabel = GUIINFO::CGUIInfoLabel::GetLabel(FilterLabel(label), INFO::DEFAULT_CONTEXT);
   }
 
   TiXmlElement *cam = pControlNode->FirstChildElement("camera");

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -127,7 +127,7 @@ void CGUIDialog::UpdateVisibility()
 {
   if (m_visibleCondition)
   {
-    if (m_visibleCondition->Get())
+    if (m_visibleCondition->Get(INFO::DEFAULT_CONTEXT))
       Open();
     else
       Close();

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -233,7 +233,8 @@ void CGUIIncludes::LoadIncludes(const TiXmlElement *node)
 
       if (condition)
       { // load include file if condition evals to true
-        if (CServiceBroker::GetGUI()->GetInfoManager().Register(condition)->Get())
+        if (CServiceBroker::GetGUI()->GetInfoManager().Register(condition)->Get(
+                INFO::DEFAULT_CONTEXT))
           Load_Internal(file);
       }
       else
@@ -414,7 +415,7 @@ void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, b
     if (condition)
     {
       INFO::InfoPtr conditionID = CServiceBroker::GetGUI()->GetInfoManager().Register(ResolveExpressions(condition));
-      bool value = conditionID->Get();
+      bool value = conditionID->Get(INFO::DEFAULT_CONTEXT);
 
       if (xmlIncludeConditions)
         xmlIncludeConditions->insert(std::make_pair(conditionID, value));

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -68,7 +68,7 @@ void CGUIListItemLayout::Process(CGUIListItem *item, int parentID, unsigned int 
     // could use a dynamic cast here if RTTI was enabled.  As it's not,
     // let's use a static cast with a virtual base function
     CFileItem *fileItem = item->IsFileItem() ? static_cast<CFileItem*>(item) : new CFileItem(*item);
-    m_isPlaying.Update(item);
+    m_isPlaying.Update(INFO::DEFAULT_CONTEXT, item);
     m_group.SetInvalid();
     m_group.UpdateInfo(fileItem);
     // delete our temporary fileitem
@@ -79,7 +79,7 @@ void CGUIListItemLayout::Process(CGUIListItem *item, int parentID, unsigned int 
   }
   else if (m_infoUpdateTimeout.IsTimePast())
   {
-    m_isPlaying.Update(item);
+    m_isPlaying.Update(INFO::DEFAULT_CONTEXT, item);
     m_group.UpdateInfo(item);
 
     m_infoUpdateTimeout.Set(m_infoUpdateMillis);
@@ -143,7 +143,7 @@ bool CGUIListItemLayout::MoveRight()
 
 bool CGUIListItemLayout::CheckCondition()
 {
-  return !m_condition || m_condition->Get();
+  return !m_condition || m_condition->Get(INFO::DEFAULT_CONTEXT);
 }
 
 void CGUIListItemLayout::LoadControl(TiXmlElement *child, CGUIControlGroup *group)

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -92,7 +92,7 @@ void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList 
   if (m_toggleSelect)
   {
     // ask our infoManager whether we are selected or not...
-    bool selected = m_toggleSelect->Get();
+    bool selected = m_toggleSelect->Get(INFO::DEFAULT_CONTEXT);
 
     if (selected != m_bSelected)
     {

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -100,7 +100,7 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
   if (infoCode)
   {
     int val;
-    if (CServiceBroker::GetGUI()->GetInfoManager().GetInt(val, infoCode))
+    if (CServiceBroker::GetGUI()->GetInfoManager().GetInt(val, infoCode, INFO::DEFAULT_CONTEXT))
       SetIntValue(val);
   }
 

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -98,7 +98,7 @@ bool CGUIStaticItem::UpdateVisibility(int contextWindow)
 {
   if (!m_visCondition)
     return false;
-  bool state = m_visCondition->Get();
+  bool state = m_visCondition->Get(contextWindow);
   if (state != m_visState)
   {
     m_visState = state;

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -129,7 +129,7 @@ void CGUITextBox::Process(unsigned int currentTime, CDirtyRegionList &dirtyregio
   // update our auto-scrolling as necessary
   if (m_autoScrollTime && m_lines.size() > m_itemsPerPage)
   {
-    if (!m_autoScrollCondition || m_autoScrollCondition->Get())
+    if (!m_autoScrollCondition || m_autoScrollCondition->Get(INFO::DEFAULT_CONTEXT))
     {
       if (m_lastRenderTime)
         m_autoScrollDelayTime += currentTime - m_lastRenderTime;

--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -26,7 +26,7 @@ void CGUIToggleButtonControl::Process(unsigned int currentTime, CDirtyRegionList
 {
   // ask our infoManager whether we are selected or not...
   if (m_toggleSelect)
-    m_bSelected = m_toggleSelect->Get();
+    m_bSelected = m_toggleSelect->Get(INFO::DEFAULT_CONTEXT);
 
   if (m_bSelected)
   {

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -479,7 +479,7 @@ CPoint CGUIWindow::GetPosition() const
   for (unsigned int i = 0; i < m_origins.size(); i++)
   {
     // no condition implies true
-    if (!m_origins[i].condition || m_origins[i].condition->Get())
+    if (!m_origins[i].condition || m_origins[i].condition->Get(INFO::DEFAULT_CONTEXT))
     { // found origin
       return CPoint(m_origins[i].x, m_origins[i].y);
     }

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -569,14 +569,14 @@ CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, u
 
 bool CAnimation::CheckCondition()
 {
-  return !m_condition || m_condition->Get();
+  return !m_condition || m_condition->Get(INFO::DEFAULT_CONTEXT);
 }
 
 void CAnimation::UpdateCondition(const CGUIListItem *item)
 {
   if (!m_condition)
     return;
-  bool condition = m_condition->Get(item);
+  bool condition = m_condition->Get(INFO::DEFAULT_CONTEXT, item);
   if (condition && !m_lastCondition)
     QueueAnimation(ANIM_PROCESS_NORMAL);
   else if (!condition && m_lastCondition)
@@ -591,7 +591,7 @@ void CAnimation::UpdateCondition(const CGUIListItem *item)
 
 void CAnimation::SetInitialCondition()
 {
-  m_lastCondition = m_condition ? m_condition->Get() : false;
+  m_lastCondition = m_condition ? m_condition->Get(INFO::DEFAULT_CONTEXT) : false;
   if (m_lastCondition)
     ApplyAnimation();
   else

--- a/xbmc/guilib/guiinfo/GUIInfoBool.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoBool.cpp
@@ -30,12 +30,12 @@ void CGUIInfoBool::Parse(const std::string &expression, int context)
   else
   {
     m_info = CServiceBroker::GetGUI()->GetInfoManager().Register(expression, context);
-    Update();
+    Update(context);
   }
 }
 
-void CGUIInfoBool::Update(const CGUIListItem *item /*= NULL*/)
+void CGUIInfoBool::Update(int contextWindow, const CGUIListItem* item /*= nullptr*/)
 {
   if (m_info)
-    m_value = m_info->Get(item);
+    m_value = m_info->Get(contextWindow, item);
 }

--- a/xbmc/guilib/guiinfo/GUIInfoBool.h
+++ b/xbmc/guilib/guiinfo/GUIInfoBool.h
@@ -34,7 +34,7 @@ public:
 
   operator bool() const { return m_value; }
 
-  void Update(const CGUIListItem *item = NULL);
+  void Update(int contextWindow, const CGUIListItem* item = nullptr);
   void Parse(const std::string &expression, int context);
 private:
   INFO::InfoPtr m_info;

--- a/xbmc/guilib/guiinfo/GUIInfoColor.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoColor.cpp
@@ -29,7 +29,7 @@ bool CGUIInfoColor::Update(const CGUIListItem* item /* = nullptr */)
     infoLabel = CServiceBroker::GetGUI()->GetInfoManager().GetItemLabel(
         static_cast<const CFileItem*>(item), 0, m_info);
   else
-    infoLabel = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(m_info);
+    infoLabel = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(m_info, INFO::DEFAULT_CONTEXT);
 
   UTILS::COLOR::Color color =
       !infoLabel.empty() ? CServiceBroker::GetGUI()->GetColorManager().GetColor(infoLabel.c_str())

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.h
@@ -26,13 +26,20 @@ namespace GUILIB
 namespace GUIINFO
 {
 
+/*! Default context for the infolabel */
+constexpr int DEFAULT_CONTEXT = 0;
+
 class CGUIInfoLabel
 {
 public:
   CGUIInfoLabel() = default;
-  CGUIInfoLabel(const std::string &label, const std::string &fallback = "", int context = 0);
+  CGUIInfoLabel(const std::string& label,
+                const std::string& fallback = "",
+                int context = DEFAULT_CONTEXT);
 
-  void SetLabel(const std::string &label, const std::string &fallback, int context = 0);
+  void SetLabel(const std::string& label,
+                const std::string& fallback,
+                int context = DEFAULT_CONTEXT);
 
   /*!
    \brief Gets a label (or image) for a given window context from the info manager.

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.h
@@ -13,6 +13,8 @@
 \brief
 */
 
+#include "interfaces/info/Info.h"
+
 #include <functional>
 #include <string>
 #include <vector>
@@ -26,20 +28,17 @@ namespace GUILIB
 namespace GUIINFO
 {
 
-/*! Default context for the infolabel */
-constexpr int DEFAULT_CONTEXT = 0;
-
 class CGUIInfoLabel
 {
 public:
   CGUIInfoLabel() = default;
   CGUIInfoLabel(const std::string& label,
                 const std::string& fallback = "",
-                int context = DEFAULT_CONTEXT);
+                int context = INFO::DEFAULT_CONTEXT);
 
   void SetLabel(const std::string& label,
                 const std::string& fallback,
-                int context = DEFAULT_CONTEXT);
+                int context = INFO::DEFAULT_CONTEXT);
 
   /*!
    \brief Gets a label (or image) for a given window context from the info manager.
@@ -72,7 +71,9 @@ public:
 
   const std::string& GetFallback() const { return m_fallback; }
 
-  static std::string GetLabel(const std::string &label, int contextWindow = 0, bool preferImage = false);
+  static std::string GetLabel(const std::string& label,
+                              int contextWindow,
+                              bool preferImage = false);
   static std::string GetItemLabel(const std::string &label, const CGUIListItem *item, bool preferImage = false);
 
   /*!

--- a/xbmc/interfaces/builtins/PVRBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PVRBuiltins.cpp
@@ -66,10 +66,12 @@ static int SeekPercentage(const std::vector<std::string>& params)
       CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
 
       int iTimeshiftProgressDuration = 0;
-      infoMgr.GetInt(iTimeshiftProgressDuration, PVR_TIMESHIFT_PROGRESS_DURATION);
+      infoMgr.GetInt(iTimeshiftProgressDuration, PVR_TIMESHIFT_PROGRESS_DURATION,
+                     INFO::DEFAULT_CONTEXT);
 
       int iTimeshiftBufferStart = 0;
-      infoMgr.GetInt(iTimeshiftBufferStart, PVR_TIMESHIFT_PROGRESS_BUFFER_START);
+      infoMgr.GetInt(iTimeshiftBufferStart, PVR_TIMESHIFT_PROGRESS_BUFFER_START,
+                     INFO::DEFAULT_CONTEXT);
 
       float fPlayerPercentage = static_cast<float>(iTimeshiftProgressDuration) /
                                 static_cast<float>(g_application.GetTotalTime()) *

--- a/xbmc/interfaces/info/CMakeLists.txt
+++ b/xbmc/interfaces/info/CMakeLists.txt
@@ -2,7 +2,8 @@ set(SOURCES InfoBool.cpp
             InfoExpression.cpp
             SkinVariable.cpp)
 
-set(HEADERS InfoBool.h
+set(HEADERS Info.h
+            InfoBool.h
             InfoExpression.h
             SkinVariable.h)
 

--- a/xbmc/interfaces/info/Info.h
+++ b/xbmc/interfaces/info/Info.h
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace INFO
+{
+/*! Default context of the INFO interface
+    @note when info conditions are evaluated different contexts can be passed. Context usually refers to the window ids where
+    the conditions are being evaluated. By default conditions, skin variables and labels are initialized using the DEFAULT_CONTEXT
+    value unless specifically bound to a given window.
+    */
+constexpr int DEFAULT_CONTEXT = 0;
+} // namespace INFO

--- a/xbmc/interfaces/info/InfoBool.h
+++ b/xbmc/interfaces/info/InfoBool.h
@@ -29,15 +29,16 @@ public:
 
   /*! \brief Get the value of this info bool
    This is called to update (if dirty) and fetch the value of the info bool
+   \param contextWindow the context (window id) where this condition is being evaluated
    \param item the item used to evaluate the bool
    */
-  inline bool Get(const CGUIListItem *item = NULL)
+  inline bool Get(int contextWindow, const CGUIListItem* item = nullptr)
   {
     if (item && m_listItemDependent)
-      Update(item);
+      Update(contextWindow, item);
     else if (m_refreshCounter != m_parentRefreshCounter || m_refreshCounter == 0)
     {
-      Update(NULL);
+      Update(contextWindow, nullptr);
       m_refreshCounter = m_parentRefreshCounter;
     }
     return m_value;
@@ -62,7 +63,7 @@ public:
   /*! \brief Update the value of this info bool
    This is called if and only if the info bool is dirty, allowing it to update it's current value
    */
-  virtual void Update(const CGUIListItem* item) {}
+  virtual void Update(int contextWindow, const CGUIListItem* item) {}
 
   const std::string &GetExpression() const { return m_expression; }
   bool ListItemDependent() const { return m_listItemDependent; }

--- a/xbmc/interfaces/info/InfoExpression.h
+++ b/xbmc/interfaces/info/InfoExpression.h
@@ -30,7 +30,8 @@ public:
   }
   void Initialize() override;
 
-  void Update(const CGUIListItem *item) override;
+  void Update(int contextWindow, const CGUIListItem* item) override;
+
 private:
   int m_condition;             ///< actual condition this represents
 };
@@ -48,7 +49,8 @@ public:
 
   void Initialize() override;
 
-  void Update(const CGUIListItem *item) override;
+  void Update(int contextWindow, const CGUIListItem* item) override;
+
 private:
   typedef enum
   {
@@ -72,7 +74,7 @@ private:
   {
   public:
     virtual ~InfoSubexpression(void) = default; // so we can destruct derived classes using a pointer to their base class
-    virtual bool Evaluate(const CGUIListItem *item) = 0;
+    virtual bool Evaluate(int contextWindow, const CGUIListItem* item) = 0;
     virtual node_type_t Type() const=0;
   };
 
@@ -83,7 +85,7 @@ private:
   {
   public:
     InfoLeaf(InfoPtr info, bool invert) : m_info(std::move(info)), m_invert(invert) {}
-    bool Evaluate(const CGUIListItem *item) override;
+    bool Evaluate(int contextWindow, const CGUIListItem* item) override;
     node_type_t Type() const override { return NODE_LEAF; }
 
   private:
@@ -98,7 +100,7 @@ private:
     InfoAssociativeGroup(node_type_t type, const InfoSubexpressionPtr &left, const InfoSubexpressionPtr &right);
     void AddChild(const InfoSubexpressionPtr &child);
     void Merge(const std::shared_ptr<InfoAssociativeGroup>& other);
-    bool Evaluate(const CGUIListItem *item) override;
+    bool Evaluate(int contextWindow, const CGUIListItem* item) override;
     node_type_t Type() const override { return m_type; }
 
   private:

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -59,7 +59,9 @@ const std::string& CSkinVariableString::GetName() const
   return m_name;
 }
 
-std::string CSkinVariableString::GetValue(bool preferImage /* = false */, const CGUIListItem *item /* = nullptr */) const
+std::string CSkinVariableString::GetValue(int contextWindow,
+                                          bool preferImage /* = false */,
+                                          const CGUIListItem* item /* = nullptr */) const
 {
   for (const auto& it : m_conditionLabelPairs)
   {
@@ -68,7 +70,13 @@ std::string CSkinVariableString::GetValue(bool preferImage /* = false */, const 
       if (item)
         return it.m_label.GetItemLabel(item, preferImage);
       else
-        return it.m_label.GetLabel(m_context, preferImage);
+      {
+        // use propagated context in case this skin variable has the default context (i.e. if not tied to a specific window)
+        // nested skin variables are supported
+        return it.m_label.GetLabel(
+            m_context == KODI::GUILIB::GUIINFO::DEFAULT_CONTEXT ? contextWindow : m_context,
+            preferImage);
+      }
     }
   }
   return "";

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -65,17 +65,16 @@ std::string CSkinVariableString::GetValue(int contextWindow,
 {
   for (const auto& it : m_conditionLabelPairs)
   {
-    if (!it.m_condition || it.m_condition->Get(item))
+    // use propagated context in case this skin variable has the default context (i.e. if not tied to a specific window)
+    // nested skin variables are supported
+    int context = m_context == INFO::DEFAULT_CONTEXT ? contextWindow : m_context;
+    if (!it.m_condition || it.m_condition->Get(context, item))
     {
       if (item)
         return it.m_label.GetItemLabel(item, preferImage);
       else
       {
-        // use propagated context in case this skin variable has the default context (i.e. if not tied to a specific window)
-        // nested skin variables are supported
-        return it.m_label.GetLabel(
-            m_context == KODI::GUILIB::GUIINFO::DEFAULT_CONTEXT ? contextWindow : m_context,
-            preferImage);
+        return it.m_label.GetLabel(context, preferImage);
       }
     }
   }

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -31,7 +31,10 @@ class CSkinVariableString
 public:
   const std::string& GetName() const;
   int GetContext() const;
-  std::string GetValue(bool preferImage = false, const CGUIListItem *item = nullptr) const;
+  std::string GetValue(int contextWindow,
+                       bool preferImage = false,
+                       const CGUIListItem* item = nullptr) const;
+
 private:
   CSkinVariableString();
 

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -129,11 +129,15 @@ JSONRPC_STATUS CGUIOperations::GetPropertyValue(const std::string &property, CVa
 {
   if (property == "currentwindow")
   {
-    result["label"] = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(CServiceBroker::GetGUI()->GetInfoManager().TranslateString("System.CurrentWindow"));
+    result["label"] = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+        CServiceBroker::GetGUI()->GetInfoManager().TranslateString("System.CurrentWindow"),
+        INFO::DEFAULT_CONTEXT);
     result["id"] = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog();
   }
   else if (property == "currentcontrol")
-    result["label"] = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(CServiceBroker::GetGUI()->GetInfoManager().TranslateString("System.CurrentControl"));
+    result["label"] = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+        CServiceBroker::GetGUI()->GetInfoManager().TranslateString("System.CurrentControl"),
+        INFO::DEFAULT_CONTEXT);
   else if (property == "skin")
   {
     std::string skinId = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN);

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -298,9 +298,9 @@ namespace XBMCAddon
       //doesn't seem to be a single InfoTag?
       //try full blown GuiInfoLabel then
       if (ret == 0)
-        return GUILIB::GUIINFO::CGUIInfoLabel::GetLabel(cLine);
+        return GUILIB::GUIINFO::CGUIInfoLabel::GetLabel(cLine, INFO::DEFAULT_CONTEXT);
       else
-        return infoMgr.GetLabel(ret);
+        return infoMgr.GetLabel(ret, INFO::DEFAULT_CONTEXT);
     }
 
     String getInfoImage(const char * infotag)

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -340,7 +340,8 @@ CUPnPRenderer::UpdateState()
     } else if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) {
         avt->SetStateVariable("TransportState", "PLAYING");
 
-        const std::string filePath = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(SLIDESHOW_FILE_PATH);
+        const std::string filePath = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+            SLIDESHOW_FILE_PATH, INFO::DEFAULT_CONTEXT);
         avt->SetStateVariable("AVTransportURI" , filePath.c_str());
         avt->SetStateVariable("CurrentTrackURI", filePath.c_str());
         avt->SetStateVariable("TransportPlaySpeed", "1");

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -91,7 +91,8 @@ void CGUIDialogPictureInfo::UpdatePictureInfo()
     if (info == SLIDESHOW_EXIF_DATE || info == SLIDESHOW_EXIF_LONG_DATE || info == SLIDESHOW_EXIF_LONG_DATE_TIME )
       continue;
 
-    std::string picInfo = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info);
+    std::string picInfo =
+        CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info, INFO::DEFAULT_CONTEXT);
     if (!picInfo.empty())
     {
       CFileItemPtr item(new CFileItem(g_localizeStrings.Get(SLIDESHOW_STRING_BASE + info)));

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -107,6 +107,7 @@
 
 using namespace ANNOUNCEMENT;
 using namespace jni;
+using namespace KODI::GUILIB;
 using namespace std::chrono_literals;
 
 std::shared_ptr<CNativeWindow> CNativeWindow::CreateFromSurface(CJNISurfaceHolder holder)
@@ -730,29 +731,34 @@ void CXBMCApp::UpdateSessionMetadata()
   CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
   CJNIMediaMetadataBuilder builder;
   builder
-      .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_TITLE, infoMgr.GetLabel(PLAYER_TITLE))
-      .putString(CJNIMediaMetadata::METADATA_KEY_TITLE, infoMgr.GetLabel(PLAYER_TITLE))
-      .putLong(CJNIMediaMetadata::METADATA_KEY_DURATION, g_application.GetAppPlayer().GetTotalTime())
-//      .putString(CJNIMediaMetadata::METADATA_KEY_ART_URI, thumb)
-//      .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_ICON_URI, thumb)
-//      .putString(CJNIMediaMetadata::METADATA_KEY_ALBUM_ART_URI, thumb)
+      .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_TITLE,
+                 infoMgr.GetLabel(PLAYER_TITLE, INFO::DEFAULT_CONTEXT))
+      .putString(CJNIMediaMetadata::METADATA_KEY_TITLE,
+                 infoMgr.GetLabel(PLAYER_TITLE, INFO::DEFAULT_CONTEXT))
+      .putLong(CJNIMediaMetadata::METADATA_KEY_DURATION,
+               g_application.GetAppPlayer().GetTotalTime())
+      //      .putString(CJNIMediaMetadata::METADATA_KEY_ART_URI, thumb)
+      //      .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_ICON_URI, thumb)
+      //      .putString(CJNIMediaMetadata::METADATA_KEY_ALBUM_ART_URI, thumb)
       ;
 
   std::string thumb;
   if (m_playback_state & PLAYBACK_STATE_VIDEO)
   {
     builder
-        .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_SUBTITLE, infoMgr.GetLabel(VIDEOPLAYER_TAGLINE))
-        .putString(CJNIMediaMetadata::METADATA_KEY_ARTIST, infoMgr.GetLabel(VIDEOPLAYER_DIRECTOR))
-        ;
+        .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_SUBTITLE,
+                   infoMgr.GetLabel(VIDEOPLAYER_TAGLINE, INFO::DEFAULT_CONTEXT))
+        .putString(CJNIMediaMetadata::METADATA_KEY_ARTIST,
+                   infoMgr.GetLabel(VIDEOPLAYER_DIRECTOR, INFO::DEFAULT_CONTEXT));
     thumb = infoMgr.GetImage(VIDEOPLAYER_COVER, -1);
   }
   else if (m_playback_state & PLAYBACK_STATE_AUDIO)
   {
     builder
-        .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_SUBTITLE, infoMgr.GetLabel(MUSICPLAYER_ARTIST))
-        .putString(CJNIMediaMetadata::METADATA_KEY_ARTIST, infoMgr.GetLabel(MUSICPLAYER_ARTIST))
-        ;
+        .putString(CJNIMediaMetadata::METADATA_KEY_DISPLAY_SUBTITLE,
+                   infoMgr.GetLabel(MUSICPLAYER_ARTIST, INFO::DEFAULT_CONTEXT))
+        .putString(CJNIMediaMetadata::METADATA_KEY_ARTIST,
+                   infoMgr.GetLabel(MUSICPLAYER_ARTIST, INFO::DEFAULT_CONTEXT));
     thumb = infoMgr.GetImage(MUSICPLAYER_COVER, -1);
   }
   bool needrecaching = false;

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -77,7 +77,8 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
         SET_CONTROL_HIDDEN(CONTROL_TB_POLICY);
       else if (m_section == CONTROL_BT_POLICY)
       {
-        SET_CONTROL_LABEL(CONTROL_TB_POLICY, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(SYSTEM_PRIVACY_POLICY));
+        SET_CONTROL_LABEL(CONTROL_TB_POLICY, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+                                                 SYSTEM_PRIVACY_POLICY, INFO::DEFAULT_CONTEXT));
         SET_CONTROL_VISIBLE(CONTROL_TB_POLICY);
       }
       return true;
@@ -117,7 +118,8 @@ void CGUIWindowSystemInfo::FrameMove()
   else if (m_section == CONTROL_BT_NETWORK)
   {
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20158));
-    SET_CONTROL_LABEL(i++, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(NETWORK_LINK_STATE));
+    SET_CONTROL_LABEL(i++, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+                               NETWORK_LINK_STATE, INFO::DEFAULT_CONTEXT));
     SetControlLabel(i++, "{}: {}", 149, NETWORK_MAC_ADDRESS);
     SetControlLabel(i++, "{}: {}", 150, NETWORK_IP_ADDRESS);
     SetControlLabel(i++, "{}: {}", 13159, NETWORK_SUBNET_MASK);
@@ -130,7 +132,8 @@ void CGUIWindowSystemInfo::FrameMove()
   else if (m_section == CONTROL_BT_VIDEO)
   {
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20159));
-    SET_CONTROL_LABEL(i++,CServiceBroker::GetGUI()->GetInfoManager().GetLabel(SYSTEM_VIDEO_ENCODER_INFO));
+    SET_CONTROL_LABEL(i++, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+                               SYSTEM_VIDEO_ENCODER_INFO, INFO::DEFAULT_CONTEXT));
     SetControlLabel(i++, "{} {}", 13287, SYSTEM_SCREEN_RESOLUTION);
 
     auto renderingSystem = CServiceBroker::GetRenderSystem();
@@ -162,8 +165,8 @@ void CGUIWindowSystemInfo::FrameMove()
 
     SetControlLabel(i++, "{} {}", 22010, SYSTEM_GPU_TEMPERATURE);
 
-    const std::string hdrTypes =
-        CServiceBroker::GetGUI()->GetInfoManager().GetLabel(SYSTEM_SUPPORTED_HDR_TYPES);
+    const std::string hdrTypes = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+        SYSTEM_SUPPORTED_HDR_TYPES, INFO::DEFAULT_CONTEXT);
     SET_CONTROL_LABEL(
         i++, StringUtils::Format("{}: {}", g_localizeStrings.Get(39174),
                                  hdrTypes.empty() ? g_localizeStrings.Get(231) : hdrTypes));
@@ -250,8 +253,8 @@ void CGUIWindowSystemInfo::ResetLabels()
 
 void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label, int info)
 {
-  std::string tmpStr =
-      StringUtils::Format(format, g_localizeStrings.Get(label),
-                          CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info));
+  std::string tmpStr = StringUtils::Format(
+      format, g_localizeStrings.Get(label),
+      CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info, INFO::DEFAULT_CONTEXT));
   SET_CONTROL_LABEL(id, tmpStr);
 }


### PR DESCRIPTION
## Description
Kodi supports nested skin variables however it doesn't propagate the window context when evaluating them. This might lead to the label to stop displaying once some other dialog pops up over the dialog where the label should be evaluated.
@ronie, @jurialmunkey. @HitcherUK (and other skinners) would be nice if you could runtime test this to see if the issue is fixed and nothing else pops up (it didn't in my tests).

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/15348

## How has this been tested?
Runtime tested with the procedure outlined in the bug report

## What is the effect on users?
Simple skin fix, some infolabels belonging to nested skin variables won't be discarded anymore


