### PR TITLE
[PVR] Fix wrong year in recordings file names. (issue 21253)

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -594,7 +594,7 @@ void CPVRRecording::SetYear(int year)
 
 int CPVRRecording::GetYear() const
 {
-  return m_premiered.GetYear();
+  return m_premiered.IsValid() ? m_premiered.GetYear() : 0;
 }
 
 bool CPVRRecording::HasYear() const


### PR DESCRIPTION
Fixes #21253

Code fix was trivial, fix for wrong strings stored in in user's video database needs db schema bump. Not a problem, just saying.

I carefully runtime-tested the change on macOS, latest master. No play counts and resume bookmarks are lost. :-)

@phunkyfish if you are in the right mood for a code review...

