### PR TITLE
[Android] Cleanup unused method in TvUtil

### DIFF
--- a/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
@@ -52,7 +52,6 @@ public class TvUtil
   private static final int CHANNEL_JOB_ID = 500;
   private static final int CHANNEL_TRIGGERED_JOB_ID_OFFSET = 1000;
   private static final int CHANNEL_TIMED_JOB_ID_OFFSET = 2000;
-  private static final int CHANNEL_IMMEDIATE_JOB_ID_OFFSET = 3000;
 
   private static final String[] CHANNELS_PROJECTION = {
           TvContractCompat.Channels._ID,
@@ -275,43 +274,13 @@ public class TvUtil
     scheduler.schedule(job);
   }
 
-  /**
-   * Schedulers syncing programs for a channel on a time base. The scheduler will listen to a {@link Uri} for a
-   * particular channel.
-   *
-   * @param context   for accessing the {@link JobScheduler}.
-   * @param channelId for the channel to listen for changes.
-   */
-  public static void scheduleSyncingProgramsForChannel(Context context, long channelId)
-  {
-    JobScheduler scheduler =
-            (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
-    if (scheduler.getPendingJob(getImmediateJobIdForChannelId(channelId)) != null)
-      return;
-
-    ComponentName componentName = new ComponentName(context, SyncProgramsJobService.class);
-
-    JobInfo.Builder builder =
-            new JobInfo.Builder(getImmediateJobIdForChannelId(channelId), componentName);
-    builder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY);
-
-    PersistableBundle bundle = new PersistableBundle();
-    bundle.putLong(TvContractCompat.EXTRA_CHANNEL_ID, channelId);
-    builder.setExtras(bundle);
-
-    scheduler.schedule(builder.build());
-  }
-
   public static int getTriggeredJobIdForChannelId(long channelId)
   {
     return (int) (CHANNEL_TRIGGERED_JOB_ID_OFFSET + channelId);
   }
+
   public static int getTimedJobIdForChannelId(long channelId)
   {
     return (int) (CHANNEL_TIMED_JOB_ID_OFFSET + channelId);
-  }
-  public static int getImmediateJobIdForChannelId(long channelId)
-  {
-    return (int) (CHANNEL_IMMEDIATE_JOB_ID_OFFSET + channelId);
   }
 }


### PR DESCRIPTION
## Description
I've seen it while reviewing how scheduled jobs are created. Currently, scheduled jobs and triggered jobs are being used.

There is a third method ```scheduleSyncingProgramsForChannel()``` that is almost identical to one of the above methods, but it has never been used. I propose to remove this method and related code.

## How has this been tested?
Tested on Android TV 9

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
