### PR TITLE
[Xbox] Fix: Xbox needs 10 bit swapchain to output true 4K resolution

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -607,6 +607,8 @@ void DX::DeviceResources::ResizeBuffers()
     const bool isHdrEnabled = (hdrStatus == HDR_STATUS::HDR_ON);
     bool is10bitSafe = (hdrStatus != HDR_STATUS::HDR_UNSUPPORTED);
 
+// Xbox needs 10 bit swapchain to output true 4K resolution
+#ifdef TARGET_WINDOWS_DESKTOP
     DXGI_ADAPTER_DESC ad = {};
     GetAdapterDesc(&ad);
 
@@ -614,6 +616,7 @@ void DX::DeviceResources::ResizeBuffers()
     // Enabled by default only in Intel and NVIDIA with latest drivers/hardware
     if (m_d3dFeatureLevel < D3D_FEATURE_LEVEL_12_1 || ad.VendorId == PCIV_ATI)
       is10bitSafe = false;
+#endif
 
     DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
     swapChainDesc.Width = lround(m_outputSize.Width);


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/21478



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
