### PR TITLE
[Xbox] Fix: Xbox needs 10 bit swapchain to output true 4K resolution

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -609,6 +609,8 @@ void DX::DeviceResources::ResizeBuffers()
     const bool isHdrEnabled = (hdrStatus == HDR_STATUS::HDR_ON);
     bool use10bit = (hdrStatus != HDR_STATUS::HDR_UNSUPPORTED);
 
+// Xbox needs 10 bit swapchain to output true 4K resolution
+#ifdef TARGET_WINDOWS_DESKTOP
     DXGI_ADAPTER_DESC ad = {};
     GetAdapterDesc(&ad);
 
@@ -616,6 +618,7 @@ void DX::DeviceResources::ResizeBuffers()
     // Enabled by default only in Intel and NVIDIA with latest drivers/hardware
     if (m_d3dFeatureLevel < D3D_FEATURE_LEVEL_12_1 || ad.VendorId == PCIV_AMD)
       use10bit = false;
+#endif
 
     // 0 = Auto | 1 = Never | 2 = Always
     int use10bitSetting = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(


### PR DESCRIPTION
## Description
Fix: Xbox needs 10 bit swapchain to output true 4K resolution

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/21357.

The referenced commit has broken the ability to output true 4K resolution on Xbox. 

Seems Xbox needs 10 bit swapchain to activate the graphic capabilities necessary to process the entire chain in 4K. Otherwise there is 4K in the output but it has the look of 1080p upscaled to 4K.

This commit reverts the previous commit for Xbox only.

## How has this been tested?
Runtime tested Xbox Series S

## What is the effect on users?
Fix 4K output broken

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
