### PR TITLE
[Windows] Fix NFSFile.cpp after nfs_stat64 update

### DIFF
--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -606,12 +606,9 @@ int CNFSFile::Stat(const CURL& url, struct __stat64* buffer)
   }
   else
   {
-    if(buffer)
+    if (buffer)
     {
-#if defined(TARGET_WINDOWS) //! @todo get rid of this define after gotham v13
-      memcpy(buffer, &tmpBuffer, sizeof(struct __stat64));
-#else
-      memset(buffer, 0, sizeof(struct __stat64));
+      *buffer = {};
       buffer->st_dev = tmpBuffer.nfs_dev;
       buffer->st_ino = tmpBuffer.nfs_ino;
       buffer->st_mode = tmpBuffer.nfs_mode;
@@ -623,7 +620,6 @@ int CNFSFile::Stat(const CURL& url, struct __stat64* buffer)
       buffer->st_atime = tmpBuffer.nfs_atime;
       buffer->st_mtime = tmpBuffer.nfs_mtime;
       buffer->st_ctime = tmpBuffer.nfs_ctime;
-#endif
     }
   }
   return ret;


### PR DESCRIPTION
## Description
Fix NFSFile.cpp after nfs_stat64 update (https://github.com/xbmc/xbmc/pull/21575)

## Motivation and context
NFS sources on Windows are broken after merge https://github.com/xbmc/xbmc/pull/21575

The reason is on Windows are used different code path:

`memcpy(buffer, &tmpBuffer, sizeof(struct __stat64));`

and `tmpBuffer` is not the same size that `buffer` now  (`nfs_stat_64`  vs `__stat64`)

In any case there is no reason to use a different code path on Windows.

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Fixes NFS sources on Windows

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
