### PR TITLE
[tools/depends] download-files.include fixes

### DIFF
--- a/tools/depends/download-files.include
+++ b/tools/depends/download-files.include
@@ -41,6 +41,7 @@ endif
 ifeq ($(HASH_FOUND),yes)
 #	we really need 2 spaces between sha hash and file name!
 #	if the hash sum doesn't match we retry up to 3 times, add verbose curl output for diagnostics on retries
+# if we fail 3 times, cleanup anything downloaded (eg bad tar)
 	@cd $(TARBALLS_LOCATION); echo "$(HASH_SUM)  $(ARCHIVE)" > $(ARCHIVE).$(HASH_TYPE) && $(HASH_TOOL) $(HASH_TOOL_FLAGS) $(ARCHIVE).$(HASH_TYPE) \
           || {\
             echo "Error: failed to verify hash sum of $(ARCHIVE), expected type: $(HASH_TYPE) value $(HASH_SUM), retrying.." ;\
@@ -52,6 +53,7 @@ ifeq ($(HASH_FOUND),yes)
               $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) -v $(BASE_URL)/$(ARCHIVE) ;\
               $(HASH_TOOL) $(HASH_TOOL_FLAGS) $(ARCHIVE).$(HASH_TYPE) && exit 0 || tries=$$((tries + 1)) ;\
             done ;\
+            rm $(TARBALLS_LOCATION)/$(ARCHIVE) ;\
             exit 1 ;\
           }
 endif

--- a/tools/depends/download-files.include
+++ b/tools/depends/download-files.include
@@ -40,7 +40,7 @@ ifeq ($(HASH_FOUND),no)
 endif
 ifeq ($(HASH_FOUND),yes)
 #	we really need 2 spaces between sha hash and file name!
-#	if the hash sum doesn't match we retry up to 3 times
+#	if the hash sum doesn't match we retry up to 3 times, add verbose curl output for diagnostics on retries
 	@cd $(TARBALLS_LOCATION); echo "$(HASH_SUM)  $(ARCHIVE)" > $(ARCHIVE).$(HASH_TYPE) && $(HASH_TOOL) $(HASH_TOOL_FLAGS) $(ARCHIVE).$(HASH_TYPE) \
           || {\
             echo "Error: failed to verify hash sum of $(ARCHIVE), expected type: $(HASH_TYPE) value $(HASH_SUM), retrying.." ;\
@@ -49,7 +49,7 @@ ifeq ($(HASH_FOUND),yes)
               echo "download $(ARCHIVE) retry $$tries" ;\
               rm $(TARBALLS_LOCATION)/$(ARCHIVE) ;\
               sleep 3 ;\
-              $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE) ;\
+              $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) -v $(BASE_URL)/$(ARCHIVE) ;\
               $(HASH_TOOL) $(HASH_TOOL_FLAGS) $(ARCHIVE).$(HASH_TYPE) && exit 0 || tries=$$((tries + 1)) ;\
             done ;\
             exit 1 ;\


### PR DESCRIPTION
## Description
Add verbose curl  output to retry logic of a tarball downoad
Cleanup download artifacts we retry loop fails 3 times.

## Motivation and context
Have had some intermittent CI failures with tarballs that jam up CI jobs. I believe the failures are actually due to mirrors 404ing the tarball request.
This provides some verbose output when retry attempts are done, so we can see what mirror is used. On top of that, it means i dont have to nag server admins to clean out bad tarballs.

Unfortunately this doesnt fix how we handle a bad mirror failure. thats still to be worked out. This just provides us some insight and cleanup

## How has this been tested?
Retry logic fails 3 times, failed tarball (404 html file) is removed and build fails.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
