### PR TITLE
[macos] packaging jenkins fix folder mv

### DIFF
--- a/tools/buildsteps/osx-arm64/package
+++ b/tools/buildsteps/osx-arm64/package
@@ -8,4 +8,4 @@ cd $WORKSPACE/build/tools/darwin/packaging/osx/
 #rename for upload
 #e.x. kodi-20130314-8c2fb31-Frodo-x86_64.dmg
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-arm64.dmg"
-mv *.dmg $WORKSPACE/tools/darwin/packaging/osx-arm64/$UPLOAD_FILENAME
+mv *.dmg $WORKSPACE/tools/darwin/packaging/osx/$UPLOAD_FILENAME


### PR DESCRIPTION
## Description
Fix folder to be osx

## Motivation and context
Jenkins jobs for m1 build. No need for a separate folder in tools/darwin/packaging for a separate osx arch. dmg files created have arch type, so wont overwrite each other anyway

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
