### PR TITLE
[VideoPlayer][FFmpegDemux] Fix pts correction/menu condition

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -990,8 +990,11 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   double starttime = 0.0;
 
   std::shared_ptr<CDVDInputStream::IMenus> menu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
-  if (!menu && m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
-    starttime = (double)m_pFormatContext->start_time / AV_TIME_BASE;
+  if ((!menu || !menu->HasMenu()) &&
+      m_pFormatContext->start_time != static_cast<int64_t>(AV_NOPTS_VALUE))
+  {
+    starttime = static_cast<double>(m_pFormatContext->start_time / AV_TIME_BASE);
+  }
 
   if (m_checkTransportStream)
     starttime = m_startTime;


### PR DESCRIPTION
## Description
The returned packet pts in ffmpeg demuxer is wrong when a bluray is started from the simplified menu (i.e. if we play a "track"/"playlist" and not from BR menu - or in other words if we don't use `bd_play`). This happens because the timestamp is not corrected with the start time. This condition checks for the menu but we are only validating the pointer and not the fact that we actually have a menu. Something similar has been done in https://github.com/xbmc/xbmc/pull/21251

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21440

## How has this been tested?
Runtime tested

## What is the effect on users?
External subtitles should be shown on the correct position if the bluray is started from the simple menu / playlist option (and not from the menu)
