### PR TITLE
[windows] run-tests call vswhere to set dev env vars

### DIFF
--- a/tools/buildsteps/windows/win32/run-tests.bat
+++ b/tools/buildsteps/windows/win32/run-tests.bat
@@ -1,7 +1,12 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
-
+CALL vswhere.bat x86
+IF ERRORLEVEL 1 (
+  ECHO ERROR! run-tests.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 SET TARGET_PLATFORM=x86
 
 CALL run-tests.bat

--- a/tools/buildsteps/windows/x64/run-tests.bat
+++ b/tools/buildsteps/windows/x64/run-tests.bat
@@ -1,7 +1,12 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
-
+CALL vswhere.bat x64
+IF ERRORLEVEL 1 (
+  ECHO ERROR! run-tests.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 SET TARGET_PLATFORM=x64
 
 CALL run-tests.bat


### PR DESCRIPTION
## Description
Call vswhere for run-tests.bat script

## Motivation and context
Fix building on a windows agent using VS bundled cmake

## How has this been tested?
with this PR
https://jenkins.kodi.tv/job/Win64-test/1/

without
https://jenkins.kodi.tv/job/WIN-32/25390/

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
