### PR TITLE
[tools/depends][cmake] addon toolchain reshuffle

### DIFF
--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -41,9 +41,9 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set(CMAKE_OSX_SYSROOT @use_sdk_path@)
+  set(CMAKE_LIBRARY_PATH ${CMAKE_FIND_ROOT_PATH}/lib:@use_sdk_path@/lib:/usr/X11R6/lib)
+  set(CMAKE_INCLUDE_PATH ${CMAKE_FIND_ROOT_PATH}/include:@use_sdk_path@/include:/usr/X11R6/include)
   list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_OSX_SYSROOT} ${CMAKE_OSX_SYSROOT}/usr /usr/X11R6)
-  set(CMAKE_LIBRARY_PATH @CMAKE_FIND_ROOT_PATH@/lib:@use_sdk_path@/lib:/usr/X11R6/lib)
-  set(CMAKE_INCLUDE_PATH @CMAKE_FIND_ROOT_PATH@/include:@use_sdk_path@/include:/usr/X11R6/include)
 endif()
 set(CMAKE_SYSTEM_VERSION 1)
 


### PR DESCRIPTION
## Description
reshuffle a couple of lines to remove the amount of sed changes in a addon toolchain

## Motivation and context
More a QOL change.
i find it easier to change the set(CMAKE_FIND_ROOT_PATH @CMAKE_FIND_ROOT_PATH@) manually when working with an individual addon rather than use a sed change every time. This just reduces the amount of @CMAKE_FIND_ROOT_PATH@, by reshuffling a couple lines around and using a variable. the reshuffle is done to insure that CMAKE_FIND_ROOT_PATH is just the single path (and not a list of paths)

## How has this been tested?
Using toolchain on addons

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
