### PR TITLE
[Subtitles] Fix text aspect ratio and size with video effects

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -115,10 +115,13 @@ struct renderOpts
 {
   float frameWidth;
   float frameHeight;
+  // Video size width, may be influenced by video settings (e.g. zoom)
   float videoWidth;
+  // Video size height, may be influenced by video settings (e.g. zoom)
   float videoHeight;
   float sourceWidth;
   float sourceHeight;
+  float m_par; // Set the pixel aspect ratio
   MarginsMode marginsMode = MarginsMode::DEFAULT;
   // Vertical line position of subtitles in percentage
   // only for bottom alignment, 0 = bottom (no change), 100 = on top

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -288,11 +288,11 @@ void CRenderer::SetVideoRect(CRect &source, CRect &dest, CRect &view)
 {
   if (m_rv != view) // Screen resolution is changed
   {
+    m_rv = view;
     OnViewChange();
   }
   m_rs = source;
   m_rd = dest;
-  m_rv = view;
 }
 
 void CRenderer::OnViewChange()
@@ -470,6 +470,8 @@ COverlay* CRenderer::ConvertLibass(
       ResetSubtitlePosition();
   }
 
+  rOpts.m_par = resInfo.fPixelRatio;
+
   // rOpts.position and margins (set to style) can invalidate the text
   // positions to subtitles type that make use of margins to position text on
   // the screen (e.g. ASS/WebVTT) then we allow to set them when position
@@ -549,14 +551,6 @@ COverlay* CRenderer::ConvertLibass(
   overlay = new COverlayQuadsDX(images, rOpts.frameWidth, rOpts.frameHeight);
 #endif
 
-  // scale to video dimensions
-  if (overlay)
-  {
-    overlay->m_width = rOpts.frameWidth / rOpts.videoWidth;
-    overlay->m_height = rOpts.frameHeight / rOpts.videoHeight;
-    overlay->m_x = (rOpts.videoWidth - rOpts.frameWidth) / 2 / rOpts.videoWidth;
-    overlay->m_y = (rOpts.videoHeight - rOpts.frameHeight) / 2 / rOpts.videoHeight;
-  }
   m_textureCache[m_textureid] = overlay;
   o->m_textureid = m_textureid;
   m_textureid++;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -66,10 +66,10 @@ namespace OVERLAY {
       POSITION_RELATIVE
     } m_pos;
 
-    float m_x;
-    float m_y;
-    float m_width;
-    float m_height;
+    float m_x{0};
+    float m_y{0};
+    float m_width{1.0f};
+    float m_height{1.0f};
     float m_source_width{0}; // Video source width resolution used to calculate aspect ratio
     float m_source_height{0}; // Video source height resolution used to calculate aspect ratio
 
@@ -177,7 +177,9 @@ namespace OVERLAY {
     std::vector<SElement> m_buffers[NUM_BUFFERS];
     std::map<unsigned int, COverlay*> m_textureCache;
     static unsigned int m_textureid;
-    CRect m_rv, m_rs, m_rd;
+    CRect m_rv; // Frame size
+    CRect m_rs; // Source size
+    CRect m_rd; // Video size, may be influenced by video settings (e.g. zoom)
     std::string m_stereomode;
     // Current subtitle position
     int m_subtitlePosition{0};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -64,7 +64,7 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, float width, float height)
 {
   m_width  = 1.0;
   m_height = 1.0;
-  m_align  = ALIGN_VIDEO;
+  m_align = ALIGN_SCREEN;
   m_pos    = POSITION_RELATIVE;
   m_x      = 0.0f;
   m_y      = 0.0f;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -263,7 +263,7 @@ COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, float width, float height)
 {
   m_width  = 1.0;
   m_height = 1.0;
-  m_align  = ALIGN_VIDEO;
+  m_align = ALIGN_SCREEN;
   m_pos    = POSITION_RELATIVE;
   m_x      = 0.0f;
   m_y      = 0.0f;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix text aspect ratio and size when video effects are used like zoom or `View mode` settings

Example of 4/3 view mode BEFORE:
![Forced43Before](https://user-images.githubusercontent.com/3257156/185798533-8864c75e-2565-4c3b-a885-745c5c10e6df.jpg)
Example of 4/3 view mode AFTER:
![Forced43After](https://user-images.githubusercontent.com/3257156/185798544-fa898ab8-aab6-4db5-b9ca-7feb3404afe8.jpg)

Example of Zoom effect used on a cropped video (position used `Bottom of video`):
![ZoomEffect](https://user-images.githubusercontent.com/3257156/185798571-a22c2c6e-683c-4255-b5c2-884b2719d9a9.gif)
You can see that not only the text size is consistent to settings, but also follow the black bars size

For native subtitles (ASS) and subtitles that make use of margins like WebVTT, the text will be fixed aligned to screen to prevent problems with positions defined by authors or possible side effects like text offscreen. Users can always enable subtilte position override settings to force change text position as preferred

~Require PR #21680~

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When you use video effects like zoom or `View mode` forced to 4/3 etc...
the subtitles are wrongly rendered with wrong aspect ratio and size

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using video settings and playing a video with SRT

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
