### PR TITLE
GUIFontTTF: use lookup table for almost any glyph

### DIFF
--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -53,6 +53,7 @@ constexpr int FONT_STYLE_UPPERCASE = (1 << 3);
 constexpr int FONT_STYLE_LOWERCASE = (1 << 4);
 constexpr int FONT_STYLE_CAPITALIZE = (1 << 5);
 constexpr int FONT_STYLE_MASK = 0xFF;
+constexpr int FONT_STYLES_COUNT = 7;
 
 class CScrollInfo
 {

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "GUIFont.h"
 #include "utils/ColorUtils.h"
 #include "utils/Geometry.h"
 
@@ -74,7 +75,10 @@ struct SVertex
 
 class CGUIFontTTF
 {
-  static constexpr size_t LOOKUPTABLE_SIZE = 256 * 8;
+  // use lookup table for the first 4096 glyphs (almost any letter or symbol) to
+  // speed up GUI rendering and decrease CPU usage and less memory reallocations
+  static constexpr int MAX_GLYPH_IDX = 4096;
+  static constexpr size_t LOOKUPTABLE_SIZE = MAX_GLYPH_IDX * FONT_STYLES_COUNT;
 
   friend class CGUIFont;
 
@@ -209,7 +213,8 @@ protected:
   UTILS::COLOR::Color m_color{UTILS::COLOR::NONE};
 
   Character* m_char{nullptr}; // our characters
-  Character* m_charquick[LOOKUPTABLE_SIZE]{nullptr}; // ascii chars (7 styles) here
+  // room for the first MAX_GLYPH_IDX glyphs in 7 styles
+  Character* m_charquick[LOOKUPTABLE_SIZE]{nullptr};
   int m_maxChars{0}; // size of character array (can be incremented)
   int m_numChars{0}; // the current number of cached characters
 


### PR DESCRIPTION
## Description
GUIFontTTF: use lookup table for almost any glyph

## Motivation and context
This is one more GUIFontTTF optimization and a follow-up of https://github.com/xbmc/xbmc/pull/20146

Is an attempt to fix the main limitations of the current lookup table implementation:

- Some common letters or symbols are not included since the glyph index can be > 255, especially when using fonts or skins different from the default.
- Some common glyphs (even with index < 255) are also not included because the letter code is  > 255.
- Since Harfbuzz merge doesn't make much sense to differentiate ASCII characters (< 255) when we are using the glyph index in most of the code and there is no direct equivalence or relationship.

## How has this been tested?
Runtime tested Windows x64 English/Spanish with Estuary skin and Cosmic skin.
Runtime tested Android (Shield Pro 2019) with Spanish Estuary skin.

**It would be desirable to test in other different languages and skins**

In order to measure the effectiveness of these changes, the following log line can be inserted after:

```c++
  // quick access to the most frequently used glyphs
  if (glyphIndex < MAX_GLYPH_IDX)
  {
    character_t ch = (style << 8) | glyphIndex;

    if (ch < LOOKUPTABLE_SIZE && m_charquick[ch])
      return m_charquick[ch];
  }
```

```
CLog::LogF(LOGINFO, "*** Letter '{:c}' not in lookup table (id = {}, glyphIndex = {})", 
static_cast<char>(chr & 0xff), static_cast<uint32_t>(letter), static_cast<uint32_t>(glyphIndex));
```

After a while browsing the skin with different texts this log line will appear less and less times indicating that all the letters are already in the lookup table. Note that the same letter can be loaded several times (different font styles) and the same letter can have several alternative glyphs (ligatures and other OpenType features).


## What is the effect on users?
Reduces CPU usage especially when there is a lot of text on the screen. For example scroll through the list of movies when the plot is visible.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
