### PR TITLE
[Android] Display some cpu info that was missing in System information

### DIFF
--- a/xbmc/platform/android/CPUInfoAndroid.cpp
+++ b/xbmc/platform/android/CPUInfoAndroid.cpp
@@ -35,10 +35,21 @@ CCPUInfoAndroid::CCPUInfoAndroid()
       {
         if (line.find("vendor_id") != std::string::npos)
           m_cpuVendor = line.substr(line.find(':') + 2);
+
         else if (line.find("model name") != std::string::npos)
           m_cpuModel = line.substr(line.find(':') + 2);
+
         else if (line.find("BogoMIPS") != std::string::npos)
           m_cpuBogoMips = line.substr(line.find(':') + 2);
+
+        else if (line.find("Hardware") != std::string::npos)
+          m_cpuHardware = line.substr(line.find(':') + 2);
+
+        else if (line.find("Serial") != std::string::npos)
+          m_cpuSerial = line.substr(line.find(':') + 2);
+
+        else if (line.find("Revision") != std::string::npos)
+          m_cpuRevision = line.substr(line.find(':') + 2);
       }
     }
 


### PR DESCRIPTION
## Description
Gets the values of the items: Hardware, Serial and Revision when they are available in from ```/proc/cpuinfo``` output.

## How has this been tested?
Tested on Amazon Fire TV Stick 4K Max (Android TV 9).

Add screenshots of before and after the change.

## Screenshots (if appropriate):
Before:
![antes](https://user-images.githubusercontent.com/76552691/173387798-cbf812b7-db87-4f01-8880-2af1576b69d3.png)

After:
![despues](https://user-images.githubusercontent.com/76552691/173387869-8ccbc16c-fba5-47f8-a4ad-65292515040d.png)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
