### PR TITLE
[Subtitles][WebVTT] Clear all overlays just before creating a new parser

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -145,6 +145,11 @@ void COverlayCodecWebVTT::Flush()
 {
   if (m_allowFlush)
   {
+    if (m_pOverlay)
+    {
+      m_pOverlay->Release();
+      m_pOverlay = nullptr;
+    }
     m_previousSubIds.clear();
     FlushSubtitles();
   }
@@ -155,7 +160,7 @@ CDVDOverlay* COverlayCodecWebVTT::GetOverlay()
   if (m_pOverlay)
     return nullptr;
   m_pOverlay = CreateOverlay();
-  m_pOverlay->SetOverlayContainerFlushable(false);
+  m_pOverlay->SetOverlayContainerFlushable(m_allowFlush);
   m_pOverlay->SetForcedMargins(m_webvttHandler.IsForcedMargins());
   return m_pOverlay->Acquire();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -194,5 +194,5 @@ private:
   std::vector<webvttCssStyle> m_cueCssStyles;
   bool m_CSSColorsLoaded{false};
   std::vector<std::pair<std::string, UTILS::COLOR::ColorInfo>> m_CSSColors;
-  double m_offset;
+  double m_offset{0.0};
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -118,7 +118,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 
-  CloseStream(true);
+  CloseStream(false);
   m_streaminfo = hints;
 
   // okey check if this is a filesubtitle


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Clear all overlays just before creating a new parser
otherwise overlays marked as not flushable are kept in memory and the subtitles of previous video are displayed over the current played video

When you play a video over another one, the flush will be done for the overlaycontainer, here:
https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp#L111
but this not delete the overlays marked as not flushable
(just webvtt case https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp#L158)
and will result that in next played video you still see the subtitle of previous video,
so we clear all overlays just before creating a new parser

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #21643

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You have to play two videos with InputStream Adaptive having WebVTT as "file mode" (like n@tflix)
then play the first one, while in playing, go back to main menu without stop the playback, then play the second video over the current one. Without the fix will result mixed subtitles as the video provided in the issue

i tried playing 4 subsequential videos

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Avoid to see subtitles of previous video over the current played

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
