### PR TITLE
[PVR] clang-tidy: Fix 'Call to virtual method 'CPVRChannelGroup(Inter…

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -56,7 +56,6 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP& group,
 CPVRChannelGroup::~CPVRChannelGroup()
 {
   GetSettings()->UnregisterCallback(this);
-  Unload();
 }
 
 bool CPVRChannelGroup::operator==(const CPVRChannelGroup& right) const

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -44,7 +44,7 @@ CPVRChannelGroupInternal::CPVRChannelGroupInternal(const CPVRChannelsPath& path)
 
 CPVRChannelGroupInternal::~CPVRChannelGroupInternal()
 {
-  Unload();
+  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
 }
 
 bool CPVRChannelGroupInternal::LoadFromDatabase(


### PR DESCRIPTION
…nal)::Unload' during destruction bypasses virtual dispatch'

No need to call `Unload` from the dtors as implementation basically only does what the dtor will do automatically - free resources.

Runtime-tested on macOS and Android, latest master.

@phunkyfish this one should be trivial to review.