### PR TITLE
[tools/depends][target] pythonmodules fix arch build for arm64 macos

### DIFF
--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -21,10 +21,6 @@ else ifeq ($(OS),darwin_embedded)
   PILPATH=$(PREFIX)/share/$(APP_NAME)/addons/script.module.pil
   PILPATHLIB=$(PILPATH)/lib
   PYTHONPATH=$(PILPATH):$(PYTHON_SITE_PKG)
-
-  # Work around an issue with xcode 11 stripping -arch arm64 flags.
-  # Not required for xcode 12+, but doesnt hurt either.
-  CFLAGS+= -target arm64-apple-darwin
 endif
 
 SED_FLAG=-i
@@ -33,6 +29,12 @@ ifeq (darwin, $(findstring darwin, $(BUILD)))
 endif
 
 ifeq (darwin, $(findstring darwin, $(HOST)))
+  ifeq ($(CPU),arm64)
+    # Work around an issue with xcode 11 stripping -arch arm64 flags.
+    # Not required for xcode 12+, but doesnt hurt either.
+    CFLAGS+= -target arm64-apple-darwin
+  endif
+
   LDSHARED:=$(CC) -bundle -undefined dynamic_lookup
   export ZLIB_ROOT=$(SDKROOT)/usr
 endif

--- a/tools/depends/target/pythonmodule-pycryptodome/Makefile
+++ b/tools/depends/target/pythonmodule-pycryptodome/Makefile
@@ -10,7 +10,7 @@ ifeq ($(OS),android)
 endif
 
 ifeq (darwin, $(findstring darwin, $(HOST)))
-  ifeq ($(OS),darwin_embedded)
+  ifeq ($(CPU),arm64)
     # Work around an issue with xcode 11 stripping -arch arm64 flags.
     # Not required for xcode 12+, but doesnt hurt either.
     CFLAGS+= -target arm64-apple-darwin


### PR DESCRIPTION
## Description
Fix pythonmodule building via jenkins targeting arm64 macos

## Motivation and context
Fix pycryptodome and PIL incorrectly building x86_64 arch for aarch64 macos target

## How has this been tested?
Extends existing ios/tvos to target arm64 cpu

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
