### PR TITLE
[dvdnav] remove references to unused dvdnav_time_search

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1170,7 +1170,7 @@ bool CDVDInputStreamNavigator::PosTime(int iTimeInMsec)
 {
   if( m_dll.dvdnav_jump_to_sector_by_time(m_dvdnav, iTimeInMsec * 90, 0) == DVDNAV_STATUS_ERR )
   {
-    CLog::Log(LOGDEBUG, "dvdnav: dvdnav_time_search failed( {} )",
+    CLog::Log(LOGDEBUG, "dvdnav: dvdnav_jump_to_sector_by_time failed( {} )",
               m_dll.dvdnav_err_to_string(m_dvdnav));
     return false;
   }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
@@ -82,7 +82,6 @@ public:
   virtual dvdnav_status_t dvdnav_part_play(dvdnav_t *self, int32_t title, int32_t part)=0;
   virtual dvdnav_status_t dvdnav_get_audio_attr(dvdnav_t * self, int32_t streamid, audio_attr_t* audio_attributes)=0;
   virtual dvdnav_status_t dvdnav_get_spu_attr(dvdnav_t * self, int32_t streamid, subp_attr_t* stitle_attributes)=0;
-  virtual dvdnav_status_t dvdnav_time_search(dvdnav_t * self, uint64_t timepos)=0;
   virtual dvdnav_status_t dvdnav_jump_to_sector_by_time(dvdnav_t* self,
                                                         uint64_t offset,
                                                         int32_t origin) = 0;
@@ -166,7 +165,6 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_part_play, (dvdnav_t *p1, int32_t p2, int32_t p3))
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_get_audio_attr, (dvdnav_t * p1, int32_t p2, audio_attr_t* p3))
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_get_spu_attr, (dvdnav_t * p1, int32_t p2, subp_attr_t* p3))
-  DEFINE_METHOD2(dvdnav_status_t, dvdnav_time_search, (dvdnav_t * p1, uint64_t p2))
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_jump_to_sector_by_time, (dvdnav_t * p1, uint64_t p2, int32_t p3))
   DEFINE_METHOD1(int64_t, dvdnav_convert_time, (dvd_time_t *p1))
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_get_angle_info, (dvdnav_t *p1, int32_t *p2,int32_t *p3))
@@ -239,7 +237,6 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
     RESOLVE_METHOD(dvdnav_part_play)
     RESOLVE_METHOD(dvdnav_get_audio_attr)
     RESOLVE_METHOD(dvdnav_get_spu_attr)
-    RESOLVE_METHOD(dvdnav_time_search)
     RESOLVE_METHOD(dvdnav_jump_to_sector_by_time)
     RESOLVE_METHOD(dvdnav_convert_time)
     RESOLVE_METHOD(dvdnav_get_angle_info)


### PR DESCRIPTION
## Description

`dvdnav_time_search` is documented as somehow broken:

```
/*
 * Stop playing the current position and start playback of the title
 * from the specified timecode.
 *
 * Currently implemented using interpolation. That interpolation is slightly
 * inaccurate.
 */
```

```
/* FIXME: right now, this function does not use the time tables but interpolates
   only the cell times */
```

It seems that in the past XBMC used to rely on this function before moving to `dvdnav_jump_to_sector_by_time`. This confused me while bringing some of our patches upstream so let's just remove the availability from the dll wrapper and fix the log line.
Not really related to this PR but we can safely drop another 3 patches from dvdnav.