### PR TITLE
[Subtitles] Rework subtitle positions

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14480,7 +14480,7 @@ msgstr ""
 #. Item list value of setting with label #21460 "Subtitle position on screen"
 #: system/settings/settings.xml
 msgctxt "#21463"
-msgid "Below video"
+msgid "Bottom of screen"
 msgstr ""
 
 #. Item list value of setting with label #21460 "Subtitle position on screen"
@@ -14492,7 +14492,7 @@ msgstr ""
 #. Item list value of setting with label #21460 "Subtitle position on screen"
 #: system/settings/settings.xml
 msgctxt "#21465"
-msgid "Above video"
+msgid "Top of screen"
 msgstr ""
 
 #. Description of setting with label #21416 "Select first unwatched TV show season/episode"
@@ -19312,7 +19312,7 @@ msgstr ""
 #. Description of setting with label #21460 "Subtitle location on screen"
 #: system/settings/settings.xml
 msgctxt "#36192"
-msgid "Location of subtitles on the screen. [Below] / [Above video] When possible the subtitles will be positioned inside the black bars (depends on video encoding). Please note that some forced positions in the subtitles cannot be changed."
+msgid "Location of subtitles on the screen. [Bottom of video] / [Top of video] When possible the subtitles will be positioned within the video area (depends on video encoding). Please note that some forced positions in the subtitles cannot be changed."
 msgstr ""
 
 #. Description of settings category with label #14087 "DVDs"
@@ -23153,4 +23153,10 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#39188"
 msgid "No background"
+msgstr ""
+
+#. Window screen calibration: calibration by using the subtitle bar
+#: xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+msgctxt "#39189"
+msgid "Available only with manual subtitle position"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -505,7 +505,7 @@
       <group id="1" label="39186">
         <setting id="subtitles.align" type="integer" label="21460" help="36192">
           <level>2</level>
-          <default>1</default> <!-- Align::BOTTOM_INSIDE -->
+          <default>2</default> <!-- Align::BOTTOM_OUTSIDE -->
           <constraints>
             <options>
               <option label="21461">0</option> <!-- Align::MANUAL -->
@@ -527,7 +527,7 @@
         </setting>
         <setting id="subtitles.fontsize" type="integer" label="289" help="36186">
           <level>3</level>
-          <default>42</default>
+          <default>42</default> <!-- in pixels -->
           <constraints>
             <minimum>12</minimum>
             <step>2</step>
@@ -563,7 +563,7 @@
         </setting>
         <setting id="subtitles.bordersize" type="integer" label="39159">
           <level>3</level>
-          <default>30</default>
+          <default>25</default>
           <dependencies>
             <dependency type="enable" setting="subtitles.backgroundtype" operator="!is">2</dependency>
           </dependencies>
@@ -662,16 +662,18 @@
         </setting>
         <setting id="subtitles.marginvertical" type="number" label="39182" help="39183">
           <level>3</level>
-          <default>7.75</default>
+          <default>4.95</default>
           <constraints>
             <minimum>0</minimum>
-            <step>0.25</step>
+            <step>0.05</step>
             <maximum>50</maximum>
           </constraints>
           <dependencies>
             <dependency type="enable" on="property" operator="!is" name="isplaying" />
           </dependencies>
-          <control type="slider" format="percentage"/>
+          <control type="slider" format="percentage">
+            <format>{:.2f} %</format>
+          </control>
         </setting>
         <setting id="subtitles.overridefonts" type="boolean" label="21368" help="36190">
           <level>3</level>

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -77,6 +77,12 @@ public:
   */
   void FlushEvents();
 
+  /*!
+  * \brief Get PlayResY value
+  * \return The PlayResY value of current track
+  */
+  int GetPlayResY();
+
 protected:
   /*!
   * \brief Create a new empty ASS track
@@ -139,7 +145,6 @@ protected:
   */
   void ChangeEventStopTime(int eventId, double stopTime);
 
-
   friend class CSubtitlesAdapter;
 
 
@@ -160,6 +165,5 @@ private:
 
   // default allocated style ID for the kodi user configured subtitle style
   int m_defaultKodiStyleId{ASS_NO_ID};
-  bool m_drawWithinBlackBars{false};
   std::string m_defaultFontFamilyName;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -68,10 +68,20 @@ enum class OverrideStyles
   STYLES_POSITIONS
 };
 
+enum class MarginsMode
+{
+  // Use style margins only
+  DEFAULT,
+  // Apply margins to position text within the video area (cropped videos)
+  INSIDE_VIDEO,
+  // Disable any kind of margin
+  DISABLED
+};
+
 struct style
 {
   std::string fontName; // Font family name
-  double fontSize; // Font size in PT
+  double fontSize; // Font size in pixel
   FontStyle fontStyle = FontStyle::NORMAL;
   UTILS::COLOR::Color fontColor = UTILS::COLOR::WHITE;
   int fontBorderSize = 15; // In %
@@ -88,7 +98,7 @@ struct style
   OverrideStyles assOverrideStyles = OverrideStyles::DISABLED;
   // Override fonts to native ASS/SSA format type only
   bool assOverrideFont = false;
-  bool drawWithinBlackBars = false;
+  // Vertical margin value in pixels scaled for VIEWPORT_HEIGHT
   int marginVertical = MARGIN_VERTICAL;
   int blur = 0; // In %
 };
@@ -109,8 +119,9 @@ struct renderOpts
   float videoHeight;
   float sourceWidth;
   float sourceHeight;
-  bool disableVerticalMargin = false;
-  // position: vertical line position of subtitles in percent. 0 = no change (bottom), 100 = on top.
+  MarginsMode marginsMode = MarginsMode::DEFAULT;
+  // Vertical line position of subtitles in percentage
+  // only for bottom alignment, 0 = bottom (no change), 100 = on top
   double position = 0;
   HorizontalAlign horizontalAlignment = HorizontalAlign::DISABLED;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -167,18 +167,28 @@ namespace OVERLAY {
      */
     void LoadSettings();
 
+    enum PositonResInfoState
+    {
+      POSRESINFO_UNSET = -1,
+      POSRESINFO_SAVE_CHANGES = -2,
+    };
+
     CCriticalSection m_section;
     std::vector<SElement> m_buffers[NUM_BUFFERS];
     std::map<unsigned int, COverlay*> m_textureCache;
     static unsigned int m_textureid;
     CRect m_rv, m_rs, m_rd;
     std::string m_stereomode;
-    int m_subtitlePosition{0}; // Current subtitle position
-    int m_subtitlePosResInfo{-1}; // Current subtitle position from resolution info
+    // Current subtitle position
+    int m_subtitlePosition{0};
+    // Current subtitle position from resolution info,
+    // or PositonResInfoState enum values for deferred processing
+    int m_subtitlePosResInfo{POSRESINFO_UNSET};
     int m_subtitleVerticalMargin{0};
     bool m_saveSubtitlePosition{false}; // To save subtitle position permanently
     KODI::SUBTITLES::HorizontalAlign m_subtitleHorizontalAlign{
         KODI::SUBTITLES::HorizontalAlign::CENTER};
+    KODI::SUBTITLES::Align m_subtitleAlign{KODI::SUBTITLES::Align::BOTTOM_INSIDE};
 
     std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_overlayStyle;
     std::atomic<bool> m_isSettingsChanged{false};

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -200,6 +200,9 @@ void CGUIMoverControl::SetInvalid()
 
 void CGUIMoverControl::Move(int iX, int iY)
 {
+  if (!m_enabled)
+    return;
+
   int iLocX = m_iLocationX + iX;
   int iLocY = m_iLocationY + iY;
   // check if we are within the bounds

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -611,10 +611,10 @@ void CGUISliderControl::SetFromPosition(const CPoint &point, bool guessSelector 
 
   switch (m_iType)
   {
-  case SLIDER_CONTROL_TYPE_FLOAT:
+    case SLIDER_CONTROL_TYPE_FLOAT:
     {
-      float fValue = m_fStart + (m_fEnd - m_fStart) * fPercent;
-      SetFloatValue(fValue, m_currentSelector, true);
+      float fValue = m_fStart + (m_fEnd - m_fStart) * fPercent + m_fInterval / 2;
+      SetFloatValue(MathUtils::RoundF(fValue, m_fInterval), m_currentSelector, true);
       break;
     }
 

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -168,14 +168,6 @@ float CSubtitlesSettings::GetVerticalMarginPerc()
 {
   // We return the vertical margin as percentage
   // to fit the current screen resolution
-  const Align subAlign{GetAlignment()};
-
-  // If the user has set the alignment type to keep the subtitle text
-  // inside the black bars, we override user vertical margin
-  // to try avoid go off the black bars
-  if (subAlign == Align::BOTTOM_OUTSIDE || subAlign == Align::TOP_OUTSIDE)
-    return MARGIN_VERTICAL_BLACKBARS;
-
   return static_cast<float>(m_settings->GetNumber(CSettings::SETTING_SUBTITLES_MARGINVERTICAL));
 }
 

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -27,10 +27,6 @@ namespace SUBTITLES
 // even if the default app font could be changed
 constexpr const char* FONT_DEFAULT_FAMILYNAME = "DEFAULT";
 
-// Default vertical margin used for the alignment
-// to keep the text inside the black bars
-constexpr float MARGIN_VERTICAL_BLACKBARS = 2.75f; // in %
-
 enum class Align
 {
   MANUAL = 0,
@@ -112,7 +108,7 @@ public:
 
   /*!
    * \brief Get font size
-   * \return The font size in PT
+   * \return The font size in PX
    */
   int GetFontSize();
 

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.h
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.h
@@ -43,4 +43,5 @@ private:
   std::map<int, std::pair<float, float>> m_controlsSize;
   int m_subtitlesHalfSpace{0};
   int m_subtitleVerticalMargin{0};
+  bool m_isSubtitleBarEnabled{false};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR rework subtitle positions and how works the manual position (e.g. by using key shortcuts) / Calibration window

After the big rework i changed the way in how the subtitle position/manual position works,
the `Bottom of Video` / `Top of Video` do not reflect the same behaviour as Kodi 19 for cropped videos,
so the text is not placed "inside the video" but act as standard Bottom / Top position, this because in the past i could not find a good solution

After the new request on #21555 i started to investigate again and i found a solution to restore the Kodi 19 behaviour of `Bottom of Video` / `Top of Video`.

Now `Bottom of Video` / `Top of Video` is same of Kodi 19
and `Below video` / `Above video` labels are renamed as `Bottom of screen` / `Top of screen` that IMO are more user friedly, but suggestions are welcome

Due to these changes, i had to revert some new changes i previously made on kodi 20, the changes are:
- Reverted the possibility to change subtitle position (e.g.key shortcuts) with all types of "subtitles positions", now you can change position only with `Bottom` and `Manual` (if i enable this for `Below video` could works but when the text go off the video margin will be cut out and disappear in the black bands, to avoid complaints from users this will not be enabled)
- The subtitle bar in Screen Calibration setting window, now works only with the `Manual` position settings, as Kodi 19
- I kept the possibility of moving the text with the `Bottom of screen` subtitle position, but will not be possible to save permanently the change with "save" parameter of `SubtitleShiftUp(save)` Player built-in.

however for those coming from Kodi 19 they dont see nothing changed

particular changes:
- CDVDSubtitlesLibass::RenderImage in DVDSubtitlesLibass.cpp:
~i added `opts.reconfigure` this to avoid call~ my oversight removed

- CDVDSubtitlesLibass::RenderImage in DVDSubtitlesLibass.cpp:
`ass_set_use_margins` was used to force place the text inside black bars and now i have set always disabled.
i see no difference between use standard `Bottom of screen` subtitle position, and enable this margin feature,
because if there are too many lines of text come out of the black bands anyway.
Therefore, we can avoiding an additional scaling and we do not need anymore also to set a specific margin `MARGIN_VERTICAL_BLACKBARS`.

- I have removed the FIXME in font size, and cleanup, this was not a problem to be fixed the values are based on a 720 window (i don't know the reason but the same conclusions came to the MPV devs)

- Some settings has been modified to accommodate these changes

- Removed todo `/! @todo Libass scale the margins values (style)` in OverlayRenderer.cpp, fixed the displacement in better way with the help of libass dev

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #21555
Fix #21699

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Use of screen calibration window, with "manual" align and other subtitle positions, while or not in playing
Try moving subtitles with shourtcut keys
Check if font size with ASS with overriding settings enabled is correct
Check if font size with adapted subtitiles (like SRT) is correct
Check if when you move the GUI subtitle bar in calibration window match the subtitle text, with/without overscan and kodi as windowed/fullscreen

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Restored Kodi 19 behaviour of  `Bottom of Video` / `Top of Video`, for cropped videos

## Screenshots (if appropriate):
![screenshot00001](https://user-images.githubusercontent.com/3257156/178701799-6c4e2093-a4b2-4f4b-9be9-96a6a104246b.png)

![screenshot00001](https://user-images.githubusercontent.com/3257156/178762510-80efb34b-1335-4299-b3be-273f90cd6c8d.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
