### PR TITLE
[Windows] Fix: incorrect colors in some AMD graphics when used 10bit in SDR

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -609,6 +609,14 @@ void DX::DeviceResources::ResizeBuffers()
     const bool isHdrEnabled = (hdrStatus == HDR_STATUS::HDR_ON);
     bool use10bit = (hdrStatus != HDR_STATUS::HDR_UNSUPPORTED);
 
+    DXGI_ADAPTER_DESC ad = {};
+    GetAdapterDesc(&ad);
+
+    // Some AMD graphics has issues with 10 bit in SDR.
+    // Enabled by default only in Intel and NVIDIA with latest drivers/hardware
+    if (m_d3dFeatureLevel < D3D_FEATURE_LEVEL_12_1 || ad.VendorId == PCIV_AMD)
+      use10bit = false;
+
     // 0 = Auto | 1 = Never | 2 = Always
     int use10bitSetting = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
         CSettings::SETTING_VIDEOSCREEN_10BITSURFACES);


### PR DESCRIPTION
## Description
Fix: incorrect colors in some AMD graphics when used 10bit in SDR

Fixes https://github.com/xbmc/xbmc/issues/21081

## Motivation and context
Some AMD graphics has issues when is used 10bit swapchain. Seems all processing inside Kodi is right but when video outputs graphics card are flagged as BT.2020 by AMD video driver.

See: https://github.com/xbmc/xbmc/issues/21081 and https://forum.kodi.tv/showthread.php?tid=365817

Screenshots are with correct colors and if in TV settings are forced BT.709 color space, correct colors are also obtained. Is not related to DXVA2 video decoding.

This incompatibility only has been reported by AMD users. In master branch this is not critical because already exist a GUI setting to enable or not 10 bit for SDR in https://github.com/xbmc/xbmc/pull/20014 but in Matrix currently cannot be disabled. 

This PR only limits the cases in which it is activated by default, although users who are not affected by this may continue to activate it the same in GUI settings. 

Also with backport to Matrix users may continue enable 10bit using advanced setting "try10bitoutput".

## How has this been tested?
Two users has confirmed issue is fixed by this: https://github.com/xbmc/xbmc/issues/21081#issuecomment-1114031692 and https://github.com/xbmc/xbmc/issues/21081#issuecomment-1114309543

## What is the effect on users?
Fixed: Wrong/too saturated colors with some AMD graphics when playing SDR video using 10bit on an HDR compatible display (with Windows HDR off).


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
