### PR TITLE
filesystem: fix bad use of c++ initializer on pointer & use c++ initializer in place of memset

### DIFF
--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -92,9 +92,9 @@ bool CFileCDDA::Exists(const CURL& url)
 
 int CFileCDDA::Stat(const CURL& url, struct __stat64* buffer)
 {
-  if (Open(url))
+  if (Open(url) && buffer)
   {
-    memset(buffer, 0, sizeof(struct __stat64));
+    *buffer = {};
     buffer->st_size = GetLength();
     buffer->st_mode = _S_IFREG;
     Close();

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1511,7 +1511,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
               url.GetRedacted());
     if (buffer)
     {
-      memset(buffer, 0, sizeof(struct __stat64));
+      *buffer = {};
       buffer->st_size = GetLength();
       buffer->st_mode = _S_IFREG;
     }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -498,7 +498,7 @@ int CFile::Stat(struct __stat64 *buffer)
 
   if (!m_pFile)
   {
-    memset(buffer, 0, sizeof(struct __stat64));
+    *buffer = {};
     errno = ENOENT;
     return -1;
   }

--- a/xbmc/filesystem/IFile.cpp
+++ b/xbmc/filesystem/IFile.cpp
@@ -27,7 +27,9 @@ IFile::~IFile() = default;
 
 int IFile::Stat(struct __stat64* buffer)
 {
-  memset(buffer, 0, sizeof(struct __stat64));
+  if (buffer)
+    *buffer = {};
+
   errno = ENOENT;
   return -1;
 }

--- a/xbmc/filesystem/ISO9660File.cpp
+++ b/xbmc/filesystem/ISO9660File.cpp
@@ -51,7 +51,10 @@ int CISO9660File::Stat(const CURL& url, struct __stat64* buffer)
   if (!m_stat->p_stat)
     return -1;
 
-  buffer = {};
+  if (!buffer)
+    return -1;
+
+  *buffer = {};
   buffer->st_size = m_stat->p_stat->size;
 
   switch (m_stat->p_stat->type)

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -61,7 +61,10 @@ int CPipeFile::Stat(const CURL& url, struct __stat64* buffer)
 
 int CPipeFile::Stat(struct __stat64* buffer)
 {
-  memset(buffer,0,sizeof(struct __stat64));
+  if (!buffer)
+    return -1;
+
+  *buffer = {};
   buffer->st_size = m_length;
   return 0;
 }

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -70,10 +70,10 @@ void CUDFFile::Close()
 
 int CUDFFile::Stat(const CURL& url, struct __stat64* buffer)
 {
-  if (!m_udf || !m_file)
+  if (!m_udf || !m_file || !buffer)
     return -1;
 
-  buffer = {};
+  *buffer = {};
   buffer->st_size = GetLength();
 
   return 0;

--- a/xbmc/filesystem/XbtFile.cpp
+++ b/xbmc/filesystem/XbtFile.cpp
@@ -112,7 +112,10 @@ int CXbtFile::Stat(struct __stat64 *buffer)
 
 int CXbtFile::Stat(const CURL& url, struct __stat64* buffer)
 {
-  memset(buffer, 0, sizeof(struct __stat64));
+  if (!buffer)
+    return -1;
+
+  *buffer = {};
 
   // check if the file exists
   CXBTFReaderPtr reader;

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -255,6 +255,9 @@ int CZipFile::Stat(struct __stat64 *buffer)
 
 int CZipFile::Stat(const CURL& url, struct __stat64* buffer)
 {
+  if (!buffer)
+    return -1;
+
   if (!g_ZipManager.GetZipEntry(url, mZipItem))
   {
     if (url.GetFileName().empty() && CFile::Exists(url.GetHostName()))
@@ -266,7 +269,7 @@ int CZipFile::Stat(const CURL& url, struct __stat64* buffer)
       return -1;
   }
 
-  memset(buffer, 0, sizeof(struct __stat64));
+  *buffer = {};
   buffer->st_gid = 0;
   buffer->st_atime = buffer->st_ctime = mZipItem.mod_time;
   buffer->st_size = mZipItem.usize;


### PR DESCRIPTION
## Description
- filesystem: fix bad use of buffer = {} on pointer
- filesystem: use default c++ initializer in place of memset and add nullptr checks

## Motivation and context
Found by chance. I'm not sure what the consequences might be but I'm pretty sure it's a latent bug since the original code intention is reset to zero the contents of the buffer (not the buffer address itself).

Review commits separately: commit 1 is a bugfix, commit 2 is a improvement 

## How has this been tested?
Build Windows x64

## What is the effect on users?
Probably nothing. 
Perhaps @enen92 has a better understanding of whether it can affect UDF / ISO9960 filesystems or how to test this code.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
