### PR TITLE
[video][osd] revert autoclose OSD (2441f82)

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23059,16 +23059,14 @@ msgctxt "#39174"
 msgid "Display supported HDR types"
 msgstr ""
 
-#empty string 39175-39179
-
 #. Progress text on splash screen, to build the font cache
 #: xbmc/Application.cpp
-msgctxt "#39180"
+msgctxt "#39175"
 msgid "Building font cache in progress - please wait"
 msgstr ""
 
 #. Helper text for gui sound volume setting
 #: system/settings/settings.xml
-msgctxt "#39181"
+msgctxt "#39176"
 msgid "Relative volume for gui sounds"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -678,7 +678,6 @@ msgid "Free"
 msgstr ""
 
 #: addons/skin.estuary/xml/Includes.xml
-#: system/settings/settings.xml
 msgctxt "#157"
 msgid "Video"
 msgstr ""
@@ -2249,8 +2248,6 @@ msgctxt "#477"
 msgid "Unable to load playlist"
 msgstr ""
 
-#. label for "OSD" setting category
-#: system/settings/settings.xml
 msgctxt "#478"
 msgid "OSD"
 msgstr ""
@@ -23062,35 +23059,7 @@ msgctxt "#39174"
 msgid "Display supported HDR types"
 msgstr ""
 
-#. Description of settings category "OSD" with label #478
-#: system/settings/settings.xml
-msgctxt "#39175"
-msgid "This category contains all the on screen display (OSD) related settings."
-msgstr ""
-
-#. Automatically close video OSD bool setting in Settings/Interface/OSD
-#: system/settings/settings.xml
-msgctxt "#39176"
-msgid "Automatically close video OSD"
-msgstr ""
-
-#. Help text for "Automatically close video OSD" setting in Settings/Interface/OSD
-#: system/settings/settings.xml
-msgctxt "#39177"
-msgid "The video OSD window will be automatically closed if visible after a specified time"
-msgstr ""
-
-#. Video OSD autoclose time (seconds) in Settings/Interface/OSD
-#: system/settings/settings.xml
-msgctxt "#39178"
-msgid "Video OSD autoclose time (seconds)"
-msgstr ""
-
-#. Help text for setting "Video OSD autoclose time (seconds)" of label #39178
-#: system/settings/settings.xml
-msgctxt "#39179"
-msgid "The time in seconds for the video OSD to be automatically closed"
-msgstr ""
+#empty string 39175-39179
 
 #. Progress text on splash screen, to build the font cache
 #: xbmc/Application.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3708,31 +3708,6 @@
         </setting>
       </group>
     </category>
-    <category id="osd" label="478" help="39175">
-      <group id="1" label="157">
-        <setting id="osd.autoclosevideoosd" type="boolean" label="39176" help="39177">
-          <level>0</level>
-          <default>true</default>
-          <control type="toggle" />
-          <dependencies>
-            <dependency type="enable" on="property" operator="!is" name="isplaying" />
-          </dependencies>
-        </setting>
-        <setting id="osd.autoclosevideoosdtime" type="integer" parent="osd.autoclosevideoosd" label="39178" help="39179">
-          <level>2</level>
-          <default>5</default>
-          <constraints>
-            <minimum>2</minimum>
-            <step>1</step>
-            <maximum>60</maximum>
-          </constraints>
-          <dependencies>
-            <dependency type="visible" setting="osd.autoclosevideoosd">true</dependency>
-          </dependencies>
-          <control type="slider" format="integer" />
-        </setting>
-      </group>
-    </category>
     <category id="regional" label="14222" help="36113">
       <group id="1" label="14218">
         <setting id="locale.language" type="addon" label="248" help="36114">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2966,7 +2966,7 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="audiooutput.guisoundvolume" type="integer" label="13376" help="39181">
+        <setting id="audiooutput.guisoundvolume" type="integer" label="13376" help="39176">
           <level>1</level>
           <default>100</default>
           <control type="slider" format="percentage" range="0,100" />

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -654,7 +654,7 @@ bool CApplication::Initialize()
     guiFontManager.Initialize();
     event.Set();
   });
-  localizedStr = g_localizeStrings.Get(39180);
+  localizedStr = g_localizeStrings.Get(39175);
   iDots = 1;
   while (!event.Wait(1000ms))
   {

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -451,8 +451,6 @@ constexpr const char* CSettings::SETTING_GENERAL_ADDONBROKENFILTER;
 constexpr const char* CSettings::SETTING_SOURCE_VIDEOS;
 constexpr const char* CSettings::SETTING_SOURCE_MUSIC;
 constexpr const char* CSettings::SETTING_SOURCE_PICTURES;
-constexpr const char* CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSD;
-constexpr const char* CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSDTIME;
 //! @todo: remove in c++17
 
 bool CSettings::Initialize()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -65,8 +65,6 @@ public:
   static constexpr auto SETTING_SCREENSAVER_TIME = "screensaver.time";
   static constexpr auto SETTING_SCREENSAVER_USEMUSICVISINSTEAD = "screensaver.usemusicvisinstead";
   static constexpr auto SETTING_SCREENSAVER_USEDIMONPAUSE = "screensaver.usedimonpause";
-  static constexpr auto SETTING_OSD_AUTOCLOSEVIDEOOSD = "osd.autoclosevideoosd";
-  static constexpr auto SETTING_OSD_AUTOCLOSEVIDEOOSDTIME = "osd.autoclosevideoosdtime";
   static constexpr auto SETTING_WINDOW_WIDTH = "window.width";
   static constexpr auto SETTING_WINDOW_HEIGHT = "window.height";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS = "videolibrary.showunwatchedplots";

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -60,19 +60,6 @@ bool CGUIDialogVideoOSD::OnAction(const CAction &action)
   return CGUIDialog::OnAction(action);
 }
 
-void CGUIDialogVideoOSD::OnInitWindow()
-{
-  std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  if (settings)
-  {
-    if (settings->GetBool(CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSD))
-    {
-      SetAutoClose(settings->GetInt(CSettings::SETTING_OSD_AUTOCLOSEVIDEOOSDTIME) * 1000);
-    }
-  }
-  CGUIDialog::OnInitWindow();
-}
-
 EVENT_RESULT CGUIDialogVideoOSD::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
   if (event.m_id == ACTION_MOUSE_WHEEL_UP)

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.h
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.h
@@ -18,7 +18,6 @@ public:
   ~CGUIDialogVideoOSD(void) override;
 
   void FrameMove() override;
-  void OnInitWindow() override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
 protected:


### PR DESCRIPTION
## Description

This PR reverts my addition in https://github.com/xbmc/xbmc/pull/20267 which added a way to close the video OSD automatically after some time has elapsed.
After thinking a bit about this I think this option should be handled by the skin and not by the core itself as it enforces presentation behaviour that should be overridden by the GUI layer if the skinner so desires. The skinning engine at the moment lacks any proper way of doing this - the functionality can only be implemented using python scripts (which add a performance penalty) or hacky custom windows such as https://github.com/b-jesch/skin.estuary.modv2/blob/Nexus/xml/Custom_1110_CloseVideoOSD.xml.

If this feature is desired the effort should be directed at adding a proper way to allow the implementation using the Skinning api instead and added to the default skin. I will work on this on the next days and try to come up with a reference implementation in estuary.
For now let's just revert this since the first alpha is not yet out.

Some user/skinner voiced about this on the forum: https://forum.kodi.tv/showthread.php?tid=367983

