### PR TITLE
[setting] Show only Disc settings matching Kodi compile flags

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -335,6 +335,7 @@
         </setting>
       </group>
       <group id="2" label="14234">
+        <requirement>HAVE_LIBBLURAY</requirement>
         <setting id="bluray.playerregion" type="integer" label="14121" help="38017">
           <level>1</level>
           <default>1</default> <!-- region A -->

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -376,6 +376,7 @@
           <control type="toggle" />
         </setting>
         <setting id="audiocds.recordingpath" type="path" label="20000" help="36285">
+          <requirement>HAS_CDDA_RIPPER</requirement>
           <level>3</level>
           <default></default>
           <constraints>
@@ -386,6 +387,7 @@
           </control>
         </setting>
         <setting id="audiocds.trackpathformat" type="string" label="13307" help="36286">
+          <requirement>HAS_CDDA_RIPPER</requirement>
           <level>3</level>
           <default>%A/%A - %B/[%N. ][%A - ]%T</default>
           <control type="edit" format="string">
@@ -393,6 +395,7 @@
           </control>
         </setting>
         <setting id="audiocds.encoder" type="addon" label="621" help="36287">
+          <requirement>HAS_CDDA_RIPPER</requirement>
           <level>3</level>
           <default>audioencoder.kodi.builtin.aac</default>
           <constraints>
@@ -403,6 +406,7 @@
           </control>
         </setting>
         <setting id="audiocds.settings" parent="audiocds.encoder" type="action" label="21417" help="37025">
+          <requirement>HAS_CDDA_RIPPER</requirement>
           <level>3</level>
           <dependencies>
             <dependency type="enable">
@@ -412,6 +416,7 @@
           <control type="button" format="action" />
         </setting>
         <setting id="audiocds.ejectonrip" type="boolean" label="14099" help="36291">
+          <requirement>HAS_CDDA_RIPPER</requirement>
           <level>3</level>
           <default>true</default>
           <control type="toggle" />

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -314,6 +314,7 @@
     <category id="discs" label="14087" help="36193">
       <group id="1" label="446">
         <setting id="dvds.autorun" type="boolean" label="14088" help="36194">
+          <requirement>HAS_DVD_DRIVE</requirement>
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
@@ -363,6 +364,7 @@
       </group>
       <group id="3" label="620">
         <setting id="audiocds.autoaction" type="integer" label="14097" help="36283">
+          <requirement>HAS_DVD_DRIVE</requirement>
           <level>1</level>
           <default>0</default> <!-- AUTOCD_NONE -->
           <constraints>
@@ -371,6 +373,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="audiocds.usecddb" type="boolean" label="227" help="36284">
+          <requirement>HAS_DVD_DRIVE</requirement>
           <level>1</level>
           <default>true</default>
           <control type="toggle" />

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -431,6 +431,10 @@ void CSettingConditions::Initialize()
   m_simpleConditions.emplace("have_libbluray");
 #endif
 
+#ifdef HAS_CDDA_RIPPER
+  m_simpleConditions.emplace("has_cdda_ripper");
+#endif
+
   // add complex conditions
   m_complexConditions.emplace("addonhassettings", AddonHasSettings);
   m_complexConditions.emplace("checkmasterlock", CheckMasterLock);

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -435,6 +435,10 @@ void CSettingConditions::Initialize()
   m_simpleConditions.emplace("has_cdda_ripper");
 #endif
 
+#ifdef HAS_DVD_DRIVE
+  m_simpleConditions.emplace("has_dvd_drive");
+#endif
+
   // add complex conditions
   m_complexConditions.emplace("addonhassettings", AddonHasSettings);
   m_complexConditions.emplace("checkmasterlock", CheckMasterLock);

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -427,6 +427,10 @@ void CSettingConditions::Initialize()
     m_simpleConditions.emplace("webserver_has_ssl");
 #endif
 
+#ifdef HAVE_LIBBLURAY
+  m_simpleConditions.emplace("have_libbluray");
+#endif
+
   // add complex conditions
   m_complexConditions.emplace("addonhassettings", AddonHasSettings);
   m_complexConditions.emplace("checkmasterlock", CheckMasterLock);


### PR DESCRIPTION
We have compile time defines for 
* physical drive support (HAS_DVD_DRIVE)
* blu-ray support (HAVE_LIBBLURAY)
* audio-cd ripping (HAS_CDDA_RIPPER)

Those flags control whether certain disc related functionality is available in Kodi, up to now the affected settings are shown unconditionally. For example, Android is build with HAVE_LIBBLURAY, but without HAS_DVD_DRIVE and HAS_CDDA_RIPPER, but currently shows all the audio-cd ripping and autorun settings. This makes not much sense. ;-) Thus, this PR changes to show only those disc settings matching the related compile flags.

Remark: DVD region and intro menu skip is provided by libdvdnav, which is not controllable via a define.

![screenshot00011](https://user-images.githubusercontent.com/3226626/178102762-10d22d0f-ae89-401e-bac0-5dd23112aa8d.png)

@enen92 what do you think?