### PR TITLE
[cmake] Fix linking of libdvd*

### DIFF
--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -10,7 +10,7 @@ set(_dvdlibs ${LIBDVDREAD_LIBRARY} ${LIBDVDCSS_LIBRARY})
 if(NOT CORE_SYSTEM_NAME MATCHES windows)
   # link a shared dvdnav library that includes the whole archives of dvdread and dvdcss as well
   # the quotes around _dvdlibs are on purpose, since we want to pass a list to the function that will be unpacked automatically
-  core_link_library(LibDvdNav::LibDvdNav system/players/VideoPlayer/libdvdnav libdvdnav archives "${_dvdlibs}")
+  core_link_library(${LIBDVDNAV_LIBRARY} system/players/VideoPlayer/libdvdnav libdvdnav archives "${_dvdlibs}")
 else()
   set(LIBDVD_TARGET_DIR .)
   if(CORE_SYSTEM_NAME STREQUAL windowsstore)


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/21598 broke the dll/so linking which leads to runtime errors in linux as long as you have a dvd drive with a disc inserted:

```
sh: line 1: /home/arch/Github/xbmc/build/kodi-xrandr: No such file or directory
libva error: vaGetDriverNameByIndex() failed with unknown libva error, driver_name = (null)
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
/home/arch/Github/xbmc/build/kodi-x11: symbol lookup error: /home/arch/Github/xbmc/build/system/players/VideoPlayer/libdvdnav-x86_64-linux.so: undefined symbol: DVDOpen2
➜  xbmc git:(update_dvdnav)
```

Dll sizes with and without the mentioned PR reverted:

```
➜  xbmc git:(update_dvdnav) ls -lh /home/arch/Github/xbmc/build/system/players/VideoPlayer/libdvdnav-x86_64-linux.so
-rwxr-xr-x 1 arch arch 352K Jun 29 12:43 /home/arch/Github/xbmc/build/system/players/VideoPlayer/libdvdnav-x86_64-linux.so
➜  xbmc git:(update_dvdnav) ls -lh /home/arch/Github/xbmc/build/system/players/VideoPlayer/libdvdnav-x86_64-linux.so
-rwxr-xr-x 1 arch arch 169K Jun 29 12:46 /home/arch/Github/xbmc/build/system/players/VideoPlayer/libdvdnav-x86_64-linux.so
```
Most likely it is only including the libdvdnav part since `DVDOpen2` comes from libdvdread.

Authorship attributed to @fuzzard (thanks mate for the quick fix), PRing myself to get this in as early as possible.
Runtime tested on linux