### PR TITLE
[Windows] Isolate precompiled/downloaded or internal compiled depends in a different path for Matrix, Nexus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,7 @@ cmake_install.cmake
 /project/BuildDependencies/win10-x64
 /project/BuildDependencies/win10-win32
 /project/BuildDependencies/win32
+/project/BuildDependencies/build-*
 
 # /system/players/VideoPlayer
 /system/players/VideoPlayer/*

--- a/cmake/installdata/windows/addons.txt
+++ b/cmake/installdata/windows/addons.txt
@@ -1,2 +1,2 @@
-project/BuildDependencies/${ARCH}/addons/script.module.pil KEEP_DIR_STRUCTURE addons
-project/BuildDependencies/${ARCH}/addons/script.module.pycryptodome KEEP_DIR_STRUCTURE addons
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/${ARCH}/addons/script.module.pil KEEP_DIR_STRUCTURE addons
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/${ARCH}/addons/script.module.pycryptodome KEEP_DIR_STRUCTURE addons

--- a/cmake/installdata/windows/dlls.txt
+++ b/cmake/installdata/windows/dlls.txt
@@ -1,2 +1,2 @@
-project/BuildDependencies/${ARCH}/bin/*.dll .
-project/BuildDependencies/${ARCH}/bin/libbluray*.jar .
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/${ARCH}/bin/*.dll .
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/${ARCH}/bin/libbluray*.jar .

--- a/cmake/installdata/windows/python.txt
+++ b/cmake/installdata/windows/python.txt
@@ -1,1 +1,1 @@
-project/BuildDependencies/${ARCH}/bin/Python KEEP_DIR_STRUCTURE system
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/${ARCH}/bin/Python KEEP_DIR_STRUCTURE system

--- a/cmake/installdata/windowsstore/addons.txt
+++ b/cmake/installdata/windowsstore/addons.txt
@@ -1,2 +1,2 @@
-project/BuildDependencies/win10-${ARCH}/addons/*
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/win10-${ARCH}/addons/*
 system/addon-manifest-uwp.xml

--- a/cmake/installdata/windowsstore/dlls.txt
+++ b/cmake/installdata/windowsstore/dlls.txt
@@ -1,1 +1,1 @@
-project/BuildDependencies/win10-${ARCH}/bin/*.dll dlls
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/win10-${ARCH}/bin/*.dll dlls

--- a/cmake/installdata/windowsstore/python.txt
+++ b/cmake/installdata/windowsstore/python.txt
@@ -1,1 +1,1 @@
-project/BuildDependencies/win10-${ARCH}/bin/Python KEEP_DIR_STRUCTURE system
+project/BuildDependencies/build-${APP_VERSION_MAJOR}/win10-${ARCH}/bin/Python KEEP_DIR_STRUCTURE system

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -33,11 +33,17 @@ set(CORE_MAIN_SOURCE ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/WinMain.cpp)
 
 # Precompiled headers fail with per target output directory. (needs CMake 3.1)
 set(PRECOMPILEDHEADER_DIR ${PROJECT_BINARY_DIR}/${CORE_BUILD_CONFIG}/objs)
+
 set(CMAKE_SYSTEM_NAME Windows)
 set(DEPS_FOLDER_RELATIVE project/BuildDependencies)
+
+# parse version.txt and versions.h to get the version and API info
+include(${CMAKE_SOURCE_DIR}/cmake/scripts/common/Macros.cmake)
+core_find_versions()
+
 set(NATIVEPREFIX ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/tools)
-set(DEPENDS_PATH ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/${ARCH})
-set(MINGW_LIBS_DIR ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/mingwlibs/${ARCH})
+set(DEPENDS_PATH ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/build-${APP_VERSION_MAJOR}/${ARCH})
+set(MINGW_LIBS_DIR ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/build-${APP_VERSION_MAJOR}/mingwlibs/${ARCH})
 
 # mingw libs
 list(APPEND CMAKE_PREFIX_PATH ${MINGW_LIBS_DIR})

--- a/cmake/scripts/windowsstore/ArchSetup.cmake
+++ b/cmake/scripts/windowsstore/ArchSetup.cmake
@@ -51,9 +51,13 @@ set(PACKAGE_GUID "281d668b-5739-4abd-b3c2-ed1cda572ed2")
 set(APP_MANIFEST_NAME package.appxmanifest)
 set(DEPS_FOLDER_RELATIVE project/BuildDependencies)
 
+# parse version.txt and versions.h to get the version and API info
+include(${CMAKE_SOURCE_DIR}/cmake/scripts/common/Macros.cmake)
+core_find_versions()
+
 set(NATIVEPREFIX ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/tools)
-set(DEPENDS_PATH ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/win10-${ARCH})
-set(MINGW_LIBS_DIR ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/mingwlibs/win10-${ARCH})
+set(DEPENDS_PATH ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/build-${APP_VERSION_MAJOR}/win10-${ARCH})
+set(MINGW_LIBS_DIR ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/build-${APP_VERSION_MAJOR}/mingwlibs/win10-${ARCH})
 
 # mingw libs
 list(APPEND CMAKE_PREFIX_PATH ${MINGW_LIBS_DIR})

--- a/tools/buildsteps/windows/buildffmpeg.sh
+++ b/tools/buildsteps/windows/buildffmpeg.sh
@@ -98,8 +98,8 @@ export CFLAGS=""
 export CXXFLAGS=""
 export LDFLAGS=""
 
-extra_cflags="-I$LOCALDESTDIR/include -I/depends/$TRIPLET/include -DWIN32_LEAN_AND_MEAN"
-extra_ldflags="-LIBPATH:\"$LOCALDESTDIR/lib\" -LIBPATH:\"$MINGW_PREFIX/lib\" -LIBPATH:\"/depends/$TRIPLET/lib\""
+extra_cflags="-I$LOCALDESTDIR/include -I/depends2/$TRIPLET/include -DWIN32_LEAN_AND_MEAN"
+extra_ldflags="-LIBPATH:\"$LOCALDESTDIR/lib\" -LIBPATH:\"$MINGW_PREFIX/lib\" -LIBPATH:\"/depends2/$TRIPLET/lib\""
 if [ $win10 == "yes" ]; then
   do_addOption "--enable-cross-compile"
   extra_cflags=$extra_cflags" -MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00"

--- a/tools/buildsteps/windows/download-dependencies.bat
+++ b/tools/buildsteps/windows/download-dependencies.bat
@@ -19,9 +19,12 @@ REM If KODI_MIRROR is not set externally to this script, set it to the default m
 IF "%KODI_MIRROR%" == "" SET KODI_MIRROR=http://mirrors.kodi.tv
 echo Downloading from mirror %KODI_MIRROR%
 
+REM read the VERSION_MAJOR value from version.txt
+FOR /f "tokens=1,2" %%i IN (%WORKSPACE%\version.txt) DO IF "%%i" == "VERSION_MAJOR" SET VERSION_MAJOR=%%j
+
 REM Locate the BuildDependencies directory, based on the path of this script
 SET BUILD_DEPS_PATH=%WORKSPACE%\project\BuildDependencies
-SET APP_PATH=%WORKSPACE%\project\BuildDependencies\%TARGETPLATFORM%
+SET APP_PATH=%WORKSPACE%\project\BuildDependencies\build-%VERSION_MAJOR%\%TARGETPLATFORM%
 SET TMP_PATH=%BUILD_DEPS_PATH%\scripts\tmp
 
 REM Change to the BuildDependencies directory, if we're not there already

--- a/tools/buildsteps/windows/download-msys2.bat
+++ b/tools/buildsteps/windows/download-msys2.bat
@@ -26,9 +26,13 @@ PUSHD %~dp0\..\..\..
 SET WORKSPACE=%CD%
 POPD
 
+REM read the VERSION_MAJOR value from version.txt
+FOR /f "tokens=1,2" %%i IN (%WORKSPACE%\version.txt) DO IF "%%i" == "VERSION_MAJOR" SET VERSION_MAJOR=%%j
+
 set msysver=20210725
 set msys2=msys64
 set instdir=%WORKSPACE%\project\BuildDependencies
+set builddir=%WORKSPACE%\project\BuildDependencies\build-%VERSION_MAJOR%
 set msyspackages=diffutils gcc make patch perl tar yasm
 set gaspreprocurl=https://github.com/FFmpeg/gas-preprocessor/archive/master.tar.gz
 set usemirror=yes
@@ -207,6 +211,9 @@ if not exist %instdir%\locals\x64\share (
     mkdir %instdir%\locals\x64\share
     )
 
+if exist %instdir%\%msys2%\etc\fstab. (
+    >nul findstr /c:"build-%VERSION_MAJOR%" %instdir%\%msys2%\etc\fstab. || del %instdir%\%msys2%\etc\fstab.
+)
 if not exist %instdir%\%msys2%\etc\fstab. GOTO writeFstab
 for /f "tokens=2 delims=/" %%a in ('findstr /i xbmc %instdir%\%msys2%\etc\fstab.') do set searchRes=%%a
 if "%searchRes%"=="xbmc" GOTO installbase
@@ -235,6 +242,11 @@ if "%cygdrive%"=="no" echo.none / cygdrive binary,posix=0,noacl,user 0 ^0>>%inst
     echo.%instdir%\win10-win32\      /depends/win10-win32
     echo.%instdir%\win10-x64\        /depends/win10-x64
     echo.%instdir%\..\..\            /xbmc
+    echo.%builddir%\win32\           /depends2/win32
+    echo.%builddir%\x64\             /depends2/x64
+    echo.%builddir%\win10-arm\       /depends2/win10-arm
+    echo.%builddir%\win10-win32\     /depends2/win10-win32
+    echo.%builddir%\win10-x64\       /depends2/win10-x64
 )>>%instdir%\%msys2%\etc\fstab.
 
 :installbase

--- a/tools/buildsteps/windows/make-mingwlibs.sh
+++ b/tools/buildsteps/windows/make-mingwlibs.sh
@@ -72,7 +72,7 @@ checkfiles() {
 }
 
 buildProcess() {
-export PREFIX=/xbmc/project/BuildDependencies/mingwlibs/$TRIPLET
+export PREFIX=/xbmc/project/BuildDependencies/build-$VERSION_MAJOR/mingwlibs/$TRIPLET
 if [ "$(pathChanged $PREFIX /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION)" == "0" ]; then
   return
 fi

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -14,7 +14,7 @@ rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
 rem also keeps MSYS2 installation
-SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools"
+SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools" -e "project/BuildDependencies/build-*"
 
 ECHO running %GIT_CLEAN_CMD%
 %GIT_CLEAN_CMD%

--- a/tools/buildsteps/windows/vswhere.bat
+++ b/tools/buildsteps/windows/vswhere.bat
@@ -42,7 +42,10 @@ IF "%vcstore%"=="store" (
   SET toolsdir="win10-%toolsdir%"
 )
 
-SET vswhere="%builddeps%\%toolsdir%\tools\vswhere\vswhere.exe"
+REM read the VERSION_MAJOR value from version.txt
+FOR /f "tokens=1,2" %%i IN (%builddeps%\..\..\version.txt) DO IF "%%i" == "VERSION_MAJOR" SET VERSION_MAJOR=%%j
+
+SET vswhere="%builddeps%\build-%VERSION_MAJOR%\%toolsdir%\tools\vswhere\vswhere.exe"
 
 FOR /f "usebackq tokens=1* delims=" %%i in (`%vswhere% -latest -property installationPath`) do (
   IF EXIST "%%i\VC\Auxiliary\Build\vcvarsall.bat" (


### PR DESCRIPTION
## Description
- Moves dependencies path to a folder that contains Kodi's `MAJOR_VERSION` to allows keep various sets of dependencies (Matrix, Nexus, etc.) and no overwrite or delete between different builds.
- Adds this new dependencies path to git clean command exceptions to avoids Jenkins delete it in every job.
- Moves `mingwlibs` folder (FFmpeg compiled libs) inside the new path to allows preserve various sets of FFmpeg for Matrix, Nexus, etc.
- Avoids Jenkins re-build FFmpeg every time that switches from master <--> Matrix branch (to compile a PR or nightlies)

## Motivation and context
Now that the Windows dependencies are being changed to be able to compile internally (See: https://github.com/xbmc/xbmc/pull/21601) the only drawback is that the compilation time can be considerably increased.

This is still not very noticeable because only a few dependencies are being compiled every time.

The reason for this PR is to reduce the compilation time as much as possible. The ultimate goal is to ensure that a dependency is only recompiled when the dependency version changes or does not previously exist. Same for FFmpeg.

This PR prepares the environment for this to be possible, but the dependencies must be adapted/updated to make use of this: mainly CMake stuff changes (out of scope of this PR).

Currently there is a mix in Windows dependencies, mainly 3 types:

**Group 1.** Already updated that are compiled from sources and can already benefit from this PR changes:
  `pcre`, `libnfs`, `spdlog`, `fmt`   ~(last two not merged yet)~

**Group 2.** Already updated that are compiled from sources but "by design" continue to be compiled every time:
 `crossguid`, `flatbuffers`, `libdvdcss`, `libdvdnav`, `libdvdread`, `rapidjson`, `taglib`

**Group 3**. Precompiled dependencies that are downloaded as-is at Kodi build time. They are all listed here:  https://github.com/xbmc/xbmc/tree/master/project/BuildDependencies/scripts

The goal is for us to migrate all dependencies to Group 1 --> compiled from source and at the same time it won't add to Kodi's build time. Of course nothing is urgent. It can be done progressively when "someone" decides to update a dependency.

## How has this been tested?
Build Windows x64 and UWP-64. 
Various cases tested. MSYS2 clean installed and updated, clean environment and previously paths structure. 
FFmpeg x64 and UWP-64 build clean and not clean, etc.

## What is the effect on users?
Nothing for final users. 
Little for sporadic developers since nothing changes in the essential build process (steps to follow).
More intensive developers can benefit from not having to recompile FFmpeg and/or dependencies when switching from Matrix / master branch.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
