### PR TITLE
[tools/depends][target] pythonmodules fix ios/tvos linking incorrect arch

### DIFF
--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -33,9 +33,10 @@ ifeq (darwin, $(findstring darwin, $(HOST)))
     # Work around an issue with xcode 11 stripping -arch arm64 flags.
     # Not required for xcode 12+, but doesnt hurt either.
     CFLAGS+= -target arm64-apple-darwin
+    LDFLAGS+= -target arm64-apple-darwin
   endif
 
-  LDSHARED:=$(CC) -bundle -undefined dynamic_lookup
+  LDSHARED:=$(CC) -bundle -undefined dynamic_lookup $(LDFLAGS)
   export ZLIB_ROOT=$(SDKROOT)/usr
 endif
 

--- a/tools/depends/target/pythonmodule-pycryptodome/Makefile
+++ b/tools/depends/target/pythonmodule-pycryptodome/Makefile
@@ -14,8 +14,9 @@ ifeq (darwin, $(findstring darwin, $(HOST)))
     # Work around an issue with xcode 11 stripping -arch arm64 flags.
     # Not required for xcode 12+, but doesnt hurt either.
     CFLAGS+= -target arm64-apple-darwin
+    LDFLAGS+= -target arm64-apple-darwin
   endif
-  LDSHARED:=$(CC) -bundle -undefined dynamic_lookup
+  LDSHARED:=$(CC) -bundle -undefined dynamic_lookup $(LDFLAGS)
 endif
 
 ifeq ($(TARGET_PLATFORM),appletvos)


### PR DESCRIPTION
## Description
Fixes #21524

python module building on jenkins xcode 11.3.1 strips -arch flags from both cflags and ldflags. Fix passing target to ldflags so linker doesnt use host arch type as link target.

## Motivation and context
Fix pil/pycryptodome loading on ios/tvos targets

## How has this been tested?
Build on jenkins. lipo -info for both .o and .so targets now correctly reflect arm64

## What is the effect on users?
Working binary python modules

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
