### PR TITLE
[macOS][iOS] Add speech recognition service implementation.

### DIFF
--- a/cmake/scripts/darwin_embedded/ArchSetup.cmake
+++ b/cmake/scripts/darwin_embedded/ArchSetup.cmake
@@ -44,6 +44,11 @@ list(APPEND DEPLIBS "-framework CoreFoundation" "-framework CoreVideo"
                     "-framework VideoToolbox" "-lresolv" "-ObjC"
                     "-framework AVKit" "-framework GameController")
 
+# Speech not available on tvOS
+if(NOT CORE_PLATFORM_NAME_LC STREQUAL tvos)
+  list(APPEND DEPLIBS "-framework Speech")
+endif()
+
 set(ENABLE_OPTICAL OFF CACHE BOOL "" FORCE)
 set(CMAKE_XCODE_ATTRIBUTE_INLINES_ARE_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN OFF)

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -46,7 +46,8 @@ list(APPEND DEPLIBS "-framework DiskArbitration" "-framework IOKit"
                     "-framework CoreAudio" "-framework AudioToolbox"
                     "-framework CoreGraphics" "-framework CoreMedia"
                     "-framework VideoToolbox" "-framework Security"
-                    "-framework GameController")
+                    "-framework GameController" "-framework Speech"
+                    "-framework AVFoundation")
 
 if(ARCH STREQUAL aarch64)
   set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)

--- a/cmake/treedata/darwin_embedded/ios/ios.txt
+++ b/cmake/treedata/darwin_embedded/ios/ios.txt
@@ -1,2 +1,3 @@
 xbmc/platform/darwin/ios              platform/ios
+xbmc/platform/darwin/speech           platform/darwin/speech
 xbmc/windowing/ios                    windowing/ios

--- a/cmake/treedata/darwin_embedded/subdirs.txt
+++ b/cmake/treedata/darwin_embedded/subdirs.txt
@@ -2,6 +2,7 @@ xbmc/cores/RetroPlayer/process/ios    cores/RetroPlayer/process/ios
 xbmc/cores/VideoPlayer/Process/ios    cores/VideoPlayer/Process/ios
 xbmc/input/touch                      input/touch
 xbmc/input/touch/generic              input/touch/generic
+xbmc/platform/common/speech           platform/common/speech
 xbmc/platform/darwin                  platform/darwin
 xbmc/platform/darwin/ios-common       platform/ios-common
 xbmc/platform/darwin/ios-common/network  platform/ios-common/network

--- a/cmake/treedata/darwin_embedded/subdirs.txt
+++ b/cmake/treedata/darwin_embedded/subdirs.txt
@@ -2,7 +2,6 @@ xbmc/cores/RetroPlayer/process/ios    cores/RetroPlayer/process/ios
 xbmc/cores/VideoPlayer/Process/ios    cores/VideoPlayer/Process/ios
 xbmc/input/touch                      input/touch
 xbmc/input/touch/generic              input/touch/generic
-xbmc/platform/common/speech           platform/common/speech
 xbmc/platform/darwin                  platform/darwin
 xbmc/platform/darwin/ios-common       platform/ios-common
 xbmc/platform/darwin/ios-common/network  platform/ios-common/network

--- a/cmake/treedata/darwin_embedded/tvos/tvos.txt
+++ b/cmake/treedata/darwin_embedded/tvos/tvos.txt
@@ -1,3 +1,4 @@
+xbmc/platform/common/speech           platform/common/speech
 xbmc/platform/darwin/tvos             platform/tvos
 xbmc/platform/darwin/tvos/filesystem  platform/darwin/tvos/filesystem
 xbmc/platform/darwin/tvos/input       platform/darwin/tvos/input

--- a/cmake/treedata/freebsd/subdirs.txt
+++ b/cmake/treedata/freebsd/subdirs.txt
@@ -1,5 +1,6 @@
 xbmc/input/touch                    input/touch
 xbmc/input/touch/generic            input/touch/generic
+xbmc/platform/common/speech         platform/common/speech
 xbmc/platform/freebsd               platform/freebsd
 xbmc/platform/freebsd/network       platform/freebsd/network
 xbmc/platform/linux/input           platform/linux/input

--- a/cmake/treedata/linux/subdirs.txt
+++ b/cmake/treedata/linux/subdirs.txt
@@ -1,5 +1,6 @@
 xbmc/input/touch                    input/touch
 xbmc/input/touch/generic            input/touch/generic
+xbmc/platform/common/speech         platform/common/speech
 xbmc/platform/linux                 platform/linux
 xbmc/platform/linux/input           platform/linux/input
 xbmc/platform/linux/network         platform/linux/network

--- a/cmake/treedata/osx/subdirs.txt
+++ b/cmake/treedata/osx/subdirs.txt
@@ -1,8 +1,8 @@
 xbmc/cores/RetroPlayer/process/osx    cores/RetroPlayer/process/osx
 xbmc/cores/VideoPlayer/Process/osx    cores/VideoPlayer/Process/osx
-xbmc/platform/common/speech           platform/common/speech
 xbmc/platform/darwin                  platform/darwin
 xbmc/platform/darwin/network          platform/darwin/network
+xbmc/platform/darwin/speech           platform/darwin/speech
 xbmc/platform/darwin/osx              platform/osx
 xbmc/platform/darwin/osx/network      platform/darwin/osx/network
 xbmc/platform/darwin/osx/peripherals  platform/osx/peripherals

--- a/cmake/treedata/osx/subdirs.txt
+++ b/cmake/treedata/osx/subdirs.txt
@@ -1,5 +1,6 @@
 xbmc/cores/RetroPlayer/process/osx    cores/RetroPlayer/process/osx
 xbmc/cores/VideoPlayer/Process/osx    cores/VideoPlayer/Process/osx
+xbmc/platform/common/speech           platform/common/speech
 xbmc/platform/darwin                  platform/darwin
 xbmc/platform/darwin/network          platform/darwin/network
 xbmc/platform/darwin/osx              platform/osx

--- a/cmake/treedata/windows/subdirs.txt
+++ b/cmake/treedata/windows/subdirs.txt
@@ -5,6 +5,7 @@ xbmc/cores/VideoPlayer/VideoRenderers/windows cores/VideoPlayer/VideoRenderers/w
 xbmc/input/touch                       input/touch
 xbmc/input/touch/generic               input/touch/generic
 xbmc/network/mdns                      network/mdns
+xbmc/platform/common/speech            platform/common/speech
 xbmc/platform/win32                    platform/win32
 xbmc/platform/win32/filesystem         platform/win32/filesystem
 xbmc/platform/win32/input              platform/win32/input

--- a/cmake/treedata/windowsstore/subdirs.txt
+++ b/cmake/treedata/windowsstore/subdirs.txt
@@ -3,6 +3,7 @@ xbmc/cores/VideoPlayer/VideoRenderers/windows cores/VideoPlayer/VideoRenderers/w
 xbmc/input/touch                       input/touch
 xbmc/input/touch/generic               input/touch/generic
 xbmc/network/mdns                      network/mdns
+xbmc/platform/common/speech            platform/common/speech
 xbmc/platform/win10                    platform/win10
 xbmc/platform/win10/filesystem         platform/win10/filesystem
 xbmc/platform/win10/network            platform/win10/network

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -86,6 +86,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/SkinSettings.h"
 #include "settings/lib/SettingsManager.h"
+#include "speech/ISpeechRecognition.h"
 #include "threads/SingleLock.h"
 #include "utils/CPUInfo.h"
 #include "utils/FileExtensionProvider.h"
@@ -851,6 +852,8 @@ bool CApplication::Initialize()
   }
 
   CJSONRPC::Initialize();
+
+  CServiceBroker::RegisterSpeechRecognition(speech::ISpeechRecognition::CreateInstance());
 
   if (!m_ServiceManager->InitStageThree(profileManager))
   {
@@ -2147,6 +2150,8 @@ bool CApplication::Cleanup()
 
     if (m_ServiceManager)
       m_ServiceManager->DeinitStageThree();
+
+    CServiceBroker::UnregisterSpeechRecognition();
 
     CLog::Log(LOGINFO, "unload skin");
     UnloadSkin();

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -412,3 +412,19 @@ std::shared_ptr<CKeyboardLayoutManager> CServiceBroker::GetKeyboardLayoutManager
 {
   return g_serviceBroker.m_keyboardLayoutManager;
 }
+
+void CServiceBroker::RegisterSpeechRecognition(
+    const std::shared_ptr<speech::ISpeechRecognition>& speechRecognition)
+{
+  g_serviceBroker.m_speechRecognition = speechRecognition;
+}
+
+void CServiceBroker::UnregisterSpeechRecognition()
+{
+  g_serviceBroker.m_speechRecognition.reset();
+}
+
+std::shared_ptr<speech::ISpeechRecognition> CServiceBroker::GetSpeechRecognition()
+{
+  return g_serviceBroker.m_speechRecognition;
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -107,6 +107,11 @@ namespace PERIPHERALS
 class CPeripherals;
 }
 
+namespace speech
+{
+class ISpeechRecognition;
+}
+
 class CServiceBroker
 {
 public:
@@ -204,6 +209,11 @@ public:
   static void UnregisterKeyboardLayoutManager();
   static std::shared_ptr<CKeyboardLayoutManager> GetKeyboardLayoutManager();
 
+  static void RegisterSpeechRecognition(
+      const std::shared_ptr<speech::ISpeechRecognition>& speechRecognition);
+  static void UnregisterSpeechRecognition();
+  static std::shared_ptr<speech::ISpeechRecognition> GetSpeechRecognition();
+
 private:
   std::shared_ptr<CAppParams> m_appParams;
   std::unique_ptr<CLog> m_logging;
@@ -219,6 +229,7 @@ private:
   std::shared_ptr<CJobManager> m_jobManager;
   std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> m_appMessenger;
   std::shared_ptr<CKeyboardLayoutManager> m_keyboardLayoutManager;
+  std::shared_ptr<speech::ISpeechRecognition> m_speechRecognition;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -37,10 +37,6 @@
 
 #include <mutex>
 
-#ifdef TARGET_ANDROID
-#include "platform/android/activity/XBMCApp.h"
-#endif
-
 using namespace KODI::MESSAGING;
 
 #define BUTTON_ID_OFFSET      100
@@ -648,14 +644,18 @@ void CGUIDialogKeyboardGeneric::OnIPAddress()
 
 void CGUIDialogKeyboardGeneric::OnVoiceRecognition()
 {
-#ifdef TARGET_ANDROID
-  if (!m_speechRecognitionListener)
-    m_speechRecognitionListener = std::make_shared<CSpeechRecognitionListener>(GetID());
+  const auto speechRecognition = CServiceBroker::GetSpeechRecognition();
+  if (speechRecognition)
+  {
+    if (!m_speechRecognitionListener)
+      m_speechRecognitionListener = std::make_shared<CSpeechRecognitionListener>(GetID());
 
-  CXBMCApp::Get().GetSpeechRecognition()->StartSpeechRecognition(m_speechRecognitionListener);
-#else
-  CLog::LogF(LOGWARNING, "No voice recognition implementation avaliable for this platform.");
-#endif
+    speechRecognition->StartSpeechRecognition(m_speechRecognitionListener);
+  }
+  else
+  {
+    CLog::LogF(LOGWARNING, "No voice recognition implementation available.");
+  }
 }
 
 void CGUIDialogKeyboardGeneric::SetControlLabel(int id, const std::string &label)

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -94,7 +94,6 @@
 #include "platform/android/activity/IInputDeviceEventHandler.h"
 #include "platform/android/network/NetworkAndroid.h"
 #include "platform/android/powermanagement/AndroidPowerSyscall.h"
-#include "platform/android/speech/SpeechRecognitionAndroid.h"
 
 #define GIGABYTES       1073741824
 
@@ -159,7 +158,6 @@ std::unique_ptr<CXBMCApp> CXBMCApp::m_appinstance;
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
   : CJNIMainActivity(nativeActivity),
     CJNIBroadcastReceiver(CJNIContext::getPackageName() + ".XBMCBroadcastReceiver"),
-    m_speechRecognition(new CSpeechRecognitionAndroid(*this)),
     m_inputHandler(inputHandler)
 {
   m_activity = nativeActivity;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -43,11 +43,6 @@ class IInputDeviceEventHandler;
 class CVideoSyncAndroid;
 class CJNIActivityManager;
 
-namespace speech
-{
-class ISpeechRecognition;
-}
-
 typedef struct _JNIEnv JNIEnv;
 
 struct androidIcon
@@ -219,11 +214,6 @@ public:
 
   bool GetMemoryInfo(long& availMem, long& totalMem);
 
-  std::shared_ptr<speech::ISpeechRecognition> GetSpeechRecognition() const
-  {
-    return m_speechRecognition;
-  }
-
 protected:
   // limit who can access Volume
   friend class CAESinkAUDIOTRACK;
@@ -240,7 +230,6 @@ private:
 
   CJNIXBMCAudioManagerOnAudioFocusChangeListener m_audioFocusListener;
   CJNIXBMCDisplayManagerDisplayListener m_displayListener;
-  std::shared_ptr<speech::ISpeechRecognition> m_speechRecognition;
   std::unique_ptr<CJNIXBMCMainView> m_mainView;
   std::unique_ptr<jni::CJNIXBMCMediaSession> m_mediaSession;
   std::string GetFilenameFromIntent(const CJNIIntent &intent);

--- a/xbmc/platform/android/speech/SpeechRecognitionAndroid.cpp
+++ b/xbmc/platform/android/speech/SpeechRecognitionAndroid.cpp
@@ -13,6 +13,7 @@
 #include "utils/log.h"
 
 #include "platform/android/activity/JNIMainActivity.h"
+#include "platform/android/activity/XBMCApp.h"
 #include "platform/android/speech/SpeechRecognitionListenerAndroid.h"
 
 #include <mutex>
@@ -24,6 +25,11 @@
 #include <androidjni/RecognizerIntent.h>
 #include <androidjni/SpeechRecognizer.h>
 #include <jni.h>
+
+std::shared_ptr<speech::ISpeechRecognition> speech::ISpeechRecognition::CreateInstance()
+{
+  return std::make_shared<CSpeechRecognitionAndroid>(CXBMCApp::Get());
+}
 
 CSpeechRecognitionAndroid::CSpeechRecognitionAndroid(const CJNIContext& context)
   : m_context(context)

--- a/xbmc/platform/common/speech/CMakeLists.txt
+++ b/xbmc/platform/common/speech/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES SpeechRecognitionStub.cpp)
+
+set(HEADERS SpeechRecognitionStub.h)
+
+core_add_library(platform_common_speech)

--- a/xbmc/platform/common/speech/SpeechRecognitionStub.cpp
+++ b/xbmc/platform/common/speech/SpeechRecognitionStub.cpp
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (C) 2012-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SpeechRecognitionStub.h"
+
+std::shared_ptr<speech::ISpeechRecognition> speech::ISpeechRecognition::CreateInstance()
+{
+  // speech recognition not implemented
+  return {};
+}

--- a/xbmc/platform/common/speech/SpeechRecognitionStub.h
+++ b/xbmc/platform/common/speech/SpeechRecognitionStub.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2012-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "speech/ISpeechRecognition.h"
+
+// This is a stub for all platforms without a speech recognition implementation
+// Saves us from feature/platform ifdeffery.
+class CSpeechRecognitionStub : public speech::ISpeechRecognition
+{
+public:
+  void StartSpeechRecognition(
+      const std::shared_ptr<speech::ISpeechRecognitionListener>& listener) override
+  {
+  }
+};

--- a/xbmc/platform/darwin/speech/CMakeLists.txt
+++ b/xbmc/platform/darwin/speech/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES SpeechRecognitionDarwin.mm)
+
+set(HEADERS SpeechRecognitionDarwin.h)
+
+core_add_library(platform_darwin_speech)

--- a/xbmc/platform/darwin/speech/SpeechRecognitionDarwin.h
+++ b/xbmc/platform/darwin/speech/SpeechRecognitionDarwin.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2012-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "speech/ISpeechRecognition.h"
+
+#include <memory>
+
+struct SpeechRecognitionDarwinImpl;
+
+class CSpeechRecognitionDarwin : public speech::ISpeechRecognition
+{
+public:
+  CSpeechRecognitionDarwin();
+  ~CSpeechRecognitionDarwin() override;
+
+  // ISpeechRecognition implementation
+  void StartSpeechRecognition(
+      const std::shared_ptr<speech::ISpeechRecognitionListener>& listener) override;
+
+  void OnRecognitionDone(speech::ISpeechRecognitionListener* listener);
+
+private:
+  std::unique_ptr<SpeechRecognitionDarwinImpl> m_impl;
+};

--- a/xbmc/platform/darwin/speech/SpeechRecognitionDarwin.mm
+++ b/xbmc/platform/darwin/speech/SpeechRecognitionDarwin.mm
@@ -1,0 +1,329 @@
+/*
+ *  Copyright (C) 2012-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SpeechRecognitionDarwin.h"
+
+#include "LangInfo.h"
+#include "speech/ISpeechRecognitionListener.h"
+#include "speech/SpeechRecognitionErrors.h"
+#include "threads/CriticalSection.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <mutex>
+#include <vector>
+
+#import <AVFoundation/AVFoundation.h>
+#import <Speech/Speech.h>
+
+API_AVAILABLE(macos(10.15), ios(10.0))
+API_UNAVAILABLE(tvos) @interface SpeechRecognitionImpl : NSObject<SFSpeechRecognizerDelegate>
+
+@property(nonatomic, strong) SFSpeechRecognizer* speechRecognizer;
+@property(nonatomic, strong) SFSpeechAudioBufferRecognitionRequest* recognitionRequest;
+@property(nonatomic, strong) SFSpeechRecognitionTask* recognitionTask;
+@property(nonatomic, strong) AVAudioEngine* audioEngine;
+@property(nonatomic, strong) NSTimer* talkTimeoutTimer;
+@property(nonatomic, copy) NSString* text;
+
+// C++ members
+@property(nonatomic) speech::ISpeechRecognitionListener* listener;
+@property(nonatomic) CSpeechRecognitionDarwin* owner;
+
+@end
+
+@implementation SpeechRecognitionImpl
+
+- (void)startSpeechRecognition:(speech::ISpeechRecognitionListener*)listener
+                         owner:(CSpeechRecognitionDarwin*)owner
+{
+  self.listener = listener;
+  self.owner = owner;
+
+  // Get current Kodi GUI locale and use it for speech recognition.
+  std::string kodiLocale = g_langInfo.GetLocale().ToShortString();
+  std::replace(kodiLocale.begin(), kodiLocale.end(), '_', '-');
+  NSString* locale = @(kodiLocale.c_str());
+
+  self.speechRecognizer =
+      [[SFSpeechRecognizer alloc] initWithLocale:[NSLocale localeWithLocaleIdentifier:locale]];
+  if (self.speechRecognizer == nil)
+  {
+    CLog::LogF(LOGWARNING,
+               "Speech recognizer not available for user's current locale. Trying en-US");
+    self.speechRecognizer =
+        [[SFSpeechRecognizer alloc] initWithLocale:[NSLocale localeWithLocaleIdentifier:@"en-US"]];
+  }
+  if (self.speechRecognizer == nil)
+  {
+    [self onError:speech::RecognitionError::SERVICE_NOT_AVAILABLE
+        logMessage:@"Unable to create an SFSpeechRecognizer instance"];
+    return;
+  }
+
+  [self.speechRecognizer setDelegate:self];
+
+  self.audioEngine = [[AVAudioEngine alloc] init];
+  if (self.audioEngine == nil)
+  {
+    [self onError:speech::RecognitionError::SERVICE_NOT_AVAILABLE
+        logMessage:@"Unable to create an AVAudioEngine instance"];
+    return;
+  }
+
+  [SFSpeechRecognizer requestAuthorization:^(SFSpeechRecognizerAuthorizationStatus authStatus) {
+    switch (authStatus)
+    {
+      case SFSpeechRecognizerAuthorizationStatusAuthorized: // User gave access to speech recognition
+        break;
+
+      case SFSpeechRecognizerAuthorizationStatusDenied: // User denied access to speech recognition
+      case SFSpeechRecognizerAuthorizationStatusRestricted: // Speech recognition restricted on this device
+      case SFSpeechRecognizerAuthorizationStatusNotDetermined: // Speech recognition not yet authorized
+      default:
+        [self onError:speech::RecognitionError::INSUFFICIENT_PERMISSIONS
+            logMessage:@"Insufficient permissions"];
+        break;
+    }
+  }];
+
+  listener->OnReadyForSpeech();
+
+  self.recognitionRequest = [[SFSpeechAudioBufferRecognitionRequest alloc] init];
+  if (self.recognitionRequest == nil)
+  {
+    [self onError:speech::RecognitionError::SERVICE_NOT_AVAILABLE
+        logMessage:@"Unable to create an SFSpeechAudioBufferRecognitionRequest instance"];
+    return;
+  }
+
+  self.recognitionRequest.shouldReportPartialResults = YES;
+
+  AVAudioNode* inputNode = [self.audioEngine inputNode];
+  if (inputNode == nil)
+  {
+    [self onError:speech::RecognitionError::AUDIO
+        logMessage:@"Audio engine instance has no input node"];
+    return;
+  }
+
+  [self.recognitionTask cancel];
+  self.recognitionTask = nil;
+
+  // stop recognition after 10 secs if the user did not start talking
+  self.talkTimeoutTimer = [NSTimer scheduledTimerWithTimeInterval:10.0
+                                                           target:self
+                                                         selector:@selector(onTalkTimeout:)
+                                                         userInfo:nil
+                                                          repeats:NO];
+
+  __typeof__(self) __weak welf = self;
+  self.recognitionTask = [self.speechRecognizer
+      recognitionTaskWithRequest:self.recognitionRequest
+                   resultHandler:^(SFSpeechRecognitionResult* _Nullable result,
+                                   NSError* _Nullable error) {
+                     __typeof__(self) sself = welf;
+                     if (!sself) // the object (self) is dead; it makes no sense to continue
+                       return;
+
+                     BOOL isFinal = NO;
+
+                     // reset talk timeout timer to fire 3 secs after user stopped talking
+                     [sself.talkTimeoutTimer invalidate];
+                     sself.talkTimeoutTimer =
+                         [NSTimer scheduledTimerWithTimeInterval:3.0
+                                                          target:sself
+                                                        selector:@selector(onTalkTimeout:)
+                                                        userInfo:nil
+                                                         repeats:NO];
+                     if (result != nil)
+                     {
+                       isFinal = result.isFinal;
+                       sself.text = result.bestTranscription.formattedString;
+                       listener->OnResults({[sself.text UTF8String]});
+                     }
+
+                     if (error == nil && !isFinal)
+                       return;
+
+                     [sself.audioEngine stop];
+                     [inputNode removeTapOnBus:0];
+
+                     if (error != nil && !isFinal)
+                     {
+                       int recognitionError = speech::RecognitionError::UNKNOWN;
+
+                       if (sself.text == nil)
+                       {
+                         recognitionError = speech::RecognitionError::NO_MATCH;
+                       }
+                       else if ([error.domain isEqualToString:@"kLSRErrorDomain"])
+                       {
+                         switch (error.code)
+                         {
+                           case 102: // Assets are not installed
+                           case 201: // Siri or Dictation is disabled
+                           case 300: // Failed to initialize recognizer
+                             recognitionError = speech::RecognitionError::SERVICE_NOT_AVAILABLE;
+                             break;
+
+                           case 301: // Request was canceled
+                             break;
+                         }
+                       }
+                       else if ([error.domain isEqualToString:@"kAFAssistantErrorDomain"])
+                       {
+                         switch (error.code)
+                         {
+                           case 1100: // Trying to start recognition while an earlier instance is still active
+                             recognitionError = speech::RecognitionError::RECOGNIZER_BUSY;
+                             break;
+
+                           case 1110: // Failed to recognize any speech
+                             recognitionError = speech::RecognitionError::NO_MATCH;
+                             break;
+
+                           case 1700: // Request is not authorized
+                             recognitionError = speech::RecognitionError::INSUFFICIENT_PERMISSIONS;
+                             break;
+
+                           case 203: // Failure occurred during speech recognition
+                           case 1101: // Connection to speech process was invalidated
+                           case 1107: // Connection to speech process was interrupted
+                             break;
+                         }
+                       }
+
+                       NSString* logMsg =
+                           [NSString stringWithFormat:@"code='%ld' description='%@'",
+                                                      (long)error.code, error.localizedDescription];
+                       [sself onError:recognitionError logMessage:logMsg];
+                     }
+                     else
+                     {
+                       owner->OnRecognitionDone(listener);
+                     }
+
+                     sself.recognitionRequest = nil;
+                     sself.recognitionTask = nil;
+                     sself.text = nil;
+                     [sself.talkTimeoutTimer invalidate];
+                     sself.talkTimeoutTimer = nil;
+                   }];
+
+  [inputNode installTapOnBus:0
+                  bufferSize:4096
+                      format:[inputNode outputFormatForBus:0]
+                       block:^(AVAudioPCMBuffer* buffer, AVAudioTime* when) {
+                         [self.recognitionRequest appendAudioPCMBuffer:buffer];
+                       }];
+
+  [self.audioEngine prepare];
+
+  NSError* outError;
+  [self.audioEngine startAndReturnError:&outError];
+
+  if (outError != nil)
+  {
+    [self onError:speech::RecognitionError::AUDIO
+        logMessage:[NSString stringWithFormat:
+                                 @"Audio engine couldn't start because of an error. code='%ld'",
+                                 outError.code]];
+  }
+}
+
+- (void)speechRecognizer:(SFSpeechRecognizer*)speechRecognizer availabilityDidChange:(BOOL)available
+{
+  if (available)
+    return;
+
+  [self.recognitionTask cancel];
+  self.recognitionTask = nil;
+
+  if (self.listener && self.owner)
+  {
+    [self onError:speech::RecognitionError::SERVICE_NOT_AVAILABLE
+        logMessage:@"Service currently not available. Try again later"];
+  }
+}
+
+- (void)onTalkTimeout:(NSTimer*)timer
+{
+  [self.recognitionRequest endAudio];
+}
+
+- (void)onError:(int)recognitionError logMessage:(NSString*)logMessage
+{
+  CLog::Log(LOGERROR, "Speech recognition error: {}", [logMessage UTF8String]);
+  self.listener->OnError(recognitionError);
+  self.owner->OnRecognitionDone(self.listener);
+}
+
+@end
+
+std::shared_ptr<speech::ISpeechRecognition> speech::ISpeechRecognition::CreateInstance()
+{
+  return std::make_shared<CSpeechRecognitionDarwin>();
+}
+
+struct API_AVAILABLE(macos(10.15), ios(10.0)) API_UNAVAILABLE(tvos) SpeechRecognitionDarwinImpl
+{
+  CCriticalSection m_listenersMutex;
+  std::vector<std::shared_ptr<speech::ISpeechRecognitionListener>> m_listeners;
+  SpeechRecognitionImpl* m_recognizer{nil};
+};
+
+CSpeechRecognitionDarwin::CSpeechRecognitionDarwin() : m_impl(new SpeechRecognitionDarwinImpl)
+{
+}
+
+void CSpeechRecognitionDarwin::StartSpeechRecognition(
+    const std::shared_ptr<speech::ISpeechRecognitionListener>& listener)
+{
+  // Speech: macOS 10.15+ iOS 10.0+. Currently not available on tvOS!
+  if (@available(macOS 10.15, iOS 10.0, *))
+  {
+    if (!m_impl->m_recognizer)
+      m_impl->m_recognizer = [[SpeechRecognitionImpl alloc] init];
+
+    if (m_impl->m_recognizer == nil)
+    {
+      CLog::LogF(LOGERROR, "Unable to create a SpeechRecognitionImpl instance");
+      return;
+    }
+
+    std::unique_lock<CCriticalSection> lock(m_impl->m_listenersMutex);
+    m_impl->m_listeners.emplace_back(
+        listener); // we need to ensure the listener lives as long as we do
+    lock.unlock();
+
+    [m_impl->m_recognizer startSpeechRecognition:listener.get() owner:this];
+  }
+  else
+  {
+    CLog::LogF(LOGERROR, "Operating system does not match the minimum required version");
+    listener->OnError(speech::RecognitionError::SERVICE_NOT_AVAILABLE);
+  }
+}
+
+CSpeechRecognitionDarwin::~CSpeechRecognitionDarwin()
+{
+}
+
+void CSpeechRecognitionDarwin::OnRecognitionDone(speech::ISpeechRecognitionListener* listener)
+{
+  std::unique_lock<CCriticalSection> lock(m_impl->m_listenersMutex);
+  for (auto it = m_impl->m_listeners.begin(); it != m_impl->m_listeners.end(); ++it)
+  {
+    if ((*it).get() == listener)
+    {
+      m_impl->m_listeners.erase(it);
+      break;
+    }
+  }
+}

--- a/xbmc/speech/ISpeechRecognition.h
+++ b/xbmc/speech/ISpeechRecognition.h
@@ -17,6 +17,8 @@ class ISpeechRecognitionListener;
 class ISpeechRecognition
 {
 public:
+  static std::shared_ptr<speech::ISpeechRecognition> CreateInstance();
+
   virtual ~ISpeechRecognition() = default;
 
   virtual void StartSpeechRecognition(


### PR DESCRIPTION
What has started with #21330 now will continue with an implementation for macOS and iOS. :-)

First commit makes the service multi platform ready by making it provided in a platform independent way at the Service Broker (same implementation gist as for example used for WSDiscovery).

Second commit is the implementation of this service based on Apple's Speech framework.

Please note that:
* the Apple Speech framework is not available for tvOS, only macOS and iOS
* on macOS, the Speech service is first available with 10.15. Our deployment target for Kodi is 10.13. I implemented the code so that Kodi should still run on 10.13, just without the speech recognition feature.

I carefully tested this on two Macs and to ensure no regressions to the Android implementation has sneaked in, I also tested on Android.

@kambala-decapitator @fuzzard  would be cool to get your review, especially on the platform specific, cmake and 10.13 related part of this PR.
@lrusak any thoughts regarding the Multiplatform approach (using xbmc/platform)?