### PR TITLE
NFS: remove deprecated use of nfs_stat and use nfs_stat64 instead

### DIFF
--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -120,7 +120,7 @@ bool CNFSDirectory::ResolveSymlink( const std::string &dirName, struct nfsdirent
 
   if(ret == 0)
   {
-    NFSSTAT tmpBuffer = {};
+    nfs_stat_64 tmpBuffer = {};
     fullpath = dirName;
     URIUtils::AddSlashAtEnd(fullpath);
     fullpath.append(resolvedLink);
@@ -139,7 +139,7 @@ bool CNFSDirectory::ResolveSymlink( const std::string &dirName, struct nfsdirent
     }
     else
     {
-      ret = nfs_stat(gNfsConnection.GetNfsContext(), fullpath.c_str(), &tmpBuffer);
+      ret = nfs_stat64(gNfsConnection.GetNfsContext(), fullpath.c_str(), &tmpBuffer);
       resolvedUrl.SetFileName(gNfsConnection.GetConnectedExport() + fullpath);
     }
 
@@ -151,21 +151,42 @@ bool CNFSDirectory::ResolveSymlink( const std::string &dirName, struct nfsdirent
     }
     else
     {
-      dirent->inode = tmpBuffer.st_ino;
-      dirent->mode = tmpBuffer.st_mode;
-      dirent->size = tmpBuffer.st_size;
-      dirent->atime.tv_sec = static_cast<long>(tmpBuffer.st_atime);
-      dirent->mtime.tv_sec = static_cast<long>(tmpBuffer.st_mtime);
-      dirent->ctime.tv_sec = static_cast<long>(tmpBuffer.st_ctime);
+      dirent->inode = tmpBuffer.nfs_ino;
+      dirent->mode = tmpBuffer.nfs_mode;
+      dirent->size = tmpBuffer.nfs_size;
+      dirent->atime.tv_sec = tmpBuffer.nfs_atime;
+      dirent->mtime.tv_sec = tmpBuffer.nfs_mtime;
+      dirent->ctime.tv_sec = tmpBuffer.nfs_ctime;
 
       //map stat mode to nf3type
-      if(S_ISBLK(tmpBuffer.st_mode)){ dirent->type = NF3BLK; }
-      else if(S_ISCHR(tmpBuffer.st_mode)){ dirent->type = NF3CHR; }
-      else if(S_ISDIR(tmpBuffer.st_mode)){ dirent->type = NF3DIR; }
-      else if(S_ISFIFO(tmpBuffer.st_mode)){ dirent->type = NF3FIFO; }
-      else if(S_ISREG(tmpBuffer.st_mode)){ dirent->type = NF3REG; }
-      else if(S_ISLNK(tmpBuffer.st_mode)){ dirent->type = NF3LNK; }
-      else if(S_ISSOCK(tmpBuffer.st_mode)){ dirent->type = NF3SOCK; }
+      if (S_ISBLK(tmpBuffer.nfs_mode))
+      {
+        dirent->type = NF3BLK;
+      }
+      else if (S_ISCHR(tmpBuffer.nfs_mode))
+      {
+        dirent->type = NF3CHR;
+      }
+      else if (S_ISDIR(tmpBuffer.nfs_mode))
+      {
+        dirent->type = NF3DIR;
+      }
+      else if (S_ISFIFO(tmpBuffer.nfs_mode))
+      {
+        dirent->type = NF3FIFO;
+      }
+      else if (S_ISREG(tmpBuffer.nfs_mode))
+      {
+        dirent->type = NF3REG;
+      }
+      else if (S_ISLNK(tmpBuffer.nfs_mode))
+      {
+        dirent->type = NF3LNK;
+      }
+      else if (S_ISSOCK(tmpBuffer.nfs_mode))
+      {
+        dirent->type = NF3SOCK;
+      }
     }
   }
   else
@@ -350,12 +371,12 @@ bool CNFSDirectory::Exists(const CURL& url2)
   if(!gNfsConnection.Connect(url,folderName))
     return false;
 
-  NFSSTAT info;
-  ret = nfs_stat(gNfsConnection.GetNfsContext(), folderName.c_str(), &info);
+  nfs_stat_64 info;
+  ret = nfs_stat64(gNfsConnection.GetNfsContext(), folderName.c_str(), &info);
 
   if (ret != 0)
   {
     return false;
   }
-  return S_ISDIR(info.st_mode) ? true : false;
+  return S_ISDIR(info.nfs_mode) ? true : false;
 }

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -421,7 +421,7 @@ void CNfsConnection::keepAlive(const std::string& _exportPath, struct nfsfh* _pF
   nfs_lseek(pContext, _pFileHandle, offset, SEEK_SET, &offset);
 }
 
-int CNfsConnection::stat(const CURL &url, NFSSTAT *statbuff)
+int CNfsConnection::stat(const CURL& url, nfs_stat_64* statbuff)
 {
   std::unique_lock<CCriticalSection> lock(*this);
   int nfsRet = 0;
@@ -444,7 +444,7 @@ int CNfsConnection::stat(const CURL &url, NFSSTAT *statbuff)
 
       if(nfsRet == 0)
       {
-        nfsRet = nfs_stat(pTmpContext, relativePath.c_str(), statbuff);
+        nfsRet = nfs_stat64(pTmpContext, relativePath.c_str(), statbuff);
       }
       else
       {
@@ -576,7 +576,6 @@ bool CNFSFile::Open(const CURL& url)
   return true;
 }
 
-
 bool CNFSFile::Exists(const CURL& url)
 {
   return Stat(url,NULL) == 0;
@@ -597,10 +596,9 @@ int CNFSFile::Stat(const CURL& url, struct __stat64* buffer)
   if(!gNfsConnection.Connect(url,filename))
     return -1;
 
+  nfs_stat_64 tmpBuffer = {};
 
-  NFSSTAT tmpBuffer = {};
-
-  ret = nfs_stat(gNfsConnection.GetNfsContext(), filename.c_str(), &tmpBuffer);
+  ret = nfs_stat64(gNfsConnection.GetNfsContext(), filename.c_str(), &tmpBuffer);
 
   //if buffer == NULL we where called from Exists - in that case don't spam the log with errors
   if (ret != 0 && buffer != NULL)
@@ -617,17 +615,17 @@ int CNFSFile::Stat(const CURL& url, struct __stat64* buffer)
       memcpy(buffer, &tmpBuffer, sizeof(struct __stat64));
 #else
       memset(buffer, 0, sizeof(struct __stat64));
-      buffer->st_dev = tmpBuffer.st_dev;
-      buffer->st_ino = tmpBuffer.st_ino;
-      buffer->st_mode = tmpBuffer.st_mode;
-      buffer->st_nlink = tmpBuffer.st_nlink;
-      buffer->st_uid = tmpBuffer.st_uid;
-      buffer->st_gid = tmpBuffer.st_gid;
-      buffer->st_rdev = tmpBuffer.st_rdev;
-      buffer->st_size = tmpBuffer.st_size;
-      buffer->st_atime = tmpBuffer.st_atime;
-      buffer->st_mtime = tmpBuffer.st_mtime;
-      buffer->st_ctime = tmpBuffer.st_ctime;
+      buffer->st_dev = tmpBuffer.nfs_dev;
+      buffer->st_ino = tmpBuffer.nfs_ino;
+      buffer->st_mode = tmpBuffer.nfs_mode;
+      buffer->st_nlink = tmpBuffer.nfs_nlink;
+      buffer->st_uid = tmpBuffer.nfs_uid;
+      buffer->st_gid = tmpBuffer.nfs_gid;
+      buffer->st_rdev = tmpBuffer.nfs_rdev;
+      buffer->st_size = tmpBuffer.nfs_size;
+      buffer->st_atime = tmpBuffer.nfs_atime;
+      buffer->st_mtime = tmpBuffer.nfs_mtime;
+      buffer->st_ctime = tmpBuffer.nfs_ctime;
 #endif
     }
   }

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -18,12 +18,7 @@
 #include <list>
 #include <map>
 
-#if defined(TARGET_WINDOWS)
-struct __stat64;
-#define NFSSTAT struct __stat64
-#else
-#define NFSSTAT struct stat
-#endif
+struct nfs_stat_64;
 
 class CNfsConnection : public CCriticalSection
 {
@@ -57,7 +52,7 @@ public:
 
   //special stat which uses its own context
   //needed for getting intervolume symlinks to work
-  int stat(const CURL &url, NFSSTAT *statbuff);
+  int stat(const CURL& url, nfs_stat_64* statbuff);
 
   void AddActiveConnection();
   void AddIdleConnection();


### PR DESCRIPTION
This removes the use of nfs_stat and uses nfs_stat64 instead. This has been available in libnfs for a long time.

This is also needed for nfsv4 support.

ref: https://github.com/sahlberg/libnfs/blob/master/include/nfsc/libnfs.h#L404