### PR TITLE
[estuary] enable texture cache for View_53_Shift/DialogVideoInfo

### DIFF
--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -30,7 +30,7 @@
 					<width>526</width>
 					<height>801</height>
 					<aspectratio>scale</aspectratio>
-					<texture fallback="DefaultVideo.png">$VAR[InfoDialogPosterVar]</texture>
+					<texture fallback="DefaultVideo.png" background="true">$VAR[InfoDialogPosterVar]</texture>
 				</control>
 				<control type="group">
 					<visible>String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)</visible>

--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -79,7 +79,7 @@
 							<width>370</width>
 							<height>480</height>
 							<aspectratio aligny="center">keep</aspectratio>
-							<texture fallback="DefaultVideo.png">$VAR[ShiftThumbVar]</texture>
+							<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
 						</control>
@@ -166,7 +166,7 @@
 							<width>370</width>
 							<height>480</height>
 							<aspectratio aligny="center">keep</aspectratio>
-							<texture fallback="DefaultVideo.png">$VAR[ShiftThumbVar]</texture>
+							<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
 						</control>


### PR DESCRIPTION
## Description
closes https://github.com/xbmc/xbmc/issues/21744

"Posters not appearing in the Shift view in Estuary if HDD not connected"

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
