### PR TITLE
Fix for font vertex caching on GL/GLES

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -68,7 +68,11 @@ bool CGUIFontTTFGL::FirstBegin()
     internalFormat = GL_R8;
   else
     internalFormat = GL_LUMINANCE;
+  renderSystem->EnableShader(ShaderMethodGL::SM_FONTS);
 #else
+  CRenderSystemGLES* renderSystem =
+      dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_FONTS);
   GLenum pixformat = GL_ALPHA; // deprecated
   GLenum internalFormat = GL_ALPHA;
 #endif
@@ -128,7 +132,6 @@ void CGUIFontTTFGL::LastEnd()
 
 #ifdef HAS_GL
   CRenderSystemGL* renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableShader(ShaderMethodGL::SM_FONTS);
 
   GLint posLoc = renderSystem->ShaderGetPos();
   GLint colLoc = renderSystem->ShaderGetCol();
@@ -184,7 +187,6 @@ void CGUIFontTTFGL::LastEnd()
   // GLES 2.0 version.
   CRenderSystemGLES* renderSystem =
       dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableGUIShader(ShaderMethodGLES::SM_FONTS);
 
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint colLoc = renderSystem->GUIShaderGetCol();


### PR DESCRIPTION
## Description
Currently for font vertices on GL/GLES, the static cache path is chosen. This means that the vertex coords get recalculated if there is a translation applied to them. Clipping is done on the CPU. Every frame, the vertex coordinates get submitted to the GPU.

The facilities are there to let the GPU handle translation. Additionally, it leaves the vertex data on the GPU, avoiding the re-upload of vertex data. This patch enables the dynamic caching and GPU translation.

There is a slight drawback to this patch. The static cache collects and then draws all vertices of a GUI element. The dynamic path draws everything as it comes in. As a result, font shadows are now rendered in a separate draw call. Multi-line texts are drawn one line at the time. This is a bit wasteful, but this is a quirk of the current code base. 

## Motivation and context
In general, dynamic effects such as translation, scaling, rotation and sheering should be done on the GPU, taking off some work off the CPU. Vertex buffer changes are not free in terms of CPU calculations and driver overhead. 

In the future, I want to phase out such CPU calculations, which makes the interface cleaner, easier and the overall performance faster. 

## How has this been tested?
Text is still rendering fine, as I far as can see. Renderdoc is happy too.

## What is the effect on users?
Lower CPU utilization.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
