### PR TITLE
[Xbox][DXVA2] Allows the use of more than 16 decoding surfaces for H265 Full HD or less

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -1204,9 +1204,17 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
     /* the HEVC DXVA2 spec asks for 128 pixel aligned surfaces to ensure
        all coding features have enough room to work with */
     m_surface_alignment = 128;
-    // a driver may use multi-thread decoding internally (PC only)
+    // a driver may use multi-thread decoding internally
+    // on Xbox only add refs for <= Full HD due memory constraints (max 16 refs for 4K)
     if (CSysInfo::GetWindowsDeviceFamily() != CSysInfo::Xbox)
+    {
       m_refs += CServiceBroker::GetCPUInfo()->GetCPUCount();
+    }
+    else
+    {
+      if (avctx->width <= 1920)
+        m_refs += CServiceBroker::GetCPUInfo()->GetCPUCount() / 2;
+    }
     // by specification hevc decoder can hold up to 8 unique refs
     // ffmpeg may report only 1 refs frame when is unknown or not present in headers
     m_refs += (avctx->refs > 1) ? avctx->refs : 8;


### PR DESCRIPTION
## Description
Fixes some specific H265 Full HD videos crashes because needs more decoding surfaces.

Fixes https://github.com/xbmc/xbmc/issues/21460

## Motivation and context
In the past the maximum number of decoding surfaces was limited to 16 due to memory constraints in 4K.

It is also taken into account that the maximum number of references in H265 is 8. However, some specific streams needs more due to the parallelization (related to tiles and slices) in the decoding.

This change allows to use more than 16 surfaces only for <= Full HD.

Typically 20 surfaces will be used if Xbox has 8 cores (16 + 8 / 2)

Tested in Xbox Series S and even forcing 24 surfaces is fine, so the change seems safe and 20 surfaces is sufficient for decode this problematic stream.

## How has this been tested?
Runtime tested Xbox Series S and sample stream provided in the issue.


## What is the effect on users?
Fix Xbox crash at decoding some H265 very specific videos using DXVA2


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
