### PR TITLE
changed: put application volume handling in separate class

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -12,6 +12,7 @@
 #include "ApplicationStackHelper.h"
 #include "ServiceManager.h"
 #include "application/ApplicationPowerHandling.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/IPlayerCallback.h"
 #include "guilib/IMsgTargetCallback.h"
 #include "guilib/IWindowManagerCallback.h"
@@ -86,10 +87,6 @@ namespace MUSIC_INFO
   class CMusicInfoScanner;
 }
 
-#define VOLUME_MINIMUM 0.0f        // -60dB
-#define VOLUME_MAXIMUM 1.0f        // 0dB
-#define VOLUME_DYNAMIC_RANGE 90.0f // 60dB
-
 // replay gain settings struct for quick access by the player multiple
 // times per second (saves doing settings lookup)
 struct ReplayGainSettings
@@ -123,7 +120,8 @@ class CApplication : public IWindowManagerCallback,
                      public ISettingsHandler,
                      public ISubSettings,
                      public KODI::MESSAGING::IMessageTarget,
-                     public CApplicationPowerHandling
+                     public CApplicationPowerHandling,
+                     public CApplicationVolumeHandling
 {
 friend class CAppInboundProtocol;
 
@@ -198,14 +196,6 @@ public:
   void ShowAppMigrationMessage();
   void Process() override;
   void ProcessSlow();
-  float GetVolumePercent() const;
-  float GetVolumeRatio() const;
-  void SetVolume(float iValue, bool isPercentage = true);
-  bool IsMuted() const;
-  bool IsMutedInternal() const { return m_muted; }
-  void ToggleMute(void);
-  void SetMute(bool mute);
-  void ShowVolumeBar(const CAction *action = NULL);
   int GetSubtitleDelay();
   int GetAudioDelay();
   /*!
@@ -338,16 +328,6 @@ protected:
   bool m_skipGuiRender = false;
 
   std::unique_ptr<MUSIC_INFO::CMusicInfoScanner> m_musicInfoScanner;
-
-  bool m_muted = false;
-  float m_volumeLevel = VOLUME_MAXIMUM;
-
-  void Mute();
-  void UnMute();
-
-  void SetHardwareVolume(float hardwareVolume);
-
-  void VolumeChanged();
 
   bool PlayStack(CFileItem& item, bool bRestart);
 

--- a/xbmc/application/ApplicationVolumeHandling.cpp
+++ b/xbmc/application/ApplicationVolumeHandling.cpp
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ApplicationVolumeHandling.h"
+
+#include "ApplicationPlayer.h"
+#include "ServiceBroker.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
+#include "dialogs/GUIDialogVolumeBar.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "interfaces/AnnouncementManager.h"
+#include "peripherals/Peripherals.h"
+#include "utils/Variant.h"
+
+CApplicationVolumeHandling::CApplicationVolumeHandling(CApplicationPlayer& appPlayer)
+  : m_appPlayer(appPlayer)
+{
+}
+
+float CApplicationVolumeHandling::GetVolumePercent() const
+{
+  // converts the hardware volume to a percentage
+  return m_volumeLevel * 100.0f;
+}
+
+float CApplicationVolumeHandling::GetVolumeRatio() const
+{
+  return m_volumeLevel;
+}
+
+void CApplicationVolumeHandling::SetHardwareVolume(float hardwareVolume)
+{
+  m_volumeLevel = std::clamp(hardwareVolume, VOLUME_MINIMUM, VOLUME_MAXIMUM);
+
+  IAE* ae = CServiceBroker::GetActiveAE();
+  if (ae)
+    ae->SetVolume(m_volumeLevel);
+}
+
+void CApplicationVolumeHandling::VolumeChanged()
+{
+  CVariant data(CVariant::VariantTypeObject);
+  data["volume"] = static_cast<int>(std::lroundf(GetVolumePercent()));
+  data["muted"] = m_muted;
+  const auto announcementMgr = CServiceBroker::GetAnnouncementManager();
+  announcementMgr->Announce(ANNOUNCEMENT::Application, "OnVolumeChanged", data);
+
+  // if player has volume control, set it.
+  m_appPlayer.SetVolume(m_volumeLevel);
+  m_appPlayer.SetMute(m_muted);
+}
+
+void CApplicationVolumeHandling::ShowVolumeBar(const CAction* action)
+{
+  const auto& wm = CServiceBroker::GetGUI()->GetWindowManager();
+  auto* volumeBar = wm.GetWindow<CGUIDialogVolumeBar>(WINDOW_DIALOG_VOLUME_BAR);
+  if (volumeBar != nullptr && volumeBar->IsVolumeBarEnabled())
+  {
+    volumeBar->Open();
+    if (action)
+      volumeBar->OnAction(*action);
+  }
+}
+
+bool CApplicationVolumeHandling::IsMuted() const
+{
+  if (CServiceBroker::GetPeripherals().IsMuted())
+    return true;
+  IAE* ae = CServiceBroker::GetActiveAE();
+  if (ae)
+    return ae->IsMuted();
+  return true;
+}
+
+void CApplicationVolumeHandling::ToggleMute(void)
+{
+  if (m_muted)
+    UnMute();
+  else
+    Mute();
+}
+
+void CApplicationVolumeHandling::SetMute(bool mute)
+{
+  if (m_muted != mute)
+  {
+    ToggleMute();
+    m_muted = mute;
+  }
+}
+
+void CApplicationVolumeHandling::Mute()
+{
+  if (CServiceBroker::GetPeripherals().Mute())
+    return;
+
+  IAE* ae = CServiceBroker::GetActiveAE();
+  if (ae)
+    ae->SetMute(true);
+  m_muted = true;
+  VolumeChanged();
+}
+
+void CApplicationVolumeHandling::UnMute()
+{
+  if (CServiceBroker::GetPeripherals().UnMute())
+    return;
+
+  IAE* ae = CServiceBroker::GetActiveAE();
+  if (ae)
+    ae->SetMute(false);
+  m_muted = false;
+  VolumeChanged();
+}
+
+void CApplicationVolumeHandling::SetVolume(float iValue, bool isPercentage)
+{
+  float hardwareVolume = iValue;
+
+  if (isPercentage)
+    hardwareVolume /= 100.0f;
+
+  SetHardwareVolume(hardwareVolume);
+  VolumeChanged();
+}

--- a/xbmc/application/ApplicationVolumeHandling.h
+++ b/xbmc/application/ApplicationVolumeHandling.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CAction;
+class CApplicationPlayer;
+
+/*!
+ * \brief Class handling application support for audio volume management.
+ */
+class CApplicationVolumeHandling
+{
+public:
+  explicit CApplicationVolumeHandling(CApplicationPlayer& appPlayer);
+
+  float GetVolumePercent() const;
+  float GetVolumeRatio() const;
+  bool IsMuted() const;
+
+  void SetVolume(float iValue, bool isPercentage = true);
+  void SetMute(bool mute);
+  void ToggleMute(void);
+
+  static constexpr float VOLUME_MINIMUM = 0.0f; // -60dB
+  static constexpr float VOLUME_MAXIMUM = 1.0f; // 0dB
+  static constexpr float VOLUME_DYNAMIC_RANGE = 90.0f; // 60dB
+
+protected:
+  bool IsMutedInternal() const { return m_muted; }
+  void ShowVolumeBar(const CAction* action = nullptr);
+
+  void Mute();
+  void UnMute();
+
+  void SetHardwareVolume(float hardwareVolume);
+
+  void VolumeChanged();
+
+  CApplicationPlayer& m_appPlayer; //!< Reference to application player
+  bool m_muted = false;
+  float m_volumeLevel = VOLUME_MAXIMUM;
+};

--- a/xbmc/application/CMakeLists.txt
+++ b/xbmc/application/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES ApplicationPowerHandling.cpp)
+set(SOURCES ApplicationPowerHandling.cpp
+            ApplicationVolumeHandling.cpp)
 
-set(HEADERS ApplicationPowerHandling.h)
+set(HEADERS ApplicationPowerHandling.h
+            ApplicationVolumeHandling.h)
 
 core_add_library(application)

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -28,7 +28,8 @@ bool CGUIDialogVolumeBar::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN || action.GetID() == ACTION_VOLUME_SET || action.GetID() == ACTION_MUTE)
   {
-    if (g_application.IsMuted() || g_application.GetVolumeRatio() <= VOLUME_MINIMUM)
+    if (g_application.IsMuted() ||
+        g_application.GetVolumeRatio() <= CApplicationVolumeHandling::VOLUME_MINIMUM)
     { // cancel the timer, dialog needs to stay visible
       CancelAutoClose();
     }

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -424,7 +424,8 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = m_playerShowTime;
       return true;
     case PLAYER_MUTED:
-      value = (g_application.IsMuted() || g_application.GetVolumeRatio() <= VOLUME_MINIMUM);
+      value = (g_application.IsMuted() ||
+               g_application.GetVolumeRatio() <= CApplicationVolumeHandling::VOLUME_MINIMUM);
       return true;
     case PLAYER_HAS_MEDIA:
       value = g_application.GetAppPlayer().IsPlaying();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1591,7 +1591,7 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
     // set amp present
     m_adapter->SetAudioSystemConnected(true);
     g_application.SetMute(false);
-    g_application.SetVolume(VOLUME_MAXIMUM, false);
+    g_application.SetVolume(CApplicationVolumeHandling::VOLUME_MAXIMUM, false);
   }
   else
   {

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -237,7 +237,11 @@ void CGUIDialogAudioSettings::InitializeSettings()
   // audio settings
   // audio volume setting
   m_volume = g_application.GetVolumeRatio();
-  std::shared_ptr<CSettingNumber> settingAudioVolume = AddSlider(groupAudio, SETTING_AUDIO_VOLUME, 13376, SettingLevel::Basic, m_volume, 14054, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM);
+  std::shared_ptr<CSettingNumber> settingAudioVolume =
+      AddSlider(groupAudio, SETTING_AUDIO_VOLUME, 13376, SettingLevel::Basic, m_volume, 14054,
+                CApplicationVolumeHandling::VOLUME_MINIMUM,
+                CApplicationVolumeHandling::VOLUME_MAXIMUM / 100.0f,
+                CApplicationVolumeHandling::VOLUME_MAXIMUM);
   settingAudioVolume->SetDependencies(depsAudioOutputPassthroughDisabled);
   std::static_pointer_cast<CSettingControlSlider>(settingAudioVolume->GetControl())->SetFormatter(SettingFormatterPercentAsDecibel);
 


### PR DESCRIPTION
## Description
Move application handling of volume management to separate class

## Motivation and context
Reduce complexity of Application.cpp

## How has this been tested?
Kodi runs, I can still change volume.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
