### PR TITLE
DVDDemuxFFmpeg: fix start_time casting issue

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -995,7 +995,7 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   if ((!menuInterface || menuInterface->GetSupportedMenuType() != MenuType::NATIVE) &&
       m_pFormatContext->start_time != static_cast<int64_t>(AV_NOPTS_VALUE))
   {
-    starttime = static_cast<double>(m_pFormatContext->start_time / AV_TIME_BASE);
+    starttime = static_cast<double>(m_pFormatContext->start_time) / AV_TIME_BASE;
   }
 
   if (m_checkTransportStream)


### PR DESCRIPTION
Fixes issue introduced in https://github.com/xbmc/xbmc/commit/c94f95b08cf9a71789dd9f5181616acc57f84fba. 

