### PR TITLE
[addons] fix update detection based on „official/any repo“ setting

### DIFF
--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -238,9 +238,13 @@ bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
   {
     if (ORIGIN_SYSTEM != addon->Origin() && !hasOfficialUpdate) // not a system addon
     {
-      // If we didn't find an official update
-      if (IsFromOfficialRepo(addon, CheckAddonPath::YES)) // is an official addon
+
+      // we didn't find an official update.
+      // either version is current or that add-on isn't contained in official repos
+      if (IsFromOfficialRepo(addon, CheckAddonPath::NO))
       {
+
+        // check further if it IS contained in official repos
         if (updateMode == AddonRepoUpdateMode::ANY_REPOSITORY)
         {
           if (!FindAddonAndCheckForUpdate(addon, m_latestPrivateVersions, update))
@@ -287,15 +291,11 @@ bool CAddonRepos::FindAddonAndCheckForUpdate(
     {
       // return addon update
       update = remote->second;
+      return true; // update found
     }
-    else
-    {
-      // addon found, but it's up to date
-      update = nullptr;
-    }
-    return true;
   }
 
+  // either addon wasn't found or it's up to date
   return false;
 }
 

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -207,9 +207,9 @@ private:
    * \param map the repository map we want to check against
    * \param[out] pointer to the found update. if the addon is
    *              up-to-date on our system, this param will return 'nullptr'
-   * \return true if the addon was found in the desired map,
-   *         either up-to-date or newer version.
-   *         false if the addon does NOT exist in the map
+   * \return true if the addon was found in the desired map and
+   *         its version is newer than our local version.
+   *         false if the addon does NOT exist in the map or it is up to date.
    */
   bool FindAddonAndCheckForUpdate(const std::shared_ptr<IAddon>& addonToCheck,
                                   const std::map<std::string, std::shared_ptr<IAddon>>& map,


### PR DESCRIPTION

## Description
Backport https://github.com/xbmc/xbmc/pull/21581
Closes https://github.com/xbmc/xbmc/issues/21572

1. `CAddonRepos::FindAddonAndCheckForUpdate()` return `false` if checked add-on is found and up to date
2. disable add-on installation path check

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
