### PR TITLE
[cmake] disable CMAKE_DEPENDS_USE_COMPILER for osx makefile generator

### DIFF
--- a/tools/depends/target/cmakebuildsys/Makefile
+++ b/tools/depends/target/cmakebuildsys/Makefile
@@ -23,6 +23,9 @@ else ifeq ($(GEN),Ninja)
   CMAKE_BUILD_ARGUMENTS = -G "Ninja" -DCMAKE_BUILD_TYPE=$(Configuration)
 else
   CMAKE_BUILD_ARGUMENTS = -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$(Configuration)
+  ifeq ($(OS),osx)
+    CMAKE_BUILD_ARGUMENTS += -DCMAKE_DEPENDS_USE_COMPILER=OFF
+  endif
 endif
 
 ifeq ($(OS),osx)


### PR DESCRIPTION
## Description
work around failure on jenkins OSX

```
  build/guilib/CMakeFiles/guilib.dir/compiler_depend.make:28830: *** multiple target patterns.  Stop.
  make[2]: *** [build/guilib/CMakeFiles/guilib.dir/all] Error 2
```

## Motivation and context


Issue is due to the generated compiler_depend.make file on subsequent runs generating the following
code that is incorrect. This generated output is provided by the compiler.

The below snippet is a clip of the failed make target that causes the failure. appears to be
inserting symbols into what should be header filenames.

```
build/guilib/CMakeFiles/guilib.dir/TextureGL.cpp.o: ../xbmc/guilib/TextureGL.cpp \
  /Applications/Xcode12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.og21custom_flag_formatterENS_14default_deleteIS5_EEEEEENS_4hashIcEELb1EEEE5firstEv$
  build/guilib/std::__1::__unordered_map_equal<char, \
  build/guilib/std::__1::__hash_value_type<char, \
  build/guilib/std::__1::unique_ptr<spdlog::custom_flag_formatter, \
  build/guilib/std::__1::default_delete<spdlog::custom_flag_formatter> \
  build/guilib/> \
  build/guilib/>, \
  build/guilib/std::__1::equal_to<char>, \
  build/guilib/true> \
  build/guilib/>__compressed_pair_elem<std::__1::__unordered_map_equal<char, \
  build/guilib/std::__1::__hash_value_type<char, \
  build/guilib/std::__1::unique_ptr<spdlog::custom_flag_formatter, \
  build/guilib/std::__1::default_delete<spdlog::custom_flag_formatter> \
  build/guilib/> \
  build/guilib/>, \
  build/guilib/std::__1::equal_to<char>, \
  build/guilib/true>, \
  build/guilib/1, \
  build/guilib/true>__unordered_map_equal<char, \
  build/guilib/std::__1::__hash_value_type<char, \
  build/guilib/std::__1::unique_ptr<spdlog::custom_flag_formatter, \
  build/guilib/std::__1::default_delete<spdlog::custom_flag_formatter> \
  build/guilib/> \
  build/guilib/>, \
  build/guilib/std::__1::equal_to<char>, \
  build/guilib/true>equal_to<char>binary_function<char, \
  build/guilib/char, \
  build/guilib/bool>_ZNKSt3__18equal_toIcEclERKcS3__ZNKSt3__121__unordered_map_equalIcNS_17__hash_value_typeIcNS_10unique_ptrIN6spdlog21custom_flag_formatterENS_14default_deleteIS4_EE$
  /Applications/Xcode12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/_types/_uint16_t.h \
```

Info around the define can be viewed at https://cmake.org/cmake/help/latest/variable/CMAKE_DEPENDS_USE_COMPILER.html
Disabling, returns to default cmake <3.20 behaviour, which is acceptable for now imo

Of note, i cant replicate the failure locally using Xcode 13.4.1.

## How has this been tested?
Jenkins

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
