### PR TITLE
Correct RTL text handling in Edit Control

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -348,7 +348,7 @@ void CGUIEditControl::OnClick()
   {
     ClearMD5();
     m_edit.clear();
-    g_charsetConverter.utf8ToW(utf8, m_text2);
+    g_charsetConverter.utf8ToW(utf8, m_text2, false);
     m_cursorPos = m_text2.size();
     UpdateText();
     m_cursorPos = m_text2.size();
@@ -672,7 +672,7 @@ void CGUIEditControl::OnPasteClipboard()
 
   // Get text from the clipboard
   utf8_text = CServiceBroker::GetWinSystem()->GetClipboardText();
-  g_charsetConverter.utf8ToW(utf8_text, unicode_text);
+  g_charsetConverter.utf8ToW(utf8_text, unicode_text, false);
 
   // Insert the pasted text at the current cursor position.
   if (unicode_text.length() > 0)


### PR DESCRIPTION
Do not set bVisualBiDiFlip in utf8ToW for certain text entries in Edit Controls

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
Modify CGUIEditControl::OnPasteClipboard() and CGUIEditControl::OnClick() for text entered in virtualkeyboard or via paste from clipboard 
<!--- Describe your change in detail here. -->
Two methods in CGUIEditControl currently call charsetConverter.utf8ToW with no bVisualBiDiFlip parameter.  In charsetConverter.utf8ToW that parameter defaults to true and as a result FriBiDi is called to process the text input.  This change forces bVisualBiDiFlip to false, so FriBiDi does not process the input
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
This is a proposed fix for issue [21721](https://github.com/xbmc/xbmc/issues/21721).  That issue was generated from an error in addon skin arctic horizon 2 where text was entered into a skin edit control in Arabic, and the control failed to work as expected.  

The originator in investigating the error realized that text in Arabic was being reversed from the logical input and also the unicode was being changed from the expected unicode Arabic block of U+0600 to the unicode Arabic Presentation Forms B block U+FE70.   This modified visual text was being stored within the control label2 and passed to builtin functions via the index(1).   As a result of this behavior, string operations (string compare, sort, etc) fail.  In some cases (example, global search addon) this behavior can be worked-around by applying normalization NFKC on the text, but this is a fragile option.

Normally text should be kept in its logical format and only converted to a visual format for rendering to an output device.  Investigation revealed that the RTL text processing is being done in FriBiDi, which provides a basic shaping capability for Arabic by doing a simple conversion of unicode codepoints from the 0600 block to the FE70 block.  Harbuzz, by using an OTF font-based shaping engine provides superior shaping for Arabic to FriBiDi and should be preferred.  Regardless, text should only be preserved in its logical format.

The change in this commit omits calling FriBiDi through charsetConverter by setting the bVisualBiDiFlip param false.
<!--- If it fixes an open issue, please link to the issue here. -->
[](https://github.com/xbmc/xbmc/issues/21721)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
A simple edit control was added to Estuary home window in order to easily see visually text as entered and verify the contents of label2 by adding an "ondown" action to save the input into a window property and skin setting.

This simple control with some context is shown here:
 ```xml
		<control type="group">
			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
			<control type="edit" id="9099">
					<posx>800</posx>
					<posy>50</posy>
					<width>250</width>
					<height>75</height>
					<textoffsetx>30</textoffsetx>
					<ondown>SetProperty(PreviousSearchTerm,$INFO[Control.GetLabel(9099).index(1)])</ondown>
					<ondown>Skin.SetString(PreviousSearchTerm, $INFO[Control.GetLabel(9099).index(1)])</ondown>
					<ondown>9000</ondown>
			</control>
			<control type="group" id="2000">
```
<!--- Include details of your testing environment, and the tests you ran to -->
Code was built and tested in Windows10 x64 21H2.  Test environment included entering text using the kodi virtualkeyboard using English QWERTY, Arabic QWERTY, and Hebrew QWERTY keyboard in the modified Estuary skin with font set to "arial based".  The text string used for Arabic testing was read from the virtualkeyboard as utf-8 hex D8 A7 D9 84 D8 AD (unicode 0627 0644 062D ARABIC LETTER ALEF ARABIC LETTER LAM ARABIC LETTER HAH).  For the default case Kodi master from nightly  8 Aug was used.  When the test string was entered, the edit control label2 that was retrieved to a skin setting was unicode FEA2 FEDF FE8D (converted from utf-8).  Test was repeated using windows arabic IME keyboards Arabic 101 and Arabic 102 from both windows OSK and hardware keyboard with like results.

Hebrew testing was performed with text string from kodi virtualkeyboard as  unicode 05D7 05E2 05D0 (HEBREW LETTER HET HEBREW LETTER AYIN HEBREW LETTER ALEF).  Again test failed as text string was reversed in the stored skin setting.

Tests were repeated with the commit and all test instances were displayed and saved to skin setting as expected.  The arctic horizon 2 skin cited in the original issue was installed and some dummy library entries with titles in Arabic added.  Using the arctic horizon 2 search facility resulted in matches as expected where previously they failed.

Since it is possible this commit can result in some regressions I need help testing this from devs and for other platforms

<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
Users of Arabic and Hebrew (I think those are the main RTL languages supported in Kodi) can enter text using the appropriate Kodi virtual keyboard layout or their system IME keyboard, or pasted from the clipboard.  The text string entered into the edit control will be properly retained in its logical format so that string operations such as compares and sorts operate as expected without work arounds such as performing KC normalizing.  This is important for Arabic as the Presentations Forms are only provided for backwards compatibility per unicode.org.  The Harfbuzz shaping engine with well-designed fonts should handle Arabic.  I have not tested with broken fonts / fonts missing OTL features, but not sure they should be supported (some one-off testing I did suggests Harfbuzz will attempt a not-worse-than FriBiDi shaping).
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
