### PR TITLE
[PVR][InputStream] Add an ID3v1/ID3v2 tag metadata stream for PVR Radio addons

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -602,8 +602,8 @@ public:
   /// See https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/codec_desc.c about
   /// available names.
   ///
-  /// @remark On @ref INPUTSTREAM_TYPE_TELETEXT and @ref INPUTSTREAM_TYPE_RDS
-  /// this can be ignored and leaved empty.
+  /// @remark On @ref INPUTSTREAM_TYPE_TELETEXT, @ref INPUTSTREAM_TYPE_RDS, and
+  /// @ref INPUTSTREAM_TYPE_ID3 this can be ignored and leaved empty.
   ///
   /// @param[in] codeName Codec name
   void SetCodecName(const std::string& codecName)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
@@ -179,6 +179,9 @@ extern "C"
 
     /// @brief **5 :** To identify @ref cpp_kodi_addon_inputstream_Defs_Info as Radio RDS
     INPUTSTREAM_TYPE_RDS,
+
+    /// @brief **6 :** To identify @ref cpp_kodi_addon_inputstream_Defs_Info as Audio ID3 tags
+    INPUTSTREAM_TYPE_ID3,
   };
   ///@}
   //------------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_stream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_stream.h
@@ -78,6 +78,9 @@ extern "C"
     /// @brief To identify @ref cpp_kodi_addon_pvr_Defs_Stream_PVRStreamProperties as Radio RDS.
     PVR_CODEC_TYPE_RDS,
 
+    /// @brief To identify @ref cpp_kodi_addon_pvr_Defs_Stream_PVRStreamProperties as Audio ID3 tags.
+    PVR_CODEC_TYPE_ID3,
+
     PVR_CODEC_TYPE_NB
   } PVR_CODEC_TYPE;
   ///@}

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -108,7 +108,7 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "c-api/addon-instance/imagedecoder.h" \
                                                       "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.1.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.1.1"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.1.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
@@ -130,8 +130,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "8.1.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "8.0.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "8.2.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "8.2.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \
                                                       "c-api/addon-instance/pvr/pvr_providers.h" \

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -101,6 +101,7 @@ public:
   virtual bool HasAudio() const = 0;
   virtual bool HasGame() const { return false; }
   virtual bool HasRDS() const { return false; }
+  virtual bool HasID3() const { return false; }
   virtual bool IsPassthrough() const { return false;}
   virtual bool CanSeek() {return true;}
   virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) = 0;

--- a/xbmc/cores/VideoPlayer/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/CMakeLists.txt
@@ -8,8 +8,9 @@ set(SOURCES AudioSinkAE.cpp
             DVDStreamInfo.cpp
             PTSTracker.cpp
             Edl.cpp
-            VideoPlayerAudio.cpp
             VideoPlayer.cpp
+            VideoPlayerAudio.cpp
+            VideoPlayerAudioID3.cpp
             VideoPlayerRadioRDS.cpp
             VideoPlayerSubtitle.cpp
             VideoPlayerTeletext.cpp
@@ -30,6 +31,7 @@ set(HEADERS AudioSinkAE.h
             PTSTracker.h
             VideoPlayer.h
             VideoPlayerAudio.h
+            VideoPlayerAudioID3.h
             VideoPlayerRadioRDS.h
             VideoPlayerSubtitle.h
             VideoPlayerTeletext.h

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -47,7 +47,8 @@ enum StreamType
   STREAM_DATA, // data stream
   STREAM_SUBTITLE, // subtitle stream
   STREAM_TELETEXT, // Teletext data stream
-  STREAM_RADIO_RDS // Radio RDS data stream
+  STREAM_RADIO_RDS, // Radio RDS data stream
+  STREAM_AUDIO_ID3 // Audio ID3 data stream
 };
 
 enum StreamSource
@@ -197,6 +198,12 @@ public:
   {
     type = STREAM_TELETEXT;
   }
+};
+
+class CDemuxStreamAudioID3 : public CDemuxStream
+{
+public:
+  CDemuxStreamAudioID3() : CDemuxStream() { type = STREAM_AUDIO_ID3; }
 };
 
 class CDemuxStreamRadioRDS : public CDemuxStream

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -573,6 +573,30 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     map[stream->uniqueId] = streamRDS;
     toStream = streamRDS;
   }
+  else if (stream->type == STREAM_AUDIO_ID3)
+  {
+    CDemuxStreamAudioID3* source = dynamic_cast<CDemuxStreamAudioID3*>(stream);
+
+    if (!source)
+    {
+      CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStream - invalid audio ID3 stream with id {}",
+                stream->uniqueId);
+      DisposeStreams();
+      return;
+    }
+
+    std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamAudioID3>> streamID3;
+    if (currentStream)
+      streamID3 = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamAudioID3>>(
+          currentStream);
+    if (!streamID3 || streamID3->codec != source->codec)
+    {
+      streamID3 = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStreamAudioID3>>();
+    }
+
+    map[stream->uniqueId] = streamID3;
+    toStream = streamID3;
+  }
   else
   {
     std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStream>> streamGen;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -389,7 +389,7 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
   AVCodec* codec = nullptr;
 
   if (stream->m_streamType != INPUTSTREAM_TYPE_TELETEXT &&
-      stream->m_streamType != INPUTSTREAM_TYPE_RDS)
+      stream->m_streamType != INPUTSTREAM_TYPE_RDS && stream->m_streamType != INPUTSTREAM_TYPE_ID3)
   {
     StringUtils::ToLower(codecName);
     codec = avcodec_find_decoder_by_name(codecName.c_str());
@@ -497,6 +497,11 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
   {
     CDemuxStreamRadioRDS* rdsStream = new CDemuxStreamRadioRDS();
     demuxStream = rdsStream;
+  }
+  else if (stream->m_streamType == INPUTSTREAM_TYPE_ID3)
+  {
+    CDemuxStreamAudioID3* id3Stream = new CDemuxStreamAudioID3();
+    demuxStream = id3Stream;
   }
   else
     return nullptr;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -343,6 +343,17 @@ void CInputStreamPVRBase::UpdateStreamMap()
 
       dStream = streamRadioRDS;
     }
+    else if (stream.iCodecType == PVR_CODEC_TYPE_ID3)
+    {
+      std::shared_ptr<CDemuxStreamAudioID3> streamAudioID3;
+
+      if (dStream)
+        streamAudioID3 = std::dynamic_pointer_cast<CDemuxStreamAudioID3>(dStream);
+      if (!streamAudioID3)
+        streamAudioID3 = std::make_shared<CDemuxStreamAudioID3>();
+
+      dStream = std::move(streamAudioID3);
+    }
     else
       dStream = std::make_shared<CDemuxStream>();
 

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -19,6 +19,7 @@
 #define VideoPlayer_SUBTITLE 3
 #define VideoPlayer_TELETEXT 4
 #define VideoPlayer_RDS      5
+#define VideoPlayer_ID3 6
 
 class CDVDMsg;
 class CDVDStreamInfo;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -579,6 +579,7 @@ void CVideoPlayer::CreatePlayers()
   m_VideoPlayerSubtitle = new CVideoPlayerSubtitle(&m_overlayContainer, *m_processInfo);
   m_VideoPlayerTeletext = new CDVDTeletextData(*m_processInfo);
   m_VideoPlayerRadioRDS = new CDVDRadioRDSData(*m_processInfo);
+  m_VideoPlayerAudioID3 = std::make_unique<CVideoPlayerAudioID3>(*m_processInfo);
   m_players_created = true;
 }
 
@@ -592,20 +593,22 @@ void CVideoPlayer::DestroyPlayers()
   delete m_VideoPlayerSubtitle;
   delete m_VideoPlayerTeletext;
   delete m_VideoPlayerRadioRDS;
+  m_VideoPlayerAudioID3.reset();
 
   m_players_created = false;
 }
 
 CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
-    : IPlayer(callback),
-      CThread("VideoPlayer"),
-      m_CurrentAudio(STREAM_AUDIO, VideoPlayer_AUDIO),
-      m_CurrentVideo(STREAM_VIDEO, VideoPlayer_VIDEO),
-      m_CurrentSubtitle(STREAM_SUBTITLE, VideoPlayer_SUBTITLE),
-      m_CurrentTeletext(STREAM_TELETEXT, VideoPlayer_TELETEXT),
-      m_CurrentRadioRDS(STREAM_RADIO_RDS, VideoPlayer_RDS),
-      m_messenger("player"),
-      m_renderManager(m_clock, this)
+  : IPlayer(callback),
+    CThread("VideoPlayer"),
+    m_CurrentAudio(STREAM_AUDIO, VideoPlayer_AUDIO),
+    m_CurrentVideo(STREAM_VIDEO, VideoPlayer_VIDEO),
+    m_CurrentSubtitle(STREAM_SUBTITLE, VideoPlayer_SUBTITLE),
+    m_CurrentTeletext(STREAM_TELETEXT, VideoPlayer_TELETEXT),
+    m_CurrentRadioRDS(STREAM_RADIO_RDS, VideoPlayer_RDS),
+    m_CurrentAudioID3(STREAM_AUDIO_ID3, VideoPlayer_ID3),
+    m_messenger("player"),
+    m_renderManager(m_clock, this)
 {
   m_outboundEvents.reset(new CJobQueue(false, 1, CJob::PRIORITY_NORMAL));
   m_players_created = false;
@@ -744,6 +747,7 @@ void CVideoPlayer::OnStartup()
   m_CurrentSubtitle.Clear();
   m_CurrentTeletext.Clear();
   m_CurrentRadioRDS.Clear();
+  m_CurrentAudioID3.Clear();
 
   UTILS::FONT::ClearTemporaryFonts();
 }
@@ -978,6 +982,19 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
   if(!valid)
     CloseStream(m_CurrentRadioRDS, false);
 
+  // open ID3 stream
+  valid = false;
+  for (const auto& stream : m_SelectionStreams.Get(STREAM_AUDIO_ID3))
+  {
+    if (OpenStream(m_CurrentAudioID3, stream.demuxerId, stream.id, stream.source))
+    {
+      valid = true;
+      break;
+    }
+  }
+  if (!valid)
+    CloseStream(m_CurrentAudioID3, false);
+
   // disable demux streams
   if (m_item.IsRemote() && m_pDemuxer)
   {
@@ -985,11 +1002,9 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
     {
       if (STREAM_SOURCE_MASK(stream.source) == STREAM_SOURCE_DEMUX)
       {
-        if (stream.id != m_CurrentVideo.id &&
-            stream.id != m_CurrentAudio.id &&
-            stream.id != m_CurrentSubtitle.id &&
-            stream.id != m_CurrentTeletext.id &&
-            stream.id != m_CurrentRadioRDS.id)
+        if (stream.id != m_CurrentVideo.id && stream.id != m_CurrentAudio.id &&
+            stream.id != m_CurrentSubtitle.id && stream.id != m_CurrentTeletext.id &&
+            stream.id != m_CurrentRadioRDS.id && stream.id != m_CurrentAudioID3.id)
         {
           m_pDemuxer->EnableStream(stream.demuxerId, stream.id, false);
         }
@@ -1201,6 +1216,7 @@ void CVideoPlayer::Prepare()
   m_CurrentSubtitle.hint.Clear();
   m_CurrentTeletext.hint.Clear();
   m_CurrentRadioRDS.hint.Clear();
+  m_CurrentAudioID3.hint.Clear();
   memset(&m_SpeedState, 0, sizeof(m_SpeedState));
   m_offset_pts = 0;
   m_CurrentAudio.lastdts = DVD_NOPTS_VALUE;
@@ -1520,6 +1536,7 @@ void CVideoPlayer::Process()
       m_CurrentSubtitle.inited = false;
       m_CurrentTeletext.inited = false;
       m_CurrentRadioRDS.inited = false;
+      m_CurrentAudioID3.inited = false;
 
       // if we are caching, start playing it again
       SetCaching(CACHESTATE_DONE);
@@ -1544,6 +1561,7 @@ void CVideoPlayer::Process()
     CheckBetterStream(m_CurrentSubtitle, pStream);
     CheckBetterStream(m_CurrentTeletext, pStream);
     CheckBetterStream(m_CurrentRadioRDS, pStream);
+    CheckBetterStream(m_CurrentAudioID3, pStream);
 
     // demux video stream
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_SUBTITLES_PARSECAPTIONS) && CheckIsCurrent(m_CurrentVideo, pStream, pPacket))
@@ -1624,6 +1642,8 @@ void CVideoPlayer::ProcessPacket(CDemuxStream* pStream, DemuxPacket* pPacket)
     ProcessTeletextData(pStream, pPacket);
   else if (CheckIsCurrent(m_CurrentRadioRDS, pStream, pPacket))
     ProcessRadioRDSData(pStream, pPacket);
+  else if (CheckIsCurrent(m_CurrentAudioID3, pStream, pPacket))
+    ProcessAudioID3Data(pStream, pPacket);
   else
   {
     CDVDDemuxUtils::FreeDemuxPacket(pPacket); // free it since we won't do anything with it
@@ -1758,6 +1778,22 @@ void CVideoPlayer::ProcessRadioRDSData(CDemuxStream* pStream, DemuxPacket* pPack
     drop = true;
 
   m_VideoPlayerRadioRDS->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
+}
+
+void CVideoPlayer::ProcessAudioID3Data(CDemuxStream* pStream, DemuxPacket* pPacket)
+{
+  CheckStreamChanges(m_CurrentAudioID3, pStream);
+
+  UpdateTimestamps(m_CurrentAudioID3, pPacket);
+
+  bool drop = false;
+  if (CheckPlayerInit(m_CurrentAudioID3))
+    drop = true;
+
+  if (CheckSceneSkip(m_CurrentAudioID3))
+    drop = true;
+
+  m_VideoPlayerAudioID3->SendMessage(std::make_shared<CDVDMsgDemuxerPacket>(pPacket, drop));
 }
 
 bool CVideoPlayer::GetCachingTimes(double& level, double& delay, double& offset)
@@ -2186,6 +2222,8 @@ bool CVideoPlayer::CheckPlayerInit(CCurrentStream& current)
         m_CurrentTeletext.startpts = current.dts;
       if(m_CurrentRadioRDS.startpts != DVD_NOPTS_VALUE)
         m_CurrentRadioRDS.startpts = current.dts;
+      if (m_CurrentAudioID3.startpts != DVD_NOPTS_VALUE)
+        m_CurrentAudioID3.startpts = current.dts;
     }
 
     if(current.dts < current.startpts)
@@ -2454,6 +2492,8 @@ IDVDStreamPlayer* CVideoPlayer::GetStreamPlayer(unsigned int target)
     return m_VideoPlayerTeletext;
   if(target == VideoPlayer_RDS)
     return m_VideoPlayerRadioRDS;
+  if (target == VideoPlayer_ID3)
+    return m_VideoPlayerAudioID3.get();
   return NULL;
 }
 
@@ -2482,6 +2522,7 @@ void CVideoPlayer::OnExit()
   CloseStream(m_CurrentVideo, !m_bAbortRequest);
   CloseStream(m_CurrentTeletext,!m_bAbortRequest);
   CloseStream(m_CurrentRadioRDS, !m_bAbortRequest);
+  CloseStream(m_CurrentAudioID3, !m_bAbortRequest);
   // the generalization principle was abused for subtitle player. actually it is not a stream player like
   // video and audio. subtitle player does not run on its own thread, hence waitForBuffers makes
   // no sense here. waitForBuffers is abused to clear overlay container (false clears container)
@@ -3103,6 +3144,11 @@ bool CVideoPlayer::HasRDS() const
   return m_CurrentRadioRDS.id >= 0;
 }
 
+bool CVideoPlayer::HasID3() const
+{
+  return m_CurrentAudioID3.id >= 0;
+}
+
 bool CVideoPlayer::IsPassthrough() const
 {
   return m_VideoPlayerAudio->IsPassthrough();
@@ -3560,6 +3606,9 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
     case STREAM_RADIO_RDS:
       res = OpenRadioRDSStream(hint);
       break;
+    case STREAM_AUDIO_ID3:
+      res = OpenAudioID3Stream(hint);
+      break;
     default:
       res = false;
       break;
@@ -3817,6 +3866,24 @@ bool CVideoPlayer::OpenRadioRDSStream(CDVDStreamInfo& hint)
   return true;
 }
 
+bool CVideoPlayer::OpenAudioID3Stream(CDVDStreamInfo& hint)
+{
+  if (!m_VideoPlayerAudioID3->CheckStream(hint))
+    return false;
+
+  IDVDStreamPlayer* player = GetStreamPlayer(m_CurrentAudioID3.player);
+  if (player == nullptr)
+    return false;
+
+  if (m_CurrentAudioID3.id < 0 || m_CurrentAudioID3.hint != hint)
+  {
+    if (!player->OpenStream(hint))
+      return false;
+  }
+
+  return true;
+}
+
 bool CVideoPlayer::CloseStream(CCurrentStream& current, bool bWaitForBuffers)
 {
   if (current.id < 0)
@@ -3885,11 +3952,16 @@ void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
   m_CurrentRadioRDS.startpts = startpts;
   m_CurrentRadioRDS.packets = 0;
 
+  m_CurrentAudioID3.dts = DVD_NOPTS_VALUE;
+  m_CurrentAudioID3.startpts = startpts;
+  m_CurrentAudioID3.packets = 0;
+
   m_VideoPlayerAudio->Flush(sync);
   m_VideoPlayerVideo->Flush(sync);
   m_VideoPlayerSubtitle->Flush();
   m_VideoPlayerTeletext->Flush();
   m_VideoPlayerRadioRDS->Flush();
+  m_VideoPlayerAudioID3->Flush();
 
   if (m_playSpeed == DVD_PLAYSPEED_NORMAL ||
       m_playSpeed == DVD_PLAYSPEED_PAUSE)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -13,6 +13,7 @@
 #include "Edl.h"
 #include "FileItem.h"
 #include "IVideoPlayer.h"
+#include "VideoPlayerAudioID3.h"
 #include "VideoPlayerRadioRDS.h"
 #include "VideoPlayerSubtitle.h"
 #include "VideoPlayerTeletext.h"
@@ -252,6 +253,7 @@ public:
   bool HasVideo() const override;
   bool HasAudio() const override;
   bool HasRDS() const override;
+  bool HasID3() const override;
   bool IsPassthrough() const override;
   bool CanSeek() override;
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
@@ -381,6 +383,7 @@ protected:
   bool OpenSubtitleStream(const CDVDStreamInfo& hint);
   bool OpenTeletextStream(CDVDStreamInfo& hint);
   bool OpenRadioRDSStream(CDVDStreamInfo& hint);
+  bool OpenAudioID3Stream(CDVDStreamInfo& hint);
 
   /** \brief Switches forced subtitles to forced subtitles matching the language of the current audio track.
   *          If these are not available, subtitles are disabled.
@@ -395,6 +398,7 @@ protected:
   void ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket);
   void ProcessTeletextData(CDemuxStream* pStream, DemuxPacket* pPacket);
   void ProcessRadioRDSData(CDemuxStream* pStream, DemuxPacket* pPacket);
+  void ProcessAudioID3Data(CDemuxStream* pStream, DemuxPacket* pPacket);
 
   int  AddSubtitleFile(const std::string& filename, const std::string& subfilename = "");
   void SetSubtitleVisibleInternal(bool bVisible);
@@ -473,6 +477,7 @@ protected:
   CCurrentStream m_CurrentSubtitle;
   CCurrentStream m_CurrentTeletext;
   CCurrentStream m_CurrentRadioRDS;
+  CCurrentStream m_CurrentAudioID3;
 
   CSelectionStreams m_SelectionStreams;
   std::vector<ProgramInfo> m_programs;
@@ -509,6 +514,7 @@ protected:
   CVideoPlayerSubtitle *m_VideoPlayerSubtitle;
   CDVDTeletextData *m_VideoPlayerTeletext;
   CDVDRadioRDSData *m_VideoPlayerRadioRDS;
+  std::unique_ptr<CVideoPlayerAudioID3> m_VideoPlayerAudioID3;
 
   CDVDClock m_clock;
   CDVDOverlayContainer m_overlayContainer;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -29,7 +29,7 @@
 using namespace TagLib;
 
 CVideoPlayerAudioID3::CVideoPlayerAudioID3(CProcessInfo& processInfo)
-  : CThread("VideoPlayerAudioID3"), IDVDStreamPlayer(processInfo), m_messageQueue("id3")
+  : IDVDStreamPlayer(processInfo), CThread("VideoPlayerAudioID3"), m_messageQueue("id3")
 {
   CLog::Log(LOGDEBUG, "Audio ID3 tag processor - new {}", __FUNCTION__);
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -1,0 +1,350 @@
+/*
+ *  Copyright (C) 2005-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoPlayerAudioID3.h"
+
+#include "Application.h"
+#include "DVDDemuxers/DVDDemuxUtils.h"
+#include "DVDStreamInfo.h"
+#include "GUIInfoManager.h"
+#include "ServiceBroker.h"
+#include "guilib/GUIComponent.h"
+#include "music/tags/MusicInfoTag.h"
+#include "utils/EmbeddedArt.h"
+#include "utils/log.h"
+
+#include <taglib/attachedpictureframe.h>
+#include <taglib/commentsframe.h>
+#include <taglib/id3v1genres.h>
+#include <taglib/id3v2framefactory.h>
+#include <taglib/mpegfile.h>
+#include <taglib/tbytevectorstream.h>
+#include <taglib/textidentificationframe.h>
+
+using namespace TagLib;
+
+CVideoPlayerAudioID3::CVideoPlayerAudioID3(CProcessInfo& processInfo)
+  : CThread("VideoPlayerAudioID3"), IDVDStreamPlayer(processInfo), m_messageQueue("id3")
+{
+  CLog::Log(LOGDEBUG, "Audio ID3 tag processor - new {}", __FUNCTION__);
+}
+
+CVideoPlayerAudioID3::~CVideoPlayerAudioID3()
+{
+  CLog::Log(LOGDEBUG, "Audio ID3 tag processor - delete {}", __FUNCTION__);
+  StopThread();
+}
+
+bool CVideoPlayerAudioID3::CheckStream(const CDVDStreamInfo& hints)
+{
+  return hints.type == STREAM_AUDIO_ID3;
+}
+
+void CVideoPlayerAudioID3::Flush()
+{
+  if (m_messageQueue.IsInited())
+  {
+    m_messageQueue.Flush();
+    m_messageQueue.Put(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_FLUSH));
+  }
+}
+
+void CVideoPlayerAudioID3::WaitForBuffers()
+{
+  m_messageQueue.WaitUntilEmpty();
+}
+
+bool CVideoPlayerAudioID3::OpenStream(CDVDStreamInfo hints)
+{
+  CloseStream(true);
+  m_messageQueue.Init();
+
+  if (hints.type == STREAM_AUDIO_ID3)
+  {
+    Flush();
+    CLog::Log(LOGINFO, "Creating Audio ID3 tag processor data thread");
+    Create();
+    return true;
+  }
+
+  return false;
+}
+
+void CVideoPlayerAudioID3::CloseStream(bool bWaitForBuffers)
+{
+  m_messageQueue.Abort();
+
+  CLog::Log(LOGINFO, "Audio ID3 tag processor - waiting for data thread to exit");
+  StopThread();
+
+  m_messageQueue.End();
+}
+
+void CVideoPlayerAudioID3::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority)
+{
+  if (m_messageQueue.IsInited())
+    m_messageQueue.Put(pMsg, priority);
+}
+
+void CVideoPlayerAudioID3::FlushMessages()
+{
+  m_messageQueue.Flush();
+}
+
+bool CVideoPlayerAudioID3::IsInited() const
+{
+  return true;
+}
+
+bool CVideoPlayerAudioID3::AcceptsData() const
+{
+  return !m_messageQueue.IsFull();
+}
+
+bool CVideoPlayerAudioID3::IsStalled() const
+{
+  return true;
+}
+
+void CVideoPlayerAudioID3::OnExit()
+{
+  CLog::Log(LOGINFO, "Audio ID3 tag processor - thread end");
+}
+
+void CVideoPlayerAudioID3::Process()
+{
+  CLog::Log(LOGINFO, "Audio ID3 tag processor - running thread");
+
+  while (!m_bStop)
+  {
+    std::shared_ptr<CDVDMsg> pMsg;
+    int iPriority = (m_speed == DVD_PLAYSPEED_PAUSE) ? 1 : 0;
+    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2000, iPriority);
+
+    // Timeout for ID3 tag data is not a bad thing, so we continue without error
+    if (ret == MSGQ_TIMEOUT)
+      continue;
+
+    if (MSGQ_IS_ERROR(ret))
+    {
+      CLog::Log(LOGERROR, "Got MSGQ_ABORT or MSGQ_IS_ERROR return true ({})", ret);
+      break;
+    }
+
+    if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
+    {
+      std::unique_lock<CCriticalSection> lock(m_critSection);
+      DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
+      if (pPacket)
+        ProcessID3(pPacket->pData, pPacket->iSize);
+    }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
+    {
+      m_speed = std::static_pointer_cast<CDVDMsgInt>(pMsg)->m_value;
+    }
+  }
+}
+
+void CVideoPlayerAudioID3::ProcessID3(const unsigned char* data, unsigned int length) const
+{
+  if (data && length > 0)
+  {
+    ByteVectorStream tagStream(ByteVector(reinterpret_cast<const char*>(data), length));
+    if (tagStream.isOpen())
+    {
+      MPEG::File tagFile = MPEG::File(&tagStream, ID3v2::FrameFactory::instance());
+      if (tagFile.isOpen())
+      {
+        if (tagFile.hasID3v1Tag())
+          ProcessID3v1(tagFile.ID3v1Tag(false));
+
+        else if (tagFile.hasID3v2Tag())
+          ProcessID3v2(tagFile.ID3v2Tag(false));
+      }
+    }
+  }
+}
+
+void CVideoPlayerAudioID3::ProcessID3v1(const ID3v1::Tag* tag) const
+{
+  if (tag != nullptr && !tag->isEmpty())
+  {
+    MUSIC_INFO::CMusicInfoTag* currentMusic = g_application.CurrentFileItem().GetMusicInfoTag();
+    if (currentMusic)
+    {
+      bool changed = false;
+
+      const String title = tag->title();
+      if (!title.isEmpty())
+      {
+        currentMusic->SetTitle(title.to8Bit(true));
+        changed = true;
+      }
+
+      const String artist = tag->artist();
+      if (!artist.isEmpty())
+      {
+        currentMusic->SetArtist(artist.to8Bit(true));
+        changed = true;
+      }
+
+      const String album = tag->album();
+      if (!album.isEmpty())
+      {
+        currentMusic->SetAlbum(album.to8Bit(true));
+        changed = true;
+      }
+
+      const String comment = tag->comment();
+      if (!comment.isEmpty())
+      {
+        currentMusic->SetComment(comment.to8Bit(true));
+        changed = true;
+      }
+
+      const String genre = tag->genre();
+      if (!genre.isEmpty())
+      {
+        currentMusic->SetGenre(genre.to8Bit(true));
+        changed = true;
+      }
+
+      const unsigned int year = tag->year();
+      if (year != 0)
+      {
+        currentMusic->SetYear(year);
+        changed = true;
+      }
+
+      const unsigned int track = tag->track();
+      if (track != 0)
+      {
+        currentMusic->SetTrackNumber(track);
+        changed = true;
+      }
+
+      if (changed)
+        CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(g_application.CurrentFileItem());
+    }
+  }
+}
+
+void CVideoPlayerAudioID3::ProcessID3v2(const ID3v2::Tag* tag) const
+{
+  if (tag != nullptr && !tag->isEmpty())
+  {
+    MUSIC_INFO::CMusicInfoTag* currentMusic = g_application.CurrentFileItem().GetMusicInfoTag();
+    if (currentMusic)
+    {
+      bool changed = false;
+
+      const ID3v2::FrameListMap& frameListMap = tag->frameListMap();
+      for (const auto& it : frameListMap)
+      {
+        if (!it.second.isEmpty())
+        {
+          if (it.first == "TIT2")
+          {
+            currentMusic->SetTitle(it.second.front()->toString().to8Bit(true));
+            changed = true;
+          }
+
+          else if (it.first == "TPE1")
+          {
+            currentMusic->SetArtist(GetID3v2StringList(it.second));
+            changed = true;
+          }
+
+          else if (it.first == "TALB")
+          {
+            currentMusic->SetAlbum(it.second.front()->toString().to8Bit(true));
+            changed = true;
+          }
+
+          else if (it.first == "COMM")
+          {
+            // Loop through and look for the main (no description) comment
+            for (const auto& ct : it.second)
+            {
+              auto commentsFrame = dynamic_cast<const ID3v2::CommentsFrame*>(ct);
+              if (commentsFrame && commentsFrame->description().isEmpty())
+              {
+                currentMusic->SetComment(commentsFrame->text().to8Bit(true));
+                changed = true;
+                break;
+              }
+            }
+          }
+
+          else if (it.first == "TCON")
+          {
+            currentMusic->SetGenre(GetID3v2StringList(it.second));
+            changed = true;
+          }
+
+          else if (it.first == "TYER")
+          {
+            currentMusic->SetYear(static_cast<int>(
+                strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
+            changed = true;
+          }
+
+          else if (it.first == "TRCK")
+          {
+            currentMusic->SetTrackNumber(static_cast<int>(
+                strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
+            changed = true;
+          }
+
+          // Support for setting the cover art image via CMusicInfoTag does not currently exist,
+          // the code sample below would check for an ID3v2 "APIC" tag of the proper type and
+          // convert the information into an EmbeddedArt object instance
+          //
+          // else if (it.first == "APIC")
+          // {
+          //  // Loop through and look for the FrontCover picture frame
+          //  for (const auto& pi : it.second)
+          //  {
+          //    auto pictureFrame = dynamic_cast<ID3v2::AttachedPictureFrame*>(pi);
+          //    if (pictureFrame && pictureFrame->type() == ID3v2::AttachedPictureFrame::FrontCover)
+          //    {
+          //      EmbeddedArt coverArt(
+          //          reinterpret_cast<const uint8_t*>(pictureFrame->picture().data()),
+          //          pictureFrame->size(), pictureFrame->mimeType().to8Bit(true));
+
+          //      // Assumes "void CMusicInfoTag::SetCoverArt(const EmbeddedArt& art)" exists
+          //      currentMusic->SetCoverArt(coverArt);
+          //      changed = true;
+          //    }
+          //  }
+          // }
+        }
+      }
+
+      if (changed)
+        CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(g_application.CurrentFileItem());
+    }
+  }
+}
+
+std::vector<std::string> CVideoPlayerAudioID3::GetID3v2StringList(const ID3v2::FrameList& frameList)
+{
+  auto frame = dynamic_cast<const ID3v2::TextIdentificationFrame*>(frameList.front());
+  if (frame)
+    return StringListToVectorString(frame->fieldList());
+  return {};
+}
+
+std::vector<std::string> CVideoPlayerAudioID3::StringListToVectorString(
+    const StringList& stringList)
+{
+  std::vector<std::string> values;
+  for (const auto& value : stringList)
+    values.emplace_back(value.to8Bit(true));
+  return values;
+}

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2005-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "DVDMessageQueue.h"
+#include "IVideoPlayer.h"
+#include "Interface/TimingConstants.h"
+#include "threads/CriticalSection.h"
+#include "threads/Thread.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <taglib/id3v1tag.h>
+#include <taglib/id3v2tag.h>
+#include <taglib/tstringlist.h>
+
+class CVideoPlayerAudioID3 : public IDVDStreamPlayer, private CThread
+{
+public:
+  explicit CVideoPlayerAudioID3(CProcessInfo& processInfo);
+  ~CVideoPlayerAudioID3() override;
+
+  bool CheckStream(const CDVDStreamInfo& hints);
+  void Flush();
+  void WaitForBuffers();
+
+  bool OpenStream(CDVDStreamInfo hints) override;
+  void CloseStream(bool bWaitForBuffers) override;
+  void SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority = 0) override;
+  void FlushMessages() override;
+  bool IsInited() const override;
+  bool AcceptsData() const override;
+  bool IsStalled() const override;
+
+protected:
+  void OnExit() override;
+  void Process() override;
+
+private:
+  void ProcessID3(const unsigned char* data, unsigned int length) const;
+  void ProcessID3v1(const TagLib::ID3v1::Tag* tag) const;
+  void ProcessID3v2(const TagLib::ID3v2::Tag* tag) const;
+
+  static std::vector<std::string> GetID3v2StringList(const TagLib::ID3v2::FrameList& frameList);
+  static std::vector<std::string> StringListToVectorString(const TagLib::StringList& stringList);
+
+  int m_speed = DVD_PLAYSPEED_NORMAL;
+  CCriticalSection m_critSection;
+  CDVDMessageQueue m_messageQueue;
+};

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -2126,6 +2126,11 @@ private:
     tmp.codec_type = PVR_CODEC_TYPE_RDS;
     tmp.codec_id = AV_CODEC_ID_NONE;
     m_lookup.insert(std::make_pair("RDS", tmp));
+
+    // ID3 is not returned by av_codec_next. we got our own decoder
+    tmp.codec_type = PVR_CODEC_TYPE_ID3;
+    tmp.codec_id = AV_CODEC_ID_NONE;
+    m_lookup.insert({"ID3", tmp});
   }
 
   std::map<std::string, PVR_CODEC> m_lookup;


### PR DESCRIPTION
## Description
This PR proposes a new PVR Radio InputStream that allows a PVR Radio addon to define an ID3 tag stream to provide real-time metadata about the playing audio stream. The changes are heavily based on the existing PVR Radio RDS/UECP stream and the existing CTagLoaderTagLib class.

I feel having this support available would augment PVR Radio in a positive way. HD Radio and DAB(+), for example, have the ability to provide information beyond what can be encoded by RDS/UECP. HD Radio actually encodes its textual metadata (Artist/Title/etc.) as ID3v2 tags.  It would also not be too difficult to convert the metadata provided by streaming protocols like SHOUTcast/ICEcast/etc into ID3 tags, which might spark interest in extending PVR Radio addons into the streaming Radio arena.

The PR does not accomplish everything I originally wanted it to and is somewhat limited. Currently, only tags supported by both ID3v1 and ID3v2 are implemented. I would have liked to at a minimum also implement the ID3v2 "APIC" tag to allow the stream to provide real-time changes to Cover Art, but found that there is no direct support for that in Kodi at this time. In this case, I left a commented-out block of code that is capable of extracting the APIC cover art ID3v2 tag data and convert it into an EmbeddedTag instance, which in theory could someday be passed into CMusicInfoTag.

I also did not make any changes to the Player GUI, which further limits immediate usefulness. As-is, only the Title and Artist tag fields have meaningful value to the Player GUI. I envisioned the Player GUI for ID3-tagged streams looking more like an HD Radio display, wherein the Title / Artist / Album / Comment would appear in the info pop-up instead of "No information available". The mux name, like "HD1" would display in the upper left where "Artist - Title" appears today. For digital inputs like HD Radio and DAB, this seems to make sense where the underlying Channel may have multiple audio streams. I felt this would over scope the PR and can be handled separately without any breaking API changes.

I do not anticipate this being accepted without changes, suggest it be marked as a work in progress PR until it has been thoroughly reviewed by the maintainer(s). Also, the code changes were made in Visual Studio 2022 which claims to fully support clang-format now, but I'm sure I'll have to fix the formatting in a file or three.

Thank you, I look forward to making any and all changes requested to try and get this into Nexus as a thing that can be expanded upon and made more valuable/useful.

## Motivation and context
I have an a PVR Radio addon that can now decode HD Radio (via tweaks to the [NRSC5](https://github.com/theori-io/nrsc5) library), and has ambition to decode DAB(+) in the future. HD Radio provides stream metadata via ID3v2 tags, and I found that trying to convert those tags into RDS/UECP/RadioText+ was limiting. RadioText+ only provides pointers into the already decoded RadioText string (64 chars max, I believe), and generating UECP packets to convert ID3 fields into RadioText, and by extension, RadioText+ pointers.

## How has this been tested?
Testing was performed on Windows 11 (Desktop), x64. Given that this is a new stream type, I found the best way to test it was to create both ID3v1 and ID3v2 encoders for my project, and break pointing Kodi at each tag type and ensuring that the data being passed into CMusicInfoTag is accurate and valid. Basically, this was tested via code coverage.  For HD Radio where the ID3 tags already exist, the testing involved passing them onto Kodi unmodified as well as copying/modifying them via the custom encoders.

The encoders I wrote and used for testing are available for review/critique here as needed:

[id3v1tag.h](https://github.com/djp952/pvr.rtlradio/blob/104bfdc6a81d936639f066786bc4f8bbfbba8250/src/id3v1tag.h)
[id3v1tag.cpp](https://github.com/djp952/pvr.rtlradio/blob/104bfdc6a81d936639f066786bc4f8bbfbba8250/src/id3v1tag.cpp)
[id3v2tag.h](https://github.com/djp952/pvr.rtlradio/blob/104bfdc6a81d936639f066786bc4f8bbfbba8250/src/id3v2tag.h)
[id3v2tag.cpp](https://github.com/djp952/pvr.rtlradio/blob/104bfdc6a81d936639f066786bc4f8bbfbba8250/src/id3v2tag.cpp)

The primary problems I ran into were with the custom encoders, there are a lot of nuances to generating valid ID3 tags.

## What is the effect on users?
If approved, my PVR Radio addon would be able to set real time Artist and Title information for HD Radio. I cannot think of any impacts for any current Kodi users. I hope that it enables future positive user impacts, however.

## Screenshots (if appropriate):
N/A

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
