### PR TITLE
[clang-tidy] fix performance-* warnings

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -411,7 +411,9 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastOpenedGroup() const
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return std::accumulate(
       m_groups.cbegin(), m_groups.cend(), std::shared_ptr<CPVRChannelGroup>{},
-      [](std::shared_ptr<CPVRChannelGroup> last, const std::shared_ptr<CPVRChannelGroup>& group) {
+      [](const std::shared_ptr<CPVRChannelGroup>& last,
+         const std::shared_ptr<CPVRChannelGroup>& group)
+      {
         return group->LastOpened() > 0 && (!last || group->LastOpened() > last->LastOpened())
                    ? group
                    : last;

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -173,7 +173,7 @@ bool CPVREpgTagsContainer::UpdateEntries(const CPVREpgTagsContainer& tags)
 
       if (it != existingTags.cend())
       {
-        const std::shared_ptr<CPVREpgInfoTag> existingTag = *it;
+        const std::shared_ptr<CPVREpgInfoTag>& existingTag = *it;
 
         existingTag->SetChannelData(m_channelData);
         existingTag->SetEpgID(m_iEpgID);


### PR DESCRIPTION
## Description
fix performance-* clang-tidy warnings

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
