### PR TITLE
[Android][CMake] Correctly escape custom target commands

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -164,6 +164,7 @@ foreach(target apk obb apk-obb apk-clean)
               STRIP=${CMAKE_STRIP}
               ${target}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/android/packaging
+      VERBATIM
   )
   if(NOT target STREQUAL apk-clean)
     add_dependencies(${target} bundle)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Android add_custom_target commands are called with VERBATIM option to escape the commands and options. This fixes shell syntax error when PATH contains parentheses.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After the issue #17830 and PR #21321, another problem stops me from building in WSL. When my PATH contains a "(", `make` fails saying:
```
/bin/sh: 1: Syntax error: "(" unexpected
make[3]: *** [CMakeFiles/apk.dir/build.make:70: CMakeFiles/apk] Error 2
make[2]: *** [CMakeFiles/Makefile2:5085: CMakeFiles/apk.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:5092: CMakeFiles/apk.dir/rule] Error 2
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Adding this VERBATIM, the makefile is
```
CMakeFiles/apk:
	cd ... && env "PATH=...:/mnt/c/Program Files (x86)/..." /usr/bin/make ...
```

Without this VERBATIM, the makefile is
```
CMakeFiles/apk:
	cd ... && env PATH=...:/mnt/c/Program\ Files\ (x86)/... /usr/bin/make ...
```

P.S.: PR #21321 was actually tested with this VERBATIM, but I did not commit it.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
