### PR TITLE
[PVR] Add home menu actions for Radio and TV

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -911,3 +911,15 @@ msgstr ""
 msgctxt "#31611"
 msgid "System"
 msgstr ""
+
+#: /xml/SkinSettings.xml
+#. Label to show TV menu action
+msgctxt "#31612"
+msgid "Choose action on TV menu selection"
+msgstr ""
+
+#: /xml/SkinSettings.xml
+#. Label to show Radio menu action
+msgctxt "#31613"
+msgid "Choose action on radio menu selection"
+msgstr ""

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -949,7 +949,10 @@
 						<item>
 							<label>$LOCALIZE[19020]</label>
 							<property name="menu_id">$NUMBER[12000]</property>
-							<onclick>ActivateWindow(TVGuide)</onclick>
+							<onclick condition="String.IsEmpty(Skin.String(pvr_tv_action))">ActivateWindow(TVGuide)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(pvr_tv_action),0)">ActivateWindow(TVGuide)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(pvr_tv_action),1)">ActivateWindow(TVChannels)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(pvr_tv_action),2)">ActivateWindow(TVRecordings)</onclick>
 							<thumb>icons/sidemenu/livetv.png</thumb>
 							<property name="id">livetv</property>
 							<visible>!Skin.HasSetting(HomeMenuNoTVButton)</visible>
@@ -957,7 +960,10 @@
 						<item>
 							<label>$LOCALIZE[19021]</label>
 							<property name="menu_id">$NUMBER[13000]</property>
-							<onclick>ActivateWindow(RadioGuide)</onclick>
+							<onclick condition="String.IsEmpty(Skin.String(pvr_radio_action))">ActivateWindow(RadioGuide)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(pvr_radio_action),0)">ActivateWindow(RadioGuide)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(pvr_radio_action),1)">ActivateWindow(RadioChannels)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(pvr_radio_action),2)">ActivateWindow(RadioRecordings)</onclick>
 							<thumb>icons/sidemenu/radio.png</thumb>
 							<property name="id">radio</property>
 							<visible>!Skin.HasSetting(HomeMenuNoRadioButton)</visible>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -207,11 +207,31 @@
 					<selected>!Skin.HasSetting(HomeMenuNoTVButton)</selected>
 					<onclick>Skin.ToggleSetting(HomeMenuNoTVButton)</onclick>
 				</control>
+				<control type="button" id="625">
+					<label>- $LOCALIZE[31612]</label>
+					<label2>$VAR[PVRTVMenuActionVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(pvr_tv_action))">Skin.SetString(pvr_tv_action,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_tv_action),2)">Skin.SetString(pvr_tv_action,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_tv_action),1)">Skin.SetString(pvr_tv_action,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_tv_action),0)">Skin.SetString(pvr_tv_action,1)</onclick>
+					<enable>!Skin.HasSetting(HomeMenuNoTVButton)</enable>
+				</control>
 				<control type="radiobutton" id="619">
 					<label>$LOCALIZE[19021]</label>
 					<include>DefaultSettingButton</include>
 					<selected>!Skin.HasSetting(HomeMenuNoRadioButton)</selected>
 					<onclick>Skin.ToggleSetting(HomeMenuNoRadioButton)</onclick>
+				</control>
+				<control type="button" id="626">
+					<label>- $LOCALIZE[31613]</label>
+					<label2>$VAR[PVRRadioMenuActionVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(pvr_radio_action))">Skin.SetString(pvr_radio_action,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_radio_action),2)">Skin.SetString(pvr_radio_action,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_radio_action),1)">Skin.SetString(pvr_radio_action,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_radio_action),0)">Skin.SetString(pvr_radio_action,1)</onclick>
+					<enable>!Skin.HasSetting(HomeMenuNoRadioButton)</enable>
 				</control>
 				<control type="radiobutton" id="614">
 					<label>$LOCALIZE[24001]</label>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -606,4 +606,16 @@
 		<value condition="VideoPlayer.SubtitlesEnabled">[B]$INFO[VideoPlayer.SubtitlesLanguage][/B]</value>
 		<value>[B]$LOCALIZE[1223][/B]</value>
 	</variable>
+	<variable name="PVRTVMenuActionVar">
+		<value condition="String.IsEmpty(Skin.String(pvr_tv_action))">$LOCALIZE[19069]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_tv_action),0)">$LOCALIZE[19069]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_tv_action),1)">$LOCALIZE[19019]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_tv_action),2)">$LOCALIZE[19017]</value>
+	</variable>
+	<variable name="PVRRadioMenuActionVar">
+		<value condition="String.IsEmpty(Skin.String(pvr_radio_action))">$LOCALIZE[19069]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_radio_action),0)">$LOCALIZE[19069]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_radio_action),1)">$LOCALIZE[19019]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_radio_action),2)">$LOCALIZE[19017]</value>
+	</variable>
 </includes>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Allow user to choose the action on the Home menu when Radio or TV are selected.  This allows one click opening of the Guide (default) Channels or Recordings.  Recordings are added since some users don't use Live TV.

Settings can be saved in the Estuary menu action settings under TV and Radio.  Default is Guide, which is current default action

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Some uses prefer quick selection of the channels view for PVR.  Some of this could be resistance to change but the channel list can al be easier to read at a glance because text is left aligned, not truncated and not obscured by the current timeline highlighting and bar.   Display of channel icons and full channel name can be important for some.

Users who primarily use recordings can also benefit. 

<!--- If it fixes an open issue, please link to the issue here. -->
Not an issue but some users don't like the order change for Nexus https://forum.kodi.tv/showthread.php?tid=367895 This keeps the order and still provides one click access.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
Tested on current master branch of Nexus.
<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
Tested skin only since code wasn't changed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
Users have more control over PVR actions.  Users who don't use Live TV can access their recordings faster.  Closes to Matrix and earlier functionality.
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
One error I could not understand is how to initialize a new persisted skin setting variable.  Review might clarify how to to this more effectively.
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [] **Improvement** (non-breaking change which improves existing functionality)
- [x ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
Unsure, I am not sure of skin coding style.
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ x] All new and existing tests passed
