### PR TITLE
Make application stack helper accessor const

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3410,7 +3410,7 @@ CFileItem& CApplication::CurrentFileItem()
   return *m_itemCurrentFile;
 }
 
-CFileItem& CApplication::CurrentUnstackedItem()
+const CFileItem& CApplication::CurrentUnstackedItem()
 {
   if (m_stackHelper.IsPlayingISOStack() || m_stackHelper.IsPlayingRegularStack())
     return m_stackHelper.GetCurrentStackPartFileItem();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3572,7 +3572,7 @@ CApplicationPlayer& CApplication::GetAppPlayer()
   return m_appPlayer;
 }
 
-CApplicationStackHelper& CApplication::GetAppStackHelper()
+const CApplicationStackHelper& CApplication::GetAppStackHelper() const
 {
   return m_stackHelper;
 }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -156,7 +156,7 @@ public:
   const std::string& CurrentFile();
   CFileItem& CurrentFileItem();
   std::shared_ptr<CFileItem> CurrentFileItemPtr();
-  CFileItem& CurrentUnstackedItem();
+  const CFileItem& CurrentUnstackedItem();
   bool OnMessage(CGUIMessage& message) override;
   CApplicationPlayer& GetAppPlayer();
   std::string GetCurrentPlayer();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -160,7 +160,7 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   CApplicationPlayer& GetAppPlayer();
   std::string GetCurrentPlayer();
-  CApplicationStackHelper& GetAppStackHelper();
+  const CApplicationStackHelper& GetAppStackHelper() const;
 
   int  GetMessageMask() override;
   void OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg) override;

--- a/xbmc/ApplicationStackHelper.cpp
+++ b/xbmc/ApplicationStackHelper.cpp
@@ -16,7 +16,6 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 
-#include <mutex>
 #include <utility>
 
 using namespace XFILE;
@@ -41,7 +40,7 @@ void CApplicationStackHelper::OnPlayBackStarted(const CFileItem& item)
     m_stackmap.clear();
   else
   {
-    CFileItemPtr stack = GetRegisteredStack(item);
+    auto stack = GetRegisteredStack(item);
     Stackmap::iterator itr = m_stackmap.begin();
     while (itr != m_stackmap.end())
     {
@@ -228,14 +227,16 @@ void CApplicationStackHelper::ClearAllRegisteredStackInformation()
   m_stackmap.clear();
 }
 
-CFileItemPtr CApplicationStackHelper::GetRegisteredStack(const CFileItem& item)
+std::shared_ptr<const CFileItem> CApplicationStackHelper::GetRegisteredStack(
+    const CFileItem& item) const
 {
   return GetStackPartInformation(item.GetPath())->m_pStack;
 }
 
-bool CApplicationStackHelper::HasRegisteredStack(const CFileItem & item)
+bool CApplicationStackHelper::HasRegisteredStack(const CFileItem& item) const
 {
-  return (m_stackmap.count(item.GetPath()) > 0 && m_stackmap[item.GetPath()]->m_pStack != nullptr);
+  const auto it = m_stackmap.find(item.GetPath());
+  return it != m_stackmap.end() && it->second != nullptr;
 }
 
 void CApplicationStackHelper::SetRegisteredStack(const CFileItem& item, CFileItemPtr stackItem)
@@ -253,7 +254,7 @@ void CApplicationStackHelper::SetRegisteredStackPartNumber(const CFileItem& item
   GetStackPartInformation(item.GetPath())->m_lStackPartNumber = partNumber;
 }
 
-uint64_t CApplicationStackHelper::GetRegisteredStackPartStartTimeMs(const CFileItem& item)
+uint64_t CApplicationStackHelper::GetRegisteredStackPartStartTimeMs(const CFileItem& item) const
 {
   return GetStackPartInformation(item.GetPath())->m_lStackPartStartTimeMs;
 }
@@ -263,7 +264,7 @@ void CApplicationStackHelper::SetRegisteredStackPartStartTimeMs(const CFileItem&
   GetStackPartInformation(item.GetPath())->m_lStackPartStartTimeMs = startTime;
 }
 
-uint64_t CApplicationStackHelper::GetRegisteredStackTotalTimeMs(const CFileItem& item)
+uint64_t CApplicationStackHelper::GetRegisteredStackTotalTimeMs(const CFileItem& item) const
 {
   return GetStackPartInformation(item.GetPath())->m_lStackTotalTimeMs;
 }
@@ -282,4 +283,16 @@ CApplicationStackHelper::StackPartInformationPtr CApplicationStackHelper::GetSta
     m_stackmap[key] = value;
   }
   return m_stackmap[key];
+}
+
+CApplicationStackHelper::StackPartInformationPtr CApplicationStackHelper::GetStackPartInformation(
+    const std::string& key) const
+{
+  const auto it = m_stackmap.find(key);
+  if (it == m_stackmap.end())
+  {
+    StackPartInformationPtr value(new StackPartInformation());
+    return value;
+  }
+  return m_stackmap.find(key)->second;
 }

--- a/xbmc/ApplicationStackHelper.cpp
+++ b/xbmc/ApplicationStackHelper.cpp
@@ -290,9 +290,6 @@ CApplicationStackHelper::StackPartInformationPtr CApplicationStackHelper::GetSta
 {
   const auto it = m_stackmap.find(key);
   if (it == m_stackmap.end())
-  {
-    StackPartInformationPtr value(new StackPartInformation());
-    return value;
-  }
-  return m_stackmap.find(key)->second;
+    return std::make_shared<StackPartInformation>();
+  return it->second;
 }

--- a/xbmc/ApplicationStackHelper.h
+++ b/xbmc/ApplicationStackHelper.h
@@ -48,12 +48,6 @@ public:
   bool IsPlayingRegularStack() const { return m_currentStack->Size() > 0 && !m_currentStackIsDiscImageStack; }
 
   /*!
-  \brief Returns a FileItem part of a (non-ISO) stack playback
-  \param partNumber the requested part number in the stack
-  */
-  CFileItem& GetStackPartFileItem(int partNumber) const { return  *(*m_currentStack)[partNumber]; }
-
-  /*!
   \brief returns true if there is a next part available
   */
   bool HasNextStackPartFileItem() const { return m_currentStackPosition < m_currentStack->Size() - 1; }
@@ -61,18 +55,27 @@ public:
   /*!
   \brief sets the next stack part as the current and returns a reference to it
   */
-  CFileItem& SetNextStackPartCurrentFileItem() { return  GetStackPartFileItem(++m_currentStackPosition); }
+  const CFileItem& SetNextStackPartCurrentFileItem()
+  {
+    return GetStackPartFileItem(++m_currentStackPosition);
+  }
 
   /*!
   \brief sets a given stack part as the current and returns a reference to it
   \param partNumber the number of the part that needs to become the current one
   */
-  CFileItem& SetStackPartCurrentFileItem(int partNumber) { return  GetStackPartFileItem(m_currentStackPosition = partNumber); }
+  const CFileItem& SetStackPartCurrentFileItem(int partNumber)
+  {
+    return GetStackPartFileItem(m_currentStackPosition = partNumber);
+  }
 
   /*!
   \brief Returns the FileItem currently playing back as part of a (non-ISO) stack playback
   */
-  CFileItem& GetCurrentStackPartFileItem() const { return GetStackPartFileItem(m_currentStackPosition); }
+  const CFileItem& GetCurrentStackPartFileItem() const
+  {
+    return GetStackPartFileItem(m_currentStackPosition);
+  }
 
   /*!
   \brief Returns the end time of a FileItem part of a (non-ISO) stack playback
@@ -112,13 +115,13 @@ public:
   /*!
   \brief Returns a smart pointer to the stack CFileItem.
   */
-  CFileItemPtr GetRegisteredStack(const CFileItem& item);
+  std::shared_ptr<const CFileItem> GetRegisteredStack(const CFileItem& item) const;
 
   /*!
   \brief Returns true if there is a registered stack for the given CFileItem part.
   \param item the reference to the item that is part of a stack
   */
-  bool HasRegisteredStack(const CFileItem& item);
+  bool HasRegisteredStack(const CFileItem& item) const;
 
   /*!
   \brief Stores a smart pointer to the stack CFileItem in the item-stack map.
@@ -144,7 +147,7 @@ public:
   \brief Returns the start time of the part in the parameter
   \param item the reference to the item that is part of a stack
   */
-  uint64_t GetRegisteredStackPartStartTimeMs(const CFileItem& item);
+  uint64_t GetRegisteredStackPartStartTimeMs(const CFileItem& item) const;
 
   /*!
   \brief Stores the part start time in the item-stack map.
@@ -157,7 +160,7 @@ public:
   \brief Returns the total time of the stack associated to the part in the parameter
   \param item the reference to the item that is part of a stack
   */
-  uint64_t GetRegisteredStackTotalTimeMs(const CFileItem& item);
+  uint64_t GetRegisteredStackTotalTimeMs(const CFileItem& item) const;
 
   /*!
   \brief Stores the stack's total time associated to the part in the item-stack map.
@@ -169,6 +172,15 @@ public:
   CCriticalSection m_critSection;
 
 protected:
+  /*!
+  \brief Returns a FileItem part of a (non-ISO) stack playback
+  \param partNumber the requested part number in the stack
+  */
+  CFileItem& GetStackPartFileItem(int partNumber) { return *(*m_currentStack)[partNumber]; }
+  const CFileItem& GetStackPartFileItem(int partNumber) const
+  {
+    return *(*m_currentStack)[partNumber];
+  }
 
   class StackPartInformation
   {
@@ -190,6 +202,7 @@ protected:
   typedef std::map<std::string, StackPartInformationPtr> Stackmap;
   Stackmap m_stackmap;
   StackPartInformationPtr GetStackPartInformation(const std::string& key);
+  StackPartInformationPtr GetStackPartInformation(const std::string& key) const;
 
   std::unique_ptr<CFileItemList> m_currentStack;
   int m_currentStackPosition = 0;


### PR DESCRIPTION
## Description
Only expose a const ref to stack helper outside CApplication

## Motivation and context
Mutable accessors is a receipe for untrackable mutation of data.

## How has this been tested?
Builds and runs

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
