### PR TITLE
Clamp textures with alpha to transparent color

### DIFF
--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -88,8 +88,62 @@ void CGLTexture::LoadToGPU()
   }
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+#ifdef HAS_GL
+  if (HasAlpha())
+  {
+    float color[] = {0.0f, 0.0f, 0.0f, 0.0f};
+    glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, color);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+  }
+  else
+  {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  }
+#else
+
+  if (HasAlpha())
+  {
+    if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_OES_texture_border_clamp"))
+    {
+      float color[] = {0.0f, 0.0f, 0.0f, 0.0f};
+      glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR_OES, color);
+
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER_OES);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER_OES);
+    }
+    else if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_border_clamp"))
+    {
+      float color[] = {0.0f, 0.0f, 0.0f, 0.0f};
+      glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR_EXT, color);
+
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER_EXT);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER_EXT);
+    }
+    else if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_NV_texture_border_clamp"))
+    {
+      float color[] = {0.0f, 0.0f, 0.0f, 0.0f};
+      glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR_NV, color);
+
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER_NV);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER_NV);
+    }
+    else
+    {
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+  }
+  else
+  {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  }
+#endif
+
 
   unsigned int maxSize = CServiceBroker::GetRenderSystem()->GetMaxTextureSize();
   if (m_textureHeight > maxSize)

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -105,6 +105,25 @@ void CGLTexture::LoadToGPU()
   }
 #else
 
+#ifndef GL_TEXTURE_BORDER_COLOR_OES
+#define GL_TEXTURE_BORDER_COLOR_OES 0x1004
+#endif
+#ifndef GL_CLAMP_TO_BORDER_OES
+#define GL_CLAMP_TO_BORDER_OES 0x812D
+#endif
+#ifndef GL_TEXTURE_BORDER_COLOR_EXT
+#define GL_TEXTURE_BORDER_COLOR_EXT 0x1004
+#endif
+#ifndef GL_CLAMP_TO_BORDER_EXT
+#define GL_CLAMP_TO_BORDER_EXT 0x812D
+#endif
+#ifndef GL_TEXTURE_BORDER_COLOR_NV
+#define GL_TEXTURE_BORDER_COLOR_NV 0x1004
+#endif
+#ifndef GL_CLAMP_TO_BORDER_NV
+#define GL_CLAMP_TO_BORDER_NV 0x812D
+#endif
+
   if (HasAlpha())
   {
     if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_OES_texture_border_clamp"))
@@ -143,7 +162,6 @@ void CGLTexture::LoadToGPU()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   }
 #endif
-
 
   unsigned int maxSize = CServiceBroker::GetRenderSystem()->GetMaxTextureSize();
   if (m_textureHeight > maxSize)


### PR DESCRIPTION
## Description
On OpenGL, textures are usually clamped to the edge. If a texture has no white space around and the texture is not sampled in a "pixel perfect" manner, outside texels in the clamped portion have some influence on the pixel.

## Motivation and context
This PR changes the clamping behavior to GL_CLAMP_TO_BORDER on systems which support it. 

## How has this been tested?
The OpenGL part looks fine. I would like to get some feedback for GLES.

## What is the effect on users?
Better behaving textures containing an alpha layer without white space.

## Screenshots (if appropriate):
The texture (zoomed in). Note that three sides of the circle are touching the border:
![source](https://user-images.githubusercontent.com/30039775/173381035-9f84e2d5-ec55-4a33-92d4-36cd843fca6e.png)

The affected regions are marked in red (zoomed in):
![affected-regions](https://user-images.githubusercontent.com/30039775/173381218-6b48a8ca-9966-412f-a253-35ac3f24eecf.png)

Before the patch:
![before](https://user-images.githubusercontent.com/30039775/173381242-79c29b8a-6364-40f5-b1dc-3fc303fece9d.png)

After the patch:
![after](https://user-images.githubusercontent.com/30039775/173381267-ee41f9c5-808c-470f-8234-57189d8ac618.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
