### PR TITLE
[cmake] FindPython KODI_DEPENDSBUILD set python_ver

### DIFF
--- a/cmake/modules/FindPython.cmake
+++ b/cmake/modules/FindPython.cmake
@@ -34,6 +34,11 @@ if(KODI_DEPENDSBUILD
    OR CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
   set(Python3_USE_STATIC_LIBS TRUE)
   set(Python3_ROOT_DIR ${libdir})
+
+  if(KODI_DEPENDSBUILD)
+    # Force set to tools/depends python version
+    set(PYTHON_VER 3.9)
+  endif()
 endif()
 
 # Provide root dir to search for Python if provided
@@ -55,7 +60,11 @@ endif()
 
 find_package(Python3 ${VERSION} ${EXACT_VER} COMPONENTS Development)
 if(CORE_SYSTEM_NAME STREQUAL linux)
-  find_package(Python3 ${VERSION} ${EXACT_VER} COMPONENTS Interpreter)
+  if(HOST_CAN_EXECUTE_TARGET)
+    find_package(Python3 ${VERSION} ${EXACT_VER} COMPONENTS Interpreter)
+  else()
+    find_package(Python3 COMPONENTS Interpreter)
+  endif()
 endif()
 
 if(KODI_DEPENDSBUILD)


### PR DESCRIPTION
## Description
Set specific python version in cmake find module for python for kodi depends builds

## Motivation and context
Currently have a failure that essentially is caused by a native python version (installed via homebrew on mac) that then causes the find module to fail to recognise the cross compile lib for an aarch64 macos build on intel host.

No other real side effect, as it will just more narrowly target the find_package call to what we need it to find for kodi depends builds.

Build failure message - aarch64-apple-darwin macos target with python installed via homebrew

```
08:24:07 -- Could NOT find Python3 (missing: Python3_INCLUDE_DIRS Python3_LIBRARIES Development Development.Module Development.Embed) 
08:24:08 CMake Error at cmake/scripts/common/Macros.cmake:432 (message):
08:24:08   PYTHON enabled but not found
08:24:08 Call Stack (most recent call first):
08:24:08   CMakeLists.txt:210 (core_optional_dep)
08:24:08 
```

digging into cmake logs shows

```
CMake Debug Log at tools/depends/xbmc-depends/x86_64-darwin19.6.0-native/share/cmake-3.21/Modules/FindPython/Support.cmake:2482 (find_program):
  find_program called with the following settings:

    VAR: _Python3_CONFIG
    NAMES: "python3.7-config"
    Documentation: Path to a program.
    Framework
      Only Search Frameworks: 0
      Search Frameworks Last: 0
      Search Frameworks First: 0
    AppBundle
      Only Search AppBundle: 0
      Search AppBundle Last: 0
      Search AppBundle First: 0
    CMAKE_FIND_USE_CMAKE_PATH: 1
    CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH: 1
    CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH: 1
    CMAKE_FIND_USE_CMAKE_SYSTEM_PATH: 1

  find_program considered the following locations:

    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/bin/bin/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/bin/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/sbin/bin/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/sbin/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/bin/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/lib/bin/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/lib/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/x86_64-darwin19.6.0-native/bin/bin/python3.7-config
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/x86_64-darwin19.6.0-native/bin/python3.7-config
    /Applications/Xcode12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bin/bin/python3.7-config
    /Applications/Xcode12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bin/python3.7-config
    /Applications/Xcode12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/usr/bin/bin/python3.7-config
    /Applications/Xcode12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/usr/bin/python3.7-config
    /usr/local/bin/bin/python3.7-config

  The item was found at

    /usr/local/bin/python3.7-config
```

Although it does find the tools/depend 3.9 version first, it chooses to use this version. The best i can explain it is it cant execute the python-config found in the 3.9 path due to arch type issues, and therefore it continues on, find the brew version with a suitable config that is build with an abi "m" modifier, that then continues to only look for libpython3.xm.a (small snippet below)

```
    VAR: _Python3_LIBRARY_RELEASE
    NAMES: "python30"
           "python3.0m"
    Documentation: Path to a library.
    Framework
      Only Search Frameworks: 0
      Search Frameworks Last: 0
      Search Frameworks First: 0
    AppBundle
      Only Search AppBundle: 0
      Search AppBundle Last: 0
      Search AppBundle First: 0
    CMAKE_FIND_USE_CMAKE_PATH: 1
    CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH: 1
    CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH: 1
    CMAKE_FIND_USE_CMAKE_SYSTEM_PATH: 1

  find_library considered the following locations:

    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/lib/(lib)python30(\.a)
    /Users/Shared/jenkins/workspace/OSX-ARM64/tools/depends/xbmc-depends/macosx11.1_arm64-target-debug/lib/(lib)python3.0m(\.a)
```

python bundled with macos doesnt have a pythonx.y-config, so the package just uses the "found" tools depends version even if it cant execute the python-config, and then continues on to work fine.

I think this is just the easiest path for an obscure corner case. I cant explain why we've had successful aarch64 macos builds up until a week ago (brew python was already on the system prior it seems), and i think this is a suitable change anyway to reduce the find_package(Python3) search paths

## How has this been tested?
Jenkins macos arm successfully builds

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
