### PR TITLE
[tools/depends][target] libuuid fix common failure due to path creation

### DIFF
--- a/tools/depends/target/libuuid/Makefile
+++ b/tools/depends/target/libuuid/Makefile
@@ -18,6 +18,9 @@ all: .installed-$(PLATFORM)
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	# e2fsprog libuuid often fails because it doesnt create include/uuid location before
+	# installing. lets just create it and move on.
+	mkdir -p $(PREFIX)/include/uuid
 	cd $(PLATFORM); ./configure --prefix=$(PREFIX) --disable-fsck --enable-libuuid
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
## Description
Fix libuuid failure due to include/uuid path creation not occuring

## Motivation and context
Fix a common failure that is caused to to the makefile install target not
creating the include/uuid directly before installing the include files.

cd aarch64-linux-android-30-debug/lib/uuid ; /Applications/Xcode.app/Contents/Developer/usr/bin/make -j1 install
	MKDIR_P /Users/Shared/xbmc-depends/aarch64-linux-android-30-debug/lib /Users/Shared/xbmc-depends/aarch64-linux-android-30-debug/include/uuid /Users/Shared/xbmc-depends/aarch64-linux-android-30-debug/share/man/man3
	INSTALL_DATA /Users/Shared/xbmc-depends/aarch64-linux-android-30-debug/lib/libuuid.a
	INSTALL_DATA /Users/Shared/xbmc-depends/aarch64-linux-android-30-debug/include/uuid/uuid.h
install: /Users/Shared/xbmc-depends/aarch64-linux-android-30-debug/include/uuid/uuid.h: No such file or directory
make[3]: *** [install] Error 71
make[2]: *** [.installed-aarch64-linux-android-30-debug] Error 2
make[1]: *** [libuuid] Error 2

The actual e2fsprog makefile has "correct" path creation, but for whatever reason (probably because we selectively only do 1 target), so rather than deal with a potential non upstream issue, we just create the path and move on.

## How has this been tested?
Builds

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
