### PR TITLE
[Subtitles] Improvements vertical margin and manual position

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23103,3 +23103,21 @@ msgstr ""
 msgctxt "#39181"
 msgid "Relative volume for gui sounds"
 msgstr ""
+
+#. Subtitle vertical margin setting
+#: system/settings/settings.xml
+msgctxt "#39182"
+msgid "Vertical margin"
+msgstr ""
+
+#. Help text for setting "Vertical margin" of label #39182
+#: system/settings/settings.xml
+msgctxt "#39183"
+msgid "Allows you to add a margin in top and bottom aligned text. Changing this setting will affect also subtitle position set with the Video calibration."
+msgstr ""
+
+#. Window screen calibration: the current subtitle calibration value with vertical margin
+#: xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+msgctxt "#39184"
+msgid "Current value: {0:d} (with vertical margin: {1:d})"
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -668,6 +668,19 @@
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
+        <setting id="subtitles.marginvertical" type="number" label="39182" help="39183">
+          <level>3</level>
+          <default>7.75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>0.25</step>
+            <maximum>50</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" on="property" operator="!is" name="isplaying" />
+          </dependencies>
+          <control type="slider" format="percentage"/>
+        </setting>
         <setting id="subtitles.overridefonts" type="boolean" label="21368" help="36190">
           <level>3</level>
           <default>false</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -480,12 +480,12 @@
         </setting>
         <setting id="subtitles.captionsalign" parent="subtitles.parsecaptions" type="integer" label="39161">
           <level>2</level>
-          <default>0</default> <!-- SUBTITLE_HORIZONTAL_ALIGN_LEFT -->
+          <default>0</default> <!-- HorizontalAlign::LEFT -->
           <constraints>
             <options>
-              <option label="39162">0</option> <!-- SUBTITLE_HORIZONTAL_ALIGN_LEFT -->
-              <option label="39163">1</option> <!-- SUBTITLE_HORIZONTAL_ALIGN_CENTER -->
-              <option label="39164">2</option> <!-- SUBTITLE_HORIZONTAL_ALIGN_RIGHT -->
+              <option label="39162">0</option> <!-- HorizontalAlign::LEFT -->
+              <option label="39163">1</option> <!-- HorizontalAlign::CENTER -->
+              <option label="39164">2</option> <!-- HorizontalAlign::RIGHT -->
             </options>
           </constraints>
           <dependencies>
@@ -495,14 +495,14 @@
         </setting>
         <setting id="subtitles.align" type="integer" label="21460" help="36192">
           <level>2</level>
-          <default>1</default> <!-- SUBTITLE_ALIGN_BOTTOM_INSIDE -->
+          <default>1</default> <!-- Align::BOTTOM_INSIDE -->
           <constraints>
             <options>
-              <option label="21461">0</option> <!-- SUBTITLE_ALIGN_MANUAL -->
-              <option label="21462">1</option> <!-- SUBTITLE_ALIGN_BOTTOM_INSIDE -->
-              <option label="21463">2</option> <!-- SUBTITLE_ALIGN_BOTTOM_OUTSIDE -->
-              <option label="21464">3</option> <!-- SUBTITLE_ALIGN_TOP_INSIDE -->
-              <option label="21465">4</option> <!-- SUBTITLE_ALIGN_TOP_OUTSIDE -->
+              <option label="21461">0</option> <!-- Align::MANUAL -->
+              <option label="21462">1</option> <!-- Align::BOTTOM_INSIDE -->
+              <option label="21463">2</option> <!-- Align::BOTTOM_OUTSIDE -->
+              <option label="21464">3</option> <!-- Align::TOP_INSIDE -->
+              <option label="21465">4</option> <!-- Align::TOP_OUTSIDE -->
             </options>
           </constraints>
           <control type="list" format="string" />
@@ -548,13 +548,13 @@
         </setting>
         <setting id="subtitles.style" type="integer" parent="subtitles.fontname" label="736" help="36187">
           <level>3</level>
-          <default>0</default> <!-- FONT_STYLE_NORMAL -->
+          <default>0</default> <!-- FontStyle::NORMAL -->
           <constraints>
             <options>
-              <option label="738">0</option> <!-- FONT_STYLE_NORMAL -->
-              <option label="739">1</option> <!-- FONT_STYLE_BOLD -->
-              <option label="740">2</option> <!-- FONT_STYLE_ITALICS -->
-              <option label="741">3</option> <!-- FONT_STYLE_BOLD | FONT_STYLE_ITALICS -->
+              <option label="738">0</option> <!-- FontStyle::NORMAL -->
+              <option label="739">1</option> <!-- FontStyle::BOLD -->
+              <option label="740">2</option> <!-- FontStyle::ITALIC -->
+              <option label="741">3</option> <!-- FontStyle::BOLD_ITALIC -->
             </options>
           </constraints>
           <control type="list" format="string" />
@@ -592,13 +592,13 @@
         </setting>
         <setting id="subtitles.backgroundtype" type="integer" parent="subtitles.fontname" label="39165" help="39169">
           <level>3</level>
-          <default>0</default>
+          <default>0</default> <!-- BackgroundType::NONE -->
           <constraints>
             <options>
-              <option label="231">0</option> <!-- SUBTITLE_BACKGROUNDTYPE_NONE -->
-              <option label="39166">1</option> <!-- SUBTITLE_BACKGROUNDTYPE_SHADOW -->
-              <option label="39167">2</option> <!-- SUBTITLE_BACKGROUNDTYPE_BOX -->
-              <option label="39168">3</option> <!-- SUBTITLE_BACKGROUNDTYPE_SQUAREBOX -->
+              <option label="231">0</option> <!-- BackgroundType::NONE -->
+              <option label="39166">1</option> <!-- BackgroundType::SHADOW -->
+              <option label="39167">2</option> <!-- BackgroundType::BOX -->
+              <option label="39168">3</option> <!-- BackgroundType::SQUAREBOX -->
             </options>
           </constraints>
           <control type="list" format="integer" />

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -15,11 +15,12 @@
 #include "Util.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
+#include "settings/SubtitlesSettings.h"
 #include "utils/StringUtils.h"
 
 #include <memory>
+
+using namespace KODI;
 
 CDVDOverlayCodecSSA::CDVDOverlayCodecSSA()
   : CDVDOverlayCodec("SSA Subtitle Decoder"), m_libass(std::make_shared<CDVDSubtitlesLibass>())
@@ -132,11 +133,8 @@ CDVDOverlay* CDVDOverlayCodecSSA::GetOverlay()
   m_pOverlay = new CDVDOverlaySSA(m_libass);
   m_pOverlay->iPTSStartTime = 0;
   m_pOverlay->iPTSStopTime = DVD_NOPTS_VALUE;
-  //! @todo To move GetSettings into SubtitleSettings
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  int overrideStyles = settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
-  m_pOverlay->SetForcedMargins(
-      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS) &&
-      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::POSITIONS));
+  auto overrideStyles{SUBTITLES::CSubtitlesSettings::GetInstance().GetOverrideStyles()};
+  m_pOverlay->SetForcedMargins(overrideStyles != SUBTITLES::OverrideStyles::STYLES_POSITIONS &&
+                               overrideStyles != SUBTITLES::OverrideStyles::POSITIONS);
   return m_pOverlay->Acquire();
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -19,6 +19,8 @@
 #include <memory>
 #include <string>
 
+using namespace KODI;
+
 COverlayCodecWebVTT::COverlayCodecWebVTT() : CDVDOverlayCodec("WebVTT Subtitle Decoder")
 {
   m_pOverlay = nullptr;
@@ -113,7 +115,7 @@ OverlayMessage COverlayCodecWebVTT::Decode(DemuxPacket* pPacket)
 
   for (auto& subData : subtitleList)
   {
-    KODI::SUBTITLES::subtitleOpts opts;
+    SUBTITLES::STYLE::subtitleOpts opts;
     opts.useMargins = subData.useMargins;
     opts.marginLeft = subData.marginLeft;
     opts.marginRight = subData.marginRight;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -11,8 +11,9 @@
 #include "DVDCodecs/Overlay/DVDOverlaySSA.h"
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
+#include "settings/SubtitlesSettings.h"
+
+using namespace KODI;
 
 CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream>&& pStream,
                                              const std::string& strFile)
@@ -40,12 +41,9 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo& hints)
   CDVDOverlaySSA* overlay = new CDVDOverlaySSA(m_libass);
   overlay->iPTSStartTime = 0.0;
   overlay->iPTSStopTime = DVD_NOPTS_VALUE;
-  //! @todo To move GetSettings into SubtitleSettings
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  int overrideStyles = settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
-  overlay->SetForcedMargins(
-      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS) &&
-      overrideStyles != static_cast<int>(KODI::SUBTITLES::OverrideStyles::POSITIONS));
+  auto overrideStyles{SUBTITLES::CSubtitlesSettings::GetInstance().GetOverrideStyles()};
+  overlay->SetForcedMargins(overrideStyles != SUBTITLES::OverrideStyles::STYLES_POSITIONS &&
+                            overrideStyles != SUBTITLES::OverrideStyles::POSITIONS);
   m_collection.Add(overlay);
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -40,9 +40,9 @@ public:
   void Configure();
 
   ASS_Image* RenderImage(double pts,
-                         KODI::SUBTITLES::renderOpts opts,
+                         KODI::SUBTITLES::STYLE::renderOpts opts,
                          bool updateStyle,
-                         const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
+                         const std::shared_ptr<struct KODI::SUBTITLES::STYLE::style>& subStyle,
                          int* changes = NULL);
 
   ASS_Event* GetEvents();
@@ -117,7 +117,7 @@ protected:
   int AddEvent(const char* text,
                double startTime,
                double stopTime,
-               KODI::SUBTITLES::subtitleOpts* opts);
+               KODI::SUBTITLES::STYLE::subtitleOpts* opts);
 
   /*!
   * \brief Append text to the specified event
@@ -144,10 +144,10 @@ protected:
 
 
 private:
-  void ConfigureAssOverride(const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
+  void ConfigureAssOverride(const std::shared_ptr<struct KODI::SUBTITLES::STYLE::style>& subStyle,
                             ASS_Style* style);
-  void ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLES::style>& subStyle,
-                  KODI::SUBTITLES::renderOpts opts);
+  void ApplyStyle(const std::shared_ptr<struct KODI::SUBTITLES::STYLE::style>& subStyle,
+                  KODI::SUBTITLES::STYLE::renderOpts opts);
 
   ASS_Library* m_library = nullptr;
   ASS_Track* m_track = nullptr;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
@@ -16,6 +16,8 @@
 
 #include <vector>
 
+using namespace KODI;
+
 CSubtitleParserWebVTT::CSubtitleParserWebVTT(std::unique_ptr<CDVDSubtitleStream>&& pStream,
                                              const std::string& strFile)
   : CDVDSubtitleParserText(std::move(pStream), strFile, "WebVTT Subtitle Parser")
@@ -60,7 +62,7 @@ bool CSubtitleParserWebVTT::Open(CDVDStreamInfo& hints)
   // Send decoded lines to the renderer
   for (auto& subData : subtitleList)
   {
-    KODI::SUBTITLES::subtitleOpts opts;
+    SUBTITLES::STYLE::subtitleOpts opts;
     opts.useMargins = subData.useMargins;
     opts.marginLeft = subData.marginLeft;
     opts.marginRight = subData.marginRight;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
@@ -38,7 +38,7 @@ int CSubtitlesAdapter::AddSubtitle(std::string& text, double startTime, double s
 int CSubtitlesAdapter::AddSubtitle(std::string& text,
                                    double startTime,
                                    double stopTime,
-                                   KODI::SUBTITLES::subtitleOpts* opts)
+                                   KODI::SUBTITLES::STYLE::subtitleOpts* opts)
 {
   PostProcess(text);
   int ret = m_libass->AddEvent(text.c_str(), startTime, stopTime, opts);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
@@ -50,7 +50,7 @@ public:
   int AddSubtitle(std::string& text,
                   double startTime,
                   double stopTime,
-                  KODI::SUBTITLES::subtitleOpts* opts);
+                  KODI::SUBTITLES::STYLE::subtitleOpts* opts);
 
   /*!
   * \brief Append text to the specified subtitle ID

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -16,15 +16,14 @@ namespace KODI
 {
 namespace SUBTITLES
 {
+namespace STYLE
+{
 
 constexpr double VIEWPORT_HEIGHT = 1080.0;
 constexpr double VIEWPORT_WIDTH = 1920.0;
 constexpr int MARGIN_VERTICAL = 75;
-// Vertical margin used when is selected the alignment
-// to keep the text inside the black bars
-constexpr float MARGIN_VERTICAL_BLACKBARS = 2.75f; // in %
 
-enum class HorizontalAlignment
+enum class HorizontalAlign
 {
   DISABLED = 0,
   LEFT,
@@ -32,7 +31,7 @@ enum class HorizontalAlignment
   RIGHT
 };
 
-enum class FontAlignment
+enum class FontAlign
 {
   TOP_LEFT = 0,
   TOP_CENTER,
@@ -53,7 +52,7 @@ enum class FontStyle
   BOLD_ITALIC
 };
 
-enum class BorderStyle
+enum class BorderType
 {
   OUTLINE_NO_SHADOW,
   OUTLINE,
@@ -78,13 +77,13 @@ struct style
   int fontBorderSize = 15; // In %
   UTILS::COLOR::Color fontBorderColor = UTILS::COLOR::BLACK;
   int fontOpacity = 100; // In %
-  BorderStyle borderStyle = BorderStyle::OUTLINE;
+  BorderType borderStyle = BorderType::OUTLINE;
   UTILS::COLOR::Color backgroundColor = UTILS::COLOR::BLACK;
   int backgroundOpacity = 0; // In %
   int shadowSize = 0; // In %
   UTILS::COLOR::Color shadowColor = UTILS::COLOR::BLACK;
   int shadowOpacity = 100; // In %
-  FontAlignment alignment = FontAlignment::TOP_LEFT;
+  FontAlign alignment = FontAlign::TOP_LEFT;
   // Override styles to native ASS/SSA format type only
   OverrideStyles assOverrideStyles = OverrideStyles::DISABLED;
   // Override fonts to native ASS/SSA format type only
@@ -113,8 +112,9 @@ struct renderOpts
   bool disableVerticalMargin = false;
   // position: vertical line position of subtitles in percent. 0 = no change (bottom), 100 = on top.
   double position = 0;
-  HorizontalAlignment horizontalAlignment = HorizontalAlignment::DISABLED;
+  HorizontalAlign horizontalAlignment = HorizontalAlign::DISABLED;
 };
 
+} // namespace STYLE
 } // namespace SUBTITLES
 } // namespace KODI

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -22,7 +22,7 @@ constexpr double VIEWPORT_WIDTH = 1920.0;
 constexpr int MARGIN_VERTICAL = 75;
 // Vertical margin used when is selected the alignment
 // to keep the text inside the black bars
-constexpr int MARGIN_VERTICAL_BLACKBARS = 30;
+constexpr float MARGIN_VERTICAL_BLACKBARS = 2.75f; // in %
 
 enum class HorizontalAlignment
 {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -12,8 +12,7 @@
 #include "cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "filesystem/SpecialProtocol.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
+#include "settings/SubtitlesSettings.h"
 #include "utils/CSSUtils.h"
 #include "utils/CharsetConverter.h"
 #include "utils/HTMLUtil.h"
@@ -31,7 +30,7 @@
 // - Cue "line" setting as number value
 // - Vertical text (used for some specific asian languages only)
 
-using namespace KODI::SUBTITLES;
+using namespace KODI::SUBTITLES::STYLE;
 
 namespace
 {
@@ -211,12 +210,11 @@ bool CWebVTTHandler::Initialize()
     m_cueCssStyleMapRegex.insert({item.first, reg});
   }
 
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  int overrideStyles = settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
-  m_overridePositions = (overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS ||
-                         overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::POSITIONS);
-  m_overrideStyle = (overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS ||
-                     overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::STYLES);
+  auto overrideStyles{KODI::SUBTITLES::CSubtitlesSettings::GetInstance().GetOverrideStyles()};
+  m_overridePositions = (overrideStyles == KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS ||
+                         overrideStyles == KODI::SUBTITLES::OverrideStyles::POSITIONS);
+  m_overrideStyle = (overrideStyles == KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS ||
+                     overrideStyles == KODI::SUBTITLES::OverrideStyles::STYLES);
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -145,7 +145,7 @@ void CDebugRenderer::CRenderer::Render(int idx)
 
 void CDebugRenderer::CRenderer::CreateSubtitlesStyle()
 {
-  m_debugOverlayStyle = std::make_shared<KODI::SUBTITLES::style>();
+  m_debugOverlayStyle = std::make_shared<KODI::SUBTITLES::STYLE::style>();
   m_debugOverlayStyle->fontName = KODI::SUBTITLES::FONT_DEFAULT_FAMILYNAME;
   m_debugOverlayStyle->fontSize = 20.0;
   m_debugOverlayStyle->marginVertical = 30;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
@@ -41,7 +41,7 @@ protected:
     // Implementation of Observer
     void Notify(const Observable& obs, const ObservableMessage msg) override{};
 
-    std::shared_ptr<struct KODI::SUBTITLES::style> m_debugOverlayStyle;
+    std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_debugOverlayStyle;
   };
 
   CRenderer m_overlayRenderer;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 
 using namespace OVERLAY;
+using namespace KODI;
 
 COverlay::COverlay()
 {
@@ -56,12 +57,12 @@ unsigned int CRenderer::m_textureid = 1;
 
 CRenderer::CRenderer()
 {
-  KODI::SUBTITLES::CSubtitlesSettings::GetInstance().RegisterObserver(this);
+  SUBTITLES::CSubtitlesSettings::GetInstance().RegisterObserver(this);
 }
 
 CRenderer::~CRenderer()
 {
-  KODI::SUBTITLES::CSubtitlesSettings::GetInstance().UnregisterObserver(this);
+  SUBTITLES::CSubtitlesSettings::GetInstance().UnregisterObserver(this);
   Flush();
 }
 
@@ -313,7 +314,7 @@ void CRenderer::ResetSubtitlePosition()
 
 void CRenderer::CreateSubtitlesStyle()
 {
-  m_overlayStyle = std::make_shared<KODI::SUBTITLES::style>();
+  m_overlayStyle = std::make_shared<SUBTITLES::style>();
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
   m_overlayStyle->fontName = settings->GetString(CSettings::SETTING_SUBTITLES_FONTNAME);
@@ -321,11 +322,11 @@ void CRenderer::CreateSubtitlesStyle()
 
   uint32_t fontStyleMask = settings->GetInt(CSettings::SETTING_SUBTITLES_STYLE) & FONT_STYLE_MASK;
   if ((fontStyleMask & FONT_STYLE_BOLD) && (fontStyleMask & FONT_STYLE_ITALICS))
-    m_overlayStyle->fontStyle = KODI::SUBTITLES::FontStyle::BOLD_ITALIC;
+    m_overlayStyle->fontStyle = SUBTITLES::FontStyle::BOLD_ITALIC;
   else if (fontStyleMask & FONT_STYLE_BOLD)
-    m_overlayStyle->fontStyle = KODI::SUBTITLES::FontStyle::BOLD;
+    m_overlayStyle->fontStyle = SUBTITLES::FontStyle::BOLD;
   else if (fontStyleMask & FONT_STYLE_ITALICS)
-    m_overlayStyle->fontStyle = KODI::SUBTITLES::FontStyle::ITALIC;
+    m_overlayStyle->fontStyle = SUBTITLES::FontStyle::ITALIC;
 
   m_overlayStyle->fontColor =
       UTILS::COLOR::ConvertHexToColor(settings->GetString(CSettings::SETTING_SUBTITLES_COLOR));
@@ -336,13 +337,13 @@ void CRenderer::CreateSubtitlesStyle()
 
   int backgroundType = settings->GetInt(CSettings::SETTING_SUBTITLES_BACKGROUNDTYPE);
   if (backgroundType == SUBTITLE_BACKGROUNDTYPE_NONE)
-    m_overlayStyle->borderStyle = KODI::SUBTITLES::BorderStyle::OUTLINE_NO_SHADOW;
+    m_overlayStyle->borderStyle = SUBTITLES::BorderStyle::OUTLINE_NO_SHADOW;
   else if (backgroundType == SUBTITLE_BACKGROUNDTYPE_SHADOW)
-    m_overlayStyle->borderStyle = KODI::SUBTITLES::BorderStyle::OUTLINE;
+    m_overlayStyle->borderStyle = SUBTITLES::BorderStyle::OUTLINE;
   else if (backgroundType == SUBTITLE_BACKGROUNDTYPE_BOX)
-    m_overlayStyle->borderStyle = KODI::SUBTITLES::BorderStyle::BOX;
+    m_overlayStyle->borderStyle = SUBTITLES::BorderStyle::BOX;
   else if (backgroundType == SUBTITLE_BACKGROUNDTYPE_SQUAREBOX)
-    m_overlayStyle->borderStyle = KODI::SUBTITLES::BorderStyle::SQUARE_BOX;
+    m_overlayStyle->borderStyle = SUBTITLES::BorderStyle::SQUARE_BOX;
 
   m_overlayStyle->backgroundColor =
       UTILS::COLOR::ConvertHexToColor(settings->GetString(CSettings::SETTING_SUBTITLES_BGCOLOR));
@@ -355,9 +356,9 @@ void CRenderer::CreateSubtitlesStyle()
 
   int subAlign = settings->GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
   if (subAlign == SUBTITLE_ALIGN_TOP_INSIDE || subAlign == SUBTITLE_ALIGN_TOP_OUTSIDE)
-    m_overlayStyle->alignment = KODI::SUBTITLES::FontAlignment::TOP_CENTER;
+    m_overlayStyle->alignment = SUBTITLES::FontAlignment::TOP_CENTER;
   else
-    m_overlayStyle->alignment = KODI::SUBTITLES::FontAlignment::SUB_CENTER;
+    m_overlayStyle->alignment = SUBTITLES::FontAlignment::SUB_CENTER;
 
   if (subAlign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE || subAlign == SUBTITLE_ALIGN_TOP_OUTSIDE)
     m_overlayStyle->drawWithinBlackBars = true;
@@ -365,25 +366,23 @@ void CRenderer::CreateSubtitlesStyle()
   m_overlayStyle->assOverrideFont = settings->GetBool(CSettings::SETTING_SUBTITLES_OVERRIDEFONTS);
 
   int overrideStyles = settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES);
-  if (overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::POSITIONS ||
-      overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::STYLES ||
-      overrideStyles == (int)KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS)
-    m_overlayStyle->assOverrideStyles =
-        static_cast<KODI::SUBTITLES::OverrideStyles>(overrideStyles);
+  if (overrideStyles == (int)SUBTITLES::OverrideStyles::POSITIONS ||
+      overrideStyles == (int)SUBTITLES::OverrideStyles::STYLES ||
+      overrideStyles == (int)SUBTITLES::OverrideStyles::STYLES_POSITIONS)
+    m_overlayStyle->assOverrideStyles = static_cast<SUBTITLES::OverrideStyles>(overrideStyles);
   else
-    m_overlayStyle->assOverrideStyles = KODI::SUBTITLES::OverrideStyles::DISABLED;
+    m_overlayStyle->assOverrideStyles = SUBTITLES::OverrideStyles::DISABLED;
 
   m_overlayStyle->marginVertical = GetSubtitleVerticalMargin();
   m_overlayStyle->blur = settings->GetInt(CSettings::SETTING_SUBTITLES_BLUR);
 }
 
-COverlay* CRenderer::ConvertLibass(
-    CDVDOverlayLibass* o,
-    double pts,
-    bool updateStyle,
-    const std::shared_ptr<struct KODI::SUBTITLES::style>& overlayStyle)
+COverlay* CRenderer::ConvertLibass(CDVDOverlayLibass* o,
+                                   double pts,
+                                   bool updateStyle,
+                                   const std::shared_ptr<struct SUBTITLES::style>& overlayStyle)
 {
-  KODI::SUBTITLES::renderOpts rOpts;
+  SUBTITLES::renderOpts rOpts;
 
   // libass render in a target area which named as frame. the frame size may bigger than video size,
   // and including margins between video to frame edge. libass allow to render subtitles into the margins.
@@ -437,8 +436,8 @@ COverlay* CRenderer::ConvertLibass(
     // to fix this problem is needed add a kind of calculation to compensate
     // the scale difference, its not clear what formula could be used,
     // the following calculation works quite well but not perfectly
-    double scaledMargin{static_cast<double>(m_subtitleVerticalMargin) /
-                        KODI::SUBTITLES::VIEWPORT_HEIGHT * (subPosPx - resInfo.Overscan.top)};
+    double scaledMargin{static_cast<double>(m_subtitleVerticalMargin) / SUBTITLES::VIEWPORT_HEIGHT *
+                        (subPosPx - resInfo.Overscan.top)};
     subPosPx -= static_cast<double>(m_subtitleVerticalMargin) - scaledMargin;
 
     // We need to scale the position to resolution based on overscan values
@@ -454,11 +453,11 @@ COverlay* CRenderer::ConvertLibass(
   if (o->IsTextAlignEnabled())
   {
     if (m_subtitleHorizontalAlign == SubtitleHorizontalAlign::LEFT)
-      rOpts.horizontalAlignment = KODI::SUBTITLES::HorizontalAlignment::LEFT;
+      rOpts.horizontalAlignment = SUBTITLES::HorizontalAlignment::LEFT;
     else if (m_subtitleHorizontalAlign == SubtitleHorizontalAlign::RIGHT)
-      rOpts.horizontalAlignment = KODI::SUBTITLES::HorizontalAlignment::RIGHT;
+      rOpts.horizontalAlignment = SUBTITLES::HorizontalAlignment::RIGHT;
     else
-      rOpts.horizontalAlignment = KODI::SUBTITLES::HorizontalAlignment::CENTER;
+      rOpts.horizontalAlignment = SUBTITLES::HorizontalAlignment::CENTER;
   }
 
   // changes: Detect changes from previously rendered images, if > 0 they are changed
@@ -591,7 +590,7 @@ int CRenderer::GetSubtitleVerticalMargin()
   // inside the black bars, we exclude custom vertical margin
   // and we force our fixed margin to try avoid go off the black bars
   if (subAlign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE || subAlign == SUBTITLE_ALIGN_TOP_OUTSIDE)
-    return KODI::SUBTITLES::MARGIN_VERTICAL_BLACKBARS;
+    return SUBTITLES::MARGIN_VERTICAL_BLACKBARS;
 
   // Try get the vertical margin customized by user
   int overrideMerginVertical =
@@ -600,5 +599,5 @@ int CRenderer::GetSubtitleVerticalMargin()
   if (overrideMerginVertical >= 0)
     return overrideMerginVertical;
 
-  return KODI::SUBTITLES::MARGIN_VERTICAL;
+  return SUBTITLES::MARGIN_VERTICAL;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -11,6 +11,7 @@
 
 #include "BaseRenderer.h"
 #include "cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h"
+#include "settings/SubtitlesSettings.h"
 #include "threads/CriticalSection.h"
 #include "utils/Observer.h"
 
@@ -25,30 +26,6 @@ class CDVDOverlayImage;
 class CDVDOverlaySpu;
 class CDVDOverlaySSA;
 class CDVDOverlayText;
-
-enum SubtitleAlign
-{
-  SUBTITLE_ALIGN_MANUAL = 0,
-  SUBTITLE_ALIGN_BOTTOM_INSIDE,
-  SUBTITLE_ALIGN_BOTTOM_OUTSIDE,
-  SUBTITLE_ALIGN_TOP_INSIDE,
-  SUBTITLE_ALIGN_TOP_OUTSIDE
-};
-
-enum class SubtitleHorizontalAlign
-{
-  LEFT = 0,
-  CENTER,
-  RIGHT
-};
-
-enum subtitleBackgroundType
-{
-  SUBTITLE_BACKGROUNDTYPE_NONE = 0,
-  SUBTITLE_BACKGROUNDTYPE_SHADOW,
-  SUBTITLE_BACKGROUNDTYPE_BOX,
-  SUBTITLE_BACKGROUNDTYPE_SQUAREBOX
-};
 
 namespace OVERLAY {
 
@@ -142,12 +119,6 @@ namespace OVERLAY {
      */
     void SetSubtitleVerticalPosition(const int value, bool save);
 
-    /*!
-     * \brief Get the subtitle vertical margin in percentage
-     * \return The percentage value
-     */
-    static float GetSubtitleVerticalMarginPerc();
-
   protected:
     /*!
      * \brief Reset the subtitle position to default value
@@ -179,10 +150,11 @@ namespace OVERLAY {
     * \param subStyle The style to be used, MUST BE SET ONLY at the first call or when user change settings
     * \return True if success, false if error
     */
-    COverlay* ConvertLibass(CDVDOverlayLibass* o,
-                            double pts,
-                            bool updateStyle,
-                            const std::shared_ptr<struct KODI::SUBTITLES::style>& overlayStyle);
+    COverlay* ConvertLibass(
+        CDVDOverlayLibass* o,
+        double pts,
+        bool updateStyle,
+        const std::shared_ptr<struct KODI::SUBTITLES::STYLE::style>& overlayStyle);
 
     void CreateSubtitlesStyle();
 
@@ -205,9 +177,10 @@ namespace OVERLAY {
     int m_subtitlePosResInfo{-1}; // Current subtitle position from resolution info
     int m_subtitleVerticalMargin{0};
     bool m_saveSubtitlePosition{false}; // To save subtitle position permanently
-    SubtitleHorizontalAlign m_subtitleHorizontalAlign{SubtitleHorizontalAlign::CENTER};
+    KODI::SUBTITLES::HorizontalAlign m_subtitleHorizontalAlign{
+        KODI::SUBTITLES::HorizontalAlign::CENTER};
 
-    std::shared_ptr<struct KODI::SUBTITLES::style> m_overlayStyle;
+    std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_overlayStyle;
     std::atomic<bool> m_isSettingsChanged{false};
   };
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -14,6 +14,7 @@
 #include "threads/CriticalSection.h"
 #include "utils/Observer.h"
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <vector>
@@ -115,6 +116,12 @@ namespace OVERLAY {
 
     void AddOverlay(CDVDOverlay* o, double pts, int index);
     virtual void Render(int idx);
+
+    /*!
+     * \brief Release resources
+     */
+    void UnInit();
+
     void Flush();
 
     /*!
@@ -136,17 +143,22 @@ namespace OVERLAY {
     void SetSubtitleVerticalPosition(const int value, bool save);
 
     /*!
+     * \brief Get the subtitle vertical margin in percentage
+     * \return The percentage value
+     */
+    static float GetSubtitleVerticalMarginPerc();
+
+  protected:
+    /*!
      * \brief Reset the subtitle position to default value
      */
     void ResetSubtitlePosition();
 
     /*!
-     * \brief Get the subtitle vertical margin
-     * \return The margin in pixel
+     * \brief Called when the screen resolution is changed
      */
-    static int GetSubtitleVerticalMargin();
+    void OnViewChange();
 
-  protected:
     struct SElement
     {
       SElement()
@@ -192,9 +204,10 @@ namespace OVERLAY {
     int m_subtitlePosition{0}; // Current subtitle position
     int m_subtitlePosResInfo{-1}; // Current subtitle position from resolution info
     int m_subtitleVerticalMargin{0};
+    bool m_saveSubtitlePosition{false}; // To save subtitle position permanently
     SubtitleHorizontalAlign m_subtitleHorizontalAlign{SubtitleHorizontalAlign::CENTER};
 
     std::shared_ptr<struct KODI::SUBTITLES::style> m_overlayStyle;
-    bool m_isSettingsChanged{false};
+    std::atomic<bool> m_isSettingsChanged{false};
   };
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -229,8 +229,8 @@ bool CRenderManager::Configure()
     m_renderDebug = false;
     m_clockSync.Reset();
     m_dvdClock.SetVsyncAdjust(0);
+    m_overlays.Reset();
     m_overlays.SetStereoMode(m_stereomode);
-    m_overlays.ResetSubtitlePosition();
 
     m_renderState = STATE_CONFIGURED;
 
@@ -398,7 +398,7 @@ void CRenderManager::UnInit()
 
   std::unique_lock<CCriticalSection> lock(m_statelock);
 
-  m_overlays.Flush();
+  m_overlays.UnInit();
   m_debugRenderer.Dispose();
 
   DeleteRenderer();

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -449,8 +449,6 @@ void CAdvancedSettings::Initialize()
   m_stereoscopicregex_sbs = "[-. _]h?sbs[-. _]";
   m_stereoscopicregex_tab = "[-. _]h?tab[-. _]";
 
-  m_videoSubtitleVerticalMargin = -1;
-
   m_logLevelHint = m_logLevel = LOG_LEVEL_NORMAL;
 
   m_openGlDebugging = false;
@@ -607,7 +605,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   pElement = pRootElement->FirstChildElement("video");
   if (pElement)
   {
-    XMLUtils::GetInt(pElement, "subtitleverticalmargin", m_videoSubtitleVerticalMargin);
     XMLUtils::GetString(pElement, "stereoscopicregex3d", m_stereoscopicregex_3d);
     XMLUtils::GetString(pElement, "stereoscopicregexsbs", m_stereoscopicregex_sbs);
     XMLUtils::GetString(pElement, "stereoscopicregextab", m_stereoscopicregex_tab);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -375,11 +375,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_stereoscopicregex_sbs;
     std::string m_stereoscopicregex_tab;
 
-    /*! \brief Change the default vertical margin of the subtitle,
-        in order to be applied to applied to all types of subtitle position.
-    */
-    int m_videoSubtitleVerticalMargin;
-
     bool m_openGlDebugging;
 
     std::string m_userAgent;

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -548,8 +548,8 @@ void CDisplaySettings::ApplyCalibrations()
         m_resolutions[res].iSubtitles = itCal->iSubtitles;
         if (m_resolutions[res].iSubtitles < 0)
           m_resolutions[res].iSubtitles = 0;
-        if (m_resolutions[res].iSubtitles > m_resolutions[res].iHeight)
-          m_resolutions[res].iSubtitles = m_resolutions[res].iHeight;
+        if (m_resolutions[res].iSubtitles > m_resolutions[res].iHeight * 3 / 2)
+          m_resolutions[res].iSubtitles = m_resolutions[res].iHeight * 3 / 2;
 
         m_resolutions[res].fPixelRatio = itCal->fPixelRatio;
         if (m_resolutions[res].fPixelRatio < 0.5f)

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -157,6 +157,7 @@ public:
   static constexpr auto SETTING_SUBTITLES_SHADOWSIZE = "subtitles.shadowsize";
   static constexpr auto SETTING_SUBTITLES_BGCOLOR = "subtitles.bgcolorpick";
   static constexpr auto SETTING_SUBTITLES_BGOPACITY = "subtitles.bgopacity";
+  static constexpr auto SETTING_SUBTITLES_MARGINVERTICAL = "subtitles.marginvertical";
   static constexpr auto SETTING_SUBTITLES_CHARSET = "subtitles.charset";
   static constexpr auto SETTING_SUBTITLES_OVERRIDEFONTS = "subtitles.overridefonts";
   static constexpr auto SETTING_SUBTITLES_OVERRIDESTYLES = "subtitles.overridestyles";

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -21,7 +21,6 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
-
 using namespace KODI;
 using namespace SUBTITLES;
 
@@ -73,6 +72,122 @@ void CSubtitlesSettings::OnSettingChanged(const std::shared_ptr<const CSetting>&
   }
 }
 
+Align CSubtitlesSettings::GetAlignment()
+{
+  return static_cast<Align>(m_settings->GetInt(CSettings::SETTING_SUBTITLES_ALIGN));
+}
+
+void CSubtitlesSettings::SetAlignment(Align align)
+{
+  m_settings->SetInt(CSettings::SETTING_SUBTITLES_ALIGN, static_cast<int>(align));
+}
+
+HorizontalAlign CSubtitlesSettings::GetHorizontalAlignment()
+{
+  return static_cast<HorizontalAlign>(
+      m_settings->GetInt(CSettings::SETTING_SUBTITLES_CAPTIONSALIGN));
+}
+
+std::string CSubtitlesSettings::GetFontName()
+{
+  return m_settings->GetString(CSettings::SETTING_SUBTITLES_FONTNAME);
+}
+
+FontStyle CSubtitlesSettings::GetFontStyle()
+{
+  return static_cast<FontStyle>(m_settings->GetInt(CSettings::SETTING_SUBTITLES_STYLE));
+}
+
+int CSubtitlesSettings::GetFontSize()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_FONTSIZE);
+}
+
+UTILS::COLOR::Color CSubtitlesSettings::GetFontColor()
+{
+  return UTILS::COLOR::ConvertHexToColor(m_settings->GetString(CSettings::SETTING_SUBTITLES_COLOR));
+}
+
+int CSubtitlesSettings::GetFontOpacity()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_OPACITY);
+}
+
+int CSubtitlesSettings::GetBorderSize()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_BORDERSIZE);
+}
+
+UTILS::COLOR::Color CSubtitlesSettings::GetBorderColor()
+{
+  return UTILS::COLOR::ConvertHexToColor(
+      m_settings->GetString(CSettings::SETTING_SUBTITLES_BORDERCOLOR));
+}
+
+int CSubtitlesSettings::GetShadowSize()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_SHADOWSIZE);
+}
+
+UTILS::COLOR::Color CSubtitlesSettings::GetShadowColor()
+{
+  return UTILS::COLOR::ConvertHexToColor(
+      m_settings->GetString(CSettings::SETTING_SUBTITLES_SHADOWCOLOR));
+}
+
+int CSubtitlesSettings::GetShadowOpacity()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_SHADOWOPACITY);
+}
+
+int CSubtitlesSettings::GetBlurSize()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_BLUR);
+}
+
+BackgroundType CSubtitlesSettings::GetBackgroundType()
+{
+  return static_cast<BackgroundType>(
+      m_settings->GetInt(CSettings::SETTING_SUBTITLES_BACKGROUNDTYPE));
+}
+
+UTILS::COLOR::Color CSubtitlesSettings::GetBackgroundColor()
+{
+  return UTILS::COLOR::ConvertHexToColor(
+      m_settings->GetString(CSettings::SETTING_SUBTITLES_BGCOLOR));
+}
+
+int CSubtitlesSettings::GetBackgroundOpacity()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_BGOPACITY);
+}
+
+bool CSubtitlesSettings::IsOverrideFonts()
+{
+  return m_settings->GetBool(CSettings::SETTING_SUBTITLES_OVERRIDEFONTS);
+}
+
+OverrideStyles CSubtitlesSettings::GetOverrideStyles()
+{
+  return static_cast<OverrideStyles>(
+      m_settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES));
+}
+
+float CSubtitlesSettings::GetVerticalMarginPerc()
+{
+  // We return the vertical margin as percentage
+  // to fit the current screen resolution
+  const Align subAlign{GetAlignment()};
+
+  // If the user has set the alignment type to keep the subtitle text
+  // inside the black bars, we override user vertical margin
+  // to try avoid go off the black bars
+  if (subAlign == Align::BOTTOM_OUTSIDE || subAlign == Align::TOP_OUTSIDE)
+    return MARGIN_VERTICAL_BLACKBARS;
+
+  return static_cast<float>(m_settings->GetNumber(CSettings::SETTING_SUBTITLES_MARGINVERTICAL));
+}
+
 void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr& setting,
                                                            std::vector<StringSettingOption>& list,
                                                            std::string& current,
@@ -94,9 +209,4 @@ void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr
   {
     list.emplace_back(familyName, familyName);
   }
-}
-
-std::shared_ptr<CSettings> CSubtitlesSettings::GetSettings()
-{
-  return CServiceBroker::GetSettingsComponent()->GetSettings();
 }

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -29,34 +29,23 @@ CSubtitlesSettings::CSubtitlesSettings()
 {
   m_settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
-  m_settings->RegisterCallback(this, {CSettings::SETTING_LOCALE_SUBTITLELANGUAGE,
-                                      CSettings::SETTING_SUBTITLES_PARSECAPTIONS,
-                                      CSettings::SETTING_SUBTITLES_ALIGN,
-                                      CSettings::SETTING_SUBTITLES_STEREOSCOPICDEPTH,
-                                      CSettings::SETTING_SUBTITLES_FONTNAME,
-                                      CSettings::SETTING_SUBTITLES_FONTSIZE,
-                                      CSettings::SETTING_SUBTITLES_STYLE,
-                                      CSettings::SETTING_SUBTITLES_COLOR,
-                                      CSettings::SETTING_SUBTITLES_BORDERSIZE,
-                                      CSettings::SETTING_SUBTITLES_BORDERCOLOR,
-                                      CSettings::SETTING_SUBTITLES_OPACITY,
-                                      CSettings::SETTING_SUBTITLES_BGCOLOR,
-                                      CSettings::SETTING_SUBTITLES_BGOPACITY,
-                                      CSettings::SETTING_SUBTITLES_BLUR,
-                                      CSettings::SETTING_SUBTITLES_BACKGROUNDTYPE,
-                                      CSettings::SETTING_SUBTITLES_SHADOWCOLOR,
-                                      CSettings::SETTING_SUBTITLES_SHADOWOPACITY,
-                                      CSettings::SETTING_SUBTITLES_SHADOWSIZE,
-                                      CSettings::SETTING_SUBTITLES_CHARSET,
-                                      CSettings::SETTING_SUBTITLES_OVERRIDEFONTS,
-                                      CSettings::SETTING_SUBTITLES_OVERRIDESTYLES,
-                                      CSettings::SETTING_SUBTITLES_LANGUAGES,
-                                      CSettings::SETTING_SUBTITLES_STORAGEMODE,
-                                      CSettings::SETTING_SUBTITLES_CUSTOMPATH,
-                                      CSettings::SETTING_SUBTITLES_PAUSEONSEARCH,
-                                      CSettings::SETTING_SUBTITLES_DOWNLOADFIRST,
-                                      CSettings::SETTING_SUBTITLES_TV,
-                                      CSettings::SETTING_SUBTITLES_MOVIE});
+  m_settings->RegisterCallback(
+      this,
+      {CSettings::SETTING_LOCALE_SUBTITLELANGUAGE,  CSettings::SETTING_SUBTITLES_PARSECAPTIONS,
+       CSettings::SETTING_SUBTITLES_ALIGN,          CSettings::SETTING_SUBTITLES_STEREOSCOPICDEPTH,
+       CSettings::SETTING_SUBTITLES_FONTNAME,       CSettings::SETTING_SUBTITLES_FONTSIZE,
+       CSettings::SETTING_SUBTITLES_STYLE,          CSettings::SETTING_SUBTITLES_COLOR,
+       CSettings::SETTING_SUBTITLES_BORDERSIZE,     CSettings::SETTING_SUBTITLES_BORDERCOLOR,
+       CSettings::SETTING_SUBTITLES_OPACITY,        CSettings::SETTING_SUBTITLES_BGCOLOR,
+       CSettings::SETTING_SUBTITLES_BGOPACITY,      CSettings::SETTING_SUBTITLES_BLUR,
+       CSettings::SETTING_SUBTITLES_BACKGROUNDTYPE, CSettings::SETTING_SUBTITLES_SHADOWCOLOR,
+       CSettings::SETTING_SUBTITLES_SHADOWOPACITY,  CSettings::SETTING_SUBTITLES_SHADOWSIZE,
+       CSettings::SETTING_SUBTITLES_MARGINVERTICAL, CSettings::SETTING_SUBTITLES_CHARSET,
+       CSettings::SETTING_SUBTITLES_OVERRIDEFONTS,  CSettings::SETTING_SUBTITLES_OVERRIDESTYLES,
+       CSettings::SETTING_SUBTITLES_LANGUAGES,      CSettings::SETTING_SUBTITLES_STORAGEMODE,
+       CSettings::SETTING_SUBTITLES_CUSTOMPATH,     CSettings::SETTING_SUBTITLES_PAUSEONSEARCH,
+       CSettings::SETTING_SUBTITLES_DOWNLOADFIRST,  CSettings::SETTING_SUBTITLES_TV,
+       CSettings::SETTING_SUBTITLES_MOVIE});
 }
 
 CSubtitlesSettings::~CSubtitlesSettings()
@@ -105,4 +94,9 @@ void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr
   {
     list.emplace_back(familyName, familyName);
   }
+}
+
+std::shared_ptr<CSettings> CSubtitlesSettings::GetSettings()
+{
+  return CServiceBroker::GetSettingsComponent()->GetSettings();
 }

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -9,9 +9,11 @@
 #pragma once
 
 #include "settings/lib/ISettingCallback.h"
+#include "utils/ColorUtils.h"
 #include "utils/Observer.h"
 
 #include <memory>
+#include <string>
 
 class CSetting;
 class CSettings;
@@ -25,6 +27,50 @@ namespace SUBTITLES
 // even if the default app font could be changed
 constexpr const char* FONT_DEFAULT_FAMILYNAME = "DEFAULT";
 
+// Default vertical margin used for the alignment
+// to keep the text inside the black bars
+constexpr float MARGIN_VERTICAL_BLACKBARS = 2.75f; // in %
+
+enum class Align
+{
+  MANUAL = 0,
+  BOTTOM_INSIDE,
+  BOTTOM_OUTSIDE,
+  TOP_INSIDE,
+  TOP_OUTSIDE
+};
+
+enum class HorizontalAlign
+{
+  LEFT = 0,
+  CENTER,
+  RIGHT
+};
+
+enum class BackgroundType
+{
+  NONE = 0,
+  SHADOW,
+  BOX,
+  SQUAREBOX
+};
+
+enum class FontStyle
+{
+  NORMAL = 0,
+  BOLD,
+  ITALIC,
+  BOLD_ITALIC
+};
+
+enum class OverrideStyles
+{
+  DISABLED = 0,
+  POSITIONS,
+  STYLES,
+  STYLES_POSITIONS
+};
+
 class CSubtitlesSettings : public ISettingCallback, public Observable
 {
 public:
@@ -33,12 +79,130 @@ public:
   // Inherited from ISettingCallback
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
+  /*!
+   * \brief Get subtitle alignment
+   * \return The alignment
+   */
+  Align GetAlignment();
+
+  /*!
+   * \brief Set the subtitle alignment
+   * \param align The alignment
+   */
+  void SetAlignment(Align align);
+
+  /*!
+   * \brief Get horizontal text alignment
+   * \return The alignment
+   */
+  HorizontalAlign GetHorizontalAlignment();
+
+  /*!
+   * \brief Get font name
+   * \return The font name
+   */
+  std::string GetFontName();
+
+  /*!
+   * \brief Get font style
+   * \return The font style
+   */
+  FontStyle GetFontStyle();
+
+  /*!
+   * \brief Get font size
+   * \return The font size in PT
+   */
+  int GetFontSize();
+
+  /*!
+   * \brief Get font color
+   * \return The font color
+   */
+  UTILS::COLOR::Color GetFontColor();
+
+  /*!
+   * \brief Get font opacity
+   * \return The font opacity in %
+   */
+  int GetFontOpacity();
+
+  /*!
+   * \brief Get border size
+   * \return The border size in %
+   */
+  int GetBorderSize();
+
+  /*!
+   * \brief Get border color
+   * \return The border color
+   */
+  UTILS::COLOR::Color GetBorderColor();
+
+  /*!
+   * \brief Get shadow size
+   * \return The shadow size in %
+   */
+  int GetShadowSize();
+
+  /*!
+   * \brief Get shadow color
+   * \return The shadow color
+   */
+  UTILS::COLOR::Color GetShadowColor();
+
+  /*!
+   * \brief Get shadow opacity
+   * \return The shadow opacity in %
+   */
+  int GetShadowOpacity();
+
+  /*!
+   * \brief Get blur size
+   * \return The blur size in %
+   */
+  int GetBlurSize();
+
+  /*!
+   * \brief Get background type
+   * \return The background type
+   */
+  BackgroundType GetBackgroundType();
+
+  /*!
+   * \brief Get background color
+   * \return The background color
+   */
+  UTILS::COLOR::Color GetBackgroundColor();
+
+  /*!
+   * \brief Get background opacity
+   * \return The background opacity in %
+   */
+  int GetBackgroundOpacity();
+
+  /*!
+   * \brief Check if font override is enabled
+   * \return True if fonts must be overriden, otherwise false
+   */
+  bool IsOverrideFonts();
+
+  /*!
+   * \brief Get override styles
+   * \return The styles to be overriden
+   */
+  OverrideStyles GetOverrideStyles();
+
+  /*!
+   * \brief Get the subtitle vertical margin
+   * \return The vertical margin in %
+   */
+  float GetVerticalMarginPerc();
+
   static void SettingOptionsSubtitleFontsFiller(const std::shared_ptr<const CSetting>& setting,
                                                 std::vector<StringSettingOption>& list,
                                                 std::string& current,
                                                 void* data);
-
-  static std::shared_ptr<CSettings> GetSettings();
 
 protected:
   CSubtitlesSettings();

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -38,6 +38,8 @@ public:
                                                 std::string& current,
                                                 void* data);
 
+  static std::shared_ptr<CSettings> GetSettings();
+
 protected:
   CSubtitlesSettings();
   ~CSubtitlesSettings() override;

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -212,7 +212,6 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
 
       // Setup the first control
       m_iControl = CONTROL_TOP_LEFT;
-      m_subtitleVerticalMargin = OVERLAY::CRenderer::GetSubtitleVerticalMargin();
       ResetControls();
       return true;
     }
@@ -314,6 +313,10 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
   CGUIMoverControl* pControl = dynamic_cast<CGUIMoverControl*>(GetControl(CONTROL_TOP_LEFT));
   RESOLUTION_INFO info =
       CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(m_Res[m_iCurRes]);
+
+  m_subtitleVerticalMargin =
+      info.iHeight / 100 * OVERLAY::CRenderer::GetSubtitleVerticalMarginPerc();
+
   if (pControl)
   {
     pControl->SetLimits(-info.iWidth / 4, -info.iHeight / 4, info.iWidth / 4, info.iHeight / 4);
@@ -350,6 +353,10 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
                         info.Overscan.bottom + m_subtitlesHalfSpace);
     pControl->SetHeight(scaledHeight);
     pControl->SetWidth(size.second / DEFAULT_GUI_WIDTH * info.iWidth);
+    // If the vertical margin has been changed from the previous calibration,
+    // the text bar could appear offscreen, then force move to visible area
+    if (info.iSubtitles - m_subtitleVerticalMargin > info.iHeight)
+      info.iSubtitles = info.Overscan.bottom;
     // We want the text to be at the base of the bar,
     // then we shift the position to include the vertical margin
     pControl->SetPosition((info.iWidth - pControl->GetWidth()) * 0.5f,
@@ -469,7 +476,7 @@ bool CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
               pControl->GetYLocation() - m_subtitlesHalfSpace + m_subtitleVerticalMargin;
           labelDescription = StringUtils::Format("[B]{}[/B][CR]{}", g_localizeStrings.Get(277),
                                                  g_localizeStrings.Get(278));
-          labelValue = StringUtils::Format(g_localizeStrings.Get(20327),
+          labelValue = StringUtils::Format(g_localizeStrings.Get(39184), info.iSubtitles,
                                            info.iSubtitles - m_subtitleVerticalMargin);
         }
         break;

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -10,7 +10,6 @@
 
 #include "Application.h"
 #include "ServiceBroker.h"
-#include "cores/VideoPlayer/VideoRenderers/OverlayRenderer.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMoverControl.h"
@@ -21,6 +20,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/SubtitlesSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -28,6 +28,8 @@
 
 #include <string>
 #include <utility>
+
+using namespace KODI;
 
 namespace
 {
@@ -315,7 +317,7 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
       CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(m_Res[m_iCurRes]);
 
   m_subtitleVerticalMargin =
-      info.iHeight / 100 * OVERLAY::CRenderer::GetSubtitleVerticalMarginPerc();
+      info.iHeight / 100 * SUBTITLES::CSubtitlesSettings::GetInstance().GetVerticalMarginPerc();
 
   if (pControl)
   {

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -25,11 +25,13 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/SubtitlesSettings.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "video/dialogs/GUIDialogAudioSettings.h"
 
+using namespace KODI;
 using namespace UTILS;
 
 CPlayerController::CPlayerController()
@@ -375,17 +377,22 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_SUBTITLE_ALIGN:
       {
-        int subalign = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
+        SUBTITLES::CSubtitlesSettings& settings{SUBTITLES::CSubtitlesSettings::GetInstance()};
+        SUBTITLES::Align align{settings.GetAlignment()};
 
-        subalign++;
-        if (subalign > SUBTITLE_ALIGN_TOP_OUTSIDE)
-          subalign = SUBTITLE_ALIGN_MANUAL;
+        align = static_cast<SUBTITLES::Align>(static_cast<int>(align) + 1);
 
-        CServiceBroker::GetSettingsComponent()->GetSettings()->SetInt(CSettings::SETTING_SUBTITLES_ALIGN, subalign);
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                              g_localizeStrings.Get(21460),
-                                              g_localizeStrings.Get(21461 + subalign),
-                                              TOAST_DISPLAY_TIME, false);
+        if (align != SUBTITLES::Align::MANUAL && align != SUBTITLES::Align::BOTTOM_INSIDE &&
+            align != SUBTITLES::Align::BOTTOM_OUTSIDE && align != SUBTITLES::Align::TOP_INSIDE &&
+            align != SUBTITLES::Align::TOP_OUTSIDE)
+        {
+          align = SUBTITLES::Align::MANUAL;
+        }
+
+        settings.SetAlignment(align);
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Info, g_localizeStrings.Get(21460),
+            g_localizeStrings.Get(21461 + static_cast<int>(align)), TOAST_DISPLAY_TIME, false);
         return true;
       }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
in PR's where i have reworked subtitles renderer/features, i have introduced vertical margin support
(until now temporary can only be overwritten through advanced settings xml)
i have noticed that vertical margin can confuse some users (see #21298)

the reason is that the calibration window displays the value of the displayed text position
therefore implicitly exclude vertical margins (because the value is from top),
so the value saved in xml is the one with vertical margins.

to make it clearer the situation i have shown both values in Video calibration GUI:
![immagine](https://user-images.githubusercontent.com/3257156/165052014-8a8a19ec-ec5c-410a-8abe-45f8b93ea150.png)

and i have add a new GUI setting "vertical margin" (and removed the one in advanced settings):
![immagine](https://user-images.githubusercontent.com/3257156/165050527-4a6efc75-337c-4cf1-bbd7-e7c9b1506f6e.png)
in this way the user is aware of the vertical margin, and can read in the description that will influence also the Video calibration.

The value is in percentage instead of pixels, this to fit the screen resolution in use,
otherwise the value will results always wrong at the resolution change ("Adjust refresh rate" setting enabled case)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An user #21298 think to a bug because did not understand the reason for the different value between xml file / GUI Calibration window

fix #21298 little bug in saving/loading position value
fix https://github.com/xbmc/xbmc/pull/21026#issuecomment-1104531231 to save value permanently position value changed via e.g. shortcut (kept after kodi restart)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
better understand vertical margin functionality and its influence
allows to change vertical margin from GUI
can save permanently subtitle position changed e.g. via keyboard (by using e.g. `SubtitleShiftUp(save)`)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
