### PR TITLE
[CPicture] Align strides to be divisible by 16 when resizing/caching textures

### DIFF
--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -161,7 +161,12 @@ bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t
   // create a buffer large enough for the resulting image
   GetScale(width, height, dest_width, dest_height);
 
-  uint8_t *buffer = new uint8_t[dest_width * dest_height * sizeof(uint32_t)];
+  // Let's align so that stride is always divisible by 16, and then add some 32 bytes more on top
+  // See: https://github.com/FFmpeg/FFmpeg/blob/75638fe9402f70645bdde4d95672fa640a327300/libswscale/tests/swscale.c#L157
+  uint32_t dest_width_aligned = ((dest_width + 15) & ~0x0f);
+  uint32_t stride = dest_width_aligned * sizeof(uint32_t);
+
+  uint32_t* buffer = new uint32_t[dest_width_aligned * dest_height + 4];
   if (buffer == NULL)
   {
     result = NULL;
@@ -169,8 +174,8 @@ bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t
     return false;
   }
 
-  if (!ScaleImage(pixels, width, height, pitch, AV_PIX_FMT_BGRA, buffer, dest_width, dest_height,
-                  dest_width * sizeof(uint32_t), AV_PIX_FMT_BGRA, scalingAlgorithm))
+  if (!ScaleImage(pixels, width, height, pitch, AV_PIX_FMT_BGRA, (uint8_t*)buffer, dest_width,
+                  dest_height, stride, AV_PIX_FMT_BGRA, scalingAlgorithm))
   {
     delete[] buffer;
     result = NULL;
@@ -178,7 +183,8 @@ bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t
     return false;
   }
 
-  bool success = GetThumbnailFromSurface(buffer, dest_width, dest_height, dest_width * sizeof(uint32_t), image, result, result_size);
+  bool success = GetThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height, stride,
+                                         image, result, result_size);
   delete[] buffer;
 
   if (!success)
@@ -239,15 +245,22 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
 
     // create a buffer large enough for the resulting image
     GetScale(width, height, dest_width, dest_height);
-    uint32_t *buffer = new uint32_t[dest_width * dest_height];
+
+    // Let's align so that stride is always divisible by 16, and then add some 32 bytes more on top
+    // See: https://github.com/FFmpeg/FFmpeg/blob/75638fe9402f70645bdde4d95672fa640a327300/libswscale/tests/swscale.c#L157
+    uint32_t dest_width_aligned = ((dest_width + 15) & ~0x0f);
+    uint32_t stride = dest_width_aligned * sizeof(uint32_t);
+
+    uint32_t* buffer = new uint32_t[dest_width_aligned * dest_height + 4];
     if (buffer)
     {
       if (ScaleImage(pixels, width, height, pitch, AV_PIX_FMT_BGRA, (uint8_t*)buffer, dest_width,
-                     dest_height, dest_width * 4, AV_PIX_FMT_BGRA, scalingAlgorithm))
+                     dest_height, stride, AV_PIX_FMT_BGRA, scalingAlgorithm))
       {
         if (!orientation || OrientateImage(buffer, dest_width, dest_height, orientation))
         {
-          success = CreateThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height, dest_width * 4, dest);
+          success = CreateThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height,
+                                               stride, dest);
         }
       }
       delete[] buffer;


### PR DESCRIPTION
## Description
Fixes a crash occurring on Nvidia Shield when thumbnails were being scaled to an odd numbered width/height.

## Motivation and context
This fixes #21558

## How has this been tested?
Tested on my Nvidia Shield. Verified via logcat that it's successfully creating the thumbnail now.
For me, Kodi crashes on startup without this.

## What is the effect on users?
Fixes a crash.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
