### PR TITLE
[gui][info] Add Addon.Setting* infos

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -132,6 +132,50 @@ typedef struct
 ///
 /// -----------------------------------------------------------------------------
 
+/// \page modules__infolabels_boolean_conditions
+/// \subsection modules__infolabels_boolean_conditions_Addon Addon
+/// \table_start
+///   \table_h3{ Labels, Type, Description }
+///   \table_row3{   <b>`Addon.Setting(addon_id\, setting_id)`</b>,
+///                  \anchor Addon_SettingString
+///                  _string_,
+///     @return The string value of the setting `setting_id` belonging to the addon with the id `addon_id`.
+///     @param addon_id - the id of the addon
+///     @param setting_id - the addon setting
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link Addon_SettingString `Addon.Setting(addon_id\, setting_id)`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Addon.SettingBool(addon_id\, setting_id)`</b>,
+///                  \anchor Addon_SettingBool
+///                  _boolean_,
+///     @return **True** if the setting `setting_id` belonging to the addon with the id `addon_id` is **True**\, **False** otherwise.
+///     @note The provided setting with `setting_id` must be boolean setting type.
+///     @param addon_id - the id of the addon
+///     @param setting_id - the addon setting
+///     <p><hr>
+///     @skinning_v20 **[New Boolean Condition]** \link Addon_SettingBool `Addon.SettingBool(addon_id\, setting_id)`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Addon.SettingInt(addon_id\, setting_id)`</b>,
+///                  \anchor Addon_SettingInt
+///                  _integer_,
+///     @return The integer value of the setting `setting_id` belong to the addon with the id `addon_id`.
+///     @note The provided setting with `setting_id` must be an integer setting type.
+///     @param addon_id - the id of the addon
+///     @param setting_id - the addon setting
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link Addon_SettingInt `Addon.SettingInt(addon_id\, setting_id)`\endlink
+///     <p>
+///   }
+/// \table_end
+///
+/// -----------------------------------------------------------------------------
+const infomap addons[] = {
+    {"setting", ADDON_SETTING},
+    {"settingbool", ADDON_SETTING_BOOL},
+    {"settingint", ADDON_SETTING_INT},
+};
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_String String
@@ -9882,6 +9926,14 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           if (prop.name == i.str)
             return AddMultiInfo(CGUIInfo(i.val, prop.param()));
         }
+      }
+    }
+    else if (cat.name == "addon")
+    {
+      for (const infomap& i : addons)
+      {
+        if (prop.name == i.str && prop.num_params() == 2)
+          return AddMultiInfo(CGUIInfo(i.val, prop.param(0), prop.param(1)));
       }
     }
     else if (cat.name == "weather")

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -141,6 +141,20 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
   switch (info.m_info)
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
+    // ADDON_*
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    case ADDON_SETTING:
+    {
+      ADDON::AddonPtr addon;
+      if (!CServiceBroker::GetAddonMgr().GetAddon(info.GetData3(), addon, ADDON::ADDON_UNKNOWN,
+                                                  ADDON::OnlyEnabled::CHOICE_YES))
+      {
+        return false;
+      }
+      value = addon->GetSetting(info.GetData5());
+      return true;
+    }
+    ///////////////////////////////////////////////////////////////////////////////////////////////
     // SYSTEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case SYSTEM_ADDON_TITLE:
@@ -184,6 +198,22 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
 
 bool CAddonsGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
+  switch (info.m_info)
+  {
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // ADDON_*
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    case ADDON_SETTING_INT:
+    {
+      ADDON::AddonPtr addon;
+      if (!CServiceBroker::GetAddonMgr().GetAddon(info.GetData3(), addon, ADDON::ADDON_UNKNOWN,
+                                                  ADDON::OnlyEnabled::CHOICE_YES))
+      {
+        return false;
+      }
+      return addon->GetSettingInt(info.GetData5(), value);
+    }
+  }
   return false;
 }
 
@@ -191,6 +221,19 @@ bool CAddonsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
 {
   switch (info.m_info)
   {
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // ADDON_*
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    case ADDON_SETTING_BOOL:
+    {
+      ADDON::AddonPtr addon;
+      if (!CServiceBroker::GetAddonMgr().GetAddon(info.GetData3(), addon, ADDON::ADDON_UNKNOWN,
+                                                  ADDON::OnlyEnabled::CHOICE_YES))
+      {
+        return false;
+      }
+      return addon->GetSettingBool(info.GetData5(), value);
+    }
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SYSTEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/xbmc/guilib/guiinfo/GUIInfo.h
+++ b/xbmc/guilib/guiinfo/GUIInfo.h
@@ -71,13 +71,15 @@ public:
   {
   }
 
+  explicit CGUIInfo(int info, const std::string& data3, const std::string& data5)
+    : m_info(info), m_data1(0), m_data3(data3), m_data4(0), m_data5(data5)
+  {
+  }
+
   bool operator ==(const CGUIInfo &right) const
   {
-    return (m_info == right.m_info &&
-            m_data1 == right.m_data1 &&
-            m_data2 == right.m_data2 &&
-            m_data3 == right.m_data3 &&
-            m_data4 == right.m_data4);
+    return (m_info == right.m_info && m_data1 == right.m_data1 && m_data2 == right.m_data2 &&
+            m_data3 == right.m_data3 && m_data4 == right.m_data4 && m_data5 == right.m_data5);
   }
 
   uint32_t GetInfoFlag() const;
@@ -85,6 +87,7 @@ public:
   int GetData2() const { return m_data2; }
   const std::string& GetData3() const { return m_data3; }
   int GetData4() const { return m_data4; }
+  const std::string& GetData5() const { return m_data5; }
 
   int m_info;
 private:
@@ -94,6 +97,7 @@ private:
   int m_data2;
   std::string m_data3;
   int m_data4;
+  std::string m_data5;
 };
 
 } // namespace GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -723,6 +723,11 @@
 #define PLAYER_PROCESS_AUDIOBITSPERSAMPLE (PLAYER_PROCESS + 11)
 #define PLAYER_PROCESS_VIDEOSCANTYPE (PLAYER_PROCESS + 12)
 
+#define ADDON_INFOS                 1600
+#define ADDON_SETTING               (ADDON_INFOS)
+#define ADDON_SETTING_BOOL          (ADDON_INFOS + 1)
+#define ADDON_SETTING_INT           (ADDON_INFOS + 2)
+
 #define WINDOW_PROPERTY             9993
 #define WINDOW_IS_VISIBLE           9995
 #define WINDOW_NEXT                 9996


### PR DESCRIPTION
## Description
This PR adds support for `Addon.Setting*` infos:

`Addon.Setting(addon_id, setting_id)` -> returns the value of the setting (as a string)
`Addon.SettingBool(addon_id, setting_id)` -> returns the value of an addon boolean setting (boolean condition)
`Addon.SettingInt(addon_id, setting_id)` -> returns the value of an addon integer setting (integer info).

## Motivation and context
It has been requested in the forum a possible way to only present context menu items depending on the settings of a given addon: https://forum.kodi.tv/showthread.php?tid=368241
The request is sane and we have no way to do it at the moment.

## How has this been tested?
This has been tested with a context menu addon with the following settings.xml:

```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<settings>
    <category label="32001">
        <setting label="32011" type="text"   id="mystr" default=""/>
        <setting label="32053" type="slider" id="myint" subsetting="true" default="20" range="5,5,100" option="int" />
        <setting id="mybool" type="bool" label="32013" default="false"/>
    </category>
</settings>
```

Then the context menu definition in addon.xml has been changed to the following variants/visible conditions:

```xml
<menu id="kodi.core.main">
	<item library="addon.py">
		<label>My context menu label</label>
		<visible>Addon.SettingBool(context.myaddon, mybool)</visible>
	</item>
</menu>
```

```xml
<menu id="kodi.core.main">
	<item library="addon.py">
		<label>My context menu label</label>
		<visible>String.IsEqual(Addon.Setting(context.myaddon, mystr), teste)</visible>
	</item>
</menu>
```

```xml
<menu id="kodi.core.main">
	<item library="addon.py">
		<label>My context menu label</label>
		<visible>Integer.IsEqual(Addon.SettingInt(context.myaddon, myint), 20)</visible>
	</item>
</menu>
```

## What is the effect on users?
Should not affect users, it gives an option for addon developers to only present some context menu item if some setting is enabled in the addon settings or if some other condition (that refers an addon setting) is used.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7375276/168486759-327733ef-d421-4598-aace-f443bf9731d7.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
