### PR TITLE
Use EAC3 for Android Audiotrack passthrough if AC3 is not supported.

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -79,6 +79,7 @@ private:
   static std::set<unsigned int>       m_sink_sampleRates;
   static bool m_sinkSupportsFloat;
   static bool m_sinkSupportsMultiChannelFloat;
+  static bool m_passthrough_use_eac3;
 
   AEAudioFormat      m_format;
   int16_t           *m_alignedS16;


### PR DESCRIPTION
## Description
This change will use EAC3 for Android Audiotrack passthrough if the device does not support regular AC3.

## Motivation and context
Some Android TV devices (including my TCL 55S434) report EAC3 support, but not regular AC3 support. Attempting to send an AC3 stream results in an error. This means that no regular AC3 content can be played on these devices, and transcoding other formats (such as DTS) also does not work.

The change will set the transcode format to EAC3 if AC3 is not supported. Because EAC3 is format backward compatible with AC3, no changes to the actual stream are required.

I have tried to keep the changes as localized as possible. They should only impact Android Audiotrack, and only in the case where EAC3 passthrough is available but AC3 is not.

## How has this been tested?
Building locally, and testing on a TCL 55S434. AC3 playing and transcoding of DTS content were verified to be working after the change.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
