### PR TITLE
[PVR] Fix crash on restart of add-on (due to changed add-on settings).

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -683,25 +683,13 @@ bool CPVRManager::UpdateComponents(std::vector<std::shared_ptr<CPVRClient>>& kno
                                    ManagerState stateToCheck,
                                    const std::unique_ptr<CPVRGUIProgressHandler>& progressHandler)
 {
-  // find clients which disappeared since last check and remove them from known clients
-  for (auto it = knownClients.begin(); it != knownClients.end();)
-  {
-    if ((*it)->IgnoreClient())
-    {
-      it = knownClients.erase(it);
-      CLog::LogFC(LOGDEBUG, LOGPVR,
-                  "PVR client '{}' disconnected. Erasing from list of known clients.", (*it)->ID());
-    }
-    else
-      ++it;
-  }
-
   // find clients which appeared since last check and update them
   CPVRClientMap clientMap;
   m_addons->GetCreatedClients(clientMap);
   if (clientMap.empty())
   {
     CLog::LogFC(LOGDEBUG, LOGPVR, "All created PVR clients gone!");
+    knownClients.clear(); // start over
     return false;
   }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -215,7 +215,11 @@ void CPVRClients::UpdateAddons(const std::string& changedAddonId /*= ""*/)
 
 bool CPVRClients::RequestRestart(const std::string& id, bool bDataChanged)
 {
-  return StopClient(id, true);
+  CServiceBroker::GetJobManager()->Submit([this, id] {
+    UpdateAddons(id);
+    return true;
+  });
+  return true;
 }
 
 bool CPVRClients::StopClient(const std::string& id, bool bRestart)


### PR DESCRIPTION
Fixes a crash I encountered on requested restart of a PVR add-on after changing some settings of that add-on.

If an add-on (temporarily) disappears at runtime, we must restart the whole PVR Manager, like we do after uninstalling/disabling PVR add-ons. For some reason this was missing for restarting an add-on -- which is unloading the shared lib and reinitiliazation of the add-on (!) -- and nobody seems to have noticed so far. I use a multi add-on setup, which kind of helped to reveal this bug.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish when you find some time for a review...