### PR TITLE
CPipewireThreadLoop: make wait use method with timeout

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -16,6 +16,8 @@
 
 #include <pipewire/pipewire.h>
 
+using namespace std::chrono_literals;
+
 namespace AE
 {
 namespace SINK
@@ -67,9 +69,16 @@ bool CPipewire::Start()
 
   m_core->Sync();
 
-  m_loop->Wait();
+  int ret = m_loop->Wait(5s);
 
   m_loop->Unlock();
+
+  if (ret == -ETIMEDOUT)
+  {
+    CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - timed out out waiting for synchronization",
+              __FUNCTION__);
+    return false;
+  }
 
   return true;
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
@@ -49,9 +49,12 @@ void CPipewireThreadLoop::Unlock()
   pw_thread_loop_unlock(m_mainloop.get());
 }
 
-void CPipewireThreadLoop::Wait()
+int CPipewireThreadLoop::Wait(std::chrono::nanoseconds timeout)
 {
-  pw_thread_loop_wait(m_mainloop.get());
+  timespec abstime;
+  pw_thread_loop_get_time(m_mainloop.get(), &abstime, timeout.count());
+
+  return pw_thread_loop_timed_wait_full(m_mainloop.get(), &abstime);
 }
 
 void CPipewireThreadLoop::Signal(bool accept)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include <pipewire/thread-loop.h>
@@ -33,7 +34,7 @@ public:
   void Lock();
   void Unlock();
 
-  void Wait();
+  int Wait(std::chrono::nanoseconds timeout);
   void Signal(bool accept);
 
 private:


### PR DESCRIPTION
This changes the pipewire wait implementation to use the `pw_thread_loop_timed_wait_full` method. This allows specifying a timeout so that we don't end up in a deadlock.

Occasionally when changing pipewire devices (or exiting Kodi) we would be stuck waiting for a signal that would never come. This makes it so that we timeout and handle that path if it happens.