### PR TITLE
[cmake] fix blacklisted files regex

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -231,7 +231,7 @@ function(copy_file_to_buildtree file)
   endif()
 
   # Exclude autotools build artefacts and other blacklisted files in source tree.
-  if(file MATCHES "(Makefile|\.in|\.xbt|\.so|\.dylib|\.gitignore)$")
+  if(file MATCHES "(Makefile|\\.in|\\.xbt|\\.so|\\.dylib|\\.gitignore)$")
     if(VERBOSE)
       message(STATUS "copy_file_to_buildtree - ignoring file: ${file}")
     endif()


### PR DESCRIPTION
## Description
Found while working on other stuff, for some reason the cmake file blacklist regex is not working properly and is matching `.iso` files unless the dot is double escaped.
Runtime tested by adding both a dummy ".iso" file and a ".so" file to the test reference data and confirming only the last is not installed.
