### PR TITLE
[tools/depends] configure allow to provide linker name

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -15,7 +15,8 @@ It should work if you're using macOS. If that is the case, read **[macOS specifi
   3.4. **[Create a key to sign debug APKs](#34-create-a-key-to-sign-debug-apks)**  
   3.5. **[macOS specific prerequisites](#35-macos-specific-prerequisites)**
 4. **[Get the source code](#4-get-the-source-code)**
-5. **[Build tools and dependencies](#5-build-tools-and-dependencies)**
+5. **[Build tools and dependencies](#5-build-tools-and-dependencies)**  
+  5.1. **[Advanced Configure Options](#51-advanced-configure-options)**  
 6. **[Build binary add-ons](#6-build-binary-add-ons)**
 7. **[Build Kodi](#7-build-kodi)**
 8. **[Package](#8-package)**
@@ -169,6 +170,89 @@ make -j$(getconf _NPROCESSORS_ONLN)
 **TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
 
 **WARNING:** Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
+
+### 5.1. Advanced Configure Options
+
+
+**All platforms:**
+
+```
+--with-toolchain=<path>
+```
+  specify path to toolchain. Auto set for android. Defaults to xcode root for darwin, /usr for linux
+
+```
+--enable-debug=<yes:no>
+```
+  enable debugging information (default is yes)
+
+```
+--disable-ccache
+```
+  disable ccache
+
+```
+--with-tarballs=<path>
+```
+  path where tarballs will be saved [prefix/xbmc-tarballs]
+
+```
+--with-cpu=<cpu>
+```
+  optional. specify target cpu. guessed if not specified
+
+```
+--with-linker=<linker>
+```
+  specify linker to use. (default is ld)
+
+```
+--with-platform=<platform>
+```
+  target platform
+
+```
+--enable-gplv3=<yes:no>
+```
+  enable gplv3 components. (default is yes)
+
+```
+--with-target-cflags=<cflags>
+```
+  C compiler flags (target)
+
+```
+--with-target-cxxflags=<cxxflags>
+```
+  C++ compiler flags (target)
+
+```
+--with-target-ldflags=<ldflags>
+```
+  linker flags. Use e.g. for -l<lib> (target)
+
+```
+--with-ffmpeg-options
+```
+  FFmpeg configure options, e.g. --enable-vaapi (target)
+
+
+**Android Specific:**
+
+```
+--with-ndk-api=<ndk number>
+```
+  specify ndk level (optional for android), default is 21.]
+
+```
+--with-ndk-path=<path>
+```
+  specify path to ndk (required for android only)
+
+```
+--with-sdk-path=<path>
+```
+  specify path to sdk (required for android only)
 
 
 **[back to top](#table-of-contents)** | **[back to section top](#5-build-tools-and-dependencies)**

--- a/docs/README.iOS.md
+++ b/docs/README.iOS.md
@@ -7,7 +7,8 @@ This guide has been tested using Xcode 11.3.1 running on MacOS 10.14.4 (Mojave).
 1. **[Document conventions](#1-document-conventions)**
 2. **[Prerequisites](#2-prerequisites)**
 3. **[Get the source code](#3-get-the-source-code)**
-4. **[Configure and build tools and dependencies](#4-configure-and-build-tools-and-dependencies)**
+4. **[Configure and build tools and dependencies](#4-configure-and-build-tools-and-dependencies)**  
+  4.1. **[Advanced Configure Options](#41-Advanced-Configure-Options)**  
 5. **[Build binary add-ons](#5-build-binary-add-ons)**  
   5.1. **[Independent Add-on building](#51-Independent-Add-on-building)**  
   5.2. **[Xcode project building](#52-Xcode-project-building)**  
@@ -103,6 +104,80 @@ make -j$(getconf _NPROCESSORS_ONLN)
 ```
 ./configure --host=aarch64-apple-darwin --with-platform=ios --with-sdk=11.0
 ```
+
+### 4.1. Advanced Configure Options
+
+
+**All platforms:**
+
+```
+--with-toolchain=<path>
+```
+  specify path to toolchain. Auto set for android. Defaults to xcode root for darwin, /usr for linux
+
+```
+--enable-debug=<yes:no>
+```
+  enable debugging information (default is yes)
+
+```
+--disable-ccache
+```
+  disable ccache
+
+```
+--with-tarballs=<path>
+```
+  path where tarballs will be saved [prefix/xbmc-tarballs]
+
+```
+--with-cpu=<cpu>
+```
+  optional. specify target cpu. guessed if not specified
+
+```
+--with-linker=<linker>
+```
+  specify linker to use. (default is ld)
+
+```
+--with-platform=<platform>
+```
+  target platform
+
+```
+--enable-gplv3=<yes:no>
+```
+  enable gplv3 components. (default is yes)
+
+```
+--with-target-cflags=<cflags>
+```
+  C compiler flags (target)
+
+```
+--with-target-cxxflags=<cxxflags>
+```
+  C++ compiler flags (target)
+
+```
+--with-target-ldflags=<ldflags>
+```
+  linker flags. Use e.g. for -l<lib> (target)
+
+```
+--with-ffmpeg-options
+```
+  FFmpeg configure options, e.g. --enable-vaapi (target)
+
+
+**Apple Specific:**
+
+```
+--with-sdk=<sdknumber>
+```
+  specify sdk platform version.
+
 
 **[back to top](#table-of-contents)** | **[back to section top](#4-configure-and-build-tools-and-dependencies)**
 

--- a/docs/README.macOS.md
+++ b/docs/README.macOS.md
@@ -7,7 +7,8 @@ This guide has been tested using Xcode 11.3.1 running on MacOS 10.14.4 (Mojave).
 1. **[Document conventions](#1-document-conventions)**
 2. **[Prerequisites](#2-prerequisites)**
 3. **[Get the source code](#3-get-the-source-code)**
-4. **[Configure and build tools and dependencies](#4-configure-and-build-tools-and-dependencies)**
+4. **[Configure and build tools and dependencies](#4-configure-and-build-tools-and-dependencies)**  
+  4.1. **[Advanced Configure Options](#41-Advanced-Configure-Options)**  
 5. **[Build binary add-ons](#5-build-binary-add-ons)**
 6. **[Build Kodi](#6-build-kodi)**  
   6.1. **[Build with Xcode](#61-build-with-xcode)**  
@@ -115,6 +116,83 @@ Developers can also select native windowing/input handling with the following
 ```
 ./configure --host=x86_64-apple-darwin --with-platform=macos --with-windowsystem=native
 ```
+
+### 4.1. Advanced Configure Options
+
+
+**All platforms:**
+
+```
+--with-toolchain=<path>
+```
+  specify path to toolchain. Auto set for android. Defaults to xcode root for darwin, /usr for linux
+
+```
+--enable-debug=<yes:no>
+```
+  enable debugging information (default is yes)
+
+```
+--disable-ccache
+```
+  disable ccache
+
+```
+--with-tarballs=<path>
+```
+  path where tarballs will be saved [prefix/xbmc-tarballs]
+
+```
+--with-cpu=<cpu>
+```
+  optional. specify target cpu. guessed if not specified
+
+```
+--with-linker=<linker>
+```
+  specify linker to use. (default is ld)
+
+```
+--with-platform=<platform>
+```
+  target platform
+
+```
+--enable-gplv3=<yes:no>
+```
+  enable gplv3 components. (default is yes)
+
+```
+--with-target-cflags=<cflags>
+```
+  C compiler flags (target)
+
+```
+--with-target-cxxflags=<cxxflags>
+```
+  C++ compiler flags (target)
+
+```
+--with-target-ldflags=<ldflags>
+```
+  linker flags. Use e.g. for -l<lib> (target)
+
+```
+--with-ffmpeg-options
+```
+  FFmpeg configure options, e.g. --enable-vaapi (target)
+
+**Apple Specific:**
+
+```
+--with-windowsystem=<native:sdl>
+```
+  Windowing system to use (default is sdl when not provided). arm64 MacOS requires native
+
+```
+--with-sdk=<sdknumber>
+```
+  specify sdk platform version.
 
 **[back to top](#table-of-contents)** | **[back to section top](#4-configure-and-build-tools-and-dependencies)**
 

--- a/docs/README.tvOS.md
+++ b/docs/README.tvOS.md
@@ -7,7 +7,8 @@ This guide has been tested using Xcode 11.3.1 running on MacOS 10.15.2 (Catalina
 1. **[Document conventions](#1-document-conventions)**
 2. **[Prerequisites](#2-prerequisites)**
 3. **[Get the source code](#3-get-the-source-code)**
-4. **[Configure and build tools and dependencies](#4-configure-and-build-tools-and-dependencies)**
+4. **[Configure and build tools and dependencies](#4-configure-and-build-tools-and-dependencies)**  
+  4.1. **[Advanced Configure Options](#41-Advanced-Configure-Options)**  
 5. **[Generate Kodi Build files](#5-Generate-Kodi-Build-files)**  
   5.1. **[Generate XCode Project Files](#51-Generate-Xcode-Project-Files)**  
   5.2. **[Build with Xcode](#62-build)**  
@@ -108,6 +109,78 @@ make -j$(getconf _NPROCESSORS_ONLN)
 ```
 ./configure --host=aarch64-apple-darwin --with-platform=tvos --with-sdk=11.0
 ```
+
+### 4.1. Advanced Configure Options
+
+
+**All platforms:**
+
+```
+--with-toolchain=<path>
+```
+  specify path to toolchain. Auto set for android. Defaults to xcode root for darwin, /usr for linux
+
+```
+--enable-debug=<yes:no>
+```
+  enable debugging information (default is yes)
+
+```
+--disable-ccache
+```
+  disable ccache
+
+```
+--with-tarballs=<path>
+```
+  path where tarballs will be saved [prefix/xbmc-tarballs]
+
+```
+--with-cpu=<cpu>
+```
+  optional. specify target cpu. guessed if not specified
+
+```
+--with-linker=<linker>
+```
+  specify linker to use. (default is ld)
+
+```
+--with-platform=<platform>
+```
+  target platform
+
+```
+--enable-gplv3=<yes:no>
+```
+  enable gplv3 components. (default is yes)
+
+```
+--with-target-cflags=<cflags>
+```
+  C compiler flags (target)
+
+```
+--with-target-cxxflags=<cxxflags>
+```
+  C++ compiler flags (target)
+
+```
+--with-target-ldflags=<ldflags>
+```
+  linker flags. Use e.g. for -l<lib> (target)
+
+```
+--with-ffmpeg-options
+```
+  FFmpeg configure options, e.g. --enable-vaapi (target)
+
+**Apple Specific:**
+
+```
+--with-sdk=<sdknumber>
+```
+  specify sdk platform version.
 
 **[back to top](#table-of-contents)**
 

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -36,6 +36,11 @@ AC_ARG_ENABLE([ccache],
   [use_ccache=no],
   [use_ccache=yes])
 
+AC_ARG_WITH([linker],
+  [AS_HELP_STRING([--with-linker],
+  [specify linker to use.])],
+  [use_linker=$withval])
+
 AC_ARG_WITH([toolchain],
   [AS_HELP_STRING([--with-toolchain],
   [specify path to toolchain. Auto set for android. Defaults to xcode root for darwin, /usr for linux])],
@@ -138,6 +143,10 @@ fi
 AC_PATH_PROG(TAR,tar,"no")
 if test "x$TAR" = "xno" ; then
   AC_MSG_ERROR("Missing program: tar")
+fi
+
+if test "x$use_linker" = "x" ; then
+  use_linker=ld
 fi
 
 if test "$use_debug" = "yes"; then
@@ -267,7 +276,7 @@ else
 fi
 
 AC_PATH_TOOL([RANLIB], [${platform_tool_prefix}ranlib],, $PATH_FOR_HOST)
-AC_PATH_TOOL([LD], [${platform_tool_prefix}ld],, $PATH_FOR_HOST)
+AC_PATH_TOOL([LD], [${use_linker}],, $PATH_FOR_HOST)
 AC_PATH_TOOL([AR], [${platform_tool_prefix}ar],, $PATH_FOR_HOST)
 AC_PATH_TOOL([READELF], [${platform_tool_prefix}readelf],, $PATH_FOR_HOST)
 AC_PATH_TOOL([STRIP], [${platform_tool_prefix}strip],, $PATH_FOR_HOST)
@@ -276,6 +285,10 @@ AC_PATH_TOOL([NM], [${platform_tool_prefix}nm],, $PATH_FOR_HOST)
 AC_PATH_TOOL([OBJDUMP], [${platform_tool_prefix}objdump],, $PATH_FOR_HOST)
 AC_PATH_TOOL([CC],[$platform_cc],,$PATH_FOR_HOST)
 AC_PATH_TOOL([CXX],[$platform_cxx],,$PATH_FOR_HOST)
+
+if test "x$LD" = "x"; then
+  AC_MSG_ERROR(No linker found with name ${use_linker}. You may want to provide using --with-linker=<linker>)
+fi
 
 case $build in
   *darwin*)


### PR DESCRIPTION
## Description
Allow user to set linker name using --with-linker=<name>. default without providing will fall back to ld

## Motivation and context
i noticed that currently android actually fails to set a linker name, and therefore it just goes with whatever the "system" linker is (often just called ld inside most dependencies).
The actual fault with android is the linker isnt called llvm-ld in bin tools, its just ld. remove platform_tool_prefix fixes this situation, but i know there are other linkers (eg mold, lld, gold, etc) that devs may wish to use/test with, hence the addition of the new option.

## How has this been tested?
configure with correct and incorrect linker for android/apple. make sure if linker given isnt found, we error to not fall into the "unknown" tool being used.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
