### PR TITLE
[gui] Implemented movingspeed to mover/resize controls

### DIFF
--- a/addons/skin.estouchy/xml/SettingsScreenCalibration.xml
+++ b/addons/skin.estouchy/xml/SettingsScreenCalibration.xml
@@ -47,6 +47,12 @@
 			<height>128</height>
 			<texturefocus>calibrate_top.png</texturefocus>
 			<texturenofocus colordiffuse="grey3">calibrate_top.png</texturenofocus>
+			<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+				<eventconfig type="up" />
+				<eventconfig type="down" />
+				<eventconfig type="left" />
+				<eventconfig type="right" />
+			</movingspeed>
 		</control>
 		<control type="mover" id="9">
 			<description>right bottom mover</description>
@@ -56,6 +62,12 @@
 			<height>128</height>
 			<texturefocus>calibrate_bottom.png</texturefocus>
 			<texturenofocus colordiffuse="grey3">calibrate_bottom.png</texturenofocus>
+			<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+				<eventconfig type="up" />
+				<eventconfig type="down" />
+				<eventconfig type="left" />
+				<eventconfig type="right" />
+			</movingspeed>
 		</control>
 		<control type="resize" id="11">
 			<description>pixel aspect ratio box</description>
@@ -65,6 +77,10 @@
 			<height>500</height>
 			<texturefocus>calibrate_aspect.png</texturefocus>
 			<texturenofocus colordiffuse="grey3">calibrate_aspect.png</texturenofocus>
+			<movingspeed acceleration="140" maxvelocity="300" resettimeout="180" delta="1">
+				<eventconfig type="left" />
+				<eventconfig type="right" />
+			</movingspeed>
 		</control>
 		<control type="mover" id="10">
 			<description>subtitle position mover</description>
@@ -75,6 +91,10 @@
 			<!-- NOTE: The image must have 40px of trasparent on top and bottom the bar -->
 			<texturefocus>calibrate_subtitles.png</texturefocus>
 			<texturenofocus colordiffuse="grey3">calibrate_subtitles.png</texturenofocus>
+			<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+				<eventconfig type="up" />
+				<eventconfig type="down" />
+			</movingspeed>
 		</control>
 		<control type="mover" id="12">
 			<description>reset calibration</description>

--- a/addons/skin.estuary/xml/SettingsScreenCalibration.xml
+++ b/addons/skin.estuary/xml/SettingsScreenCalibration.xml
@@ -11,6 +11,12 @@
 			<height>128</height>
 			<texturefocus colordiffuse="button_focus">calibrate/cal_tl.png</texturefocus>
 			<texturenofocus>calibrate/cal_tl.png</texturenofocus>
+			<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+				<eventconfig type="up" />
+				<eventconfig type="down" />
+				<eventconfig type="left" />
+				<eventconfig type="right" />
+			</movingspeed>
 		</control>
 		<control type="mover" id="9">
 			<description>right bottom mover</description>
@@ -20,6 +26,12 @@
 			<height>128</height>
 			<texturefocus colordiffuse="button_focus">calibrate/cal_br.png</texturefocus>
 			<texturenofocus>calibrate/cal_br.png</texturenofocus>
+			<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+				<eventconfig type="up" />
+				<eventconfig type="down" />
+				<eventconfig type="left" />
+				<eventconfig type="right" />
+			</movingspeed>
 		</control>
 		<control type="resize" id="11">
 			<description>pixel aspect ratio</description>
@@ -29,6 +41,10 @@
 			<height>500</height>
 			<texturefocus colordiffuse="button_focus">calibrate/cal_ratio.png</texturefocus>
 			<texturenofocus>calibrate/cal_ratio.png</texturenofocus>
+			<movingspeed acceleration="140" maxvelocity="300" resettimeout="180" delta="1">
+				<eventconfig type="left" />
+				<eventconfig type="right" />
+			</movingspeed>
 		</control>
 		<control type="mover" id="10">
 			<description>subtitle position mover</description>
@@ -39,6 +55,10 @@
 			<!-- NOTE: The image must have 40px of trasparent on top and bottom the bar -->
 			<texturefocus colordiffuse="button_focus">calibrate/cal_sub.png</texturefocus>
 			<texturenofocus>calibrate/cal_sub.png</texturenofocus>
+			<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+				<eventconfig type="up" />
+				<eventconfig type="down" />
+			</movingspeed>
 		</control>
 		<control type="mover" id="12">
 			<description>reset calibration</description>

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -55,6 +55,7 @@
 #include "utils/RssManager.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
+#include "utils/log.h"
 
 using namespace KODI;
 using namespace KODI::GUILIB;
@@ -660,6 +661,51 @@ std::string CGUIControlFactory::GetType(const TiXmlElement *pControlNode)
   return type;
 }
 
+bool CGUIControlFactory::GetMovingSpeedConfig(const TiXmlNode* pRootNode,
+                                              const char* strTag,
+                                              UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg)
+{
+  const TiXmlElement* msNode = pRootNode->FirstChildElement(strTag);
+  if (!msNode)
+    return false;
+
+  float globalAccel{StringUtils::ToFloat(XMLUtils::GetAttribute(msNode, "acceleration"))};
+  float globalMaxVel{StringUtils::ToFloat(XMLUtils::GetAttribute(msNode, "maxvelocity"))};
+  uint32_t globalResetTimeout{
+      StringUtils::ToUint32(XMLUtils::GetAttribute(msNode, "resettimeout"))};
+  float globalDelta{StringUtils::ToFloat(XMLUtils::GetAttribute(msNode, "delta"))};
+
+  const TiXmlElement* configElement{msNode->FirstChildElement("eventconfig")};
+  while (configElement)
+  {
+    const char* eventType = configElement->Attribute("type");
+    if (!eventType)
+    {
+      CLog::LogF(LOGERROR, "Failed to parse XML \"eventconfig\" tag missing \"type\" attribute");
+      continue;
+    }
+
+    const char* accelerationStr{configElement->Attribute("acceleration")};
+    float acceleration = accelerationStr ? StringUtils::ToFloat(accelerationStr) : globalAccel;
+
+    const char* maxVelocityStr{configElement->Attribute("maxvelocity")};
+    float maxVelocity = maxVelocityStr ? StringUtils::ToFloat(maxVelocityStr) : globalMaxVel;
+
+    const char* resetTimeoutStr{configElement->Attribute("resettimeout")};
+    uint32_t resetTimeout =
+        resetTimeoutStr ? StringUtils::ToUint32(resetTimeoutStr) : globalResetTimeout;
+
+    const char* deltaStr{configElement->Attribute("delta")};
+    float delta = deltaStr ? StringUtils::ToFloat(deltaStr) : globalDelta;
+
+    UTILS::MOVING_SPEED::EventCfg eventCfg{acceleration, maxVelocity, resetTimeout, delta};
+    movingSpeedCfg.emplace(UTILS::MOVING_SPEED::ParseEventType(eventType), eventCfg);
+
+    configElement = configElement->NextSiblingElement("eventconfig");
+  }
+  return true;
+}
+
 CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlElement* pControlNode, bool insideContainer)
 {
   // get the control type
@@ -783,6 +829,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   bool resetOnLabelChange = true;
   bool bPassword = false;
   std::string visibleCondition;
+
+  UTILS::MOVING_SPEED::MapEventConfig movingSpeedCfg;
 
   /////////////////////////////////////////////////////////////////////////////
   // Read control properties from XML
@@ -1092,6 +1140,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetString(pControlNode, "scrollsuffix", labelInfo.scrollSuffix);
 
   XMLUtils::GetString(pControlNode, "action", action);
+
+  GetMovingSpeedConfig(pControlNode, "movingspeed", movingSpeedCfg);
 
   /////////////////////////////////////////////////////////////////////////////
   // Instantiate a new control using the properties gathered above
@@ -1460,16 +1510,14 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     break;
   case CGUIControl::GUICONTROL_MOVER:
     {
-      control = new CGUIMoverControl(
-        parentID, id, posX, posY, width, height,
-        textureFocus, textureNoFocus);
+      control = new CGUIMoverControl(parentID, id, posX, posY, width, height, textureFocus,
+                                     textureNoFocus, movingSpeedCfg);
     }
     break;
   case CGUIControl::GUICONTROL_RESIZE:
     {
-      control = new CGUIResizeControl(
-        parentID, id, posX, posY, width, height,
-        textureFocus, textureNoFocus);
+      control = new CGUIResizeControl(parentID, id, posX, posY, width, height, textureFocus,
+                                      textureNoFocus, movingSpeedCfg);
     }
     break;
   case CGUIControl::GUICONTROL_SPINEX:

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -15,6 +15,7 @@
 
 #include "GUIControl.h"
 #include "utils/ColorUtils.h"
+#include "utils/MovingSpeed.h"
 
 #include <string>
 #include <vector>
@@ -101,6 +102,9 @@ public:
   static bool GetScroller(const TiXmlNode *pControlNode, const std::string &scrollerTag, CScroller& scroller);
 private:
   static std::string GetType(const TiXmlElement *pControlNode);
+  static bool GetMovingSpeedConfig(const TiXmlNode* pRootNode,
+                                   const char* strTag,
+                                   UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg);
   static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition, std::string &allowHiddenFocus);
   bool GetString(const TiXmlNode* pRootNode, const char* strTag, std::string& strString);
   static bool GetFloatRange(const TiXmlNode* pRootNode, const char* strTag, float& iMinValue, float& iMaxValue, float& iIntervalValue);

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -12,8 +12,7 @@
 #include "input/Key.h"
 #include "utils/TimeUtils.h"
 
-// time to reset accelerated cursors (digital movement)
-#define MOVE_TIME_OUT 500L
+using namespace UTILS;
 
 CGUIMoverControl::CGUIMoverControl(int parentID,
                                    int controlID,
@@ -22,17 +21,15 @@ CGUIMoverControl::CGUIMoverControl(int parentID,
                                    float width,
                                    float height,
                                    const CTextureInfo& textureFocus,
-                                   const CTextureInfo& textureNoFocus)
+                                   const CTextureInfo& textureNoFocus,
+                                   UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg)
   : CGUIControl(parentID, controlID, posX, posY, width, height),
     m_imgFocus(CGUITexture::CreateTexture(posX, posY, width, height, textureFocus)),
     m_imgNoFocus(CGUITexture::CreateTexture(posX, posY, width, height, textureNoFocus))
 {
   m_frameCounter = 0;
-  m_lastMoveTime = 0;
-  m_fSpeed = 1.0;
+  m_movingSpeed.AddEventMapConfig(movingSpeedCfg);
   m_fAnalogSpeed = 2.0f; //! @todo implement correct analog speed
-  m_fAcceleration = 0.2f; //! @todo implement correct computation of acceleration
-  m_fMaxSpeed = 10.0;  //! @todo implement correct computation of maxspeed
   ControlType = GUICONTROL_MOVER;
   SetLimits(0, 0, 720, 576); // defaults
   SetLocation(0, 0, false);  // defaults
@@ -43,16 +40,13 @@ CGUIMoverControl::CGUIMoverControl(const CGUIMoverControl& control)
     m_imgFocus(control.m_imgFocus->Clone()),
     m_imgNoFocus(control.m_imgNoFocus->Clone()),
     m_frameCounter(control.m_frameCounter),
-    m_lastMoveTime(control.m_lastMoveTime),
-    m_nDirection(control.m_nDirection),
-    m_fSpeed(control.m_fSpeed),
+    m_movingSpeed(control.m_movingSpeed),
     m_fAnalogSpeed(control.m_fAnalogSpeed),
-    m_fMaxSpeed(control.m_fMaxSpeed),
-    m_fAcceleration(control.m_fAcceleration),
     m_iX1(control.m_iX1),
     m_iX2(control.m_iX2),
     m_iY1(control.m_iY1),
     m_iY2(control.m_iY2),
+    m_iLocationX(control.m_iLocationX),
     m_iLocationY(control.m_iLocationY)
 {
 }
@@ -130,29 +124,25 @@ bool CGUIMoverControl::OnAction(const CAction &action)
 void CGUIMoverControl::OnUp()
 {
   // if (m_dwAllowedDirections == ALLOWED_DIRECTIONS_LEFTRIGHT) return;
-  UpdateSpeed(DIRECTION_UP);
-  Move(0, (int) - m_fSpeed);
+  Move(0, -static_cast<int>(m_movingSpeed.GetUpdatedDistance(MOVING_SPEED::EventType::UP)));
 }
 
 void CGUIMoverControl::OnDown()
 {
   // if (m_dwAllowedDirections == ALLOWED_DIRECTIONS_LEFTRIGHT) return;
-  UpdateSpeed(DIRECTION_DOWN);
-  Move(0, (int)m_fSpeed);
+  Move(0, static_cast<int>(m_movingSpeed.GetUpdatedDistance(MOVING_SPEED::EventType::DOWN)));
 }
 
 void CGUIMoverControl::OnLeft()
 {
   // if (m_dwAllowedDirections == ALLOWED_DIRECTIONS_UPDOWN) return;
-  UpdateSpeed(DIRECTION_LEFT);
-  Move((int) - m_fSpeed, 0);
+  Move(-static_cast<int>(m_movingSpeed.GetUpdatedDistance(MOVING_SPEED::EventType::LEFT)), 0);
 }
 
 void CGUIMoverControl::OnRight()
 {
   // if (m_dwAllowedDirections == ALLOWED_DIRECTIONS_UPDOWN) return;
-  UpdateSpeed(DIRECTION_RIGHT);
-  Move((int)m_fSpeed, 0);
+  Move(static_cast<int>(m_movingSpeed.GetUpdatedDistance(MOVING_SPEED::EventType::RIGHT)), 0);
 }
 
 EVENT_RESULT CGUIMoverControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
@@ -173,26 +163,6 @@ EVENT_RESULT CGUIMoverControl::OnMouseEvent(const CPoint &point, const CMouseEve
     return EVENT_RESULT_HANDLED;
   }
   return EVENT_RESULT_UNHANDLED;
-}
-
-void CGUIMoverControl::UpdateSpeed(int nDirection)
-{
-  if (CTimeUtils::GetFrameTime() - m_lastMoveTime > MOVE_TIME_OUT)
-  {
-    m_fSpeed = 1;
-    m_nDirection = DIRECTION_NONE;
-  }
-  m_lastMoveTime = CTimeUtils::GetFrameTime();
-  if (nDirection == m_nDirection)
-  { // accelerate
-    m_fSpeed += m_fAcceleration;
-    if (m_fSpeed > m_fMaxSpeed) m_fSpeed = m_fMaxSpeed;
-  }
-  else
-  { // reset direction and speed
-    m_fSpeed = 1;
-    m_nDirection = nDirection;
-  }
 }
 
 void CGUIMoverControl::AllocResources()

--- a/xbmc/guilib/GUIMoverControl.dox
+++ b/xbmc/guilib/GUIMoverControl.dox
@@ -22,6 +22,12 @@ choose the size and look of the mover control.
       <texturefocus>mytexture.png</texturefocus>
       <texturenofocus>mytexture.png</texturenofocus>
       <pulseonselect>true</pulseonselect>
+      <movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+            <eventconfig type="up">
+            <eventconfig type="down">
+            <eventconfig type="left" acceleration="100" maxvelocity="100" resettimeout="160" delta="1">
+            <eventconfig type="right" acceleration="100" maxvelocity="100" resettimeout="160" delta="1">
+      </movingspeed>
 </control>
 ~~~~~~~~~~~~~
 
@@ -37,10 +43,46 @@ important, as xml tags are case-sensitive.
 |----------------:|:--------------------------------------------------------------|
 | texturefocus    | Specifies the image file which should be displayed when the mover has focus. [See here for additional information about textures](http://kodi.wiki/view/Texture_Attributes).
 | texturenofocus  | Specifies the image file which should be displayed when the mover does not have focus.
+| movingspeed     | Specifies the allowed directional movements and respective configurations. The <c>`<movingspeed>`</c> tag section can contain as many <c>`<eventconfig>`</c> tags as required.
 
 
 --------------------------------------------------------------------------------
-\section Mover_Control_sect3 See also
+\section Mover_Control_sect3 Note on use of movingspeed tag
+
+The <c>`movingspeed`</c> tag must be specified to allow the control to be moved via
+an input device such as keyboard. Each direction can be specified and configured
+to simulate the motion effect with the <c>`eventconfig`</c> tag.
+
+The following attributes allow the motion effect of the control to be configured:
+
+| Attribute       | Description                                                   |
+|----------------:|:--------------------------------------------------------------|
+| type            | Specifies the direction of movement. Accepted values are: <c>`up`</c>, <c>`down`</c>, <c>`left`</c>, <c>`right`</c>. All directions are optional and do not have to be included.
+| acceleration    | Specifies the acceleration in pixels per second (integer value).
+| maxvelocity     | Specifies the maximum movement speed. This depends on the acceleration value, e.g. a suitable value could be (acceleration value)*3. Set to 0 to disable. (integer value).
+| resettimeout    | Specifies the idle timeout before resetting the acceleration speed (in milliseconds, integer value).
+| delta           | Specifies the minimal pixel increment step (integer value).
+
+The attributes <c>`acceleration`</c>, <c>`maxvelocity`</c>, <c>`resettimeout`</c>,
+<c>`delta`</c> can be specified individually for each <c>`eventconfig`</c> tag,
+or globally in the <c>`movingspeed`</c> tag, or a mixture, as the following example:
+
+~~~~~~~~~~~~~
+<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+    <eventconfig type="up">
+    <eventconfig type="down">
+    <eventconfig type="left" acceleration="100" maxvelocity="100" resettimeout="160">
+    <eventconfig type="right" acceleration="100" maxvelocity="100" resettimeout="160">
+</movingspeed>
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\section Mover_Control_sect4 Revision History
+
+@skinning_v20 <b>[movingspeed]</b> New tag added.
+
+--------------------------------------------------------------------------------
+\section Mover_Control_sect5 See also
 
 #### Development:
 

--- a/xbmc/guilib/GUIMoverControl.h
+++ b/xbmc/guilib/GUIMoverControl.h
@@ -15,16 +15,11 @@
 
 #include "GUIControl.h"
 #include "GUITexture.h"
+#include "utils/MovingSpeed.h"
 
 #define ALLOWED_DIRECTIONS_ALL   0
 #define ALLOWED_DIRECTIONS_UPDOWN  1
 #define ALLOWED_DIRECTIONS_LEFTRIGHT 2
-
-#define DIRECTION_NONE 0
-#define DIRECTION_UP 1
-#define DIRECTION_DOWN 2
-#define DIRECTION_LEFT 3
-#define DIRECTION_RIGHT 4
 
 /*!
  \ingroup controls
@@ -33,9 +28,15 @@
 class CGUIMoverControl : public CGUIControl
 {
 public:
-  CGUIMoverControl(int parentID, int controlID,
-                   float posX, float posY, float width, float height,
-                   const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus);
+  CGUIMoverControl(int parentID,
+                   int controlID,
+                   float posX,
+                   float posY,
+                   float width,
+                   float height,
+                   const CTextureInfo& textureFocus,
+                   const CTextureInfo& textureNoFocus,
+                   UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg);
 
   ~CGUIMoverControl(void) override = default;
   CGUIMoverControl* Clone() const override { return new CGUIMoverControl(*this); }
@@ -62,19 +63,14 @@ protected:
   EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event) override;
   bool UpdateColors(const CGUIListItem* item) override;
   bool SetAlpha(unsigned char alpha);
-  void UpdateSpeed(int nDirection);
   void Move(int iX, int iY);
   std::unique_ptr<CGUITexture> m_imgFocus;
   std::unique_ptr<CGUITexture> m_imgNoFocus;
   unsigned int m_frameCounter;
-  unsigned int m_lastMoveTime;
-  int m_nDirection;
-  float m_fSpeed;
   float m_fAnalogSpeed;
-  float m_fMaxSpeed;
-  float m_fAcceleration;
   int m_iX1, m_iX2, m_iY1, m_iY2;
   int m_iLocationX, m_iLocationY;
+  UTILS::MOVING_SPEED::CMovingSpeed m_movingSpeed;
 
 private:
   CGUIMoverControl(const CGUIMoverControl& control);

--- a/xbmc/guilib/GUIResizeControl.dox
+++ b/xbmc/guilib/GUIResizeControl.dox
@@ -23,6 +23,12 @@ the resizer.
       <texturefocus>mytexture.png</texturefocus>
       <texturenofocus>mytexture.png</texturenofocus>
       <pulseonselect>true</pulseonselect>
+      <movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+            <eventconfig type="up">
+            <eventconfig type="down">
+            <eventconfig type="left" acceleration="100" maxvelocity="100" resettimeout="160" delta="1">
+            <eventconfig type="right" acceleration="100" maxvelocity="100" resettimeout="160" delta="1">
+      </movingspeed>
 </control>
 ~~~~~~~~~~~~~
 
@@ -38,10 +44,46 @@ important, as `xml` tags are case-sensitive.
 |----------------:|:--------------------------------------------------------------|
 | texturefocus    | Specifies the image file which should be displayed when the resizer has focus. [See here for additional information about textures](http://kodi.wiki/view/Texture_Attributes).
 | texturenofocus  | Specifies the image file which should be displayed when the resizer does not have focus.
+| movingspeed     | Specifies the allowed directional movements and respective configurations. The <c>`<movingspeed>`</c> tag section can contain as many <c>`<eventconfig>`</c> tags as required.
 
 
 --------------------------------------------------------------------------------
-\section Resize_Control_sect3 See also
+\section Resize_Control_sect3 Note on use of movingspeed tag
+
+The <c>`movingspeed`</c> tag must be specified to allow the control to be moved via
+an input device such as keyboard. Each direction can be specified and configured
+to simulate the motion effect with the <c>`eventconfig`</c> tag.
+
+The following attributes allow the motion effect of the control to be configured:
+
+| Attribute       | Description                                                   |
+|----------------:|:--------------------------------------------------------------|
+| type            | Specifies the direction of movement. Accepted values are: <c>`up`</c>, <c>`down`</c>, <c>`left`</c>, <c>`right`</c>. All directions are optional and do not have to be included.
+| acceleration    | Specifies the acceleration in pixels per second (integer value).
+| maxvelocity     | Specifies the maximum movement speed. This depends on the acceleration value, e.g. a suitable value could be (acceleration value)*3. Set to 0 to disable. (integer value).
+| resettimeout    | Specifies the idle timeout before resetting the acceleration speed (in milliseconds, integer value).
+| delta           | Specifies the minimal pixel increment step (integer value).
+
+The attributes <c>`acceleration`</c>, <c>`maxvelocity`</c>, <c>`resettimeout`</c>,
+<c>`delta`</c> can be specified individually for each <c>`eventconfig`</c> tag,
+or globally in the <c>`movingspeed`</c> tag, or a mixture, as the following example:
+
+~~~~~~~~~~~~~
+<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
+    <eventconfig type="up">
+    <eventconfig type="down">
+    <eventconfig type="left" acceleration="100" maxvelocity="100" resettimeout="160">
+    <eventconfig type="right" acceleration="100" maxvelocity="100" resettimeout="160">
+</movingspeed>
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\section Resize_Control_sect4 Revision History
+
+@skinning_v20 <b>[movingspeed]</b> New tag added.
+
+--------------------------------------------------------------------------------
+\section Resize_Control_sect5 See also
 
 #### Development:
 

--- a/xbmc/guilib/GUIResizeControl.h
+++ b/xbmc/guilib/GUIResizeControl.h
@@ -15,12 +15,7 @@
 
 #include "GUIControl.h"
 #include "GUITexture.h"
-
-#define DIRECTION_NONE 0
-#define DIRECTION_UP 1
-#define DIRECTION_DOWN 2
-#define DIRECTION_LEFT 3
-#define DIRECTION_RIGHT 4
+#include "utils/MovingSpeed.h"
 
 /*!
  \ingroup controls
@@ -29,9 +24,15 @@
 class CGUIResizeControl : public CGUIControl
 {
 public:
-  CGUIResizeControl(int parentID, int controlID,
-                    float posX, float posY, float width, float height,
-                    const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus);
+  CGUIResizeControl(int parentID,
+                    int controlID,
+                    float posX,
+                    float posY,
+                    float width,
+                    float height,
+                    const CTextureInfo& textureFocus,
+                    const CTextureInfo& textureNoFocus,
+                    UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg);
 
   ~CGUIResizeControl() override = default;
   CGUIResizeControl* Clone() const override { return new CGUIResizeControl(*this); }
@@ -55,18 +56,13 @@ protected:
   EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event) override;
   bool UpdateColors(const CGUIListItem* item) override;
   bool SetAlpha(unsigned char alpha);
-  void UpdateSpeed(int nDirection);
   void Resize(float x, float y);
   std::unique_ptr<CGUITexture> m_imgFocus;
   std::unique_ptr<CGUITexture> m_imgNoFocus;
   unsigned int m_frameCounter;
-  unsigned int m_lastMoveTime;
-  int m_nDirection;
-  float m_fSpeed;
   float m_fAnalogSpeed;
-  float m_fMaxSpeed;
-  float m_fAcceleration;
   float m_x1, m_x2, m_y1, m_y2;
+  UTILS::MOVING_SPEED::CMovingSpeed m_movingSpeed;
 
 private:
   CGUIResizeControl(const CGUIResizeControl& control);

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include <stdint.h>
 #include <assert.h>
 #include <climits>
 #include <cmath>
+#include <stdint.h>
+#include <type_traits>
 
 #if defined(HAVE_SSE2) && defined(__SSE2__)
 #include <emmintrin.h>
@@ -198,6 +199,18 @@ namespace MathUtils
   inline bool FloatEquals(FloatT f1, FloatT f2, FloatT maxDelta)
   {
     return (std::abs(f2 - f1) < maxDelta);
+  }
+
+  /*!
+   * \brief Round a floating point number to nearest multiple
+   * \param value The value to round
+   * \param multiple The multiple
+   * \return The rounded value
+   */
+  template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+  inline T RoundF(const T value, const T multiple)
+  {
+    return value - std::fmod(value, multiple);
   }
 
 #if 0

--- a/xbmc/utils/MovingSpeed.cpp
+++ b/xbmc/utils/MovingSpeed.cpp
@@ -8,6 +8,7 @@
 
 #include "MovingSpeed.h"
 
+#include "utils/MathUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 
@@ -23,6 +24,14 @@ void UTILS::MOVING_SPEED::CMovingSpeed::AddEventConfig(uint32_t eventId,
 void UTILS::MOVING_SPEED::CMovingSpeed::AddEventConfig(uint32_t eventId, EventCfg event)
 {
   m_eventsData.emplace(eventId, EventData{event});
+}
+
+void UTILS::MOVING_SPEED::CMovingSpeed::AddEventMapConfig(MapEventConfig& configs)
+{
+  for (auto& cfg : configs)
+  {
+    AddEventConfig(static_cast<uint32_t>(cfg.first), cfg.second);
+  }
 }
 
 void UTILS::MOVING_SPEED::CMovingSpeed::Reset()
@@ -55,42 +64,59 @@ float UTILS::MOVING_SPEED::CMovingSpeed::GetUpdatedDistance(uint32_t eventId)
 
   if (mapEventIt == m_eventsData.end())
   {
-    CLog::LogF(LOGERROR, "No event configuration with event ID {}", eventId);
+    CLog::LogF(LOGDEBUG, "No event set for event ID {}", eventId);
     return 0;
   }
+
+  EventData& eventData = mapEventIt->second;
+  EventCfg& eventCfg = eventData.m_config;
+
+  uint32_t currentFrameTime{CTimeUtils::GetFrameTime()};
+  uint32_t deltaFrameTime{currentFrameTime - eventData.m_lastFrameTime};
+  float distance = (eventCfg.m_delta == 0.0f) ? 1.0f : eventCfg.m_delta;
+
+  if (eventData.m_lastFrameTime != 0 && deltaFrameTime > eventCfg.m_resetTimeout)
+  {
+    // If the delta time exceed the timeout then reset values
+    Reset(eventId);
+  }
+  else if (m_currentEventId != eventId)
+  {
+    // If the event id is changed then reset values
+    Reset(eventId);
+  }
+  else if (eventData.m_lastFrameTime != 0)
+  {
+    // Calculate the new speed based on time so as not to depend on the frame rate
+    eventData.m_currentVelocity +=
+        eventCfg.m_acceleration * (static_cast<float>(deltaFrameTime) / 1000);
+
+    if (eventCfg.m_maxVelocity > 0 && eventData.m_currentVelocity > eventCfg.m_maxVelocity)
+      eventData.m_currentVelocity = eventCfg.m_maxVelocity;
+
+    distance = eventData.m_currentVelocity * (static_cast<float>(deltaFrameTime) / 1000);
+    if (eventCfg.m_delta > 0.0f)
+      distance = MathUtils::RoundF(distance, eventCfg.m_delta);
+  }
+
+  m_currentEventId = eventId;
+  eventData.m_lastFrameTime = currentFrameTime;
+  return distance;
+}
+
+UTILS::MOVING_SPEED::EventType UTILS::MOVING_SPEED::ParseEventType(std::string_view eventType)
+{
+  if (eventType == "up")
+    return EventType::UP;
+  else if (eventType == "down")
+    return EventType::DOWN;
+  else if (eventType == "left")
+    return EventType::LEFT;
+  else if (eventType == "right")
+    return EventType::RIGHT;
   else
   {
-    EventData& eventData = mapEventIt->second;
-    EventCfg& eventCfg = eventData.m_config;
-
-    uint32_t currentFrameTime{CTimeUtils::GetFrameTime()};
-    uint32_t deltaFrameTime{currentFrameTime - eventData.m_lastFrameTime};
-    float distance{1};
-
-    if (eventData.m_lastFrameTime != 0 && deltaFrameTime > eventCfg.m_resetTimeout)
-    {
-      // If the delta time exceed the timeout then reset values
-      Reset(eventId);
-    }
-    else if (m_currentEventId != eventId)
-    {
-      // If the event id is changed then reset values
-      Reset(eventId);
-    }
-    else if (eventData.m_lastFrameTime != 0)
-    {
-      // Calculate the new speed based on time so as not to depend on the frame rate
-      eventData.m_currentVelocity +=
-          eventCfg.m_acceleration * (static_cast<float>(deltaFrameTime) / 1000);
-
-      if (eventCfg.m_maxVelocity > 0 && eventData.m_currentVelocity > eventCfg.m_maxVelocity)
-        eventData.m_currentVelocity = eventCfg.m_maxVelocity;
-
-      distance = eventData.m_currentVelocity * (static_cast<float>(deltaFrameTime) / 1000);
-    }
-
-    m_currentEventId = eventId;
-    eventData.m_lastFrameTime = currentFrameTime;
-    return distance;
+    CLog::LogF(LOGERROR, "Unsupported event type \"{}\"", eventType);
+    return EventType::NONE;
   }
 }

--- a/xbmc/utils/MovingSpeed.h
+++ b/xbmc/utils/MovingSpeed.h
@@ -10,11 +10,13 @@
 
 #include <map>
 #include <stdint.h>
+#include <string_view>
 
 namespace UTILS
 {
 namespace MOVING_SPEED
 {
+
 struct EventCfg
 {
   /*!
@@ -28,10 +30,38 @@ struct EventCfg
   {
   }
 
+  /*!
+   * \param acceleration Acceleration in pixels per second (px/sec)
+   * \param maxVelocity Max movement speed, it depends from acceleration value,
+   *        a suitable value could be (acceleration value)*3. Set 0 to disable it
+   * \param resetTimeout Resets acceleration speed if idle for specified millisecs
+   * \param delta Specify the minimal increment step, and the result of distance
+            value will be rounded by delta. Set 0 to disable it
+   */
+  EventCfg(float acceleration, float maxVelocity, uint32_t resetTimeout, float delta)
+    : m_acceleration{acceleration},
+      m_maxVelocity{maxVelocity},
+      m_resetTimeout{resetTimeout},
+      m_delta{delta}
+  {
+  }
+
   float m_acceleration;
   float m_maxVelocity;
   uint32_t m_resetTimeout;
+  float m_delta{0};
 };
+
+enum class EventType
+{
+  NONE = 0,
+  UP,
+  DOWN,
+  LEFT,
+  RIGHT
+};
+
+typedef std::map<EventType, EventCfg> MapEventConfig;
 
 /*!
  * \brief Class to calculate the velocity for a motion effect.
@@ -57,9 +87,16 @@ public:
 
   /*!
    * \brief Add the configuration for an event
+   * \param eventId The id for the event, must be unique
    * \param event The event configuration
    */
   void AddEventConfig(uint32_t eventId, EventCfg event);
+
+  /*!
+   * \brief Add a map of events configuration
+   * \param configs The map of events configuration where key value is event id, 
+   */
+  void AddEventMapConfig(MapEventConfig& configs);
 
   /*!
    * \brief Reset stored velocity to all events
@@ -80,6 +117,16 @@ public:
    */
   float GetUpdatedDistance(uint32_t eventId);
 
+  /*!
+   * \brief Get the updated distance based on acceleration speed
+   * \param eventType The event type to handle
+   * \return The distance
+   */
+  float GetUpdatedDistance(EventType eventType)
+  {
+    return GetUpdatedDistance(static_cast<uint32_t>(eventType));
+  }
+
 private:
   struct EventData
   {
@@ -93,6 +140,13 @@ private:
   uint32_t m_currentEventId{0};
   std::map<uint32_t, EventData> m_eventsData;
 };
+
+/*!
+ * \brief Parse a string event type to enum EventType.
+ * \param eventType The event type as string
+ * \return The EventType if has success, otherwise EventType::NONE
+ */
+EventType ParseEventType(std::string_view eventType);
 
 } // namespace MOVING_SPEED
 } // namespace UTILS

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -53,6 +53,24 @@
 
 #define FORMAT_BLOCK_SIZE 512 // # of bytes for initial allocation for printf
 
+namespace
+{
+/*!
+ * \brief Converts a string to a number of a specified type, by using istringstream.
+ * \param str The string to convert
+ * \param fallback [OPT] The number to return when the conversion fails
+ * \return The converted number, otherwise fallback if conversion fails
+ */
+template<typename T>
+T NumberFromSS(std::string_view str, T fallback) noexcept
+{
+  std::istringstream iss{str.data()};
+  T result{fallback};
+  iss >> result;
+  return result;
+}
+} // unnamed namespace
+
 static constexpr const char* ADDON_GUID_RE = "^(\\{){0,1}[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}(\\}){0,1}$";
 
 /* empty string for use in returns by ref */
@@ -1819,12 +1837,19 @@ void StringUtils::Tokenize(const std::string& input, std::vector<std::string>& t
   }
 }
 
-uint64_t StringUtils::ToUint64(const std::string& str, uint64_t fallback) noexcept
+uint32_t StringUtils::ToUint32(std::string_view str, uint32_t fallback /* = 0 */) noexcept
 {
-  std::istringstream iss(str);
-  uint64_t result(fallback);
-  iss >> result;
-  return result;
+  return NumberFromSS(str, fallback);
+}
+
+uint64_t StringUtils::ToUint64(std::string_view str, uint64_t fallback /* = 0 */) noexcept
+{
+  return NumberFromSS(str, fallback);
+}
+
+float StringUtils::ToFloat(std::string_view str, float fallback /* = 0.0f */) noexcept
+{
+  return NumberFromSS(str, fallback);
 }
 
 std::string StringUtils::FormatFileSize(uint64_t bytes)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -366,7 +366,30 @@ public:
   static void Tokenize(const std::string& input, std::vector<std::string>& tokens, const std::string& delimiters);
   static std::vector<std::string> Tokenize(const std::string& input, const char delimiter);
   static void Tokenize(const std::string& input, std::vector<std::string>& tokens, const char delimiter);
-  static uint64_t ToUint64(const std::string& str, uint64_t fallback) noexcept;
+
+  /*!
+   * \brief Converts a string to a unsigned int number.
+   * \param str The string to convert
+   * \param fallback [OPT] The number to return when the conversion fails
+   * \return The converted number, otherwise fallback if conversion fails
+   */
+  static uint32_t ToUint32(std::string_view str, uint32_t fallback = 0) noexcept;
+
+  /*!
+   * \brief Converts a string to a unsigned long long number.
+   * \param str The string to convert
+   * \param fallback [OPT] The number to return when the conversion fails
+   * \return The converted number, otherwise fallback if conversion fails
+   */
+  static uint64_t ToUint64(std::string_view str, uint64_t fallback = 0) noexcept;
+
+  /*!
+   * \brief Converts a string to a float number.
+   * \param str The string to convert
+   * \param fallback [OPT] The number to return when the conversion fails
+   * \return The converted number, otherwise fallback if conversion fails
+   */
+  static float ToFloat(std::string_view str, float fallback = 0.0f) noexcept;
 
   /*!
    * Returns bytes in a human readable format using the smallest unit that will fit `bytes` in at


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Since a new class has been added to simulate the speed of movement `CMovingSpeed`, i have replaced the old implementation,
this implementation now allows much more control and can be configured through skin XML 

This will fix also the bug in Calibration window that when you move the pixel square, in some cases it is not possible to restore the value to 0. This is because pixels were considered with decimal values instead of integers.

### `movingspeed` tag
- Is the parent tag of the feature
- Can contains optionals global attribute values, that will be applied on each event type, unless otherwise specified in the children themselves
- Attributes supported: acceleration, maxvelocity, resettimeout, delta

### `eventconfig` tag
- Is the only child supported by `movingspeed` tag
- Attributes supported: type, acceleration, maxvelocity, resettimeout, delta
- Mandatory attribute is `type` 

### Tag attributes
`type`: The direction of movement, currently accepted values are: `up`, `down`, `left`, `right`
`acceleration`: Acceleration in pixels per second (px/sec) (int type)
`maxvelocity`: Max movement speed, it depends from acceleration value a suitable value could be (acceleration value)*3. Set 0 to disable it. (int type)
`resettimeout`: Will resets the acceleration speed if idle for specified millisecs (int type)
`delta`: Specify the minimal increment step can be as integer of float (for example for pixel movement we have to increment by 1 without decimals) (float or int type)

### Example 1
Example of global configuration applied to all moviments types except one (override global config):
```xml
<control type="mover" id="8">
...
	<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
		<eventconfig type="up" />
		<eventconfig type="down" />
		<eventconfig type="left" acceleration="100" maxvelocity="100" resettimeout="160" delta="1">
		<eventconfig type="right" />
	</movingspeed>
</control>
```
In this case the control can be moved in 4 directions

### Example 2
Set eventconfig without some attributes

```xml
<control type="mover" id="8">
...
	<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">
		<eventconfig type="left" acceleration="100" maxvelocity="100">
	</movingspeed>
</control>
```

These attributes `resettimeout` and `delta` since are not specified in `eventconfig` tag, will be taken from the global (if sets).
In this case the control can be moved in 1 direction only

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Mover and resize controls had incomplete implementation of speed simulation

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Calibration window is the only xml that use these controls

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
