### PR TITLE
[doxygen] fix skinning revision page list

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3808,6 +3808,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     @return String containing the name of the detected HDR type or empty if not HDR. See \ref StreamHdrType for the list of possible values.
 ///     <p><hr>
 ///     @skinning_v20 **[New Infolabel]** \link VideoPlayer_HdrType `VideoPlayer.HdrType`\endlink
+///     <p>
 ///   }
 /// \table_end
 ///


### PR DESCRIPTION
## Description
This fixes the revision history for the skinning engine after https://github.com/xbmc/xbmc/pull/19983 has been merged a while ago.
Trivial fix so I'll just merge this once jenkins is green.

**master**
![image](https://user-images.githubusercontent.com/7375276/168487822-b62e5208-b1f8-4e6f-a0e9-e345a99db09e.png)

**pr**
![image](https://user-images.githubusercontent.com/7375276/168487847-3ba05a9d-4cfa-4eb6-bdc5-b946e21eb04b.png)
