### PR TITLE
[Discs] Remove HasMenu in favor of GetSupportedMenuType

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -408,10 +408,14 @@ bool CApplicationPlayer::IsInMenu() const
   return (player && player->IsInMenu());
 }
 
-bool CApplicationPlayer::HasMenu() const
+MenuType CApplicationPlayer::GetSupportedMenuType() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();
-  return (player && player->HasMenu());
+  if (!player)
+  {
+    return MenuType::NONE;
+  }
+  return player->GetSupportedMenuType();
 }
 
 int CApplicationPlayer::GetCacheLevel() const

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -10,6 +10,7 @@
 
 #include "SeekHandler.h"
 #include "cores/IPlayer.h"
+#include "cores/MenuType.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 #include "windowing/Resolution.h"
@@ -105,7 +106,13 @@ public:
   void SetProgram(int progId);
   int GetProgramsCount();
   bool HasAudio() const;
-  bool HasMenu() const;
+
+  /*!
+   * \brief Get the supported menu type
+   * \return The supported menu type
+  */
+  MenuType GetSupportedMenuType() const;
+
   bool HasVideo() const;
   bool HasGame() const;
   bool HasRDS() const;

--- a/xbmc/cores/CMakeLists.txt
+++ b/xbmc/cores/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADERS DataCacheCore.h
             GameSettings.h
             IPlayer.h
             IPlayerCallback.h
+            MenuType.h
             VideoSettings.h)
 
 core_add_library(cores)

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -10,6 +10,7 @@
 
 #include "IPlayerCallback.h"
 #include "Interface/StreamInfo.h"
+#include "MenuType.h"
 #include "VideoSettings.h"
 
 #include <memory>
@@ -196,7 +197,12 @@ public:
   virtual int GetCacheLevel() const { return -1; }
 
   virtual bool IsInMenu() const { return false; }
-  virtual bool HasMenu() const { return false; }
+
+  /*!
+   * \brief Get the supported menu type
+   * \return The supported menu type
+  */
+  virtual MenuType GetSupportedMenuType() const { return MenuType::NONE; }
 
   virtual void DoAudioWork() {}
   virtual bool OnAction(const CAction& action) { return false; }

--- a/xbmc/cores/MenuType.h
+++ b/xbmc/cores/MenuType.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+/*!
+* \brief Represents a Menu type (e.g. dvd menus, bluray menus, etc)
+*/
+enum class MenuType
+{
+  /*! No supported menu */
+  NONE,
+  /*! Supports native menus (e.g. those provided natively by blurays or dvds) */
+  NATIVE,
+  /*! Application specific menu such as the simplified menu for blurays */
+  SIMPLIFIED
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -16,6 +16,7 @@
 #include "Util.h"
 #include "commons/Exception.h"
 #include "cores/FFmpeg.h"
+#include "cores/MenuType.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h" // for DVD_TIME_BASE
 #include "filesystem/CurlFile.h"
 #include "filesystem/Directory.h"
@@ -989,8 +990,9 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   double timestamp = (double)pts * num / den;
   double starttime = 0.0;
 
-  std::shared_ptr<CDVDInputStream::IMenus> menu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
-  if ((!menu || !menu->HasMenu()) &&
+  const std::shared_ptr<CDVDInputStream::IMenus> menuInterface =
+      std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
+  if ((!menuInterface || menuInterface->GetSupportedMenuType() != MenuType::NATIVE) &&
       m_pFormatContext->start_time != static_cast<int64_t>(AV_NOPTS_VALUE))
   {
     starttime = static_cast<double>(m_pFormatContext->start_time / AV_TIME_BASE);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "URL.h"
+#include "cores/MenuType.h"
 #include "filesystem/IFileTypes.h"
 #include "utils/BitstreamStats.h"
 #include "utils/Geometry.h"
@@ -108,7 +109,13 @@ public:
     virtual void OnPrevious() = 0;
     virtual bool OnMouseMove(const CPoint &point) = 0;
     virtual bool OnMouseClick(const CPoint &point) = 0;
-    virtual bool HasMenu() = 0;
+
+    /*!
+    * \brief Get the supported menu type
+    * \return The supported menu type
+    */
+    virtual MenuType GetSupportedMenuType() = 0;
+
     virtual bool IsInMenu() = 0;
     virtual void SkipStill() = 0;
     virtual double GetTimeStampCorrection() { return 0.0; }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1181,9 +1181,13 @@ bool CDVDInputStreamBluray::CanSeek()
   return !IsInMenu() || !m_isInMainMenu;
 }
 
-bool CDVDInputStreamBluray::HasMenu()
+MenuType CDVDInputStreamBluray::GetSupportedMenuType()
 {
-  return m_navmode;
+  if (m_navmode)
+  {
+    return MenuType::NATIVE;
+  }
+  return MenuType::NONE;
 }
 
 void CDVDInputStreamBluray::SetupPlayerSettings()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -86,7 +86,13 @@ public:
   }
   void OnNext() override {}
   void OnPrevious() override {}
-  bool HasMenu() override;
+
+  /*!
+   * \brief Get the supported menu type
+   * \return The supported menu type
+  */
+  MenuType GetSupportedMenuType() override;
+
   bool IsInMenu() override;
   bool OnMouseMove(const CPoint &point) override  { return MouseMove(point); }
   bool OnMouseClick(const CPoint &point) override { return MouseClick(point); }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -15,6 +15,7 @@
 #include "DVDInputStreamFile.h"
 #include "DVDStateSerializer.h"
 #include "DllDvdNav.h"
+#include "cores/MenuType.h"
 #include "utils/Geometry.h"
 
 #include <string>
@@ -76,7 +77,12 @@ public:
   int GetTotalButtons() override;
   bool GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPicture, CDVDDemuxSPU* pSPU, int iButtonType /* 0 = selection, 1 = action (clicked)*/);
 
-  bool HasMenu() override { return true; }
+  /*!
+   * \brief Get the supported menu type
+   * \return The supported menu type
+  */
+  MenuType GetSupportedMenuType() override { return MenuType::NATIVE; }
+
   bool IsInMenu() override { return m_bInMenu; }
   double GetTimeStampCorrection() override { return (double)(m_iVobUnitCorrection * 1000) / 90; }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4471,10 +4471,10 @@ bool CVideoPlayer::IsInMenu() const
   return m_State.isInMenu;
 }
 
-bool CVideoPlayer::HasMenu() const
+MenuType CVideoPlayer::GetSupportedMenuType() const
 {
   std::unique_lock<CCriticalSection> lock(m_StateSection);
-  return m_State.hasMenu;
+  return m_State.menuType;
 }
 
 std::string CVideoPlayer::GetPlayerState()
@@ -4706,7 +4706,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   state.canseek = false;
   state.cantempo = false;
   state.isInMenu = false;
-  state.hasMenu = false;
+  state.menuType = MenuType::NONE;
 
   if (m_pInputStream)
   {
@@ -4784,7 +4784,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         if (!pMenu->CanSeek())
           state.time_offset = 0;
       }
-      state.hasMenu = pMenu->HasMenu();
+      state.menuType = pMenu->GetSupportedMenuType();
     }
 
     state.canpause = m_pInputStream->CanPause();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -18,6 +18,7 @@
 #include "VideoPlayerTeletext.h"
 #include "VideoPlayerVideo.h"
 #include "cores/IPlayer.h"
+#include "cores/MenuType.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "guilib/DispResource.h"
@@ -45,7 +46,7 @@ struct SPlayerState
     dts = DVD_NOPTS_VALUE;
     player_state  = "";
     isInMenu = false;
-    hasMenu = false;
+    menuType = MenuType::NONE;
     chapter = 0;
     chapters.clear();
     canpause = false;
@@ -72,7 +73,7 @@ struct SPlayerState
 
   std::string player_state; // full player state
   bool isInMenu;
-  bool hasMenu;
+  MenuType menuType;
   bool streamsReady;
 
   int chapter;              // current chapter
@@ -263,7 +264,12 @@ public:
   void SetAVDelay(float fValue = 0.0f) override;
   float GetAVDelay() override;
   bool IsInMenu() const override;
-  bool HasMenu() const override;
+
+  /*!
+   * \brief Get the supported menu type
+   * \return The supported menu type
+  */
+  MenuType GetSupportedMenuType() const override;
 
   void SetSubTitleDelay(float fValue = 0.0f) override;
   float GetSubTitleDelay() override;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -776,7 +776,7 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
               CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME;
       return true;
     case VIDEOPLAYER_HASMENU:
-      value = g_application.GetAppPlayer().HasMenu();
+      value = g_application.GetAppPlayer().GetSupportedMenuType() != MenuType::NONE;
       return true;
     case VIDEOPLAYER_HASTELETEXT:
       if (g_application.GetAppPlayer().GetTeletextCache())


### PR DESCRIPTION
## Description
Currently there's a problem in the way we handle bluray playback. If playback is started from the simplified menu (or if we just resume a bluray) navigation mode is not enabled due to the way libbluray is initialized, and the user cannot move to a different title (or force open the native bluray menu).  I plan to enable the menu icon in such cases, forcing kodi to display the simplified menu, which will solve the issue.

To be able to do that, we can't rely on a simple bool (HasMenu) but have to expose the supported menu type. The "hasmenu" infobool will then return true if the inputstream supports either the native menus or the simplified menu, and the logic will be started from the OnMenu call, back to the player and then via messaging to gui.

This PR gets things started by dropping the old `HasMenu()` method (which for me is not even self-explanatory since it doesn't exactly mean a menu is active) replacing it by `GetSupportedMenuType()`.
Functionality-wise everything should be exactly the same.

## Motivation and context
Being able to open the simplified menu from the video osd if native menus are not supported in the near future.

## How has this been tested?
Runtime tested with isos and physical discs

## What is the effect on users?
None, just an internal change.
