### PR TITLE
CThread: fix memory leak

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -200,6 +200,7 @@ void CThread::StopThread(bool bWait /*= true*/)
     lock.unlock();
     if (!Join(std::chrono::milliseconds::max())) // eh?
       lthread->join();
+    delete lthread;
     m_thread = nullptr;
   }
 }


### PR DESCRIPTION
## Description
m_thread was allocated with a "new", this commit ensures that the thread is properly freed.
