### PR TITLE
[cmake] Allow specifying HOST_CAN_EXECUTE_TARGET

### DIFF
--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -59,7 +59,7 @@ endif()
 # this variable is set if we can execute build artefacts on the host system (for example unit tests).
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL CMAKE_SYSTEM_PROCESSOR AND
    CMAKE_HOST_SYSTEM_NAME STREQUAL CMAKE_SYSTEM_NAME)
-  if(NOT HOST_CAN_EXECUTE_TARGET)
+  if(NOT DEFINED HOST_CAN_EXECUTE_TARGET)
     set(HOST_CAN_EXECUTE_TARGET TRUE)
   endif()
 else()


### PR DESCRIPTION
## Description
Executing the target binary will not work when cross-compiling to a
uClibc-based target on a glibc-based host.

https://github.com/xbmc/xbmc/commit/b9a0c7b1f402613e96876ccfec316831801352bd (added with https://github.com/xbmc/xbmc/pull/21597) broke cross-compiling in this case:
```
-- Found Python3: /home/buildroot/buildroot/output/per-package/kodi/host/x86_64-buildroot-linux-uclibc/sysroot/usr/include/python3.10
 (found suitable exact version "3.10.5") found components: Development Development.Module Development.Embed
-- Could NOT find Python3 (missing: Interpreter) (Required is exact version "3.10")
    Reason given by package:
        Interpreter: Cannot run the interpreter
          "/home/buildroot/buildroot/output/per-package/kodi/host/x86_64-buildroot-linux-uclibc/sysroot/usr/bin/python3.10"
```
```
$ file /home/buildroot/buildroot/output/per-package/kodi/host/x86_64-buildroot-linux-uclibc/sysroot/usr/bin/python3.10
/home/buildroot/buildroot/output/per-package/kodi/host/x86_64-buildroot-linux-uclibc/sysroot/usr/bin/python3.10:
 ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld64-uClibc.so.0, not stripped
```
This patch allows to force -DHOST_CAN_EXECUTE_TARGET=FALSE to avoid
executing the target version of python3 although the host version was set
in configure options:

-DPYTHON_EXECUTABLE=/home/buildroot/buildroot/output/per-package/kodi/host/bin/python3.10
```
$ file /home/buildroot/buildroot/output/per-package/kodi/host/bin/python3.10
/home/buildroot/buildroot/output/per-package/kodi/host/bin/python3.10:
 ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2,
 BuildID[sha1]=0502eef4c126feb4162aea6d36f321387f2a58fc, for GNU/Linux 3.2.0, with debug_info, not stripped
```
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
