### PR TITLE
Kill subtitles settings global static instance.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -15,6 +15,7 @@
 #include "Util.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "settings/SettingsComponent.h"
 #include "settings/SubtitlesSettings.h"
 #include "utils/StringUtils.h"
 
@@ -133,7 +134,8 @@ CDVDOverlay* CDVDOverlayCodecSSA::GetOverlay()
   m_pOverlay = new CDVDOverlaySSA(m_libass);
   m_pOverlay->iPTSStartTime = 0;
   m_pOverlay->iPTSStopTime = DVD_NOPTS_VALUE;
-  auto overrideStyles{SUBTITLES::CSubtitlesSettings::GetInstance().GetOverrideStyles()};
+  auto overrideStyles{
+      CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->GetOverrideStyles()};
   m_pOverlay->SetForcedMargins(overrideStyles != SUBTITLES::OverrideStyles::STYLES_POSITIONS &&
                                overrideStyles != SUBTITLES::OverrideStyles::POSITIONS);
   return m_pOverlay->Acquire();

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -11,6 +11,7 @@
 #include "DVDCodecs/Overlay/DVDOverlaySSA.h"
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "settings/SettingsComponent.h"
 #include "settings/SubtitlesSettings.h"
 
 using namespace KODI;
@@ -41,7 +42,8 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo& hints)
   CDVDOverlaySSA* overlay = new CDVDOverlaySSA(m_libass);
   overlay->iPTSStartTime = 0.0;
   overlay->iPTSStopTime = DVD_NOPTS_VALUE;
-  auto overrideStyles{SUBTITLES::CSubtitlesSettings::GetInstance().GetOverrideStyles()};
+  auto overrideStyles{
+      CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->GetOverrideStyles()};
   overlay->SetForcedMargins(overrideStyles != SUBTITLES::OverrideStyles::STYLES_POSITIONS &&
                             overrideStyles != SUBTITLES::OverrideStyles::POSITIONS);
   m_collection.Add(overlay);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -12,6 +12,7 @@
 #include "cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "filesystem/SpecialProtocol.h"
+#include "settings/SettingsComponent.h"
 #include "settings/SubtitlesSettings.h"
 #include "utils/CSSUtils.h"
 #include "utils/CharsetConverter.h"
@@ -210,7 +211,8 @@ bool CWebVTTHandler::Initialize()
     m_cueCssStyleMapRegex.insert({item.first, reg});
   }
 
-  auto overrideStyles{KODI::SUBTITLES::CSubtitlesSettings::GetInstance().GetOverrideStyles()};
+  auto overrideStyles{
+      CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->GetOverrideStyles()};
   m_overridePositions = (overrideStyles == KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS ||
                          overrideStyles == KODI::SUBTITLES::OverrideStyles::POSITIONS);
   m_overrideStyle = (overrideStyles == KODI::SUBTITLES::OverrideStyles::STYLES_POSITIONS ||

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -54,12 +54,12 @@ unsigned int CRenderer::m_textureid = 1;
 
 CRenderer::CRenderer()
 {
-  SUBTITLES::CSubtitlesSettings::GetInstance().RegisterObserver(this);
+  CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->RegisterObserver(this);
 }
 
 CRenderer::~CRenderer()
 {
-  SUBTITLES::CSubtitlesSettings::GetInstance().UnregisterObserver(this);
+  CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->UnregisterObserver(this);
   Flush();
 }
 
@@ -327,7 +327,8 @@ void CRenderer::ResetSubtitlePosition()
   m_saveSubtitlePosition = false;
   RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
   m_subtitleVerticalMargin =
-      resInfo.iHeight / 100 * SUBTITLES::CSubtitlesSettings::GetInstance().GetVerticalMarginPerc();
+      resInfo.iHeight / 100 *
+      CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->GetVerticalMarginPerc();
   m_subtitlePosResInfo = resInfo.iSubtitles;
   // Update player value (and callback to CRenderer::SetSubtitleVerticalPosition)
   g_application.GetAppPlayer().SetSubtitleVerticalPosition(
@@ -337,12 +338,12 @@ void CRenderer::ResetSubtitlePosition()
 void CRenderer::CreateSubtitlesStyle()
 {
   m_overlayStyle = std::make_shared<SUBTITLES::STYLE::style>();
-  SUBTITLES::CSubtitlesSettings& settings{SUBTITLES::CSubtitlesSettings::GetInstance()};
+  const auto settings{CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()};
 
-  m_overlayStyle->fontName = settings.GetFontName();
-  m_overlayStyle->fontSize = static_cast<double>(settings.GetFontSize());
+  m_overlayStyle->fontName = settings->GetFontName();
+  m_overlayStyle->fontSize = static_cast<double>(settings->GetFontSize());
 
-  SUBTITLES::FontStyle fontStyle = settings.GetFontStyle();
+  SUBTITLES::FontStyle fontStyle = settings->GetFontStyle();
   if (fontStyle == SUBTITLES::FontStyle::BOLD_ITALIC)
     m_overlayStyle->fontStyle = SUBTITLES::STYLE::FontStyle::BOLD_ITALIC;
   else if (fontStyle == SUBTITLES::FontStyle::BOLD)
@@ -350,12 +351,12 @@ void CRenderer::CreateSubtitlesStyle()
   else if (fontStyle == SUBTITLES::FontStyle::ITALIC)
     m_overlayStyle->fontStyle = SUBTITLES::STYLE::FontStyle::ITALIC;
 
-  m_overlayStyle->fontColor = settings.GetFontColor();
-  m_overlayStyle->fontBorderSize = settings.GetBorderSize();
-  m_overlayStyle->fontBorderColor = settings.GetBorderColor();
-  m_overlayStyle->fontOpacity = settings.GetFontOpacity();
+  m_overlayStyle->fontColor = settings->GetFontColor();
+  m_overlayStyle->fontBorderSize = settings->GetBorderSize();
+  m_overlayStyle->fontBorderColor = settings->GetBorderColor();
+  m_overlayStyle->fontOpacity = settings->GetFontOpacity();
 
-  SUBTITLES::BackgroundType backgroundType = settings.GetBackgroundType();
+  SUBTITLES::BackgroundType backgroundType = settings->GetBackgroundType();
   if (backgroundType == SUBTITLES::BackgroundType::NONE)
     m_overlayStyle->borderStyle = SUBTITLES::STYLE::BorderType::OUTLINE_NO_SHADOW;
   else if (backgroundType == SUBTITLES::BackgroundType::SHADOW)
@@ -365,14 +366,14 @@ void CRenderer::CreateSubtitlesStyle()
   else if (backgroundType == SUBTITLES::BackgroundType::SQUAREBOX)
     m_overlayStyle->borderStyle = SUBTITLES::STYLE::BorderType::SQUARE_BOX;
 
-  m_overlayStyle->backgroundColor = settings.GetBackgroundColor();
-  m_overlayStyle->backgroundOpacity = settings.GetBackgroundOpacity();
+  m_overlayStyle->backgroundColor = settings->GetBackgroundColor();
+  m_overlayStyle->backgroundOpacity = settings->GetBackgroundOpacity();
 
-  m_overlayStyle->shadowColor = settings.GetShadowColor();
-  m_overlayStyle->shadowOpacity = settings.GetShadowOpacity();
-  m_overlayStyle->shadowSize = settings.GetShadowSize();
+  m_overlayStyle->shadowColor = settings->GetShadowColor();
+  m_overlayStyle->shadowOpacity = settings->GetShadowOpacity();
+  m_overlayStyle->shadowSize = settings->GetShadowSize();
 
-  SUBTITLES::Align subAlign = settings.GetAlignment();
+  SUBTITLES::Align subAlign = settings->GetAlignment();
   if (subAlign == SUBTITLES::Align::TOP_INSIDE || subAlign == SUBTITLES::Align::TOP_OUTSIDE)
     m_overlayStyle->alignment = SUBTITLES::STYLE::FontAlign::TOP_CENTER;
   else
@@ -381,9 +382,9 @@ void CRenderer::CreateSubtitlesStyle()
   if (subAlign == SUBTITLES::Align::BOTTOM_OUTSIDE || subAlign == SUBTITLES::Align::TOP_OUTSIDE)
     m_overlayStyle->drawWithinBlackBars = true;
 
-  m_overlayStyle->assOverrideFont = settings.IsOverrideFonts();
+  m_overlayStyle->assOverrideFont = settings->IsOverrideFonts();
 
-  SUBTITLES::OverrideStyles overrideStyles = settings.GetOverrideStyles();
+  SUBTITLES::OverrideStyles overrideStyles = settings->GetOverrideStyles();
   if (overrideStyles == SUBTITLES::OverrideStyles::POSITIONS)
     m_overlayStyle->assOverrideStyles = SUBTITLES::STYLE::OverrideStyles::POSITIONS;
   else if (overrideStyles == SUBTITLES::OverrideStyles::STYLES)
@@ -398,7 +399,7 @@ void CRenderer::CreateSubtitlesStyle()
   // for now vertical margin setting will be disabled during playback
   m_overlayStyle->marginVertical = m_subtitleVerticalMargin;
 
-  m_overlayStyle->blur = settings.GetBlurSize();
+  m_overlayStyle->blur = settings->GetBlurSize();
 }
 
 COverlay* CRenderer::ConvertLibass(
@@ -600,6 +601,7 @@ void CRenderer::Notify(const Observable& obs, const ObservableMessage msg)
 
 void CRenderer::LoadSettings()
 {
-  m_subtitleHorizontalAlign = SUBTITLES::CSubtitlesSettings::GetInstance().GetHorizontalAlignment();
+  m_subtitleHorizontalAlign =
+      CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->GetHorizontalAlignment();
   ResetSubtitlePosition();
 }

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -8,11 +8,9 @@
 
 #include "SettingsComponent.h"
 
-#include "AdvancedSettings.h"
 #include "AppParams.h"
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
-#include "Settings.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
@@ -23,18 +21,22 @@
 #include "platform/Environment.h"
 #endif
 #include "profiles/ProfileManager.h"
-#include "utils/log.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "settings/SubtitlesSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
 #ifdef TARGET_WINDOWS
 #include "win32util.h"
 #endif
 
 CSettingsComponent::CSettingsComponent()
+  : m_settings(new CSettings()),
+    m_advancedSettings(new CAdvancedSettings()),
+    m_subtitlesSettings(new KODI::SUBTITLES::CSubtitlesSettings(m_settings)),
+    m_profileManager(new CProfileManager())
 {
-  m_advancedSettings.reset(new CAdvancedSettings());
-  m_settings.reset(new CSettings());
-  m_profileManager.reset(new CProfileManager());
 }
 
 CSettingsComponent::~CSettingsComponent()
@@ -105,6 +107,8 @@ void CSettingsComponent::Deinitialize()
   {
     if (m_state == State::LOADED)
     {
+      m_subtitlesSettings.reset();
+
       m_settings->Unload();
 
       XFILE::IDirectory::UnregisterProfileManager();
@@ -128,6 +132,11 @@ std::shared_ptr<CSettings> CSettingsComponent::GetSettings()
 std::shared_ptr<CAdvancedSettings> CSettingsComponent::GetAdvancedSettings()
 {
   return m_advancedSettings;
+}
+
+std::shared_ptr<KODI::SUBTITLES::CSubtitlesSettings> CSettingsComponent::GetSubtitlesSettings()
+{
+  return m_subtitlesSettings;
 }
 
 std::shared_ptr<CProfileManager> CSettingsComponent::GetProfileManager()

--- a/xbmc/settings/SettingsComponent.h
+++ b/xbmc/settings/SettingsComponent.h
@@ -14,6 +14,14 @@ class CAdvancedSettings;
 class CProfileManager;
 class CSettings;
 
+namespace KODI
+{
+namespace SUBTITLES
+{
+class CSubtitlesSettings;
+} // namespace SUBTITLES
+} // namespace KODI
+
 class CSettingsComponent
 {
 public:
@@ -49,6 +57,12 @@ public:
   std::shared_ptr<CAdvancedSettings> GetAdvancedSettings();
 
   /*!
+   * @brief Get access to the subtitles settings subcomponent.
+   * @return the subtiltles settings subcomponent.
+   */
+  std::shared_ptr<KODI::SUBTITLES::CSubtitlesSettings> GetSubtitlesSettings();
+
+  /*!
    * @brief Get access to the profiles manager subcomponent.
    * @return the profiles manager subcomponent.
    */
@@ -70,5 +84,6 @@ private:
 
   std::shared_ptr<CSettings> m_settings;
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
+  std::shared_ptr<KODI::SUBTITLES::CSubtitlesSettings> m_subtitlesSettings;
   std::shared_ptr<CProfileManager> m_profileManager;
 };

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -9,13 +9,11 @@
 #include "SubtitlesSettings.h"
 
 #include "FileItem.h"
-#include "ServiceBroker.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "guilib/GUIFontManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "utils/FontUtils.h"
 #include "utils/StringUtils.h"
@@ -24,10 +22,9 @@
 using namespace KODI;
 using namespace SUBTITLES;
 
-CSubtitlesSettings::CSubtitlesSettings()
+CSubtitlesSettings::CSubtitlesSettings(const std::shared_ptr<CSettings>& settings)
+  : m_settings(settings)
 {
-  m_settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-
   m_settings->RegisterCallback(
       this,
       {CSettings::SETTING_LOCALE_SUBTITLELANGUAGE,  CSettings::SETTING_SUBTITLES_PARSECAPTIONS,
@@ -50,12 +47,6 @@ CSubtitlesSettings::CSubtitlesSettings()
 CSubtitlesSettings::~CSubtitlesSettings()
 {
   m_settings->UnregisterCallback(this);
-}
-
-CSubtitlesSettings& CSubtitlesSettings::GetInstance()
-{
-  static CSubtitlesSettings sSubtitlesSettings;
-  return sSubtitlesSettings;
 }
 
 void CSubtitlesSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -74,7 +74,8 @@ enum class OverrideStyles
 class CSubtitlesSettings : public ISettingCallback, public Observable
 {
 public:
-  static CSubtitlesSettings& GetInstance();
+  explicit CSubtitlesSettings(const std::shared_ptr<CSettings>& settings);
+  ~CSubtitlesSettings() override;
 
   // Inherited from ISettingCallback
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
@@ -204,13 +205,10 @@ public:
                                                 std::string& current,
                                                 void* data);
 
-protected:
-  CSubtitlesSettings();
-  ~CSubtitlesSettings() override;
-
 private:
-  // Construction parameters
-  std::shared_ptr<CSettings> m_settings;
+  CSubtitlesSettings() = delete;
+
+  const std::shared_ptr<CSettings> m_settings;
 };
 
 } // namespace SUBTITLES

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -317,7 +317,8 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
       CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(m_Res[m_iCurRes]);
 
   m_subtitleVerticalMargin =
-      info.iHeight / 100 * SUBTITLES::CSubtitlesSettings::GetInstance().GetVerticalMarginPerc();
+      info.iHeight / 100 *
+      CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()->GetVerticalMarginPerc();
 
   if (pControl)
   {

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -377,8 +377,8 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_SUBTITLE_ALIGN:
       {
-        SUBTITLES::CSubtitlesSettings& settings{SUBTITLES::CSubtitlesSettings::GetInstance()};
-        SUBTITLES::Align align{settings.GetAlignment()};
+        const auto settings{CServiceBroker::GetSettingsComponent()->GetSubtitlesSettings()};
+        SUBTITLES::Align align{settings->GetAlignment()};
 
         align = static_cast<SUBTITLES::Align>(static_cast<int>(align) + 1);
 
@@ -389,7 +389,7 @@ bool CPlayerController::OnAction(const CAction &action)
           align = SUBTITLES::Align::MANUAL;
         }
 
-        settings.SetAlignment(align);
+        settings->SetAlignment(align);
         CGUIDialogKaiToast::QueueNotification(
             CGUIDialogKaiToast::Info, g_localizeStrings.Get(21460),
             g_localizeStrings.Get(21461 + static_cast<int>(align)), TOAST_DISPLAY_TIME, false);


### PR DESCRIPTION
Fixes #21439 

Tested on Android 11, Nvidia Shield Pro 2019, latest Kodi master.

@thexai could you do a runtime test, please?