### PR TITLE
[discs] Fix crash on android when playing dvd folder structures from vfs

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -2029,7 +2029,7 @@ extern "C"
     if (!fp)
       return nullptr;
 
-#if defined(TARGET_LINUX)
+#if defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
     struct mntent* mountPoint = getmntent(fp);
     if (mountPoint)
       return mountPoint;

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -2047,6 +2047,19 @@ extern "C"
 #endif
   }
 
+  struct mntent* dll_getmntent_r(FILE* fp, struct mntent* result, char* buffer, int bufsize)
+  {
+    if (!fp || !result || !buffer)
+      return nullptr;
+
+#if defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
+    struct mntent* mountPoint = getmntent_r(fp, result, buffer, bufsize);
+    if (mountPoint)
+      return mountPoint;
+#endif
+    return nullptr;
+  }
+
   // this needs to be wrapped, since dll's have their own file
   // descriptor list, but we always use app's list with our wrappers
   int __cdecl dll_open_osfhandle(intptr_t _OSFileHandle, int _Flags)

--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -95,6 +95,7 @@ FILE* dll_popen(const char *command, const char *mode);
 void* dll_dlopen(const char *filename, int flag);
 int dll_setvbuf(FILE *stream, char *buf, int type, size_t size);
 struct mntent *dll_getmntent(FILE *fp);
+struct mntent* dll_getmntent_r(FILE* fp, struct mntent* result, char* buffer, int bufsize);
 
 void *__wrap_dlopen(const char *filename, int flag)
 {
@@ -441,6 +442,14 @@ struct mntent *__wrap_getmntent(FILE *fp)
 {
 #ifdef TARGET_POSIX
   return dll_getmntent(fp);
+#endif
+  return NULL;
+}
+
+struct mntent* __wrap_getmntent_r(FILE* fp, struct mntent* result, char* buffer, int bufsize)
+{
+#ifdef TARGET_POSIX
+  return dll_getmntent_r(fp, result, buffer, bufsize);
 #endif
   return NULL;
 }


### PR DESCRIPTION
## Description
Partly a regression from https://github.com/xbmc/xbmc/pull/21018/files but also caused by the recent update of libdvdread (which introduces `getmntent_r`). Kodi in android is crashing when playing dvd folder structures stored on remote vfs paths (smb, nfs, etc). Crash occurs inside libc:

```
06-20 16:28:04.593  1255  1255 I /system/bin/tombstoned: received crash request for pid 19625
06-20 16:28:04.595 19629 19629 I crash_dump32: performing dump of process 19483 (target tid = 19625)
06-20 16:28:04.628 19629 19629 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
06-20 16:28:04.628 19629 19629 F DEBUG   : Build fingerprint: 'OnePlus/OnePlus6/OnePlus6:10/QKQ1.190716.003/2107132155:user/release-keys'
06-20 16:28:04.628 19629 19629 F DEBUG   : Revision: '0'
06-20 16:28:04.628 19629 19629 F DEBUG   : ABI: 'arm'
06-20 16:28:04.628 19629 19629 F DEBUG   : Timestamp: 2022-06-20 16:28:04+0100
06-20 16:28:04.628 19629 19629 F DEBUG   : pid: 19483, tid: 19625, name: Thread-4  >>> org.xbmc.kodi <<<
06-20 16:28:04.628 19629 19629 F DEBUG   : uid: 10635
06-20 16:28:04.628 19629 19629 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x20
06-20 16:28:04.628 19629 19629 F DEBUG   : Cause: null pointer dereference
06-20 16:28:04.628 19629 19629 F DEBUG   :     r0  00000000  r1  00002000  r2  c0873e3c  r3  00002000
06-20 16:28:04.628 19629 19629 F DEBUG   :     r4  c0873e3c  r5  00002000  r6  86959344  r7  c0873e3c
06-20 16:28:04.628 19629 19629 F DEBUG   :     r8  00002000  r9  869592d4  r10 86959280  r11 869592d0
06-20 16:28:04.628 19629 19629 F DEBUG   :     ip  ed63cfd4  sp  86959230  lr  ed5ec0cd  pc  ed628740
06-20 16:28:04.653 19629 19629 F DEBUG   : 
06-20 16:28:04.653 19629 19629 F DEBUG   : backtrace:
06-20 16:28:04.653 19629 19629 F DEBUG   :       #00 pc 000a1740  /apex/com.android.runtime/lib/bionic/libc.so (fgets+12) (BuildId: dc42f83dc4923ba221d4d2d85eb935a3)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #01 pc 000650c9  /apex/com.android.runtime/lib/bionic/libc.so (getmntent_r+64) (BuildId: dc42f83dc4923ba221d4d2d85eb935a3)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #02 pc 00012ba4  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libdvdnav-arm.so
06-20 16:28:04.653 19629 19629 F DEBUG   :       #03 pc 0000dc8c  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libdvdnav-arm.so (vm_reset+500)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #04 pc 00006c34  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libdvdnav-arm.so
06-20 16:28:04.653 19629 19629 F DEBUG   :       #05 pc 00006cf0  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libdvdnav-arm.so (dvdnav_open2+20)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #06 pc 0106f340  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so (CDVDInputStreamNavigator::Open()+580)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #07 pc 01100ce4  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so (CVideoPlayer::OpenInputStream()+412)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #08 pc 01103540  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so (CVideoPlayer::Prepare()+304)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #09 pc 01104dd0  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so (CVideoPlayer::Process()+64)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #10 pc 013378e4  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so (CThread::Action()+40)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #11 pc 01337e00  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so
06-20 16:28:04.653 19629 19629 F DEBUG   :       #12 pc 01337c88  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so
06-20 16:28:04.653 19629 19629 F DEBUG   :       #13 pc 01337abc  /data/app/org.xbmc.kodi-jPy2ATgYTNhSTztjUzWaiA==/lib/arm/libkodi.so
06-20 16:28:04.653 19629 19629 F DEBUG   :       #14 pc 000a6aa1  /apex/com.android.runtime/lib/bionic/libc.so (__pthread_start(void*)+20) (BuildId: dc42f83dc4923ba221d4d2d85eb935a3)
06-20 16:28:04.653 19629 19629 F DEBUG   :       #15 pc 0005fdc9  /apex/com.android.runtime/lib/bionic/libc.so (__start_thread+30) (BuildId: dc42f83dc4923ba221d4d2d85eb935a3)
```

This PR adds `getmntent_r` to the list of wrapped functions on the dllwrapper and disables any `getmntent` callbacks for android just like before. Tested with dvdfolder structures and isos on nfs on my phone and on android tv.