### PR TITLE
[tools/depends][target] libpng disable hardware call for apple aarch64 targets

### DIFF
--- a/tools/depends/target/libpng/Makefile
+++ b/tools/depends/target/libpng/Makefile
@@ -7,17 +7,20 @@ CMAKE_OPTIONS=-DPNG_SHARED=OFF \
               -DPNG_TESTS=OFF \
               -DPNG_DEBUG=OFF
 
-ifneq ($(findstring apple-darwin, $(HOST)), apple-darwin)
+ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
+  # hardware optimizations require NEON instructions that
+  # fail on m1 hardware and ios/tvos, so just disable for any arm64 target cpu on
+  # an apple-darwin target
+  ifeq ($(CPU), arm64)
+    CMAKE_OPTIONS+= -DPNG_HARDWARE_OPTIMIZATIONS=OFF
+  else
+    CMAKE_OPTIONS+= -DPNG_HARDWARE_OPTIMIZATIONS=ON
+  endif
+else
   CMAKE_OPTIONS+= -DPNG_HARDWARE_OPTIMIZATIONS=ON \
                   -DPNG_BUILD_ZLIB=ON \
                   -DZLIB_LIBRARY=$(PREFIX)/lib/libz.a \
                   -DZLIB_INCLUDE_DIR=$(PREFIX)/include
-else
-  ifeq ($(OS), osx)
-    CMAKE_OPTIONS+= -DPNG_HARDWARE_OPTIMIZATIONS=ON
-  else
-    CMAKE_OPTIONS+= -DPNG_HARDWARE_OPTIMIZATIONS=OFF
-  endif
 endif
 
 LIBDYLIB=$(PLATFORM)/build/$(BYPRODUCT)


### PR DESCRIPTION
## Description
Disable hardware accelleration for libpng for apple aarch64 targets

## Motivation and context
M1 fails to build due to NEON instructions missing. disable hardware accelleration
for darwin_embedded and aarch64 macos targets

## How has this been tested?
Build aarch64 macos target

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
