### PR TITLE
[utils] Optimize CFileItem::IsPicture and URIUtils::HasExtension.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1042,7 +1042,7 @@ bool CFileItem::IsGame() const
 
 bool CFileItem::IsPicture() const
 {
-  if(StringUtils::StartsWithNoCase(m_mimetype, "image/"))
+  if (StringUtils::StartsWithNoCase(m_mimetype, "image/"))
     return true;
 
   if (HasPictureInfoTag())
@@ -1057,7 +1057,14 @@ bool CFileItem::IsPicture() const
   if (HasVideoInfoTag())
     return false;
 
-  return CUtil::IsPicture(m_strPath);
+  if (HasPVRTimerInfoTag() || HasPVRChannelInfoTag() || HasPVRChannelGroupMemberInfoTag() ||
+      HasPVRRecordingInfoTag() || HasEPGInfoTag() || HasEPGSearchFilter())
+    return false;
+
+  if (!m_strPath.empty())
+    return CUtil::IsPicture(m_strPath);
+
+  return false;
 }
 
 bool CFileItem::IsLyrics() const

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -92,30 +92,23 @@ bool URIUtils::HasExtension(const std::string& strFileName, const std::string& s
 {
   if (IsURL(strFileName))
   {
-    CURL url(strFileName);
+    const CURL url(strFileName);
     return HasExtension(url.GetFileName(), strExtensions);
   }
 
-  // Search backwards so that '.' can be used as a search terminator.
-  std::string::const_reverse_iterator itExtensions = strExtensions.rbegin();
-  while (itExtensions != strExtensions.rend())
+  const size_t pos = strFileName.find_last_of("./\\");
+  if (pos == std::string::npos || strFileName[pos] != '.')
+    return false;
+
+  const std::string extensionLower = StringUtils::ToLower(strFileName.substr(pos));
+
+  const std::vector<std::string> extensionsLower =
+      StringUtils::Split(StringUtils::ToLower(strExtensions), '|');
+
+  for (const auto& ext : extensionsLower)
   {
-    // Iterate backwards over strFileName until we hit a '.' or a mismatch
-    for (std::string::const_reverse_iterator itFileName = strFileName.rbegin();
-         itFileName != strFileName.rend() && itExtensions != strExtensions.rend() &&
-         tolower(*itFileName) == *itExtensions;
-         ++itFileName, ++itExtensions)
-    {
-      if (*itExtensions == '.')
-        return true; // Match
-    }
-
-    // No match. Look for more extensions to try.
-    while (itExtensions != strExtensions.rend() && *itExtensions != '|')
-      ++itExtensions;
-
-    while (itExtensions != strExtensions.rend() && *itExtensions == '|')
-      ++itExtensions;
+    if (ext == extensionLower)
+      return true;
   }
 
   return false;


### PR DESCRIPTION
Optimize `CFileItem::IsPicture` to avoid super expensive calls to `URIUtils::HasExtension`. Optimize `URIUtils::HasExtension` implementation,

Before:

<img width="1177" alt="Screenshot 2022-07-28 at 11 01 48" src="https://user-images.githubusercontent.com/3226626/184674295-7fc5cfb7-533b-4b3a-9eb8-4844add90d00.png">

After:

<img width="1314" alt="Screenshot 2022-07-28 at 14 55 23" src="https://user-images.githubusercontent.com/3226626/184674324-4f0209ed-a6ef-40a4-bba6-40511eb3b702.png">

Runtime-tested on Android and macOS.
Profiled on macOS.

@phunkyfish when you find some time for a review. 