### PR TITLE
[cmake] rename CORE_HOST_IS_TARGET to HOST_CAN_EXECUTE_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,7 +392,7 @@ else()
 endif()
 
 # testing
-if(CORE_HOST_IS_TARGET AND ENABLE_TESTING)
+if(HOST_CAN_EXECUTE_TARGET AND ENABLE_TESTING)
   find_package(Gtest)
 
   copy_files_from_filelist_to_buildtree(${CMAKE_SOURCE_DIR}/cmake/installdata/test-reference-data.txt NO_INSTALL)

--- a/cmake/modules/FindTexturePacker.cmake
+++ b/cmake/modules/FindTexturePacker.cmake
@@ -57,9 +57,9 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
       set(INTERNAL_TEXTUREPACKER_INSTALLABLE TRUE)
     endif()
 
-    # Use it during build if build architecture is same as host
-    # (not cross-compiling) and TEXTUREPACKER_EXECUTABLE is not found
-    if(CORE_HOST_IS_TARGET AND NOT TEXTUREPACKER_EXECUTABLE)
+    # Use it during build if build architecture can be executed on host
+    # and TEXTUREPACKER_EXECUTABLE is not found
+    if(HOST_CAN_EXECUTE_TARGET AND NOT TEXTUREPACKER_EXECUTABLE)
       set(INTERNAL_TEXTUREPACKER_EXECUTABLE TRUE)
     endif()
 

--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -59,9 +59,13 @@ endif()
 # this variable is set if we can execute build artefacts on the host system (for example unit tests).
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL CMAKE_SYSTEM_PROCESSOR AND
    CMAKE_HOST_SYSTEM_NAME STREQUAL CMAKE_SYSTEM_NAME)
-  set(CORE_HOST_IS_TARGET TRUE)
+  if(NOT HOST_CAN_EXECUTE_TARGET)
+    set(HOST_CAN_EXECUTE_TARGET TRUE)
+  endif()
 else()
-  set(CORE_HOST_IS_TARGET FALSE)
+  if(NOT HOST_CAN_EXECUTE_TARGET)
+    set(HOST_CAN_EXECUTE_TARGET FALSE)
+  endif()
 endif()
 
 # system specific arch setup

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -23,6 +23,12 @@ else()
   endif()
 endif()
 
+# m1 macs can execute x86_64 code via rosetta
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND
+   CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+  set(HOST_CAN_EXECUTE_TARGET TRUE)
+endif()
+
 if(NOT TARBALL_DIR)
   set(TARBALL_DIR "/Users/Shared/xbmc-depends/xbmc-tarballs")
 endif()


### PR DESCRIPTION
## Description
We are now in a time where some platforms/archs can execute "foreign" (x86_64)
arch code locally (Apple via Rosetta, Windows on arm).
Rename CORE_HOST_IS_TARGET to HOST_CAN_EXECUTE_TARGET to allow platforms ArchSetup
to set and therefore execute tests if desired.

Have created the ability to override via options if desired (eg -DHOST_CAN_EXECUTE_TARGET=ON). This may not be totally necessary, but its a minor change, so ive gone with it anyway

## Motivation and context
Allows platforms to indicate if they can execute different arch code. This allows for example an Apple M1 host to build x86_64 kodi and execute x86_64 tests.
I know that Windows on Arm can also execute x86_64 code, but i have not enabled this at this time. If any windows devs want to dive into that at some other point in time, please do.

@ksooo this ones for you
@wsnipex for the cmake review
@Paxxi maybe you can provide info RE Windows on Arm and suitable checks/locations in the windows cmake stuff. No hassle if you've got no time.

## How has this been tested?
Build x86_64 on m1. call test target via make kodi-test

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
