### PR TITLE
[Subtitles][WebVTT] Reset data before get a new packet

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -117,6 +117,9 @@ OverlayMessage COverlayCodecWebVTT::Decode(DemuxPacket* pPacket)
 
     // We send an empty line to mark the end of the last Cue
     m_webvttHandler.DecodeLine("", &subtitleList);
+
+    // Reset to decode next packet
+    m_webvttHandler.Reset();
   }
 
   for (auto& subData : subtitleList)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -221,6 +221,18 @@ bool CWebVTTHandler::Initialize()
   return true;
 }
 
+void CWebVTTHandler::Reset()
+{
+  m_previousLines[0].clear();
+  m_previousLines[1].clear();
+  m_previousLines[2].clear();
+  m_currentSection = WebvttSection::UNDEFINED;
+  m_cueCurrentCssStyleSelectors.clear();
+  m_cueCssStyles.clear();
+  AddDefaultCssClasses();
+  m_offset = 0;
+}
+
 bool CWebVTTHandler::CheckSignature(const std::string& data)
 {
   // Check the sequence of chars to identify WebVTT signature

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -129,6 +129,11 @@ public:
   */
   bool Initialize();
 
+  /*
+   * \brief Reset handler data
+   */
+  void Reset();
+
   /*!
   * \brief Verify the validity of the WebVTT signature
   */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After recently fixes for WebVTT and the new one on ISAdaptive, i found that another cause of non-synchronous subtitles is due to previous stored data not resetted when decoding next packet

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found the problem by testing new PR in InputStream Adaptive to fix subtitle sync:
https://github.com/xbmc/inputstream.adaptive/pull/1027

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By playing segmented test stream:
https://s3.amazonaws.com/_bc_dml/example-content/bipbop-advanced/bipbop_16x9_variant.m3u8

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
See subtitles in-sync with video

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
