### PR TITLE
changed: move application ActionListener handling to separate class

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -222,7 +222,8 @@ using namespace std::chrono_literals;
 #define MAX_FFWD_SPEED 5
 
 CApplication::CApplication(void)
-  : CApplicationPlayerCallback(m_appPlayer, m_stackHelper),
+  : CApplicationActionListeners(m_critSection),
+    CApplicationPlayerCallback(m_appPlayer, m_stackHelper),
     CApplicationPowerHandling(m_appPlayer),
     CApplicationSkinHandling(m_appPlayer),
     CApplicationVolumeHandling(m_appPlayer)
@@ -3774,32 +3775,4 @@ void CApplication::CloseNetworkShares()
 
   for (const auto& vfsAddon : CServiceBroker::GetVFSAddonCache().GetAddonInstances())
     vfsAddon->DisconnectAll();
-}
-
-void CApplication::RegisterActionListener(IActionListener *listener)
-{
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  std::vector<IActionListener *>::iterator it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
-  if (it == m_actionListeners.end())
-    m_actionListeners.push_back(listener);
-}
-
-void CApplication::UnregisterActionListener(IActionListener *listener)
-{
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  std::vector<IActionListener *>::iterator it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
-  if (it != m_actionListeners.end())
-    m_actionListeners.erase(it);
-}
-
-bool CApplication::NotifyActionListeners(const CAction &action) const
-{
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  for (std::vector<IActionListener *>::const_iterator it = m_actionListeners.begin(); it != m_actionListeners.end(); ++it)
-  {
-    if ((*it)->OnAction(action))
-      return true;
-  }
-
-  return false;
 }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -11,6 +11,7 @@
 #include "ApplicationPlayer.h"
 #include "ApplicationStackHelper.h"
 #include "ServiceManager.h"
+#include "application/ApplicationActionListeners.h"
 #include "application/ApplicationPlayerCallback.h"
 #include "application/ApplicationPowerHandling.h"
 #include "application/ApplicationSkinHandling.h"
@@ -47,7 +48,6 @@ class CSeekHandler;
 class CInertialScrollingHandler;
 class CSplash;
 class CBookmark;
-class IActionListener;
 class CGUIComponent;
 class CAppInboundProtocol;
 class CSettingsComponent;
@@ -111,6 +111,7 @@ class CApplication : public IWindowManagerCallback,
                      public ISettingsHandler,
                      public ISubSettings,
                      public KODI::MESSAGING::IMessageTarget,
+                     public CApplicationActionListeners,
                      public CApplicationPlayerCallback,
                      public CApplicationPowerHandling,
                      public CApplicationSkinHandling,
@@ -214,17 +215,6 @@ public:
 
   void SetLoggingIn(bool switchingProfiles);
 
-  /*!
-   \brief Register an action listener.
-   \param listener The listener to register
-   */
-  void RegisterActionListener(IActionListener *listener);
-  /*!
-   \brief Unregister an action listener.
-   \param listener The listener to unregister
-   */
-  void UnregisterActionListener(IActionListener *listener);
-
   std::unique_ptr<CServiceManager> m_ServiceManager;
 
   /*!
@@ -251,13 +241,6 @@ protected:
 
   // inbound protocol
   bool OnEvent(XBMC_Event& newEvent);
-
-  /*!
-   \brief Delegates the action to all registered action handlers.
-   \param action The action
-   \return true, if the action was taken by one of the action listener.
-   */
-  bool NotifyActionListeners(const CAction &action) const;
 
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
   std::unique_ptr<CGUIComponent> m_pGUI;
@@ -300,7 +283,6 @@ protected:
 
   CInertialScrollingHandler *m_pInertialScrollingHandler;
 
-  std::vector<IActionListener *> m_actionListeners;
   std::vector<ADDON::AddonInfoPtr>
       m_incompatibleAddons; /*!< Result of addon migration (incompatible addon infos) */
 

--- a/xbmc/application/ApplicationActionListeners.cpp
+++ b/xbmc/application/ApplicationActionListeners.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ApplicationActionListeners.h"
+
+#include "interfaces/IActionListener.h"
+#include "threads/CriticalSection.h"
+
+#include <algorithm>
+#include <mutex>
+
+CApplicationActionListeners::CApplicationActionListeners(CCriticalSection& section)
+  : m_critSection(section)
+{
+}
+
+void CApplicationActionListeners::RegisterActionListener(IActionListener* listener)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  const auto it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
+  if (it == m_actionListeners.end())
+    m_actionListeners.push_back(listener);
+}
+
+void CApplicationActionListeners::UnregisterActionListener(IActionListener* listener)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  auto it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
+  if (it != m_actionListeners.end())
+    m_actionListeners.erase(it);
+}
+
+bool CApplicationActionListeners::NotifyActionListeners(const CAction& action) const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  for (const auto& listener : m_actionListeners)
+  {
+    if (listener->OnAction(action))
+      return true;
+  }
+
+  return false;
+}

--- a/xbmc/application/ApplicationActionListeners.h
+++ b/xbmc/application/ApplicationActionListeners.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <vector>
+
+class CAction;
+class CCriticalSection;
+class IActionListener;
+
+/*!
+ * \brief Class handling application support for action listeners.
+ */
+
+class CApplicationActionListeners
+{
+public:
+  CApplicationActionListeners(CCriticalSection& sect);
+
+  /*!
+   \brief Register an action listener.
+   \param listener The listener to register
+   */
+  void RegisterActionListener(IActionListener* listener);
+  /*!
+   \brief Unregister an action listener.
+   \param listener The listener to unregister
+   */
+  void UnregisterActionListener(IActionListener* listener);
+
+protected:
+  /*!
+   \brief Delegates the action to all registered action handlers.
+   \param action The action
+   \return true, if the action was taken by one of the action listener.
+   */
+  bool NotifyActionListeners(const CAction& action) const;
+
+  std::vector<IActionListener*> m_actionListeners;
+
+  CCriticalSection& m_critSection;
+};

--- a/xbmc/application/CMakeLists.txt
+++ b/xbmc/application/CMakeLists.txt
@@ -1,9 +1,11 @@
-set(SOURCES ApplicationPlayerCallback.cpp
+set(SOURCES ApplicationActionListeners.cpp
+            ApplicationPlayerCallback.cpp
             ApplicationPowerHandling.cpp
             ApplicationSkinHandling.cpp
             ApplicationVolumeHandling.cpp)
 
-set(HEADERS ApplicationPlayerCallback.h
+set(HEADERS ApplicationActionListeners.h
+            ApplicationPlayerCallback.h
             ApplicationPowerHandling.h
             ApplicationSkinHandling.h
             ApplicationVolumeHandling.h)


### PR DESCRIPTION
## Description
Split out action listener handling to separate class

## Motivation and context
Reduce complexity of Application.h/cp

## How has this been tested?
It builds..

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
