### PR TITLE
Add option to slice the diffuse texture only

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -355,6 +355,9 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
   if (flipY && StringUtils::CompareNoCase(flipY, "true") == 0)
     image.orientation = 3 - image.orientation; // either 3 or 2
   image.diffuse = XMLUtils::GetAttribute(pNode, "diffuse");
+  const char* diffuseslice = pNode->Attribute("sliceonlydiffuse");
+  if (diffuseslice && StringUtils::CompareNoCase(diffuseslice, "true", 4) == 0)
+    image.m_diffuseSlice = true;
   image.diffuseColor.Parse(XMLUtils::GetAttribute(pNode, "colordiffuse"), 0);
   const char *background = pNode->Attribute("background");
   if (background && StringUtils::CompareNoCase(background, "true", 4) == 0)

--- a/xbmc/guilib/GUIImage.dox
+++ b/xbmc/guilib/GUIImage.dox
@@ -74,17 +74,19 @@ important, as `xml` tags are case-sensitive.
 
 For the tags "texture" and "bordertexture", the following attributes are available.
 
-| Attribute     | Description                                                   |
-|--------------:|:--------------------------------------------------------------|
-| border        | Used to specify a region of the texture to be considered a border that should not be scaled when the texture is scaled to fit a control's dimensions. The portion in the border region will remain unscaled. Particularly useful to achieve rounded corners that do not change size when a control is resized. Note that zoom animations and GUI rescaling will still affect the border region - it is just the scaling of the texture to the control size which is unaffected. Using border="5" will give a 5 pixel border all around the texture. You can specify each of the border amounts on each edge individually using border="left,top,right,bottom".
-| infill        | Available if the "border" attribute is used. Hint for the GUI drawing routine if the center portion or just the outer frame should be drawn. Useful if the texture center is fully transparent. Accepts boolean values "true" (default) and "false".
-| flipx         | Specifies that the texture should be flipped in the horizontal direction, useful for reflections.
-| flipy         | Specifies that the texture should be flipped in the vertical direction, useful for reflections. 
-| background    | Used on the <b>`<imagepath>`</b> tag. When set to "true", this forces the image to be loaded via the large texture manager (except for textures located in Textures.xbt).
-| diffuse       | Specifies a diffuse texture which is "modulated" or multiplied with the texture in order to give specific effects, such as making the image gain transparency, or tint it in various ways. As it's applied per-pixel many effects are possible, the most popular being by a transparent reflection which slowly gets more and more opaque. This is achieved using a WHITE image where the transparency increases as you move down the texture.
-| colordiffuse  | This specifies the color to be used for the texture basis. It's is specified in hexadecimal notation using the AARRGGBB format. If you define <b>`<texture colordiffuse="FFFFAAFF">texture.png</texture>`</b> (magenta), the image will be given a magenta tint when rendered. You can also specify this as a name from the colour theme, or you can also use $VAR and $INFO for dynamic values.
+| Attribute        | Description                                                   |
+|-----------------:|:--------------------------------------------------------------|
+| border           | Used to specify a region of the texture to be considered a border that should not be scaled when the texture is scaled to fit a control's dimensions. The portion in the border region will remain unscaled. Particularly useful to achieve rounded corners that do not change size when a control is resized. Note that zoom animations and GUI rescaling will still affect the border region - it is just the scaling of the texture to the control size which is unaffected. Using border="5" will give a 5 pixel border all around the texture. You can specify each of the border amounts on each edge individually using border="left,top,right,bottom".
+| infill           | Available if the "border" attribute is used. Hint for the GUI drawing routine if the center portion or just the outer frame should be drawn. Useful if the texture center is fully transparent. Accepts boolean values "true" (default) and "false".
+| flipx            | Specifies that the texture should be flipped in the horizontal direction, useful for reflections.
+| flipy            | Specifies that the texture should be flipped in the vertical direction, useful for reflections. 
+| background       | Used on the <b>`<imagepath>`</b> tag. When set to "true", this forces the image to be loaded via the large texture manager (except for textures located in Textures.xbt).
+| diffuse          | Specifies a diffuse texture which is "modulated" or multiplied with the texture in order to give specific effects, such as making the image gain transparency, or tint it in various ways. As it's applied per-pixel many effects are possible, the most popular being by a transparent reflection which slowly gets more and more opaque. This is achieved using a WHITE image where the transparency increases as you move down the texture.
+| sliceonlydiffuse | Limits the texture slicing of the <b>border</b> attribute to the <b>diffuse</b> texture. Useful for manipulating the border of an image.
+| colordiffuse     | This specifies the color to be used for the texture basis. It's is specified in hexadecimal notation using the AARRGGBB format. If you define <b>`<texture colordiffuse="FFFFAAFF">texture.png</texture>`</b> (magenta), the image will be given a magenta tint when rendered. You can also specify this as a name from the colour theme, or you can also use $VAR and $INFO for dynamic values.
 
 @skinning_v20 <b>infill</b> New texture attribute added.
+@skinning_v20 <b>sliceonlydiffuse</b> New texture attribute added.
 
 --------------------------------------------------------------------------------
 \section Image_Control_sect4 See also

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -190,13 +190,34 @@ void CGUITexture::Render()
   Begin(color);
 
   // compute the texture coordinates
-  float u1, u2, u3, v1, v2, v3;
-  u1 = m_info.border.x1;
-  u2 = m_frameWidth - m_info.border.x2;
-  u3 = m_frameWidth;
-  v1 = m_info.border.y1;
-  v2 = m_frameHeight - m_info.border.y2;
-  v3 = m_frameHeight;
+  float u1, u2, u3, v1, v2, v3, du1, du2, du3, dv1, dv2, dv3;
+
+  if (m_info.m_diffuseSlice)
+  {
+    float width = m_vertex.x2 - m_vertex.x1;
+    float height = m_vertex.y2 - m_vertex.y1;
+    u1 = m_frameWidth * m_info.border.x1 / width;
+    u2 = m_frameWidth * (width - m_info.border.x2) / width;
+    u3 = m_frameWidth;
+    v1 = m_frameHeight * m_info.border.y1 / height;
+    v2 = m_frameHeight * (height - m_info.border.y2) / height;
+    v3 = m_frameHeight;
+    du1 = m_info.border.x1;
+    du2 = m_diffuse.m_texWidth - m_info.border.x2;
+    du3 = m_diffuse.m_texWidth;
+    dv1 = m_info.border.y1;
+    dv2 = m_diffuse.m_texHeight - m_info.border.y2;
+    dv3 = m_diffuse.m_texHeight;
+  }
+  else
+  {
+    u1 = du1 = m_info.border.x1;
+    u2 = du2 = m_frameWidth - m_info.border.x2;
+    u3 = du3 = m_frameWidth;
+    v1 = dv1 = m_info.border.y1;
+    v2 = dv2 = m_frameHeight - m_info.border.y2;
+    v3 = dv3 = m_frameHeight;
+  }
 
   if (!m_texture.m_texCoordsArePixels)
   {
@@ -206,6 +227,12 @@ void CGUITexture::Render()
     v1 *= m_texCoordsScaleV;
     v2 *= m_texCoordsScaleV;
     v3 *= m_texCoordsScaleV;
+    du1 /= m_diffuse.m_texWidth;
+    du2 /= m_diffuse.m_texWidth;
+    du3 /= m_diffuse.m_texWidth;
+    dv1 /= m_diffuse.m_texHeight;
+    dv2 /= m_diffuse.m_texHeight;
+    dv3 /= m_diffuse.m_texHeight;
   }
 
   //! @todo The diffuse coloring applies to all vertices, which will
@@ -216,27 +243,37 @@ void CGUITexture::Render()
   if (m_info.border.x1)
   {
     if (m_info.border.y1)
-      Render(m_vertex.x1, m_vertex.y1, m_vertex.x1 + m_info.border.x1, m_vertex.y1 + m_info.border.y1, 0, 0, u1, v1, u3, v3);
-    Render(m_vertex.x1, m_vertex.y1 + m_info.border.y1, m_vertex.x1 + m_info.border.x1, m_vertex.y2 - m_info.border.y2, 0, v1, u1, v2, u3, v3);
+      Render(m_vertex.x1, m_vertex.y1, m_vertex.x1 + m_info.border.x1,
+             m_vertex.y1 + m_info.border.y1, 0, 0, u1, v1, u3, v3, 0, 0, du1, dv1, du3, dv3);
+    Render(m_vertex.x1, m_vertex.y1 + m_info.border.y1, m_vertex.x1 + m_info.border.x1,
+           m_vertex.y2 - m_info.border.y2, 0, v1, u1, v2, u3, v3, 0, dv1, du1, dv2, du3, dv3);
     if (m_info.border.y2)
-      Render(m_vertex.x1, m_vertex.y2 - m_info.border.y2, m_vertex.x1 + m_info.border.x1, m_vertex.y2, 0, v2, u1, v3, u3, v3);
+      Render(m_vertex.x1, m_vertex.y2 - m_info.border.y2, m_vertex.x1 + m_info.border.x1,
+             m_vertex.y2, 0, v2, u1, v3, u3, v3, 0, dv2, du1, dv3, du3, dv3);
   }
   // middle segment (u1,0,u2,v3)
   if (m_info.border.y1)
-    Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1, m_vertex.x2 - m_info.border.x2, m_vertex.y1 + m_info.border.y1, u1, 0, u2, v1, u3, v3);
+    Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1, m_vertex.x2 - m_info.border.x2,
+           m_vertex.y1 + m_info.border.y1, u1, 0, u2, v1, u3, v3, du1, 0, du2, dv1, du3, dv3);
   if (m_info.m_infill)
     Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1 + m_info.border.y1,
-           m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, u1, v1, u2, v2, u3, v3);
+           m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, u1, v1, u2, v2, u3, v3,
+           du1, dv1, du2, dv2, du3, dv3);
   if (m_info.border.y2)
-    Render(m_vertex.x1 + m_info.border.x1, m_vertex.y2 - m_info.border.y2, m_vertex.x2 - m_info.border.x2, m_vertex.y2, u1, v2, u2, v3, u3, v3);
+    Render(m_vertex.x1 + m_info.border.x1, m_vertex.y2 - m_info.border.y2,
+           m_vertex.x2 - m_info.border.x2, m_vertex.y2, u1, v2, u2, v3, u3, v3, du1, dv2, du2, dv3,
+           du3, dv3);
   // right segment
   if (m_info.border.x2)
   { // have a left border
     if (m_info.border.y1)
-      Render(m_vertex.x2 - m_info.border.x2, m_vertex.y1, m_vertex.x2, m_vertex.y1 + m_info.border.y1, u2, 0, u3, v1, u3, v3);
-    Render(m_vertex.x2 - m_info.border.x2, m_vertex.y1 + m_info.border.y1, m_vertex.x2, m_vertex.y2 - m_info.border.y2, u2, v1, u3, v2, u3, v3);
+      Render(m_vertex.x2 - m_info.border.x2, m_vertex.y1, m_vertex.x2,
+             m_vertex.y1 + m_info.border.y1, u2, 0, u3, v1, u3, v3, du2, 0, du3, dv1, du3, dv3);
+    Render(m_vertex.x2 - m_info.border.x2, m_vertex.y1 + m_info.border.y1, m_vertex.x2,
+           m_vertex.y2 - m_info.border.y2, u2, v1, u3, v2, u3, v3, du2, dv1, du3, dv2, du3, dv3);
     if (m_info.border.y2)
-      Render(m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, m_vertex.x2, m_vertex.y2, u2, v2, u3, v3, u3, v3);
+      Render(m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, m_vertex.x2,
+             m_vertex.y2, u2, v2, u3, v3, u3, v3, du2, dv2, du3, dv3, du3, dv3);
   }
 
   // close off our renderer
@@ -255,9 +292,15 @@ void CGUITexture::Render(float left,
                          float u2,
                          float v2,
                          float u3,
-                         float v3)
+                         float v3,
+                         float du1,
+                         float dv1,
+                         float du2,
+                         float dv2,
+                         float du3,
+                         float dv3)
 {
-  CRect diffuse(u1, v1, u2, v2);
+  CRect diffuse(du1, dv1, du2, dv2);
   CRect texture(u1, v1, u2, v2);
   CRect vertex(left, top, right, bottom);
   CServiceBroker::GetWinSystem()->GetGfxContext().ClipRect(vertex, texture, m_diffuse.size() ? &diffuse : NULL);
@@ -272,8 +315,10 @@ void CGUITexture::Render(float left,
   {
     // flip the texture as necessary.  Diffuse just gets flipped according to m_info.orientation.
     // Main texture gets flipped according to GetOrientation().
-    diffuse.x1 *= m_diffuseScaleU / u3; diffuse.x2 *= m_diffuseScaleU / u3;
-    diffuse.y1 *= m_diffuseScaleV / v3; diffuse.y2 *= m_diffuseScaleV / v3;
+    diffuse.x1 *= m_diffuseScaleU / du3;
+    diffuse.x2 *= m_diffuseScaleU / du3;
+    diffuse.y1 *= m_diffuseScaleV / dv3;
+    diffuse.y2 *= m_diffuseScaleV / dv3;
     diffuse += m_diffuseOffset;
     OrientateTexture(diffuse, m_diffuseU, m_diffuseV, m_info.orientation);
   }

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -190,7 +190,18 @@ void CGUITexture::Render()
   Begin(color);
 
   // compute the texture coordinates
-  float u1, u2, u3, v1, v2, v3, du1, du2, du3, dv1, dv2, dv3;
+  float u1 = m_info.border.x1;
+  float u2 = m_frameWidth - m_info.border.x2;
+  float u3 = m_frameWidth;
+  float v1 = m_info.border.y1;
+  float v2 = m_frameHeight - m_info.border.y2;
+  float v3 = m_frameHeight;
+  float du1 = u1;
+  float du2 = u2;
+  float du3 = u3;
+  float dv1 = v1;
+  float dv2 = v2;
+  float dv3 = v3;
 
   if (m_info.m_diffuseSlice)
   {
@@ -208,15 +219,6 @@ void CGUITexture::Render()
     dv1 = m_info.border.y1;
     dv2 = m_diffuse.m_texHeight - m_info.border.y2;
     dv3 = m_diffuse.m_texHeight;
-  }
-  else
-  {
-    u1 = du1 = m_info.border.x1;
-    u2 = du2 = m_frameWidth - m_info.border.x2;
-    u3 = du3 = m_frameWidth;
-    v1 = dv1 = m_info.border.y1;
-    v2 = dv2 = m_frameHeight - m_info.border.y2;
-    v3 = dv3 = m_frameHeight;
   }
 
   if (!m_texture.m_texCoordsArePixels)
@@ -245,8 +247,10 @@ void CGUITexture::Render()
     if (m_info.border.y1)
       Render(m_vertex.x1, m_vertex.y1, m_vertex.x1 + m_info.border.x1,
              m_vertex.y1 + m_info.border.y1, 0, 0, u1, v1, u3, v3, 0, 0, du1, dv1, du3, dv3);
+
     Render(m_vertex.x1, m_vertex.y1 + m_info.border.y1, m_vertex.x1 + m_info.border.x1,
            m_vertex.y2 - m_info.border.y2, 0, v1, u1, v2, u3, v3, 0, dv1, du1, dv2, du3, dv3);
+
     if (m_info.border.y2)
       Render(m_vertex.x1, m_vertex.y2 - m_info.border.y2, m_vertex.x1 + m_info.border.x1,
              m_vertex.y2, 0, v2, u1, v3, u3, v3, 0, dv2, du1, dv3, du3, dv3);
@@ -255,10 +259,12 @@ void CGUITexture::Render()
   if (m_info.border.y1)
     Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1, m_vertex.x2 - m_info.border.x2,
            m_vertex.y1 + m_info.border.y1, u1, 0, u2, v1, u3, v3, du1, 0, du2, dv1, du3, dv3);
+
   if (m_info.m_infill)
     Render(m_vertex.x1 + m_info.border.x1, m_vertex.y1 + m_info.border.y1,
            m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, u1, v1, u2, v2, u3, v3,
            du1, dv1, du2, dv2, du3, dv3);
+
   if (m_info.border.y2)
     Render(m_vertex.x1 + m_info.border.x1, m_vertex.y2 - m_info.border.y2,
            m_vertex.x2 - m_info.border.x2, m_vertex.y2, u1, v2, u2, v3, u3, v3, du1, dv2, du2, dv3,
@@ -269,8 +275,10 @@ void CGUITexture::Render()
     if (m_info.border.y1)
       Render(m_vertex.x2 - m_info.border.x2, m_vertex.y1, m_vertex.x2,
              m_vertex.y1 + m_info.border.y1, u2, 0, u3, v1, u3, v3, du2, 0, du3, dv1, du3, dv3);
+
     Render(m_vertex.x2 - m_info.border.x2, m_vertex.y1 + m_info.border.y1, m_vertex.x2,
            m_vertex.y2 - m_info.border.y2, u2, v1, u3, v2, u3, v3, du2, dv1, du3, dv2, du3, dv3);
+
     if (m_info.border.y2)
       Render(m_vertex.x2 - m_info.border.x2, m_vertex.y2 - m_info.border.y2, m_vertex.x2,
              m_vertex.y2, u2, v2, u3, v3, u3, v3, du2, dv2, du3, dv3, du3, dv3);

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -59,6 +59,7 @@ public:
       true}; // if false, the main body of a texture is not drawn. useful for borders with no inner filling
   int        orientation;     // orientation of the texture (0 - 7 == EXIForientation - 1)
   std::string diffuse;         // diffuse overlay texture
+  bool m_diffuseSlice; // 9-slice only the diffuse texture
   KODI::GUILIB::GUIINFO::CGUIInfoColor diffuseColor; // diffuse color
   std::string filename;        // main texture file
 };
@@ -144,7 +145,13 @@ protected:
               float u2,
               float v2,
               float u3,
-              float v3);
+              float v3,
+              float du1,
+              float dv1,
+              float du2,
+              float dv2,
+              float du3,
+              float dv3);
   static void OrientateTexture(CRect &rect, float width, float height, int orientation);
   void ResetAnimState();
 


### PR DESCRIPTION
## Description
In our GUI engine, diffuse textures can be specified to augment a primary texture. Often, this gets used to give the primary a nice border. But this needs a diffuse texture of fairly large size in order to give good results.

## Motivation and context
This PR extends the already builtin texture slicing to ignore the primary texture if the attribute "sliceonlydiffuse" is added to the texture tag. Skinners may now employ one smaller (e.g. 64x64) diffuse texture for all elements

## How has this been tested?
I've tried it by modifying Estuary. It looks good from my side, but I'm offering builds i the forum for testing.

## What is the effect on users?
Nicer texture borders, with some minor texture bandwidth savings. It also makes the lives of our skinners a bit easier.

## Screenshots (if appropriate):
Before:
![before](https://user-images.githubusercontent.com/30039775/173460979-cd05d62c-afc7-4d93-9529-a5735236b01b.png)

And after:
![after](https://user-images.githubusercontent.com/30039775/173460994-d974e1e4-e7e2-4501-858d-fe150b6fe520.png)

This was done with the assets of Estuary. They are not optimal, but should demonstrate the point.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
