### PR TITLE
[VideoPlayer] Do not update resolution on DMX_SPECIALID_STREAMCHANGE

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3692,8 +3692,9 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     return false;
 
   // set desired refresh rate
-  if (m_playerOptions.fullscreen && CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot() &&
-      hint.fpsrate != 0 && hint.fpsscale != 0)
+  if (m_CurrentVideo.id < 0 && m_playerOptions.fullscreen &&
+      CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot() && hint.fpsrate != 0 &&
+      hint.fpsscale != 0)
   {
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I am working on InputStream Adaptive addon and by testing adaptive bitrate streaming technology i found a bug
for `Adjust refresh rate` setting when enabled:

### Case DMX_SPECIALID_STREAMCHANGE packet (to signal quality change during playback)
If a user want to let the TV upscale Kodi GUI instead of Kodi engine, we can have this situation:
Kodi GUI resolution set to 1080p, `Adjust refresh rate` enabled to allow switch to 4k, when we play a 4k video.

This situation is new, and can be reproduced only with InputStream Adaptive with adaptive bitrate streaming technology,
where i am working on #21319 PR, ~(but updated PR locally not published yet)~ and https://github.com/xbmc/inputstream.adaptive/pull/989

in this example the screen will be switched to 4k when playback starts, until now is all good,
but if with ISA we lower the video stream quality during playback, for example because the network is more busy
at this point the video stream can be changed from 4k until to 1080p (adaptive bitrate streaming technology)
and we send the DMX_SPECIALID_STREAMCHANGE packet to signal the quality change to Kodi,
but the `Adjust refresh rate` setting despite being set to "start/stop" force change the screen resolution from 4k to 1080p resolution.

This because there was no condition verifying whether playback is in progress therefore in any case the screen will be forced switched. To avoid this problem i add in the condition a check for `m_CurrentVideo.id < 0` that is -1 at first playback run.

PS. i think this case 2 is replicable also with a stream that have AD insertions

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Is required the #21319 PR, and InputStream changes https://github.com/xbmc/inputstream.adaptive/pull/989. If needed i will provide all instructions to replicate it

`Adjust refresh rate` set to `always` works as before, tested also VFR mkv

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
A working `Adjust refresh rate` with playlist,
and that not switch screen resolution during playback despite being set to "start/stop"

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
