### PR TITLE
[guilib] Fix GUIFontTTF glyph caching if no glyph index was given.

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -731,12 +731,16 @@ std::vector<CGUIFontTTF::Glyph> CGUIFontTTF::GetHarfBuzzShapedGlyphs(const vecTe
 
 CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyphIndex)
 {
-  wchar_t letter = (wchar_t)(chr & 0xffff);
-  character_t style = (chr & 0x7000000) >> 24;
+  const wchar_t letter = static_cast<wchar_t>(chr & 0xffff);
 
   // ignore linebreaks
   if (letter == L'\r')
     return nullptr;
+
+  const character_t style = (chr & 0x7000000) >> 24;
+
+  if (!glyphIndex)
+    glyphIndex = FT_Get_Char_Index(m_face, letter);
 
   // quick access to ascii chars
   if (letter < 255 && glyphIndex < 255)
@@ -825,9 +829,6 @@ CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyph
 
 bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, FT_UInt glyphIndex)
 {
-  if (!glyphIndex)
-    glyphIndex = FT_Get_Char_Index(m_face, letter);
-
   FT_Glyph glyph = nullptr;
   if (FT_Load_Glyph(m_face, glyphIndex, FT_LOAD_TARGET_LIGHT))
   {


### PR DESCRIPTION
On my Nvidia Shield Pro 2019 I noticed non-smooth animation effects when navigating from one Estuary home screen section to another (most notably when entering or leaving the "TV" section). Even on my beefy MacBook Pro this can be observed if one looks close enough, but on low power machines it is easy to spot and just not acceptable. 

This is a regression since in Matrix on the same box the animation runs very smooth.

Root cause of the problem lies in the changes done in the context of the HarfBuzz font rendering feature introduced for Nexus.

The ASCII glyph cache of `CGUIFontTTF` does not work if `CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyphIndex)` get called with `glyphIndex = 0`, which happens quite often from different code paths and for different letters! 

<img width="884" alt="Screenshot 2022-07-09 at 22 11 41" src="https://user-images.githubusercontent.com/3226626/178121778-4e316ab6-3473-4692-bf81-22bc0b1504dc.png">

With the current code different letters are cached with the same index in the ASCII letter glyph cache `m_charquick`, as the glyph index will be used as part of the key for the cache. This leads to many many cache misses, which results in very high CPU load causing stuttering for animations if many text fields are to be rendered (like for "Live TV" section of Estuary home screen, if recent channels, recent recordings, ... contain lots of items).

Fix is to obtain the glyph index if none was passed to `CGUIFontTTF::Character* CGUIFontTTF::GetCharacter(character_t chr, FT_UInt glyphIndex)`. This was formerly done in `bool CGUIFontTTF::CacheCharacter(wchar_t letter, uint32_t style, Character* ch, FT_UInt glyphIndex)`, but this is to late, because `GetCharacter` needs the proper glyph index to access the ASCII glyph cache correctly before it calls `CacheCharacter`.

I carefully runtime-tested the fix on Androd and macOS.

@thexai when you find some time for review...