### PR TITLE
[Android] Fix: fallback to deprecated API mistakenly

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -609,10 +609,9 @@ void CXBMCApp::SetRefreshRateCallback(CVariant* rateVariant)
   CXBMCApp::Get().m_displayChangeEvent.Set();
 }
 
-void CXBMCApp::SetDisplayModeCallback(CVariant* variant)
+void CXBMCApp::SetDisplayModeCallback(CVariant* modeVariant)
 {
-  int mode = (*variant)["mode"].asInteger();
-  float rate = (*variant)["rate"].asFloat();
+  int mode = modeVariant->asInteger();
   delete variant;
 
   CJNIWindow window = getWindow();
@@ -622,7 +621,6 @@ void CXBMCApp::SetDisplayModeCallback(CVariant* variant)
     if (params.getpreferredDisplayModeId() != mode)
     {
       params.setpreferredDisplayModeId(mode);
-      params.setpreferredRefreshRate(rate);
       window.setAttributes(params);
       return;
     }
@@ -670,11 +668,8 @@ void CXBMCApp::SetDisplayMode(int mode, float rate)
   }
 
   m_displayChangeEvent.Reset();
-  std::map<std::string, CVariant> vmap;
-  vmap["mode"] = mode;
-  vmap["rate"] = rate;
   m_refreshRate = rate;
-  CVariant *variant = new CVariant(vmap);
+  CVariant *variant = new CVariant(mode);
   runNativeOnUiThread(SetDisplayModeCallback, variant);
   if (g_application.IsInitialized())
   {

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -81,46 +81,59 @@ static void fetchDisplayModes()
     CJNIDisplayMode m = display.getMode();
     if (m)
     {
-      if (m.getPhysicalWidth() > m.getPhysicalHeight())   // Assume unusable if portrait is returned
-      {
-        s_hasModeApi = true;
+      s_hasModeApi = true;
 
-        CLog::Log(LOGDEBUG, "CAndroidUtils: current mode: {}: {}x{}@{:f}", m.getModeId(),
-                  m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
-        s_res_cur_displayMode.strId = std::to_string(m.getModeId());
+      CLog::Log(LOGDEBUG, "CAndroidUtils: current mode: {}: {}x{}@{:f}", m.getModeId(),
+                m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
+      s_res_cur_displayMode.strId = std::to_string(m.getModeId());
+      if (m.getPhysicalWidth() < m.getPhysicalHeight()) // Process portrait resolution
+      {
+        s_res_cur_displayMode.iWidth = s_res_cur_displayMode.iScreenWidth = m.getPhysicalHeight();
+        s_res_cur_displayMode.iHeight = s_res_cur_displayMode.iScreenHeight = m.getPhysicalWidth();
+      }
+      else
+      {
         s_res_cur_displayMode.iWidth = s_res_cur_displayMode.iScreenWidth = m.getPhysicalWidth();
         s_res_cur_displayMode.iHeight = s_res_cur_displayMode.iScreenHeight = m.getPhysicalHeight();
-        s_res_cur_displayMode.fRefreshRate = m.getRefreshRate();
-        s_res_cur_displayMode.dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
-        s_res_cur_displayMode.bFullScreen   = true;
-        s_res_cur_displayMode.iSubtitles = s_res_cur_displayMode.iHeight;
-        s_res_cur_displayMode.fPixelRatio   = 1.0f;
-        s_res_cur_displayMode.strMode = StringUtils::Format(
-            "{}x{} @ {:.6f}{} - Full Screen", s_res_cur_displayMode.iScreenWidth,
-            s_res_cur_displayMode.iScreenHeight, s_res_cur_displayMode.fRefreshRate,
-            s_res_cur_displayMode.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+      }
+      s_res_cur_displayMode.fRefreshRate = m.getRefreshRate();
+      s_res_cur_displayMode.dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+      s_res_cur_displayMode.bFullScreen = true;
+      s_res_cur_displayMode.iSubtitles = s_res_cur_displayMode.iHeight;
+      s_res_cur_displayMode.fPixelRatio = 1.0f;
+      s_res_cur_displayMode.strMode = StringUtils::Format(
+          "{}x{} @ {:.6f}{} - Full Screen", s_res_cur_displayMode.iScreenWidth,
+          s_res_cur_displayMode.iScreenHeight, s_res_cur_displayMode.fRefreshRate,
+          s_res_cur_displayMode.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
 
-        std::vector<CJNIDisplayMode> modes = display.getSupportedModes();
-        for (auto m : modes)
+      std::vector<CJNIDisplayMode> modes = display.getSupportedModes();
+      for (auto m : modes)
+      {
+        CLog::Log(LOGDEBUG, "CAndroidUtils: available mode: {}: {}x{}@{:f}", m.getModeId(),
+                  m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
+
+        RESOLUTION_INFO res;
+        res.strId = std::to_string(m.getModeId());
+        if (m.getPhysicalWidth() < m.getPhysicalHeight()) // Process portrait resolution
         {
-          CLog::Log(LOGDEBUG, "CAndroidUtils: available mode: {}: {}x{}@{:f}", m.getModeId(),
-                    m.getPhysicalWidth(), m.getPhysicalHeight(), m.getRefreshRate());
-
-          RESOLUTION_INFO res;
-          res.strId = std::to_string(m.getModeId());
+          res.iWidth = res.iScreenWidth = m.getPhysicalHeight();
+          res.iHeight = res.iScreenHeight = m.getPhysicalWidth();
+        }
+        else
+        {
           res.iWidth = res.iScreenWidth = m.getPhysicalWidth();
           res.iHeight = res.iScreenHeight = m.getPhysicalHeight();
-          res.fRefreshRate = m.getRefreshRate();
-          res.dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
-          res.bFullScreen   = true;
-          res.iSubtitles = res.iHeight;
-          res.fPixelRatio   = 1.0f;
-          res.strMode = StringUtils::Format("{}x{} @ {:.6f}{} - Full Screen", res.iScreenWidth,
-                                            res.iScreenHeight, res.fRefreshRate,
-                                            res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
-
-          s_res_displayModes.push_back(res);
         }
+        res.fRefreshRate = m.getRefreshRate();
+        res.dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+        res.bFullScreen = true;
+        res.iSubtitles = res.iHeight;
+        res.fPixelRatio = 1.0f;
+        res.strMode = StringUtils::Format("{}x{} @ {:.6f}{} - Full Screen", res.iScreenWidth,
+                                          res.iScreenHeight, res.fRefreshRate,
+                                          res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+
+        s_res_displayModes.push_back(res);
       }
     }
   }
@@ -151,7 +164,7 @@ CAndroidUtils::CAndroidUtils()
   std::string displaySize;
   m_width = m_height = 0;
 
-  if (CJNIBase::GetSDKVersion() >= 24)
+  if (CJNIBase::GetSDKVersion() >= 23)
   {
     fetchDisplayModes();
     for (const auto& res : s_res_displayModes)
@@ -339,7 +352,7 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
 
 bool CAndroidUtils::UpdateDisplayModes()
 {
-  if (CJNIBase::GetSDKVersion() >= 24)
+  if (CJNIBase::GetSDKVersion() >= 23)
     fetchDisplayModes();
   return true;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Handle portrait resolution return in display.getMode correctly, make devices with API 23 to try new display API. Also remove a unwanted field set.   
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Koid Android will fallback to deprecated API when display.getMode return portrait resolution. New display API should be added in API level 23 as android developer docs.
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test ok on my XiaoMi Pad5 Pro, Android 11 (API level 30), aarch64 debug build.
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
N/A
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
