### PR TITLE
FFmpegImage: Reduce quality a tiny bit

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -582,7 +582,7 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
   tdm.avOutctx->flags = AV_CODEC_FLAG_QSCALE;
   tdm.avOutctx->mb_lmin = tdm.avOutctx->qmin * FF_QP2LAMBDA;
   tdm.avOutctx->mb_lmax = tdm.avOutctx->qmax * FF_QP2LAMBDA;
-  tdm.avOutctx->global_quality = tdm.avOutctx->qmin * FF_QP2LAMBDA;
+  tdm.avOutctx->global_quality = jpg_output ? 4 * FF_QP2LAMBDA : tdm.avOutctx->qmin * FF_QP2LAMBDA;
 
   unsigned int internalBufOutSize = 0;
 

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -6,9 +6,13 @@
  *  See LICENSES/README.md for more information.
  */
 #include "FFmpegImage.h"
-#include "utils/log.h"
+
 #include "cores/FFmpeg.h"
 #include "guilib/Texture.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/log.h"
 
 #include <algorithm>
 
@@ -582,7 +586,10 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
   tdm.avOutctx->flags = AV_CODEC_FLAG_QSCALE;
   tdm.avOutctx->mb_lmin = tdm.avOutctx->qmin * FF_QP2LAMBDA;
   tdm.avOutctx->mb_lmax = tdm.avOutctx->qmax * FF_QP2LAMBDA;
-  tdm.avOutctx->global_quality = jpg_output ? 4 * FF_QP2LAMBDA : tdm.avOutctx->qmin * FF_QP2LAMBDA;
+  unsigned int quality =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageQualityJpeg;
+  tdm.avOutctx->global_quality =
+      jpg_output ? quality * FF_QP2LAMBDA : tdm.avOutctx->qmin * FF_QP2LAMBDA;
 
   unsigned int internalBufOutSize = 0;
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -287,6 +287,7 @@ void CAdvancedSettings::Initialize()
   m_fanartRes = 1080;
   m_imageRes = 720;
   m_imageScalingAlgorithm = CPictureScalingAlgorithm::Default;
+  m_imageQualityJpeg = 4;
 
   m_sambaclienttimeout = 30;
   m_sambadoscodepage = "";
@@ -1086,6 +1087,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 9999);
   if (XMLUtils::GetString(pRootElement, "imagescalingalgorithm", tmp))
     m_imageScalingAlgorithm = CPictureScalingAlgorithm::FromString(tmp);
+  XMLUtils::GetUInt(pRootElement, "imagequalityjpeg", m_imageQualityJpeg, 0, 21);
   XMLUtils::GetBoolean(pRootElement, "playlistasfolders", m_playlistAsFolders);
   XMLUtils::GetBoolean(pRootElement, "uselocalecollation", m_useLocaleCollation);
   XMLUtils::GetBoolean(pRootElement, "detectasudf", m_detectAsUdf);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -229,6 +229,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     unsigned int m_fanartRes; ///< \brief the maximal resolution to cache fanart at (assumes 16x9)
     unsigned int m_imageRes;  ///< \brief the maximal resolution to cache images at (assumes 16x9)
     CPictureScalingAlgorithm::Algorithm m_imageScalingAlgorithm;
+    unsigned int
+        m_imageQualityJpeg; ///< \brief the stored jpeg quality the lower the better (default: 4)
 
     int m_sambaclienttimeout;
     std::string m_sambadoscodepage;


### PR DESCRIPTION
While reading the forum I have seen that a user copied his Thumbnails
directory to a PC and "optimized" the jpegs. From this I checked what
we do in code and have seen that we use the "maximum" possible quality
when storing a lossy jpeg format. This results in very large jpegs
which from quality POV hardly to distinguish at all from a little
compress image. I chose 4 as a sensible value.

Size comparisons:
53K Mai 18 19:16 1b005dd9.jpg
53K Mai 18 19:40 1b005dd9-2.jpg
43K Mai 18 19:40 1b005dd9-3.jpg
30K Mai 18 19:40 1b005dd9-4.jpg
28K Mai 18 19:41 1b005dd9-5.jpg
26K Mai 18 19:41 1b005dd9-6.jpg
22K Mai 18 19:41 1b005dd9-7.jpg
21K Mai 18 19:41 1b005dd9-8.jpg

## What is the effect on users?
Thumbnails will look normally but only use 50% of the size.

## Screenshots (if appropriate):

qscale=1 (highest quality) towards qscale=8 (lowest quality tested)
Original (1):
![1b005dd9](https://user-images.githubusercontent.com/1089309/169109582-82463ab9-fee2-4a9e-8fdf-68d6aa5eadfd.jpg)
2:
![1b005dd9-2](https://user-images.githubusercontent.com/1089309/169109682-d0e0c82b-42b5-43a1-b487-6188cb4f7f9f.jpg)
3:
![1b005dd9-3](https://user-images.githubusercontent.com/1089309/169109764-25e7de82-a52e-4dcd-9b22-a04096c49b9a.jpg)
4:
![1b005dd9-4](https://user-images.githubusercontent.com/1089309/169109791-fe852b2c-3d3e-4431-9de0-e6f2639b8605.jpg)
5:
![1b005dd9-5](https://user-images.githubusercontent.com/1089309/169109820-fa694c7d-790a-4f7c-8514-b1f2310d70ba.jpg)
6:
![1b005dd9-6](https://user-images.githubusercontent.com/1089309/169109851-ceb5bfc9-ffbc-4b0e-89b6-7e9cf2c9658a.jpg)
7:
![1b005dd9-7](https://user-images.githubusercontent.com/1089309/169109879-2badab03-62ac-4414-8bfd-c77175a6e976.jpg)
8:
![1b005dd9-8](https://user-images.githubusercontent.com/1089309/169109900-5e5392c8-af25-47da-876f-c9bd8b502d01.jpg)



