### PR TITLE
[Subtitles][WebVTT] Parsing improvements

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -78,6 +78,8 @@ OverlayMessage COverlayCodecWebVTT::Decode(DemuxPacket* pPacket)
   const char* data = reinterpret_cast<const char*>(pPacket->pData);
   std::vector<subtitleData> subtitleList;
 
+  m_webvttHandler.Reset();
+
   SubtitlePacketExtraData sideData;
   if (GetSubtitlePacketExtraData(pPacket, sideData))
   {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -36,6 +36,7 @@ constexpr int ASS_BORDER_STYLE_BOX = 3; // Box + drop shadow
 constexpr int ASS_BORDER_STYLE_SQUARE_BOX = 4; // Square box + outline
 
 constexpr int ASS_FONT_ENCODING_AUTO = -1;
+constexpr int COLOR_OPACITY_30 = 30;
 
 // Convert RGB/ARGB to RGBA by also applying the opacity value
 COLOR::Color ConvColor(COLOR::Color argbColor, int opacity = 100)
@@ -394,12 +395,11 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
     style->Bold = isFontBold * -1;
     style->Italic = isFontItalic * -1;
 
-    // Compute the font color, depending on the opacity
-    COLOR::Color subColor = ConvColor(subStyle->fontColor, subStyle->fontOpacity);
     // Set default subtitles color
-    style->PrimaryColour = subColor;
-    // Set SecondaryColour may be used to prevent an onscreen collision
-    style->SecondaryColour = subColor;
+    style->PrimaryColour = ConvColor(subStyle->fontColor, subStyle->fontOpacity);
+    // Set secondary colour for karaoke
+    // left part is filled with PrimaryColour, right one with SecondaryColour
+    style->SecondaryColour = ConvColor(subStyle->fontColor, COLOR_OPACITY_30);
 
     // Configure the effects
     double lineSpacing = 0.0;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -12,17 +12,19 @@
 #include "utils/ColorUtils.h"
 #include "utils/RegExp.h"
 
+#include <deque>
 #include <map>
 #include <stdio.h>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
-
 
 enum class WebvttSection
 {
   UNDEFINED = 0,
   STYLE,
+  STYLE_CONTENT,
   REGION,
   CUE,
   CUE_TEXT,
@@ -74,11 +76,22 @@ struct webvttCueSettings
   WebvttAlign positionAlign;
   double size;
   WebvttAlign align;
+
+  bool operator==(webvttCueSettings const& other) const
+  {
+    return this->verticalAlign == other.verticalAlign && this->snapToLines == other.snapToLines &&
+           this->line.isAuto == other.line.isAuto && this->line.value == other.line.value &&
+           this->position.isAuto == other.position.isAuto &&
+           this->position.value == other.position.value &&
+           this->positionAlign == other.positionAlign && this->size == other.size &&
+           this->align == other.align;
+  }
 };
 
 struct subtitleData
 {
   std::string text;
+  std::string textRaw; // Text without tags
   webvttCueSettings cueSettings;
   double startTime;
   double stopTime;
@@ -95,27 +108,38 @@ enum class WebvttSelector
   ID,
   TYPE,
   CLASS,
+  ATTRIBUTE,
   UNSUPPORTED
 };
 
 struct webvttCssStyle
 {
-  WebvttSelector selectorType;
-  std::string selectorName;
-  std::string color;
-  bool isFontBold = false;
-  bool isFontItalic = false;
-  bool isFontUnderline = false;
+  webvttCssStyle() {}
+  webvttCssStyle(WebvttSelector selectorType,
+                 const std::string& selectorName,
+                 const std::string& colorHexRGB)
+    : m_selectorType{selectorType}, m_selectorName{selectorName}
+  {
+    // Color hex values need to be in BGR format
+    m_color = colorHexRGB.substr(4, 2) + colorHexRGB.substr(2, 2) + colorHexRGB.substr(0, 2);
+  }
+
+  WebvttSelector m_selectorType = WebvttSelector::ANY;
+  std::string m_selectorName;
+  std::string m_color;
+  bool m_isFontBold = false;
+  bool m_isFontItalic = false;
+  bool m_isFontUnderline = false;
 };
 
-class FindCssStyleName
+struct tagToken
 {
-public:
-  FindCssStyleName(std::string name) : m_name(std::move(name)) {}
-  bool operator()(const webvttCssStyle& other) const { return other.selectorName == m_name; }
-
-private:
-  std::string m_name;
+  std::string m_token; // Entire tag
+  std::string m_tag;
+  std::string m_timestampTag;
+  std::string m_annotation;
+  std::vector<std::string> m_classes;
+  bool m_isClosing;
 };
 
 class CWebVTTHandler
@@ -128,6 +152,11 @@ public:
   * \brief Prepare the handler to the decoding
   */
   bool Initialize();
+
+  /*
+   * \brief Reset handler data
+   */
+  void Reset();
 
   /*!
   * \brief Verify the validity of the WebVTT signature
@@ -165,33 +194,37 @@ private:
                                  std::string defaultValue);
   std::string GetCueCssValue(const std::string& cssPropName, std::string& line);
   void AddDefaultCssClasses();
-  void InsertCssStyleStartTag(std::string& tagName,
+  void InsertCssStyleStartTag(const tagToken& tag,
                               std::string& text,
                               int& pos,
                               int flagTags[],
-                              std::map<std::string, std::string>& cssTagsOpened);
-  void InsertCssStyleCloseTag(std::string& tagName,
+                              std::deque<std::pair<std::string, webvttCssStyle*>>& cssTagsOpened);
+  void InsertCssStyleCloseTag(const tagToken& tag,
                               std::string& text,
                               int& pos,
                               int flagTags[],
-                              std::map<std::string, std::string>& cssTagsOpened,
+                              std::deque<std::pair<std::string, webvttCssStyle*>>& cssTagsOpened,
                               webvttCssStyle& baseStyle);
   bool GetBaseStyle(webvttCssStyle& style);
+  void ConvertAddSubtitle(std::vector<subtitleData>* subList);
   void LoadColors();
+  double GetTimeFromRegexTS(CRegExp& regex, int indexStart = 1);
 
   std::string m_previousLines[3];
   bool m_overrideStyle{false};
   bool m_overridePositions{false};
   WebvttSection m_currentSection{WebvttSection::UNDEFINED};
   CRegExp m_cueTimeRegex;
+  CRegExp m_timeRegex;
   std::map<std::string, CRegExp> m_cuePropsMapRegex;
   CGUIColorManager m_colorManager;
   CRegExp m_tagsRegex;
   CRegExp m_cueCssTagRegex;
   std::map<std::string, CRegExp> m_cueCssStyleMapRegex;
-  std::vector<std::string> m_cueCurrentCssStyleSelectors;
+  std::vector<std::string> m_feedCssSelectorNames;
   webvttCssStyle m_feedCssStyle;
-  std::vector<webvttCssStyle> m_cueCssStyles;
+  std::map<WebvttSelector, std::map<std::string, webvttCssStyle>> m_cssSelectors;
+
   bool m_CSSColorsLoaded{false};
   std::vector<std::pair<std::string, UTILS::COLOR::ColorInfo>> m_CSSColors;
   double m_offset{0.0};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This will superseed PR #21727 and add the following parsing improvements:
- Handled in better way css selector priorities:
`less --- to ---> higher importance`
cue selector -> ID selector -> type selector -> class selector -> class target selector _or_ attribute selector
- Default color css classes can now be overridden by authors as specs (and also solve the review request in PR #21727)
- Always reset handler data members when parsing segmented packages to fix subtitle sync (PR #21727)
- Add support to `Attribute selector`: `lang` and `voice` (but without "applicable language" attribute selector, maybe in future changes)
- Add support to parsing `timestamp` tag (e.g. `<00:00:16.000>`) this is like karaoke style:
![Animation2](https://user-images.githubusercontent.com/3257156/184935085-654ecf9e-2d5e-4e5a-b41c-c710364ef72d.gif)
How you can see in the video the karaoke color on the right usually is less visible, currently is derived from subtitle color setting by appling a higher transparency, if you have other suggests please let me know, maybe better use a fixed black color with higher transparency?
- Fixed Youtube WebVTT format that was causing unexpected multiple text on screen
- Fixed Youtube WebVTT format where some Styles was not parsed
- Fixed problem that could lead to text outside the horizontal sides of the screen

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was investigating to resolve the review in to PR #21727 and i realized that more changes was needed to solve it in best way,
and more tests with css parsing also found that some futher parsing improvements was needed

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Mainly with this sample: [sampleTestWithCss.vtt.txt](https://github.com/xbmc/xbmc/files/9352898/sampleTestWithCss.vtt.txt)

For test subtitle sync problem play this test stream as STRM with InputStream Adaptive nightly:
https://s3.amazonaws.com/_bc_dml/example-content/bipbop-advanced/bipbop_16x9_variant.m3u8

For testing Youtube WebVTT format problem:
[Evangelion-3-0-1-0-Theme-Song-en.vtt.txt](https://github.com/xbmc/xbmc/files/9375752/Evangelion-3-0-1-0-Theme-Song-en.vtt.txt)
[Bitter Choco Decoration.vtt.txt](https://github.com/xbmc/xbmc/files/9375750/Bitter.Choco.Decoration.vtt.txt)
On this last one is possible to notice that the multiline text is ordered is reversed order, this should depends on forced top alignment, and seems not easy to find a solution

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
WebVTT in sync with video HSL streams
Better compatibility with Youtube WebVTT format
More consistent CSS support

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
