### PR TITLE
[swig] generate python consts based off constexpr variables

### DIFF
--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -918,9 +918,17 @@ namespace PythonBindings
    PyModule_AddStringConstant(module, "__platform__", "ALL");
 
    // need to handle constants
+   // #define constants
 <% module.depthFirst().findAll( { it.name() == 'constant'} ).each {
      String pyCall =
         (it.@type == 'int' || it.@type == 'long' || it.@type == 'unsigned int' || it.@type == 'unsigned long' || it.@type == 'bool') ?
+        'PyModule_AddIntConstant' : 'PyModule_AddStringConstant' %>
+   ${pyCall}(module,"${it.@sym_name}",${it.@value}); <%
+  } %>
+  // constexpr constants
+<% module.depthFirst().findAll( { it.name() == 'variable' && it.@storage && it.@storage == "constexpr" && !it.@error } ).each {
+     String pyCall =
+        ( it.@type == 'q(const).int' || it.@type == 'q(const).long' || it.@type == 'q(const).unsigned int' || it.@type == 'q(const).unsigned long' || it.@type == 'q(const).bool' ) ?
         'PyModule_AddIntConstant' : 'PyModule_AddStringConstant' %>
    ${pyCall}(module,"${it.@sym_name}",${it.@value}); <%
   } %>


### PR DESCRIPTION
## Description
Fallout from #21264 with the transition from #define to constexpr.


## Motivation and context
Fixes #21389 

## How has this been tested?
swig generation compared to pre #21264

We now get something like the following in the generated module code, where pre this PR, they arent added at all

```
  PyModule_AddIntConstant(module, "ACTION_NONE", 0);
  PyModule_AddIntConstant(module, "ACTION_MOVE_LEFT", 1);
  PyModule_AddIntConstant(module, "ACTION_MOVE_RIGHT", 2);
  PyModule_AddIntConstant(module, "ACTION_MOVE_UP", 3);
  PyModule_AddIntConstant(module, "ACTION_MOVE_DOWN", 4);
  PyModule_AddIntConstant(module, "ACTION_PAGE_UP", 5);
  PyModule_AddIntConstant(module, "ACTION_PAGE_DOWN", 6);
  PyModule_AddIntConstant(module, "ACTION_SELECT_ITEM", 7);
  PyModule_AddIntConstant(module, "ACTION_HIGHLIGHT_ITEM", 8);
  PyModule_AddIntConstant(module, "ACTION_PARENT_DIR", 9);
  PyModule_AddIntConstant(module, "ACTION_PREVIOUS_MENU", 10);
  PyModule_AddIntConstant(module, "ACTION_SHOW_INFO", 11);
  PyModule_AddIntConstant(module, "ACTION_PAUSE", 12);
  PyModule_AddIntConstant(module, "ACTION_STOP", 13);
```

I'll ping @jimfcarroll if you have a minute to tell me if i should do this in a different approach.
Its been split as a second loop, so technically we could do it all in the single loop, and just add the constexpr type and name checks where applicable, however i think it gives us an idea to see whats constexpr, and whats still being pulled in as a #define. Also this is only generated at compile time, and not done at runtime, so its a single time cost for what i hope can give some clarity around generated types.

As an fyi, the check for error is due to redefinitions. If a constexpr redefines something, it provides an error field with a message like the following

```
                    <cdecl id="12206" addr="0x1520737a0" >
                        <attributelist id="12207" addr="0x1520737a0" >
                            <attribute name="name" value="INPUT_ALPHANUM" id="12208" addr="0x1520d7b40" />
                            <attribute name="decl" value="" id="12209" addr="0x1520d7b40" />
                            <attribute name="feature_immutable" value="1" id="12210" addr="0x1520d7b40" />
                            <attribute name="error" value="/Users/brent/Dev/macos/xbmc/interfaces/legacy/Dialog.h:27:Identifier 'INPUT_ALPHANUM' redefined (ignored),&#10;/Users/brent/Dev/macos/xbmc/interfaces/legacy/ModuleXbmcgui.h:134:previous definition of 'INPUT_ALPHANUM'.&#10;" id="12211" addr="0x1520d7b40" />
                            <attribute name="storage" value="constexpr" id="12212" addr="0x1520d7b40" />
                            <attribute name="code" value="{0}" id="12213" addr="0x1520d7b40" />
                            <attribute name="kind" value="variable" id="12214" addr="0x1520d7b40" />
                            <attribute name="hasconsttype" value="1" id="12215" addr="0x1520d7b40" />
                            <attribute name="type" value="int" id="12216" addr="0x1520d7b40" />
                        </attributelist >
                     
                    </cdecl >
```

This then would get added with null fields, so we just skip them.

just for info's sake, heres the xml generated when a #define is read in

```
                    <constant id="871" addr="0x15201ebc0" >
                        <attributelist id="872" addr="0x15201ebc0" >
                            <attribute name="value" value="INPUT_ALPHANUM" id="873" addr="0x1520d7b40" />
                            <attribute name="name" value="INPUT_ALPHANUM" id="874" addr="0x1520d7b40" />
                            <attribute name="sym_symtab" value="0x15201ba20" id="875" addr="0x15201ba20" />
                            <attribute name="csym_nextSibling" value="0x1520737a0" id="876" addr="0x1520737a0" />
                            <attribute name="feature_immutable" value="1" id="877" addr="0x1520d7b40" />
                            <attribute name="sym_name" value="INPUT_ALPHANUM" id="878" addr="0x1520d7b40" />
                            <attribute name="type" value="int" id="879" addr="0x1520d7b40" />
                            <attribute name="sym_overname" value="__SWIG_0" id="880" addr="0x1520d7b40" />
                            <attribute name="storage" value="%constant" id="881" addr="0x1520d7b40" />
                            <attribute name="rawval" value="INPUT_ALPHANUM" id="882" addr="0x1520d7b40" />
                        </attributelist >
                     
                    </constant >
```

## What is the effect on users?
working python addons

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
