### PR TITLE
Controllers: Fix segfault when features can't be created

### DIFF
--- a/xbmc/input/joysticks/generic/InputHandling.cpp
+++ b/xbmc/input/joysticks/generic/InputHandling.cpp
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <cmath>
+#include <tuple>
 
 using namespace KODI;
 using namespace JOYSTICK;
@@ -102,13 +103,16 @@ bool CInputHandling::OnDigitalMotion(const CDriverPrimitive& source, bool bPress
   FeatureName featureName;
   if (m_buttonMap->GetFeature(source, featureName))
   {
-    FeaturePtr& feature = m_features[featureName];
+    auto it = m_features.find(featureName);
+    if (it == m_features.end())
+    {
+      FeaturePtr feature(CreateFeature(featureName));
+      if (feature)
+        std::tie(it, std::ignore) = m_features.insert({featureName, std::move(feature)});
+    }
 
-    if (!feature)
-      feature = FeaturePtr(CreateFeature(featureName));
-
-    if (feature)
-      bHandled = feature->OnDigitalMotion(source, bPressed);
+    if (it != m_features.end())
+      bHandled = it->second->OnDigitalMotion(source, bPressed);
   }
   else if (bPressed)
   {
@@ -131,13 +135,16 @@ bool CInputHandling::OnAnalogMotion(const CDriverPrimitive& source, float magnit
   FeatureName featureName;
   if (m_buttonMap->GetFeature(source, featureName))
   {
-    FeaturePtr& feature = m_features[featureName];
+    auto it = m_features.find(featureName);
+    if (it == m_features.end())
+    {
+      FeaturePtr feature(CreateFeature(featureName));
+      if (feature)
+        std::tie(it, std::ignore) = m_features.insert({featureName, std::move(feature)});
+    }
 
-    if (!feature)
-      feature = FeaturePtr(CreateFeature(featureName));
-
-    if (feature)
-      bHandled = feature->OnAnalogMotion(source, magnitude);
+    if (it != m_features.end())
+      bHandled = it->second->OnAnalogMotion(source, magnitude);
   }
 
   return bHandled;


### PR DESCRIPTION
## Description

During development, some feature definitions were missing from the controller XML definition, causing features to not be created. However, we pre-allocate features in the array, which means that until the feature is created, the array holds a nullptr.

Later, we use the array without checking for nullptrs, leading to a segfault. Instead of checking for nullptrs, though, we just ensure that no nullptrs enter the array in the first place.

## Motivation and context

In production, features won't be missing, but a segfault due to mistakes when editing XML is never fun.

## How has this been tested?

Tested as part of the Player Manager based on 20 alpha 2 release.

If I get time I'll write up the exact steps to reproduce.

## What is the effect on users?

No effect, because features aren't missing from XML in production.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
