### PR TITLE
Improving/fixing transparent control rendering

### DIFF
--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -125,6 +125,15 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
   if (Animate(currentTime))
     MarkDirtyRegion();
 
+  // if the control changed culling state from true to false, mark it
+  const bool culled = m_transform.alpha <= 0.01f;
+  if (m_isCulled != culled)
+  {
+    m_isCulled = false;
+    MarkDirtyRegion();
+  }
+  m_isCulled = culled;
+
   if (IsVisible())
   {
     m_cachedTransform = CServiceBroker::GetWinSystem()->GetGfxContext().AddTransform(m_transform);
@@ -168,7 +177,7 @@ void CGUIControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregio
 // 3. reset the animation transform
 void CGUIControl::DoRender()
 {
-  if (IsVisible())
+  if (IsVisible() && !m_isCulled)
   {
     bool hasStereo =
         m_stereo != 0.0f &&
@@ -402,7 +411,7 @@ bool CGUIControl::CanFocus() const
 
 bool CGUIControl::IsVisible() const
 {
-  if (m_forceHidden || m_transform.alpha <= 0.01f)
+  if (m_forceHidden)
     return false;
   return m_visible == VISIBLE;
 }
@@ -474,6 +483,9 @@ float CGUIControl::GetHeight() const
 
 void CGUIControl::MarkDirtyRegion(const unsigned int dirtyState)
 {
+  // if the control is culled, bail
+  if (dirtyState == DIRTY_STATE_CONTROL && m_isCulled)
+    return;
   if (!m_controlDirtyState && m_parentControl)
     m_parentControl->MarkDirtyRegion(DIRTY_STATE_CHILD);
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -370,6 +370,7 @@ protected:
   float m_stereo;
   TransformMatrix m_transform;
   TransformMatrix m_cachedTransform; // Contains the absolute transform the control
+  bool m_isCulled{true};
 
   static const unsigned int DIRTY_STATE_CONTROL = 1; //This control is dirty
   static const unsigned int DIRTY_STATE_CHILD = 2; //One / more children are dirty


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/21387 introduced focusing issues with skins. Originally, it was intended to avoid rendering/processing chunks of the GUI nodes which are transparent.

This PR limits the the scope of this to the actual rendering and dirty regions. 

## Motivation and context
See https://github.com/xbmc/xbmc/issues/21615 for details.

## How has this been tested?
Renderdoc shows the regions rendered with now change to the previous PR.

Also, I can't see any apparent issues.

For further testing, I'll provide a test build.

## What is the effect on users?
Undoes some skin breakage.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
