### PR TITLE
[cmake] fixup buildtype after #21043

### DIFF
--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -18,11 +18,7 @@ if(ENABLE_INTERNAL_CROSSGUID)
 
   set(MODULE_LC crossguid)
 
-  # Temp: We force CMAKE_BUILD_TYPE to release, and makefile builds respect this
-  # Multi config generators (eg VS, Xcode) dont, so handle debug postfix build/link for them only
-  if(NOT (CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL "Ninja"))
-    set(CROSSGUID_DEBUG_POSTFIX "-dgb")
-  endif()
+  set(CROSSGUID_DEBUG_POSTFIX "-dgb")
 
   SETUP_BUILD_VARS()
 
@@ -38,9 +34,6 @@ if(ENABLE_INTERNAL_CROSSGUID)
 
   set(PATCH_COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/001-fix-unused-function.patch
             COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/002-disable-Wall-error.patch)
-
-  # Force release build type. crossguid forces a debug postfix -dgb. may want to patch this
-  set(CROSSGUID_BUILD_TYPE Release)
 
   set(CMAKE_ARGS -DCROSSGUID_TESTS=OFF
                  -DDISABLE_WALL=ON)

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -17,6 +17,9 @@ if(ENABLE_INTERNAL_FMT)
 
   set(MODULE_LC fmt)
 
+  # fmt debug uses postfix d for all platforms
+  set(FMT_DEBUG_POSTFIX d)
+
   SETUP_BUILD_VARS()
 
   if(APPLE)

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -18,6 +18,9 @@ if(ENABLE_INTERNAL_SPDLOG)
 
   set(MODULE_LC spdlog)
 
+  # spdlog debug uses postfix d for all platforms
+  set(SPDLOG_DEBUG_POSTFIX d)
+
   SETUP_BUILD_VARS()
 
   if(APPLE)

--- a/cmake/scripts/android/ArchSetup.cmake
+++ b/cmake/scripts/android/ArchSetup.cmake
@@ -42,4 +42,6 @@ set(ENABLE_X11 OFF CACHE BOOL "" FORCE)
 set(ENABLE_OPTICAL OFF CACHE BOOL "" FORCE)
 set(ENABLE_MDNS OFF CACHE BOOL "" FORCE)
 
+set(DEBUG_POSTFIX d CACHE STRING "Debug library postfix.")
+
 list(APPEND DEPLIBS android log jnigraphics mediandk)

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -141,6 +141,13 @@ macro(BUILD_DEP_TARGET)
     # if MODULE has set a manual build type, use it, otherwise use project build type
     if(${MODULE}_BUILD_TYPE)
       list(APPEND CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${${MODULE}_BUILD_TYPE}")
+      # Build_type is forced, so unset the opposite <MODULE>_LIBRARY_<TYPE> to only give
+      # select_library_configurations one library name to choose from
+      if(${MODULE}_BUILD_TYPE STREQUAL "Release")
+        unset(${MODULE}_LIBRARY_DEBUG)
+      else()
+        unset(${MODULE}_LIBRARY_RELEASE)
+      endif()
     else()
       # single config generator (ie Make, Ninja)
       if(CMAKE_BUILD_TYPE)


### PR DESCRIPTION
## Description
set default postfix for all android libs (similar to apple)
if \<MODULE\>\_RELEASE\_TYPE is forced, remove the alternative \<MODULE\>\_LIBRARY\_\<TYPE\>
build can now handle crossguid -dbg postfix, so allow it.

## Motivation and context
Fixup after #21043 
@howie-f this ones for you. thanks for the constant testing you do for me, haha.

Currently i only set an arch define for DEBUG_POSTFIX for true platforms using tools/depends builds (Apple/android). I dont particularly want to override that for linux, as im not totally sure it wont bite me in the ass later. What i might do in the long run is to move the POSTFIX to be set as part of the find module, rather than a generic arch level.
I initially implemented the override for \<MODULE\>\_DEBUG\_POSTFIX for instances like crossguid which uses a wild -dgb postfix, however it may just be better to have it set by each find module as a required step if that build uses a postfix.

## How has this been tested?
cmake output for internal_libs done via cmake. Correct optimised and and debug libs, and links correctly with the correctly named libs

```
-- Found CrossGUID: optimized;/Users/Shared/xbmc-depends/aarch64-linux-android-31-debug/lib/libcrossguid.a;debug;/Users/Shared/xbmc-depends/aarch64-linux-android-31-debug/lib/libcrossguid-dgb.a (found version "ca1bf4b810e2d188d04cb6286f957008ee1b7681") 
-- Found Fmt: optimized;/Users/Shared/xbmc-depends/aarch64-linux-android-31-debug/lib/libfmt.a;debug;/Users/Shared/xbmc-depends/aarch64-linux-android-31-debug/lib/libfmtd.a (found version "8.0.1") 
-- Found Spdlog: optimized;/Users/Shared/xbmc-depends/aarch64-linux-android-31-debug/lib/libspdlog.a;debug;/Users/Shared/xbmc-depends/aarch64-linux-android-31-debug/lib/libspdlogd.a (found version "1.9.2") 
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
