### PR TITLE
[gui][info] Remove Player.DisplayAfterSeek

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -866,7 +866,6 @@ const infomap player_labels[] = {{"hasmedia", PLAYER_HAS_MEDIA},
                                  {"forwarding8x", PLAYER_FORWARDING_8x},
                                  {"forwarding16x", PLAYER_FORWARDING_16x},
                                  {"forwarding32x", PLAYER_FORWARDING_32x},
-                                 {"displayafterseek", PLAYER_DISPLAY_AFTER_SEEK},
                                  {"caching", PLAYER_CACHING},
                                  {"seekbar", PLAYER_SEEKBAR},
                                  {"seeking", PLAYER_SEEKING},
@@ -9675,9 +9674,13 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 ///
 /// -----------------------------------------------------------------------------
 
-
 /// \page modules__infolabels_boolean_conditions
 /// \section modules_rm_infolabels_booleans Additional revision history for Infolabels and Boolean Conditions
+/// <hr>
+/// \subsection modules_rm_infolabels_booleans_v20 Kodi v20 (Nexus)
+/// @skinning_v20 **[Removed Boolean conditions]** The following boolean conditions have been removed:
+///   - `Player.DisplayAfterSeek` - use \link Player_HasPerformedSeek `Player.HasPerformedSeek(interval)`\endlink instead
+///
 /// <hr>
 /// \subsection modules_rm_infolabels_booleans_v19 Kodi v19 (Matrix)
 /// @skinning_v19 **[Removed Infolabels]** The following infolabels have been removed:

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -10,7 +10,6 @@
 
 #include "ApplicationPlayer.h"
 #include "ApplicationStackHelper.h"
-#include "GUIInfoManager.h"
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
@@ -248,11 +247,6 @@ void CApplicationPlayerCallback::OnPlayBackSeek(int64_t iTime, int64_t seekOffse
                                                      m_itemCurrentFile, param);
 
   CDataCacheCore::GetInstance().SeekFinished(static_cast<int>(seekOffset));
-  CServiceBroker::GetGUI()
-      ->GetInfoManager()
-      .GetInfoProviders()
-      .GetPlayerInfoProvider()
-      .SetDisplayAfterSeek(2500, static_cast<int>(seekOffset));
 }
 
 void CApplicationPlayerCallback::OnPlayBackSeekChapter(int iChapter)

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -14,6 +14,7 @@
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
+#include "cores/DataCacheCore.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
@@ -245,6 +246,8 @@ void CApplicationPlayerCallback::OnPlayBackSeek(int64_t iTime, int64_t seekOffse
   param["player"]["speed"] = (int)m_appPlayer.GetPlaySpeed();
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnSeek",
                                                      m_itemCurrentFile, param);
+
+  CDataCacheCore::GetInstance().SeekFinished(static_cast<int>(seekOffset));
   CServiceBroker::GetGUI()
       ->GetInfoManager()
       .GetInfoProviders()

--- a/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
+++ b/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
@@ -175,7 +175,6 @@ void CGameWindowFullScreen::OnInitWindow()
   GUIINFO::CPlayerGUIInfo& guiInfo =
       CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider();
   guiInfo.SetShowInfo(false);
-  guiInfo.SetDisplayAfterSeek(0); // Make sure display after seek is off
 
   // Switch resolution
   CServiceBroker::GetWinSystem()->GetGfxContext().SetFullScreenVideo(true); //! @todo

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -27,7 +27,6 @@
 #include "DVDInputStreams/DVDInputStreamNavigator.h"
 #include "DVDInputStreams/InputStreamPVRBase.h"
 #include "FileItem.h"
-#include "GUIInfoManager.h"
 #include "GUIUserMessages.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
@@ -2622,7 +2621,6 @@ void CVideoPlayer::HandleMessages()
 
       if (!msg.GetTrickPlay())
       {
-        CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
         m_processInfo->SeekFinished(0);
         SetCaching(CACHESTATE_FLUSH);
       }
@@ -2681,7 +2679,6 @@ void CVideoPlayer::HandleMessages()
       // set flag to indicate we have finished a seeking request
       if(!msg.GetTrickPlay())
       {
-        CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
         m_processInfo->SeekFinished(0);
       }
 
@@ -2695,7 +2692,6 @@ void CVideoPlayer::HandleMessages()
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_SEEK) == 0 &&
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_SEEK_CHAPTER) == 0)
     {
-      CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
       m_processInfo->SeekFinished(0);
       SetCaching(CACHESTATE_FLUSH);
 
@@ -2723,7 +2719,6 @@ void CVideoPlayer::HandleMessages()
         }
       }
       m_processInfo->SeekFinished(offset);
-      CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(2500, offset);
     }
     else if (pMsg->IsType(CDVDMsg::DEMUXER_RESET))
     {
@@ -2852,7 +2847,6 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_STATE))
     {
-      CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(100000);
       SetCaching(CACHESTATE_FLUSH);
 
       auto pMsgPlayerSetState = std::static_pointer_cast<CDVDMsgPlayerSetState>(pMsg);
@@ -2868,7 +2862,6 @@ void CVideoPlayer::HandleMessages()
       }
 
       m_processInfo->SeekFinished(0);
-      CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
     {
@@ -2897,9 +2890,6 @@ void CVideoPlayer::HandleMessages()
       {
         m_callback.OnPlayBackSpeedChanged(speed / DVD_PLAYSPEED_NORMAL);
         m_processInfo->SeekFinished(0);
-        // notify GUI, skins may want to show the seekbar
-        CServiceBroker::GetGUI()->
-          GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
       }
 
       if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) && speed != m_playSpeed)
@@ -4251,7 +4241,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
         THREAD_ACTION(action);
         CLog::Log(LOGDEBUG, " - pushed prev");
         pMenus->OnPrevious();
-        CServiceBroker::GetGUI()->GetInfoManager().SetDisplayAfterSeek();
         m_processInfo->SeekFinished(0);
         return true;
       }
@@ -4261,7 +4250,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
         THREAD_ACTION(action);
         CLog::Log(LOGDEBUG, " - pushed next");
         pMenus->OnNext();
-        CServiceBroker::GetGUI()->GetInfoManager().SetDisplayAfterSeek();
         m_processInfo->SeekFinished(0);
         return true;
       }
@@ -4297,7 +4285,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
         else
           pMenus->OnNext();
 
-        CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
         m_processInfo->SeekFinished(0);
         return true;
       case ACTION_PREV_ITEM:
@@ -4308,7 +4295,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
         else
           pMenus->OnPrevious();
 
-        CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
         m_processInfo->SeekFinished(0);
         return true;
       case ACTION_PREVIOUS_MENU:
@@ -4422,7 +4408,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
       if (GetChapter() > 0 && GetChapter() < GetChapterCount())
       {
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() + 1));
-        CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
         m_processInfo->SeekFinished(0);
         return true;
       }
@@ -4434,7 +4419,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
       if (GetChapter() > 0)
       {
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeekChapter>(GetChapter() - 1));
-        CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
         m_processInfo->SeekFinished(0);
         return true;
       }

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -27,7 +27,7 @@
 #define PLAYER_FORWARDING_16x        16
 #define PLAYER_FORWARDING_32x        17
 #define PLAYER_CACHING               20
-#define PLAYER_DISPLAY_AFTER_SEEK    21
+// unused id 21
 #define PLAYER_PROGRESS              22
 #define PLAYER_SEEKBAR               23
 #define PLAYER_SEEKTIME              24

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -122,26 +122,6 @@ std::string CPlayerGUIInfo::GetSeekTime(TIME_FORMAT format) const
   return StringUtils::SecondsToTimeString(iSeekTimeCode, format);
 }
 
-void CPlayerGUIInfo::SetDisplayAfterSeek(unsigned int timeOut, int seekOffset)
-{
-  if (timeOut > 0)
-  {
-    m_AfterSeekTimeout = CTimeUtils::GetFrameTime() +  timeOut;
-    if (seekOffset)
-      m_seekOffset = seekOffset;
-  }
-  else
-    m_AfterSeekTimeout = 0;
-}
-
-bool CPlayerGUIInfo::GetDisplayAfterSeek() const
-{
-  if (CTimeUtils::GetFrameTime() < m_AfterSeekTimeout)
-    return true;
-  m_seekOffset = 0;
-  return false;
-}
-
 void CPlayerGUIInfo::SetShowInfo(bool showinfo)
 {
   m_playerShowInfo = showinfo;
@@ -419,9 +399,6 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case PLAYER_SHOWINFO:
       value = m_playerShowInfo;
-      return true;
-    case PLAYER_DISPLAY_AFTER_SEEK:
-      value = GetDisplayAfterSeek();
       return true;
     case PLAYER_SHOWTIME:
       value = m_playerShowTime;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -39,8 +39,6 @@ public:
   bool GetInt(int& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 
-  bool GetDisplayAfterSeek() const;
-  void SetDisplayAfterSeek(unsigned int timeOut = 2500, int seekOffset = 0);
   void SetShowTime(bool showtime) { m_playerShowTime = showtime; }
   void SetShowInfo(bool showinfo);
   bool GetShowInfo() const { return m_playerShowInfo; }
@@ -49,8 +47,6 @@ public:
 private:
   std::unique_ptr<CFileItem> m_currentItem;
 
-  unsigned int m_AfterSeekTimeout = 0;
-  mutable int m_seekOffset = 0;
   std::atomic_bool m_playerShowTime;
   std::atomic_bool m_playerShowInfo;
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -494,7 +494,6 @@ void CUPnPPlayer::SeekTime(int64_t ms)
                                 , m_delegate), failed);
 
   CDataCacheCore::GetInstance().SeekFinished(0);
-  CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
   return;
 failed:
   m_logger->error("SeekTime - unable to seek playback");

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -231,7 +231,6 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       GUIINFO::CPlayerGUIInfo& guiInfo = CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider();
       guiInfo.SetShowInfo(false);
       m_bShowCurrentTime = false;
-      guiInfo.SetDisplayAfterSeek(0); // Make sure display after seek is off.
 
       // switch resolution
       CServiceBroker::GetWinSystem()->GetGfxContext().SetFullScreenVideo(true);
@@ -289,11 +288,6 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
 
 void CGUIWindowFullScreen::FrameMove()
 {
-  float playspeed = g_application.GetAppPlayer().GetPlaySpeed();
-  if (playspeed != 1.0f && !g_application.GetAppPlayer().HasGame() &&
-      !g_application.GetAppPlayer().IsPausedPlayback())
-    CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
-
   if (!g_application.GetAppPlayer().HasPlayer())
     return;
 
@@ -416,9 +410,6 @@ void CGUIWindowFullScreen::RenderEx()
 void CGUIWindowFullScreen::SeekChapter(int iChapter)
 {
   g_application.GetAppPlayer().SeekChapter(iChapter);
-
-  // Make sure gui items are visible.
-  CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek();
 }
 
 void CGUIWindowFullScreen::ToggleOSD()

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -13,7 +13,6 @@
 #include "messaging/ApplicationMessenger.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/GUIProgressControl.h"
 #include "guilib/GUILabelControl.h"
 #include "video/dialogs/GUIDialogSubtitleSettings.h"
 #include "guilib/GUIWindowManager.h"
@@ -186,32 +185,6 @@ void CGUIWindowFullScreen::OnWindowLoaded()
   CGUIWindow::OnWindowLoaded();
   // override the clear colour - we must never clear fullscreen
   m_clearBackground = 0;
-
-  CGUIProgressControl* pProgress = dynamic_cast<CGUIProgressControl*>(GetControl(CONTROL_PROGRESS));
-  if (pProgress)
-  {
-    if( pProgress->GetInfo() == 0 || !pProgress->HasVisibleCondition())
-    {
-      pProgress->SetInfo(PLAYER_PROGRESS);
-      pProgress->SetVisibleCondition("player.displayafterseek");
-      pProgress->SetVisible(true);
-    }
-  }
-
-  CGUILabelControl* pLabel = dynamic_cast<CGUILabelControl*>(GetControl(LABEL_BUFFERING));
-  if(pLabel && !pLabel->HasVisibleCondition())
-  {
-    pLabel->SetVisibleCondition("player.caching");
-    pLabel->SetVisible(true);
-  }
-
-  pLabel = dynamic_cast<CGUILabelControl*>(GetControl(LABEL_CURRENT_TIME));
-  if(pLabel && !pLabel->HasVisibleCondition())
-  {
-    pLabel->SetVisibleCondition("player.displayafterseek");
-    pLabel->SetVisible(true);
-    pLabel->SetLabel("$INFO(VIDEOPLAYER.TIME) / $INFO(VIDEOPLAYER.DURATION)");
-  }
 }
 
 bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)

--- a/xbmc/video/windows/GUIWindowFullScreenDefines.h
+++ b/xbmc/video/windows/GUIWindowFullScreenDefines.h
@@ -12,14 +12,3 @@
 #define LABEL_ROW1                       10
 #define LABEL_ROW2                       11
 #define LABEL_ROW3                       12
-
- // Displays current position, visible after seek or when forced
- // Alt, use conditional visibility Player.DisplayAfterSeek
-#define LABEL_CURRENT_TIME               22
-
- // Displays when video is rebuffering
- // Alt, use conditional visibility Player.IsCaching
-#define LABEL_BUFFERING                  24
-
- // Progressbar used for buffering status and after seeking
-#define CONTROL_PROGRESS                 23


### PR DESCRIPTION
## Description
The aforementioned infolabel is a design flaw of VP according to FernetMenta (see: https://github.com/xbmc/xbmc/pull/20753#issuecomment-1015707100) as it ties the player with the info interface. `Player.HasPerformedSeek` was introduced in https://github.com/xbmc/xbmc/pull/21366 as an alternative. Usages of `Player.DisplayAfterSeek` were removed from builtin skins (estuary and estouchy) in favor of the new infobool in https://github.com/xbmc/xbmc/pull/21380.
This further removes all usages and the main logic of `DisplayerAfterSeek` from kodi core.
While the cleanup is smooth and should not cause regressions there is a little issue in the last commit (https://github.com/xbmc/xbmc/commit/89e34c6c12e37285d9757fb74a005f0fc97f75dd):

In VideoFullScreen window we were forcing visibility conditions manually on static controls. While I could have just replaced the visibility conditions with the new one I don't think it is correct. Skinners should have full control of their skin elements, i.e., shouldn't be the core to dictate when to show/hide a control. So...decided to remove them all together. Note that the big majority of skins on our repo (nexus and matrix) do not use those controls. The only two exceptions are:

- **skin.pelucid** by @theDeadman
https://github.com/xbmc/repo-skins/blob/matrix/skin.pellucid/1080i/VideoFullScreen.xml#L82-L92
skinner must add `<visible>player.caching</visible>` to retain same behavior

- **skin.amber** by @bartolomesoriano
https://github.com/xbmc/repo-skins/blob/matrix/skin.amber/1080i/VideoFullScreen.xml#L74
Unsure about this one. It uses the static ids we're using but with a different type (image vs label). Likely nothing needed. Please confirm @bartolomesoriano 

## Motivation and context
Cleanup. Decouple stuff.

## How has this been tested?
Runtime tested in estuary.

## What is the effect on users?
Skinners should adapt the usage of `Player.DisplayAfterSeek` to `Player.HasPerformedSeek(interval)`
