### PR TITLE
[addons][inputstream] Add new SetVideoResolution with max resolution

### DIFF
--- a/xbmc/addons/interfaces/gui/General.cpp
+++ b/xbmc/addons/interfaces/gui/General.cpp
@@ -37,6 +37,8 @@
 #include "dialogs/YesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
 #include <mutex>
@@ -85,6 +87,8 @@ void Interface_GUIGeneral::Init(AddonGlobalInterface* addonInterface)
       get_current_window_dialog_id;
   addonInterface->toKodi->kodi_gui->general->get_current_window_id = get_current_window_id;
   addonInterface->toKodi->kodi_gui->general->get_hw_context = get_hw_context;
+  addonInterface->toKodi->kodi_gui->general->get_adjust_refresh_rate_status =
+      get_adjust_refresh_rate_status;
 }
 
 void Interface_GUIGeneral::DeInit(AddonGlobalInterface* addonInterface)
@@ -210,6 +214,37 @@ int Interface_GUIGeneral::get_current_window_id(KODI_HANDLE kodiBase)
 ADDON_HARDWARE_CONTEXT Interface_GUIGeneral::get_hw_context(KODI_HANDLE kodiBase)
 {
   return CServiceBroker::GetWinSystem()->GetHWContext();
+}
+
+AdjustRefreshRateStatus Interface_GUIGeneral::get_adjust_refresh_rate_status(KODI_HANDLE kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::{} - invalid data", __func__);
+    return ADJUST_REFRESHRATE_STATUS_OFF;
+  }
+
+  switch (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE))
+  {
+    case AdjustRefreshRate::ADJUST_REFRESHRATE_OFF:
+      return ADJUST_REFRESHRATE_STATUS_OFF;
+      break;
+    case AdjustRefreshRate::ADJUST_REFRESHRATE_ON_START:
+      return ADJUST_REFRESHRATE_STATUS_ON_START;
+      break;
+    case AdjustRefreshRate::ADJUST_REFRESHRATE_ON_STARTSTOP:
+      return ADJUST_REFRESHRATE_STATUS_ON_STARTSTOP;
+      break;
+    case AdjustRefreshRate::ADJUST_REFRESHRATE_ALWAYS:
+      return ADJUST_REFRESHRATE_STATUS_ALWAYS;
+      break;
+    default:
+      CLog::Log(LOGERROR, "kodi::gui::{} - Unhandled Adjust refresh rate setting", __func__);
+      return ADJUST_REFRESHRATE_STATUS_OFF;
+      break;
+  }
 }
 
 //@}

--- a/xbmc/addons/interfaces/gui/General.h
+++ b/xbmc/addons/interfaces/gui/General.h
@@ -51,6 +51,7 @@ extern "C"
     static int get_current_window_dialog_id(KODI_HANDLE kodiBase);
     static int get_current_window_id(KODI_HANDLE kodiBase);
     static ADDON_HARDWARE_CONTEXT get_hw_context(KODI_HANDLE kodiBase);
+    static AdjustRefreshRateStatus get_adjust_refresh_rate_status(KODI_HANDLE kodiBase);
     //@}
 
   private:

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -1555,12 +1555,28 @@ public:
   //----------------------------------------------------------------------------
 
   //============================================================================
-  /// @brief Sets desired width / height
+  /// @brief Notify current screen resolution
   ///
   /// @param[in] width Width to set
   /// @param[in] height Height to set
   ///
-  virtual void SetVideoResolution(int width, int height) {}
+  virtual void SetVideoResolution(unsigned int width, unsigned int height) {}
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @brief Notify current screen resolution and max screen resolution allowed
+  ///
+  /// @param[in] width Width to set
+  /// @param[in] height Height to set
+  /// @param[in] maxWidth Max width allowed
+  /// @param[in] maxHeight Max height allowed
+  ///
+  virtual void SetVideoResolution(unsigned int width,
+                                  unsigned int height,
+                                  unsigned int maxWidth,
+                                  unsigned int maxHeight)
+  {
+  }
   //----------------------------------------------------------------------------
 
   //=============================================================================
@@ -1927,13 +1943,16 @@ private:
   }
 
   inline static void ADDON_SetVideoResolution(const AddonInstance_InputStream* instance,
-                                              int width,
-                                              int height)
+                                              unsigned int width,
+                                              unsigned int height,
+                                              unsigned int maxWidth,
+                                              unsigned int maxHeight)
   {
     static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->SetVideoResolution(width, height);
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
+        ->SetVideoResolution(width, height, maxWidth, maxHeight);
   }
-
 
   // IDisplayTime
   inline static int ADDON_GetTotalTime(const AddonInstance_InputStream* instance)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
@@ -657,8 +657,10 @@ extern "C"
                                    double* startpts);
     void(__cdecl* demux_set_speed)(const struct AddonInstance_InputStream* instance, int speed);
     void(__cdecl* set_video_resolution)(const struct AddonInstance_InputStream* instance,
-                                        int width,
-                                        int height);
+                                        unsigned int width,
+                                        unsigned int height,
+                                        unsigned int maxWidth,
+                                        unsigned int maxHeight);
 
     // IDisplayTime
     int(__cdecl* get_total_time)(const struct AddonInstance_InputStream* instance);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/general.h
@@ -16,6 +16,20 @@ extern "C"
 {
 #endif /* __cplusplus */
 
+  //==============================================================================
+  /// @ingroup cpp_kodi_gui_general
+  /// @brief **Adjust refresh rate enum**\n
+  /// Used to get the Adjust refresh rate status info.
+  ///
+  enum AdjustRefreshRateStatus
+  {
+    ADJUST_REFRESHRATE_STATUS_OFF = 0,
+    ADJUST_REFRESHRATE_STATUS_ALWAYS,
+    ADJUST_REFRESHRATE_STATUS_ON_STARTSTOP,
+    ADJUST_REFRESHRATE_STATUS_ON_START,
+  };
+  //------------------------------------------------------------------------------
+
   typedef struct AddonToKodiFuncTable_kodi_gui_general
   {
     void (*lock)();
@@ -26,6 +40,7 @@ extern "C"
     int (*get_current_window_dialog_id)(KODI_HANDLE kodiBase);
     int (*get_current_window_id)(KODI_HANDLE kodiBase);
     ADDON_HARDWARE_CONTEXT (*get_hw_context)(KODI_HANDLE kodiBase);
+    AdjustRefreshRateStatus (*get_adjust_refresh_rate_status)(KODI_HANDLE kodiBase);
   } AddonToKodiFuncTable_kodi_gui_general;
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/General.h
@@ -170,6 +170,20 @@ inline kodi::HardwareContext GetHWContext()
 }
 //------------------------------------------------------------------------------
 
+//==============================================================================
+/// @ingroup cpp_kodi_gui_general
+/// @brief Get Adjust refresh rate setting status.
+///
+/// @return The Adjust refresh rate setting status
+///
+inline AdjustRefreshRateStatus ATTR_DLL_LOCAL GetAdjustRefreshRateStatus()
+{
+  using namespace ::kodi::addon;
+  return CPrivateBase::m_interface->toKodi->kodi_gui->general->get_adjust_refresh_rate_status(
+      CPrivateBase::m_interface->toKodi->kodiBase);
+}
+//------------------------------------------------------------------------------
+
 } /* namespace gui */
 } /* namespace kodi */
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -108,8 +108,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "c-api/addon-instance/imagedecoder.h" \
                                                       "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.1.1"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.1.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.2.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.2.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
                                                       "c-api/addon-instance/inputstream/demux_packet.h" \

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -355,7 +355,7 @@ public:
    * sets desired width / height for video stream
    * adaptive demuxers like DASH can use this to choose best fitting video stream
    */
-  virtual void SetVideoResolution(int width, int height) {}
+  virtual void SetVideoResolution(unsigned int width, unsigned int height) {}
 
   /*
   * return the id of the demuxer

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -748,11 +748,11 @@ void CDVDDemuxClient::OpenStream(int id)
   }
 }
 
-void CDVDDemuxClient::SetVideoResolution(int width, int height)
+void CDVDDemuxClient::SetVideoResolution(unsigned int width, unsigned int height)
 {
   if (m_IDemux)
   {
-    m_IDemux->SetVideoResolution(width, height);
+    m_IDemux->SetVideoResolution(width, height, width, height);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -42,7 +42,7 @@ public:
   std::string GetStreamCodecName(int iStreamId) override;
   void EnableStream(int id, bool enable) override;
   void OpenStream(int id) override;
-  void SetVideoResolution(int width, int height) override;
+  void SetVideoResolution(unsigned int width, unsigned int height) override;
 
 protected:
   void RequestStreams();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -144,7 +144,12 @@ public:
     virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) = 0;
     virtual void AbortDemux() = 0;
     virtual void FlushDemux() = 0;
-    virtual void SetVideoResolution(int width, int height) {}
+    virtual void SetVideoResolution(unsigned int width,
+                                    unsigned int height,
+                                    unsigned int maxWidth,
+                                    unsigned int maxHeight)
+    {
+    }
   };
 
   enum ENextStream

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -89,7 +89,10 @@ public:
   bool SeekTime(double time, bool backward = false, double* startpts = nullptr) override;
   void AbortDemux() override;
   void FlushDemux() override;
-  void SetVideoResolution(int width, int height) override;
+  void SetVideoResolution(unsigned int width,
+                          unsigned int height,
+                          unsigned int maxWidth,
+                          unsigned int maxHeight) override;
   bool IsRealtime() override;
 
   // IChapter
@@ -106,6 +109,11 @@ protected:
   IVideoPlayer* m_player;
 
 private:
+  void DetectScreenResolution();
+
+  unsigned int m_currentVideoWidth{0};
+  unsigned int m_currentVideoHeight{0};
+
   std::vector<std::string> m_fileItemProps;
   INPUTSTREAM_CAPABILITIES m_caps;
 

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -424,3 +424,51 @@ void CResolutionUtils::PrintWhitelist()
     CLog::Log(LOGDEBUG, "[WHITELIST] whitelisted modes:{}", modeStr);
   }
 }
+
+void CResolutionUtils::GetMaxAllowedResolution(unsigned int& width, unsigned int& height)
+{
+  if (!CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot())
+    return;
+
+  std::vector<RESOLUTION_INFO> resList;
+
+  auto indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+      CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+
+  unsigned int maxWidth{0};
+  unsigned int maxHeight{0};
+
+  if (!indexList.empty())
+  {
+    for (const auto& mode : indexList)
+    {
+      RESOLUTION res = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+      RESOLUTION_INFO resInfo{CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res)};
+      if (static_cast<unsigned int>(resInfo.iWidth) > maxWidth &&
+          static_cast<unsigned int>(resInfo.iHeight) > maxHeight)
+      {
+        maxWidth = static_cast<unsigned int>(resInfo.iWidth);
+        maxHeight = static_cast<unsigned int>(resInfo.iHeight);
+      }
+    }
+  }
+  else
+  {
+    std::vector<RESOLUTION> resList;
+    CServiceBroker::GetWinSystem()->GetGfxContext().GetAllowedResolutions(resList);
+
+    for (const auto& res : resList)
+    {
+      RESOLUTION_INFO resInfo{CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res)};
+      if (static_cast<unsigned int>(resInfo.iWidth) > maxWidth &&
+          static_cast<unsigned int>(resInfo.iHeight) > maxHeight)
+      {
+        maxWidth = static_cast<unsigned int>(resInfo.iWidth);
+        maxHeight = static_cast<unsigned int>(resInfo.iHeight);
+      }
+    }
+  }
+
+  width = maxWidth;
+  height = maxHeight;
+}

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -93,6 +93,13 @@ public:
   static bool HasWhitelist();
   static void PrintWhitelist();
 
+  /*!
+   * \brief Get the max allowed resolution, if fullscreen
+   * \param width [OUT] Max width resolution
+   * \param height [OUT] Max height resolution
+   */
+  static void GetMaxAllowedResolution(unsigned int& width, unsigned int& height);
+
 protected:
   static void FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution);
   static bool FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Currently from `SetVideoResolution` callback we provide current GUI resolution,
but if `Adjust refresh rate` feature is enabled the GUI resolution is no longer relevant

Adjust refresh rate will change screen resolution based on stream resolution (takin in account also whitelist, if any) OFC this happens when the video stream in the demuxer

therefore for InputStream addons, `Adjust refresh rate` cannot works correctly,
because the addon has as reference the GUI resolution then we will send in demuxer a stream resolution with GUI resolution instead the max allowed resolution of display (switchable by Adjust refresh rate)

so having the max resolution info before the playback take place,
allow addon to provide in the demuxer the best stream resolution that can fit the supported screen resolution (changed when playback will start).

~Is kept compatibility to original `SetVideoResolution`, then no changes are required to existings inputStream addons~

Plus feature: provide callback also when the resolution is changed while in playback, e.g. for window resize
allow us to change stream quality to fit current screen resolution and then optimize bandwidth (adaptive stream technology)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Alternative to PR #21296

Often users use `Adjust refresh rate` feature and whitelist to make match stream resolution to the screen resolution at playback start

but this feature prevent us to provide the right stream resolution at playback start,
and make adaptive stream technology to work partially
because we know only the GUI resolution provided before the playback

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see log when callback happens
```
void CInputStreamAdaptive::SetVideoResolution(unsigned int width, unsigned int height, unsigned int maxWidth, unsigned int maxHeight)
{
  LOG::Log(LOGINFO, "SetVideoResolution (%ux%u max: %ux%u)", width, height, maxWidth, maxHeight);
}
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
An example is allow to auto-switch kodi resolution at 4k having GUI at 1080P
In future with InputStream Adaptive

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
