### PR TITLE
[VideoPlayer][PVR] STREAMCHANGE demux packet does not reset/apply new stream properties

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -323,7 +323,7 @@ DemuxPacket* CDVDDemuxClient::Read()
   }
   else if (m_packet->iStreamId == DMX_SPECIALID_STREAMCHANGE)
   {
-    RequestStreams();
+    RequestStreams(true);
   }
   else if (m_packet->iStreamId >= 0 && m_streams.count(m_packet->iStreamId) > 0)
   {
@@ -387,11 +387,11 @@ std::vector<CDemuxStream*> CDVDDemuxClient::GetStreams() const
   return streams;
 }
 
-void CDVDDemuxClient::RequestStreams()
+void CDVDDemuxClient::RequestStreams(bool forceInit /*=false*/)
 {
   std::map<int, std::shared_ptr<CDemuxStream>> newStreamMap;
   for (auto stream : m_IDemux->GetStreams())
-    SetStreamProps(stream, newStreamMap, false);
+    SetStreamProps(stream, newStreamMap, forceInit);
   m_streams = newStreamMap;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -45,7 +45,7 @@ public:
   void SetVideoResolution(int width, int height) override;
 
 protected:
-  void RequestStreams();
+  void RequestStreams(bool forceInit = false);
   void SetStreamProps(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map, bool forceInit);
   bool ParsePacket(DemuxPacket* pPacket);
   void DisposeStreams();


### PR DESCRIPTION
## Description
When a PVR client that supports demuxing posts a DMX_SPECIALID_STREAMCHANGE packet, VideoPlayer does not fully reset/reinitialize the previous set of stream properties.  Whatever stream parameters were originally supplied via the initial call to the PVR's GetStreamProperties() callback will persist for the life of the VideoPlayer session.

I was able to narrow this down to CDVDDemuxClient::RequestStreams(). When a DMX_SPECIALID_STREAMCHANGE packet is processed, it requests new stream properties as expected, but any new properties will not be used unless the stream ID or codec has also changed. The follow-on call to CDVDDemuxClient::SetStreamProps() does not force re-initialization of the stream properties and allows the cached values to persist.

I did not change the handler for DMX_SPECIALID_STREAMINFO intentionally. I found that seemingly the only value to this special packet is to force a callback to add **new** streams that might are available to demux? Those packets are simply discarded by CDVDDemuxClient and do not cause a STREAMCHANGE event that VideoPlayer would pick up on regardless.  I did try changing it, and found no value in doing so.

If this PR is ultimately accepted, I would like to request the opportunity to back-port to Matrix as well.

## Motivation and context
I'm working on a DAB/DAB+ PVR Radio addon. DAB streams (and HD Radio streams, for that matter), take a non-negligible amount of time to decode enough data to start producing audio packets. If the signal is bad or overloaded, they may never produce audio.  It's impractical for a PVR addon to "wait" for audio before allowing demuxing to take place, that causes Kodi to become unresponsive.  The better solution is to return NULL (zero-length) demuxer packets until audio data is available. This keeps Kodi responsive, and allows the user to stop playback at any time.

For HD Radio, this is not a problem, as the audio output sample rate is always 44.1KHz. The stream properties are fixed and will never change from what was initially reported by the PVR addon.

DAB/DAB+, on the other hand, supports multiple audio output sample rates for each subchannel in its "Ensemble". One subchannel might be 48KHz, one might be 32KHz, and so on. The audio output sample rate of the eventually tuned subchannel within the Ensemble is unknown at the time of opening the PVR Radio stream. Once the specific metadata for the tuned subchannel becomes available, the addon must have a way to alter the original stream properties. DMX_SPECIALID_STREAMCHANGE appeared to be what was needed, but it didn't work.

After the proposed change, I was able to specify a placeholder audio output rate of 48KHz on stream open, and VideoPlayer would properly adjust the audio output rate if the PVR addon sent a DMX_SPECIALID_STREAMCHANGE followed by the properly resampled audio and DTS/PTS timestamps.

## How has this been tested?
Tested on Windows 11, x64 (Desktop) using an in-progress set of changes to a PVR radio addon that wants to support DAB/DAB+. I am in North America and have no access to DAB(+), but have been using a sample file I found via a closed Issue on welle.io's GitHub.

Prior to the change, if the ultimately tuned DAB subchannel was not 48KHz, the audio would either play too quickly and cause sync errors or play too slowly and also cause sync errors.  After the change, the discovered audio output sample rate for the subchannel was properly applied in all cases, and VideoPlayer showed the correct adjusted bitrate in the "o key" "Player/Audio stream" information.

I both welcome to and am happy to execute any additional unit test(s) the maintainer(s) request? I sincerely don't want to break anything, but this a showstopper for me on DAB(+) support in a PVR addon; I don't think I can move forward without this being accepted.

## What is the effect on users?
None? There are no PVR addons in existence that I am aware of that are trying to accomplish what I am trying to accomplish right now.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
