### PR TITLE
[Subtitles][WevVTT] Sync cue timestamps with period start

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.cpp
@@ -38,3 +38,28 @@ void CDVDOverlayCodec::GetAbsoluteTimes(double& starttime, double& stoptime, Dem
   else
     stoptime = 0;
 }
+
+bool CDVDOverlayCodec::GetSubtitlePacketExtraData(DemuxPacket* pPacket,
+                                                  SubtitlePacketExtraData& extraData)
+{
+  if (!pPacket->pSideData)
+    return false;
+
+  AVPacketSideData* sideData{reinterpret_cast<AVPacketSideData*>(pPacket->pSideData)};
+
+  for (int i{0}; i < pPacket->iSideDataElems; i++)
+  {
+    AVPacketSideData* sd = &sideData[i];
+
+    if (sd->type != AV_PKT_DATA_NEW_EXTRADATA)
+      continue;
+
+    if (sd->data && sd->size > 0)
+    {
+      extraData = *reinterpret_cast<SubtitlePacketExtraData*>(sd->data);
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
@@ -89,6 +89,18 @@ protected:
    */
   static void GetAbsoluteTimes(double& starttime, double& stoptime, DemuxPacket* pkt);
 
+  struct SubtitlePacketExtraData
+  {
+    double m_chapterStartTime;
+  };
+
+  /*!
+   * \brief Get subtitle extra data from packet side data with AV_PKT_DATA_NEW_EXTRADATA type.
+   * \param pPacket The demux packet
+   * \param extraData [OUT] The subtitle extra data
+   * \return True if extra data has been found, otherwise false
+   */
+  static bool GetSubtitlePacketExtraData(DemuxPacket* pPacket, SubtitlePacketExtraData& extraData);
 
 private:
   std::string m_codecName;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -78,6 +78,12 @@ OverlayMessage COverlayCodecWebVTT::Decode(DemuxPacket* pPacket)
   const char* data = reinterpret_cast<const char*>(pPacket->pData);
   std::vector<subtitleData> subtitleList;
 
+  SubtitlePacketExtraData sideData;
+  if (GetSubtitlePacketExtraData(pPacket, sideData))
+  {
+    m_webvttHandler.SetPeriodStart(sideData.m_chapterStartTime);
+  }
+
   if (m_isISOFormat)
   {
     double prevSubStopTime = 0.0;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -146,6 +146,11 @@ public:
    */
   bool IsForcedMargins() const { return !m_overridePositions; }
 
+  /*
+   * \brief Set the period start pts to sync subtitles
+   */
+  void SetPeriodStart(double pts) { m_offset = pts; }
+
 protected:
   void CalculateTextPosition(std::string& subtitleText);
   void ConvertSubtitle(std::string& text);
@@ -191,4 +196,5 @@ private:
   std::vector<webvttCssStyle> m_cueCssStyles;
   bool m_CSSColorsLoaded{false};
   std::vector<std::pair<std::string, UTILS::COLOR::ColorInfo>> m_CSSColors;
+  double m_offset;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
To sync subtitle text with the video with segmented WebVTT
we need to add an offset to each webvtt cue start/stop timestamps

so the sync is done by adding the period start pts (current chapter pos) and by taking in account of X-TIMESTAMP-MAP
an example is in shaka player:
https://github.com/shaka-project/shaka-player/blob/main/lib/text/vtt_text_parser.js#L73
https://github.com/shaka-project/shaka-player/blob/main/lib/text/vtt_text_parser.js#L114

~This PR is WIP but working for testing,
since i am totally unsure in what is the better implementation approach
i need someone say to me if the current PR approach can go well and can be completed
please let me know the best way~

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
synchronisation problems have been reported to inpoutStream adaptive:
https://github.com/xbmc/inputstream.adaptive/issues/993

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This can be tested with Disn@y+ or with HSL videos having segmented WebVTT and multiple periods
by using PR: https://github.com/xbmc/inputstream.adaptive/pull/1014

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
keep subtitles in sync with video

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
