### PR TITLE
[cmake][addons] allow passing extra args to built addon dependencies

### DIFF
--- a/cmake/addons/depends/README
+++ b/cmake/addons/depends/README
@@ -31,3 +31,5 @@ into it when executing cmake with the -D<variable-name>=<value> option) to e.g.
 access specific paths:
   * DEPENDS_TO_BUILD is a quoted, space delimited list of <dependency>s that
     you want to build (default is "all").
+  * ADDON_EXTRA_ARGS is a quoted, space delimited list of arguments passed to
+    all <dependency>s built (eg -DADDON_EXTRA_ARGS="-Darg1=1 -Darg2=2").

--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -99,6 +99,12 @@ function(add_addon_depends addon searchpath)
           message(${BUILD_ARGS})
         endif()
 
+        if(ADDON_EXTRA_ARGS)
+          string(REPLACE " " ";" ADDON_EXTRA_ARGS ${ADDON_EXTRA_ARGS})
+          list(APPEND BUILD_ARGS ${ADDON_EXTRA_ARGS})
+          message("Addon Extra Args: ${ADDON_EXTRA_ARGS}")
+        endif()
+
         # used for addons where need special folders to store there content (if
         # not set the addon define it byself).
         # e.g. Google Chromium addon where his git bring:


### PR DESCRIPTION
## Description
Allows a user to pass through cmake arguments to all addon dependencies that are built
Be aware, this is a global addition, and will be passed through to all addons built.

## Motivation and context


Usage:

-DADDON_EXTRA_ARGS="-Ddefine1=1 -Ddefine2=2"

The arguments will be passed through as a list (ie -Ddefine1=1;-Ddefine2=2) to all
addon dependencies built, and will be accessible via their CMakelists.txt files

an example is with visualization.projectm. If a user wishes to set -DAPP_RENDER_SYSTEM=gles
for the projectm dependency to build projectm as gles compatible.

Currently this can be done with a toolchain file, but a user cant set -DAPP_RENDER_SYSTEM=gles
as part of their cmake stanza to build the addon, as dependencies are passed through filtered
lists, of which APP_RENDER_SYSTEM isnt specifically passed through.

https://github.com/xbmc/visualization.projectm/issues/87

This solution provides a more generic way to pass through arguments to cmake dependencies
without us explicitly handling each option in HandleDepends.cmake

## How has this been tested?
Building visualization.projectm and verifying passing through arbitrary defines to dependencies

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
