### PR TITLE
[info] Fix division by 0

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1050,7 +1050,7 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry,
       pItem->SetProperty("numepisodes", episodes);
       pItem->SetProperty("watchedepisodes", played);
       pItem->SetProperty("unwatchedepisodes", episodes - played);
-      pItem->SetProperty("watchedepisodepercent", played * 100 / episodes);
+      pItem->SetProperty("watchedepisodepercent", episodes > 0 ? played * 100 / episodes : 0);
       watched = (episodes && played >= episodes);
       pItem->GetVideoInfoTag()->SetPlayCount(watched ? 1 : 0);
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4132,7 +4132,9 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
     item->SetProperty("numepisodes", details.m_iEpisode); // will be changed later to reflect watchmode setting
     item->SetProperty("watchedepisodes", details.GetPlayCount());
     item->SetProperty("unwatchedepisodes", details.m_iEpisode - details.GetPlayCount());
-    item->SetProperty("watchedepisodepercent", (details.GetPlayCount() * 100 / details.m_iEpisode));
+    item->SetProperty("watchedepisodepercent",
+                      details.m_iEpisode > 0 ? (details.GetPlayCount() * 100 / details.m_iEpisode)
+                                             : 0);
   }
   details.SetPlayCount((details.m_iEpisode <= details.GetPlayCount()) ? 1 : 0);
 

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -77,11 +77,14 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
       watched += static_cast<int>(item->GetProperty("watchedepisodes").asInteger());
       unwatched += static_cast<int>(item->GetProperty("unwatchedepisodes").asInteger());
     }
-    pItem->SetProperty("totalepisodes", watched + unwatched);
-    pItem->SetProperty("numepisodes", watched + unwatched); // will be changed later to reflect watchmode setting
+    const int totalEpisodes = watched + unwatched;
+    pItem->SetProperty("totalepisodes", totalEpisodes);
+    pItem->SetProperty("numepisodes",
+                       totalEpisodes); // will be changed later to reflect watchmode setting
     pItem->SetProperty("watchedepisodes", watched);
     pItem->SetProperty("unwatchedepisodes", unwatched);
-    pItem->SetProperty("watchedepisodepercent", watched * 100 / (watched + unwatched));
+    pItem->SetProperty("watchedepisodepercent",
+                       totalEpisodes > 0 ? watched * 100 / totalEpisodes : 0);
 
     // @note: The items list may contain additional items that do not belong to the show.
     // This is the case of the up directory (..) or movies linked to the tvshow.


### PR DESCRIPTION
## Description
Introduced in https://github.com/xbmc/xbmc/issues/21619 Kodi is crashing for empty tvshows. Make sure we don't reach a division by 0 situation

FIxes https://github.com/xbmc/xbmc/issues/21619 