### PR TITLE
[Discs] Fix resume of blurays and bluray isos (state serializer)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.cpp
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "BlurayStateSerializer.h"
+
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "utils/log.h"
+
+#include <charconv>
+#include <cstring>
+#include <sstream>
+
+namespace
+{
+// Serializer version - used to avoid processing deprecated/legacy schemas
+constexpr int BLURAYSTATESERIALIZER_VERSION = 1;
+} // namespace
+
+bool CBlurayStateSerializer::BlurayStateToXML(std::string& xmlstate, const BlurayState& state)
+{
+  CXBMCTinyXML xmlDoc{"libbluraystate"};
+
+  TiXmlElement eRoot{"libbluraystate"};
+  eRoot.SetAttribute("version", BLURAYSTATESERIALIZER_VERSION);
+
+  TiXmlElement xmlElement{"playlistId"};
+  TiXmlText xmlElementValue = std::to_string(state.playlistId);
+  xmlElement.InsertEndChild(xmlElementValue);
+  eRoot.InsertEndChild(xmlElement);
+  xmlDoc.InsertEndChild(eRoot);
+
+  std::stringstream stream;
+  stream << xmlDoc;
+  xmlstate = stream.str();
+  return true;
+}
+
+bool CBlurayStateSerializer::XMLToBlurayState(BlurayState& state, const std::string& xmlstate)
+{
+  CXBMCTinyXML xmlDoc;
+
+  xmlDoc.Parse(xmlstate);
+  if (xmlDoc.Error())
+    return false;
+
+  TiXmlHandle hRoot(xmlDoc.RootElement());
+  if (!hRoot.Element() || !StringUtils::EqualsNoCase(hRoot.Element()->Value(), "libbluraystate"))
+  {
+    CLog::LogF(LOGERROR, "Failed to deserialize bluray state - failed to detect root element.");
+    return false;
+  }
+
+  auto version = hRoot.Element()->Attribute("version");
+  if (!version ||
+      !StringUtils::EqualsNoCase(version, std::to_string(BLURAYSTATESERIALIZER_VERSION)))
+  {
+    CLog::LogF(LOGERROR, "Failed to deserialize bluray state - incompatible serializer version.");
+    return false;
+  }
+
+  const TiXmlElement* childElement = hRoot.Element()->FirstChildElement();
+  while (childElement)
+  {
+    const std::string property = childElement->Value();
+    if (property == "playlistId")
+    {
+      std::from_chars(childElement->GetText(),
+                      childElement->GetText() + std::strlen(childElement->GetText()),
+                      state.playlistId);
+    }
+    else
+    {
+      CLog::LogF(LOGWARNING, "Unmapped bluray state property {}, ignored.", childElement->Value());
+    }
+    childElement = childElement->NextSiblingElement();
+  }
+  return true;
+}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+class TiXmlElement;
+
+/*! \brief Pod structure which represents the current Bluray state */
+struct BlurayState
+{
+  /*! The current playlist id */
+  int32_t playlistId = -1;
+};
+
+/*! \brief Auxiliar class to serialize/deserialize the Bluray state (into/from XML)
+*/
+class CBlurayStateSerializer
+{
+public:
+  /*! \brief Default constructor */
+  CBlurayStateSerializer() = default;
+
+  /*! \brief Default destructor */
+  ~CBlurayStateSerializer() = default;
+
+  /*! \brief Provided the state in xml format, fills a BlurayState struct representing the Bluray state and returns the
+  * success status of the operation
+  * \param[in,out] state the Bluray state struct to be filled
+  * \param xmlstate a string describing the Bluray state (XML)
+  * \return true if it was possible to fill the state struct based on the XML content, false otherwise
+  */
+  bool XMLToBlurayState(BlurayState& state, const std::string& xmlstate);
+
+  /*! \brief Provided the BlurayState struct of the current playing dvd, serializes the struct to XML
+  * \param[in,out] xmlstate a string describing the Bluray state (XML)
+  * \param state the Bluray state struct
+  * \return true if it was possible to serialize the struct into XML, false otherwise
+  */
+  bool BlurayStateToXML(std::string& xmlstate, const BlurayState& state);
+};

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES DVDFactoryInputStream.cpp
+set(SOURCES BlurayStateSerializer.cpp
+            DVDFactoryInputStream.cpp
             DVDInputStream.cpp
             DVDInputStreamFFmpeg.cpp
             DVDInputStreamFile.cpp
@@ -12,7 +13,8 @@ set(SOURCES DVDFactoryInputStream.cpp
             InputStreamPVRChannel.cpp
             InputStreamPVRRecording.cpp)
 
-set(HEADERS DVDFactoryInputStream.h
+set(HEADERS BlurayStateSerializer.h
+            DVDFactoryInputStream.h
             DVDInputStream.h
             DVDInputStreamFFmpeg.h
             DVDInputStreamFile.h

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include "BlurayStateSerializer.h"
 #include "DVDInputStream.h"
+
 #include <list>
 #include <memory>
 
@@ -89,8 +91,8 @@ public:
   bool OnMouseMove(const CPoint &point) override  { return MouseMove(point); }
   bool OnMouseClick(const CPoint &point) override { return MouseClick(point); }
   void SkipStill() override;
-  bool GetState(std::string &xmlstate) override { return false; }
-  bool SetState(const std::string &xmlstate) override { return false; }
+  bool GetState(std::string& xmlstate) override;
+  bool SetState(const std::string& xmlstate) override;
   bool CanSeek() override;
 
 
@@ -174,4 +176,7 @@ protected:
     void FreeTitleInfo();
     std::unique_ptr<CDVDInputStreamFile> m_pstream = nullptr;
     std::string m_rootPath;
+
+    /*! Bluray state serializer handler */
+    CBlurayStateSerializer m_blurayStateSerializer;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
https://github.com/xbmc/xbmc/pull/21250 attempted to fix the resume of blurays and iso's, however it was assuming the user was always resuming to the disc longest track (the movie track). However, this doesn't work for tvshow blurays where multiple tracks/playlists are present.
Similar to dvds, this implements a minimal version of the state serializer so that we can later access the playlist id the user was previously playing.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21285

## How has this been tested?
Runtime tested with physical discs and iso's.
