### PR TITLE
[cmake][addons] enable cpu arch specific flags for flags.txt usage

### DIFF
--- a/cmake/addons/depends/README
+++ b/cmake/addons/depends/README
@@ -23,6 +23,7 @@ are:
   * install.txt: instructions on how to install the dependency's built files
   * noinstall.txt: no installation step required (content is ignored)
   * flags.txt: additional build flags
+  * flags-<CPU>.txt: additional arch specific platform build flags
   * deps.txt: whitespace separated list of dependencies of this dependency
 
 The buildsystem uses the following depends-related variables (which can be passed

--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -19,7 +19,7 @@ function(add_addon_depends addon searchpath)
     if(NOT (file MATCHES CMakeLists.txt OR
             file MATCHES install.txt OR
             file MATCHES noinstall.txt OR
-            file MATCHES flags.txt OR
+            file MATCHES "flags.*[.]txt" OR
             file MATCHES deps.txt OR
             file MATCHES "[a-z]+-deps[.]txt" OR
             file MATCHES platforms.txt))
@@ -57,6 +57,15 @@ function(add_addon_depends addon searchpath)
           string(REPLACE " " ";" extraflags ${extraflags})
 
           message(STATUS "${id} extraflags: ${extraflags}")
+        endif()
+
+        if(EXISTS ${dir}/flags-${CPU}.txt)
+          set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${dir}/flags-${CPU}.txt)
+          file(STRINGS ${dir}/flags-${CPU}.txt archextraflags)
+          string(REPLACE " " ";" archextraflags ${archextraflags})
+
+          message(STATUS "${id} ${CPU} extraflags: ${archextraflags}")
+          list(APPEND extraflags ${archextraflags})
         endif()
 
         set(BUILD_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}


### PR DESCRIPTION
## Description
Allows us to append arch specific flags to platform generic deps
eg, allow flags-arm64.txt and flags-x86_64.txt to append to extraflags
passed to a cmake based dep only when the specific arch type of the platform is built

Many platforms have the ability for multiple arch (osx x86_64/arm64, android armv7/aarch64, etc)
So this allows us to provide targeted arch specific flags where appropriate

This APPENDS to any flags found in flags.txt of a dep. flags.txt continues to hold any flags
that are common across all platform arch types.

## Motivation and context
Allow us to use arch specific flags for addon deps.

An example is GLM dep for osx in visualisation.shadertoy. currently -DGLM_TEST_ENABLE_SIMD_SSE2=1 is set as a flag in flags.txt. This is x86 specific (SIMD SSE2 is not available on arm64 chips), therefore arm64 macos builds currently fail to build.

Example addon PR - https://github.com/xbmc/visualization.shadertoy/pull/104

## How has this been tested?
Build vis.shadertoy targeting osx arm64 platform

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
