### PR TITLE
NFS: add preliminary nfs4 support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4196,7 +4196,10 @@ msgctxt "#1200"
 msgid "SMB client"
 msgstr ""
 
-#empty string with id 1201
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#1201"
+msgid "NFS Client"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#1202"
@@ -20279,7 +20282,11 @@ msgctxt "#36355"
 msgid "In a multi-screen configuration, the screens not displaying this application are blacked out."
 msgstr ""
 
-#empty string with id 36356
+#. Description of settings category with label #1201 "NFS Client"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#36356"
+msgid "This category contains the settings for how the NFS client is handled."
+msgstr ""
 
 #. Description of setting with label #214 "Video calibration..."
 #: system/settings/settings.xml
@@ -21878,7 +21885,19 @@ msgctxt "#37050"
 msgid "Verbose logging for the [B]WS-Discovery[/B] component"
 msgstr ""
 
-#empty strings from id 37051 to 38010
+#. Setting #37051 NFS Protocol Version"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37051"
+msgid "NFS Protocol Version"
+msgstr ""
+
+#. Description of setting #37051 NFS Protocol Version"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37052"
+msgid "NFS protocol version to use when establishing NFS connections"
+msgstr ""
+
+#empty strings from id 37053 to 38010
 
 #. Setting #38011 "Show All Items entry"
 #: system/settings/settings.xml

--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -43,7 +43,7 @@ if(NOT LIBNFS_FOUND)
   else()
     # Try pkgconfig based search. Linux may not have a version with cmake config installed
     if(PKG_CONFIG_FOUND)
-      pkg_check_modules(PC_NFS libnfs QUIET)
+      pkg_check_modules(PC_NFS libnfs>=3.0.0 QUIET)
     endif()
 
     find_path(NFS_INCLUDE_DIR nfsc/libnfs.h

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2377,6 +2377,21 @@
         </setting>
       </group>
     </category>
+    <category id="nfs" label="1201" help="36356">
+      <requirement>HAS_FILESYSTEM_NFS</requirement>
+      <group id="1" label="16000">
+        <setting id="nfs.version" type="integer" label="37051" help="37052">
+          <level>2</level>
+          <default>3</default>
+          <constraints>
+            <minimum>3</minimum>
+            <step>1</step>
+            <maximum>4</maximum>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+      </group>
+    </category>
     <category id="weather" label="8" help="36316">
       <group id="1" label="16000">
         <setting id="weather.currentlocation" type="integer" label="0" help="36317">

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -381,6 +381,9 @@ void CSettingConditions::Initialize()
 #ifdef HAS_FILESYSTEM_SMB
   m_simpleConditions.emplace("has_filesystem_smb");
 #endif
+#ifdef HAS_FILESYSTEM_NFS
+  m_simpleConditions.insert("has_filesystem_nfs");
+#endif
 #ifdef HAS_ZEROCONF
   m_simpleConditions.emplace("has_zeroconf");
 #endif


### PR DESCRIPTION
This adds NFSv4 support to Kodi's vfs.

This works by using a setting `nfs_set_version` after a context has been created.

NFSv4 also operates on the root always, this make it so there is only one context per hostname/ip. This also makes it so that we don't have to call `mount_getexports`. We can simply test if the file exists using `nfs_stat64`.

I'm not a big fan of how the nfs vfs is written and this seems like a bit of a shoehorn to get it working. I also don't like the new setting. This doesn't really allow switching protocols without restarting kodi (maybe a setting callback could be added in the future?).

If I had the time I would rather like to implement NFSv4 into a separate protocol or to add the ability to set the protocol version in `CGUIDialogNetworkSetup`. This PR is probably good enough for now though and would be a nice addition for Nexus.

I'm not sure if @sahlberg has any other pointer or maybe he can correct me if I got some facts wrong (I really have no idea about NFS).