### PR TITLE
Get Harfbuzz glyphs only when cache is dirty

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -363,7 +363,6 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
   }
 
   Begin();
-  std::vector<Glyph> glyphs = GetHarfBuzzShapedGlyphs(text);
   uint32_t rawAlignment = alignment;
   bool dirtyCache(false);
   bool hardwareClipping = m_renderSystem->ScissorsCanEffectClipping();
@@ -389,6 +388,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
                              std::chrono::steady_clock::now(), dirtyCache));
   if (dirtyCache)
   {
+    const std::vector<Glyph> glyphs = GetHarfBuzzShapedGlyphs(text);
     // save the origin, which is scaled separately
     m_originX = x;
     m_originY = y;
@@ -575,12 +575,12 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
 
 float CGUIFontTTF::GetTextWidthInternal(const vecText& text)
 {
-  std::vector<Glyph> glyphs = GetHarfBuzzShapedGlyphs(text);
+  const std::vector<Glyph> glyphs = GetHarfBuzzShapedGlyphs(text);
   return GetTextWidthInternal(text, glyphs);
 }
 
 // this routine assumes a single line (i.e. it was called from GUITextLayout)
-float CGUIFontTTF::GetTextWidthInternal(const vecText& text, std::vector<Glyph>& glyphs)
+float CGUIFontTTF::GetTextWidthInternal(const vecText& text, const std::vector<Glyph>& glyphs)
 {
   float width = 0;
   for (auto it = glyphs.begin(); it != glyphs.end(); it++)

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -151,7 +151,7 @@ protected:
   std::vector<Glyph> GetHarfBuzzShapedGlyphs(const vecText& text);
 
   float GetTextWidthInternal(const vecText& text);
-  float GetTextWidthInternal(const vecText& text, std::vector<Glyph>& glyph);
+  float GetTextWidthInternal(const vecText& text, const std::vector<Glyph>& glyph);
   float GetCharWidthInternal(character_t ch);
   float GetTextHeight(float lineSpacing, int numLines) const;
   float GetTextBaseLine() const { return static_cast<float>(m_cellBaseLine); }


### PR DESCRIPTION
## Description
This PR moves the HarfBuzz shaping call after the dirtyCache check.

## Motivation and context
I've done some performance analysis on a Chromecast. On this platform, our rendering is severely throttled by the GUI engine/rendering thread hitting 100% load.

A considerable amount of wasted CPU cycles stems from HarfBuzz shaping, which is done for every element in a frame. Shaping is needed only if the element is dirty, so it should take place after the related check. While dirty elements will still lead to frame drops, this is a huge improvement.

## How has this been tested?
Compiles and runs fine on my desktop and on a Chromecast.

## What is the effect on users?
Lower CPU usage. If the rendering thread is the bottleneck, it will improve framerates. In a heavy scene with Estuary on the Chromecast, it jumps from 30-35 fps to 44-47 fps.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
