### PR TITLE
[INFO] Make listitem.art("thumb") hide the thumb if configured

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11176,7 +11176,13 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
         return strThumb;
       }
       case LISTITEM_ART:
+      {
+        if (info.GetData3() == "thumb")
+        {
+          return item->GetThumbHideIfUnwatched(item);
+        }
         return item->GetArt(info.GetData3());
+      }
       case LISTITEM_OVERLAY:
         return item->GetOverlayImage();
       case LISTITEM_THUMB:


### PR DESCRIPTION
## Description
Currently `Listitem.Art(thumb)` is ignoring the fact the user has the option to hide episode thumb if unwatched setting. Let's fix it making it behave just like `Listitem.Thumb`

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21656
