### PR TITLE
CNfsConnection: make getContextForExport return an enum class

### DIFF
--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -74,6 +74,13 @@ public:
   const std::string GetContextMapId() const {return m_hostName + m_exportPath;}
 
 private:
+  enum class ContextStatus
+  {
+    INVALID,
+    NEW,
+    CACHED
+  };
+
   struct nfs_context *m_pNfsContext;//current nfs context
   std::string m_exportPath;//current connected export path
   std::string m_hostName;//current connected host
@@ -92,7 +99,9 @@ private:
 
   void clearMembers();
   struct nfs_context *getContextFromMap(const std::string &exportname, bool forceCacheHit = false);
-  int getContextForExport(const std::string &exportname);//get context for given export and add to open contexts map - sets m_pNfsContext (my return a already mounted cached context)
+
+  // get context for given export and add to open contexts map - sets m_pNfsContext (may return an already mounted cached context)
+  ContextStatus getContextForExport(const std::string& exportname);
   void destroyOpenContexts();
   void destroyContext(const std::string &exportName);
   void resolveHost(const CURL &url);//resolve hostname by dnslookup


### PR DESCRIPTION
This makes `CNfsConnection::getContextForExport` return an enum class instead of an int. This allows removing some defines and improves readability.