### PR TITLE
[INFO] Add ListItem.Property(WatchedEpisodePercent) for tvshows

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5051,6 +5051,14 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     currently selected tvshow or season\, based on the the current watched filter.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`ListItem.Property(WatchedEpisodePercent)`</b>,
+///                  \anchor ListItem_Property_WatchedEpisodePercent
+///                  _string_,
+///     @return The percentage of watched episodes in the tvshow (watched/total*100).
+///     <p><hr>
+///     @skinning_v20 **[New Infolabel]** \link ListItem_Property_WatchedEpisodePercent `ListItem.Property(WatchedEpisodePercent)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`ListItem.PictureAperture`</b>,
 ///                  \anchor ListItem_PictureAperture
 ///                  _string_,

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1050,6 +1050,7 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry,
       pItem->SetProperty("numepisodes", episodes);
       pItem->SetProperty("watchedepisodes", played);
       pItem->SetProperty("unwatchedepisodes", episodes - played);
+      pItem->SetProperty("watchedepisodepercent", played * 100 / episodes);
       watched = (episodes && played >= episodes);
       pItem->GetVideoInfoTag()->SetPlayCount(watched ? 1 : 0);
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4132,6 +4132,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
     item->SetProperty("numepisodes", details.m_iEpisode); // will be changed later to reflect watchmode setting
     item->SetProperty("watchedepisodes", details.GetPlayCount());
     item->SetProperty("unwatchedepisodes", details.m_iEpisode - details.GetPlayCount());
+    item->SetProperty("watchedepisodepercent", (details.GetPlayCount() * 100 / details.m_iEpisode));
   }
   details.SetPlayCount((details.m_iEpisode <= details.GetPlayCount()) ? 1 : 0);
 

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -81,6 +81,7 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
     pItem->SetProperty("numepisodes", watched + unwatched); // will be changed later to reflect watchmode setting
     pItem->SetProperty("watchedepisodes", watched);
     pItem->SetProperty("unwatchedepisodes", unwatched);
+    pItem->SetProperty("watchedepisodepercent", watched * 100 / (watched + unwatched));
 
     // @note: The items list may contain additional items that do not belong to the show.
     // This is the case of the up directory (..) or movies linked to the tvshow.


### PR DESCRIPTION
## Description
Sounded quite easy to implement and was requested by one of our team skinners - this adds `ListItem.Property(WatchedEpisodePercent)` for tvshows so the skin can display the percentage of watched episodes/show.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21543

## How has this been tested?
In estuary:
```
diff --git a/addons/skin.estuary/xml/Variables.xml b/addons/skin.estuary/xml/Variables.xml
index d875941d08..46f49557d6 100644
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -79,7 +79,7 @@
                <value>$INFO[ListItem.Label]</value>
        </variable>
        <variable name="ListLabel2Var">
-               <value condition="String.IsEmpty(Container.PluginName) + Container.Content(tvshows) + Container.SortMethod(29)">$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</value>
+               <value condition="String.IsEmpty(Container.PluginName) + Container.Content(tvshows) + Container.SortMethod(29)">$INFO[ListItem.Property(watchedepisodepercent)]%</value>
                <value condition="Container.SortMethod(7) | Container.SortMethod(29)">$INFO[ListItem.Year]</value>
                <value condition="!String.isempty(ListItem.Appearances)">$LOCALIZE[38026]: $INFO[ListItem.Appearances]</value>
                <value condition="Window.IsActive(musicplaylist) | Window.IsActive(videoplaylist)">$INFO[ListItem.Duration]</value>
```
![Screenshot from 2022-06-26 16-20-26](https://user-images.githubusercontent.com/7375276/175821414-7a2db72f-b5a6-4b39-9c15-91d0b7644af9.png)

![Screenshot from 2022-06-26 16-20-40](https://user-images.githubusercontent.com/7375276/175821419-6e70abd2-ea56-4de2-9e77-b4d431378129.png)


## What is the effect on users?
If the skin takes advantage of it, a percentage mark can be shown in the skin for the several tvshows.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
