### PR TITLE
[backport] GLUtils/WinSystemX11: support building with libfmt 9.0.0

### DIFF
--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -148,27 +148,27 @@ void _VerifyGLState(const char* szfile, const char* szfunction, int lineno)
 void LogGraphicsInfo()
 {
 #if defined(HAS_GL) || defined(HAS_GLES)
-  const GLubyte *s;
+  const char* s;
 
-  s = glGetString(GL_VENDOR);
+  s = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
   if (s)
     CLog::Log(LOGINFO, "GL_VENDOR = %s", s);
   else
     CLog::Log(LOGINFO, "GL_VENDOR = NULL");
 
-  s = glGetString(GL_RENDERER);
+  s = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
   if (s)
     CLog::Log(LOGINFO, "GL_RENDERER = %s", s);
   else
     CLog::Log(LOGINFO, "GL_RENDERER = NULL");
 
-  s = glGetString(GL_VERSION);
+  s = reinterpret_cast<const char*>(glGetString(GL_VERSION));
   if (s)
     CLog::Log(LOGINFO, "GL_VERSION = %s", s);
   else
     CLog::Log(LOGINFO, "GL_VERSION = NULL");
 
-  s = glGetString(GL_SHADING_LANGUAGE_VERSION);
+  s = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
   if (s)
     CLog::Log(LOGINFO, "GL_SHADING_LANGUAGE_VERSION = %s", s);
   else

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -1038,7 +1038,10 @@ bool CWinSystemX11::HasWindowManager()
 
   if(status == Success && items_read)
   {
-    CLog::Log(LOGDEBUG,"Window Manager Name: %s", data);
+    const char* s;
+
+    s = reinterpret_cast<const char*>(data);
+    CLog::Log(LOGDEBUG, "Window Manager Name: {}", s);
   }
   else
     CLog::Log(LOGDEBUG,"Window Manager Name: ");


### PR DESCRIPTION
took the freedom to backport https://github.com/xbmc/xbmc/pull/21649
thanks @heitbaum 

## Description
Support building with libfmt 9.0.0.

Changelog from libfmt 9.0.0 is here:
- https://github.com/fmtlib/fmt/blob/master/ChangeLog.rst

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
updating libfmt to 9.0.0 results in kodi failing to build with the following error:
```
/usr/include/fmt/core.h:1727:17: error: static assertion failed: Formatting of non-void pointers is disallowed.
 1727 |   static_assert(formattable_pointer,
```
Reference code in libfmt is:
- https://github.com/fmtlib/fmt/blob/d5e9166f54ed71f92eb6ba189342f706fe97469e/include/fmt/core.h#L1721-L1728


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
