### PR TITLE
[settings] Introduce new string id for BackgroundType::NONE …

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23138,3 +23138,9 @@ msgstr ""
 msgctxt "#39187"
 msgid "Closed caption subtitles"
 msgstr ""
+
+#. Item list value of setting with label #39166 "Background type"
+#: system/settings/settings.xml
+msgctxt "#39188"
+msgid "No background"
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -578,7 +578,7 @@
           <default>0</default> <!-- BackgroundType::NONE -->
           <constraints>
             <options>
-              <option label="231">0</option> <!-- BackgroundType::NONE -->
+              <option label="39188">0</option> <!-- BackgroundType::NONE -->
               <option label="39166">1</option> <!-- BackgroundType::SHADOW -->
               <option label="39167">2</option> <!-- BackgroundType::BOX -->
               <option label="39168">3</option> <!-- BackgroundType::SQUAREBOX -->


### PR DESCRIPTION
…as the English word 'None' needs translation to different words for some languages. Example: In German, 'none' can be 'kein', 'keiner', keine', depending on the context.

@da-anda changed string is used in subtitle settings to indicate that no background  type shall be used, which is "None" in English, corresponding string id is 231 which exists since a long time and got reused here. It is translated to "Keine" in German. This translation fits for the other places this id was used before, but for the background type this needs to read "Keiner" in German, thus we need to introduce another string id with the English text "None", that will be translated to German "Keiner".

231 English "None" => German "Keine"
39188 English "None" => German "Keiner" (because of "Der Typ")