### PR TITLE
[cmake] link atomic library for certain CPU architectures

### DIFF
--- a/cmake/modules/FindAtomic.cmake
+++ b/cmake/modules/FindAtomic.cmake
@@ -1,0 +1,56 @@
+#.rst:
+# FindAtomic
+# -----
+# Finds the ATOMIC library
+#
+# This will define the following variables::
+#
+# ATOMIC_FOUND - system has ATOMIC
+# ATOMIC_LIBRARIES - the ATOMIC libraries
+#
+# and the following imported targets::
+#
+#   ATOMIC::ATOMIC    - The ATOMIC library
+
+
+include(CheckCXXSourceCompiles)
+
+set(atomic_code
+    "
+     #include <atomic>
+     #include <cstdint>
+     std::atomic<uint8_t> n8 (0); // riscv64
+     std::atomic<uint64_t> n64 (0); // armel, mipsel, powerpc
+     int main() {
+       ++n8;
+       ++n64;
+       return 0;
+     }")
+
+check_cxx_source_compiles("${atomic_code}" ATOMIC_LOCK_FREE_INSTRUCTIONS)
+
+if(ATOMIC_LOCK_FREE_INSTRUCTIONS)
+  set(ATOMIC_FOUND TRUE)
+  set(ATOMIC_LIBRARIES)
+else()
+  set(CMAKE_REQUIRED_LIBRARIES "-latomic")
+  check_cxx_source_compiles("${atomic_code}" ATOMIC_IN_LIBRARY)
+  set(CMAKE_REQUIRED_LIBRARIES)
+  if(ATOMIC_IN_LIBRARY)
+    set(ATOMIC_LIBRARY atomic)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(Atomic DEFAULT_MSG ATOMIC_LIBRARY)
+    set(ATOMIC_LIBRARIES ${ATOMIC_LIBRARY})
+    if(NOT TARGET ATOMIC::ATOMIC)
+      add_library(ATOMIC::ATOMIC UNKNOWN IMPORTED)
+      set_target_properties(ATOMIC::ATOMIC PROPERTIES
+	      IMPORTED_LOCATION "${ATOMIC_LIBRARY}")
+    endif()
+    unset(ATOMIC_LIBRARY)
+  else()
+    if(Atomic_FIND_REQUIRED)
+      message(FATAL_ERROR "Neither lock free instructions nor -latomic found.")
+    endif()
+  endif()
+endif()
+unset(atomic_code)

--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -199,3 +199,6 @@ if(NOT USE_INTERNAL_LIBS)
     set(USE_INTERNAL_LIBS OFF)
   endif()
 endif()
+
+# Atomic library
+list(APPEND PLATFORM_REQUIRED_DEPS Atomic)


### PR DESCRIPTION
For those CPU architectures:
RISC-V lack 8-bit and 16-bit atomic instructions, and
ARM/MIPS/PPC lack 64-bit atomic instruction.

GCC is supposed  to convert these atomics via masking and shifting
like LLVM, which means anything that wants to use these instructions
needs the link option -latomic.

In this patch, we will try to detect if 8-bit, 64-bit atomic instructions exist,
otherwise the atomic library will append to the DEPLIBS list.

Signed-off-by: Yixun Lan <dlan@gentoo.org>

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
