### PR TITLE
[cmake] Flesh out FindPatch module for windows use

### DIFF
--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -33,8 +33,8 @@ if(ENABLE_INTERNAL_CROSSGUID)
     list(APPEND CROSSGUID_DEFINITIONS -DGUID_ANDROID)
   endif()
 
-  # Use custom findpatch to handle windows patch binary if not available
-  include(cmake/modules/FindPatch.cmake)
+  # find the path to the patch executable
+  find_package(Patch MODULE REQUIRED)
 
   set(PATCH_COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/001-fix-unused-function.patch
             COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/002-disable-Wall-error.patch)

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -27,7 +27,7 @@ if(ENABLE_INTERNAL_FMT)
 
   if(WIN32 OR WINDOWS_STORE)
     # find the path to the patch executable
-    find_program(PATCH_EXECUTABLE NAMES patch patch.exe REQUIRED)
+    find_package(Patch MODULE REQUIRED)
 
     set(patch ${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/001-windows-pdb-symbol-gen.patch)
     PATCH_LF_CHECK(${patch})

--- a/cmake/modules/FindPatch.cmake
+++ b/cmake/modules/FindPatch.cmake
@@ -8,53 +8,72 @@
 #
 # PATCH_EXECUTABLE - patch executable
 
-find_program(PATCH_EXECUTABLE NAMES patch patch.exe)
-if(NOT PATCH_EXECUTABLE)
-  if(WIN32 OR WINDOWSSTORE)
-    # Set mirror for potential patch binary download
-    if(NOT KODI_MIRROR)
-      set(KODI_MIRROR "http://mirrors.kodi.tv")
-    endif()
+if(CMAKE_HOST_WIN32)
 
-    set(PATCH_ARCHIVE_NAME "patch-2.7.6-bin")
-    set(PATCH_ARCHIVE "${PATCH_ARCHIVE_NAME}.zip")
-    set(PATCH_URL "${KODI_MIRROR}/build-deps/win32/${PATCH_ARCHIVE}")
-    set(PATCH_DOWNLOAD ${TARBALL_DIR}/${PATCH_ARCHIVE})
-
-    # download the archive containing patch.exe
-    message(STATUS "Downloading patch utility from ${PATCH_URL}...")
-    file(DOWNLOAD "${PATCH_URL}" "${PATCH_DOWNLOAD}" STATUS PATCH_DL_STATUS LOG PATCH_LOG SHOW_PROGRESS)
-    list(GET PATCH_DL_STATUS 0 PATCH_RETCODE)
-    if(NOT PATCH_RETCODE EQUAL 0)
-      message(FATAL_ERROR "ERROR downloading ${PATCH_URL} - status: ${PATCH_DL_STATUS} log: ${PATCH_LOG}")
-    endif()
-
-    # CORE_BUILD_DIR may not exist as yet, so create just in case
-    if(NOT EXISTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
-      file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
-    endif()
-
-    # extract the archive containing patch.exe
-    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf ${PATCH_DOWNLOAD}
-                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
-
-    # make sure the extraction worked and that patch.exe is there
-    set(PATCH_PATH ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${PATCH_ARCHIVE_NAME})
-    if(NOT EXISTS "${PATCH_PATH}/bin/patch.exe")
-      message(FATAL_ERROR "ERROR extracting patch utility from ${PATCH_PATH}")
-    endif()
-
-    # copy patch.exe into the output directory
-    file(INSTALL "${PATCH_PATH}/bin/patch.exe" DESTINATION ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin)
-    # copy patch depends
-    file(GLOB PATCH_BINARIES ${PATCH_PATH}/bin/*.dll)
-    if(NOT "${PATCH_BINARIES}" STREQUAL "")
-      file(INSTALL ${PATCH_BINARIES} DESTINATION ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin)
-    endif()
-
-    # make sure that cmake can find the copied patch.exe
-    find_program(PATCH_EXECUTABLE NAMES patch.exe HINTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin REQUIRED)
-  else()
-    message(FATAL_ERROR "ERROR - No patch executable found")
+  find_package(Git)
+  if(Git_FOUND)
+    get_filename_component(GIT_DIR ${GIT_EXECUTABLE} DIRECTORY)
   endif()
+
+  find_program(PATCH_EXE NAMES patch.exe HINTS "${GIT_DIR}/.." PATH_SUFFIXES usr/bin)
+else()
+  # Freebsd patch is insufficient (too old) look for gnu patch first
+  find_program(PATCH_EXE NAMES gpatch patch)
+endif()
+
+if(CMAKE_HOST_WIN32 AND NOT PATCH_EXE)
+  # Set mirror for potential patch binary download
+  if(NOT KODI_MIRROR)
+    set(KODI_MIRROR "http://mirrors.kodi.tv")
+  endif()
+
+  set(PATCH_ARCHIVE_NAME "patch-2.7.6-bin")
+  set(PATCH_ARCHIVE "${PATCH_ARCHIVE_NAME}.zip")
+  set(PATCH_URL "${KODI_MIRROR}/build-deps/win32/${PATCH_ARCHIVE}")
+  set(PATCH_DOWNLOAD ${TARBALL_DIR}/${PATCH_ARCHIVE})
+
+  # download the archive containing patch.exe
+  message(STATUS "Downloading patch utility from ${PATCH_URL}...")
+  file(DOWNLOAD "${PATCH_URL}" "${PATCH_DOWNLOAD}" STATUS PATCH_DL_STATUS LOG PATCH_LOG SHOW_PROGRESS)
+  list(GET PATCH_DL_STATUS 0 PATCH_RETCODE)
+  if(NOT PATCH_RETCODE EQUAL 0)
+    message(FATAL_ERROR "ERROR downloading ${PATCH_URL} - status: ${PATCH_DL_STATUS} log: ${PATCH_LOG}")
+  endif()
+
+  # CORE_BUILD_DIR may not exist as yet, so create just in case
+  if(NOT EXISTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
+  endif()
+
+  # extract the archive containing patch.exe
+  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf ${PATCH_DOWNLOAD}
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
+
+  # make sure the extraction worked and that patch.exe is there
+  set(PATCH_PATH ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${PATCH_ARCHIVE_NAME})
+  if(NOT EXISTS "${PATCH_PATH}/bin/patch.exe")
+    message(FATAL_ERROR "ERROR extracting patch utility from ${PATCH_PATH}")
+  endif()
+
+  # copy patch.exe into the output directory
+  file(INSTALL "${PATCH_PATH}/bin/patch.exe" DESTINATION ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin)
+  # copy patch depends
+  file(GLOB PATCH_BINARIES ${PATCH_PATH}/bin/*.dll)
+  if(NOT "${PATCH_BINARIES}" STREQUAL "")
+    file(INSTALL ${PATCH_BINARIES} DESTINATION ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin)
+  endif()
+
+  # make sure that cmake can find the copied patch.exe
+  find_program(PATCH_EXE NAMES patch.exe HINTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin REQUIRED)
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+set(FPHSA_NAME_MISMATCHED 1) # Suppress warnings, see https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html
+find_package_handle_standard_args(PATCH REQUIRED_VARS PATCH_EXE)
+unset(FPHSA_NAME_MISMATCHED)
+
+if(PATCH_FOUND)
+  set(PATCH_EXECUTABLE "${PATCH_EXE}")
+  mark_as_advanced(PATCH_EXE)
 endif()

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -18,8 +18,8 @@ if(ENABLE_INTERNAL_RapidJSON)
   set(RapidJSON_INCLUDE_DIR ${${MODULE}_INCLUDE_DIR})
   set(RapidJSON_VERSION ${${MODULE}_VER})
 
-  # Use custom findpatch to handle windows patch binary if not available
-  include(cmake/modules/FindPatch.cmake)
+  # find the path to the patch executable
+  find_package(Patch MODULE REQUIRED)
 
   set(PATCH_COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CORE_SOURCE_DIR}/tools/depends/target/rapidjson/001-remove_custom_cxx_flags.patch
             COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CORE_SOURCE_DIR}/tools/depends/target/rapidjson/002-cmake-removedocs-examples.patch

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -26,7 +26,7 @@ if(ENABLE_INTERNAL_SPDLOG)
 
   if(WIN32 OR WINDOWS_STORE)
     # find the path to the patch executable
-    find_program(PATCH_EXECUTABLE NAMES patch patch.exe REQUIRED)
+    find_package(Patch MODULE REQUIRED)
 
     set(patch ${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/001-windows-pdb-symbol-gen.patch)
     PATCH_LF_CHECK(${patch})

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -217,7 +217,7 @@ endmacro()
 # Macro to test format of line endings of a patch
 # Windows Specific
 macro(PATCH_LF_CHECK patch)
-  if(WIN32 OR WINDOWS_STORE)
+  if(CMAKE_HOST_WIN32)
     # On Windows "patch.exe" can only handle CR-LF line-endings.
     # Our patches have LF-only line endings - except when they
     # have been checked out as part of a dependency hosted on Git


### PR DESCRIPTION
## Description
Update FindPatch module for windows use

## Motivation and context
Windows we want to preference git patch, so adapt find module to check specifically
for it. Update other find modules importing FindPatch.cmake to actual find_package calls

@thexai just an fyi ping

## How has this been tested?
Locally

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
