### PR TITLE
changed: move CApplication::IsCurrentThread into AppMessenger

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -393,9 +393,6 @@ bool CApplication::Create()
 {
   m_bStop = false;
 
-  // Grab a handle to our thread to be used later in identifying the render thread.
-  m_threadID = CThread::GetCurrentThreadId();
-
   RegisterSettings();
 
   CServiceBroker::RegisterCPUInfo(CCPUInfo::GetCPUInfo());
@@ -425,7 +422,8 @@ bool CApplication::Create()
   // after that we can send messages to the corresponding modules
   appMessenger->RegisterReceiver(this);
   appMessenger->RegisterReceiver(&CServiceBroker::GetPlaylistPlayer());
-  appMessenger->SetGUIThread(m_threadID);
+  appMessenger->SetGUIThread(CThread::GetCurrentThreadId());
+  appMessenger->SetProcessThread(CThread::GetCurrentThreadId());
 
   // copy required files
   CUtil::CopyUserDataIfNeeded("special://masterprofile/", "RssFeeds.xml");
@@ -3643,11 +3641,6 @@ bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlay
     return true;
   }
   return false;
-}
-
-bool CApplication::IsCurrentThread() const
-{
-  return m_threadID == CThread::GetCurrentThreadId();
 }
 
 bool CApplication::SetLanguage(const std::string &strLanguage)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -151,7 +151,6 @@ public:
   bool CreateGUI();
   bool InitWindow(RESOLUTION res = RES_INVALID);
 
-  bool IsCurrentThread() const;
   bool Stop(int exitCode);
   void ReloadSkin(bool confirm = false);
   const std::string& CurrentFile();
@@ -298,7 +297,6 @@ protected:
   XbmcThreads::EndTime<> m_guiRefreshTimer;
 
   std::string m_prevMedia;
-  std::thread::id m_threadID;       // application thread ID.  Used in applicationMessenger to know where we are firing a thread with delay from.
   bool m_bInitializing = true;
 
   int m_nextPlaylistItem = -1;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -14,7 +14,6 @@
 
 #include "DVDVideoCodecAndroidMediaCodec.h"
 
-#include "Application.h"
 #include "DVDCodecs/DVDFactoryCodec.h"
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
@@ -1640,7 +1639,7 @@ void CDVDVideoCodecAndroidMediaCodec::InitSurfaceTexture(void)
   // to create/fetch/create from g_RenderManager. But g_RenderManager
   // does not know we are using MediaCodec until Configure and we
   // we need m_surfaceTexture valid before then. Chicken, meet Egg.
-  if (g_application.IsCurrentThread())
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     // localize GLuint so we do not spew gles includes in our header
     GLuint texture_id;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -367,7 +367,7 @@ void CRenderManager::PreInit()
       return;
   }
 
-  if (!g_application.IsCurrentThread())
+  if (!CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     m_initEvent.Reset();
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RENDERER_PREINIT);
@@ -396,7 +396,7 @@ void CRenderManager::PreInit()
 
 void CRenderManager::UnInit()
 {
-  if (!g_application.IsCurrentThread())
+  if (!CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     m_initEvent.Reset();
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RENDERER_UNINIT);
@@ -427,7 +427,7 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
   if (!m_pRenderer)
     return true;
 
-  if (g_application.IsCurrentThread())
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     CLog::Log(LOGDEBUG, "{} - flushing renderer", __FUNCTION__);
 
@@ -560,7 +560,7 @@ void CRenderManager::StartRenderCapture(unsigned int captureId, unsigned int wid
   capture->SetFlags(flags);
   capture->GetEvent().Reset();
 
-  if (g_application.IsCurrentThread())
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     if (flags & CAPTUREFLAG_IMMEDIATELY)
     {

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -8,7 +8,6 @@
 
 #include "Directory.h"
 
-#include "Application.h"
 #include "DirectoryCache.h"
 #include "DirectoryFactory.h"
 #include "FileDirectoryFactory.h"
@@ -19,6 +18,7 @@
 #include "commons/Exception.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Job.h"
@@ -196,7 +196,8 @@ bool CDirectory::GetDirectory(const CURL& url,
         {
           // @TODO ProcessRequirements() can bring up the keyboard input dialog
           // filesystem must not depend on GUI
-          if (g_application.IsCurrentThread() && pDirectory->ProcessRequirements())
+          if (CServiceBroker::GetAppMessenger()->IsProcessThread() &&
+              pDirectory->ProcessRequirements())
           {
             authUrl.SetDomain("");
             authUrl.SetUserName("");

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -8,7 +8,6 @@
 
 #include "GUIDialog.h"
 
-#include "Application.h"
 #include "GUIComponent.h"
 #include "GUIControlFactory.h"
 #include "GUILabelControl.h"
@@ -191,7 +190,7 @@ void CGUIDialog::Open(const std::string &param /* = "" */)
 
 void CGUIDialog::Open(bool bProcessRenderLoop, const std::string& param /* = "" */)
 {
-  if (!g_application.IsCurrentThread())
+  if (!CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -256,7 +256,7 @@ constexpr const int GUI_MSG_CODINGTABLE_LOOKUP_COMPLETED = 65000;
   { \
     CGUIMessage _msg(GUI_MSG_LABEL_SET, GetID(), controlID); \
     _msg.SetLabel(label); \
-    if (g_application.IsCurrentThread()) \
+    if (CServiceBroker::GetAppMessenger()->IsProcessThread()) \
       OnMessage(_msg); \
     else \
       CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(_msg, GetID()); \

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -8,7 +8,6 @@
 
 #include "GUIWindow.h"
 
-#include "Application.h"
 #include "GUIAudioManager.h"
 #include "GUIComponent.h"
 #include "GUIControlFactory.h"
@@ -399,7 +398,7 @@ void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*
 
 void CGUIWindow::Close(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/, bool bWait /* = true */)
 {
-  if (!g_application.IsCurrentThread())
+  if (!CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());
@@ -820,7 +819,7 @@ bool CGUIWindow::Initialize()
     return false;
   if (!NeedLoad())
     return true;
-  if (g_application.IsCurrentThread())
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread())
     AllocResources(false);
   else
   {

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -765,7 +765,7 @@ void CGUIWindowManager::ForceActivateWindow(int iWindowID, const std::string& st
 
 void CGUIWindowManager::ActivateWindow(int iWindowID, const std::vector<std::string>& params, bool swappingWindows /* = false */, bool force /* = false */)
 {
-  if (!g_application.IsCurrentThread())
+  if (!CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());
@@ -1181,7 +1181,7 @@ bool RenderOrderSortFunction(CGUIWindow *first, CGUIWindow *second)
 
 void CGUIWindowManager::Process(unsigned int currentTime)
 {
-  assert(g_application.IsCurrentThread());
+  assert(CServiceBroker::GetAppMessenger()->IsProcessThread());
   std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_dirtyregions.clear();
@@ -1262,7 +1262,7 @@ void CGUIWindowManager::RenderEx() const
 
 bool CGUIWindowManager::Render()
 {
-  assert(g_application.IsCurrentThread());
+  assert(CServiceBroker::GetAppMessenger()->IsProcessThread());
   CSingleExit lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   CDirtyRegionList dirtyRegions = m_tracker.GetDirtyRegions();
@@ -1333,7 +1333,7 @@ void CGUIWindowManager::AfterRender()
 
 void CGUIWindowManager::FrameMove()
 {
-  assert(g_application.IsCurrentThread());
+  assert(CServiceBroker::GetAppMessenger()->IsProcessThread());
   std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   if(m_iNested == 0)
@@ -1387,7 +1387,7 @@ bool CGUIWindowManager::ProcessRenderLoop(bool renderOnly)
 {
   bool renderGui = true;
 
-  if (g_application.IsCurrentThread() && m_pCallback)
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread() && m_pCallback)
   {
     renderGui = m_pCallback->GetRenderGUI();
     m_iNested++;

--- a/xbmc/interfaces/generic/ScriptRunner.cpp
+++ b/xbmc/interfaces/generic/ScriptRunner.cpp
@@ -8,7 +8,7 @@
 
 #include "ScriptRunner.h"
 
-#include "Application.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogProgress.h"
@@ -16,6 +16,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "interfaces/generic/RunningScriptObserver.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
+#include "messaging/ApplicationMessenger.h"
 #include "threads/SystemClock.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -127,7 +128,7 @@ bool CScriptRunner::WaitOnScriptResult(int scriptId,
   // Add-on scripts can be called from the main and other threads. If called
   // form the main thread, we need to bring up the BusyDialog in order to
   // keep the render loop alive
-  if (g_application.IsCurrentThread())
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     if (!m_scriptDone.Wait(20ms))
     {

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -133,7 +133,7 @@ namespace XBMCAddon
       //! @todo rework locking
       // Python GIL and CServiceBroker::GetWinSystem()->GetGfxContext() are deadlock happy
       // dispose is called from GUIWindowManager and in this case DelayGuard must not be used.
-      if (!g_application.IsCurrentThread())
+      if (!CServiceBroker::GetAppMessenger()->IsProcessThread())
       {
         SingleLockWithDelayGuard gslock(CServiceBroker::GetWinSystem()->GetGfxContext(), languageHook);
       }

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -12,7 +12,6 @@
 #include <Python.h>
 // clang-format on
 
-#include "Application.h"
 #include "PythonInvoker.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
@@ -28,6 +27,7 @@
 #include "interfaces/python/swig.h"
 #include "messaging/ApplicationMessenger.h"
 #include "threads/SingleLock.h"
+#include "threads/SystemClock.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -510,7 +510,7 @@ bool CPythonInvoker::stop(bool abort)
       // We can't empty-spin in the main thread and expect scripts to be able to
       // dismantle themselves. Python dialogs aren't normal XBMC dialogs, they rely
       // on TMSG_GUI_PYTHON_DIALOG messages, so pump the message loop.
-      if (g_application.IsCurrentThread())
+      if (CServiceBroker::GetAppMessenger()->IsProcessThread())
       {
         CServiceBroker::GetAppMessenger()->ProcessMessages();
       }

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -287,5 +287,9 @@ void CApplicationMessenger::RegisterReceiver(IMessageTarget* target)
   m_mapTargets.insert(std::make_pair(target->GetMessageMask(), target));
 }
 
+bool CApplicationMessenger::IsProcessThread() const
+{
+  return m_processThreadId == CThread::GetCurrentThreadId();
+}
 }
 }

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -401,10 +401,20 @@ public:
    */
   void SetGUIThread(const std::thread::id thread) { m_guiThreadId = thread; }
 
+  /*!
+   * \brief Set the processing thread id to avoid messenger being dependent on
+   * CApplication to determine if marshaling is required
+   * \param thread The processing thread ID
+   */
+  void SetProcessThread(const std::thread::id thread) { m_processThreadId = thread; }
+
   /*
    * \brief Signals the shutdown of the application and message processing
    */
   void Stop() { m_bStop = true; }
+
+  //! \brief Returns true if this is the process / app loop thread.
+  bool IsProcessThread() const;
 
 private:
   CApplicationMessenger(const CApplicationMessenger&) = delete;
@@ -418,6 +428,7 @@ private:
   std::map<int, IMessageTarget*> m_mapTargets; /*!< a map of registered receivers indexed on the message mask*/
   CCriticalSection m_critSection;
   std::thread::id m_guiThreadId;
+  std::thread::id m_processThreadId;
   bool m_bStop{ false };
 };
 }

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -15,6 +15,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -239,7 +240,7 @@ public:
 class NestDetect
 {
 public:
-  NestDetect() : m_gui_thread (g_application.IsCurrentThread())
+  NestDetect() : m_gui_thread(CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     if (m_gui_thread)
       ++m_nest;
@@ -271,7 +272,7 @@ class ProgressDialogHelper
 public:
   explicit ProgressDialogHelper (const std::string& heading) : m_dialog(0)
   {
-    if (g_application.IsCurrentThread())
+    if (CServiceBroker::GetAppMessenger()->IsProcessThread())
     {
       CGUIComponent *gui = CServiceBroker::GetGUI();
       if (gui)
@@ -527,7 +528,8 @@ bool CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
   {
     CLog::Log(LOGERROR,"WakeOnAccess failed to send. (Is it blocked by firewall?)");
 
-    if (g_application.IsCurrentThread() || !g_application.GetAppPlayer().IsPlaying())
+    if (CServiceBroker::GetAppMessenger()->IsProcessThread() ||
+        !g_application.GetAppPlayer().IsPlaying())
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, heading, LOCALIZED(13029));
     return false;
   }

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -382,7 +382,7 @@ bool CGraphicContext::IsValidResolution(RESOLUTION res)
 // call SetVideoResolutionInternal and ensure its done from mainthread
 void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate)
 {
-  if (g_application.IsCurrentThread())
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
     SetVideoResolutionInternal(res, forceUpdate);
   }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -2228,7 +2228,8 @@ bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool us
     }
     else if (!getItems.m_result)
     {
-      if (g_application.IsCurrentThread() && m_rootDir.GetDirImpl() && !m_rootDir.GetDirImpl()->ProcessRequirements())
+      if (CServiceBroker::GetAppMessenger()->IsProcessThread() && m_rootDir.GetDirImpl() &&
+          !m_rootDir.GetDirImpl()->ProcessRequirements())
       {
         ret = false;
       }


### PR DESCRIPTION
## Description
slightly reduces complexity of CApplication and
avoids pulling Application.h in various places

## Motivation and context
Since this is mainly used by the messenger, it is a more natural home for the variable.
I introduce another method akin to SetGUIThread for when the day comes that we
render off main thread.

## How has this been tested?
It builds and runs.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
