### PR TITLE
[dbwrappers] Optimize Dataset::FieldIndexMapEntry::operator<.

### DIFF
--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -330,7 +330,7 @@ bool Dataset::get_index_map_entry(const char *f_name) {
   if (~fieldIndexMapID)
   {
     unsigned int next(fieldIndexMapID+1 >= fieldIndexMap_Entries.size() ? 0 : fieldIndexMapID + 1);
-    if (fieldIndexMap_Entries[next].strName == f_name) //Yes, our assumption hits.
+    if (strncmp(fieldIndexMap_Entries[next].strName, f_name, strlen(f_name)) == 0)
     {
       fieldIndexMapID = next;
       return true;

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -394,10 +394,33 @@ public:
 /* Struct to store an indexMapped field access entry */
   struct FieldIndexMapEntry
   {
-    explicit FieldIndexMapEntry(const char* name) : fieldIndex(~0), strName(name) {}
-    bool operator<(const FieldIndexMapEntry& other) const { return strName < other.strName; }
-    unsigned int fieldIndex;
-    std::string strName;
+    explicit FieldIndexMapEntry(const char* name) : strName(strdup(name)) {}
+
+    FieldIndexMapEntry(const FieldIndexMapEntry& other)
+      : fieldIndex(other.fieldIndex), strName(strdup(other.strName))
+    {
+    }
+
+    ~FieldIndexMapEntry() { free(strName); }
+
+    FieldIndexMapEntry& operator=(const FieldIndexMapEntry& other)
+    {
+      if (this != &other)
+      {
+        fieldIndex = other.fieldIndex;
+        free(strName);
+        strName = strdup(other.strName);
+      }
+      return *this;
+    }
+
+    bool operator<(const FieldIndexMapEntry& other) const
+    {
+      return strncmp(strName, other.strName, strlen(other.strName)) < 0;
+    }
+
+    unsigned int fieldIndex{static_cast<unsigned int>(~0)};
+    char* strName{nullptr};
   };
 
 /* Comparator to quickly find an indexMapped field access entry in the unsorted fieldIndexMap_Entries vector */


### PR DESCRIPTION


Optimize `Dataset::FieldIndexMapEntry::operator<`. C++ might be elegant, but can be a performance killer:

before:

<img width="1108" alt="Screenshot 2022-07-27 at 15 03 50" src="https://user-images.githubusercontent.com/3226626/184673341-1c9de1bf-524d-418c-8fd3-80d88bbeb7c8.png">

after:

<img width="1112" alt="Screenshot 2022-07-27 at 16 42 04" src="https://user-images.githubusercontent.com/3226626/184673364-c3047dbc-341c-4df2-920b-ad2bb1520607.png">


Runtime-tested on Android and macOS.
Profiled on macOS.

@phunkyfish when you find some time for a review. Increases for example updating EPG.
