### PR TITLE
[cmake] Reorganise Dependency build options into single include file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,42 +47,25 @@ include(CMakeDependentOption)
 
 # general
 option(VERBOSE            "Enable verbose output?" OFF)
+
+# Build Tool options
 option(ENABLE_CLANGTIDY   "Enable clang-tidy support?" OFF)
 option(ENABLE_CPPCHECK    "Enable cppcheck support?" OFF)
-option(ENABLE_DVDCSS      "Enable libdvdcss support?" ON)
 option(ENABLE_INCLUDEWHATYOUUSE "Enable include-what-you-use support?" OFF)
-option(ENABLE_UPNP        "Enable UPnP support?" ON)
+
+# Feature Options
 option(ENABLE_AIRTUNES    "Enable AirTunes support?" ON)
+option(ENABLE_DVDCSS      "Enable libdvdcss support?" ON)
 option(ENABLE_OPTICAL     "Enable optical support?" ON)
 option(ENABLE_PYTHON      "Enable python support?" ON)
+option(ENABLE_UPNP        "Enable UPnP support?" ON)
+
+# Testing - Host must be able to execute Target
 option(ENABLE_TESTING     "Enable testing support?" ON)
 
-# Internal Depends - supported on all platforms
-option(ENABLE_INTERNAL_CROSSGUID "Enable internal crossguid?" ON)
-# use ffmpeg from depends or system
-option(ENABLE_INTERNAL_FFMPEG "Enable internal ffmpeg?" OFF)
-option(ENABLE_INTERNAL_RapidJSON "Enable internal rapidjson?" ON)
-cmake_dependent_option(ENABLE_INTERNAL_FLATBUFFERS "Enable internal flatbuffers?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
-cmake_dependent_option(ENABLE_INTERNAL_NFS "Enable internal libnfs?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
-cmake_dependent_option(ENABLE_INTERNAL_PCRE "Enable internal pcre?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
-cmake_dependent_option(ENABLE_INTERNAL_TAGLIB "Enable internal taglib?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
+# All Dependency build options are in the following include
+include(CmakeBuildDepOptions.cmake)
 
-# Internal Depends - supported on UNIX platforms
-if(UNIX)
-  option(FFMPEG_PATH        "Path to external ffmpeg?" "")
-  option(ENABLE_INTERNAL_FMT "Enable internal fmt?" OFF)
-  option(ENABLE_INTERNAL_FSTRCMP "Enable internal fstrcmp?" OFF)
-  option(ENABLE_INTERNAL_DAV1D "Enable internal dav1d?" OFF)
-  option(ENABLE_INTERNAL_GTEST "Enable internal gtest?" OFF)
-  option(ENABLE_INTERNAL_UDFREAD "Enable internal udfread?" OFF)
-  option(ENABLE_INTERNAL_SPDLOG "Enable internal spdlog?" OFF)
-
-  if(ENABLE_INTERNAL_SPDLOG)
-    set(ENABLE_INTERNAL_FMT ON CACHE BOOL "" FORCE)
-  endif()
-endif()
-# prefer kissfft from xbmc/contrib but let use system one on unices
-cmake_dependent_option(ENABLE_INTERNAL_KISSFFT "Enable internal kissfft?" ON "UNIX" ON)
 # System options
 if(NOT WIN32)
   option(WITH_ARCH              "build with given arch" OFF)

--- a/CmakeBuildDepOptions.cmake
+++ b/CmakeBuildDepOptions.cmake
@@ -1,0 +1,45 @@
+# Dependency build options for all platforms
+#
+# Note cmake_dependent_option only allows an option to be set by user if it fulfils the
+# conditions for its first state (eg ON/OFF after the description string). If it does not,
+# the last state is used, but is forced and cant be overridden with a set( CACHE FORCE) or
+# user define (-DENABLE_XXX=STATE)
+#
+# Example
+# cmake_dependent_option(ENABLE_INTERNAL_CEC "Enable internal cec?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
+# For all platforms that set USE_INTERNAL_LIBS=OFF (Linux/freebsd), they can override and set
+# -DENABLE_INTERNAL_CEC=ON if they wish to still build the cec lib.
+# Apple/Windows/Android/KODI_DEPENDS will be given the FORCED state of ON, and is not possible
+# to change unless the user sets -DUSE_INTERNAL_LIBS=OFF AND then also supplies -DENABLE_INTERNAL_CEC=<STATE>
+# If a user goes this route, they will need to manually set most ENABLE_INTERNAL_XXX to build
+#
+
+# Internal Depends - supported on all platforms
+option(ENABLE_INTERNAL_CROSSGUID "Enable internal crossguid?" ON)
+option(ENABLE_INTERNAL_RapidJSON "Enable internal rapidjson?" ON)
+
+# use ffmpeg from depends or system
+option(ENABLE_INTERNAL_FFMPEG "Enable internal ffmpeg?" OFF)
+
+cmake_dependent_option(ENABLE_INTERNAL_FLATBUFFERS "Enable internal flatbuffers?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
+cmake_dependent_option(ENABLE_INTERNAL_NFS "Enable internal libnfs?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
+cmake_dependent_option(ENABLE_INTERNAL_PCRE "Enable internal pcre?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
+cmake_dependent_option(ENABLE_INTERNAL_TAGLIB "Enable internal taglib?" OFF "DEFINED USE_INTERNAL_LIBS;NOT USE_INTERNAL_LIBS" ON)
+
+# Internal Depends - supported on UNIX platforms
+if(UNIX)
+  option(FFMPEG_PATH        "Path to external ffmpeg?" "")
+  option(ENABLE_INTERNAL_FMT "Enable internal fmt?" OFF)
+  option(ENABLE_INTERNAL_FSTRCMP "Enable internal fstrcmp?" OFF)
+  option(ENABLE_INTERNAL_DAV1D "Enable internal dav1d?" OFF)
+  option(ENABLE_INTERNAL_GTEST "Enable internal gtest?" OFF)
+  option(ENABLE_INTERNAL_UDFREAD "Enable internal udfread?" OFF)
+  option(ENABLE_INTERNAL_SPDLOG "Enable internal spdlog?" OFF)
+
+  if(ENABLE_INTERNAL_SPDLOG)
+    set(ENABLE_INTERNAL_FMT ON CACHE BOOL "" FORCE)
+  endif()
+endif()
+
+# prefer kissfft from xbmc/contrib but let use system one on unices
+cmake_dependent_option(ENABLE_INTERNAL_KISSFFT "Enable internal kissfft?" ON "UNIX" ON)


### PR DESCRIPTION
## Description
Groups all dependency build options into a single file to make it easy to
see the multitude of ENABLE_INTERNAL_XXX options

## Motivation and context
Little bit of reorganisation. I think it makes it a little bit easier to group options and understand what their use is for.
Its likely that all Required and Optional Kodi deps will get an enable_internal_xxx entry for the foreseeable future.

Open to different opinions on the name of the included file, and also if people dont think this is useful at all, can be closed out as not wanted.

The commentary around cmake_dependent_option may be a bit verbose, but its given me enough hassle that i thought id clearly outline the behaviour.

## How has this been tested?
cmake generation still sets same options as current master

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
