### PR TITLE
[Estuary] Re-write topbaroverlay time condition using skin timers

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <window type="dialog" id="1109">
-	<onload>AlarmClock(seekbartimer,SetProperty(timerelapsed,1,1109),00:00:05,silent,false])</onload>
-	<onunload>CancelAlarm(seekbartimer,silent)</onunload>
-	<onunload>ClearProperty(timerelapsed,1109)</onunload>
+	<onload>Skin.TimerStart(1110_topbaroverlay)</onload>
 	<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)</visible>
 	<visible>Window.IsActive(seekbar) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)</visible>
 	<depth>DepthOSD</depth>
@@ -12,7 +10,7 @@
 		<control type="group">
 			<visible>![Player.ShowInfo | Window.IsActive(fullscreeninfo) | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(PVR.ChannelNumberInput) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)] + [!String.IsEmpty(Player.SeekNumeric) | Player.Seeking | Player.HasPerformedSeek(3) | Player.Forwarding | Player.Rewinding | Player.Paused]</visible>
 			<animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>
-			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="Player.Paused + String.IsEqual(Window(1109).Property(timerelapsed),1)">Conditional</animation>
+			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="Player.Paused + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)">Conditional</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>

--- a/addons/skin.estuary/xml/Timers.xml
+++ b/addons/skin.estuary/xml/Timers.xml
@@ -8,4 +8,9 @@
         <stop>!Window.IsActive(videoosd) | String.IsEmpty(Skin.String(OSDAutoCloseTime)) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd), 4) | !String.IsEmpty(Skin.String(OSDAutoCloseTime)) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd),Skin.Numeric(OSDAutoCloseTime))</stop>
         <onstop>Dialog.Close(videoosd)</onstop>
     </timer>
+    <timer>
+        <name>1110_topbaroverlay</name>
+        <description>A timer that is activated when the topbaroverlay is loaded and stops automatically after 5 seconds (or playback is resumed)</description>
+        <stop>!Player.Paused | Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)</stop>
+    </timer>
 </timers>


### PR DESCRIPTION
## Description
Re-writes https://github.com/xbmc/xbmc/pull/20816 using skin timers (hopefully introduced with https://github.com/xbmc/xbmc/pull/21320)

Depends on https://github.com/xbmc/xbmc/pull/21320

## Motivation and context
The `AlarmClock` approach was introduced to fix an inconsistency in behaviour depending on the fact pause was issued from input/remotes or json-rpc but I never liked the implementation. Using skin properties with an `AlarmClock` is quite hacky and ugly. Furthermore the AlarmClock is not really designed to run "headless", i.e. it's supposed to start an alarm and notify when the alarm interval is elapsed. Since we had no other way to do it, it was implemented this way to fix the issue. Now we can exploit skin timers to do the same on a cleaner way.

## How has this been tested?
Runtime tested

## What is the effect on users?
Hopefully none, same functionality but with different implementations.

