### PR TITLE
Improve the user experience concerning library cleanup

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1494,7 +1494,7 @@ msgstr ""
 
 #. generic "cleaning database" label used in different places
 #: xbmc/music/MusicDatabase.cpp
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActions.cpp
 #: xbmc/settings/MediaSettings.cpp
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#313"
@@ -1592,6 +1592,7 @@ msgid "Error compressing database"
 msgstr ""
 
 #: xbmc/music/MusicDatabase.cpp
+#: xbmc/settings/MediaSettings.cpp
 msgctxt "#333"
 msgid "Do you want to clean the library?"
 msgstr ""
@@ -3221,8 +3222,11 @@ msgstr ""
 
 #empty strings from id 688 to 699
 
+#: xbmc/interfaces/builtins/LibraryBuiltins.cpp
+#: xbmc/music/MusicLibraryQueue.cpp
 #: xbmc/music/infoscanner/MusicInfoScanner.cpp
-#: xbmc/music/MusicDatabase.cpp
+#: xbmc/settings/MediaSettings.cpp
+#: xbmc/video/VideoDatabase.cpp
 msgctxt "#700"
 msgid "Cleaning up library"
 msgstr ""
@@ -3236,7 +3240,13 @@ msgctxt "#702"
 msgid "This path has been scanned before"
 msgstr ""
 
-#empty strings from id 703 to 704
+#: xbmc/interfaces/builtins/LibraryBuiltins.cpp
+#: xbmc/settings/MediaSettings.cpp
+msgctxt "#703"
+msgid "Can't clean up library while running background tasks"
+msgstr ""
+
+#empty string with id 704
 
 msgctxt "#705"
 msgid "Network"

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "settings/LibExportSettings.h"
@@ -47,7 +48,9 @@ static int CleanLibrary(const std::vector<std::string>& params)
   {
     if (!CVideoLibraryQueue::GetInstance().IsScanningLibrary())
     {
-      if (!(userInitiated && CVideoLibraryQueue::GetInstance().IsRunning()))
+      if (userInitiated && CVideoLibraryQueue::GetInstance().IsRunning())
+        HELPERS::ShowOKDialogText(CVariant{700}, CVariant{703});
+      else
       {
         const std::string content = (params.empty() || params[0] == "video") ? "" : params[0];
         const std::string directory = params.size() > 2 ? params[2] : "";

--- a/xbmc/messaging/helpers/DialogOKHelper.h
+++ b/xbmc/messaging/helpers/DialogOKHelper.h
@@ -35,11 +35,10 @@ struct DialogOKMessage
 };
 
 /*!
-  \brief This is a helper method to send a threadmessage to open a Ok dialog box
+  \brief This is a helper method to send a threadmessage to update a Ok dialog text
 
   \param[in]  heading           The text to display as the dialog box header
   \param[in]  text              The text to display in the dialog body
-  \return if it's confirmed
   \sa ShowOKDialogLines
   \sa CGUIDialogOK::ShowAndGetInput
   \sa DialogOKMessage
@@ -47,12 +46,14 @@ struct DialogOKMessage
 void UpdateOKDialogText(CVariant heading, CVariant text);
 
 /*!
-\brief This is a helper method to send a threadmessage to update a Ok dialog text
-\param[in]  heading           The text to display as the dialog box header
-\param[in]  text              The text to display in the dialog body
-\sa UpdateOKDialogLines
-\sa CGUIDialogOK::ShowAndGetInput
-\sa DialogOKMessage
+  \brief This is a helper method to send a threadmessage to open a Ok dialog box
+
+  \param[in]  heading           The text to display as the dialog box header
+  \param[in]  text              The text to display in the dialog body
+  \return if it's confirmed
+  \sa UpdateOKDialogLines
+  \sa CGUIDialogOK::ShowAndGetInput
+  \sa DialogOKMessage
 */
 bool ShowOKDialogText(CVariant heading, CVariant text);
 

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -213,31 +213,6 @@ void CMusicLibraryQueue::CleanLibrary(bool showDialog /* = false */)
     progress->Wait(20);
 }
 
-void CMusicLibraryQueue::CleanLibraryModal()
-{
-  // We can't perform a modal library cleaning if other jobs are running
-  if (IsRunning())
-    return;
-
-  CGUIDialogProgress* progress = nullptr;
-  progress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
-  if (progress)
-  {
-    progress->SetHeading(CVariant{ 700 });
-    progress->SetPercentage(0);
-    progress->Open();
-    progress->ShowProgressBar(true);
-  }
-
-  m_modal = true;
-  m_cleaning = true;
-  CMusicLibraryCleaningJob cleaningJob(progress);
-  cleaningJob.DoWork();
-  m_cleaning = false;
-  m_modal = false;
-  Refresh();
-}
-
 void CMusicLibraryQueue::AddJob(CMusicLibraryJob *job)
 {
   if (job == NULL)

--- a/xbmc/music/MusicLibraryQueue.h
+++ b/xbmc/music/MusicLibraryQueue.h
@@ -90,13 +90,6 @@ public:
   void CleanLibrary(bool showDialog = false);
 
   /*!
-   \brief Executes a library cleaning with a modal dialog.
-   However UI rendering of dialog is on same thread as the cleaning process, so mouse movement
-   is stilted and opportunities to cancel the process limited
-   */
-  void CleanLibraryModal();
-
-  /*!
    \brief Adds the given job to the queue.
    \param[in] job Music library job to be queued.
    */

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -16,6 +16,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/builtins/Builtins.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicLibraryQueue.h"
 #include "settings/Settings.h"
 #include "settings/dialogs/GUIDialogLibExportSettings.h"
@@ -307,7 +308,9 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   {
     if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::CHOICE_YES)
     {
-      if (!CMusicLibraryQueue::GetInstance().IsRunning())
+      if (CMusicLibraryQueue::GetInstance().IsRunning())
+        HELPERS::ShowOKDialogText(CVariant{700}, CVariant{703});
+      else
         CMusicLibraryQueue::GetInstance().CleanLibrary(true);
     }
   }
@@ -338,8 +341,8 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   {
     if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::CHOICE_YES)
     {
-      if (!CVideoLibraryQueue::GetInstance().IsRunning())
-        CVideoLibraryQueue::GetInstance().CleanLibraryModal();
+      if (!CVideoLibraryQueue::GetInstance().CleanLibraryModal())
+        HELPERS::ShowOKDialogText(CVariant{700}, CVariant{703});
     }
   }
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_EXPORT)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9261,6 +9261,26 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
                                                        "OnCleanStarted");
 
+    if (handle)
+    {
+      handle->SetTitle(g_localizeStrings.Get(700));
+      handle->SetText("");
+    }
+    else if (showProgress)
+    {
+      progress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+      if (progress)
+      {
+        progress->SetHeading(CVariant{ 700 });
+        progress->SetLine(0, CVariant{ "" });
+        progress->SetLine(1, CVariant{ 313 });
+        progress->SetLine(2, CVariant{ 330 });
+        progress->SetPercentage(0);
+        progress->Open();
+        progress->ShowProgressBar(true);
+      }
+    }
+
     BeginTransaction();
 
     // find all the files
@@ -9277,340 +9297,321 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     sql += " ORDER BY path.strPath";
 
     m_pDS2->query(sql);
-    if (m_pDS2->num_rows() == 0) return;
-
-    if (handle)
+    if (m_pDS2->num_rows() > 0)
     {
-      handle->SetTitle(g_localizeStrings.Get(700));
-      handle->SetText("");
-    }
-    else if (showProgress)
-    {
-      progress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
-      if (progress)
+      std::string filesToTestForDelete;
+      VECSOURCES videoSources(*CMediaSourceSettings::GetInstance().GetSources("video"));
+      CServiceBroker::GetMediaManager().GetRemovableDrives(videoSources);
+
+      int total = m_pDS2->num_rows();
+      int current = 0;
+      std::string lastDir;
+      bool gotDir = true;
+
+      while (!m_pDS2->eof())
       {
-        progress->SetHeading(CVariant{700});
-        progress->SetLine(0, CVariant{""});
-        progress->SetLine(1, CVariant{313});
-        progress->SetLine(2, CVariant{330});
-        progress->SetPercentage(0);
-        progress->Open();
-        progress->ShowProgressBar(true);
-      }
-    }
+        std::string path = m_pDS2->fv("path.strPath").get_asString();
+        std::string fileName = m_pDS2->fv("files.strFileName").get_asString();
+        std::string fullPath;
+        ConstructPath(fullPath, path, fileName);
 
-    std::string filesToTestForDelete;
-    VECSOURCES videoSources(*CMediaSourceSettings::GetInstance().GetSources("video"));
-    CServiceBroker::GetMediaManager().GetRemovableDrives(videoSources);
+        // get the first stacked file
+        if (URIUtils::IsStack(fullPath))
+          fullPath = CStackDirectory::GetFirstStackedFile(fullPath);
 
-    int total = m_pDS2->num_rows();
-    int current = 0;
-    std::string lastDir;
-    bool gotDir = true;
+        // get the actual archive path
+        if (URIUtils::IsInArchive(fullPath))
+          fullPath = CURL(fullPath).GetHostName();
 
-    while (!m_pDS2->eof())
-    {
-      std::string path = m_pDS2->fv("path.strPath").get_asString();
-      std::string fileName = m_pDS2->fv("files.strFileName").get_asString();
-      std::string fullPath;
-      ConstructPath(fullPath, path, fileName);
-
-      // get the first stacked file
-      if (URIUtils::IsStack(fullPath))
-        fullPath = CStackDirectory::GetFirstStackedFile(fullPath);
-
-      // get the actual archive path
-      if (URIUtils::IsInArchive(fullPath))
-        fullPath = CURL(fullPath).GetHostName();
-
-      bool del = true;
-      if (URIUtils::IsPlugin(fullPath))
-      {
-        SScanSettings settings;
-        bool foundDirectly = false;
-        ScraperPtr scraper = GetScraperForPath(fullPath, settings, foundDirectly);
-        if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), fullPath))
-          del = false;
-      }
-      else
-      {
-        // Only consider keeping this file if not optical and belonging to a (matching) source
-        bool bIsSource;
-        if (!URIUtils::IsOnDVD(fullPath) &&
-            CUtil::GetMatchingSource(fullPath, videoSources, bIsSource) >= 0)
+        bool del = true;
+        if (URIUtils::IsPlugin(fullPath))
         {
-          const std::string pathDir = URIUtils::GetDirectory(fullPath);
-
-          // Cache file's directory in case it's different from the previous file
-          if (lastDir != pathDir)
-          {
-            lastDir = pathDir;
-            CFileItemList items; // Dummy list
-            gotDir = CDirectory::GetDirectory(pathDir, items, "", DIR_FLAG_NO_FILE_DIRS |
-                                              DIR_FLAG_NO_FILE_INFO);
-          }
-
-          // Keep existing files
-          if (gotDir && CFile::Exists(fullPath, true))
+          SScanSettings settings;
+          bool foundDirectly = false;
+          ScraperPtr scraper = GetScraperForPath(fullPath, settings, foundDirectly);
+          if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), fullPath))
             del = false;
         }
-      }
-      if (del)
-        filesToTestForDelete += m_pDS2->fv("files.idFile").get_asString() + ",";
-
-      if (handle == NULL && progress != NULL)
-      {
-        int percentage = current * 100 / total;
-        if (percentage > progress->GetPercentage())
+        else
         {
-          progress->SetPercentage(percentage);
-          progress->Progress();
+          // Only consider keeping this file if not optical and belonging to a (matching) source
+          bool bIsSource;
+          if (!URIUtils::IsOnDVD(fullPath) &&
+              CUtil::GetMatchingSource(fullPath, videoSources, bIsSource) >= 0)
+          {
+            const std::string pathDir = URIUtils::GetDirectory(fullPath);
+
+            // Cache file's directory in case it's different from the previous file
+            if (lastDir != pathDir)
+            {
+              lastDir = pathDir;
+              CFileItemList items; // Dummy list
+              gotDir = CDirectory::GetDirectory(pathDir, items, "", DIR_FLAG_NO_FILE_DIRS |
+                                                DIR_FLAG_NO_FILE_INFO);
+            }
+
+            // Keep existing files
+            if (gotDir && CFile::Exists(fullPath, true))
+              del = false;
+          }
         }
-        if (progress->IsCanceled())
+        if (del)
+          filesToTestForDelete += m_pDS2->fv("files.idFile").get_asString() + ",";
+
+        if (handle == NULL && progress != NULL)
         {
-          progress->Close();
-          m_pDS2->close();
-          CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
-                                                             "OnCleanFinished");
-          return;
+          int percentage = current * 100 / total;
+          if (percentage > progress->GetPercentage())
+          {
+            progress->SetPercentage(percentage);
+            progress->Progress();
+          }
+          if (progress->IsCanceled())
+          {
+            progress->Close();
+            m_pDS2->close();
+            CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                               "OnCleanFinished");
+            return;
+          }
         }
+        else if (handle != NULL)
+          handle->SetPercentage(current * 100 / (float)total);
+
+        m_pDS2->next();
+        current++;
       }
-      else if (handle != NULL)
-        handle->SetPercentage(current * 100 / (float)total);
+      m_pDS2->close();
 
-      m_pDS2->next();
-      current++;
-    }
-    m_pDS2->close();
+      std::string filesToDelete;
 
-    std::string filesToDelete;
-
-    // Add any files that don't have a valid idPath entry to the filesToDelete list.
-    m_pDS->query("SELECT files.idFile FROM files WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = files.idPath)");
-    while (!m_pDS->eof())
-    {
-      std::string file = m_pDS->fv("files.idFile").get_asString() + ",";
-      filesToTestForDelete += file;
-      filesToDelete += file;
-
-      m_pDS->next();
-    }
-    m_pDS->close();
-
-    std::map<int, bool> pathsDeleteDecisions;
-    std::vector<int> movieIDs;
-    std::vector<int> tvshowIDs;
-    std::vector<int> episodeIDs;
-    std::vector<int> musicVideoIDs;
-
-    if (!filesToTestForDelete.empty())
-    {
-      StringUtils::TrimRight(filesToTestForDelete, ",");
-
-      movieIDs = CleanMediaType(MediaTypeMovie, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-      episodeIDs = CleanMediaType(MediaTypeEpisode, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-      musicVideoIDs = CleanMediaType(MediaTypeMusicVideo, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-    }
-
-    if (progress != NULL)
-    {
-      progress->SetPercentage(100);
-      progress->Progress();
-    }
-
-    if (!filesToDelete.empty())
-    {
-      filesToDelete = "(" + StringUtils::TrimRight(filesToDelete, ",") + ")";
-
-      // Clean hashes of all paths that files are deleted from
-      // Otherwise there is a mismatch between the path contents and the hash in the
-      // database, leading to potentially missed items on re-scan (if deleted files are
-      // later re-added to a source)
-      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning path hashes");
-      m_pDS->query("SELECT DISTINCT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile IN " + filesToDelete);
-      int pathHashCount = m_pDS->num_rows();
+      // Add any files that don't have a valid idPath entry to the filesToDelete list.
+      m_pDS->query("SELECT files.idFile FROM files WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = files.idPath)");
       while (!m_pDS->eof())
       {
-        InvalidatePathHash(m_pDS->fv("strPath").get_asString());
+        std::string file = m_pDS->fv("files.idFile").get_asString() + ",";
+        filesToTestForDelete += file;
+        filesToDelete += file;
+
         m_pDS->next();
       }
-      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaned {} path hashes", pathHashCount);
+      m_pDS->close();
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning files table", __FUNCTION__);
-      sql = "DELETE FROM files WHERE idFile IN " + filesToDelete;
-      m_pDS->exec(sql);
-    }
+      std::map<int, bool> pathsDeleteDecisions;
+      std::vector<int> movieIDs;
+      std::vector<int> tvshowIDs;
+      std::vector<int> episodeIDs;
+      std::vector<int> musicVideoIDs;
 
-    if (!movieIDs.empty())
-    {
-      std::string moviesToDelete;
-      for (const auto &i : movieIDs)
-        moviesToDelete += StringUtils::Format("{},", i);
-      moviesToDelete = "(" + StringUtils::TrimRight(moviesToDelete, ",") + ")";
-
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning movie table", __FUNCTION__);
-      sql = "DELETE FROM movie WHERE idMovie IN " + moviesToDelete;
-      m_pDS->exec(sql);
-    }
-
-    if (!episodeIDs.empty())
-    {
-      std::string episodesToDelete;
-      for (const auto &i : episodeIDs)
-        episodesToDelete += StringUtils::Format("{},", i);
-      episodesToDelete = "(" + StringUtils::TrimRight(episodesToDelete, ",") + ")";
-
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning episode table", __FUNCTION__);
-      sql = "DELETE FROM episode WHERE idEpisode IN " + episodesToDelete;
-      m_pDS->exec(sql);
-    }
-
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning paths that don't exist and have content set...",
-              __FUNCTION__);
-    sql = "SELECT path.idPath, path.strPath, path.idParentPath FROM path "
-            "WHERE NOT ((strContent IS NULL OR strContent = '') "
-                   "AND (strSettings IS NULL OR strSettings = '') "
-                   "AND (strHash IS NULL OR strHash = '') "
-                   "AND (exclude IS NULL OR exclude != 1))";
-    m_pDS2->query(sql);
-    std::string strIds;
-    while (!m_pDS2->eof())
-    {
-      auto pathsDeleteDecision = pathsDeleteDecisions.find(m_pDS2->fv(0).get_asInt());
-      // Check if we have a decision for the parent path
-      auto pathsDeleteDecisionByParent = pathsDeleteDecisions.find(m_pDS2->fv(2).get_asInt());
-      std::string path = m_pDS2->fv(1).get_asString();
-
-      bool exists = false;
-      if (URIUtils::IsPlugin(path))
+      if (!filesToTestForDelete.empty())
       {
-        SScanSettings settings;
-        bool foundDirectly = false;
-        ScraperPtr scraper = GetScraperForPath(path, settings, foundDirectly);
-        if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), path))
-          exists = true;
+        StringUtils::TrimRight(filesToTestForDelete, ",");
+
+        movieIDs = CleanMediaType(MediaTypeMovie, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
+        episodeIDs = CleanMediaType(MediaTypeEpisode, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
+        musicVideoIDs = CleanMediaType(MediaTypeMusicVideo, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
       }
-      else
-        exists = CDirectory::Exists(path, false);
 
-      if (((pathsDeleteDecision != pathsDeleteDecisions.end() && pathsDeleteDecision->second) ||
-           (pathsDeleteDecision == pathsDeleteDecisions.end() && !exists)) &&
-          ((pathsDeleteDecisionByParent != pathsDeleteDecisions.end() && pathsDeleteDecisionByParent->second) ||
-           (pathsDeleteDecisionByParent == pathsDeleteDecisions.end())))
-        strIds += m_pDS2->fv(0).get_asString() + ",";
+      if (progress != NULL)
+      {
+        progress->SetPercentage(100);
+        progress->Progress();
+      }
 
-      m_pDS2->next();
-    }
-    m_pDS2->close();
+      if (!filesToDelete.empty())
+      {
+        filesToDelete = "(" + StringUtils::TrimRight(filesToDelete, ",") + ")";
 
-    if (!strIds.empty())
-    {
-      sql = PrepareSQL("DELETE FROM path WHERE idPath IN (%s)", StringUtils::TrimRight(strIds, ",").c_str());
+        // Clean hashes of all paths that files are deleted from
+        // Otherwise there is a mismatch between the path contents and the hash in the
+        // database, leading to potentially missed items on re-scan (if deleted files are
+        // later re-added to a source)
+        CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning path hashes");
+        m_pDS->query("SELECT DISTINCT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile IN " + filesToDelete);
+        int pathHashCount = m_pDS->num_rows();
+        while (!m_pDS->eof())
+        {
+          InvalidatePathHash(m_pDS->fv("strPath").get_asString());
+          m_pDS->next();
+        }
+        CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaned {} path hashes", pathHashCount);
+
+        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning files table", __FUNCTION__);
+        sql = "DELETE FROM files WHERE idFile IN " + filesToDelete;
+        m_pDS->exec(sql);
+      }
+
+      if (!movieIDs.empty())
+      {
+        std::string moviesToDelete;
+        for (const auto &i : movieIDs)
+          moviesToDelete += StringUtils::Format("{},", i);
+        moviesToDelete = "(" + StringUtils::TrimRight(moviesToDelete, ",") + ")";
+
+        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning movie table", __FUNCTION__);
+        sql = "DELETE FROM movie WHERE idMovie IN " + moviesToDelete;
+        m_pDS->exec(sql);
+      }
+
+      if (!episodeIDs.empty())
+      {
+        std::string episodesToDelete;
+        for (const auto &i : episodeIDs)
+          episodesToDelete += StringUtils::Format("{},", i);
+        episodesToDelete = "(" + StringUtils::TrimRight(episodesToDelete, ",") + ")";
+
+        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning episode table", __FUNCTION__);
+        sql = "DELETE FROM episode WHERE idEpisode IN " + episodesToDelete;
+        m_pDS->exec(sql);
+      }
+
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning paths that don't exist and have content set...",
+                __FUNCTION__);
+      sql = "SELECT path.idPath, path.strPath, path.idParentPath FROM path "
+              "WHERE NOT ((strContent IS NULL OR strContent = '') "
+                     "AND (strSettings IS NULL OR strSettings = '') "
+                     "AND (strHash IS NULL OR strHash = '') "
+                     "AND (exclude IS NULL OR exclude != 1))";
+      m_pDS2->query(sql);
+      std::string strIds;
+      while (!m_pDS2->eof())
+      {
+        auto pathsDeleteDecision = pathsDeleteDecisions.find(m_pDS2->fv(0).get_asInt());
+        // Check if we have a decision for the parent path
+        auto pathsDeleteDecisionByParent = pathsDeleteDecisions.find(m_pDS2->fv(2).get_asInt());
+        std::string path = m_pDS2->fv(1).get_asString();
+
+        bool exists = false;
+        if (URIUtils::IsPlugin(path))
+        {
+          SScanSettings settings;
+          bool foundDirectly = false;
+          ScraperPtr scraper = GetScraperForPath(path, settings, foundDirectly);
+          if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), path))
+            exists = true;
+        }
+        else
+          exists = CDirectory::Exists(path, false);
+
+        if (((pathsDeleteDecision != pathsDeleteDecisions.end() && pathsDeleteDecision->second) ||
+             (pathsDeleteDecision == pathsDeleteDecisions.end() && !exists)) &&
+            ((pathsDeleteDecisionByParent != pathsDeleteDecisions.end() && pathsDeleteDecisionByParent->second) ||
+             (pathsDeleteDecisionByParent == pathsDeleteDecisions.end())))
+          strIds += m_pDS2->fv(0).get_asString() + ",";
+
+        m_pDS2->next();
+      }
+      m_pDS2->close();
+
+      if (!strIds.empty())
+      {
+        sql = PrepareSQL("DELETE FROM path WHERE idPath IN (%s)", StringUtils::TrimRight(strIds, ",").c_str());
+        m_pDS->exec(sql);
+        sql = "DELETE FROM tvshowlinkpath WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = tvshowlinkpath.idPath)";
+        m_pDS->exec(sql);
+      }
+
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning tvshow table", __FUNCTION__);
+
+      std::string tvshowsToDelete;
+      sql = "SELECT idShow FROM tvshow WHERE NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idShow = tvshow.idShow)";
+      m_pDS->query(sql);
+      while (!m_pDS->eof())
+      {
+        tvshowIDs.push_back(m_pDS->fv(0).get_asInt());
+        tvshowsToDelete += m_pDS->fv(0).get_asString() + ",";
+        m_pDS->next();
+      }
+      m_pDS->close();
+      if (!tvshowsToDelete.empty())
+      {
+        sql = "DELETE FROM tvshow WHERE idShow IN (" + StringUtils::TrimRight(tvshowsToDelete, ",") + ")";
+        m_pDS->exec(sql);
+      }
+
+      if (!musicVideoIDs.empty())
+      {
+        std::string musicVideosToDelete;
+        for (const auto &i : musicVideoIDs)
+          musicVideosToDelete += StringUtils::Format("{},", i);
+        musicVideosToDelete = "(" + StringUtils::TrimRight(musicVideosToDelete, ",") + ")";
+
+        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning musicvideo table", __FUNCTION__);
+        sql = "DELETE FROM musicvideo WHERE idMVideo IN " + musicVideosToDelete;
+        m_pDS->exec(sql);
+      }
+
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning path table", __FUNCTION__);
+      sql = StringUtils::Format(
+          "DELETE FROM path "
+          "WHERE (strContent IS NULL OR strContent = '') "
+          "AND (strSettings IS NULL OR strSettings = '') "
+          "AND (strHash IS NULL OR strHash = '') "
+          "AND (exclude IS NULL OR exclude != 1) "
+          "AND (idParentPath IS NULL OR NOT EXISTS (SELECT 1 FROM (SELECT idPath FROM path) as "
+          "parentPath WHERE parentPath.idPath = path.idParentPath)) " // MySQL only fix (#5007)
+          "AND NOT EXISTS (SELECT 1 FROM files WHERE files.idPath = path.idPath) "
+          "AND NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idPath = path.idPath) "
+          "AND NOT EXISTS (SELECT 1 FROM movie WHERE movie.c{:02} = path.idPath) "
+          "AND NOT EXISTS (SELECT 1 FROM episode WHERE episode.c{:02} = path.idPath) "
+          "AND NOT EXISTS (SELECT 1 FROM musicvideo WHERE musicvideo.c{:02} = path.idPath)",
+          VIDEODB_ID_PARENTPATHID, VIDEODB_ID_EPISODE_PARENTPATHID,
+          VIDEODB_ID_MUSICVIDEO_PARENTPATHID);
       m_pDS->exec(sql);
-      sql = "DELETE FROM tvshowlinkpath WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = tvshowlinkpath.idPath)";
+
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning genre table", __FUNCTION__);
+      sql = "DELETE FROM genre "
+              "WHERE NOT EXISTS (SELECT 1 FROM genre_link WHERE genre_link.genre_id = genre.genre_id)";
       m_pDS->exec(sql);
-    }
 
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning tvshow table", __FUNCTION__);
-
-    std::string tvshowsToDelete;
-    sql = "SELECT idShow FROM tvshow WHERE NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idShow = tvshow.idShow)";
-    m_pDS->query(sql);
-    while (!m_pDS->eof())
-    {
-      tvshowIDs.push_back(m_pDS->fv(0).get_asInt());
-      tvshowsToDelete += m_pDS->fv(0).get_asString() + ",";
-      m_pDS->next();
-    }
-    m_pDS->close();
-    if (!tvshowsToDelete.empty())
-    {
-      sql = "DELETE FROM tvshow WHERE idShow IN (" + StringUtils::TrimRight(tvshowsToDelete, ",") + ")";
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning country table", __FUNCTION__);
+      sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM country_link WHERE country_link.country_id = country.country_id)";
       m_pDS->exec(sql);
-    }
 
-    if (!musicVideoIDs.empty())
-    {
-      std::string musicVideosToDelete;
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning actor table of actors, directors and writers",
+                __FUNCTION__);
+      sql = "DELETE FROM actor "
+              "WHERE NOT EXISTS (SELECT 1 FROM actor_link WHERE actor_link.actor_id = actor.actor_id) "
+                "AND NOT EXISTS (SELECT 1 FROM director_link WHERE director_link.actor_id = actor.actor_id) "
+                "AND NOT EXISTS (SELECT 1 FROM writer_link WHERE writer_link.actor_id = actor.actor_id)";
+      m_pDS->exec(sql);
+
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning studio table", __FUNCTION__);
+      sql = "DELETE FROM studio "
+              "WHERE NOT EXISTS (SELECT 1 FROM studio_link WHERE studio_link.studio_id = studio.studio_id)";
+      m_pDS->exec(sql);
+
+      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning set table", __FUNCTION__);
+      sql = "DELETE FROM sets WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = sets.idSet)";
+      m_pDS->exec(sql);
+
+      CommitTransaction();
+
+      if (handle)
+        handle->SetTitle(g_localizeStrings.Get(331));
+
+      Compress(false);
+
+      CUtil::DeleteVideoDatabaseDirectoryCache();
+
+      auto end = std::chrono::steady_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+      CLog::Log(LOGINFO, "{}: Cleaning videodatabase done. Operation took {} ms", __FUNCTION__,
+                duration.count());
+
+      for (const auto &i : movieIDs)
+        AnnounceRemove(MediaTypeMovie, i, true);
+
+      for (const auto &i : episodeIDs)
+        AnnounceRemove(MediaTypeEpisode, i, true);
+
+      for (const auto &i : tvshowIDs)
+        AnnounceRemove(MediaTypeTvShow, i, true);
+
       for (const auto &i : musicVideoIDs)
-        musicVideosToDelete += StringUtils::Format("{},", i);
-      musicVideosToDelete = "(" + StringUtils::TrimRight(musicVideosToDelete, ",") + ")";
-
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning musicvideo table", __FUNCTION__);
-      sql = "DELETE FROM musicvideo WHERE idMVideo IN " + musicVideosToDelete;
-      m_pDS->exec(sql);
+        AnnounceRemove(MediaTypeMusicVideo, i, true);
     }
-
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning path table", __FUNCTION__);
-    sql = StringUtils::Format(
-        "DELETE FROM path "
-        "WHERE (strContent IS NULL OR strContent = '') "
-        "AND (strSettings IS NULL OR strSettings = '') "
-        "AND (strHash IS NULL OR strHash = '') "
-        "AND (exclude IS NULL OR exclude != 1) "
-        "AND (idParentPath IS NULL OR NOT EXISTS (SELECT 1 FROM (SELECT idPath FROM path) as "
-        "parentPath WHERE parentPath.idPath = path.idParentPath)) " // MySQL only fix (#5007)
-        "AND NOT EXISTS (SELECT 1 FROM files WHERE files.idPath = path.idPath) "
-        "AND NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idPath = path.idPath) "
-        "AND NOT EXISTS (SELECT 1 FROM movie WHERE movie.c{:02} = path.idPath) "
-        "AND NOT EXISTS (SELECT 1 FROM episode WHERE episode.c{:02} = path.idPath) "
-        "AND NOT EXISTS (SELECT 1 FROM musicvideo WHERE musicvideo.c{:02} = path.idPath)",
-        VIDEODB_ID_PARENTPATHID, VIDEODB_ID_EPISODE_PARENTPATHID,
-        VIDEODB_ID_MUSICVIDEO_PARENTPATHID);
-    m_pDS->exec(sql);
-
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning genre table", __FUNCTION__);
-    sql = "DELETE FROM genre "
-            "WHERE NOT EXISTS (SELECT 1 FROM genre_link WHERE genre_link.genre_id = genre.genre_id)";
-    m_pDS->exec(sql);
-
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning country table", __FUNCTION__);
-    sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM country_link WHERE country_link.country_id = country.country_id)";
-    m_pDS->exec(sql);
-
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning actor table of actors, directors and writers",
-              __FUNCTION__);
-    sql = "DELETE FROM actor "
-            "WHERE NOT EXISTS (SELECT 1 FROM actor_link WHERE actor_link.actor_id = actor.actor_id) "
-              "AND NOT EXISTS (SELECT 1 FROM director_link WHERE director_link.actor_id = actor.actor_id) "
-              "AND NOT EXISTS (SELECT 1 FROM writer_link WHERE writer_link.actor_id = actor.actor_id)";
-    m_pDS->exec(sql);
-
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning studio table", __FUNCTION__);
-    sql = "DELETE FROM studio "
-            "WHERE NOT EXISTS (SELECT 1 FROM studio_link WHERE studio_link.studio_id = studio.studio_id)";
-    m_pDS->exec(sql);
-
-    CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning set table", __FUNCTION__);
-    sql = "DELETE FROM sets WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = sets.idSet)";
-    m_pDS->exec(sql);
-
-    CommitTransaction();
-
-    if (handle)
-      handle->SetTitle(g_localizeStrings.Get(331));
-
-    Compress(false);
-
-    CUtil::DeleteVideoDatabaseDirectoryCache();
-
-    auto end = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-
-    CLog::Log(LOGINFO, "{}: Cleaning videodatabase done. Operation took {} ms", __FUNCTION__,
-              duration.count());
-
-    for (const auto &i : movieIDs)
-      AnnounceRemove(MediaTypeMovie, i, true);
-
-    for (const auto &i : episodeIDs)
-      AnnounceRemove(MediaTypeEpisode, i, true);
-
-    for (const auto &i : tvshowIDs)
-      AnnounceRemove(MediaTypeTvShow, i, true);
-
-    for (const auto &i : musicVideoIDs)
-      AnnounceRemove(MediaTypeMusicVideo, i, true);
   }
   catch (...)
   {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9244,9 +9244,11 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
   }
 }
 
-void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const std::set<int>& paths, bool showProgress)
+void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
+                                   const std::set<int>& paths,
+                                   bool showProgress)
 {
-  CGUIDialogProgress *progress=NULL;
+  CGUIDialogProgress* progress = NULL;
   try
   {
     if (nullptr == m_pDB)
@@ -9268,13 +9270,14 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     }
     else if (showProgress)
     {
-      progress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+      progress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(
+          WINDOW_DIALOG_PROGRESS);
       if (progress)
       {
-        progress->SetHeading(CVariant{ 700 });
-        progress->SetLine(0, CVariant{ "" });
-        progress->SetLine(1, CVariant{ 313 });
-        progress->SetLine(2, CVariant{ 330 });
+        progress->SetHeading(CVariant{700});
+        progress->SetLine(0, CVariant{""});
+        progress->SetLine(1, CVariant{313});
+        progress->SetLine(2, CVariant{330});
         progress->SetPercentage(0);
         progress->Open();
         progress->ShowProgressBar(true);
@@ -9284,11 +9287,12 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     BeginTransaction();
 
     // find all the files
-    std::string sql = "SELECT files.idFile, files.strFileName, path.strPath FROM files INNER JOIN path ON path.idPath=files.idPath";
+    std::string sql = "SELECT files.idFile, files.strFileName, path.strPath FROM files "
+                      "INNER JOIN path ON path.idPath=files.idPath";
     if (!paths.empty())
     {
       std::string strPaths;
-      for (const auto &i : paths)
+      for (const auto& i : paths)
         strPaths += StringUtils::Format(",{}", i);
       sql += PrepareSQL(" AND path.idPath IN (%s)", strPaths.substr(1).c_str());
     }
@@ -9329,7 +9333,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
           SScanSettings settings;
           bool foundDirectly = false;
           ScraperPtr scraper = GetScraperForPath(fullPath, settings, foundDirectly);
-          if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), fullPath))
+          if (scraper &&
+              CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), fullPath))
             del = false;
         }
         else
@@ -9346,8 +9351,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
             {
               lastDir = pathDir;
               CFileItemList items; // Dummy list
-              gotDir = CDirectory::GetDirectory(pathDir, items, "", DIR_FLAG_NO_FILE_DIRS |
-                                                DIR_FLAG_NO_FILE_INFO);
+              gotDir = CDirectory::GetDirectory(pathDir, items, "",
+                                                DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
             }
 
             // Keep existing files
@@ -9386,7 +9391,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       std::string filesToDelete;
 
       // Add any files that don't have a valid idPath entry to the filesToDelete list.
-      m_pDS->query("SELECT files.idFile FROM files WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = files.idPath)");
+      m_pDS->query("SELECT files.idFile FROM files WHERE NOT EXISTS (SELECT 1 FROM path "
+                   "WHERE path.idPath = files.idPath)");
       while (!m_pDS->eof())
       {
         std::string file = m_pDS->fv("files.idFile").get_asString() + ",";
@@ -9407,9 +9413,12 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       {
         StringUtils::TrimRight(filesToTestForDelete, ",");
 
-        movieIDs = CleanMediaType(MediaTypeMovie, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-        episodeIDs = CleanMediaType(MediaTypeEpisode, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-        musicVideoIDs = CleanMediaType(MediaTypeMusicVideo, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
+        movieIDs = CleanMediaType(MediaTypeMovie, filesToTestForDelete, pathsDeleteDecisions,
+                                  filesToDelete, !showProgress);
+        episodeIDs = CleanMediaType(MediaTypeEpisode, filesToTestForDelete, pathsDeleteDecisions,
+                                    filesToDelete, !showProgress);
+        musicVideoIDs = CleanMediaType(MediaTypeMusicVideo, filesToTestForDelete,
+                                       pathsDeleteDecisions, filesToDelete, !showProgress);
       }
 
       if (progress != NULL)
@@ -9427,7 +9436,9 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
         // database, leading to potentially missed items on re-scan (if deleted files are
         // later re-added to a source)
         CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning path hashes");
-        m_pDS->query("SELECT DISTINCT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile IN " + filesToDelete);
+        m_pDS->query("SELECT DISTINCT strPath FROM path JOIN files ON files.idPath=path.idPath "
+                     "WHERE files.idFile IN " +
+                     filesToDelete);
         int pathHashCount = m_pDS->num_rows();
         while (!m_pDS->eof())
         {
@@ -9444,7 +9455,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       if (!movieIDs.empty())
       {
         std::string moviesToDelete;
-        for (const auto &i : movieIDs)
+        for (const auto& i : movieIDs)
           moviesToDelete += StringUtils::Format("{},", i);
         moviesToDelete = "(" + StringUtils::TrimRight(moviesToDelete, ",") + ")";
 
@@ -9456,7 +9467,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       if (!episodeIDs.empty())
       {
         std::string episodesToDelete;
-        for (const auto &i : episodeIDs)
+        for (const auto& i : episodeIDs)
           episodesToDelete += StringUtils::Format("{},", i);
         episodesToDelete = "(" + StringUtils::TrimRight(episodesToDelete, ",") + ")";
 
@@ -9465,13 +9476,13 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
         m_pDS->exec(sql);
       }
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning paths that don't exist and have content set...",
-                __FUNCTION__);
+      CLog::Log(LOGDEBUG, LOGDATABASE,
+                "{}: Cleaning paths that don't exist and have content set...", __FUNCTION__);
       sql = "SELECT path.idPath, path.strPath, path.idParentPath FROM path "
-              "WHERE NOT ((strContent IS NULL OR strContent = '') "
-                     "AND (strSettings IS NULL OR strSettings = '') "
-                     "AND (strHash IS NULL OR strHash = '') "
-                     "AND (exclude IS NULL OR exclude != 1))";
+            "WHERE NOT ((strContent IS NULL OR strContent = '') "
+            "AND (strSettings IS NULL OR strSettings = '') "
+            "AND (strHash IS NULL OR strHash = '') "
+            "AND (exclude IS NULL OR exclude != 1))";
       m_pDS2->query(sql);
       std::string strIds;
       while (!m_pDS2->eof())
@@ -9495,7 +9506,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
         if (((pathsDeleteDecision != pathsDeleteDecisions.end() && pathsDeleteDecision->second) ||
              (pathsDeleteDecision == pathsDeleteDecisions.end() && !exists)) &&
-            ((pathsDeleteDecisionByParent != pathsDeleteDecisions.end() && pathsDeleteDecisionByParent->second) ||
+            ((pathsDeleteDecisionByParent != pathsDeleteDecisions.end() &&
+              pathsDeleteDecisionByParent->second) ||
              (pathsDeleteDecisionByParent == pathsDeleteDecisions.end())))
           strIds += m_pDS2->fv(0).get_asString() + ",";
 
@@ -9505,16 +9517,20 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
       if (!strIds.empty())
       {
-        sql = PrepareSQL("DELETE FROM path WHERE idPath IN (%s)", StringUtils::TrimRight(strIds, ",").c_str());
+        sql = PrepareSQL("DELETE FROM path WHERE idPath IN (%s)",
+                         StringUtils::TrimRight(strIds, ",").c_str());
         m_pDS->exec(sql);
-        sql = "DELETE FROM tvshowlinkpath WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = tvshowlinkpath.idPath)";
+        sql = "DELETE FROM tvshowlinkpath "
+              "WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = tvshowlinkpath.idPath)";
         m_pDS->exec(sql);
       }
 
       CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning tvshow table", __FUNCTION__);
 
       std::string tvshowsToDelete;
-      sql = "SELECT idShow FROM tvshow WHERE NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idShow = tvshow.idShow)";
+      sql = "SELECT idShow FROM tvshow "
+            "WHERE NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idShow = "
+            "tvshow.idShow)";
       m_pDS->query(sql);
       while (!m_pDS->eof())
       {
@@ -9525,14 +9541,15 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       m_pDS->close();
       if (!tvshowsToDelete.empty())
       {
-        sql = "DELETE FROM tvshow WHERE idShow IN (" + StringUtils::TrimRight(tvshowsToDelete, ",") + ")";
+        sql = "DELETE FROM tvshow WHERE idShow IN (" +
+              StringUtils::TrimRight(tvshowsToDelete, ",") + ")";
         m_pDS->exec(sql);
       }
 
       if (!musicVideoIDs.empty())
       {
         std::string musicVideosToDelete;
-        for (const auto &i : musicVideoIDs)
+        for (const auto& i : musicVideoIDs)
           musicVideosToDelete += StringUtils::Format("{},", i);
         musicVideosToDelete = "(" + StringUtils::TrimRight(musicVideosToDelete, ",") + ")";
 
@@ -9560,29 +9577,35 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       m_pDS->exec(sql);
 
       CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning genre table", __FUNCTION__);
-      sql = "DELETE FROM genre "
-              "WHERE NOT EXISTS (SELECT 1 FROM genre_link WHERE genre_link.genre_id = genre.genre_id)";
+      sql =
+          "DELETE FROM genre "
+          "WHERE NOT EXISTS (SELECT 1 FROM genre_link WHERE genre_link.genre_id = genre.genre_id)";
       m_pDS->exec(sql);
 
       CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning country table", __FUNCTION__);
-      sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM country_link WHERE country_link.country_id = country.country_id)";
+      sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM country_link WHERE "
+            "country_link.country_id = country.country_id)";
       m_pDS->exec(sql);
 
       CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning actor table of actors, directors and writers",
                 __FUNCTION__);
-      sql = "DELETE FROM actor "
-              "WHERE NOT EXISTS (SELECT 1 FROM actor_link WHERE actor_link.actor_id = actor.actor_id) "
-                "AND NOT EXISTS (SELECT 1 FROM director_link WHERE director_link.actor_id = actor.actor_id) "
-                "AND NOT EXISTS (SELECT 1 FROM writer_link WHERE writer_link.actor_id = actor.actor_id)";
+      sql =
+          "DELETE FROM actor "
+          "WHERE NOT EXISTS (SELECT 1 FROM actor_link WHERE actor_link.actor_id = actor.actor_id) "
+          "AND NOT EXISTS (SELECT 1 FROM director_link WHERE director_link.actor_id = "
+          "actor.actor_id) "
+          "AND NOT EXISTS (SELECT 1 FROM writer_link WHERE writer_link.actor_id = actor.actor_id)";
       m_pDS->exec(sql);
 
       CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning studio table", __FUNCTION__);
       sql = "DELETE FROM studio "
-              "WHERE NOT EXISTS (SELECT 1 FROM studio_link WHERE studio_link.studio_id = studio.studio_id)";
+            "WHERE NOT EXISTS (SELECT 1 FROM studio_link WHERE studio_link.studio_id = "
+            "studio.studio_id)";
       m_pDS->exec(sql);
 
       CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning set table", __FUNCTION__);
-      sql = "DELETE FROM sets WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = sets.idSet)";
+      sql = "DELETE FROM sets "
+            "WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = sets.idSet)";
       m_pDS->exec(sql);
 
       CommitTransaction();
@@ -9600,16 +9623,16 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       CLog::Log(LOGINFO, "{}: Cleaning videodatabase done. Operation took {} ms", __FUNCTION__,
                 duration.count());
 
-      for (const auto &i : movieIDs)
+      for (const auto& i : movieIDs)
         AnnounceRemove(MediaTypeMovie, i, true);
 
-      for (const auto &i : episodeIDs)
+      for (const auto& i : episodeIDs)
         AnnounceRemove(MediaTypeEpisode, i, true);
 
-      for (const auto &i : tvshowIDs)
+      for (const auto& i : tvshowIDs)
         AnnounceRemove(MediaTypeTvShow, i, true);
 
-      for (const auto &i : musicVideoIDs)
+      for (const auto& i : musicVideoIDs)
         AnnounceRemove(MediaTypeMusicVideo, i, true);
     }
   }

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -122,7 +122,7 @@ void CVideoLibraryQueue::RefreshItem(CFileItemPtr item, bool ignoreNfo /* = fals
 
 bool CVideoLibraryQueue::RefreshItemModal(CFileItemPtr item, bool forceRefresh /* = true */, bool refreshAll /* = false */)
 {
-  // we can't perform a modal library cleaning if other jobs are running
+  // we can't perform a modal item refresh if other jobs are running
   if (IsRunning())
     return false;
 

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -80,7 +80,9 @@ void CVideoLibraryQueue::StopLibraryScanning()
   Refresh();
 }
 
-void CVideoLibraryQueue::CleanLibrary(const std::set<int>& paths /* = std::set<int>() */, bool asynchronous /* = true */, CGUIDialogProgressBarHandle* progressBar /* = NULL */)
+bool CVideoLibraryQueue::CleanLibrary(const std::set<int>& paths /* = std::set<int>() */,
+                                      bool asynchronous /* = true */,
+                                      CGUIDialogProgressBarHandle* progressBar /* = NULL */)
 {
   CVideoLibraryCleaningJob* cleaningJob = new CVideoLibraryCleaningJob(paths, progressBar);
 
@@ -90,7 +92,7 @@ void CVideoLibraryQueue::CleanLibrary(const std::set<int>& paths /* = std::set<i
   {
     // we can't perform a modal library cleaning if other jobs are running
     if (IsRunning())
-      return;
+      return false;
 
     m_modal = true;
     m_cleaning = true;
@@ -101,13 +103,15 @@ void CVideoLibraryQueue::CleanLibrary(const std::set<int>& paths /* = std::set<i
     m_modal = false;
     Refresh();
   }
+
+  return true;
 }
 
-void CVideoLibraryQueue::CleanLibraryModal(const std::set<int>& paths /* = std::set<int>() */)
+bool CVideoLibraryQueue::CleanLibraryModal(const std::set<int>& paths /* = std::set<int>() */)
 {
   // we can't perform a modal library cleaning if other jobs are running
   if (IsRunning())
-    return;
+    return false;
 
   m_modal = true;
   m_cleaning = true;
@@ -116,6 +120,8 @@ void CVideoLibraryQueue::CleanLibraryModal(const std::set<int>& paths /* = std::
   m_cleaning = false;
   m_modal = false;
   Refresh();
+
+  return true;
 }
 
 void CVideoLibraryQueue::RefreshItem(CFileItemPtr item, bool ignoreNfo /* = false */, bool forceRefresh /* = true */, bool refreshAll /* = false */, const std::string& searchTitle /* = "" */)

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -88,6 +88,10 @@ void CVideoLibraryQueue::CleanLibrary(const std::set<int>& paths /* = std::set<i
     AddJob(cleaningJob);
   else
   {
+    // we can't perform a modal library cleaning if other jobs are running
+    if (IsRunning())
+      return;
+
     m_modal = true;
     m_cleaning = true;
     cleaningJob->DoWork();

--- a/xbmc/video/VideoLibraryQueue.h
+++ b/xbmc/video/VideoLibraryQueue.h
@@ -61,15 +61,19 @@ public:
    \param[in] paths Set with database IDs of paths to be cleaned
    \param[in] asynchronous Run the clean job asynchronously. Defaults to true
    \param[in] progressBar Progress bar to update in GUI. Defaults to NULL (no progress bar to update)
+   \return True if the video library cleaning job has started, false otherwise
    */
-  void CleanLibrary(const std::set<int>& paths = std::set<int>(), bool asynchronous = true, CGUIDialogProgressBarHandle* progressBar = NULL);
+  bool CleanLibrary(const std::set<int>& paths = std::set<int>(),
+                    bool asynchronous = true,
+                    CGUIDialogProgressBarHandle* progressBar = NULL);
 
   /*!
   \brief Executes a library cleaning with a modal dialog.
 
   \param[in] paths Set with database IDs of paths to be cleaned
+  \return True if the video library cleaning job has started, false otherwise
   */
-  void CleanLibraryModal(const std::set<int>& paths = std::set<int>());
+  bool CleanLibraryModal(const std::set<int>& paths = std::set<int>());
 
   /*!
    \brief Enqueues a job to refresh the details of the given item.


### PR DESCRIPTION
## Description
This PR contains some commits from my media import work which are related to (mainly video) library cleaning. The two main changes are:
* Show the progress dialog in `CVideoDatabase::CleanDatabase()` before retrieving the list of potential files to be cleaned. On small libraries the current implementation is not an issue because the first query will be fast but on large libraries the UI simply freezes without showing anything until the first query finishes. Showing the progress dialog before doing the query will improve the UI / UX. In case there's nothing to clean the dialog will simply close again.
* Show an error dialog in case the user tries to clean a (video or music) library while a background task / job (e.g. updating the library) is running. Right now if the user clicks on the button to start the process nothing happens at all.

There are some additional commits which mainly clean up related code I came across while making the above changes:
* clang-format `CVideoDatabase::CleanDatabase()`
* fix bad comments
* removed the unused method `CMusicLibraryQueue::CleanLibraryModal()`

## How has this been tested?
Manually with a large video library.

## What is the effect on users?
* Improve the user experience when cleaning large video libraries.
* Improve the user experience when trying to clean the video or music library while updating said library in the background.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed