### PR TITLE
[settings] Moved subtitles settings to appropriate category

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1362,6 +1362,7 @@ msgctxt "#286"
 msgid "Preferred subtitle language"
 msgstr ""
 
+#. Title of category and group menu subtitles
 #: system/settings/settings.xml
 msgctxt "#287"
 msgid "Subtitles"
@@ -7967,9 +7968,10 @@ msgctxt "#14088"
 msgid "Play DVDs automatically"
 msgstr ""
 
+#. Subtitle font selection setting
 #: system/settings/settings.xml
 msgctxt "#14089"
-msgid "Font to use for text subtitles"
+msgid "Font"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -14450,7 +14452,7 @@ msgstr ""
 #. Subtitle position on screen setting list
 #: system/settings/settings.xml
 msgctxt "#21460"
-msgid "Subtitle position on screen"
+msgid "Position on screen"
 msgstr ""
 
 #. Item list value of setting with label #21460 "Subtitle position on screen"
@@ -19255,10 +19257,10 @@ msgctxt "#36184"
 msgid "This category contains the settings for how subtitles are handled."
 msgstr ""
 
-#. Description of setting with label #14089 "Font to use for text subtitles"
+#. Description of setting with label #14089 "Font"
 #: system/settings/settings.xml
 msgctxt "#36185"
-msgid "Set the font type to be used for text based (usually downloaded) subtitles."
+msgid "Set the font type to be used for subtitles."
 msgstr ""
 
 #. Description of setting with label #289 "Size"
@@ -21703,16 +21705,16 @@ msgctxt "#37031"
 msgid "Specifies how Blu-rays should be opened / played back. Note: Some disc menus are not fully supported and may cause problems."
 msgstr ""
 
-#. Title of category #37032 Accessibility
+#. Title of accessibility menu group
 #: system/settings/settings.xml
 msgctxt "#37032"
 msgid "Accessibility"
 msgstr ""
 
-#. Description of category #37032 Accessibility
+#. Description of category #287 Subtitles
 #: system/settings/settings.xml
 msgctxt "#37033"
-msgid "Video playback related accessibility settings, e.g. \"Prefer subtitles for the hearing impaired\"."
+msgid "This category contains the settings for subtitles"
 msgstr ""
 
 #. Setting #37034 Accessibility
@@ -22177,7 +22179,7 @@ msgstr ""
 #. Description of category #14213 "Language"
 #: system/settings/settings.xml
 msgctxt "#38106"
-msgid "This category contains the settings for audio & subtitle language"
+msgid "This category contains the settings for audio / subtitles language and accessibility"
 msgstr ""
 
 #. Description of category #14210 "Videos"
@@ -23123,4 +23125,16 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
 msgctxt "#39185"
 msgid "Insufficient permissions for speech recognition"
+msgstr ""
+
+#. Title of group menu subtitles
+#: system/settings/settings.xml
+msgctxt "#39186"
+msgid "Styles for text based subtitles"
+msgstr ""
+
+#. Title of group menu subtitles
+#: system/settings/settings.xml
+msgctxt "#39187"
+msgid "Closed caption subtitles"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -473,26 +473,27 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.parsecaptions" type="boolean" label="24130" help="24131">
-          <level>1</level>
+      </group>
+      <group id="3" label="37032">
+        <setting id="accessibility.audiovisual" type="boolean" label="37034" help="37035">
+          <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="subtitles.captionsalign" parent="subtitles.parsecaptions" type="integer" label="39161">
-          <level>2</level>
-          <default>0</default> <!-- HorizontalAlign::LEFT -->
-          <constraints>
-            <options>
-              <option label="39162">0</option> <!-- HorizontalAlign::LEFT -->
-              <option label="39163">1</option> <!-- HorizontalAlign::CENTER -->
-              <option label="39164">2</option> <!-- HorizontalAlign::RIGHT -->
-            </options>
-          </constraints>
-          <dependencies>
-            <dependency type="visible" setting="subtitles.parsecaptions" operator="is">true</dependency>
-          </dependencies>
-          <control type="list" format="string" />
+        <setting id="accessibility.audiohearing" type="boolean" label="37036" help="37037">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
+        <setting id="accessibility.subhearing" type="boolean" label="37038" help="37039">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="subtitles" label="287" help="37033">
+      <group id="1" label="39186">
         <setting id="subtitles.align" type="integer" label="21460" help="36192">
           <level>2</level>
           <default>1</default> <!-- Align::BOTTOM_INSIDE -->
@@ -507,16 +508,6 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.stereoscopicdepth" type="integer" label="36545" help="36546">
-          <level>2</level>
-          <default>0</default>
-          <constraints>
-            <minimum>0</minimum>
-            <step>1</step>
-            <maximum>10</maximum>
-          </constraints>
-          <control type="spinner" format="integer" delayed="true"/>
-        </setting>
         <setting id="subtitles.fontname" type="string" label="14089" help="36185">
           <level>1</level>
           <default>DEFAULT</default>
@@ -525,15 +516,7 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.charset" type="string" parent="subtitles.fontname" label="735" help="36189">
-          <level>1</level>
-          <default>DEFAULT</default>
-          <constraints>
-            <options>charsets</options>
-          </constraints>
-          <control type="list" format="string" />
-        </setting>
-        <setting id="subtitles.fontsize" type="integer" parent="subtitles.fontname" label="289" help="36186">
+        <setting id="subtitles.fontsize" type="integer" label="289" help="36186">
           <level>3</level>
           <default>42</default>
           <constraints>
@@ -546,7 +529,7 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.style" type="integer" parent="subtitles.fontname" label="736" help="36187">
+        <setting id="subtitles.style" type="integer" label="736" help="36187">
           <level>3</level>
           <default>0</default> <!-- FontStyle::NORMAL -->
           <constraints>
@@ -559,17 +542,17 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="subtitles.colorpick" type="string" parent="subtitles.fontname" label="737" help="36188">
+        <setting id="subtitles.colorpick" type="string" label="737" help="36188">
           <level>3</level>
           <default>FFFFFFFF</default> <!-- White -->
           <control type="colorbutton" />
         </setting>
-        <setting id="subtitles.opacity" type="integer" parent="subtitles.fontname" label="752" help="36295">
+        <setting id="subtitles.opacity" type="integer" label="752" help="36295">
           <level>3</level>
           <default>100</default>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
-        <setting id="subtitles.bordersize" type="integer" parent="subtitles.fontname" label="39159">
+        <setting id="subtitles.bordersize" type="integer" label="39159">
           <level>3</level>
           <default>30</default>
           <dependencies>
@@ -577,7 +560,7 @@
           </dependencies>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
-        <setting id="subtitles.bordercolorpick" type="string" parent="subtitles.fontname" label="39160">
+        <setting id="subtitles.bordercolorpick" type="string" label="39160">
           <level>3</level>
           <default>FF000000</default> <!-- Black -->
           <dependencies>
@@ -585,12 +568,12 @@
           </dependencies>
           <control type="colorbutton" />
         </setting>
-        <setting id="subtitles.blur" type="integer" parent="subtitles.fontname" label="39173">
+        <setting id="subtitles.blur" type="integer" label="39173">
           <level>3</level>
           <default>0</default>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
-        <setting id="subtitles.backgroundtype" type="integer" parent="subtitles.fontname" label="39165" help="39169">
+        <setting id="subtitles.backgroundtype" type="integer" label="39165" help="39169">
           <level>3</level>
           <default>0</default> <!-- BackgroundType::NONE -->
           <constraints>
@@ -705,8 +688,48 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="subtitles.stereoscopicdepth" type="integer" label="36545" help="36546">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>10</maximum>
+          </constraints>
+          <control type="spinner" format="integer" delayed="true"/>
+        </setting>
+        <setting id="subtitles.charset" type="string" label="735" help="36189">
+          <level>1</level>
+          <default>DEFAULT</default>
+          <constraints>
+            <options>charsets</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
       </group>
-      <group id="3" label="14235">
+      <group id="3" label="39187">
+        <setting id="subtitles.parsecaptions" type="boolean" label="24130" help="24131">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="subtitles.captionsalign" parent="subtitles.parsecaptions" type="integer" label="39161">
+          <level>2</level>
+          <default>0</default> <!-- HorizontalAlign::LEFT -->
+          <constraints>
+            <options>
+              <option label="39162">0</option> <!-- HorizontalAlign::LEFT -->
+              <option label="39163">1</option> <!-- HorizontalAlign::CENTER -->
+              <option label="39164">2</option> <!-- HorizontalAlign::RIGHT -->
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="subtitles.parsecaptions" operator="is">true</dependency>
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
+      </group>
+      <group id="4" label="14235">
         <setting id="subtitles.languages" type="list[string]" label="24111" help="24112">
           <level>1</level>
           <default>English</default>
@@ -775,27 +798,6 @@
           <control type="button" format="addon">
             <show more="true" details="true">installed</show>
           </control>
-        </setting>
-      </group>
-    </category>
-    <category id="accessibility" label="37032" help="37033">
-      <group id="1" label="14221">
-        <setting id="accessibility.audiovisual" type="boolean" label="37034" help="37035">
-          <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="accessibility.audiohearing" type="boolean" label="37036" help="37037">
-          <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-      </group>
-      <group id="2" label="24012">
-        <setting id="accessibility.subhearing" type="boolean" label="37038" help="37039">
-          <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
         </setting>
       </group>
     </category>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add new "Subtitles" category menu to contains all settings related to subtitles

The existing "Language" category now contains only settings for language purposes
and has been merged with Accessibility which have the same purpose

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A lot of changes has been done for subtitles in v20 that has introduced also a lot of new features,
therefore the current "Language" menu is no longer appropriate to contains all these subtitles settings

@enen92 this was the menu scheme discussed long time ago

suggestions for setting levels? otherwise i keep as original

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
A better consistent setting menu

## Screenshots (if appropriate):
![immagine](https://user-images.githubusercontent.com/3257156/166667768-fdf8f708-8475-412b-a1af-80d5dc69b10f.png)
![immagine](https://user-images.githubusercontent.com/3257156/166667799-2d42ede5-b118-4a78-8807-9d6fc70c9cfe.png)
![immagine](https://user-images.githubusercontent.com/3257156/166668691-d8bdec03-4d5e-476e-a493-8061ee5b174b.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
