### PR TITLE
[docs][skin] Document missing skin infos

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7034,6 +7034,39 @@ const infomap fanart_labels[] =  {{ "color1",           FANART_COLOR1 },
 /// \subsection modules__infolabels_boolean_conditions_Skin Skin
 /// \table_start
 ///   \table_h3{ Labels, Type, Description }
+///   \table_row3{   <b>`Skin.HasSetting(setting)`</b>,
+///                  \anchor Skin_HasSetting
+///                  _boolean_,
+///     @param setting - the requested skin setting
+///     @return **True** if the requested skin setting is true\, false otherwise.
+///     @sa \link Skin_SetBool `Skin.SetBool(setting[\,value])`
+///     <p>
+///   }
+///   \table_row3{   <b>`Skin.String(setting)`</b>,
+///                  \anchor Skin_StringValue
+///                  _string_,
+///     @param setting - the requested skin setting
+///     @return The value of the requested string setting (as a string)
+///     @sa \link Skin_SetString `Skin.SetString(setting[\,value])`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Skin.String(setting[\,value])`</b>,
+///                  \anchor Skin_StringCompare
+///                  _boolean_,
+///     @param setting - the requested skin setting
+///     @param value [opt] - the string value to compare the requested setting to
+///     @return **True** if the setting value equals the provided value\, false otherwise.
+///     @sa \link Skin_SetString `Skin.SetString(setting[\,value])`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Skin.HasTheme(theme)`</b>,
+///                  \anchor Skin_HasTheme
+///                  _boolean_,
+///     @param theme - the requested skin theme
+///     @return **True** if the requested theme is enabled\, false otherwise.
+///     @sa \link Skin_CycleTheme `Skin.Theme()`\endlink and \link Skin_CurrentTheme `Skin.CurrentTheme`\endlink.
+///     <p>
+///   }
 ///   \table_row3{   <b>`Skin.CurrentTheme`</b>,
 ///                  \anchor Skin_CurrentTheme
 ///                  _string_,

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -507,10 +507,10 @@ static int SkinDebug(const std::vector<std::string>& params)
 ///     @param[in] type[1\,...]           Add-on types to allow selecting.
 ///   }
 ///   \table_row2_l{
-///     <b>`Skin.SetBool(setting[\,value)`</b>
-///     ,
+///     <b>`Skin.SetBool(setting[\,value])`</b>
+///     \anchor Skin_SetBool,
 ///     Sets the skin `setting` to true\, for use with the conditional visibility
-///     tags containing `Skin.HasSetting(setting)`. The settings are saved
+///     tags containing \link Skin_HasSetting `Skin.HasSetting(setting)`\endlink. The settings are saved
 ///     per-skin in settings.xml just like all the other Kodi settings.
 ///     @param[in] setting               Name of skin setting.
 ///     @param[in] value                 Value to set ("false"\, or "true") (optional).
@@ -575,17 +575,19 @@ static int SkinDebug(const std::vector<std::string>& params)
 ///   }
 ///   \table_row2_l{
 ///     <b>`Skin.SetString(string[\,value])`</b>
-///     ,
+///     \anchor Skin_SetString,
 ///     Pops up a keyboard dialog and allows the user to input a string which can
 ///     be used in a label control elsewhere in the skin via the info tag
-///     `Skin.String(string)`. If the value parameter is specified\, then the
+///     \link Skin_StringValue `Skin.String(string)`\endlink. The value of the setting
+///     can also be compared to another value using the info bool \link Skin_StringCompare `Skin.String(string\, value)`\endlink.
+///     If the value parameter is specified\, then the
 ///     keyboard dialog does not pop up\, and the string is set directly.
 ///     @param[in] string                Name of skin setting.
 ///     @param[in] value                 Value of skin setting (optional).
 ///   }
 ///   \table_row2_l{
 ///     <b>`Skin.Theme(cycle)`</b>
-///     ,
+///     \anchor Skin_CycleTheme,
 ///     Cycles the skin theme. Skin.theme(-1) will go backwards.
 ///     @param[in] cycle                 0 or 1 to increase theme\, -1 to decrease.
 ///   }


### PR DESCRIPTION
## Description
While working on https://github.com/xbmc/xbmc/pull/21329 I noticed there were several Skin infos that were not documented in doxygen. All those missing infos were added in Frodo, so they don't need skinning revision tags (we only track changes since gotham). Also added links to the setter counterparts.