### PR TITLE
[Android] Fix video stutter after #21385

### DIFF
--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -132,12 +132,15 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
   if (IsHdmiModeTriggered())
     SetHdmiState(true);
 
-  // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
-  // we can't actually do anything about it
-  if (rendered && !m_pGLContext.TrySwapBuffers())
-    CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
-
-  CXBMCApp::Get().WaitVSync(1000);
+  if (rendered)
+  {
+    // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
+    // we can't actually do anything about it
+    if (m_pGLContext.TrySwapBuffers())
+      CXBMCApp::Get().WaitVSync(1000);
+    else
+      CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
+  }
 }
 
 float CWinSystemAndroidGLESContext::GetFrameLatencyAdjustment()


### PR DESCRIPTION
[Android] CWinSystemAndroidGLESContext::PresentRenderImpl: Only wait for vsync if we rendered.

Fixes fallout from #21385 - video stuttering when libkodi.so gets reused - which is the case on second and subsequent frequent restarts of the Kodi app on Android.

I carefully runtime-tested this change for about a month, but was not aware that this is needed to complete #21385.

@thexai please review.

