### PR TITLE
changed: move ReplayGain cache to ApplicationVolumeHandling

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -485,10 +485,7 @@ bool CApplication::Create()
   CServiceBroker::RegisterAE(m_pActiveAE.get());
 
   // initialize m_replayGainSettings
-  m_replayGainSettings.iType = settings->GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINTYPE);
-  m_replayGainSettings.iPreAmp = settings->GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINPREAMP);
-  m_replayGainSettings.iNoGainPreAmp = settings->GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINNOGAINPREAMP);
-  m_replayGainSettings.bAvoidClipping = settings->GetBool(CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING);
+  CacheReplayGainSettings(*settings);
 
   // load the keyboard layouts
   if (!keyboardLayoutManager->Load())

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -89,16 +89,6 @@ namespace MUSIC_INFO
   class CMusicInfoScanner;
 }
 
-// replay gain settings struct for quick access by the player multiple
-// times per second (saves doing settings lookup)
-struct ReplayGainSettings
-{
-  int iPreAmp;
-  int iNoGainPreAmp;
-  int iType;
-  bool bAvoidClipping;
-};
-
 enum StartupAction
 {
   STARTUP_ACTION_NONE = 0,
@@ -222,8 +212,6 @@ public:
   bool SetLanguage(const std::string &strLanguage);
   bool LoadLanguage(bool reload);
 
-  ReplayGainSettings& GetReplayGainSettings() { return m_replayGainSettings; }
-
   void SetLoggingIn(bool switchingProfiles);
 
   /*!
@@ -312,7 +300,6 @@ protected:
 
   CInertialScrollingHandler *m_pInertialScrollingHandler;
 
-  ReplayGainSettings m_replayGainSettings;
   std::vector<IActionListener *> m_actionListeners;
   std::vector<ADDON::AddonInfoPtr>
       m_incompatibleAddons; /*!< Result of addon migration (incompatible addon infos) */

--- a/xbmc/application/ApplicationVolumeHandling.cpp
+++ b/xbmc/application/ApplicationVolumeHandling.cpp
@@ -16,6 +16,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "interfaces/AnnouncementManager.h"
 #include "peripherals/Peripherals.h"
+#include "settings/Settings.h"
 #include "utils/Variant.h"
 
 CApplicationVolumeHandling::CApplicationVolumeHandling(CApplicationPlayer& appPlayer)
@@ -128,4 +129,15 @@ void CApplicationVolumeHandling::SetVolume(float iValue, bool isPercentage)
 
   SetHardwareVolume(hardwareVolume);
   VolumeChanged();
+}
+
+void CApplicationVolumeHandling::CacheReplayGainSettings(const CSettings& settings)
+{
+  // initialize m_replayGainSettings
+  m_replayGainSettings.iType = settings.GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINTYPE);
+  m_replayGainSettings.iPreAmp = settings.GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINPREAMP);
+  m_replayGainSettings.iNoGainPreAmp =
+      settings.GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINNOGAINPREAMP);
+  m_replayGainSettings.bAvoidClipping =
+      settings.GetBool(CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING);
 }

--- a/xbmc/application/ApplicationVolumeHandling.h
+++ b/xbmc/application/ApplicationVolumeHandling.h
@@ -10,6 +10,7 @@
 
 class CAction;
 class CApplicationPlayer;
+class CSettings;
 
 /*!
  * \brief Class handling application support for audio volume management.
@@ -17,6 +18,16 @@ class CApplicationPlayer;
 class CApplicationVolumeHandling
 {
 public:
+  // replay gain settings struct for quick access by the player multiple
+  // times per second (saves doing settings lookup)
+  struct ReplayGainSettings
+  {
+    int iPreAmp;
+    int iNoGainPreAmp;
+    int iType;
+    bool bAvoidClipping;
+  };
+
   explicit CApplicationVolumeHandling(CApplicationPlayer& appPlayer);
 
   float GetVolumePercent() const;
@@ -27,6 +38,8 @@ public:
   void SetMute(bool mute);
   void ToggleMute(void);
 
+  const ReplayGainSettings& GetReplayGainSettings() const { return m_replayGainSettings; }
+
   static constexpr float VOLUME_MINIMUM = 0.0f; // -60dB
   static constexpr float VOLUME_MAXIMUM = 1.0f; // 0dB
   static constexpr float VOLUME_DYNAMIC_RANGE = 90.0f; // 60dB
@@ -34,6 +47,8 @@ public:
 protected:
   bool IsMutedInternal() const { return m_muted; }
   void ShowVolumeBar(const CAction* action = nullptr);
+
+  void CacheReplayGainSettings(const CSettings& settings);
 
   void Mute();
   void UnMute();
@@ -45,4 +60,5 @@ protected:
   CApplicationPlayer& m_appPlayer; //!< Reference to application player
   bool m_muted = false;
   float m_volumeLevel = VOLUME_MAXIMUM;
+  ReplayGainSettings m_replayGainSettings;
 };

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -331,7 +331,7 @@ int CAudioDecoder::ReadSamples(int numsamples)
 float CAudioDecoder::GetReplayGain(float &peakVal)
 {
 #define REPLAY_GAIN_DEFAULT_LEVEL 89.0f
-  const ReplayGainSettings &replayGainSettings = g_application.GetReplayGainSettings();
+  const auto& replayGainSettings = g_application.GetReplayGainSettings();
   if (replayGainSettings.iType == ReplayGain::NONE)
     return 1.0f;
 


### PR DESCRIPTION
## Description
Move replay gain setting cache to the volume handling subclass

## Motivation and context
This is obviously volume handling related. Oversight from initial refactor.

## How has this been tested?
It builds and runs.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
