### PR TITLE
GUIFontTTF: use std::vector for m_char

### DIFF
--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -208,11 +208,10 @@ protected:
 
   UTILS::COLOR::Color m_color{UTILS::COLOR::NONE};
 
-  Character* m_char{nullptr}; // our characters
+  std::vector<Character> m_char; // our characters
+
   // room for the first MAX_GLYPH_IDX glyphs in 7 styles
   Character* m_charquick[LOOKUPTABLE_SIZE]{nullptr};
-  int m_maxChars{0}; // size of character array (can be incremented)
-  int m_numChars{0}; // the current number of cached characters
 
   bool m_ellipseCached{false};
   float m_ellipsesWidth{0.0f}; // this is used every character (width of '.')


### PR DESCRIPTION
## Description
GUIFontTTF: use std::vector for m_char

## Motivation and context
`m_char` dynamic array is perfect candidate to use `std::vector`:

`m_numChars` ---> `m_char.size()`
`m_maxChars` ---> `m_char.capacity()`

`new Character[CHAR_CHUNK]` ---> `m_char.reserve(CHAR_CHUNK)`

Also is possible some efficiency gain because I think `std::vector` not always reallocates all memory when capacity increases. In the worst case the same efficiency as before is expected.

Since the default std::vector growth factor is not used the behavior should be identical before/after.

In any case, the reason for this change is not to gain performance but to simplify and modernize the code a bit.

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
