### PR TITLE
[content] http header: check if content-type starts with "text/html"

### DIFF
--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -73,8 +73,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   {
     /* if Content-Length is found and its not text/html, URL is pointing to file so don't treat URL as HTTPDirectory */
     if (!http.GetHttpHeader().GetValue("Content-Length").empty() &&
-        http.GetHttpHeader().GetValue("Content-type") != "text/html")
+        !StringUtils::StartsWithNoCase(http.GetHttpHeader().GetValue("Content-type"), "text/html"))
+    {
       return false;
+    }
 
     std::string fileCharset(http.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET));
     if (!fileCharset.empty() && fileCharset != "UTF-8")


### PR DESCRIPTION
closes https://github.com/xbmc/xbmc/issues/21590
backport of https://github.com/xbmc/xbmc/pull/21594

## Description
need to check if content-type _starts with_ "text/html"

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
