### PR TITLE
[PVR][guiinfo] Fix RDS.GetLine(x) returning data for the wrong channel.

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -489,15 +489,6 @@ std::shared_ptr<TextCacheStruct_t> CApplicationPlayer::GetTeletextCache()
     return NULL;
 }
 
-std::string CApplicationPlayer::GetRadioText(unsigned int line)
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    return player->GetRadioText(line);
-  else
-    return "";
-}
-
 float CApplicationPlayer::GetPercentage() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -93,7 +93,6 @@ public:
   void GetSubtitleStreamInfo(int index, SubtitleStreamInfo &info);
   bool GetSubtitleVisible();
   std::shared_ptr<TextCacheStruct_t> GetTeletextCache();
-  std::string GetRadioText(unsigned int line);
   int64_t GetTime() const;
   int64_t GetMinTime() const;
   int64_t GetMaxTime() const;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -8386,7 +8386,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///   \table_row3{   <b>`RDS.HasRadioText`</b>,
 ///                  \anchor RDS_HasRadioText
 ///                  _boolean_,
-///     @return **True** if RDS contains also Radiotext.
+///     @return **True** if RDS contains also RadioText.
 ///     <p><hr>
 ///     @skinning_v16 **[New Boolean Condition]** \link RDS_HasRadioText `RDS.HasRadioText`\endlink
 ///     <p>
@@ -8394,7 +8394,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///   \table_row3{   <b>`RDS.HasRadioTextPlus`</b>,
 ///                  \anchor RDS_HasRadioTextPlus
 ///                  _boolean_,
-///     @return **True** if RDS with Radiotext contains also the plus information.
+///     @return **True** if RDS with RadioText contains also the plus information.
 ///     <p><hr>
 ///     @skinning_v16 **[New Boolean Condition]** \link RDS_HasRadioTextPlus `RDS.HasRadioTextPlus`\endlink
 ///     <p>
@@ -8403,7 +8403,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_HasHotline
 ///                  _boolean_,
 ///     @return **True** if a hotline phone number is present.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Boolean Condition]** \link RDS_HasHotline `RDS.HasHotline`\endlink
 ///     <p>
@@ -8412,7 +8412,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_HasStudio
 ///                  _boolean_,
 ///     @return **True** if a studio name is present.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Boolean Condition]** \link RDS_HasStudio `RDS.HasStudio`\endlink
 ///     <p>
@@ -8447,7 +8447,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_Title
 ///                  _string_,
 ///     @return The title of item; e.g. track title of an album.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_Title `RDS.Title`\endlink
 ///     <p>
@@ -8456,7 +8456,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_Artist
 ///                  _string_,
 ///     @return A person or band/collective generally considered responsible for the work.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_Artist `RDS.Artist`\endlink
 ///     <p>
@@ -8465,7 +8465,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_Band
 ///                  _string_,
 ///     @return The band/orchestra/musician.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_Band `RDS.Band`\endlink
 ///     <p>
@@ -8474,7 +8474,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_Composer
 ///                  _string_,
 ///     @return The name of the original composer/author.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_Composer `RDS.Composer`\endlink
 ///     <p>
@@ -8484,7 +8484,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  _string_,
 ///     @return The artist(s) who performed the work. In classical music this would be
 ///     the conductor.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_Conductor `RDS.Conductor`\endlink
 ///     <p>
@@ -8493,7 +8493,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_Album
 ///                  _string_,
 ///     @return The album of the song.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_Album `RDS.Album`\endlink
 ///     <p>
@@ -8503,7 +8503,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  _string_,
 ///     @return The track number of the item on the album on which it was originally
 ///     released.
-///     @note Only be available on RadiotextPlus
+///     @note Only be available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_TrackNumber `RDS.TrackNumber`\endlink
 ///     <p>
@@ -8557,7 +8557,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_Comment
 ///                  _string_,
 ///     @return The radio station comment string if available.
-///     @note Only available on RadiotextPlus)
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_Comment `RDS.Comment`\endlink
 ///     <p>
@@ -8566,7 +8566,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoNews
 ///                  _string_,
 ///     @return The message / headline (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoNews `RDS.InfoNews`\endlink
 ///     <p>
@@ -8575,7 +8575,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoNewsLocal
 ///                  _string_,
 ///     @return The local information news sended from radio channel (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoNewsLocal `RDS.InfoNewsLocal`\endlink
 ///     <p>
@@ -8585,7 +8585,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  _string_,
 ///     @return The stock information; either as one part or as several distinct parts:
 ///     "name 99latest value 99change 99high 99low 99volume" (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoStock `RDS.InfoStock`\endlink
 ///     <p>
@@ -8594,7 +8594,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoStockSize
 ///                  _string_,
 ///     @return The number of rows present in stock information.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoStockSize `RDS.InfoStockSize`\endlink
 ///     <p>
@@ -8604,7 +8604,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  _string_,
 ///     @return The result of a match; either as one part or as several distinct parts:
 ///     "match 99result"\, e.g. "Bayern München : Borussia 995:5"  (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoSport `RDS.InfoSport`\endlink
 ///     <p>
@@ -8613,7 +8613,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoSportSize
 ///                  _string_,
 ///     @return The number of rows present in sport information.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoSportSize `RDS.InfoSportSize`\endlink
 ///     <p>
@@ -8622,7 +8622,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoLottery
 ///                  _string_,
 ///     @return The raffle / lottery: "key word 99values" (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoLottery `RDS.InfoLottery`\endlink
 ///     <p>
@@ -8631,7 +8631,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoLotterySize
 ///                  _string_,
 ///     @return The number of rows present in lottery information.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoLotterySize `RDS.InfoLotterySize`\endlink
 ///     <p>
@@ -8640,7 +8640,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoWeather
 ///                  _string_,
 ///     @return The weather information (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoWeather `RDS.InfoWeather`\endlink
 ///     <p>
@@ -8649,7 +8649,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoWeatherSize
 ///                  _string_,
 ///     @return The number of rows present in weather information.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoWeatherSize `RDS.InfoWeatherSize`\endlink
 ///     <p>
@@ -8658,7 +8658,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoCinema
 ///                  _string_,
 ///     @return The information about movies in cinema (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoCinema `RDS.InfoCinema`\endlink
 ///     <p>
@@ -8667,7 +8667,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoCinemaSize
 ///                  _string_,
 ///     @return The number of rows present in cinema information.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoCinemaSize `RDS.InfoCinemaSize`\endlink
 ///     <p>
@@ -8677,7 +8677,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  _string_,
 ///     @return The horoscope; either as one part or as two distinct parts:
 ///     "key word 99text"\, e.g. "sign of the zodiac 99blablabla" (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoHoroscope `RDS.InfoHoroscope`\endlink
 ///     <p>
@@ -8686,7 +8686,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoHoroscopeSize
 ///                  _string_,
 ///     @return The Number of rows present in horoscope information.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoHoroscopeSize `RDS.InfoHoroscopeSize`\endlink
 ///     <p>
@@ -8695,7 +8695,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoOther
 ///                  _string_,
 ///     @return Other information\, not especially specified: "key word 99info" (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoOther `RDS.InfoOther`\endlink
 ///     <p>
@@ -8704,7 +8704,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_InfoOtherSize
 ///                  _string_,
 ///     @return The number of rows present with other information.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_InfoOtherSize `RDS.InfoOtherSize`\endlink
 ///     <p>
@@ -8748,7 +8748,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_ProgEditStaff
 ///                  _string_,
 ///     @return The name of the editorial staff; e.g. name of editorial journalist.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_ProgEditStaff `RDS.ProgEditStaff`\endlink
 ///     <p>
@@ -8757,7 +8757,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_ProgHomepage
 ///                  _string_,
 ///     @return The Link to radio station homepage
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_ProgHomepage `RDS.ProgHomepage`\endlink
 ///     <p>
@@ -8774,7 +8774,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_PhoneHotline
 ///                  _string_,
 ///     @return The telephone number of the radio station's hotline.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_PhoneHotline `RDS.PhoneHotline`\endlink
 ///     <p>
@@ -8783,7 +8783,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_PhoneStudio
 ///                  _string_,
 ///     @return The telephone number of the radio station's studio.
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_PhoneStudio `RDS.PhoneStudio`\endlink
 ///     <p>
@@ -8793,7 +8793,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  _string_,
 ///     @return The sms number of the radio stations studio (to send directly a sms to
 ///     the studio) (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_SmsStudio `RDS.SmsStudio`\endlink
 ///     <p>
@@ -8802,7 +8802,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_EmailHotline
 ///                  _string_,
 ///     @return The email address of the radio stations hotline (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_EmailHotline `RDS.EmailHotline`\endlink
 ///     <p>
@@ -8811,7 +8811,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 ///                  \anchor RDS_EmailStudio
 ///                  _string_,
 ///     @return The email address of the radio station's studio (if available).
-///     @note Only available on RadiotextPlus
+///     @note Only available on RadioText Plus
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link RDS_EmailStudio `RDS.EmailStudio`\endlink
 ///     <p>

--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -130,7 +130,7 @@ constexpr const int GUI_MSG_SHOW_PICTURE            = GUI_MSG_USER + 36;
 constexpr const int GUI_MSG_EVENT_ADDED             = GUI_MSG_USER + 39;
 constexpr const int GUI_MSG_EVENT_REMOVED           = GUI_MSG_USER + 40;
 
-// Send to RDS Radiotext handlers to inform about changed data
+// Send to RDS RadioText handlers to inform about changed data
 constexpr const int GUI_MSG_UPDATE_RADIOTEXT        = GUI_MSG_USER + 41;
 
 constexpr const int GUI_MSG_PLAYBACK_ERROR          = GUI_MSG_USER + 42;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -154,8 +154,6 @@ public:
   virtual std::shared_ptr<TextCacheStruct_t> GetTeletextCache() { return NULL; }
   virtual void LoadPage(int p, int sp, unsigned char* buffer) {}
 
-  virtual std::string GetRadioText(unsigned int line) { return ""; }
-
   virtual int  GetChapterCount()                               { return 0; }
   virtual int  GetChapter()                                    { return -1; }
   virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) {}

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3341,14 +3341,6 @@ void CVideoPlayer::LoadPage(int p, int sp, unsigned char* buffer)
   return m_VideoPlayerTeletext->LoadPage(p, sp, buffer);
 }
 
-std::string CVideoPlayer::GetRadioText(unsigned int line)
-{
-  if (m_CurrentRadioRDS.id < 0)
-      return "";
-
-  return m_VideoPlayerRadioRDS->GetRadioText(line);
-}
-
 void CVideoPlayer::SeekTime(int64_t iTime)
 {
   int64_t seekOffset = iTime - GetTime();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -306,8 +306,6 @@ public:
   std::shared_ptr<TextCacheStruct_t> GetTeletextCache() override;
   void LoadPage(int p, int sp, unsigned char* buffer) override;
 
-  std::string GetRadioText(unsigned int line) override;
-
   int  GetChapterCount() override;
   int  GetChapter() override;
   void GetChapterName(std::string& strChapterName, int chapterIdx=-1) override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -1025,7 +1025,7 @@ inline void rtrim_str(std::string &text)
 
 unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
 {
-  m_currentInfoTag->SetPlayingRadiotext(true);
+  m_currentInfoTag->SetPlayingRadioText(true);
 
   int bufConf = (msgElement[UECP_ME_DATA] >> 5) & 0x03;
   unsigned int msgLength = msgElement[UECP_ME_MEL];
@@ -1146,7 +1146,7 @@ unsigned int CDVDRadioRDSData::DecodeRTPlus(uint8_t *msgElement, unsigned int le
   if (m_RTPlus_iToggle == 0)    // RTplus tags V2.1, only if RT
     return 10;
 
-  m_currentInfoTag->SetPlayingRadiotextPlus(true);
+  m_currentInfoTag->SetPlayingRadioTextPlus(true);
 
   if (msgElement[1] > len-2 || msgElement[1] != 8)  // byte 6 = MEL, only 8 byte for 2 tags
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -572,14 +572,6 @@ void CDVDRadioRDSData::ResetRDSCache()
 
   m_EPP_TM_INFO_ExtendedCountryCode = 0;
 
-  m_PS_Present = false;
-  m_PS_Index = 0;
-  for (auto& text : m_PS_Text)
-  {
-    memset(text, 0x20, 8);
-    text[8] = 0;
-  }
-
   m_DI_IsStereo = true;
   m_DI_ArtificialHead = false;
   m_DI_Compressed = false;
@@ -595,16 +587,9 @@ void CDVDRadioRDSData::ResetRDSCache()
   m_PTYN[8] = 0;
   m_PTYN_Present = false;
 
-  m_RT_Present = false;
-  m_RT_MaxSize = 4;
   m_RT_NewItem = false;
-  m_RT_Index = 0;
-  for (int i = 0; i < 5; ++i)
-    memset(m_RT_Text[i], 0, RT_MEL);
-  m_RT.clear();
 
   m_RTPlus_TToggle = false;
-  m_RTPlus_Present = false;
   m_RTPlus_Show = false;
   m_RTPlus_iToggle = 0;
   m_RTPlus_ItemToggle = 1;
@@ -679,48 +664,6 @@ void CDVDRadioRDSData::Flush()
 void CDVDRadioRDSData::OnExit()
 {
   CLog::Log(LOGINFO, "Radio UECP (RDS) Processor - thread end");
-}
-
-std::string CDVDRadioRDSData::GetRadioText(unsigned int line)
-{
-  std::string str = "";
-
-  if (m_RT_Present)
-  {
-    if (line > MAX_RADIOTEXT_LISTSIZE)
-      return "";
-
-    if ((int)line+1 > m_RT_MaxSize)
-    {
-      m_RT_MaxSize = line+1;
-      return "";
-    }
-    if (m_RT.size() <= line)
-      return "";
-
-    return m_RT[line];
-  }
-  else if (m_PS_Present)
-  {
-    std::string temp = "";
-    int ind = (m_PS_Index == 0) ? 11 : m_PS_Index - 1;
-    for (int i = ind+1; i < PS_TEXT_ENTRIES; ++i)
-    {
-      temp += m_PS_Text[i];
-      temp += ' ';
-    }
-    for (int i = 0; i <= ind; ++i)
-    {
-      temp += m_PS_Text[i];
-      temp += ' ';
-    }
-
-    if (line == 0)
-      str.insert(0, temp, 6*9, 6*9);
-    else if (line == 1)
-      str.insert(0, temp.c_str(), 6*9);
-  }
-  return str;
 }
 
 void CDVDRadioRDSData::SetRadioStyle(const std::string& genre)
@@ -878,17 +821,17 @@ unsigned int CDVDRadioRDSData::DecodePS(uint8_t *msgElement)
 {
   uint8_t *text = msgElement+3;
 
+  char decodedText[9] = {};
   for (int i = 0; i < 8; ++i)
   {
     if (text[i] <= 0xfe)
-      m_PS_Text[m_PS_Index][i] = (text[i] >= 0x80) ? sRDSAddChar[text[i]-0x80] : text[i]; //!< additional rds-character, see RBDS-Standard, Annex E
+      decodedText[i] = (text[i] >= 0x80)
+                           ? sRDSAddChar[text[i] - 0x80]
+                           : text[i]; //!< additional rds-character, see RBDS-Standard, Annex E
   }
 
-  ++m_PS_Index;
-  if (m_PS_Index >= PS_TEXT_ENTRIES)
-    m_PS_Index = 0;
+  m_currentInfoTag->SetProgramServiceText(decodedText);
 
-  m_PS_Present = true;
   return 11;
 }
 
@@ -1082,11 +1025,7 @@ inline void rtrim_str(std::string &text)
 
 unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
 {
-  if (!m_RT_Present)
-  {
-    m_currentInfoTag->SetPlayingRadiotext(true);
-    m_RT_Present = true;
-  }
+  m_currentInfoTag->SetPlayingRadiotext(true);
 
   int bufConf = (msgElement[UECP_ME_DATA] >> 5) & 0x03;
   unsigned int msgLength = msgElement[UECP_ME_MEL];
@@ -1100,10 +1039,7 @@ unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
   }
   else if (msgLength == 0 || (msgLength == 1 && bufConf == 0))
   {
-    m_RT.clear();
-    m_RT_Index = 0;
-    for (int i = 0; i < 5; ++i)
-      memset(m_RT_Text[i], 0, RT_MEL);
+    return msgLength + 4;
   }
   else
   {
@@ -1119,32 +1055,12 @@ unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
       if (msgElement[UECP_ME_DATA+i] <= 0xfe) // additional rds-character, see RBDS-Standard, Annex E
         temptext[ii++] = (msgElement[UECP_ME_DATA+i] >= 0x80) ? sRDSAddChar[msgElement[UECP_ME_DATA+i]-0x80] : msgElement[UECP_ME_DATA+i];
     }
+
     memcpy(m_RTPlus_WorkText, temptext, RT_MEL);
     rds_entitychar(temptext);
 
-    // check repeats
-    bool repeat = false;
-    for (int ind = 0; ind < m_RT_MaxSize; ++ind)
-    {
-      if (memcmp(m_RT_Text[ind], temptext, RT_MEL) == 0)
-        repeat = true;
-    }
-    if (!repeat)
-    {
-      memcpy(m_RT_Text[m_RT_Index], temptext, RT_MEL);
+    m_currentInfoTag->SetRadioText(temptext);
 
-      std::string rdsline = m_RT_Text[m_RT_Index];
-      rtrim_str(rdsline);
-      g_charsetConverter.unknownToUTF8(rdsline);
-      m_RT.push_front(StringUtils::Trim(rdsline));
-
-      if ((int)m_RT.size() > m_RT_MaxSize)
-        m_RT.pop_back();
-
-      ++m_RT_Index;
-      if (m_RT_Index >= m_RT_MaxSize)
-        m_RT_Index = 0;
-    }
     m_RTPlus_iToggle = 0x03;     // Bit 0/1 = Title/Artist
   }
   return msgLength+4;
@@ -1230,11 +1146,7 @@ unsigned int CDVDRadioRDSData::DecodeRTPlus(uint8_t *msgElement, unsigned int le
   if (m_RTPlus_iToggle == 0)    // RTplus tags V2.1, only if RT
     return 10;
 
-  if (!m_RTPlus_Present)
-  {
-    m_currentInfoTag->SetPlayingRadiotextPlus(true);
-    m_RTPlus_Present = true;
-  }
+  m_currentInfoTag->SetPlayingRadiotextPlus(true);
 
   if (msgElement[1] > len-2 || msgElement[1] != 8)  // byte 6 = MEL, only 8 byte for 2 tags
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
@@ -14,7 +14,6 @@
 #include "threads/Thread.h"
 #include "utils/Stopwatch.h"
 
-#include <deque>
 #include <memory>
 
 class CDVDStreamInfo;
@@ -33,7 +32,6 @@ class CPVRRadioRDSInfoTag;
                                                    max. 255(MSG)+4(ADD/SQC/MFL)+2(CRC)+2(Start/Stop) of RDS-data */
 #define RT_MEL                        65
 #define MAX_RTPC                      50
-#define MAX_RADIOTEXT_LISTSIZE        6
 
 class CDVDRadioRDSData : public CThread, public IDVDStreamPlayer
 {
@@ -57,8 +55,6 @@ public:
   void FlushMessages() override { m_messageQueue.Flush(); }
   bool IsInited() const override { return true; }
   bool IsStalled() const override { return true; }
-
-  std::string GetRadioText(unsigned int line);
 
 protected:
   void OnExit() override;
@@ -114,11 +110,6 @@ private:
 
   unsigned int                m_EPP_TM_INFO_ExtendedCountryCode;
 
-  #define PS_TEXT_ENTRIES     12
-  bool                        m_PS_Present;
-  int                         m_PS_Index;
-  char                        m_PS_Text[PS_TEXT_ENTRIES][9];
-
   bool                        m_DI_IsStereo;
   bool                        m_DI_ArtificialHead;
   bool                        m_DI_Compressed;
@@ -133,14 +124,8 @@ private:
   char                        m_PTYN[9];
   bool                        m_PTYN_Present;
 
-  bool                        m_RT_Present;
-  std::deque<std::string>     m_RT;
-  int                         m_RT_Index;
-  int                         m_RT_MaxSize;
   bool                        m_RT_NewItem;
-  char                        m_RT_Text[6][RT_MEL+1];
 
-  bool                        m_RTPlus_Present;
   uint8_t                     m_RTPlus_WorkText[RT_MEL+1];
   bool                        m_RTPlus_TToggle;
   int                         m_RTPlus_iDiffs;

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -138,8 +138,8 @@ bool CPVRRadioRDSInfoTag::operator==(const CPVRRadioRDSInfoTag& right) const
       m_strProgramServiceText == right.m_strProgramServiceText &&
       m_strProgramServiceLine0 == right.m_strProgramServiceLine0 &&
       m_strProgramServiceLine1 == right.m_strProgramServiceLine1 &&
-      m_bHaveRadiotext == right.m_bHaveRadiotext &&
-      m_bHaveRadiotextPlus == right.m_bHaveRadiotextPlus);
+      m_bHaveRadioText == right.m_bHaveRadioText &&
+      m_bHaveRadioTextPlus == right.m_bHaveRadioTextPlus);
 }
 
 bool CPVRRadioRDSInfoTag::operator !=(const CPVRRadioRDSInfoTag& right) const
@@ -186,8 +186,8 @@ void CPVRRadioRDSInfoTag::Clear()
   m_strProgramServiceLine0.erase();
   m_strProgramServiceLine1.erase();
 
-  m_bHaveRadiotext = false;
-  m_bHaveRadiotextPlus = false;
+  m_bHaveRadioText = false;
+  m_bHaveRadioTextPlus = false;
 }
 
 void CPVRRadioRDSInfoTag::ResetSongInformation()
@@ -655,28 +655,28 @@ void CPVRRadioRDSInfoTag::SetProgramServiceText(const std::string& strPSText)
   }
 }
 
-void CPVRRadioRDSInfoTag::SetPlayingRadiotext(bool yesNo)
+void CPVRRadioRDSInfoTag::SetPlayingRadioText(bool yesNo)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  m_bHaveRadiotext = yesNo;
+  m_bHaveRadioText = yesNo;
 }
 
-bool CPVRRadioRDSInfoTag::IsPlayingRadiotext() const
+bool CPVRRadioRDSInfoTag::IsPlayingRadioText() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  return m_bHaveRadiotext;
+  return m_bHaveRadioText;
 }
 
-void CPVRRadioRDSInfoTag::SetPlayingRadiotextPlus(bool yesNo)
+void CPVRRadioRDSInfoTag::SetPlayingRadioTextPlus(bool yesNo)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  m_bHaveRadiotextPlus = yesNo;
+  m_bHaveRadioTextPlus = yesNo;
 }
 
-bool CPVRRadioRDSInfoTag::IsPlayingRadiotextPlus() const
+bool CPVRRadioRDSInfoTag::IsPlayingRadioTextPlus() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  return m_bHaveRadiotextPlus;
+  return m_bHaveRadioTextPlus;
 }
 
 std::string CPVRRadioRDSInfoTag::Trim(const std::string& value)

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -117,40 +117,29 @@ bool CPVRRadioRDSInfoTag::operator==(const CPVRRadioRDSInfoTag& right) const
     return true;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  return (m_strLanguage == right.m_strLanguage &&
-          m_strCountry == right.m_strCountry &&
-          m_strTitle == right.m_strTitle &&
-          m_strBand == right.m_strBand &&
-          m_strArtist == right.m_strArtist &&
-          m_strComposer == right.m_strComposer &&
-          m_strConductor == right.m_strConductor &&
-          m_strAlbum == right.m_strAlbum &&
-          m_iAlbumTracknumber == right.m_iAlbumTracknumber &&
-          m_strInfoNews == right.m_strInfoNews &&
-          m_strInfoNewsLocal == right.m_strInfoNewsLocal &&
-          m_strInfoSport == right.m_strInfoSport &&
-          m_strInfoStock == right.m_strInfoStock &&
-          m_strInfoWeather == right.m_strInfoWeather &&
-          m_strInfoLottery == right.m_strInfoLottery &&
-          m_strInfoOther == right.m_strInfoOther &&
-          m_strProgStyle == right.m_strProgStyle &&
-          m_strProgHost == right.m_strProgHost &&
-          m_strProgStation == right.m_strProgStation &&
-          m_strProgWebsite == right.m_strProgWebsite &&
-          m_strProgNow == right.m_strProgNow &&
-          m_strProgNext == right.m_strProgNext &&
-          m_strPhoneHotline == right.m_strPhoneHotline &&
-          m_strEMailHotline == right.m_strEMailHotline &&
-          m_strPhoneStudio == right.m_strPhoneStudio &&
-          m_strEMailStudio == right.m_strEMailStudio &&
-          m_strSMSStudio == right.m_strSMSStudio &&
-          m_strRadioStyle == right.m_strRadioStyle &&
-          m_strInfoHoroscope == right.m_strInfoHoroscope &&
-          m_strInfoCinema == right.m_strInfoCinema &&
-          m_strComment == right.m_strComment &&
-          m_strEditorialStaff == right.m_strEditorialStaff &&
-          m_bHaveRadiotext == right.m_bHaveRadiotext &&
-          m_bHaveRadiotextPlus == right.m_bHaveRadiotextPlus);
+  return (
+      m_strLanguage == right.m_strLanguage && m_strCountry == right.m_strCountry &&
+      m_strTitle == right.m_strTitle && m_strBand == right.m_strBand &&
+      m_strArtist == right.m_strArtist && m_strComposer == right.m_strComposer &&
+      m_strConductor == right.m_strConductor && m_strAlbum == right.m_strAlbum &&
+      m_iAlbumTracknumber == right.m_iAlbumTracknumber && m_strInfoNews == right.m_strInfoNews &&
+      m_strInfoNewsLocal == right.m_strInfoNewsLocal && m_strInfoSport == right.m_strInfoSport &&
+      m_strInfoStock == right.m_strInfoStock && m_strInfoWeather == right.m_strInfoWeather &&
+      m_strInfoLottery == right.m_strInfoLottery && m_strInfoOther == right.m_strInfoOther &&
+      m_strProgStyle == right.m_strProgStyle && m_strProgHost == right.m_strProgHost &&
+      m_strProgStation == right.m_strProgStation && m_strProgWebsite == right.m_strProgWebsite &&
+      m_strProgNow == right.m_strProgNow && m_strProgNext == right.m_strProgNext &&
+      m_strPhoneHotline == right.m_strPhoneHotline &&
+      m_strEMailHotline == right.m_strEMailHotline && m_strPhoneStudio == right.m_strPhoneStudio &&
+      m_strEMailStudio == right.m_strEMailStudio && m_strSMSStudio == right.m_strSMSStudio &&
+      m_strRadioStyle == right.m_strRadioStyle && m_strInfoHoroscope == right.m_strInfoHoroscope &&
+      m_strInfoCinema == right.m_strInfoCinema && m_strComment == right.m_strComment &&
+      m_strEditorialStaff == right.m_strEditorialStaff && m_strRadioText == right.m_strRadioText &&
+      m_strProgramServiceText == right.m_strProgramServiceText &&
+      m_strProgramServiceLine0 == right.m_strProgramServiceLine0 &&
+      m_strProgramServiceLine1 == right.m_strProgramServiceLine1 &&
+      m_bHaveRadiotext == right.m_bHaveRadiotext &&
+      m_bHaveRadiotextPlus == right.m_bHaveRadiotextPlus);
 }
 
 bool CPVRRadioRDSInfoTag::operator !=(const CPVRRadioRDSInfoTag& right) const
@@ -192,6 +181,10 @@ void CPVRRadioRDSInfoTag::Clear()
   m_strSMSStudio.erase();
   m_strRadioStyle = "unknown";
   m_strEditorialStaff.Clear();
+  m_strRadioText.Clear();
+  m_strProgramServiceText.Clear();
+  m_strProgramServiceLine0.erase();
+  m_strProgramServiceLine1.erase();
 
   m_bHaveRadiotext = false;
   m_bHaveRadiotextPlus = false;
@@ -616,6 +609,52 @@ const std::string CPVRRadioRDSInfoTag::GetRadioStyle() const
   return m_strRadioStyle;
 }
 
+void CPVRRadioRDSInfoTag::SetRadioText(const std::string& strRadioText)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  m_strRadioText.Add(strRadioText);
+}
+
+std::string CPVRRadioRDSInfoTag::GetRadioText(unsigned int line) const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  if (m_strRadioText.Size() > 0)
+  {
+    return m_strRadioText.GetLine(line);
+  }
+  else if (line == 0)
+  {
+    return m_strProgramServiceLine0;
+  }
+  else if (line == 1)
+  {
+    return m_strProgramServiceLine1;
+  }
+  return {};
+}
+
+void CPVRRadioRDSInfoTag::SetProgramServiceText(const std::string& strPSText)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  m_strProgramServiceText.Add(strPSText);
+
+  m_strProgramServiceLine0.erase();
+  for (size_t i = m_strProgramServiceText.MaxSize() / 2 + 1; i < m_strProgramServiceText.MaxSize();
+       ++i)
+  {
+    m_strProgramServiceLine0 += m_strProgramServiceText.GetLine(i);
+    m_strProgramServiceLine0 += ' ';
+  }
+
+  m_strProgramServiceLine1.erase();
+  for (size_t i = 0; i < m_strProgramServiceText.MaxSize() / 2; ++i)
+  {
+    m_strProgramServiceLine1 += m_strProgramServiceText.GetLine(i);
+    m_strProgramServiceLine1 += ' ';
+  }
+}
+
 void CPVRRadioRDSInfoTag::SetPlayingRadiotext(bool yesNo)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -653,8 +692,8 @@ bool CPVRRadioRDSInfoTag::Info::operator==(const CPVRRadioRDSInfoTag::Info& righ
   if (this == &right)
     return true;
 
-  return (m_infoText == right.m_infoText &&
-          m_data == right.m_data);
+  return (m_infoText == right.m_infoText && m_data == right.m_data &&
+          m_maxSize == right.m_maxSize && m_prependData == right.m_prependData);
 }
 
 void CPVRRadioRDSInfoTag::Info::Clear()
@@ -671,10 +710,18 @@ void CPVRRadioRDSInfoTag::Info::Add(const std::string& text)
   if (std::find(m_data.begin(), m_data.end(), tmp) != m_data.end())
     return;
 
-  if (m_data.size() >= 10)
-    m_data.pop_front();
+  if (m_data.size() >= m_maxSize)
+  {
+    if (m_prependData)
+      m_data.pop_back();
+    else
+      m_data.pop_front();
+  }
 
-  m_data.emplace_back(std::move(tmp));
+  if (m_prependData)
+    m_data.emplace_front(std::move(tmp));
+  else
+    m_data.emplace_back(std::move(tmp));
 
   m_infoText.clear();
   for (const std::string& data : m_data)

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
@@ -38,6 +38,9 @@ public:
   const std::string& GetLanguage() const;
   void SetCountry(const std::string& strCountry);
   const std::string& GetCountry() const;
+  void SetRadioText(const std::string& strRadioText);
+  std::string GetRadioText(unsigned int line) const;
+  void SetProgramServiceText(const std::string& strPSText);
 
   /**! RDS Radiotext related information */
   void SetTitle(const std::string& strTitle);
@@ -146,29 +149,46 @@ private:
   class Info
   {
   public:
-    Info() = default;
+    Info() = delete;
+    Info(size_t maxSize, bool prependData) : m_maxSize(maxSize), m_prependData(prependData) {}
 
     bool operator==(const Info& right) const;
 
+    size_t Size() const { return m_data.size(); }
+    size_t MaxSize() const { return m_maxSize; }
+
     void Clear();
     void Add(const std::string& text);
+
     const std::string& GetText() const { return m_infoText; }
+    std::string GetLine(unsigned int line) const
+    {
+      return line < m_data.size() ? m_data.at(line) : "";
+    }
 
   private:
+    const size_t m_maxSize = 10;
+    const bool m_prependData = false;
     std::deque<std::string> m_data;
     std::string m_infoText;
   };
 
-  Info m_strInfoNews;
-  Info m_strInfoNewsLocal;
-  Info m_strInfoSport;
-  Info m_strInfoStock;
-  Info m_strInfoWeather;
-  Info m_strInfoLottery;
-  Info m_strInfoOther;
-  Info m_strInfoHoroscope;
-  Info m_strInfoCinema;
-  Info m_strEditorialStaff;
+  Info m_strInfoNews{10, false};
+  Info m_strInfoNewsLocal{10, false};
+  Info m_strInfoSport{10, false};
+  Info m_strInfoStock{10, false};
+  Info m_strInfoWeather{10, false};
+  Info m_strInfoLottery{10, false};
+  Info m_strInfoOther{10, false};
+  Info m_strInfoHoroscope{10, false};
+  Info m_strInfoCinema{10, false};
+  Info m_strEditorialStaff{10, false};
+
+  Info m_strRadioText{6, true};
+
+  Info m_strProgramServiceText{12, false};
+  std::string m_strProgramServiceLine0;
+  std::string m_strProgramServiceLine1;
 
   std::string m_strProgStyle;
   std::string m_strProgHost;

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
@@ -42,7 +42,7 @@ public:
   std::string GetRadioText(unsigned int line) const;
   void SetProgramServiceText(const std::string& strPSText);
 
-  /**! RDS Radiotext related information */
+  /**! RDS RadioText related information */
   void SetTitle(const std::string& strTitle);
   void SetBand(const std::string& strBand);
   void SetArtist(const std::string& strArtist);
@@ -118,11 +118,11 @@ public:
   void SetRadioStyle(const std::string& style);
   const std::string GetRadioStyle() const;
 
-  void SetPlayingRadiotext(bool yesNo);
-  bool IsPlayingRadiotext() const;
+  void SetPlayingRadioText(bool yesNo);
+  bool IsPlayingRadioText() const;
 
-  void SetPlayingRadiotextPlus(bool yesNo);
-  bool IsPlayingRadiotextPlus() const;
+  void SetPlayingRadioTextPlus(bool yesNo);
+  bool IsPlayingRadioTextPlus() const;
 
 private:
   CPVRRadioRDSInfoTag(const CPVRRadioRDSInfoTag& tag) = delete;
@@ -202,7 +202,7 @@ private:
   std::string m_strEMailStudio;
   std::string m_strSMSStudio;
 
-  bool m_bHaveRadiotext;
-  bool m_bHaveRadiotextPlus;
+  bool m_bHaveRadioText;
+  bool m_bHaveRadioTextPlus;
 };
 }

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1133,14 +1133,10 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item, const CGUIInfo& info, 
       case RDS_AUDIO_LANG:
         strValue = tag->GetLanguage();
         return true;
+      case RDS_GET_RADIOTEXT_LINE:
+        strValue = tag->GetRadioText(info.GetData1());
+        return true;
     }
-  }
-
-  switch (info.m_info)
-  {
-    case RDS_GET_RADIOTEXT_LINE:
-      strValue = g_application.GetAppPlayer().GetRadioText(info.GetData1());
-      return true;
   }
   return false;
 }

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1623,10 +1623,10 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
     switch (info.m_info)
     {
       case RDS_HAS_RADIOTEXT:
-        bValue = tag->IsPlayingRadiotext();
+        bValue = tag->IsPlayingRadioText();
         return true;
       case RDS_HAS_RADIOTEXT_PLUS:
-        bValue = tag->IsPlayingRadiotextPlus();
+        bValue = tag->IsPlayingRadioTextPlus();
         return true;
       case RDS_HAS_HOTLINE_DATA:
         bValue = (!tag->GetEMailHotline().empty() || !tag->GetPhoneHotline().empty());


### PR DESCRIPTION
1) Start playback of a PVR Radio channel supporting RDS
2) In fullscreen open the player controls
3) Open the RDS dialog
4) Press up or down. 
=> RDS data of the prv/next channel are displayed, but the content in the lower right "RDS-Radio" box does still show the RDS data of the playing channel 

Fix is to get the RDS from the selected RDS tag, not from the player. For this, `CPVRRadioRDSInfoTag` needed to be extended to be able to hold the RDS data lines.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish when you find some time for a review.