### PR TITLE
[tools/depends][target] crossguid set cmake var for non crosscompile path

### DIFF
--- a/tools/depends/target/crossguid/Makefile
+++ b/tools/depends/target/crossguid/Makefile
@@ -16,6 +16,8 @@ else
     BASE_URL := http://mirrors.kodi.tv/build-deps/sources
     RETRIEVE_TOOL := curl -Ls --create-dirs -f -O
     ARCHIVE_TOOL := tar --strip-components=1 -xf
+    CMAKE := cmake
+    CMAKE_OPTIONS := -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(CMAKE_OPTIONS)
     HASH_TOOL = sha512sum
     HASH_TOOL_FLAGS = -c --status
   endif


### PR DESCRIPTION
## Description
Fix building from tools depends when a CROSSCOMPILING=false (eg linux/ppa)

## Motivation and context
Intel engineer raised the concern

## How has this been tested?

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
