### PR TITLE
[infoscanner][discs] Check .nomedia before stacking

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2268,6 +2268,13 @@ void CFileItemList::Remove(CFileItem* pItem)
   }
 }
 
+VECFILEITEMS::iterator CFileItemList::erase(VECFILEITEMS::iterator first,
+                                            VECFILEITEMS::iterator last)
+{
+  std::unique_lock<CCriticalSection> lock(m_lock);
+  return m_items.erase(first, last);
+}
+
 void CFileItemList::Remove(int iItem)
 {
   std::unique_lock<CCriticalSection> lock(m_lock);

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -808,6 +808,7 @@ public:
 
   VECFILEITEMS::iterator begin() { return m_items.begin(); }
   VECFILEITEMS::iterator end() { return m_items.end(); }
+  VECFILEITEMS::iterator erase(VECFILEITEMS::iterator first, VECFILEITEMS::iterator last);
   VECFILEITEMS::const_iterator begin() const { return m_items.begin(); }
   VECFILEITEMS::const_iterator end() const { return m_items.end(); }
   VECFILEITEMS::const_iterator cbegin() const { return m_items.cbegin(); }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -298,6 +298,12 @@ namespace VIDEO
       { // need to fetch the folder
         CDirectory::GetDirectory(strDirectory, items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
                                  DIR_FLAG_DEFAULTS);
+        // do not consider inner folders with .nomedia
+        items.erase(std::remove_if(items.begin(), items.end(),
+                                   [this](const CFileItemPtr& item) {
+                                     return item->m_bIsFolder && HasNoMedia(item->GetPath());
+                                   }),
+                    items.end());
         items.Stack();
 
         // check whether to re-use previously computed fast hash


### PR DESCRIPTION
## Description
`items.Stack();` translates any directory that is a DVD or Bluray folder structure to the respective "manifest" path (e.g. `folder/` gets translated to `/folder/video_ts/video_ts.ifo`. This effectively bypasses any possible checks for `.nomedia` in the root folder. Kodi needs to check for nomedia before considering stacking directory entries (remove the inner folders than have a `.nomedia` file inside). I've done this in the VideoInfoScanner.cpp file to avoid spreading those checks elsewhere for components that shouldn't be responsible for this (e.g. could have been added in `GetOpticalMediaPath` instead)

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/16877

## How has this been tested?
Runtime tested on linux with dvds and blurays

## What is the effect on users?
Dvd folder structures or bluray folder structures are no longer scanned to the library if they contain a `.nomedia` file inside.

