### PR TITLE
fix metadata from mkv tags

### DIFF
--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -175,16 +175,32 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
     CNfoFile nfo;
     auto* data = m_fctx->streams[m_metadata_stream]->codecpar->extradata;
     const char* content = reinterpret_cast<const char*>(data);
-    nfo.GetDetails(tag, content);
     if (!m_override_data)
+    {
+      nfo.GetDetails(tag, content);
       return CInfoScanner::FULL_NFO;
+    }
+    else
+    {
+      nfo.Create(content, m_info);
+      m_url = nfo.ScraperUrl();
+      return CInfoScanner::URL_NFO;
+    }
   }
 
   AVDictionaryEntry* avtag = nullptr;
   bool hastag = false;
   while ((avtag = av_dict_get(m_fctx->metadata, "", avtag, AV_DICT_IGNORE_SUFFIX)))
   {
-    if (StringUtils::CompareNoCase(avtag->key, "title") == 0)
+    if (StringUtils::CompareNoCase(avtag->key, "imdburl") == 0 ||
+        StringUtils::CompareNoCase(avtag->key, "tmdburl") == 0)
+    {
+      CNfoFile nfo;
+      nfo.Create(avtag->value, m_info);
+      m_url = nfo.ScraperUrl();
+      return CInfoScanner::URL_NFO;
+    }
+    else if (StringUtils::CompareNoCase(avtag->key, "title") == 0)
       tag.SetTitle(avtag->value);
     else if (StringUtils::CompareNoCase(avtag->key, "director") == 0)
     {


### PR DESCRIPTION
## Description

As described [here](https://kodi.wiki/view/Video_file_tagging#Title) it should be possible to specify a TMDB or IMDB scraper URL in the mkv tags. In addition it should be possible to to embedd nfo and override nfo files into the mkv file [described here](https://kodi.wiki/view/Video_file_tagging#MKV_tag_options).

Most of this functionality is not working, the only things that seem to work is setting title, year and director using tags and embedding a nfo file. The TMDBURL and IMDBURL tags are not working.

## Motivation and context

This pull request adds the missing code to use the nfo override from attachments and handle the TMDBURL and IMDBURL tags to do the same.

## How has this been tested?

Local build with the changes and a test mkv with a random name which was changed between each of the test runs to make sure no data is reused from the database.

Different test runs where executed:

* For the first test an override nfo which just contains an url to TMDB was added as kodi-override-metadata using MKVToolnix. Before the code changes Kodi was not able to fetch any metadata, after the code changes Kodi hsa taken the url from the kodi-override-metadata and used it for scraping like expected.

* Another test was done by removing the kodi-override-metadata again and adding a tag TMDBURL pointing to a different TMDB url then the test before. The tag was added with mkvpropedit to the mkv file. For this a small xml file was created, which contain the tag and with this the metadata of the mkv file was changed `mkvpropedit --tags all:tags.xml sdgjlkSHJgalkghl.mkv`

tags.xml

```
<?xml version="1.0" encoding="ISO-8859-1"?>
<!DOCTYPE Tags SYSTEM "matroskatags.dtd">
<Tags>
<Tag>
<Simple>
<Name>TMDBURL</Name>
<String>https://www.themoviedb.org/movie/2637</String>
</Simple>
</Tag>
</Tags>
```

## What is the effect on users?

The already documented functionality of using metadata/nfo url from mkv files is now working.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
