### PR TITLE
[macOS] improve signing app bundle and dmg creation

### DIFF
--- a/tools/darwin/packaging/osx/dmgmaker.pl
+++ b/tools/darwin/packaging/osx/dmgmaker.pl
@@ -57,6 +57,7 @@ sub make_dmg {
     `xcrun SetFile -a V "/Volumes/$pkgname/background"`;
     `xcrun SetFile -a C "/Volumes/$pkgname/"`;
     `cp VolumeDSStoreApp "/Volumes/$pkgname/.DS_Store"`;
+    `diskutil unmountDisk $dev_handle`;
     `hdiutil detach $dev_handle`;
     `hdiutil convert "$volname.dmg" -format UDZO -imagekey zlib-level=9 -o "$volname.udzo.dmg"`;
     `rm -f "$volname.dmg"`;

--- a/tools/darwin/packaging/osx/mkdmg-osx.sh.in
+++ b/tools/darwin/packaging/osx/mkdmg-osx.sh.in
@@ -40,9 +40,9 @@ if [ "$EXPANDED_CODE_SIGN_IDENTITY_NAME" ]; then
   # execute codesign script
   "$DIRNAME/Codesign.command"
   # sign helper tool
-  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --options runtime --timestamp --entitlements Kodi.entitlements "$APP/Contents/Resources/Kodi/tools/darwin/runtime/XBMCHelper"
+  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --force --options runtime --timestamp --entitlements Kodi.entitlements "$APP/Contents/Resources/Kodi/tools/darwin/runtime/XBMCHelper"
   # perform top-level signing (Xcode does it automatically when signing settings are configured)
-  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --options runtime --timestamp --entitlements Kodi.entitlements "$APP"
+  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --force --options runtime --timestamp --entitlements Kodi.entitlements "$APP"
 fi
 
 PACKAGE=org.xbmc.@APP_NAME_LC@-osx


### PR DESCRIPTION
## Description

- ensures that executables are signed correctly
- unmounts dmg disk before detaching it

## Motivation and context

Fixes ARM builds on the Keith's slave.

## How has this been tested?

Successful build: https://jenkins.kodi.tv/view/All/job/OSX-ARM64/41/

## What is the effect on users?

ARM builds are signed.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
