### PR TITLE
[Settings] Add an option to show or hide the splash image

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7313,7 +7313,16 @@ msgctxt "#13457"
 msgid "Prefer VAAPI render method"
 msgstr ""
 
-#empty strings from id 13458 to 13459
+#: system/settings/settings.xml
+msgctxt "#13458"
+msgid "Show splash image"
+msgstr ""
+
+#. Description of setting with label #13458 "Show splash image"
+#: system/settings/settings.xml
+msgctxt "#13459"
+msgid "Show or hide the splash image on startup"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13460"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3997,6 +3997,16 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="lookandfeel.showsplash" type="boolean" label="13458" help="13459">
+          <dependencies>
+            <dependency type="visible">
+              <condition on="property" name="isSplashEnabled" />
+            </dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
     <category id="window" label="0" help="36135">

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUIImage.h"
 #include "guilib/GUILabelControl.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 
 CRenderSystemBase::CRenderSystemBase()
@@ -57,7 +58,10 @@ bool CRenderSystemBase::SupportsStereo(RENDER_STEREO_MODE mode) const
 
 void CRenderSystemBase::ShowSplash(const std::string& message)
 {
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_splashImage && !(m_splashImage || !message.empty()))
+  if ((!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_splashImage ||
+       !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+           CSettings::SETTING_LOOKANDFEEL_SHOWSPLASH)) &&
+      !(m_splashImage || !message.empty()))
     return;
 
   if (!m_splashImage)

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -24,6 +24,7 @@
 #endif
 #include "peripherals/Peripherals.h"
 #include "profiles/ProfileManager.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/SettingAddon.h"
 #include "settings/SettingsComponent.h"
 #include "utils/FontUtils.h"
@@ -257,6 +258,14 @@ bool ProfileLockMode(const std::string& condition,
   return CSettingConditions::GetCurrentProfile().getLockMode() == lock;
 }
 
+bool IsSplashEnabled(const std::string& condition,
+                     const std::string& value,
+                     const SettingConstPtr& setting,
+                     void* data)
+{
+  return CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_splashImage;
+}
+
 bool GreaterThan(const std::string& condition,
                  const std::string& value,
                  const SettingConstPtr& setting,
@@ -455,6 +464,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("gte",                           GreaterThanOrEqual));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("lt",                            LessThan));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("lte",                           LessThanOrEqual));
+  m_complexConditions.emplace("isSplashEnabled", IsSplashEnabled);
 }
 
 void CSettingConditions::Deinitialize()

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -76,6 +76,7 @@ constexpr const char* CSettings::SETTING_LOOKANDFEEL_SOUNDSKIN;
 constexpr const char* CSettings::SETTING_LOOKANDFEEL_ENABLERSSFEEDS;
 constexpr const char* CSettings::SETTING_LOOKANDFEEL_RSSEDIT;
 constexpr const char* CSettings::SETTING_LOOKANDFEEL_STEREOSTRENGTH;
+constexpr const char* CSettings::SETTING_LOOKANDFEEL_SHOWSPLASH;
 constexpr const char* CSettings::SETTING_LOCALE_LANGUAGE;
 constexpr const char* CSettings::SETTING_LOCALE_COUNTRY;
 constexpr const char* CSettings::SETTING_LOCALE_CHARSET;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -40,6 +40,7 @@ public:
   static constexpr auto SETTING_LOOKANDFEEL_ENABLERSSFEEDS = "lookandfeel.enablerssfeeds";
   static constexpr auto SETTING_LOOKANDFEEL_RSSEDIT = "lookandfeel.rssedit";
   static constexpr auto SETTING_LOOKANDFEEL_STEREOSTRENGTH = "lookandfeel.stereostrength";
+  static constexpr auto SETTING_LOOKANDFEEL_SHOWSPLASH = "lookandfeel.showsplash";
   static constexpr auto SETTING_LOCALE_LANGUAGE = "locale.language";
   static constexpr auto SETTING_LOCALE_COUNTRY = "locale.country";
   static constexpr auto SETTING_LOCALE_CHARSET = "locale.charset";


### PR DESCRIPTION
## Description
This PR adds an option in settings that allows to show or hide the splash image at boot time.
By default it's enabled.

## Motivation
I like the splash image but sometimes I prefer to hide it for a while.
With this option I avoid editing ```advancedsettings.xml``` each time, especially on Android TV.

## How has this been tested?
Tested on Android TV 9

## Screenshots
![splash](https://user-images.githubusercontent.com/76552691/172178940-1971603d-ed42-46d7-831b-3eb549bacd45.png)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
