### PR TITLE
[Security] [Backport] Use passwords.xml for more protocols

### DIFF
--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -118,7 +118,13 @@ bool CPasswordManager::IsURLSupported(const CURL &url)
 {
   return url.IsProtocol("smb")
     || url.IsProtocol("nfs")
-    || url.IsProtocol("sftp");
+    || url.IsProtocol("ftp")
+    || url.IsProtocol("ftps")
+    || url.IsProtocol("sftp")
+    || url.IsProtocol("http")
+    || url.IsProtocol("https")
+    || url.IsProtocol("dav")
+    || url.IsProtocol("davs");
 }
 
 void CPasswordManager::Clear()


### PR DESCRIPTION
## Description

Backported from 19f0e1cd1af5f473cfad1191f4ad37161fdc6d0f, PR #19217

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

I didn't, but this isn't a super invasive change - I figured I'd let CI take care of it, though I will likely manually test tomorrow as well, just in case.

## What is the effect on users?

Newly created or modified media sources using `dav://`, `davs://`, `http://`, `https://`, `ftp://`, or `ftps://` protocol schemes now store passwords in `passwords.xml`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
