### PR TITLE
GUIFontTTF: Improves memory allocation (save ~5 MB of RAM)

### DIFF
--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -213,6 +213,7 @@ protected:
   int m_maxChars{0}; // size of character array (can be incremented)
   int m_numChars{0}; // the current number of cached characters
 
+  bool m_ellipseCached{false};
   float m_ellipsesWidth{0.0f}; // this is used every character (width of '.')
 
   unsigned int m_cellBaseLine{0};


### PR DESCRIPTION
## Description
GUIFontTTF: Improves memory allocation (save ~5 MB of RAM)

## Motivation and context
Currently a lot of memory is reserved that is never used here:

https://github.com/xbmc/xbmc/blob/966f3434efc0643f581039b75a407a235a0fa344/xbmc/guilib/GUIFontTTF.cpp#L168

It is not because more quantity than necessary is reserved, but because this variable is never used in modern systems that supports hardware clipping i.e.:

https://github.com/xbmc/xbmc/blob/966f3434efc0643f581039b75a407a235a0fa344/xbmc/guilib/GUIFontTTF.cpp#L563-L568

memory saved is:

44 bytes per vertex * 4 * 1024  = 180,224 bytes  

And since there are 27 instances of GUIFontTTF...

180,224 * 27 = 4,886,048 bytes  = ~**4.6 MB**

Instead memory is reserved for `m_vertexTrans` which is much smaller:

40 bytes of struct * 32 used = 1,280 bytes

1,280 * 27 instances = 34,560 bytes but is less because only is reserved for instances used

Also is delayed cache the ellipses width for the same reason in this way is saved to allocate `m_char` memory in instances not used. See https://github.com/xbmc/xbmc/pull/21720#discussion_r935255485 for understand this.

32 bytes Character struct * CHAR_CHUNK * num_of_instances


## How has this been tested?
Runtime Windows x64

## What is the effect on users?
~5 MB RAM memory savings and probably loads marginally faster

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
