### PR TITLE
[PlayListPlayer] Fixed wrong player playlist with playlist files

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -258,13 +258,23 @@ bool CPlayListPlayer::PlaySongId(int songId)
 bool CPlayListPlayer::Play(const CFileItemPtr& pItem, const std::string& player)
 {
   int playlist;
-  if (pItem->IsAudio())
+  bool isVideo{pItem->IsVideo()};
+  bool isAudio{pItem->IsAudio()};
+  if (isVideo && isAudio && pItem->HasProperty("playlist_type_hint"))
+  {
+    // If an extension is set in both audio / video lists (e.g. playlist .strm),
+    // is not possible detect the type of playlist then we rely on the hint
+    playlist = pItem->GetProperty("playlist_type_hint").asInteger32(PLAYLIST_NONE);
+  }
+  else if (isAudio)
     playlist = PLAYLIST_MUSIC;
-  else if (pItem->IsVideo())
+  else if (isVideo)
     playlist = PLAYLIST_VIDEO;
   else
   {
-    CLog::Log(LOGWARNING,"Playlist Player: ListItem type must be audio or video, use ListItem::setInfo to specify!");
+    CLog::Log(
+        LOGWARNING,
+        "Playlist Player: ListItem type must be audio or video, use ListItem::setInfo to specify!");
     return false;
   }
 

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -61,8 +61,11 @@ public:
   bool PlaySongId(int songId);
   bool Play();
 
-  /*! \brief Creates a new playlist for an item and starts playing it
-   \param pItem The item to play.
+  /*!
+   * \brief Creates a new playlist for an item and starts playing it
+   * \param pItem The item to play.
+   * \param player The player name.
+   * \return True if has success, otherwise false.
    */
   bool Play(const CFileItemPtr& pItem, const std::string& player);
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -893,6 +893,7 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
       OnQueueItem(iItem);
       return true;
     }
+    pItem->SetProperty("playlist_type_hint", PLAYLIST_MUSIC);
     CServiceBroker::GetPlaylistPlayer().Play(pItem, player);
     return true;
   }

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -280,6 +280,7 @@ void SetPathAndPlay(CFileItem& item)
   }
   else
   {
+    item.SetProperty("playlist_type_hint", PLAYLIST_VIDEO);
     CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
   }
 }

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -606,3 +606,29 @@ void CGUIViewStateVideoEpisodes::SaveViewState()
   SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, CViewStateSettings::GetInstance().Get("videonavepisodes"));
 }
 
+CGUIViewStateVideoPlaylist::CGUIViewStateVideoPlaylist(const CFileItemList& items)
+  : CGUIViewStateWindowVideo(items)
+{
+  SortAttribute sortAttributes = SortAttributeNone;
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
+    sortAttributes = SortAttributeIgnoreArticle;
+
+  AddSortMethod(SortByLabel, sortAttributes, 551,
+                LABEL_MASKS("%L", "%I", "%L", "")); // Label, Size | Label, empty
+  AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I")); // Label, Size | Label, Size
+  AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J")); // Label, Date | Label, Date
+  AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", "")); // Label, Size | Label, empty
+
+  const CViewState* viewState = CViewStateSettings::GetInstance().Get("videofiles");
+  SetSortMethod(viewState->m_sortDescription);
+  SetViewAsControl(viewState->m_viewMode);
+  SetSortOrder(viewState->m_sortDescription.sortOrder);
+
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
+}
+
+void CGUIViewStateVideoPlaylist::SaveViewState()
+{
+  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV);
+}

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -23,6 +23,15 @@ protected:
   bool AutoPlayNextItem() override;
 };
 
+class CGUIViewStateVideoPlaylist : public CGUIViewStateWindowVideo
+{
+public:
+  explicit CGUIViewStateVideoPlaylist(const CFileItemList& items);
+
+protected:
+  void SaveViewState() override;
+};
+
 class CGUIViewStateWindowVideoNav : public CGUIViewStateWindowVideo
 {
 public:

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -739,6 +739,8 @@ void CGUIDialogVideoInfo::Play(bool resume)
       Open();
       return;
     }
+    m_movieItem->SetProperty("playlist_type_hint", PLAYLIST_VIDEO);
+
     pWindow->PlayMovie(m_movieItem.get());
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1165,6 +1165,8 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   }
   CLog::Log(LOGDEBUG, "{} {}", __FUNCTION__, CURL::GetRedacted(item.GetPath()));
 
+  item.SetProperty("playlist_type_hint", PLAYLIST_VIDEO);
+
   PlayMovie(&item, player);
 
   return true;

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -101,7 +101,13 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
     return new CGUIViewStateLibrary(items);
 
   if (items.IsPlayList())
-    return new CGUIViewStateMusicPlaylist(items);
+  {
+    // Playlists (like .strm) can be music or video type
+    if (windowId == WINDOW_VIDEO_NAV)
+      return new CGUIViewStateVideoPlaylist(items);
+    else
+      return new CGUIViewStateMusicPlaylist(items);
+  }
 
   if (items.GetPath() == "special://musicplaylists/")
     return new CGUIViewStateWindowMusicNav(items);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The old PR https://github.com/xbmc/xbmc/pull/11747
has changed the way in how the playlist type is set
by moving all code in one method: `CPlayListPlayer::Play` where now the type is detected by using `IsAudio`/`IsVideo `methods
but this change however, led to a regression with playlist files like STRM, M3U, ...

the strm is an extension set in both audio and video extensions lists,
therefore when you test for `IsAudio`/`IsVideo `this will return true on both methods:
https://github.com/xbmc/xbmc/blob/master/xbmc/PlayListPlayer.cpp#L260-L273
since both methods return true, only the first one is taken in account `IsAudio`
therefore set a wrong playlist, with further repercussions
on the JSON-RPC calls by returning missing/wrong data due to wrong playlist set
such as:
`Player.GetProperties`
`Player.GetActivePlayers`
becoming unusable for addons from first version of Kodi 19 (not sure about Kodi 18)

Then this PR restore the old hint value for playlist type that has been removed,
and that will be used as fallback only when `IsAudio`/`IsVideo` both return true as happens with strm

**A secondary use case fix**
is when you use `Play from here` context menu when you have opened a STRM file that contains more than one links

in this case the video is played from `CGUIMediaWindow::OnPlayAndQueueMedia`
but the playlist set/returned from here https://github.com/xbmc/xbmc/blob/master/xbmc/windows/GUIMediaWindow.cpp#L1512 is wrong. Use `Play from here` from a multiple links STRM is not so popular, therefore is possible that no one complained over the time, this code has never changed in more than 10 years, this is the reason of my changes in `xbmc/view/GUIViewState.cpp`

If possible need to be backported

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #17915

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
call JSON RPC `Player.GetActivePlayers`  and see the player id when you play a strm video must be "1"
call JSON RPC `Player.GetProperties` and check if `currentsubtitle`, `currentvideostream`, `subtitles` data fields exists
more info in the Issue

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Have a working JSON RPC response when you play videos with STRM/M3U files

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
