### PR TITLE
[dvdnav] Do not use no longer exposed headers

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -36,6 +36,30 @@ constexpr int HOLDMODE_HELD = 1;
 constexpr int HOLDMODE_SKIP = 2;
 /* set after hold mode has been exited, and action that inited it has been executed */
 constexpr int HOLDMODE_DATA = 3;
+
+// DVD Subpicture types
+constexpr int DVD_SUBPICTURE_TYPE_NOTSPECIFIED = 0;
+constexpr int DVD_SUBPICTURE_TYPE_LANGUAGE = 1;
+
+// DVD Subpicture language extensions
+constexpr int DVD_SUBPICTURE_LANG_EXT_NOTSPECIFIED = 0;
+constexpr int DVD_SUBPICTURE_LANG_EXT_NORMALCAPTIONS = 1;
+constexpr int DVD_SUBPICTURE_LANG_EXT_BIGCAPTIONS = 2;
+constexpr int DVD_SUBPICTURE_LANG_EXT_CHILDRENSCAPTIONS = 3;
+constexpr int DVD_SUBPICTURE_LANG_EXT_NORMALCC = 5;
+constexpr int DVD_SUBPICTURE_LANG_EXT_BIGCC = 6;
+constexpr int DVD_SUBPICTURE_LANG_EXT_CHILDRENSCC = 7;
+constexpr int DVD_SUBPICTURE_LANG_EXT_FORCED = 9;
+constexpr int DVD_SUBPICTURE_LANG_EXT_NORMALDIRECTORSCOMMENTS = 13;
+constexpr int DVD_SUBPICTURE_LANG_EXT_BIGDIRECTORSCOMMENTS = 14;
+constexpr int DVD_SUBPICTURE_LANG_EXT_CHILDRENDIRECTORSCOMMENTS = 15;
+
+// DVD Audio language extensions
+constexpr int DVD_AUDIO_LANG_EXT_NOTSPECIFIED = 0;
+constexpr int DVD_AUDIO_LANG_EXT_NORMALCAPTIONS = 1;
+constexpr int DVD_AUDIO_LANG_EXT_VISUALLYIMPAIRED = 2;
+constexpr int DVD_AUDIO_LANG_EXT_DIRECTORSCOMMENTS1 = 3;
+constexpr int DVD_AUDIO_LANG_EXT_DIRECTORSCOMMENTS2 = 4;
 } // namespace
 
 static int dvd_inputstreamnavigator_cb_seek(void * p_stream, uint64_t i_pos);
@@ -891,32 +915,32 @@ SubtitleStreamInfo CDVDInputStreamNavigator::GetSubtitleStreamInfo(const int iId
 
 void CDVDInputStreamNavigator::SetSubtitleStreamName(SubtitleStreamInfo &info, const subp_attr_t &subp_attributes)
 {
-  if (subp_attributes.type == DVD_SUBPICTURE_TYPE_Language ||
-    subp_attributes.type == DVD_SUBPICTURE_TYPE_NotSpecified)
+  if (subp_attributes.type == DVD_SUBPICTURE_TYPE_LANGUAGE ||
+      subp_attributes.type == DVD_SUBPICTURE_TYPE_NOTSPECIFIED)
   {
     switch (subp_attributes.code_extension)
     {
-    case DVD_SUBPICTURE_LANG_EXT_NotSpecified:
-    case DVD_SUBPICTURE_LANG_EXT_ChildrensCaptions:
-      break;
+      case DVD_SUBPICTURE_LANG_EXT_NOTSPECIFIED:
+      case DVD_SUBPICTURE_LANG_EXT_CHILDRENSCAPTIONS:
+        break;
 
-    case DVD_SUBPICTURE_LANG_EXT_NormalCaptions:
-    case DVD_SUBPICTURE_LANG_EXT_NormalCC:
-    case DVD_SUBPICTURE_LANG_EXT_BigCaptions:
-    case DVD_SUBPICTURE_LANG_EXT_BigCC:
-    case DVD_SUBPICTURE_LANG_EXT_ChildrensCC:
-      info.flags = StreamFlags::FLAG_HEARING_IMPAIRED;
-      break;
-    case DVD_SUBPICTURE_LANG_EXT_Forced:
-      info.flags = StreamFlags::FLAG_FORCED;
-      break;
-    case DVD_SUBPICTURE_LANG_EXT_NormalDirectorsComments:
-    case DVD_SUBPICTURE_LANG_EXT_BigDirectorsComments:
-    case DVD_SUBPICTURE_LANG_EXT_ChildrensDirectorsComments:
-      info.name = g_localizeStrings.Get(37001);
-      break;
-    default:
-      break;
+      case DVD_SUBPICTURE_LANG_EXT_NORMALCAPTIONS:
+      case DVD_SUBPICTURE_LANG_EXT_NORMALCC:
+      case DVD_SUBPICTURE_LANG_EXT_BIGCAPTIONS:
+      case DVD_SUBPICTURE_LANG_EXT_BIGCC:
+      case DVD_SUBPICTURE_LANG_EXT_CHILDRENSCC:
+        info.flags = StreamFlags::FLAG_HEARING_IMPAIRED;
+        break;
+      case DVD_SUBPICTURE_LANG_EXT_FORCED:
+        info.flags = StreamFlags::FLAG_FORCED;
+        break;
+      case DVD_SUBPICTURE_LANG_EXT_NORMALDIRECTORSCOMMENTS:
+      case DVD_SUBPICTURE_LANG_EXT_BIGDIRECTORSCOMMENTS:
+      case DVD_SUBPICTURE_LANG_EXT_CHILDRENDIRECTORSCOMMENTS:
+        info.name = g_localizeStrings.Get(37001);
+        break;
+      default:
+        break;
     }
   }
 }
@@ -961,20 +985,20 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
 {
   switch( audio_attributes.code_extension )
   {
-  case DVD_AUDIO_LANG_EXT_VisuallyImpaired:
-    info.name = g_localizeStrings.Get(37000);
-    info.flags = StreamFlags::FLAG_VISUAL_IMPAIRED;
-    break;
-  case DVD_AUDIO_LANG_EXT_DirectorsComments1:
-    info.name = g_localizeStrings.Get(37001);
-    break;
-  case DVD_AUDIO_LANG_EXT_DirectorsComments2:
-    info.name = g_localizeStrings.Get(37002);
-    break;
-  case DVD_AUDIO_LANG_EXT_NotSpecified:
-  case DVD_AUDIO_LANG_EXT_NormalCaptions:
-  default:
-    break;
+    case DVD_AUDIO_LANG_EXT_VISUALLYIMPAIRED:
+      info.name = g_localizeStrings.Get(37000);
+      info.flags = StreamFlags::FLAG_VISUAL_IMPAIRED;
+      break;
+    case DVD_AUDIO_LANG_EXT_DIRECTORSCOMMENTS1:
+      info.name = g_localizeStrings.Get(37001);
+      break;
+    case DVD_AUDIO_LANG_EXT_DIRECTORSCOMMENTS2:
+      info.name = g_localizeStrings.Get(37002);
+      break;
+    case DVD_AUDIO_LANG_EXT_NOTSPECIFIED:
+    case DVD_AUDIO_LANG_EXT_NORMALCAPTIONS:
+    default:
+      break;
   }
 
   switch(audio_attributes.audio_format)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvd_types.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvd_types.h
@@ -89,59 +89,6 @@ typedef enum
   DVD_AUDIO_FORMAT_SDDS = 7
 } DVDAudioFormat_t;
 
-/* Subpicture language extension */
-typedef enum
-{
-  DVD_SUBPICTURE_LANG_EXT_NotSpecified = 0,
-  DVD_SUBPICTURE_LANG_EXT_NormalCaptions = 1,
-  DVD_SUBPICTURE_LANG_EXT_BigCaptions = 2,
-  DVD_SUBPICTURE_LANG_EXT_ChildrensCaptions = 3,
-  DVD_SUBPICTURE_LANG_EXT_NormalCC = 5,
-  DVD_SUBPICTURE_LANG_EXT_BigCC = 6,
-  DVD_SUBPICTURE_LANG_EXT_ChildrensCC = 7,
-  DVD_SUBPICTURE_LANG_EXT_Forced = 9,
-  DVD_SUBPICTURE_LANG_EXT_NormalDirectorsComments = 13,
-  DVD_SUBPICTURE_LANG_EXT_BigDirectorsComments = 14,
-  DVD_SUBPICTURE_LANG_EXT_ChildrensDirectorsComments = 15,
-} DVDSubpictureLangExt_t;
-
-/* Audio language extension */
-typedef enum
-{
-  DVD_AUDIO_LANG_EXT_NotSpecified = 0,
-  DVD_AUDIO_LANG_EXT_NormalCaptions = 1,
-  DVD_AUDIO_LANG_EXT_VisuallyImpaired = 2,
-  DVD_AUDIO_LANG_EXT_DirectorsComments1 = 3,
-  DVD_AUDIO_LANG_EXT_DirectorsComments2 = 4
-} DVDAudioLangExt_t;
-
-/* Language ID (ISO-639 language code) */
-typedef uint16_t DVDLangID_t;
-
-/* Country ID (ISO-3166 country code) */
-typedef uint16_t DVDCountryID_t;
-
-/* Subpicture attributes */
-typedef enum
-{
-  DVD_SUBPICTURE_TYPE_NotSpecified = 0,
-  DVD_SUBPICTURE_TYPE_Language = 1,
-  DVD_SUBPICTURE_TYPE_Other = 2
-} DVDSubpictureType_t;
-typedef enum
-{
-  DVD_SUBPICTURE_CODING_RunLength = 0,
-  DVD_SUBPICTURE_CODING_Extended = 1,
-  DVD_SUBPICTURE_CODING_Other = 2
-} DVDSubpictureCoding_t;
-typedef struct
-{
-  DVDSubpictureType_t Type;
-  DVDSubpictureCoding_t CodingMode;
-  DVDLangID_t Language;
-  DVDSubpictureLangExt_t LanguageExtension;
-} DVDSubpictureAttributes_t;
-
 /* the following types are currently unused */
 
 #if 0
@@ -188,6 +135,11 @@ typedef enum {
   DVD_PARENTAL_LEVEL_None = 15
 } DVDParentalLevel_t;
 
+/* Language ID (ISO-639 language code) */
+typedef uint16_t DVDLangID_t;
+
+/* Country ID (ISO-3166 country code) */
+typedef uint16_t DVDCountryID_t;
 
 /* Register */
 typedef uint16_t DVDRegister_t;
@@ -227,6 +179,30 @@ typedef enum {
   DVD_AUDIO_APP_MODE_Surround = 2,
   DVD_AUDIO_APP_MODE_Other    = 3
 } DVDAudioAppMode_t;
+
+/* Audio language extension */
+typedef enum {
+  DVD_AUDIO_LANG_EXT_NotSpecified       = 0,
+  DVD_AUDIO_LANG_EXT_NormalCaptions     = 1,
+  DVD_AUDIO_LANG_EXT_VisuallyImpaired   = 2,
+  DVD_AUDIO_LANG_EXT_DirectorsComments1 = 3,
+  DVD_AUDIO_LANG_EXT_DirectorsComments2 = 4
+} DVDAudioLangExt_t;
+
+/* Subpicture language extension */
+typedef enum {
+  DVD_SUBPICTURE_LANG_EXT_NotSpecified  = 0,
+  DVD_SUBPICTURE_LANG_EXT_NormalCaptions  = 1,
+  DVD_SUBPICTURE_LANG_EXT_BigCaptions  = 2,
+  DVD_SUBPICTURE_LANG_EXT_ChildrensCaptions  = 3,
+  DVD_SUBPICTURE_LANG_EXT_NormalCC  = 5,
+  DVD_SUBPICTURE_LANG_EXT_BigCC  = 6,
+  DVD_SUBPICTURE_LANG_EXT_ChildrensCC  = 7,
+  DVD_SUBPICTURE_LANG_EXT_Forced  = 9,
+  DVD_SUBPICTURE_LANG_EXT_NormalDirectorsComments  = 13,
+  DVD_SUBPICTURE_LANG_EXT_BigDirectorsComments  = 14,
+  DVD_SUBPICTURE_LANG_EXT_ChildrensDirectorsComments  = 15,
+} DVDSubpictureLangExt_t;
 
 /* Karaoke Downmix mode */
 typedef enum {
@@ -269,6 +245,24 @@ typedef struct {
 typedef int DVDAudioSampleFreq_t;
 typedef int DVDAudioSampleQuant_t;
 typedef int DVDChannelNumber_t;
+
+/* Subpicture attributes */
+typedef enum {
+  DVD_SUBPICTURE_TYPE_NotSpecified = 0,
+  DVD_SUBPICTURE_TYPE_Language     = 1,
+  DVD_SUBPICTURE_TYPE_Other        = 2
+} DVDSubpictureType_t;
+typedef enum {
+  DVD_SUBPICTURE_CODING_RunLength = 0,
+  DVD_SUBPICTURE_CODING_Extended  = 1,
+  DVD_SUBPICTURE_CODING_Other     = 2
+} DVDSubpictureCoding_t;
+typedef struct {
+  DVDSubpictureType_t    Type;
+  DVDSubpictureCoding_t  CodingMode;
+  DVDLangID_t            Language;
+  DVDSubpictureLangExt_t LanguageExtension;
+} DVDSubpictureAttributes_t;
 
 /* Video attributes */
 typedef struct {


### PR DESCRIPTION
## Description
While doing https://github.com/xbmc/xbmc/pull/21493 I had to expose some types in the dvdnav header that kodi needed and that are no longer exposed (see: https://code.videolan.org/videolan/libdvdnav/-/blob/master/src/dvdnav/dvd_types.h#L188-263). They have probably been dropped with the split between dvd libs as most of these structs belong to libdvdread.

However, this diverges from upstream and affects our future usage of system libs. This PR defines the values we need as constexpr on the recently introduced anonymous namespace.
Runtime tested.