### PR TITLE
Python: replace deprecated c-api usage

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -61,12 +61,10 @@ protected:
 private:
   void initializeModules(const std::map<std::string, PythonModuleInitialization>& modules);
   bool initializeModule(PythonModuleInitialization module);
-  void addPath(const std::string& path); // add path in UTF-8 encoding
   void getAddonModuleDeps(const ADDON::AddonPtr& addon, std::set<std::string>& paths);
   bool execute(const std::string& script, std::vector<std::wstring>& arguments);
   FILE* PyFile_AsFileWithMode(PyObject* py_file, const char* mode);
 
-  std::string m_pythonPath;
   PyThreadState* m_threadState;
   bool m_stop;
   CEvent m_stoppedEvent;

--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -63,7 +63,7 @@ private:
   bool initializeModule(PythonModuleInitialization module);
   void addPath(const std::string& path); // add path in UTF-8 encoding
   void getAddonModuleDeps(const ADDON::AddonPtr& addon, std::set<std::string>& paths);
-  bool execute(const std::string& script, const std::vector<std::wstring>& arguments);
+  bool execute(const std::string& script, std::vector<std::wstring>& arguments);
   FILE* PyFile_AsFileWithMode(PyObject* py_file, const char* mode);
 
   std::string m_pythonPath;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -531,10 +531,6 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
     if (!PyGILState_Check())
       PyEval_RestoreThread((PyThreadState*)m_mainThreadState);
 
-    const wchar_t* python_argv[1] = {L""};
-    //! @bug libpython isn't const correct
-    PySys_SetArgv(1, const_cast<wchar_t**>(python_argv));
-
     if (!(m_mainThreadState = PyThreadState_Get()))
       CLog::Log(LOGERROR, "Python threadstate is NULL.");
     savestate = PyEval_SaveThread();


### PR DESCRIPTION
This PR replaces the deprecated use of some c-api's, specifically:
 - [PySys_SetArgv](https://docs.python.org/3.11/c-api/init.html?highlight=pysys_setargv#c.PySys_SetArgv)
 - [PySys_SetArgvEx](https://docs.python.org/3.11/c-api/init.html?highlight=pysys_setargvex#c.PySys_SetArgvEx)
 - [PySys_SetPath](https://docs.python.org/3.11/c-api/sys.html?highlight=pysys_setpath#c.PySys_SetPath)

```
/home/lukas/Documents/git/xbmc/xbmc/interfaces/python/XBPython.cpp:536:18: warning: ‘void PySys_SetArgv(int, wchar_t**)’ is deprecated [-Wdeprecated-declarations]
In file included from /usr/include/python3.11/Python.h:96,
                 from /home/lukas/Documents/git/xbmc/xbmc/interfaces/python/XBPython.cpp:12:
/usr/include/python3.11/sysmodule.h:13:79: note: declared here
[100%] Built target xbmc
/home/lukas/Documents/git/xbmc/xbmc/interfaces/python/PythonInvoker.cpp: In member function ‘bool CPythonInvoker::execute(const std::string&, const std::vector<std::__cxx11::basic_string<wchar_t> >&)’:
/home/lukas/Documents/git/xbmc/xbmc/interfaces/python/PythonInvoker.cpp:282:18: warning: ‘void PySys_SetPath(const wchar_t*)’ is deprecated [-Wdeprecated-declarations]
  282 |     PySys_SetPath(pypath.c_str());
      |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
In file included from /usr/include/python3.11/Python.h:96,
                 from /home/lukas/Documents/git/xbmc/xbmc/interfaces/python/PythonInvoker.cpp:12:
/usr/include/python3.11/sysmodule.h:15:38: note: declared here
   15 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) PySys_SetPath(const wchar_t *);
      |                                      ^~~~~~~~~~~~~
/home/lukas/Documents/git/xbmc/xbmc/interfaces/python/PythonInvoker.cpp:294:18: warning: ‘void PySys_SetArgvEx(int, wchar_t**, int)’ is deprecated [-Wdeprecated-declarations]
  294 |   PySys_SetArgvEx(argc, &argv[0], 0);
      |   ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/usr/include/python3.11/sysmodule.h:14:38: note: declared here
   14 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) PySys_SetArgvEx(int, wchar_t **, int);
      |                                      ^~~~~~~~~~~~~~~
```

I've replaced the usage with the recommended `PySys_GetObject` as recommended in https://docs.python.org/3.11/c-api/init_config.html#init-config

We could probably do a larger cleanup of the initialization by using the PyConfig initialization.

I tested these changes with a few python add-ons however more testing would be appreciated.

As noted on slack it seems that add-ons require having at least `sys.argv[0]` exist (even just being blank). I'm not sure why this behaviour exists but I'm not sure it's something we can change without breaking a bunch of add-ons.

The log now looks like this:
```
2022-07-22 19:52:06.018 T:97096   DEBUG <general>: -->Python Interpreter Initialized<--
2022-07-22 19:52:06.018 T:97096   DEBUG <general>: 
                                                   
2022-07-22 19:52:06.018 T:97096   DEBUG <general>: CPythonInvoker(5, /home/lukas/.kodi/addons/plugin.video.twitch/resources/lib/addon_runner.py): the source file to load is "/home/lukas/.kodi/addons/plugin.video.twitch/resources/lib/addon_runner.py"
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5): default python path:
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):   /usr/lib64/python311.zip
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):   /usr/lib64/python3.11
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):   /usr/lib64/python3.11/lib-dynload
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):   /usr/local/lib/python3.11/site-packages
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):   /usr/lib64/python3.11/site-packages
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):   /usr/lib/python3.11/site-packages
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5): adding path:
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/plugin.video.twitch/resources/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/script.module.certifi/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/script.module.chardet/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/script.module.idna/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/script.module.python.twitch/resources/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/script.module.requests/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/script.module.six/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  /home/lukas/.kodi/addons/script.module.urllib3/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5): adding args:
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  plugin://plugin.video.twitch/
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  1
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5):  resume:false
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5, /home/lukas/.kodi/addons/plugin.video.twitch/resources/lib/addon_runner.py): entering source directory /home/lukas/.kodi/addons/plugin.video.twitch/resources/lib
2022-07-22 19:52:06.019 T:97096   DEBUG <general>: CPythonInvoker(5, /home/lukas/.kodi/addons/plugin.video.twitch/resources/lib/addon_runner.py): instantiating addon using automatically obtained id of "plugin.video.twitch" dependent on version 3.0.0 of the xbmc.python api
```

and
```
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: -->Python Interpreter Initialized<--
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: 
                                                   
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: CPythonInvoker(4, /home/lukas/.kodi/addons/weather.multi/default.py): the source file to load is "/home/lukas/.kodi/addons/weather.multi/default.py"
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: CPythonInvoker(4): default python path:
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: CPythonInvoker(4):   /usr/lib64/python311.zip
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: CPythonInvoker(4):   /usr/lib64/python3.11
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: CPythonInvoker(4):   /usr/lib64/python3.11/lib-dynload
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: CPythonInvoker(4):   /usr/local/lib/python3.11/site-packages
2022-07-22 19:51:49.734 T:97054   DEBUG <general>: CPythonInvoker(4):   /usr/lib64/python3.11/site-packages
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):   /usr/lib/python3.11/site-packages
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4): adding path:
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/script.module.certifi/lib
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/script.module.chardet/lib
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/script.module.dateutil/lib
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/script.module.idna/lib
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/script.module.requests/lib
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/script.module.six/lib
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/script.module.urllib3/lib
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/weather.multi
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4): adding args:
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  /home/lukas/.kodi/addons/weather.multi/default.py
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4):  1
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4, /home/lukas/.kodi/addons/weather.multi/default.py): entering source directory /home/lukas/.kodi/addons/weather.multi
2022-07-22 19:51:49.735 T:97054   DEBUG <general>: CPythonInvoker(4, /home/lukas/.kodi/addons/weather.multi/default.py): instantiating addon using automatically obtained id of "weather.multi" dependent on version 3.0.0 of the xbmc.python api
```