### PR TITLE
Fix for alpha fades

### DIFF
--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -204,12 +204,17 @@ CFadeEffect::CFadeEffect(UTILS::COLOR::Color start,
 
 void CFadeEffect::ApplyEffect(float offset, const CPoint &center)
 {
-  UTILS::COLOR::ColorFloats startColor = m_startColor;
-  UTILS::COLOR::ColorFloats endColor = m_endColor;
-  m_matrix.SetFader(((endColor.alpha - startColor.alpha) * offset + startColor.alpha),
-                    ((endColor.red - startColor.red) * offset + startColor.red),
-                    ((endColor.green - startColor.green) * offset + startColor.green),
-                    ((endColor.blue - startColor.blue) * offset + startColor.blue));
+  if (m_effect == EFFECT_TYPE_FADE)
+  {
+    m_matrix.SetFader(((m_endAlpha - m_startAlpha) * offset + m_startAlpha) * 0.01f);
+  }
+  else if (m_effect == EFFECT_TYPE_FADE_DIFFUSE)
+  {
+    m_matrix.SetFader(((m_endColor.alpha - m_startColor.alpha) * offset + m_startColor.alpha),
+                      ((m_endColor.red - m_startColor.red) * offset + m_startColor.red),
+                      ((m_endColor.green - m_startColor.green) * offset + m_startColor.green),
+                      ((m_endColor.blue - m_startColor.blue) * offset + m_startColor.blue));
+  }
 }
 
 CSlideEffect::CSlideEffect(const TiXmlElement *node) : CAnimEffect(node, EFFECT_TYPE_SLIDE)


### PR DESCRIPTION
## Description
This PR fixes alpha fading, which is used by effects like the dimming animation of the screensaver.

## Motivation and context
With PR https://github.com/xbmc/xbmc/pull/21400, color fading was introduced. It broke the few (one?) instances where alpha fading is still used.

## How has this been tested?
GUI fading is still working fine. The screensaver dimming works now

## What is the effect on users?
A working screensaver.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
