### PR TITLE
[GUI][INFO] Add Skin.Numeric() info (integer)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7060,6 +7060,15 @@ const infomap fanart_labels[] =  {{ "color1",           FANART_COLOR1 },
 ///     @skinning_v18 **[New Infolabel]** \link Skin_Font `Skin.Font`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Skin.Numeric(settingid)`</b>,
+///                  \anchor Skin_Numeric
+///                  _integer_,
+///     @return return the setting value as an integer/numeric value.
+///     @sa \link Skin_SetNumeric `Skin.SetNumeric(settingid)`\endlink
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link Skin_Numeric `Skin.Numeric(settingid)`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
@@ -10078,7 +10087,12 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           else
             return AddMultiInfo(CGUIInfo(SKIN_STRING, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
         }
-        if (prop.name == "hassetting")
+        else if (prop.name == "numeric")
+        {
+          return AddMultiInfo(
+              CGUIInfo(SKIN_INTEGER, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
+        }
+        else if (prop.name == "hassetting")
           return AddMultiInfo(CGUIInfo(SKIN_BOOL, CSkinSettings::GetInstance().TranslateBool(prop.param(0))));
         else if (prop.name == "hastheme")
           return AddMultiInfo(CGUIInfo(SKIN_HAS_THEME, prop.param(0)));

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -26,11 +26,13 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "threads/Timer.h"
-#include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/XMLUtils.h"
 #include "utils/Variant.h"
+#include "utils/XMLUtils.h"
+#include "utils/log.h"
+
+#include <charconv>
 
 #define XML_SETTINGS      "settings"
 #define XML_SETTING       "setting"
@@ -586,6 +588,18 @@ int CSkinInfo::TranslateString(const std::string &setting)
   m_strings.insert(std::pair<int, CSkinSettingStringPtr>(number, skinString));
 
   return number;
+}
+
+int CSkinInfo::GetInt(int setting) const
+{
+  const std::string settingValue = GetString(setting);
+  if (settingValue.empty())
+  {
+    return -1;
+  }
+  int settingValueInt{-1};
+  std::from_chars(settingValue.data(), settingValue.data() + settingValue.size(), settingValueInt);
+  return settingValueInt;
 }
 
 const std::string& CSkinInfo::GetString(int setting) const

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -199,6 +199,12 @@ public:
   bool GetBool(int setting) const;
   void SetBool(int setting, bool set);
 
+  /*! \brief Get the skin setting value as an integer value
+   * \param setting - the setting id
+   * \return the setting value as an integer, -1 if no conversion is possible
+   */
+  int GetInt(int setting) const;
+
   std::set<CSkinSettingPtr> GetSkinSettings() const;
   CSkinSettingPtr GetSkinSetting(const std::string& settingId);
   std::shared_ptr<const CSkinSetting> GetSkinSetting(const std::string& settingId) const;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -403,6 +403,7 @@
 #define SKIN_HAS_THEME              606
 #define SKIN_ASPECT_RATIO           607
 #define SKIN_FONT                   608
+#define SKIN_INTEGER 609
 
 #define SYSTEM_IS_SCREENSAVER_INHIBITED 641
 #define SYSTEM_ADDON_UPDATE_COUNT   642

--- a/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
@@ -79,6 +79,14 @@ bool CSkinGUIInfo::GetLabel(std::string& value, const CFileItem *item, int conte
 
 bool CSkinGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
+  switch (info.m_info)
+  {
+    case SKIN_INTEGER:
+    {
+      value = CSkinSettings::GetInstance().GetInt(info.GetData1());
+      return true;
+    }
+  }
   return false;
 }
 

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -558,7 +558,7 @@ static int SkinDebug(const std::vector<std::string>& params)
 ///   }
 ///   \table_row2_l{
 ///     <b>`Skin.SetNumeric(numeric[\,value])`</b>
-///     ,
+///     \anchor Skin_SetNumeric,
 ///     Pops up a keyboard dialog and allows the user to input a numerical.
 ///     @param[in] numeric               Name of skin setting.
 ///     @param[in] value                 Value of skin setting (optional).

--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -62,6 +62,11 @@ bool CSkinSettings::GetBool(int setting) const
   return g_SkinInfo->GetBool(setting);
 }
 
+int CSkinSettings::GetInt(int setting) const
+{
+  return g_SkinInfo->GetInt(setting);
+}
+
 void CSkinSettings::SetBool(int setting, bool set)
 {
   g_SkinInfo->SetBool(setting, set);

--- a/xbmc/settings/SkinSettings.h
+++ b/xbmc/settings/SkinSettings.h
@@ -36,6 +36,12 @@ public:
   bool GetBool(int setting) const;
   void SetBool(int setting, bool set);
 
+  /*! \brief Get the skin setting value as an integer value
+   * \param setting - the setting id
+   * \return the setting value as an integer, -1 if no conversion is possible
+   */
+  int GetInt(int setting) const;
+
   std::set<ADDON::CSkinSettingPtr> GetSettings() const;
   ADDON::CSkinSettingPtr GetSetting(const std::string& settingId);
   std::shared_ptr<const ADDON::CSkinSetting> GetSetting(const std::string& settingId) const;


### PR DESCRIPTION
## Description
Currently there is no way of getting a skin setting as an integer value. This is particularly useful when evaluating `Integer.xx()` info expressions against stored skin settings.
The skinning API provides a `Skin.SetNumeric()` builtin action which opens a numeric keyboard and stores the (integer) skin setting as a string. We have no way of getting that saved value as an integer though.

