### PR TITLE
[gui][info] Add VideoPlayer.Art(type) and positional variants

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3318,6 +3318,35 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     @skinning_v19 **[New Infolabel]** \link VideoPlayer_Position_mpaa `VideoPlayer.position(number).mpaa`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`VideoPlayer.Art(type)`</b>,
+///                  \anchor VideoPlayer_art
+///                  _string_,
+///     @return The art path for the requested arttype and for the currently playing video.
+///     @param type - can virtually be anything\, refers to the art type keyword in the art map (poster\, fanart\, banner\, thumb\, etc)
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link VideoPlayer_art `VideoPlayer.Art(type)`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`VideoPlayer.offset(number).Art(type)`</b>,
+///                  \anchor VideoPlayer_Offset_art
+///                  _string_,
+///     @return The art path for the requested arttype and for the video which has an offset `number` with respect to the currently playing video.
+///     @param number - the offset with respect to the start of the playlist
+///     @param type - can virtually be anything\, refers to the art type keyword in the art map (poster\, fanart\, banner\, thumb\, etc)
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link VideoPlayer_Offset_mpaa `VideoPlayer.offset(number).Art(type)`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`VideoPlayer.position(number).Art(type)`</b>,
+///                  \anchor VideoPlayer_position_art
+///                  _string_,
+///     @return The art path for the requested arttype and for the video which has an offset `number` with respect to the start of the playlist.
+///     @param number - the offset with respect to the start of the playlist
+///     @param type - can virtually be anything\, refers to the art type keyword in the art map (poster\, fanart\, banner\, thumb\, etc)
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link VideoPlayer_position_art `VideoPlayer.position(number).Art(type)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`VideoPlayer.IMDBNumber`</b>,
 ///                  \anchor VideoPlayer_IMDBNumber
 ///                  _string_,
@@ -3859,6 +3888,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
+// clang-format off
 const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
                                   { "genre",            VIDEOPLAYER_GENRE },
                                   { "country",          VIDEOPLAYER_COUNTRY },
@@ -3930,7 +3960,9 @@ const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
                                   { "tvshowdbid",       VIDEOPLAYER_TVSHOWDBID },
                                   { "audiostreamcount", VIDEOPLAYER_AUDIOSTREAMCOUNT },
                                   { "hdrtype",          VIDEOPLAYER_HDR_TYPE },
+                                  { "art",              VIDEOPLAYER_ART},
 };
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_RetroPlayer RetroPlayer
@@ -10135,6 +10167,10 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_UNIQUEID, prop.param(), 0));
       }
+      if (prop.name == "art" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(CGUIInfo(VIDEOPLAYER_ART, prop.param(), 0));
+      }
       return TranslateVideoPlayerString(prop.name);
     }
     else if (cat.name == "retroplayer")
@@ -10373,13 +10409,18 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       {
         int position = atoi(info[1].param().c_str());
         int value = TranslateVideoPlayerString(info[2].name); // videoplayer.position(foo).bar
-        return AddMultiInfo(CGUIInfo(value, 2, position)); // 2 => absolute (0 used for not set)
+        // additional param for the requested infolabel, e.g. VideoPlayer.Position(1).Art(poster): art is the value, poster is the param
+        const std::string& param = info[2].param();
+        return AddMultiInfo(
+            CGUIInfo(value, 2, position, param)); // 2 => absolute (0 used for not set)
       }
       else if (info[1].name == "offset")
       {
         int position = atoi(info[1].param().c_str());
         int value = TranslateVideoPlayerString(info[2].name); // videoplayer.offset(foo).bar
-        return AddMultiInfo(CGUIInfo(value, 1, position)); // 1 => relative
+        // additional param for the requested infolabel, e.g. VideoPlayer.Offset(1).Art(poster): art is the value, poster is the param
+        const std::string& param = info[2].param();
+        return AddMultiInfo(CGUIInfo(value, 1, position, param)); // 1 => relative
       }
     }
     else if (info[0].name == "player")

--- a/xbmc/guilib/guiinfo/GUIInfo.h
+++ b/xbmc/guilib/guiinfo/GUIInfo.h
@@ -44,6 +44,11 @@ public:
       SetInfoFlag(flag);
   }
 
+  CGUIInfo(int info, uint32_t data1, int data2, const std::string& data3)
+    : m_info(info), m_data1(data1), m_data2(data2), m_data3(data3), m_data4(0)
+  {
+  }
+
   CGUIInfo(int info, uint32_t data1, const std::string& data3)
   : m_info(info),
     m_data1(data1),

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -223,6 +223,8 @@
 #define MUSICPLAYER_CONTENT         246
 #define MUSICPLAYER_ISMULTIDISC     247
 
+// Videoplayer infolabels
+#define VIDEOPLAYER_HDR_TYPE          249
 // Keep videoplayer infolabels that work with offset and position together
 #define VIDEOPLAYER_TITLE             250
 #define VIDEOPLAYER_GENRE             251
@@ -254,11 +256,11 @@
 #define VIDEOPLAYER_USER_RATING       277
 #define VIDEOPLAYER_DBID              278
 #define VIDEOPLAYER_TVSHOWDBID        279
-#define VIDEOPLAYER_HDR_TYPE          280
+#define VIDEOPLAYER_ART               280
 
 // Range of videoplayer infolabels that work with offset and position
 #define VIDEOPLAYER_OFFSET_POSITION_FIRST VIDEOPLAYER_TITLE
-#define VIDEOPLAYER_OFFSET_POSITION_LAST VIDEOPLAYER_TVSHOWDBID
+#define VIDEOPLAYER_OFFSET_POSITION_LAST VIDEOPLAYER_ART
 
 #define VIDEOPLAYER_AUDIO_BITRATE     281
 #define VIDEOPLAYER_VIDEO_BITRATE     282

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -102,6 +102,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       /////////////////////////////////////////////////////////////////////////////////////////////
       // PLAYER_* / VIDEOPLAYER_* / LISTITEM_*
       /////////////////////////////////////////////////////////////////////////////////////////////
+      case VIDEOPLAYER_ART:
+        value = item->GetArt(info.GetData3());
+        return true;
       case PLAYER_PATH:
       case PLAYER_FILENAME:
       case PLAYER_FILEPATH:
@@ -637,6 +640,11 @@ bool CVideoGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo& info) co
   else if (info.m_info == VIDEOPLAYER_COVER)
   {
     value = playlistItem->GetArt("thumb");
+    return true;
+  }
+  else if (info.m_info == VIDEOPLAYER_ART)
+  {
+    value = playlistItem->GetArt(info.GetData3());
     return true;
   }
 


### PR DESCRIPTION
## Description
This PR adds the `VideoPlayer.Art(type)` infolabel as well as all the positional variants:
- `VideoPlayer.Offset(x).Art(type)` - returns the path for the requested art `type` for the `x` item in the playlist, with respect to the current playing item
- `VideoPlayer.Position(x).Art(type)` - returns the path for the requested art `type` for the `x` item in the playlist, with respect to the playlist start

Changes the index of `VIDEOPLAYER_HDR_TYPE` as, according to the code, all infolabels that support positional variants should be kept together in the list is compared against `VIDEOPLAYER_OFFSET_POSITION_LAST`. The index of this infolabel was making it impossible to have any other valid id after `VIDEOPLAYER_TVSHOWDBID`.

@jjd-uk please check if this fits your needs or if you still need something else added.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21399, request seems sensible and the implementation seemed not to be too hard as I've been playing with this stuff lately.

## How has this been tested?
Runtime tested with infos added to the seekbar, see diff below

## What is the effect on users?
Should be able to display art for other items in the playlist in the video osd.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7375276/168479810-d2383857-014b-45c6-8f8c-40d3c4ae7c7d.png)

```
diff --git a/addons/skin.estuary/xml/DialogSeekBar.xml b/addons/skin.estuary/xml/DialogSeekBar.xml
index 80090f144f..14d5b0548b 100644
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -386,6 +386,19 @@
                                <bordersize>20</bordersize>
                                <include>OpenClose_Left</include>
                        </control>
+                       <control type="image">
+                               <depth>DepthOSD+</depth>
+                               <left>400</left>
+                               <bottom>445</bottom>
+                               <width>200</width>
+                               <height>400</height>
+                               <aspectratio aligny="bottom">keep</aspectratio>
+                               <texture fallback="DefaultVideo.png" background="true">$INFO[VideoPlayer.Offset(1).Art(poster)]</texture>
+                               <bordertexture border="21">overlays/shadow.png</bordertexture>
+                               <bordersize>20</bordersize>
+                               <include>OpenClose_Left</include>
+                               <visible>Integer.IsGreater(Playlist.Length(video),1)</visible>
+                       </control>
                        <control type="grouplist">
                                <left>420</left>
                                <top>10</top>
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
