### PR TITLE
[android] Allow target apk generation for Store use, bump SDK 30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                                             -DPYTHON_VERSION=${PYTHON_VERSION}
                                             -Dprefix=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                             -DKODI_WEBSERVER_EXTRA_WHITELIST="${KODI_WEBSERVER_EXTRA_WHITELIST}"
+                                            -DINFO_STORE_DISPLAYNAME=${INFO_STORE_DISPLAYNAME}
                                             -P ${CMAKE_SOURCE_DIR}/cmake/scripts/common/GenerateVersionedFiles.cmake
                    DEPENDS ${CMAKE_SOURCE_DIR}/version.txt
                            export-files

--- a/cmake/platform/android/android.cmake
+++ b/cmake/platform/android/android.cmake
@@ -1,2 +1,7 @@
 set(PLATFORM_REQUIRED_DEPS LibAndroidJNI OpenGLES EGL Zip)
 set(APP_RENDER_SYSTEM gles)
+
+# Store SDK compile version
+set(TARGET_SDK 29)
+# Minimum supported SDK version
+set(TARGET_MINSDK 21)

--- a/cmake/platform/android/android.cmake
+++ b/cmake/platform/android/android.cmake
@@ -5,3 +5,9 @@ set(APP_RENDER_SYSTEM gles)
 set(TARGET_SDK 29)
 # Minimum supported SDK version
 set(TARGET_MINSDK 21)
+
+if(DEFINED ENV{ANDROIDSTORE} AND ("$ENV{ANDROIDSTORE}" STREQUAL "GOOGLE"))
+  set(PLAYSTORE_STATE "true")
+else()
+  set(PLAYSTORE_STATE "false")
+endif()

--- a/cmake/platform/android/android.cmake
+++ b/cmake/platform/android/android.cmake
@@ -2,12 +2,13 @@ set(PLATFORM_REQUIRED_DEPS LibAndroidJNI OpenGLES EGL Zip)
 set(APP_RENDER_SYSTEM gles)
 
 # Store SDK compile version
-set(TARGET_SDK 29)
+set(TARGET_SDK 30)
 # Minimum supported SDK version
 set(TARGET_MINSDK 21)
 
 if(DEFINED ENV{ANDROIDSTORE} AND ("$ENV{ANDROIDSTORE}" STREQUAL "GOOGLE"))
   set(PLAYSTORE_STATE "true")
 else()
+  set(PERMISSION.MANAGE_EXTERNAL_STORAGE "<uses-permission android:name=\"android.permission.MANAGE_EXTERNAL_STORAGE\" />")
   set(PLAYSTORE_STATE "false")
 endif()

--- a/cmake/platform/android/android.cmake
+++ b/cmake/platform/android/android.cmake
@@ -8,6 +8,7 @@ set(TARGET_MINSDK 21)
 
 if(DEFINED ENV{ANDROIDSTORE} AND ("$ENV{ANDROIDSTORE}" STREQUAL "GOOGLE"))
   set(PLAYSTORE_STATE "true")
+  set(INFO_STORE_DISPLAYNAME " Google Play Store")
 else()
   set(PERMISSION.MANAGE_EXTERNAL_STORAGE "<uses-permission android:name=\"android.permission.MANAGE_EXTERNAL_STORAGE\" />")
   set(PLAYSTORE_STATE "false")

--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -163,6 +163,7 @@ foreach(target apk obb apk-obb apk-clean)
               NDKROOT=${NDKROOT}
               SDKROOT=${SDKROOT}
               STRIP=${CMAKE_STRIP}
+              STORE=$ENV{ANDROIDSTORE}
               ${target}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/android/packaging
       VERBATIM

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -31,6 +31,10 @@ ifeq ($(KODI_ANDROID_KEY_PASSWORD),)
 export KODI_ANDROID_KEY_PASSWORD:=android
 endif
 
+ifeq ($(STORE),GOOGLE)
+STORENAME=-$(STORE)
+endif
+
 #this fixes a android ndk fuckup where the paths to
 #prebuilt stuff follow different name schemes for
 #arm and x86
@@ -137,7 +141,7 @@ java: res
 package: libs python java
 	@echo "Gradle build and sign..."
 	ANDROID_HOME=$(SDKROOT) ./gradlew assemble$(BUILD_TYPE)
-	@cp xbmc/build/outputs/apk/$(BUILD_TYPE_LC)/xbmc-$(BUILD_TYPE_LC).apk $(CMAKE_SOURCE_DIR)/@APP_NAME_LC@app-$(CPU)-$(BUILD_TYPE_LC).apk
+	@cp xbmc/build/outputs/apk/$(BUILD_TYPE_LC)/xbmc-$(BUILD_TYPE_LC).apk $(CMAKE_SOURCE_DIR)/@APP_NAME_LC@app-$(CPU)-$(BUILD_TYPE_LC)$(STORENAME).apk
 
 $(PREFIX)/lib/xbmc/lib@APP_NAME_LC@.so: $(SRCLIBS)
 	$(MAKE) -C ../../depends/target/xbmc

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -6,8 +6,8 @@
     android:versionName="@APP_VERSION@">
 
     <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="29" />
+        android:minSdkVersion="@TARGET_MINSDK@"
+        android:targetSdkVersion="@TARGET_SDK@" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -9,6 +9,7 @@
         android:minSdkVersion="@TARGET_MINSDK@"
         android:targetSdkVersion="@TARGET_SDK@" />
 
+    @PERMISSION.MANAGE_EXTERNAL_STORAGE@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion @TARGET_SDK@
     defaultConfig {
         applicationId "@APP_PACKAGE@"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion @TARGET_MINSDK@
+        targetSdkVersion @TARGET_SDK@
         versionCode @APP_VERSION_CODE_ANDROID@
         versionName "@APP_VERSION@"
     }

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -68,6 +68,7 @@ public class Splash extends Activity
   private static final int StartingXBMC = 99;
 
   private static final String TAG = "@APP_NAME@";
+  private static final boolean PLAYSTORE = @PLAYSTORE_STATE@;
 
   private static final int PERMISSION_RESULT_CODE = 8947;
 

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -1,5 +1,6 @@
 package @APP_PACKAGE@;
 
+import static android.content.pm.PackageManager.FEATURE_LEANBACK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 import android.Manifest;
@@ -21,6 +22,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Message;
+import android.provider.Settings;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
@@ -135,8 +137,26 @@ public class Splash extends Activity
           mSplash.mTextView.setText("Asking for permissions...");
           mSplash.mProgress.setVisibility(View.INVISIBLE);
 
-          requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.RECORD_AUDIO},
-                    PERMISSION_RESULT_CODE);
+          if (!PLAYSTORE && (Build.VERSION.SDK_INT >= 30) && !isAndroidTV())
+          {
+            try
+            {
+              Intent intent = new Intent();
+              intent.setAction(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+              intent.setData(Uri.parse(String.format("package:%s", getPackageName())));
+              startActivityForResult(intent, PERMISSION_RESULT_CODE);
+            }
+            catch (Exception e)
+            {
+              Log.d(TAG, "Exception asking for permissions: " + e.getMessage());
+            }
+          }
+          else
+          {
+            requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                                            Manifest.permission.RECORD_AUDIO},
+                               PERMISSION_RESULT_CODE);
+          }
           break;
         case CheckingPermissionsDone:
           if (mPermissionOK)
@@ -735,7 +755,14 @@ public class Splash extends Activity
   private boolean CheckPermissions()
   {
     boolean retVal = false;
-    if (android.os.Build.VERSION.SDK_INT > 22)
+    if ((Build.VERSION.SDK_INT >= 30) && !isAndroidTV())
+    {
+      if (Environment.isExternalStorageManager())
+      {
+        retVal = true;
+      }
+    }
+    else if (Build.VERSION.SDK_INT > 22)
     {
       int permissionCheck;
       permissionCheck = checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
@@ -764,6 +791,20 @@ public class Splash extends Activity
       }
     }
     mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data)
+  {
+    super.onActivityResult(requestCode, resultCode, data);
+    if (requestCode == PERMISSION_RESULT_CODE)
+    {
+      if (Environment.isExternalStorageManager())
+      {
+        mPermissionOK = true;
+      }
+      mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+    }
   }
 
   void updateExternalStorageState()
@@ -964,4 +1005,17 @@ public class Splash extends Activity
     }
   }
 
+  private boolean isAndroidTV()
+  {
+    if (getPackageManager().hasSystemFeature(FEATURE_LEANBACK))
+    {
+      Log.d(TAG, "Running on an Android TV Device");
+      return true;
+    }
+    else
+    {
+      Log.d(TAG, "Running on a non Android TV Device");
+      return false;
+    }
+  }
 }

--- a/tools/buildsteps/android-arm64-v8a/package
+++ b/tools/buildsteps/android-arm64-v8a/package
@@ -8,13 +8,17 @@ else
   TARGET=apk
 fi
 
+if [ "x$ANDROIDSTORE" == "xGOOGLE" ]; then
+  STORESUFFIX="-google"
+fi
+
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
 cd $WORKSPACE
 
 #rename for upload
 #e.x. xbmc-20130314-8c2fb31-Frodo-arm64-v8a.apk
-UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-arm64-v8a"
+UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)${STORESUFFIX}-arm64-v8a"
 mv kodiapp-arm64-v8a-*.apk $UPLOAD_FILENAME.apk
 if [ -f *.obb ]
 then

--- a/tools/buildsteps/android-x86_64/package
+++ b/tools/buildsteps/android-x86_64/package
@@ -8,13 +8,17 @@ else
   TARGET=apk
 fi
 
+if [ "x$ANDROIDSTORE" == "xGOOGLE" ]; then
+  STORESUFFIX="-google"
+fi
+
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
 cd $WORKSPACE
 
 #rename for upload
 #e.x. xbmc-20130314-8c2fb31-Frodo-x86_64.apk
-UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-x86_64"
+UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)${STORESUFFIX}-x86_64"
 mv kodiapp-x86_64-*.apk $UPLOAD_FILENAME.apk
 if [ -f *.obb ]
 then

--- a/tools/buildsteps/android/package
+++ b/tools/buildsteps/android/package
@@ -8,13 +8,17 @@ else
   TARGET=apk
 fi
 
+if [ "x$ANDROIDSTORE" == "xGOOGLE" ]; then
+  STORESUFFIX="-google"
+fi
+
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
 cd $WORKSPACE
 
 #rename for upload
 #e.x. xbmc-20130314-8c2fb31-Frodo-armeabi-v7a.apk
-UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-armeabi-v7a"
+UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)${STORESUFFIX}-armeabi-v7a"
 mv kodiapp-armeabi-*.apk $UPLOAD_FILENAME.apk
 if [ -f *.obb ]
 then

--- a/tools/buildsteps/androidx86/package
+++ b/tools/buildsteps/androidx86/package
@@ -8,13 +8,17 @@ else
   TARGET=apk
 fi
 
+if [ "x$ANDROIDSTORE" == "xGOOGLE" ]; then
+  STORESUFFIX="-google"
+fi
+
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
 cd $WORKSPACE
 
 #rename for upload
 #e.x. xbmc-20130314-8c2fb31-Frodo-x86.apk
-UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-x86"
+UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)${STORESUFFIX}-x86"
 mv kodiapp-x86-*.apk $UPLOAD_FILENAME.apk
 if [ -f *.obb ]
 then

--- a/xbmc/CompileInfo.cpp.in
+++ b/xbmc/CompileInfo.cpp.in
@@ -79,7 +79,7 @@ std::string CCompileInfo::GetBuildDate()
 
 const char*  CCompileInfo::GetVersionCode()
 {
-  return "@APP_VERSION_CODE@";
+  return "@APP_VERSION_CODE@@INFO_STORE_DISPLAYNAME@";
 }
 
 std::vector<ADDON::RepoInfo> CCompileInfo::LoadOfficialRepoInfos()


### PR DESCRIPTION
## Description
Introduce infrastructure capabilities to create and deploy an APK targeted at a specific deployment store.
Bump SDK 30

## Motivation and context
This allows us the ability to conditionally generate an apk that adheres to certain requirements for store deployment (ie Google Play).
A jenkins job will be created, that can be triggered to create a google play compatible apk (without MANAGE_EXTERNAL_STORAGE permission in this particular instance). This is generated by setting an environment variable at cmake generation time (eg ANDROIDSTORE=GOOGLE make -C tools/depends/target/cmakebuildsys) and an apk can then be created with a -GOOGLE set in the apk name to distinguish between an apk not built with the environment variable set.

Additionally, extract out min and target SDK numbers to a single cmake variable location. We could extend this to allow set at generation via a define, but for now, i think just setting them is suitable.

SDK 30 bump is done as per #21229 to use MANAGE_EXTERNAL_STORAGE to provide a "full featured" version when not deployed via Play store.

## How has this been tested?
Generation/build. manifest is correct in both instances, build naming is correct, and mirror deployment naming is now done (thanks @wsnipex )

## What is the effect on users?
The ability to deploy to the Google Playstore, and adhere to their "limitations". It also gives us an easy way to generate apk's (nightlies, releases, test builds, etc) that have the full kodi experience for local object manipulation.

Google play installs will be limited to only being able to read from local storage filetypes allowed by google. These limitations do NOT affect users who access their media/files from remote shares (ie nfs, smb, webdav, etc), only from things like physically attached USB storage to shields (or other devices), or "external storage" (SD cards, local locations) on phones.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
