### PR TITLE
[cmake] Fix libdvd build failure after #21579

### DIFF
--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -74,7 +74,11 @@ else()
   if(ENABLE_DVDCSS)
     list(APPEND dvdlibs libdvdcss)
   endif()
-  set(DEPENDS_TARGETS_DIR ${CMAKE_SOURCE_DIR}/tools/depends/target)
+
+  # Set variables normally set in SETUP_BUILD_VARS macro
+  set(LIB_TYPE "target")
+  set(PROJECTSOURCE ${CMAKE_SOURCE_DIR})
+  set(DEP_LOCATION "${DEPENDS_PATH}")
 
   foreach(dvdlib ${dvdlibs})
 
@@ -82,7 +86,7 @@ else()
 
     # Variables required being set for clean get_versionfile_data use
     set(MODULE_LC ${dvdlib})
-    set(PROJECTSOURCE ${CMAKE_SOURCE_DIR})
+
     get_versionfile_data()
 
     # allow user to override the download URL with a local tarball

--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -80,6 +80,9 @@ else()
   set(PROJECTSOURCE ${CMAKE_SOURCE_DIR})
   set(DEP_LOCATION "${DEPENDS_PATH}")
 
+  # clear any potentially set variables
+  CLEAR_BUILD_VARS()
+
   foreach(dvdlib ${dvdlibs})
 
     string(TOUPPER ${dvdlib} MODULE)

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -131,6 +131,10 @@ macro(SETUP_BUILD_VARS)
     message(STATUS "${MODULE}_URL: ${${MODULE}_URL}")
   endif()
 
+  CLEAR_BUILD_VARS()
+endmacro()
+
+macro(CLEAR_BUILD_VARS)
   # unset all build_dep_target variables to insure clean state
   unset(BUILD_NAME)
   unset(INSTALL_DIR)


### PR DESCRIPTION
## Description
libdvd doesnt use SETUP_BUILD_VARS macro, so some variables arent set.
Manually set the required vars.

## Motivation and context
Fix build failure in circumstances provided in https://github.com/xbmc/xbmc/pull/21579#commitcomment-76612490

@Portisch @vpeter4 this should fix your build failures.

this is a short term fix. We will look to redo the find module for libdvd* completely and to use the full macro suite properly so we dont have to set these variables independently.

## How has this been tested?
Build dvdnav with no other libs built prior and with libdvd being first findmodule checked (relocated to top of optional), means theres no variables being carried into the scope

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
