### PR TITLE
[Android] check Neon support

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -884,7 +884,7 @@ public class Splash extends Activity
 
     if (mState != InError)
     {
-      if (pkg_arch.equalsIgnoreCase("arm"))
+      if (pkg_arch.equalsIgnoreCase("armeabi-v7a"))
       {
         // arm arch: check if the cpu supports neon
         boolean ret = ParseCpuFeature();


### PR DESCRIPTION
## Description
When Kodi starts, it checks if supports ARM Advanced SIMD (known as Neon).

The current IF statement is never true as there is no ABI with the name "arm".

## How has this been tested?
Runtime tested on AFTV (armeabi-v7a)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
