### PR TITLE
CGUIDialogNetworkSetup: fix log call

### DIFF
--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -403,7 +403,7 @@ bool CGUIDialogNetworkSetup::SetPath(const std::string &path)
   }
   if (m_protocol == -1)
   {
-    CLog::Log(LOGERROR, "__PRETTY_FUNCTION__: Asked to initialize for unknown path {}", path);
+    CLog::LogF(LOGERROR, "Asked to initialize for unknown path {}", path);
     Reset();
     return false;
   }


### PR DESCRIPTION
Just something I found when fuzzing. 

Simple fix. Looks like it dates all the way back to a1c4476a3ee
