### PR TITLE
[skin][info] discard leading whitespaces before conversion to int via…

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -36,6 +36,7 @@
 #include <iterator>
 #include <memory>
 #include <mutex>
+#include <string_view>
 
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
@@ -9946,8 +9947,12 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           std::array<int, 2> data = {-1, -1};
           for (size_t i = 0; i < data.size(); i++)
           {
-            std::from_chars_result result = std::from_chars(
-                prop.param(i).data(), prop.param(i).data() + prop.param(i).size(), data.at(i));
+            std::string_view v = prop.param(i);
+            v.remove_prefix(std::min(v.find_first_not_of(" "), v.size()));
+
+            std::from_chars_result result =
+                std::from_chars(v.data(), v.data() + v.size(), data.at(i));
+
             if (result.ec == std::errc::invalid_argument)
             {
               // could not translate provided value to int, translate the info string
@@ -10854,9 +10859,16 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
               // Handle the case when a value contains time separator (:). This makes Integer.IsGreater
               // useful for Player.Time* members without adding a separate set of members returning time in seconds
               if (value.find_first_of(':') != value.npos)
+              {
                 intValue = StringUtils::TimeStringToSeconds(value);
+              }
               else
-                std::from_chars(value.data(), value.data() + value.size(), intValue);
+              {
+                std::string_view v = value;
+                v.remove_prefix(std::min(v.find_first_not_of(" "), v.size()));
+
+                std::from_chars(v.data(), v.data() + v.size(), intValue);
+              }
             }
             return intValue;
           };


### PR DESCRIPTION
… std::from_chars()

## Description
in https://github.com/xbmc/xbmc/pull/21352 the function `std::atoi()` has been replaced with `std::from_chars()`.
while `std::atoi("   1")` will discard the leading whitespaces, `std::from_chars()` will not convert this but set `std::errc::invalid_argument` in the result.

i think it is a good idea to restore the old behavior because a skin could rely on it. example:
`DialogVolumeBar.xml`
```
<control type="progress" id="20">
          <include>HiddenObject</include>
          <info>Player.Volume</info>
</control>

<!--
       if volume is at 5% the above label will return " 5" ... leading whitespace.
       the following Integer.IsGreater() doesnt work
-->

<variable name="VolumeColorVar">
                <value condition="String.IsEqual(Control.GetLabel(20),100)">FFFF2409</value>
                <value condition="Integer.IsGreater(Control.GetLabel(20),95)">FFFD3809</value>
                <value condition="Integer.IsGreater(Control.GetLabel(20),90)">FFFC4C08</value>
.
.
                <value condition="Integer.IsGreater(Control.GetLabel(20),5)">FF3CE700</value>
                <value condition="Integer.IsGreater(Control.GetLabel(20),1)">FF28E600</value>
                <value>FF13E500</value>
</variable>
```

will look to make this workaround obsolete in a future pr by introducing a new info label `PLAYER_VOLUME_PERCENTAGE`

## Motivation and context
noticed with a skin that colors the volume bar texture depending on the volume level.
it is not an issue with estuary atm.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
