### PR TITLE
[InputStream] Add AV1 codec support

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_codec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_codec.h
@@ -120,6 +120,27 @@ extern "C"
     /// [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling): 4:2:0, 4:2:2, 4:4:4,
     /// see [VP9 Bitstream & Decoding Process Specification](https://storage.googleapis.com/downloads.webmproject.org/docs/vp9/vp9-bitstream-specification-v0.6-20160331-draft.pdf)
     VP9CodecProfile3,
+
+    /// @brief **AV1** Main profile\n
+    /// \n
+    /// [Color depth](https://en.wikipedia.org/wiki/Color_depth): 8–10 bit,
+    /// [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling): 4:2:0
+    /// see [AV1 specification](https://aomedia.org/av1/specification/)
+    AV1CodecProfileMain,
+
+    /// @brief **AV1** High profile\n
+    /// \n
+    /// [Color depth](https://en.wikipedia.org/wiki/Color_depth): 8–10 bit,
+    /// [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling): 4:2:0, 4:4:4
+    /// see [AV1 specification](https://aomedia.org/av1/specification/)
+    AV1CodecProfileHigh,
+
+    /// @brief **AV1** Professional profile\n
+    /// \n
+    /// [Color depth](https://en.wikipedia.org/wiki/Color_depth): 8–12 bit,
+    /// [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling): 4:2:0, 4:2:2, 4:4:4
+    /// see [AV1 specification](https://aomedia.org/av1/specification/)
+    AV1CodecProfileProfessional,
   };
   ///@}
   //------------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
@@ -87,7 +87,14 @@ extern "C"
     /// VP9 is the successor to VP8 and competes mainly with MPEG's
     /// [High Efficiency Video Coding](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding)
     /// (HEVC/H.265).
-    VIDEOCODEC_VP9
+    VIDEOCODEC_VP9,
+
+    /// @brief [AV1](https://en.wikipedia.org/wiki/AV1) video coding format\n
+    /// \n
+    /// AV1 is the successor to VP9 and competes mainly with MPEG's
+    /// [High Efficiency Video Coding](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding)
+    /// (HEVC/H.265).
+    VIDEOCODEC_AV1,
   };
   //----------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -108,7 +108,7 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "c-api/addon-instance/imagedecoder.h" \
                                                       "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.1.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.1.1"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.1.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
@@ -174,7 +174,7 @@
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h" \
                                                       "c-api/addon-instance/visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.0.2"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.0.3"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "2.0.1"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "c-api/addon-instance/video_codec.h" \

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -117,6 +117,26 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
       return false;
     }
     break;
+  case AV_CODEC_ID_AV1:
+    initData.codec = VIDEOCODEC_AV1;
+    switch (hints.profile)
+    {
+    case FF_PROFILE_UNKNOWN:
+      initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
+      break;
+    case FF_PROFILE_AV1_MAIN:
+      initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileMain;
+      break;
+    case FF_PROFILE_AV1_HIGH:
+      initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileHigh;
+      break;
+    case FF_PROFILE_AV1_PROFESSIONAL:
+      initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileProfessional;
+      break;
+    default:
+      return false;
+    }
+    break;
   default:
     return false;
   }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -696,6 +696,12 @@ int CInputStreamAddon::ConvertVideoCodecProfile(STREAMCODEC_PROFILE profile)
     return FF_PROFILE_VP9_2;
   case VP9CodecProfile3:
     return FF_PROFILE_VP9_3;
+  case AV1CodecProfileMain:
+    return FF_PROFILE_AV1_MAIN;
+  case AV1CodecProfileHigh:
+    return FF_PROFILE_AV1_HIGH;
+  case AV1CodecProfileProfessional:
+    return FF_PROFILE_AV1_PROFESSIONAL;
   default:
     return FF_PROFILE_UNKNOWN;
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add AV1 codec support to InputStream addons

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was testing AV1 with InputStream adaptive and playback not works
after investigating i realized that has been not added the InputStream implementation
by testing webm container playback works good image are correct (libdav)

and this is the InputStream Adaptive PR for AV1 implementation:
https://github.com/xbmc/inputstream.adaptive/pull/972

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see https://github.com/xbmc/inputstream.adaptive/pull/972

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Playback AV1 streams with InputStream based addons

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
