### PR TITLE
[dvdnav] use highlight area palette for active overlay colors

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -135,14 +135,6 @@ protected:
 
   int ProcessBlock(uint8_t* buffer, int* read);
 
-  /*! \brief Get the color and alpha of a given button
-   * \param button - the button id
-   * \param[in,out] alpha - the alpha of the button
-   * \param[in,out] color - the color of the button
-   * \return true if the operation (obtaining data) succeeded, false otherwise
-   */
-  bool GetButtonColorAndAlpha(int button, int alpha[2][4], int color[2][4]);
-
   static void SetAudioStreamName(AudioStreamInfo &info, const audio_attr_t &audio_attributes);
   static void SetSubtitleStreamName(SubtitleStreamInfo &info, const subp_attr_t &subp_attributes);
 


### PR DESCRIPTION
## Description

DVD menu overlays got broken for windows on https://github.com/xbmc/xbmc/pull/21154 which attempted to remove one of our dvdnav patches. For some reason the pci struct doesn't get filled with the properties we were trying to access. Oddly enough, it works fine on linux...

Diving a bit more on this, instead of abusing struct members that likely shouldn't be publicly accessed I've looked into how VLC does it. It's much more clean than our approach since the color information for the active button is already part of the `highlight_area` returned by `dvdnav_get_highlight_area`:

https://github.com/videolan/vlc/blob/79d852d5be832729375860f9d9fce0e3d391aa89/modules/access/dvdnav.c#L1341-L1379

Allow us to finally drop that ugly method too.

Run time tested on windows and linux.

**Current master on Windows:**
![image](https://user-images.githubusercontent.com/7375276/171471326-b6d1faba-9655-410b-a257-e8db25a253db.png)

**PR on Windows**
![image](https://user-images.githubusercontent.com/7375276/171471387-1f5f3dfd-1884-470a-aa35-a61caafe61a3.png)

