### PR TITLE
[GUI][Info] Add Player.HasPerformedSeek(interval)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -889,7 +889,8 @@ const infomap player_labels[] = {{"hasmedia", PLAYER_HAS_MEDIA},
 ///     <p>
 ///   }
 
-const infomap player_param[] = {{"art", PLAYER_ITEM_ART}, {"hasperformedseek", PLAYER_HASSEEKED}};
+const infomap player_param[] = {{"art", PLAYER_ITEM_ART},
+                                {"hasperformedseek", PLAYER_HASPERFORMEDSEEK}};
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Player.SeekTime`</b>,

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -879,9 +879,17 @@ const infomap player_labels[] = {{"hasmedia", PLAYER_HAS_MEDIA},
 ///     while still making it clear they can have any value.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.HasPerformedSeek(interval)`</b>,
+///                  \anchor Player_HasPerformedSeek
+///                  _boolean_,
+///     @return **True** if the Player has performed a seek operation in the last provided second `interval`\, **False** otherwise.
+///     @param interval - the time interval (in seconds)
+///     <p><hr>
+///     @skinning_v20 **[New Boolean Condition]** \link Player_HasPerformedSeek `Player.HasPerformedSeek(interval)`\endlink
+///     <p>
+///   }
 
-
-const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
+const infomap player_param[] = {{"art", PLAYER_ITEM_ART}, {"hasperformedseek", PLAYER_HASSEEKED}};
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Player.SeekTime`</b>,

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -320,6 +320,24 @@ bool CDataCacheCore::IsRenderClockSync()
 }
 
 // player states
+void CDataCacheCore::SeekFinished()
+{
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  m_stateInfo.m_lastSeekTime = std::chrono::system_clock::now();
+}
+
+bool CDataCacheCore::HasPerformedSeek(int64_t lastSecondInterval) const
+{
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  if (m_stateInfo.m_lastSeekTime == std::chrono::time_point<std::chrono::system_clock>{})
+  {
+    return false;
+  }
+  return (std::chrono::system_clock::now() - m_stateInfo.m_lastSeekTime) <
+         std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::duration<int64_t>(lastSecondInterval));
+}
+
 void CDataCacheCore::SetStateSeeking(bool active)
 {
   std::unique_lock<CCriticalSection> lock(m_stateSection);

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -320,10 +320,17 @@ bool CDataCacheCore::IsRenderClockSync()
 }
 
 // player states
-void CDataCacheCore::SeekFinished()
+void CDataCacheCore::SeekFinished(int64_t offset)
 {
   std::unique_lock<CCriticalSection> lock(m_stateSection);
   m_stateInfo.m_lastSeekTime = std::chrono::system_clock::now();
+  m_stateInfo.m_lastSeekOffset = offset;
+}
+
+int64_t CDataCacheCore::GetSeekOffSet() const
+{
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  return m_stateInfo.m_lastSeekOffset;
 }
 
 bool CDataCacheCore::HasPerformedSeek(int64_t lastSecondInterval) const

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -12,9 +12,9 @@
 #include "threads/CriticalSection.h"
 
 #include <atomic>
+#include <chrono>
 #include <string>
 #include <vector>
-
 
 class CDataCacheCore
 {
@@ -119,8 +119,21 @@ public:
   bool IsRenderClockSync();
 
   // player states
+  /*!
+   * @brief Notifies the cache core that a seek operation has finished
+  */
+  void SeekFinished();
+
   void SetStateSeeking(bool active);
   bool IsSeeking();
+
+  /*!
+   * @brief Checks if a seek has been performed in the last provided seconds interval
+   * @param lastSecondInterval - the last elapsed second interval to check for a seek operation
+   * @return true if a seek was performed in the lastSecondInterval, false otherwise
+  */
+  bool HasPerformedSeek(int64_t lastSecondInterval) const;
+
   void SetSpeed(float tempo, float speed);
   float GetSpeed();
   float GetTempo();
@@ -288,7 +301,7 @@ protected:
     bool m_isClockSync;
   } m_renderInfo;
 
-  CCriticalSection m_stateSection;
+  mutable CCriticalSection m_stateSection;
   bool m_playerStateChanged = false;
   struct SStateInfo
   {
@@ -298,6 +311,9 @@ protected:
     float m_tempo;
     float m_speed;
     bool m_frameAdvance;
+    /*! Time point of the last seek operation */
+    std::chrono::time_point<std::chrono::system_clock> m_lastSeekTime{
+        std::chrono::time_point<std::chrono::system_clock>{}};
   } m_stateInfo;
 
   struct STimeInfo

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -121,8 +121,9 @@ public:
   // player states
   /*!
    * @brief Notifies the cache core that a seek operation has finished
+   * @param offset - the seek offset
   */
-  void SeekFinished();
+  void SeekFinished(int64_t offset);
 
   void SetStateSeeking(bool active);
   bool IsSeeking();
@@ -133,6 +134,12 @@ public:
    * @return true if a seek was performed in the lastSecondInterval, false otherwise
   */
   bool HasPerformedSeek(int64_t lastSecondInterval) const;
+
+  /*!
+   * @brief Gets the last seek offset
+   * @return the last seek offset
+  */
+  int64_t GetSeekOffSet() const;
 
   void SetSpeed(float tempo, float speed);
   float GetSpeed();
@@ -314,6 +321,8 @@ protected:
     /*! Time point of the last seek operation */
     std::chrono::time_point<std::chrono::system_clock> m_lastSeekTime{
         std::chrono::time_point<std::chrono::system_clock>{}};
+    /*! Last seek offset */
+    int64_t m_lastSeekOffset{0};
   } m_stateInfo;
 
   struct STimeInfo

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -467,6 +467,13 @@ std::vector<AVPixelFormat> CProcessInfo::GetRenderFormats()
 //******************************************************************************
 // player states
 //******************************************************************************
+void CProcessInfo::SeekFinished()
+{
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  if (m_dataCache)
+    m_dataCache->SeekFinished();
+}
+
 void CProcessInfo::SetStateSeeking(bool active)
 {
   std::unique_lock<CCriticalSection> lock(m_renderSection);

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -467,11 +467,11 @@ std::vector<AVPixelFormat> CProcessInfo::GetRenderFormats()
 //******************************************************************************
 // player states
 //******************************************************************************
-void CProcessInfo::SeekFinished()
+void CProcessInfo::SeekFinished(int64_t offset)
 {
   std::unique_lock<CCriticalSection> lock(m_stateSection);
   if (m_dataCache)
-    m_dataCache->SeekFinished();
+    m_dataCache->SeekFinished(offset);
 }
 
 void CProcessInfo::SetStateSeeking(bool active)

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -82,6 +82,11 @@ public:
   virtual std::vector<AVPixelFormat> GetRenderFormats();
 
   // player states
+  /*!
+   * @brief Notifies that a seek operation has finished
+  */
+  void SeekFinished();
+
   void SetStateSeeking(bool active);
   bool IsSeeking();
   void SetStateRealtime(bool state);

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -84,8 +84,9 @@ public:
   // player states
   /*!
    * @brief Notifies that a seek operation has finished
+   * @param offset - the seek offset
   */
-  void SeekFinished();
+  void SeekFinished(int64_t offset);
 
   void SetStateSeeking(bool active);
   bool IsSeeking();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2623,7 +2623,7 @@ void CVideoPlayer::HandleMessages()
       if (!msg.GetTrickPlay())
       {
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         SetCaching(CACHESTATE_FLUSH);
       }
 
@@ -2682,7 +2682,7 @@ void CVideoPlayer::HandleMessages()
       if(!msg.GetTrickPlay())
       {
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
       }
 
       // dvd's will issue a HOP_CHANNEL that we need to skip
@@ -2696,7 +2696,7 @@ void CVideoPlayer::HandleMessages()
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_SEEK_CHAPTER) == 0)
     {
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
-      m_processInfo->SeekFinished();
+      m_processInfo->SeekFinished(0);
       SetCaching(CACHESTATE_FLUSH);
 
       CDVDMsgPlayerSeekChapter& msg(*std::static_pointer_cast<CDVDMsgPlayerSeekChapter>(pMsg));
@@ -2722,7 +2722,7 @@ void CVideoPlayer::HandleMessages()
           m_callback.OnPlayBackSeekChapter(msg.GetChapter());
         }
       }
-      m_processInfo->SeekFinished();
+      m_processInfo->SeekFinished(offset);
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(2500, offset);
     }
     else if (pMsg->IsType(CDVDMsg::DEMUXER_RESET))
@@ -2867,7 +2867,7 @@ void CVideoPlayer::HandleMessages()
         }
       }
 
-      m_processInfo->SeekFinished();
+      m_processInfo->SeekFinished(0);
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
@@ -2896,7 +2896,7 @@ void CVideoPlayer::HandleMessages()
       if (speed != DVD_PLAYSPEED_PAUSE && m_playSpeed != DVD_PLAYSPEED_PAUSE && speed != m_playSpeed)
       {
         m_callback.OnPlayBackSpeedChanged(speed / DVD_PLAYSPEED_NORMAL);
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         // notify GUI, skins may want to show the seekbar
         CServiceBroker::GetGUI()->
           GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
@@ -3370,6 +3370,7 @@ void CVideoPlayer::SeekTime(int64_t iTime)
   m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
   SynchronizeDemuxer();
   m_callback.OnPlayBackSeek(iTime, seekOffset);
+  m_processInfo->SeekFinished(seekOffset);
 }
 
 bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
@@ -3398,6 +3399,7 @@ bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
   m_processInfo->SetStateSeeking(true);
 
   m_callback.OnPlayBackSeek(abstime, iTime);
+  m_processInfo->SeekFinished(iTime);
   return true;
 }
 
@@ -4250,7 +4252,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
         CLog::Log(LOGDEBUG, " - pushed prev");
         pMenus->OnPrevious();
         CServiceBroker::GetGUI()->GetInfoManager().SetDisplayAfterSeek();
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         return true;
       }
       break;
@@ -4260,7 +4262,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
         CLog::Log(LOGDEBUG, " - pushed next");
         pMenus->OnNext();
         CServiceBroker::GetGUI()->GetInfoManager().SetDisplayAfterSeek();
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         return true;
       }
       break;
@@ -4296,7 +4298,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
           pMenus->OnNext();
 
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         return true;
       case ACTION_PREV_ITEM:
         THREAD_ACTION(action);
@@ -4307,7 +4309,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
           pMenus->OnPrevious();
 
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         return true;
       case ACTION_PREVIOUS_MENU:
       case ACTION_NAV_BACK:
@@ -4421,7 +4423,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
       {
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() + 1));
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         return true;
       }
       else if (SeekScene(true))
@@ -4433,7 +4435,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
       {
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() - 1));
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
-        m_processInfo->SeekFinished();
+        m_processInfo->SeekFinished(0);
         return true;
       }
       else if (SeekScene(false))

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2623,6 +2623,7 @@ void CVideoPlayer::HandleMessages()
       if (!msg.GetTrickPlay())
       {
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
+        m_processInfo->SeekFinished();
         SetCaching(CACHESTATE_FLUSH);
       }
 
@@ -2679,7 +2680,10 @@ void CVideoPlayer::HandleMessages()
 
       // set flag to indicate we have finished a seeking request
       if(!msg.GetTrickPlay())
+      {
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
+        m_processInfo->SeekFinished();
+      }
 
       // dvd's will issue a HOP_CHANNEL that we need to skip
       if(m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
@@ -2692,6 +2696,7 @@ void CVideoPlayer::HandleMessages()
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_SEEK_CHAPTER) == 0)
     {
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
+      m_processInfo->SeekFinished();
       SetCaching(CACHESTATE_FLUSH);
 
       CDVDMsgPlayerSeekChapter& msg(*std::static_pointer_cast<CDVDMsgPlayerSeekChapter>(pMsg));
@@ -2717,6 +2722,7 @@ void CVideoPlayer::HandleMessages()
           m_callback.OnPlayBackSeekChapter(msg.GetChapter());
         }
       }
+      m_processInfo->SeekFinished();
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(2500, offset);
     }
     else if (pMsg->IsType(CDVDMsg::DEMUXER_RESET))
@@ -2861,6 +2867,7 @@ void CVideoPlayer::HandleMessages()
         }
       }
 
+      m_processInfo->SeekFinished();
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
@@ -2889,7 +2896,7 @@ void CVideoPlayer::HandleMessages()
       if (speed != DVD_PLAYSPEED_PAUSE && m_playSpeed != DVD_PLAYSPEED_PAUSE && speed != m_playSpeed)
       {
         m_callback.OnPlayBackSpeedChanged(speed / DVD_PLAYSPEED_NORMAL);
-
+        m_processInfo->SeekFinished();
         // notify GUI, skins may want to show the seekbar
         CServiceBroker::GetGUI()->
           GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
@@ -4243,6 +4250,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
         CLog::Log(LOGDEBUG, " - pushed prev");
         pMenus->OnPrevious();
         CServiceBroker::GetGUI()->GetInfoManager().SetDisplayAfterSeek();
+        m_processInfo->SeekFinished();
         return true;
       }
       break;
@@ -4252,6 +4260,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
         CLog::Log(LOGDEBUG, " - pushed next");
         pMenus->OnNext();
         CServiceBroker::GetGUI()->GetInfoManager().SetDisplayAfterSeek();
+        m_processInfo->SeekFinished();
         return true;
       }
       break;
@@ -4287,6 +4296,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
           pMenus->OnNext();
 
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
+        m_processInfo->SeekFinished();
         return true;
       case ACTION_PREV_ITEM:
         THREAD_ACTION(action);
@@ -4297,6 +4307,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
           pMenus->OnPrevious();
 
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
+        m_processInfo->SeekFinished();
         return true;
       case ACTION_PREVIOUS_MENU:
       case ACTION_NAV_BACK:
@@ -4410,6 +4421,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
       {
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() + 1));
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
+        m_processInfo->SeekFinished();
         return true;
       }
       else if (SeekScene(true))
@@ -4421,6 +4433,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
       {
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() - 1));
         CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
+        m_processInfo->SeekFinished();
         return true;
       }
       else if (SeekScene(false))

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -36,7 +36,7 @@
 #define PLAYER_TIME                  27
 #define PLAYER_TIME_REMAINING        28
 #define PLAYER_DURATION              29
-// unused 30
+#define PLAYER_HASPERFORMEDSEEK      30
 #define PLAYER_SHOWINFO              31
 #define PLAYER_VOLUME                32
 #define PLAYER_MUTED                 33

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -176,10 +176,12 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case PLAYER_SEEKOFFSET:
     {
-      std::string seekOffset = StringUtils::SecondsToTimeString(std::abs(m_seekOffset / 1000), static_cast<TIME_FORMAT>(info.GetData1()));
-      if (m_seekOffset < 0)
+      int lastSeekOffset = CServiceBroker::GetDataCacheCore().GetSeekOffSet();
+      std::string seekOffset = StringUtils::SecondsToTimeString(
+          std::abs(lastSeekOffset / 1000), static_cast<TIME_FORMAT>(info.GetData1()));
+      if (lastSeekOffset < 0)
         value = "-" + seekOffset;
-      else if (m_seekOffset > 0)
+      else if (lastSeekOffset > 0)
         value = "+" + seekOffset;
       return true;
     }

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -28,6 +28,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <charconv>
 #include <cmath>
 
 using namespace KODI::GUILIB::GUIINFO;
@@ -508,6 +509,21 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case PLAYER_SEEKING:
       value = g_application.GetAppPlayer().GetSeekHandler().InProgress();
       return true;
+    case PLAYER_HASPERFORMEDSEEK:
+    {
+      int requestedLastSecondInterval{0};
+      std::from_chars_result result =
+          std::from_chars(info.GetData3().data(), info.GetData3().data() + info.GetData3().size(),
+                          requestedLastSecondInterval);
+      if (result.ec == std::errc::invalid_argument)
+      {
+        value = false;
+        return false;
+      }
+
+      value = CServiceBroker::GetDataCacheCore().HasPerformedSeek(requestedLastSecondInterval);
+      return true;
+    }
     case PLAYER_PASSTHROUGH:
       value = g_application.GetAppPlayer().IsPassthrough();
       return true;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -493,6 +493,7 @@ void CUPnPPlayer::SeekTime(int64_t ms)
                                 , "REL_TIME", PLT_Didl::FormatTimeStamp((NPT_UInt32)(ms / 1000))
                                 , m_delegate), failed);
 
+  CDataCacheCore::GetInstance().SeekFinished();
   CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
   return;
 failed:

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -493,7 +493,7 @@ void CUPnPPlayer::SeekTime(int64_t ms)
                                 , "REL_TIME", PLT_Didl::FormatTimeStamp((NPT_UInt32)(ms / 1000))
                                 , m_delegate), failed);
 
-  CDataCacheCore::GetInstance().SeekFinished();
+  CDataCacheCore::GetInstance().SeekFinished(0);
   CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
   return;
 failed:


### PR DESCRIPTION
## Description
This PR adds a new info boolean condition: `Player.HasPerformedSeek(interval)`. It allows skins to display stuff or take actions if the player has performed a seek on the last provided second interval. For instance:

- `Player.HasPerformedSeek(1)` returns true if the player has performed a seek in the last second.
- `Player.HasPerformedSeek(3)` returns true if the player has performed a seek in the last 3 seconds.

## Motivation and context
To be able to remove the `Player.DisplayAfterSeek` and the respective VideoPlayer dependency on GUI/GUIInfo we need to have a way of checking, from the skin, if a seek has happened - or in other words, to signal the end of a seek operation. 

Removing `Player.DisplayAfterSeek`  will be made possible with skin timers: we'll be able to display something for a predefined amount of time giving that we have a way to start the timer after a seek (pretty much what this PR provides).

Note that since infobools are evaluated per frame, `Player.Seeking` is most of the time not an option. Sometimes the player just seeks internally (e.g. the case of chapters) or processes the seek on the same thread and in the context of the same loop process evaluation - leading `Player.Seeking` rather useless.

## How has this been tested?

with a label on a window
```
<control type="label">
  <left>25</left>
  <top>6</top>
  <width>700</width>
  <height>60</height>
  <label>Player has seeked</label>
  <visible>Player.HasPerformedSeek(2)</visible>
  <font>font30_title</font>
  <shadowcolor>black</shadowcolor>
</control>
```

## What is the effect on users?
Just a new infobool and the possibilities it opens. Will be able to do stuff depending on the player past behaviour.

