### PR TITLE
Disable OpenGL when building OpenGL ES

### DIFF
--- a/xbmc/rendering/gl/CMakeLists.txt
+++ b/xbmc/rendering/gl/CMakeLists.txt
@@ -1,9 +1,12 @@
-set(SOURCES RenderSystemGL.cpp
-            ScreenshotSurfaceGL.cpp
-            GLShader.cpp)
+if(OPENGL_FOUND)
+  set(SOURCES RenderSystemGL.cpp
+              ScreenshotSurfaceGL.cpp
+              GLShader.cpp)
 
-set(HEADERS RenderSystemGL.h
-            ScreenshotSurfaceGL.h
-            GLShader.h)
+  set(HEADERS RenderSystemGL.h
+              ScreenshotSurfaceGL.h
+              GLShader.h)
 
-core_add_library(rendering_gl)
+  core_add_library(rendering_gl)
+endif()
+


### PR DESCRIPTION
## Description
This PR explicitly disables the build of OpenGL components if the system is configured for OpenGL ES.

## Motivation and context
I'm switching between GL and GLES regularly. GLES would not build after having GL configured.

With this PR, I can change builds without having to clean up the build directory, saving time.

## How has this been tested?
GL and GLES still builds fine.

## What is the effect on users?
No effect unless you switch between render backends often.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
