### PR TITLE
Disable rendering highly transparent elements

### DIFF
--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -402,7 +402,8 @@ bool CGUIControl::CanFocus() const
 
 bool CGUIControl::IsVisible() const
 {
-  if (m_forceHidden) return false;
+  if (m_forceHidden || m_transform.alpha <= 0.01f)
+    return false;
   return m_visible == VISIBLE;
 }
 


### PR DESCRIPTION
## Description
This patch disables rendering of highly transparent GUI elements. The threshold is at 99% transparency.

## Motivation and context
In some scenes in Estuary (and on others, I presume), textures and text might be faded away while still being rendered. This has a negative GPU performance impact.

## How has this been tested?
One obvious scene where this patch shines is the info dialog of Estuary. As you can see in the screenshots, the amount of overdraw is hugely reduced. The amount of draw calls is halved (160 vs. 80). According to Renderdoc, the rendering time went from 1.74ms to 1.17ms (-33%) on my RX570 at 4k.

Another benefit I could observe is on the Estuary home screen. In between the category transition animation (where the old set of element fades out while the new one fades in), zero to one elements get rendered at all times. Before, both elements would get rendered.

I couldn't find any rendering issues.

## What is the effect on users?
It shouldn't have any impact except improved GPU performance.

## Screenshots (if appropriate):
The Estuary info dialog:
![infoscreen](https://user-images.githubusercontent.com/30039775/167965422-fed409f5-e8a0-48ca-8d7c-9eddcfeb2b37.png)
Overdraw before the patch (notice the home screen in the background)
![before_overlay](https://user-images.githubusercontent.com/30039775/167965355-475b474b-fe17-4622-9011-c95c5870e207.png)
Overdraw after the patch:
![after_overlay](https://user-images.githubusercontent.com/30039775/167965366-0f8a4519-6fae-4870-817b-f3c070b3b15a.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
