### PR TITLE
[subtitles] Fix CC condition for valid captions

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -154,7 +154,9 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
 
   while ((len = pSrcPacket->iSize - p) > 3)
   {
-    if ((startcode & 0xffffff00) == 0x00000100)
+    uint8_t* buf = pSrcPacket->pData + p;
+    bool validCaption = (buf[0] & 0x04) > 0;
+    if (validCaption)
     {
       if (m_codec == AV_CODEC_ID_MPEG2VIDEO)
       {
@@ -163,13 +165,11 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
         {
           if (len > 4)
           {
-            uint8_t *buf = pSrcPacket->pData + p;
             picType = (buf[1] & 0x38) >> 3;
           }
         }
         else if (scode == 0xb2) // user data
         {
-          uint8_t *buf = pSrcPacket->pData + p;
           if (len >= 6 &&
             buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4' &&
             buf[4] == 3 && (buf[5] & 0x40))
@@ -231,7 +231,6 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
         // slice data comes after SEI
         if (scode >= 1 && scode <= 5)
         {
-          uint8_t *buf = pSrcPacket->pData + p;
           CBitstream bs(buf, len * 8);
           bs.readGolombUE();
           int sliceType = bs.readGolombUE();
@@ -250,7 +249,6 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
         }
         if (scode == 0x06) // SEI
         {
-          uint8_t *buf = pSrcPacket->pData + p;
           if (len >= 12 &&
             buf[3] == 0 && buf[4] == 49 &&
             buf[5] == 'G' && buf[6] == 'A' && buf[7] == '9' && buf[8] == '4' && buf[9] == 3)


### PR DESCRIPTION
## Description
"Borrowed" from VLC (https://github.com/videolan/vlc/commit/67dd7637ff03343b1a80fcf1dcc55629ec12bdca) this attempts to fix the condition used to let the demuxing of closed captions proceed.

## Motivation and context
A user reported the bug and provided a sample file in https://forum.kodi.tv/showthread.php?tid=368221
Kodi is unable to show those captions while vlc or mpv play them without any issues.

## How has this been tested?
Runtime tested, played some samples I knew Kodi was able to handle before + the failing one.

## What is the effect on users?
Some CC subs that were previously not playing should now be playable.

## Screenshots (if appropriate):

**Master:**
![image](https://user-images.githubusercontent.com/7375276/168626121-14b5b1a3-d683-4079-8163-53f793d7df99.png)
![Screenshot from 2022-05-16 16-12-27](https://user-images.githubusercontent.com/7375276/168625546-3fd76cd5-9ae2-43c8-9b4d-ba7f2425fd06.png)

**PR:**
![image](https://user-images.githubusercontent.com/7375276/168625862-3fe4ecfc-5435-44f3-a01e-92624190ae2a.png)

![Screenshot from 2022-05-16 16-10-59](https://user-images.githubusercontent.com/7375276/168625276-c67a70fb-3ace-4bf5-9447-32f1e99d8dc9.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
