### PR TITLE
[linux] add build time option to disable automatic addon configure at…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if(NOT WIN32)
 endif()
 if(CORE_SYSTEM_NAME STREQUAL linux)
   option(ENABLE_EVENTCLIENTS    "Enable event clients support?" OFF)
+  option(ADDONS_CONFIGURE_AT_STARTUP "Configure binary addons at startup?" ON)
 endif()
 
 # set scope of INTERNAL_DEPS

--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -25,4 +25,8 @@ if(DBUS_FOUND)
                       DBusUtil.h)
 endif()
 
+if(ADDONS_CONFIGURE_AT_STARTUP)
+  add_compile_definitions(ADDONS_CONFIGURE_AT_STARTUP)
+endif()
+
 core_add_library(linuxsupport)

--- a/xbmc/platform/linux/PlatformLinux.cpp
+++ b/xbmc/platform/linux/PlatformLinux.cpp
@@ -152,3 +152,12 @@ void CPlatformLinux::DeinitStageOne()
   DeregisterService(typeid(CFDEventMonitor));
 #endif // HAS_ALSA
 }
+
+bool CPlatformLinux::IsConfigureAddonsAtStartupEnabled()
+{
+#if defined(ADDONS_CONFIGURE_AT_STARTUP)
+  return true;
+#else
+  return false;
+#endif
+}

--- a/xbmc/platform/linux/PlatformLinux.h
+++ b/xbmc/platform/linux/PlatformLinux.h
@@ -23,7 +23,7 @@ public:
   bool InitStageOne() override;
   void DeinitStageOne() override;
 
-  bool IsConfigureAddonsAtStartupEnabled() override { return true; }
+  bool IsConfigureAddonsAtStartupEnabled() override;
 
 private:
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;


### PR DESCRIPTION
… startup

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Adds a cmake compile time option  `ADDONS_NO_CONFIGURE_AT_STARTUP`  to disable automatic enable/configure of binary addons on startup.
Fixes crashes with (bundled) pvr addons on e.g. flatpak.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows us to get rid of patches such as https://github.com/flathub/tv.kodi.Kodi/blob/master/addons-no-startupenable.patch
IIRC, LE uses something similar.


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
