### PR TITLE
Application player constness

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -23,7 +23,13 @@
 
 using namespace std::chrono_literals;
 
-std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal() const
+std::shared_ptr<const IPlayer> CApplicationPlayer::GetInternal() const
+{
+  std::unique_lock<CCriticalSection> lock(m_playerLock);
+  return m_pPlayer;
+}
+
+std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal()
 {
   std::unique_lock<CCriticalSection> lock(m_playerLock);
   return m_pPlayer;
@@ -66,9 +72,9 @@ void CApplicationPlayer::CreatePlayer(const CPlayerCoreFactory &factory, const s
   }
 }
 
-std::string CApplicationPlayer::GetCurrentPlayer()
+std::string CApplicationPlayer::GetCurrentPlayer() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
   {
     return player->m_name;
@@ -162,8 +168,8 @@ void CApplicationPlayer::OpenNext(const CPlayerCoreFactory &factory)
 
 bool CApplicationPlayer::HasPlayer() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
-  return player != NULL;
+  std::shared_ptr<const IPlayer> player = GetInternal();
+  return player != nullptr;
 }
 
 int CApplicationPlayer::GetChapter()
@@ -203,19 +209,19 @@ int64_t CApplicationPlayer::GetChapterPos(int chapterIdx)
 
 bool CApplicationPlayer::HasAudio() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->HasAudio());
 }
 
 bool CApplicationPlayer::HasVideo() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->HasVideo());
 }
 
 bool CApplicationPlayer::HasGame() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->HasGame());
 }
 
@@ -232,7 +238,7 @@ int CApplicationPlayer::GetPreferredPlaylist() const
 
 bool CApplicationPlayer::HasRDS() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->HasRDS());
 }
 
@@ -243,7 +249,7 @@ bool CApplicationPlayer::IsPaused()
 
 bool CApplicationPlayer::IsPlaying() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->IsPlaying());
 }
 
@@ -311,7 +317,7 @@ void CApplicationPlayer::SeekPercentage(float fPercent)
 
 bool CApplicationPlayer::IsPassthrough() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->IsPassthrough());
 }
 
@@ -350,7 +356,7 @@ void CApplicationPlayer::SeekTimeRelative(int64_t iTime)
 
 int64_t CApplicationPlayer::GetTime() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
     return CDataCacheCore::GetInstance().GetPlayTime();
   else
@@ -359,7 +365,7 @@ int64_t CApplicationPlayer::GetTime() const
 
 int64_t CApplicationPlayer::GetMinTime() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
     return CDataCacheCore::GetInstance().GetMinTime();
   else
@@ -368,7 +374,7 @@ int64_t CApplicationPlayer::GetMinTime() const
 
 int64_t CApplicationPlayer::GetMaxTime() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
     return CDataCacheCore::GetInstance().GetMaxTime();
   else
@@ -377,7 +383,7 @@ int64_t CApplicationPlayer::GetMaxTime() const
 
 time_t CApplicationPlayer::GetStartTime() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
     return CDataCacheCore::GetInstance().GetStartTime();
   else
@@ -386,7 +392,7 @@ time_t CApplicationPlayer::GetStartTime() const
 
 int64_t CApplicationPlayer::GetTotalTime() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
   {
     int64_t total = CDataCacheCore::GetInstance().GetMaxTime() - CDataCacheCore::GetInstance().GetMinTime();
@@ -398,19 +404,19 @@ int64_t CApplicationPlayer::GetTotalTime() const
 
 bool CApplicationPlayer::IsCaching() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->IsCaching());
 }
 
 bool CApplicationPlayer::IsInMenu() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   return (player && player->IsInMenu());
 }
 
 MenuType CApplicationPlayer::GetSupportedMenuType() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (!player)
   {
     return MenuType::NONE;
@@ -420,7 +426,7 @@ MenuType CApplicationPlayer::GetSupportedMenuType() const
 
 int CApplicationPlayer::GetCacheLevel() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
     return player->GetCacheLevel();
   else
@@ -491,7 +497,7 @@ std::shared_ptr<TextCacheStruct_t> CApplicationPlayer::GetTeletextCache()
 
 float CApplicationPlayer::GetPercentage() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
   {
     float fPercent = CDataCacheCore::GetInstance().GetPlayPercentage();
@@ -503,7 +509,7 @@ float CApplicationPlayer::GetPercentage() const
 
 float CApplicationPlayer::GetCachePercentage() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
     return player->GetCachePercentage();
   else
@@ -787,9 +793,9 @@ void CApplicationPlayer::SetPlaySpeed(float speed)
   SetSpeed(speed);
 }
 
-float CApplicationPlayer::GetPlaySpeed()
+float CApplicationPlayer::GetPlaySpeed() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
   {
     return CDataCacheCore::GetInstance().GetSpeed();
@@ -798,9 +804,9 @@ float CApplicationPlayer::GetPlaySpeed()
     return 0;
 }
 
-float CApplicationPlayer::GetPlayTempo()
+float CApplicationPlayer::GetPlayTempo() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
   {
     return CDataCacheCore::GetInstance().GetTempo();
@@ -983,9 +989,9 @@ bool CApplicationPlayer::IsRemotePlaying()
   return false;
 }
 
-CVideoSettings CApplicationPlayer::GetVideoSettings()
+CVideoSettings CApplicationPlayer::GetVideoSettings() const
 {
-  std::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)
   {
     return player->GetVideoSettings();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -37,9 +37,9 @@ public:
   // player management
   void ClosePlayer();
   void ResetPlayer();
-  std::string GetCurrentPlayer();
-  float GetPlaySpeed();
-  float GetPlayTempo();
+  std::string GetCurrentPlayer() const;
+  float GetPlaySpeed() const;
+  float GetPlayTempo() const;
   bool HasPlayer() const;
   bool OpenFile(const CFileItem& item, const CPlayerOptions& options,
                 const CPlayerCoreFactory &factory,
@@ -160,7 +160,7 @@ public:
   void SetSpeed(float speed);
   bool SupportsTempo();
 
-  CVideoSettings GetVideoSettings();
+  CVideoSettings GetVideoSettings() const;
   void SetVideoSettings(CVideoSettings& settings);
 
   CSeekHandler& GetSeekHandler();
@@ -173,7 +173,8 @@ public:
   bool HasGameAgent();
 
 private:
-  std::shared_ptr<IPlayer> GetInternal() const;
+  std::shared_ptr<const IPlayer> GetInternal() const;
+  std::shared_ptr<IPlayer> GetInternal();
   void CreatePlayer(const CPlayerCoreFactory &factory, const std::string &player, IPlayerCallback& callback);
   void CloseFile(bool reopen = false);
 

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -106,7 +106,7 @@ public:
   virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) = 0;
   virtual bool SeekScene(bool bPlus = true) {return false;}
   virtual void SeekPercentage(float fPercent = 0){}
-  virtual float GetCachePercentage(){ return 0;}
+  virtual float GetCachePercentage() const { return 0; }
   virtual void SetMute(bool bOnOff){}
   virtual void SetVolume(float volume){}
   virtual void SetDynamicRangeCompression(long drc){}

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -253,7 +253,7 @@ public:
   }
 
   // video and audio settings
-  virtual CVideoSettings GetVideoSettings() { return CVideoSettings(); }
+  virtual CVideoSettings GetVideoSettings() const { return CVideoSettings(); }
   virtual void SetVideoSettings(CVideoSettings& settings) {}
 
   /*!

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -331,7 +331,7 @@ void CRetroPlayer::SeekPercentage(float fPercent /* = 0 */)
     SeekTime(static_cast<int64_t>(totalTime * fPercent / 100.0f));
 }
 
-float CRetroPlayer::GetCachePercentage()
+float CRetroPlayer::GetCachePercentage() const
 {
   const float cacheMs = static_cast<float>(m_playback->GetCacheTimeMs());
   const float totalMs = static_cast<float>(m_playback->GetTotalTimeMs());

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -56,7 +56,7 @@ public:
   bool CanSeek() override;
   void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) override;
   void SeekPercentage(float fPercent = 0) override;
-  float GetCachePercentage() override;
+  float GetCachePercentage() const override;
   void SetMute(bool bOnOff) override;
   void SeekTime(int64_t iTime = 0) override;
   bool SeekTimeRelative(int64_t iTime) override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4876,7 +4876,7 @@ void CVideoPlayer::SetDynamicRangeCompression(long drc)
   m_VideoPlayerAudio->SetDynamicRangeCompression(drc);
 }
 
-CVideoSettings CVideoPlayer::GetVideoSettings()
+CVideoSettings CVideoPlayer::GetVideoSettings() const
 {
   return m_processInfo->GetVideoSettings();
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3263,7 +3263,7 @@ float CVideoPlayer::GetPercentage()
   return GetTime() * 100 / (float)iTotalTime;
 }
 
-float CVideoPlayer::GetCachePercentage()
+float CVideoPlayer::GetCachePercentage() const
 {
   std::unique_lock<CCriticalSection> lock(m_StateSection);
   return (float) (m_State.cache_offset * 100); // NOTE: Percentage returned is relative

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -352,7 +352,7 @@ public:
   int OnDiscNavResult(void* pData, int iMessage) override;
   void GetVideoResolution(unsigned int &width, unsigned int &height) override;
 
-  CVideoSettings GetVideoSettings() override;
+  CVideoSettings GetVideoSettings() const override;
   void SetVideoSettings(CVideoSettings& settings) override;
 
   void SetUpdateStreamDetails();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -257,7 +257,7 @@ public:
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   bool SeekScene(bool bPlus = true) override;
   void SeekPercentage(float iPercent) override;
-  float GetCachePercentage() override;
+  float GetCachePercentage() const override;
 
   void SetDynamicRangeCompression(long drc) override;
   bool CanPause() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -48,7 +48,7 @@ protected:
   virtual void UpdateRenderBuffers(int queued, int discard, int free) = 0;
   virtual void UpdateGuiRender(bool gui) = 0;
   virtual void UpdateVideoRender(bool video) = 0;
-  virtual CVideoSettings GetVideoSettings() = 0;
+  virtual CVideoSettings GetVideoSettings() const = 0;
 };
 
 class CRenderManager


### PR DESCRIPTION
## Description
This fixes some of the constness issues in ApplicationPlayer. 
There are some more left but they all require  surgery in IPlayer and its implementations,
and they did not bother me in my refactor so..

## Motivation and context
Being able to only allow const ref access to ApplicationPlayer outside of CApplication.

## How has this been tested?
It builds and runs.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
