### PR TITLE
[guilib] GUIFontTTF optimizations

### DIFF
--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -132,7 +132,6 @@ protected:
     float m_advance;
     FT_UInt m_glyphIndex;
     character_t m_glyphAndStyle;
-    wchar_t m_letter;
   };
 
   struct RunInfo
@@ -171,7 +170,7 @@ protected:
 
   // Stuff for pre-rendering for speed
   Character* GetCharacter(character_t letter, FT_UInt glyphIndex);
-  bool CacheCharacter(wchar_t letter, uint32_t style, Character* ch, FT_UInt glyphIndex);
+  bool CacheCharacter(FT_UInt glyphIndex, uint32_t style, Character* ch);
   void RenderCharacter(CGraphicContext& context,
                        float posX,
                        float posY,

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -110,19 +110,15 @@ public:
 protected:
   explicit CGUIFontTTF(const std::string& fontIdent);
 
-
   struct Glyph
   {
-    hb_glyph_info_t m_glyphInfo;
-    hb_glyph_position_t m_glyphPosition;
+    hb_glyph_info_t m_glyphInfo{};
+    hb_glyph_position_t m_glyphPosition{};
 
-    // converter for harfbuzz library
-    Glyph(hb_glyph_info_t gInfo, hb_glyph_position_t gPos)
+    Glyph(const hb_glyph_info_t& glyphInfo, const hb_glyph_position_t& glyphPosition)
+      : m_glyphInfo(glyphInfo), m_glyphPosition(glyphPosition)
     {
-      m_glyphInfo = gInfo;
-      m_glyphPosition = gPos;
     }
-    Glyph() {}
   };
 
   struct Character


### PR DESCRIPTION
~~Currently `CGUIFontTTF` uses a dynamic size array `m_char`to cache characters and a fixed size array `m_quickchar` to cache 4096 characters as pointers to the respective `m_char` entries. Whenever `m_char`content and/or size changes, the memory address of the `m_quickchar` characters might change. Thus, `m_charquick` currently gets erased and recalculated whenever `m_charquick` changes. This happens quite often, especially shortly after starting Kodi, because the cache fills over time, while visiting more and more dialogs/windows. Recalculation of `m_charquick`sums up to a reasonable amount of time, especially after last PR that increaded `m_charquick`size from `255*8` to `4096*8`.~~

~~This PR eliminates the need to recalculate `m_quickchar` on changes of `m_char`by separating the arrays for the 4096 "quick" chars and the rest of the chars hold in `m_char`. This is possible as the quick chars formerly held in `m_char` are never accessed through `m_char`, but always through `m_quickchar`- even today.~~

The two other commits are just small cleanups.

I runtime-tested the changes on macOS and Android, latest master, with German and English. No regressions found.

@thexai , @AlwinEsch I would appreciate your review. Review commit by commit should ease up things.