### PR TITLE
[Windows] Simplifies build scripts, removes dependency on MSYS2

### DIFF
--- a/tools/buildsteps/windows/run-tests.bat
+++ b/tools/buildsteps/windows/run-tests.bat
@@ -6,14 +6,9 @@ PUSHD %~dp0\..\..\..
 SET WORKSPACE=%CD%
 POPD
 cd %WORKSPACE%\kodi-build.%TARGET_PLATFORM%
-SET builddeps_dir=%WORKSPACE%\project\BuildDependencies
-SET msys_dir=%builddeps_dir%\msys64
-IF NOT EXIST %msys_dir% (SET msys_dir=%builddeps_dir%\msys32)
-SET awk_exe=%msys_dir%\usr\bin\awk.exe
-SET sed_exe=%msys_dir%\usr\bin\sed.exe
 
 REM read the version values from version.txt
-FOR /f %%i IN ('%awk_exe% "/APP_NAME/ {print $2}" %WORKSPACE%\version.txt') DO SET APP_NAME=%%i
+FOR /f "tokens=1,2" %%i IN (%WORKSPACE%\version.txt) DO IF "%%i" == "APP_NAME" SET APP_NAME=%%j
 
 CLS
 COLOR 1B
@@ -54,7 +49,7 @@ ECHO Running testsuite...
   rem <testcase name="IsStarted" status="notrun" time="0" classname="TestWebServer"/>
   rem becomes
   rem <testcase name="IsStarted" status="notrun" time="0" classname="TestWebServer"><skipped/></testcase>
-  %sed_exe% "s/<testcase\(.*\)\"notrun\"\(.*\)\/>$/<testcase\1\"notrun\"\2><skipped\/><\/testcase>/" %WORKSPACE%\gtestresults.xml > %WORKSPACE%\gtestresults-skipped.xml
+  @PowerShell "(GC %WORKSPACE%\gtestresults.xml)|%%{$_ -Replace '(<testcase.+)("notrun")(.+)(/>)','$1$2$3><skipped/></testcase>'}|SC %WORKSPACE%\gtestresults-skipped.xml"
   del %WORKSPACE%\gtestresults.xml
   move %WORKSPACE%\gtestresults-skipped.xml %WORKSPACE%\gtestresults.xml
 ECHO Done running testsuite!


### PR DESCRIPTION
## Description
[Windows] Simplifies build scripts, removes dependency on MSYS2

## Motivation and context
MSYS2 is still needed to build FFmpeg but it was being abused for other simple tasks that can be done with native Windows tools.

This is a simple change that shouldn't cause any problems.

An advantage with this is that once the FFmpeg libs have been compiled it's possible to delete the `msys64` folder (700 MB) and continue building Kodi installers with `BuildSetup.bat` (as long as the FFmpeg version does not changes).

## How has this been tested?
Build Windows x64 and UWP-64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
