### PR TITLE
[dvdnav] hook dvd_logger into dvd open calls

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
@@ -35,7 +35,15 @@ class DllDvdNavInterface
 public:
   virtual ~DllDvdNavInterface() = default;
   virtual dvdnav_status_t dvdnav_open(dvdnav_t **dest, const char *path)=0;
+  virtual dvdnav_status_t dvdnav_open2(dvdnav_t** dest,
+                                       void*,
+                                       const dvdnav_logger_cb*,
+                                       const char* path) = 0;
   virtual dvdnav_status_t dvdnav_open_stream(dvdnav_t **dest, void *stream, dvdnav_stream_cb *stream_cb) = 0;
+  virtual dvdnav_status_t dvdnav_open_stream2(dvdnav_t** dest,
+                                              void* stream,
+                                              const dvdnav_logger_cb*,
+                                              dvdnav_stream_cb* stream_cb) = 0;
   virtual dvdnav_status_t dvdnav_close(dvdnav_t *self)=0;
   virtual dvdnav_status_t dvdnav_reset(dvdnav_t *self)=0;
   virtual const char* dvdnav_err_to_string(dvdnav_t *self)=0;
@@ -116,7 +124,13 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
   DECLARE_DLL_WRAPPER(DllDvdNav, DLL_PATH_LIBDVDNAV)
 
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_open, (dvdnav_t **p1, const char *p2))
+  DEFINE_METHOD4(dvdnav_status_t,
+                 dvdnav_open2,
+                 (dvdnav_t * *p1, void* p2, const dvdnav_logger_cb* p3, const char* p4))
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_open_stream, (dvdnav_t **p1, void *p2, dvdnav_stream_cb *p3))
+  DEFINE_METHOD4(dvdnav_status_t,
+                 dvdnav_open_stream2,
+                 (dvdnav_t * *p1, void* p2, const dvdnav_logger_cb* p3, dvdnav_stream_cb* p4))
   DEFINE_METHOD1(dvdnav_status_t, dvdnav_close, (dvdnav_t *p1))
   DEFINE_METHOD1(dvdnav_status_t, dvdnav_reset, (dvdnav_t *p1))
   DEFINE_METHOD1(const char*, dvdnav_err_to_string, (dvdnav_t *p1))
@@ -188,7 +202,9 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
                  (dvdnav_t * p1, int32_t* p2, int32_t* p3, int32_t* p4))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(dvdnav_open)
+    RESOLVE_METHOD(dvdnav_open2)
     RESOLVE_METHOD(dvdnav_open_stream)
+    RESOLVE_METHOD(dvdnav_open_stream2)
     RESOLVE_METHOD(dvdnav_close)
     RESOLVE_METHOD(dvdnav_reset)
     RESOLVE_METHOD(dvdnav_err_to_string)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvdnav.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvdnav.h
@@ -33,6 +33,7 @@ extern "C" {
 #include "dvd_types.h"
 #include "dvdnav_events.h"
 #include "nav_types.h"
+#include "version.h"
 
 #include <stdarg.h>
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/version.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/version.h
@@ -1,0 +1,29 @@
+/*
+* This file is part of libdvdnav, a DVD navigation library.
+*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+*/
+#pragma once
+
+#define DVDNAV_VERSION_CODE(major, minor, micro) (((major)*10000) + ((minor)*100) + ((micro)*1))
+
+#define DVDNAV_VERSION_MAJOR 6
+#define DVDNAV_VERSION_MINOR 1
+#define DVDNAV_VERSION_MICRO 1
+
+#define DVDNAV_VERSION_STRING "6.1.1"
+
+#define DVDNAV_VERSION \
+  DVDNAV_VERSION_CODE(DVDNAV_VERSION_MAJOR, DVDNAV_VERSION_MINOR, DVDNAV_VERSION_MICRO)


### PR DESCRIPTION
## Description
Old versions of dvdnav used to just print stuff to stdout or stderr. Since version 6.1.0 new open calls (well not pretty...) are available which allow us to hook into logger implementations. We ship and wrap 6.1.1 atm.
This will help figuring out the vfs implementation in libdvd* since kodi will now log stuff from libdvdread.