### PR TITLE
[dialogs] Busy Dialog Improvements

### DIFF
--- a/addons/skin.estuary/xml/DialogBusy.xml
+++ b/addons/skin.estuary/xml/DialogBusy.xml
@@ -44,9 +44,6 @@
 					<height>30</height>
 					<texture colordiffuse="button_focus">$INFO[Control.GetLabel(10),dialogs/volume/progress/p,.png]</texture>
 				</control>
-				<control type="progress" id="10">
-					<include>HiddenObject</include>
-				</control>
 			</control>
 		</control>
 	</controls>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2658,11 +2658,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 
       // we don't want a busy dialog when switching channels
       if (!m_itemCurrentFile->IsLiveTV())
-      {
-        CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
-        if (dialog && !dialog->IsDialogRunning())
-          dialog->WaitOnEvent(m_playerEvent);
-      }
+        CGUIDialogBusy::WaitOnEvent(m_playerEvent);
 
       return true;
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -675,8 +675,6 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
 
   m_item = file;
   m_playerOptions = options;
-  // Try to resolve the correct mime type
-  m_item.SetMimeTypeForInternetFile();
 
   m_processInfo->SetPlayTimes(0,0,0,0);
   m_bAbortRequest = false;
@@ -1336,6 +1334,11 @@ void CVideoPlayer::Prepare()
 
 void CVideoPlayer::Process()
 {
+  // Try to resolve the correct mime type. This can take some time, for example if a requested
+  // item is located at a slow/not reachable remote source. So, do mime type detection in vp worker
+  // thread, not directly when initalizing the player to keep GUI responsible.
+  m_item.SetMimeTypeForInternetFile();
+
   CServiceBroker::GetWinSystem()->RegisterRenderLoop(this);
 
   Prepare();

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -10,15 +10,12 @@
 
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "threads/IRunnable.h"
 #include "threads/Thread.h"
 #include "utils/log.h"
 
 using namespace std::chrono_literals;
-
-#define PROGRESS_CONTROL 10
 
 class CBusyWaiter : public CThread
 {
@@ -113,7 +110,6 @@ CGUIDialogBusy::CGUIDialogBusy(void)
 {
   m_loadType = LOAD_ON_GUI_INIT;
   m_bCanceled = false;
-  m_progress = -1;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void) = default;
@@ -122,7 +118,6 @@ void CGUIDialogBusy::Open_Internal(bool bProcessRenderLoop, const std::string& p
 {
   m_bCanceled = false;
   m_bLastVisible = true;
-  m_progress = -1;
 
   CGUIDialog::Open_Internal(false, param);
 }
@@ -134,15 +129,6 @@ void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirty
   if(!visible && m_bLastVisible)
     dirtyregions.push_back(CDirtyRegion(m_renderRegion));
   m_bLastVisible = visible;
-
-  // update the progress control if available
-  CGUIControl *control = GetControl(PROGRESS_CONTROL);
-  if (control && control->GetControlType() == CGUIControl::GUICONTROL_PROGRESS)
-  {
-    CGUIProgressControl *progress = static_cast<CGUIProgressControl*>(control);
-    progress->SetPercentage(m_progress);
-    progress->SetVisible(m_progress > -1);
-  }
 
   CGUIDialog::DoProcess(currentTime, dirtyregions);
 }
@@ -158,9 +144,4 @@ bool CGUIDialogBusy::OnBack(int actionID)
 {
   m_bCanceled = true;
   return true;
-}
-
-void CGUIDialogBusy::SetProgress(float percent)
-{
-  m_progress = percent;
 }

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -24,8 +24,6 @@ public:
   /*! \brief set the current progress of the busy operation
    \param progress a percentage of progress
    */
-  void SetProgress(float progress);
-
   bool IsCanceled() { return m_bCanceled; }
 
   /*! \brief Wait for a runnable to execute off-thread.
@@ -50,5 +48,4 @@ protected:
   void Open_Internal(bool bProcessRenderLoop, const std::string& param = "") override;
   bool m_bCanceled;
   bool m_bLastVisible = false;
-  float m_progress; ///< current progress
 };

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -13,19 +13,11 @@
 class IRunnable;
 class CEvent;
 
-class CGUIDialogBusy: public CGUIDialog
+class CGUIDialogBusy : private CGUIDialog
 {
-public:
-  CGUIDialogBusy(void);
-  ~CGUIDialogBusy(void) override;
-  bool OnBack(int actionID) override;
-  void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
-  void Render() override;
-  /*! \brief set the current progress of the busy operation
-   \param progress a percentage of progress
-   */
-  bool IsCanceled() { return m_bCanceled; }
+  friend class CGUIWindowManager;
 
+public:
   /*! \brief Wait for a runnable to execute off-thread.
    Creates a thread to run the given runnable, and while waiting
    it displays the busy dialog.
@@ -44,8 +36,17 @@ public:
    \return true if the event completed, false if cancelled.
    */
   static bool WaitOnEvent(CEvent &event, unsigned int displaytime = 100, bool allowCancel = true);
-protected:
+
+private:
+  CGUIDialogBusy();
+  ~CGUIDialogBusy() override;
+
   void Open_Internal(bool bProcessRenderLoop, const std::string& param = "") override;
-  bool m_bCanceled;
-  bool m_bLastVisible = false;
+  bool OnBack(int actionID) override;
+  void DoProcess(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
+  void Render() override;
+
+  bool m_bLastVisible{false};
+  bool m_cancelled{false};
+  uint32_t m_waiters{0};
 };

--- a/xbmc/dialogs/GUIDialogBusyNoCancel.cpp
+++ b/xbmc/dialogs/GUIDialogBusyNoCancel.cpp
@@ -10,18 +10,13 @@
 
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "threads/Thread.h"
-
-#define PROGRESS_CONTROL 10
-
 
 CGUIDialogBusyNoCancel::CGUIDialogBusyNoCancel(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY_NOCANCEL, "DialogBusy.xml", DialogModalityType::MODAL)
 {
   m_loadType = LOAD_ON_GUI_INIT;
-  m_progress = -1;
 }
 
 CGUIDialogBusyNoCancel::~CGUIDialogBusyNoCancel(void) = default;
@@ -30,11 +25,9 @@ void CGUIDialogBusyNoCancel::Open_Internal(bool bProcessRenderLoop,
                                            const std::string& param /* = "" */)
 {
   m_bLastVisible = true;
-  m_progress = -1;
 
   CGUIDialog::Open_Internal(false, param);
 }
-
 
 void CGUIDialogBusyNoCancel::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
@@ -42,15 +35,6 @@ void CGUIDialogBusyNoCancel::DoProcess(unsigned int currentTime, CDirtyRegionLis
   if (!visible && m_bLastVisible)
     dirtyregions.push_back(CDirtyRegion(m_renderRegion));
   m_bLastVisible = visible;
-
-  // update the progress control if available
-  CGUIControl *control = GetControl(PROGRESS_CONTROL);
-  if (control && control->GetControlType() == CGUIControl::GUICONTROL_PROGRESS)
-  {
-    CGUIProgressControl *progress = static_cast<CGUIProgressControl*>(control);
-    progress->SetPercentage(m_progress);
-    progress->SetVisible(m_progress > -1);
-  }
 
   CGUIDialog::DoProcess(currentTime, dirtyregions);
 }

--- a/xbmc/dialogs/GUIDialogBusyNoCancel.h
+++ b/xbmc/dialogs/GUIDialogBusyNoCancel.h
@@ -21,5 +21,4 @@ public:
 protected:
   void Open_Internal(bool bProcessRenderLoop, const std::string& param = "") override;
   bool m_bLastVisible = false;
-  float m_progress;
 };

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -236,8 +236,6 @@ bool CGUIWindowMusicPlayList::OnAction(const CAction &action)
 
 bool CGUIWindowMusicPlayList::OnBack(int actionID)
 {
-  CancelUpdateItems();
-
   if (actionID == ACTION_NAV_BACK)
     return CGUIWindow::OnBack(actionID); // base class goes up a folder, but none to go up
   return CGUIWindowMusicBase::OnBack(actionID);

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -17,7 +17,6 @@
 #include <string>
 
 class PLT_MediaController;
-class CGUIDialogBusy;
 
 namespace UPNP
 {
@@ -59,7 +58,6 @@ public:
 
   int PlayFile(const CFileItem& file,
                const CPlayerOptions& options,
-               CGUIDialogBusy*& dialog,
                XbmcThreads::EndTime<>& timeout);
 
 private:

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -13,7 +13,7 @@
 #include "PowerTypes.h"
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
-#include "dialogs/GUIDialogBusy.h"
+#include "dialogs/GUIDialogBusyNoCancel.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -107,7 +107,9 @@ bool CPowerManager::Powerdown()
 {
   if (CanPowerdown() && m_instance->Powerdown())
   {
-    CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+    CGUIDialogBusyNoCancel* dialog =
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusyNoCancel>(
+            WINDOW_DIALOG_BUSY_NOCANCEL);
     if (dialog)
       dialog->Open();
 
@@ -135,7 +137,9 @@ bool CPowerManager::Reboot()
   {
     CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnRestart");
 
-    CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+    CGUIDialogBusyNoCancel* dialog =
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusyNoCancel>(
+            WINDOW_DIALOG_BUSY_NOCANCEL);
     if (dialog)
       dialog->Open();
   }
@@ -180,7 +184,9 @@ void CPowerManager::OnSleep()
 {
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnSleep");
 
-  CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+  CGUIDialogBusyNoCancel* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusyNoCancel>(
+          WINDOW_DIALOG_BUSY_NOCANCEL);
   if (dialog)
     dialog->Open();
 
@@ -205,7 +211,9 @@ void CPowerManager::OnWake()
   // reset out timers
   g_application.ResetShutdownTimers();
 
-  CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+  CGUIDialogBusyNoCancel* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusyNoCancel>(
+          WINDOW_DIALOG_BUSY_NOCANCEL);
   if (dialog)
     dialog->Close(true); // force close. no closing animation, sound etc at this early stage
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -221,8 +221,6 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
 
 bool CGUIMediaWindow::OnBack(int actionID)
 {
-  CancelUpdateItems();
-
   CURL filterUrl(m_strFilterPath);
   if (actionID == ACTION_NAV_BACK &&
       !m_vecItems->IsVirtualDirectoryRoot() &&
@@ -240,25 +238,23 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
   switch ( message.GetMessage() )
   {
   case GUI_MSG_WINDOW_DEINIT:
+  {
+    m_iLastControl = GetFocusedControlID();
+    CGUIWindow::OnMessage(message);
+
+    // get rid of any active filtering
+    if (m_canFilterAdvanced)
     {
-      CancelUpdateItems();
-
-      m_iLastControl = GetFocusedControlID();
-      CGUIWindow::OnMessage(message);
-
-      // get rid of any active filtering
-      if (m_canFilterAdvanced)
-      {
-        m_canFilterAdvanced = false;
-        m_filter.Reset();
-      }
-      m_strFilterPath.clear();
-
-      // Call ClearFileItems() after our window has finished doing any WindowClose
-      // animations
-      ClearFileItems();
-      return true;
+      m_canFilterAdvanced = false;
+      m_filter.Reset();
     }
+    m_strFilterPath.clear();
+
+    // Call ClearFileItems() after our window has finished doing any WindowClose
+    // animations
+    ClearFileItems();
+    return true;
+  }
     break;
 
   case GUI_MSG_CLICKED:
@@ -2221,7 +2217,7 @@ bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool us
     bool ret = true;
     CGetDirectoryItems getItems(m_rootDir, url, items, useDir);
 
-    if (!WaitGetDirectoryItems(getItems))
+    if (!CGUIDialogBusy::Wait(&getItems, 100, true))
     {
       // cancelled
       ret = false;
@@ -2233,69 +2229,17 @@ bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool us
       {
         ret = false;
       }
-      else if (!WaitGetDirectoryItems(getItems) || !getItems.m_result)
+      else if (!CGUIDialogBusy::Wait(&getItems, 100, true) || !getItems.m_result)
       {
         ret = false;
       }
     }
 
-    m_updateJobActive = false;
     m_rootDir.ReleaseDirImpl();
     return ret;
   }
   else
   {
     return m_rootDir.GetDirectory(url, items, useDir, false);
-  }
-}
-
-bool CGUIMediaWindow::WaitGetDirectoryItems(CGetDirectoryItems &items)
-{
-  bool ret = true;
-  CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
-  if (dialog && !dialog->IsDialogRunning())
-  {
-    if (!CGUIDialogBusy::Wait(&items, 100, true))
-    {
-      // cancelled
-      ret = false;
-    }
-  }
-  else
-  {
-    m_updateJobActive = true;
-    m_updateEvent.Reset();
-    CServiceBroker::GetJobManager()->Submit(
-        [&]() {
-          items.Run();
-          m_updateEvent.Set();
-        },
-        nullptr, CJob::PRIORITY_NORMAL);
-
-    while (!m_updateEvent.Wait(1ms))
-    {
-      if (!ProcessRenderLoop(false))
-        break;
-    }
-
-    if (m_updateAborted || !items.m_result)
-    {
-      ret = false;
-    }
-  }
-  return ret;
-}
-
-void CGUIMediaWindow::CancelUpdateItems()
-{
-  if (m_updateJobActive)
-  {
-    m_rootDir.CancelDirectory();
-    m_updateAborted = true;
-    if (!m_updateEvent.Wait(5000ms))
-    {
-      CLog::Log(LOGERROR, "CGUIMediaWindow::CancelUpdateItems - error cancel update");
-    }
-    m_updateJobActive = false;
   }
 }

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -159,9 +159,7 @@ protected:
   virtual void OnDeleteItem(int iItem);
   void OnRenameItem(int iItem);
   bool WaitForNetwork() const;
-  bool GetDirectoryItems(CURL &url, CFileItemList &items, bool useDir);
-  bool WaitGetDirectoryItems(CGetDirectoryItems &items);
-  void CancelUpdateItems();
+  bool GetDirectoryItems(CURL& url, CFileItemList& items, bool useDir);
 
   /*! \brief Translate the folder to start in from the given quick path
    \param url the folder the user wants
@@ -200,9 +198,6 @@ protected:
   protected:
     std::atomic_bool &m_update;
   };
-  CEvent m_updateEvent;
-  std::atomic_bool m_updateAborted = {false};
-  std::atomic_bool m_updateJobActive = {false};
 
   // save control state on window exit
   int m_iLastControl;


### PR DESCRIPTION
A couple of busy dialog related cleanups and improvements:

* Remove dead progress control code from `CGUIDialogBusy` and `CGUIDialogBusyNoCancel`. The progress was never set, `CGUIDialogNoCancel` did not even have a method to set it! . The code that set progress was removed years ago and it seems it was simply forgotten to cleanup the dialog code.
* Cleanup `CUPnPPlayer` code. remove unneeded calls to close the dialog as this gets done automatically by `CGUIDialogBusy::WaitOnEvent`. Could be fallout from refactroings done years ago.
* Simplify `CPowerMananager` code to use the simple `CGUIDialogNoCancel` as power management actions cannot be cancelled.
* **Most important commit in this PR**: Make `CGUIDialogBusy::WaitOnEvent` reentrant instead of throwing an exception in case this method gets called when another busy dialog is already running.
* Prevent blocking of GUI when opening internet streams. Put long lasting operation to create and load the playlist into a thread and display a busy dialog until create/load has finished. Note: what actually takes long here is mime type detection via HAED (?) HTTP request.
*  Prevent blocking of GUI when opening internet streams. Put mime type detection into VideoPlayer's worker thread instead of doing this in `CVideoPlayer::OpenFile`which gets called from the GUI thread.

Changes were carefully runtime-tested on macOS and Android, latest master.

No idea who could review the changes as many and partly orphaned components are affected.