### PR TITLE
[Android] Clean exit from native activity. Reuse kodi shared lib.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3744,8 +3744,16 @@ void CApplication::PrintStartupLog()
             StringUtils::Join(CCompileInfo::GetWebserverExtraWhitelist(), ", "));
 #endif
 
-  std::string executable = CUtil::ResolveExecutablePath();
-  CLog::Log(LOGINFO, "The executable running is: {}", executable);
+  // Check, whether libkodi.so was reused (happens on Android, where the system does not unload
+  // the lib on activity end, but keeps it loaded (as long as there is enough memory) and reuses
+  // it on next activity start.
+  static bool firstRun = true;
+
+  CLog::Log(LOGINFO, "The executable running is: {}{}", CUtil::ResolveExecutablePath(),
+            firstRun ? "" : " [reused]");
+
+  firstRun = false;
+
   std::string hostname("[unknown]");
   m_ServiceManager->GetNetwork().GetHostName(hostname);
   CLog::Log(LOGINFO, "Local hostname: {}", hostname);

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -41,14 +41,10 @@
 // Only required for Py3 < 3.7
 PyThreadState* savestate;
 
+bool XBPython::m_bInitialized = false;
+
 XBPython::XBPython()
 {
-  m_bInitialized = false;
-  m_mainThreadState = NULL;
-  m_iDllScriptCounter = 0;
-  m_vecPlayerCallbackList.clear();
-  m_vecMonitorCallbackList.clear();
-
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
 }
 

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -103,10 +103,11 @@ public:
   bool WaitForEvent(CEvent& hEvent, unsigned int milliseconds);
 
 private:
+  static bool m_bInitialized; // whether global python runtime was already initialized
+
   CCriticalSection m_critSection;
-  void* m_mainThreadState;
-  bool m_bInitialized;
-  int m_iDllScriptCounter; // to keep track of the total scripts running that need the dll
+  void* m_mainThreadState{nullptr};
+  int m_iDllScriptCounter{0}; // to keep track of the total scripts running that need the dll
 
   //Vector with list of threads used for running scripts
   PyList m_vecPyList;

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -98,34 +98,28 @@ LogRedirector g_LogRedirector;
 
 extern void android_main(struct android_app* state)
 {
+  // revector inputPollSource.process so we can shut up
+  // its useless verbose logging on new events (see ouya)
+  // and fix the error in handling multiple input events.
+  // see https://code.google.com/p/android/issues/detail?id=41755
+  state->inputPollSource.process = process_input;
+
+  CEventLoop eventLoop(state);
+  IInputHandler inputHandler;
+  CXBMCApp& theApp = CXBMCApp::Create(state->activity, inputHandler);
+  if (theApp.isValid())
   {
-    // revector inputPollSource.process so we can shut up
-    // its useless verbose logging on new events (see ouya)
-    // and fix the error in handling multiple input events.
-    // see https://code.google.com/p/android/issues/detail?id=41755
-    state->inputPollSource.process = process_input;
-
-    CEventLoop eventLoop(state);
-    IInputHandler inputHandler;
-    CXBMCApp& theApp = CXBMCApp::Create(state->activity, inputHandler);
-    if (theApp.isValid())
-    {
-      eventLoop.run(theApp, inputHandler);
-      theApp.Quit();
-    }
-    else
-      CXBMCApp::android_printf("android_main: setup failed");
-
-    CXBMCApp::android_printf("android_main: Exiting");
-
-    CXBMCApp::Destroy();
+    eventLoop.run(theApp, inputHandler);
+    theApp.Quit();
   }
-  // We need to call exit() so that all loaded libraries are properly unloaded
-  // otherwise on the next start of the Activity android will simply re-use
-  // those loaded libs in the state they were in when we quit Kodi last time
-  // which will lead to crashes because of global/static classes that haven't
-  // been properly uninitialized
-  exit(0);
+  else
+  {
+    CXBMCApp::android_printf("android_main: setup failed");
+  }
+
+  CXBMCApp::Destroy();
+
+  CXBMCApp::android_printf("android_main: Exiting");
 }
 
 extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)


### PR DESCRIPTION
This is the final PR to let Kodi on Android native activity exit in a clean way - longer forced lib unload with call to `exit()`. Android now can manage the lifetime of Kodi's shared library, for example keep it in memory and reuse the lib once Kodi gets restarted.

It was a longer list of PRs needed to properly de-init and re-init the Kodi code without reloading it:

* https://github.com/xbmc/xbmc/pull/20971
* https://github.com/xbmc/xbmc/pull/21049
* https://github.com/xbmc/xbmc/pull/21088
* https://github.com/xbmc/xbmc/pull/21096
* https://github.com/xbmc/xbmc/pull/21098
* https://github.com/xbmc/xbmc/pull/21146
* https://github.com/xbmc/xbmc/pull/21148
* https://github.com/xbmc/xbmc/pull/21149
* https://github.com/xbmc/xbmc/pull/21174
* ... and some more induced by changed logging/settings init/deinit

This PR:

Python must not re-initialized on subsequent Kodi start. I tried a clean deinit on Kodi exit, but it always bombed. so, i decided to use a static "initialized" flag to prevent multiple initialization of Pythin.

Application now logs on startup if the executable was reused. No need for a platform ifdef here.

Last not least, the elimination of the infamous `exit()`call in `android_main()`.

I runtime-tested this carefully on my NVidia Shield TV Pro 2019 (running Android 11).

BTW: In case of problems after merge of this PR, we can simply revert the last commit (the one that removes the `exit()` call. There will be no side effects.