### PR TITLE
[subtitles] Changed CC demuxer codec id to AV_CODEC_ID_TEXT

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -252,6 +252,13 @@ std::unique_ptr<CDVDOverlayCodec> CDVDFactoryCodec::CreateOverlayCodec(CDVDStrea
   switch (hint.codec)
   {
     case AV_CODEC_ID_TEXT:
+    {
+      if (hint.source == STREAM_SOURCE_VIDEOMUX)
+        pCodec = std::make_unique<CDVDOverlayCodecCCText>();
+      else
+        pCodec = std::make_unique<CDVDOverlayCodecText>();
+      break;
+    }
     case AV_CODEC_ID_SUBRIP:
       pCodec = std::make_unique<CDVDOverlayCodecText>();
       break;
@@ -263,10 +270,6 @@ std::unique_ptr<CDVDOverlayCodec> CDVDFactoryCodec::CreateOverlayCodec(CDVDStrea
 
     case AV_CODEC_ID_MOV_TEXT:
       pCodec = std::make_unique<CDVDOverlayCodecTX3G>();
-      break;
-
-    case AV_CODEC_ID_EIA_608:
-      pCodec = std::make_unique<CDVDOverlayCodecCCText>();
       break;
 
     case AV_CODEC_ID_WEBVTT:

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -318,7 +318,7 @@ void CDVDDemuxCC::Handler(int service, void *userdata)
     stream.source = STREAM_SOURCE_VIDEOMUX;
     stream.language = "cc";
     stream.flags = FLAG_HEARING_IMPAIRED;
-    stream.codec = AV_CODEC_ID_EIA_608;
+    stream.codec = AV_CODEC_ID_TEXT;
     stream.uniqueId = service;
     ctx->m_streams.push_back(stream);
 

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -29,6 +29,7 @@ void CDVDStreamInfo::Clear()
   codec = AV_CODEC_ID_NONE;
   type = STREAM_NONE;
   uniqueId = -1;
+  source = STREAM_SOURCE_NONE;
   codecOptions = 0;
   codec_tag  = 0;
   flags = 0;
@@ -185,6 +186,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   type = right.type;
   uniqueId = right.uniqueId;
   demuxerId = right.demuxerId;
+  source = right.source;
   codec_tag = right.codec_tag;
   flags = right.flags;
   filename = right.filename;
@@ -252,6 +254,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
   type = right.type;
   uniqueId = right.uniqueId;
   demuxerId = right.demuxerId;
+  source = right.source;
   codec_tag = right.codec_fourcc;
   profile = right.profile;
   level = right.level;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -47,6 +47,7 @@ public:
   StreamType type;
   int uniqueId;
   int demuxerId = -1;
+  int source{STREAM_SOURCE_NONE};
   int flags;
   std::string filename;
   bool dvd;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Changed CC demuxer codec id as raw text AV_CODEC_ID_TEXT

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see comment https://github.com/xbmc/xbmc/pull/21297#issuecomment-1112500552
so we avoid use `AV_CODEC_ID_EIA_608` for our CC demuxer/decoder

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run a couple of cc videos

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
no effect

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
