### PR TITLE
[addons] add CStructHdl operator= support for 'A = A'

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -263,6 +263,10 @@ public:
   const CStructHdl& operator=(const CStructHdl& right)
   {
     assert(&right.m_cStructure);
+
+    if (this == &right)
+      return *this;
+
     if (m_cStructure && !m_owner)
     {
       memcpy(m_cStructure, right.m_cStructure, sizeof(C_STRUCT));
@@ -280,6 +284,10 @@ public:
   const CStructHdl& operator=(const C_STRUCT& right)
   {
     assert(&right);
+
+    if (m_cStructure == &right)
+      return *this;
+
     if (m_cStructure && !m_owner)
     {
       memcpy(m_cStructure, &right, sizeof(C_STRUCT));


### PR DESCRIPTION
This change fixes the issue described here:
https://github.com/kodi-pvr/pvr.vdr.vnsi/pull/186

