### PR TITLE
wayland: CSignalHandlerList: remove use of deprecated std::iterator

### DIFF
--- a/xbmc/windowing/wayland/Signals.h
+++ b/xbmc/windowing/wayland/Signals.h
@@ -10,7 +10,6 @@
 
 #include "threads/CriticalSection.h"
 
-#include <iterator>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -104,39 +103,6 @@ class CSignalHandlerList
   CSignalHandlerList& operator=(CSignalHandlerList const& other) = delete;
 
 public:
-  /**
-   * Iterator for iterating through registered signal handlers
-   *
-   * Just wraps the std::map iterator
-   */
-  class iterator : public std::iterator<std::input_iterator_tag, ManagedT const>
-  {
-    typename std::map<RegistrationIdentifierType, ManagedT>::const_iterator m_it;
-
-  public:
-    iterator(typename std::map<RegistrationIdentifierType, ManagedT>::const_iterator it)
-    : m_it{it}
-    {
-    }
-    iterator& operator++()
-    {
-      ++m_it;
-      return *this;
-    }
-    bool operator==(iterator const& right) const
-    {
-      return m_it == right.m_it;
-    }
-    bool operator!=(iterator const& right) const
-    {
-      return !(*this == right);
-    }
-    ManagedT const& operator*()
-    {
-      return m_it->second;
-    }
-  };
-
   CSignalHandlerList()
   : m_data{new Data}
   {}
@@ -163,19 +129,13 @@ public:
     std::unique_lock<CCriticalSection> lock(m_data->m_handlerCriticalSection);
     for (auto const& handler : *this)
     {
-      handler.operator() (std::forward<ArgsT>(args)...);
+      handler.second(std::forward<ArgsT>(args)...);
     }
   }
 
-  iterator begin() const
-  {
-    return iterator(m_data->m_handlers.cbegin());
-  }
+  auto begin() const { return m_data->m_handlers.cbegin(); }
 
-  iterator end() const
-  {
-    return iterator(m_data->m_handlers.cend());
-  }
+  auto end() const { return m_data->m_handlers.cend(); }
 
   /**
    * Get critical section for accessing the handler list


### PR DESCRIPTION
I'm not sure if @yol had other ideas about how this should work but this seems to fix the deprecated warning.

```
In file included from /home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/WinSystemWayland.h:16,
                 from /home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h:11,
                 from /home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.h:11,
                 from /home/lukas/Documents/git/xbmc/xbmc/platform/linux/PlatformLinux.cpp:39:
/home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/Signals.h:112:32: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
  112 |   class iterator : public std::iterator<std::input_iterator_tag, ManagedT const>
      |                                ^~~~~~~~
In file included from /usr/include/c++/12/string:45,
                 from /usr/include/c++/12/stdexcept:39,
                 from /usr/include/c++/12/system_error:41,
                 from /usr/include/c++/12/mutex:41,
                 from /home/lukas/Documents/git/xbmc/xbmc/platform/posix/threads/RecursiveMutex.h:11,
                 from /home/lukas/Documents/git/xbmc/xbmc/threads/CriticalSection.h:14,
                 from /home/lukas/Documents/git/xbmc/xbmc/platform/Platform.h:11,
                 from /home/lukas/Documents/git/xbmc/xbmc/platform/posix/PlatformPosix.h:11,
                 from /home/lukas/Documents/git/xbmc/xbmc/platform/linux/PlatformLinux.h:12,
                 from /home/lukas/Documents/git/xbmc/xbmc/platform/linux/PlatformLinux.cpp:9:
/usr/include/c++/12/bits/stl_iterator_base_types.h:127:34: note: declared here
  127 |     struct _GLIBCXX17_DEPRECATED iterator
      |                                  ^~~~~~~~
```

ref: https://en.cppreference.com/w/cpp/iterator/iterator