### PR TITLE
[cmake] small cmake QOL improvements and fixup for android packaging

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -148,7 +148,7 @@ add_bundle_file(${SMBCLIENT_LIBRARY} ${libdir} "")
 if(CPU MATCHES i686)
   set(CPU x86)
 endif()
-foreach(target apk obb apk-unsigned apk-obb apk-obb-unsigned apk-noobb apk-clean apk-sign)
+foreach(target apk obb apk-obb apk-clean)
   add_custom_target(${target}
       COMMAND env PATH=${NATIVEPREFIX}/bin:$ENV{PATH} ${CMAKE_MAKE_PROGRAM}
               -C ${CMAKE_BINARY_DIR}/tools/android/packaging

--- a/cmake/scripts/darwin_embedded/ArchSetup.cmake
+++ b/cmake/scripts/darwin_embedded/ArchSetup.cmake
@@ -49,10 +49,6 @@ set(CMAKE_XCODE_ATTRIBUTE_INLINES_ARE_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_COPY_PHASE_STRIP OFF)
 
-if(NOT TARBALL_DIR)
-  set(TARBALL_DIR "/Users/Shared/xbmc-depends/xbmc-tarballs")
-endif()
-
 include(cmake/scripts/darwin/Macros.cmake)
 enable_arc()
 

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -29,10 +29,6 @@ if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND
   set(HOST_CAN_EXECUTE_TARGET TRUE)
 endif()
 
-if(NOT TARBALL_DIR)
-  set(TARBALL_DIR "/Users/Shared/xbmc-depends/xbmc-tarballs")
-endif()
-
 set(CMAKE_OSX_ARCHITECTURES ${CPU})
 
 if(CMAKE_GENERATOR STREQUAL Xcode)

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -1,6 +1,8 @@
 set(DEPENDS_PATH "@prefix@/@deps_dir@")
 set(NATIVEPREFIX "@prefix@/@tool_dir@")
 
+set(TARBALL_DIR "@use_tarballs@")
+
 set(OS "@platform_os@")
 set(CMAKE_SYSTEM_PROCESSOR @host_cpu@)
 set(CPU "@use_cpu@")


### PR DESCRIPTION
## Description
commit 1 Removes targets that no longer exist in android packaging makefile after PR #20599
commit 2 Propagates tarball location from tools/depends configure script to generated toolchain for use in core cmake build

## Motivation and context
Cleanups
Noticed that a standard run of make -C tools/depends/target/cmakebuildsys would redownload tarball even when --with-tarballs was provided for configure. If we propagate that through to those platforms via the toolchain, we only need to use --with-tarballs during configure to have the tarball location set, rather than setting it during configure, and then additionally setting -DTARBALL_DIR during cmake generation

If anyone could think of why someone would ever want a tarball location set for tools/depends, and then an alternate for the core cmake, let me know. Toolchain variables cant be overridden, so if such a circumstance was deemed necessary, we can just do the following in the Toolchain.cmake.in

```
if(NOT TARBALL_DIR)
  set(TARBALL_DIR "@use_tarballs@")
endif()
```

## How has this been tested?
Locally building aarch64 android, osx x86_64


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
