### PR TITLE
[addons] class CAddonRepos refactor, no functional changes

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -389,7 +389,7 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
     const AddonVersion& version = it.version;
     bool optional = it.optional;
     AddonPtr dep;
-    bool haveInstalledAddon =
+    const bool haveInstalledAddon =
         CServiceBroker::GetAddonMgr().GetAddon(addonID, dep, ADDON_UNKNOWN, OnlyEnabled::CHOICE_NO);
     if ((haveInstalledAddon && !dep->MeetsVersion(versionMin, version)) ||
         (!haveInstalledAddon && !optional))
@@ -953,15 +953,9 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
   if (ShouldCancel(0, totalSteps))
     return false;
 
-  const auto& addonMgr = CServiceBroker::GetAddonMgr();
-  CAddonRepos addonRepos(addonMgr);
-  CAddonDatabase database;
-
-  if (database.Open())
-  {
-    addonRepos.LoadAddonsFromDatabase(database);
-    database.Close();
-  }
+  CAddonRepos addonRepos;
+  if (!addonRepos.IsValid())
+    return false;
 
   // The first thing we do is install dependencies
   for (auto it = deps.begin(); it != deps.end(); ++it)
@@ -973,8 +967,8 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
       const AddonVersion& version = it->version;
       bool optional = it->optional;
       AddonPtr dependency;
-      bool haveInstalledAddon =
-          addonMgr.GetAddon(addonID, dependency, ADDON_UNKNOWN, OnlyEnabled::CHOICE_NO);
+      const bool haveInstalledAddon = CServiceBroker::GetAddonMgr().GetAddon(
+          addonID, dependency, ADDON_UNKNOWN, OnlyEnabled::CHOICE_NO);
       if ((haveInstalledAddon && !dependency->MeetsVersion(versionMin, version)) ||
           (!haveInstalledAddon && !optional))
       {

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "AddonDatabase.h"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -17,7 +19,6 @@ namespace ADDON
 {
 
 class AddonVersion;
-class CAddonDatabase;
 class CAddonMgr;
 class CRepository;
 class IAddon;
@@ -47,33 +48,9 @@ struct CAddonWithUpdate
 class CAddonRepos
 {
 public:
-  CAddonRepos() = delete;
-  explicit CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr) {}
-
-  /*!
-   * \brief Load the map of all available addon versions in any installed repository
-   * \param database reference to the database to load addons from
-   * \return true on success, false otherwise
-   */
-  bool LoadAddonsFromDatabase(const CAddonDatabase& database);
-
-  /*!
-   * \brief Load the map of all available versions of an addonId in any installed repository
-   * \param database reference to the database to load addons from
-   * \param addonId the addon id we want to retrieve versions for
-   * \return true on success, false otherwise
-   */
-  bool LoadAddonsFromDatabase(const CAddonDatabase& database, const std::string& addonId);
-
-  /*!
-   * \brief Load the map of all available versions in one installed repository
-   * \param database reference to the database to load addons from
-   * \param repoAddon pointer to the repo we want to retrieve versions from
-   *        note this is of type AddonPtr, not RepositoryPtr
-   * \return true on success, false otherwise
-   */
-  bool LoadAddonsFromDatabase(const CAddonDatabase& database,
-                              const std::shared_ptr<IAddon>& repoAddon);
+  CAddonRepos(); // load all add-ons from all installed repositories
+  explicit CAddonRepos(const std::string& addonId); // load a specific add-on id only
+  explicit CAddonRepos(const std::shared_ptr<IAddon>& repoAddon); // load add-ons of a specific repo
 
   /*!
    * \brief Build the list of addons to be updated depending on defined rules
@@ -87,7 +64,6 @@ public:
   void BuildUpdateOrOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
                                  std::vector<std::shared_ptr<IAddon>>& result,
                                  AddonCheckType addonCheckType) const;
-
 
   /*!
    * \brief Build the list of outdated addons and their available updates.
@@ -191,15 +167,18 @@ public:
    */
   void BuildCompatibleVersionsList(std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const;
 
-private:
   /*!
-   * \brief Load the map of addons
-   * \note this function should only by called from publicly exposed wrappers
+   * \brief Return whether add-ons repo/version information was properly loaded after construction
    * \return true on success, false otherwise
    */
-  bool LoadAddonsFromDatabase(const CAddonDatabase& database,
-                              const std::string& addonId,
-                              const std::shared_ptr<IAddon>& repoAddon);
+  bool IsValid() const { return m_valid; }
+
+private:
+  /*!
+   * \brief Load and configure add-on maps
+   * \return true on success, false otherwise
+   */
+  bool LoadAddonsFromDatabase(const std::string& addonId, const std::shared_ptr<IAddon>& repoAddon);
 
   /*!
    * \brief Looks up an addon in a given repository map and
@@ -215,11 +194,6 @@ private:
   bool FindAddonAndCheckForUpdate(const std::shared_ptr<IAddon>& addonToCheck,
                                   const std::map<std::string, std::shared_ptr<IAddon>>& map,
                                   std::shared_ptr<IAddon>& update) const;
-
-  /*!
-   * \brief Sets up latest version maps from scratch
-   */
-  void SetupLatestVersionMaps();
 
   /*!
    * \brief Adds the latest version of an addon to the desired map
@@ -253,6 +227,8 @@ private:
                              std::shared_ptr<IAddon>& addon) const;
 
   const CAddonMgr& m_addonMgr;
+  CAddonDatabase m_addonDb;
+  bool m_valid{false};
 
   std::vector<std::shared_ptr<IAddon>> m_allAddons;
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -522,15 +522,9 @@ static bool Browse(const CURL& path, CFileItemList &items)
   items.SetPath(path.Get());
   if (repoId == "all")
   {
-    const auto& addonMgr = CServiceBroker::GetAddonMgr();
-    CAddonRepos addonRepos(addonMgr);
-    CAddonDatabase database;
-
-    if (!database.Open() || !addonRepos.LoadAddonsFromDatabase(database))
-    {
+    CAddonRepos addonRepos;
+    if (!addonRepos.IsValid())
       return false;
-    }
-    database.Close();
 
     // get all latest addon versions by repo
     addonRepos.GetLatestAddonVersionsFromAllRepos(addons);
@@ -541,19 +535,15 @@ static bool Browse(const CURL& path, CFileItemList &items)
   else
   {
     AddonPtr repoAddon;
-    const auto& addonMgr = CServiceBroker::GetAddonMgr();
-
-    if (!addonMgr.GetAddon(repoId, repoAddon, ADDON_REPOSITORY, OnlyEnabled::CHOICE_YES))
-      return false;
-
-    CAddonRepos addonRepos(addonMgr);
-    CAddonDatabase database;
-
-    if (!database.Open() || !addonRepos.LoadAddonsFromDatabase(database, repoAddon))
+    if (!CServiceBroker::GetAddonMgr().GetAddon(repoId, repoAddon, ADDON_REPOSITORY,
+                                                OnlyEnabled::CHOICE_YES))
     {
       return false;
     }
-    database.Close();
+
+    CAddonRepos addonRepos(repoAddon);
+    if (!addonRepos.IsValid())
+      return false;
 
     // get all addons from the single repository
     addonRepos.GetLatestAddonVersions(addons);


### PR DESCRIPTION
## Description
this shouldn't change the behavior of CAddonRepos but simplify its usage, clean it up and add some error checking.
there's three ctor's used now to setup CAddonRepos for all add-ons (by the default ctor), the single add-on id or the repository we want it for.

putting such a load on constructors is open to discussion, imo it is fine.
before using the instance its validity should be checked via `CAddonRepos::IsValid()`.

also CAddonRepos is provided now with its own `CAddonDatabase` member, which has been passed in prior to this change.

## Motivation and context
felt some room for improvement after revisiting.

## How has this been tested?
it's running weeks on my live system

## What is the effect on users?
nothing

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
