### PR TITLE
[PVR] Sync channel groups with backend: Fix local removal of channel …

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -610,9 +610,13 @@ bool CPVRChannelGroup::HasValidDataForClient(int iClientId) const
          m_failedClients.end();
 }
 
-bool CPVRChannelGroup::HasValidDataForAllClients() const
+bool CPVRChannelGroup::HasValidDataForClients(
+    const std::vector<std::shared_ptr<CPVRClient>>& clients) const
 {
-  return m_failedClients.empty();
+  return m_failedClients.empty() || std::none_of(clients.cbegin(), clients.cend(),
+                                                 [this](const std::shared_ptr<CPVRClient>& client) {
+                                                   return !HasValidDataForClient(client->GetID());
+                                                 });
 }
 
 bool CPVRChannelGroup::UpdateChannelNumbersFromAllChannelsGroup()

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -416,11 +416,12 @@ namespace PVR
     bool HasValidDataForClient(int iClientId) const;
 
     /*!
-     * @brief Check, whether data for all active pvr clients are currently valid. For instance, data
+     * @brief Check, whether data for given pvr clients are currently valid. For instance, data
      * can be invalid because the client's backend was offline when data was last queried.
+     * @param clients The clients to check. Check all active clients if vector is empty.
      * @return True, if data is currently valid, false otherwise.
      */
-    bool HasValidDataForAllClients() const;
+    bool HasValidDataForClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
     /*!
      * @brief Update the channel numbers according to the all channels group and publish event.

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -229,11 +229,12 @@ namespace PVR
     void SortGroups();
 
     /*!
-     * @brief Check, whether data for all active pvr clients are currently valid. For instance, data
+     * @brief Check, whether data for given pvr clients are currently valid. For instance, data
      * can be invalid because the client's backend was offline when data was last queried.
+     * @param clients The clients to check. Check all active clients if vector is empty.
      * @return True, if data is currently valid, false otherwise.
      */
-    bool HasValidDataForAllClients() const;
+    bool HasValidDataForClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
     bool m_bRadio; /*!< true if this is a container for radio channels, false if it is for tv channels */
     std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups; /*!< the groups in this container */


### PR DESCRIPTION
…groups that were removed on backend.

Fixes an edge case for multi PVR client scenario, where at least one client supports async connect, and at least one doesn't.

1. Sync channel groups with backend must be enabled.
2. While Kodi is not running, remove a channel group on the backend of one of the clients supporting async connect.
3. Start Kodi => Bug: The removed channel group is still present

Fix is to check only the just called clients for valid data, not all, when looking whether a group shall be locally removed.
 
Runtime tested on macOS and Android, latest master.

@phunkyfish hope my explanation is sufficient for a code review.