### PR TITLE
[cmake] libdvd*_url lower case insanity

### DIFF
--- a/cmake/modules/FindLibDvdCSS.cmake
+++ b/cmake/modules/FindLibDvdCSS.cmake
@@ -21,6 +21,9 @@ if(ENABLE_DVDCSS)
   # We require this due to the odd nature of github URL's compared to our other tarball
   # mirror system. If User sets LIBDVDCSS_URL or libdvdcss_URL, allow get_filename_component in SETUP_BUILD_VARS
   if(LIBDVDCSS_URL OR ${MODULE_LC}_URL)
+    if(${MODULE_LC}_URL)
+      set(LIBDVDCSS_URL ${${MODULE_LC}_URL})
+    endif()
     set(LIBDVDCSS_URL_PROVIDED TRUE)
   endif()
 

--- a/cmake/modules/FindLibDvdNav.cmake
+++ b/cmake/modules/FindLibDvdNav.cmake
@@ -28,6 +28,9 @@ if(NOT TARGET LibDvdNav::LibDvdNav)
   # We require this due to the odd nature of github URL's compared to our other tarball
   # mirror system. If User sets LIBDVDNAV_URL or libdvdnav_URL, allow get_filename_component in SETUP_BUILD_VARS
   if(LIBDVDNAV_URL OR ${MODULE_LC}_URL)
+    if(${MODULE_LC}_URL)
+      set(LIBDVDNAV_URL ${${MODULE_LC}_URL})
+    endif()
     set(LIBDVDNAV_URL_PROVIDED TRUE)
   endif()
 

--- a/cmake/modules/FindLibDvdRead.cmake
+++ b/cmake/modules/FindLibDvdRead.cmake
@@ -30,6 +30,9 @@ if(NOT TARGET LibDvdRead::LibDvdRead)
   # We require this due to the odd nature of github URL's compared to our other tarball
   # mirror system. If User sets LIBDVDREAD_URL or libdvdread_URL, allow get_filename_component in SETUP_BUILD_VARS
   if(LIBDVDREAD_URL OR ${MODULE_LC}_URL)
+    if(${MODULE_LC}_URL)
+      set(LIBDVDREAD_URL ${${MODULE_LC}_URL})
+    endif()
     set(LIBDVDREAD_URL_PROVIDED TRUE)
   endif()
 


### PR DESCRIPTION
## Description
allow lowercase libdvd*_URL usage

## Motivation and context
@wsnipex honestly i think id prefer we change the requirement to be always uppercase if provided. This use of either upper or lowercase only occurs in the libdvd* URL usage currently, just annoys me to not just have things standardised on what every other define provided/uses throughout core (ie UPPERCASE). Let me know which way you want to go.

## How has this been tested?


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
