### PR TITLE
Remove root type addon sources from GUI, move them to mediamanager

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -611,6 +611,9 @@ bool CApplication::Initialize()
   if (!LoadLanguage(false))
     return false;
 
+  // load media manager sources (e.g. root addon type sources depend on language strings to be available)
+  CServiceBroker::GetMediaManager().LoadSources();
+
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   profileManager->GetEventLog().Add(EventPtr(new CNotificationEvent(

--- a/xbmc/games/windows/GUIViewStateWindowGames.cpp
+++ b/xbmc/games/windows/GUIViewStateWindowGames.cpp
@@ -83,12 +83,6 @@ VECSOURCES& CGUIViewStateWindowGames::GetSources()
     return empty;
   }
 
-  // Game add-ons
-  AddAddonsSource("game", g_localizeStrings.Get(35049), "DefaultAddonGame.png");
-
-  // Global sources
-  AddOrReplace(*pGameSources, CGUIViewState::GetSources());
-
   return *pGameSources;
 }
 

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -81,12 +81,6 @@ VECSOURCES& CGUIViewStateWindowPictures::GetSources()
     return empty;
   }
 
-  // Picture add-ons
-  AddAddonsSource("image", g_localizeStrings.Get(1039), "DefaultAddonPicture.png");
-
-  // Global sources
-  AddOrReplace(*pictureSources, CGUIViewState::GetSources());
-
   return *pictureSources;
 }
 

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -52,7 +52,6 @@ std::string CGUIViewStateWindowPrograms::GetExtensions()
 
 VECSOURCES& CGUIViewStateWindowPrograms::GetSources()
 {
-  AddAddonsSource("executable", g_localizeStrings.Get(1043), "DefaultAddonProgram.png");
 #if defined(TARGET_ANDROID)
   {
     CMediaSource source;

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -116,6 +116,26 @@ protected:
   std::string m_strFirstAvailDrive;
 
 private:
+  /*! \brief Loads the addon sources for the different supported browsable addon types
+   */
+  void LoadAddonSources() const;
+
+  /*! \brief Get the addons root source for the given content type
+   \param type the type of addon content desired
+   \return the given CMediaSource for the addon root directory
+   */
+  CMediaSource GetRootAddonTypeSource(const std::string& type) const;
+
+  /*! \brief Generate the addons source for the given content type
+   \param type the type of addon content desired
+   \param label the name of the addons source
+   \param thumb image to use as the icon
+   \return the given CMediaSource for the addon root directory
+   */
+  CMediaSource ComputeRootAddonTypeSource(const std::string& type,
+                                          const std::string& label,
+                                          const std::string& thumb) const;
+
   std::unique_ptr<IStorageProvider> m_platformStorage;
 #ifdef HAS_DVD_DRIVE
   std::shared_ptr<IDiscDriveHandler> m_platformDiscDriveHander;

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -21,7 +21,6 @@
 #include "addons/gui/GUIViewStateAddonBrowser.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "events/windows/GUIViewStateEventLog.h"
-#include "filesystem/AddonsDirectory.h"
 #include "games/windows/GUIViewStateWindowGames.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -32,7 +31,6 @@
 #include "profiles/ProfileManager.h"
 #include "programs/GUIViewStatePrograms.h"
 #include "pvr/windows/GUIViewStatePVR.h"
-#include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
@@ -444,25 +442,6 @@ std::string CGUIViewState::GetExtensions()
 VECSOURCES& CGUIViewState::GetSources()
 {
   return m_sources;
-}
-
-void CGUIViewState::AddAddonsSource(const std::string &content, const std::string &label, const std::string &thumb)
-{
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bVirtualShares)
-    return;
-
-  CFileItemList items;
-  if (XFILE::CAddonsDirectory::GetScriptsAndPlugins(content, items))
-  { // add the plugin source
-    CMediaSource source;
-    source.strPath = "addons://sources/" + content + "/";
-    source.strName = label;
-    if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
-      source.m_strThumbnailImage = thumb;
-    source.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    source.m_ignore = true;
-    m_sources.push_back(source);
-  }
 }
 
 void CGUIViewState::AddLiveTVSources()

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -60,12 +60,6 @@ protected:
   virtual void SaveViewToDb(const std::string &path, int windowID, CViewState *viewState = NULL);
   void LoadViewState(const std::string &path, int windowID);
 
-  /*! \brief Add the addons source for the given content type, if the user has suitable addons
-   \param content the type of addon content desired
-   \param label the name of the addons source
-   \param thumb the skin image to use as the icon
-   */
-  void AddAddonsSource(const std::string &content, const std::string &label, const std::string& thumb);
   void AddLiveTVSources();
 
   /*! \brief Add the sort order defined in a smartplaylist


### PR DESCRIPTION
## Description
Currently the addition of addon type root sources (e.g. "Video Add-ons", "Picture Add-ons", etc) is done in GUI views which can cause all sorts of weird issues (e.g. some of them will only be shown after you have navigating to the appropriate skin view). View states have to iterate the `CMediaSourceSettings` sources to add (or avoid adding) the root addon type source to the settings vector.
I think this is wrong, even in the hypothetical case kodi runs headless those directories should be also available to consume. This moves the addition of such entries to the `MediaManager`, loaded when the app initializes (after language strings are available)

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21574

## How has this been tested?
Using the procedure outlined in the bug report. Navigating to "games", "pictures", etc to check "Game Add-ons", "Picture Add-ons", are listed.

## What is the effect on users?
Hopefully none, apart from fixing issues exactly like the one described in the linked bug report
