### PR TITLE
[PVR] CPVREpgInfoTag optimizations

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -758,7 +758,7 @@ public:
       m_strEpisodeName(kodiTag->EpisodeName()),
       m_strIconPath(kodiTag->ClientIconPath()),
       m_strSeriesLink(kodiTag->SeriesLink()),
-      m_strGenreDescription(kodiTag->GetGenresLabel()),
+      m_strGenreDescription(kodiTag->GenreDescription()),
       m_strParentalRatingCode(kodiTag->ParentalRatingCode())
   {
     time_t t;

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -426,8 +426,9 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(
     newTag->m_iFlags = m_pDS->fv("iFlags").get_asInt();
     newTag->m_strSeriesLink = m_pDS->fv("sSeriesLink").get_asString();
     newTag->m_strParentalRatingCode = m_pDS->fv("sParentalRatingCode").get_asString();
-    newTag->SetGenre(m_pDS->fv("iGenreType").get_asInt(), m_pDS->fv("iGenreSubType").get_asInt(),
-                     m_pDS->fv("sGenre").get_asString().c_str());
+    newTag->m_iGenreType = m_pDS->fv("iGenreType").get_asInt();
+    newTag->m_iGenreSubType = m_pDS->fv("iGenreSubType").get_asInt();
+    newTag->m_strGenreDescription = m_pDS->fv("sGenre").get_asString();
 
     return newTag;
   }
@@ -1192,9 +1193,6 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
   int iBroadcastId = tag.DatabaseID();
   std::string strQuery;
 
-  /* Only store the genre string when needed */
-  std::string strGenre = (tag.GenreType() == EPG_GENRE_USE_STRING || tag.GenreSubType() == EPG_GENRE_USE_STRING) ? tag.DeTokenize(tag.Genre()) : "";
-
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
   if (iBroadcastId < 0)
@@ -1214,7 +1212,7 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
         tag.OriginalTitle().c_str(), tag.DeTokenize(tag.Cast()).c_str(),
         tag.DeTokenize(tag.Directors()).c_str(), tag.DeTokenize(tag.Writers()).c_str(), tag.Year(),
         tag.IMDBNumber().c_str(), tag.ClientIconPath().c_str(), tag.GenreType(), tag.GenreSubType(),
-        strGenre.c_str(), sFirstAired.c_str(), tag.ParentalRating(), tag.StarRating(),
+        tag.GenreDescription().c_str(), sFirstAired.c_str(), tag.ParentalRating(), tag.StarRating(),
         tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.Flags(), tag.SeriesLink().c_str(), tag.ParentalRatingCode().c_str(),
         tag.UniqueBroadcastID());
@@ -1236,7 +1234,7 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
         tag.OriginalTitle().c_str(), tag.DeTokenize(tag.Cast()).c_str(),
         tag.DeTokenize(tag.Directors()).c_str(), tag.DeTokenize(tag.Writers()).c_str(), tag.Year(),
         tag.IMDBNumber().c_str(), tag.ClientIconPath().c_str(), tag.GenreType(), tag.GenreSubType(),
-        strGenre.c_str(), sFirstAired.c_str(), tag.ParentalRating(), tag.StarRating(),
+        tag.GenreDescription().c_str(), sFirstAired.c_str(), tag.ParentalRating(), tag.StarRating(),
         tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.Flags(), tag.SeriesLink().c_str(), tag.ParentalRatingCode().c_str(),
         tag.UniqueBroadcastID(), iBroadcastId);

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -428,7 +428,6 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(
     newTag->m_strParentalRatingCode = m_pDS->fv("sParentalRatingCode").get_asString();
     newTag->SetGenre(m_pDS->fv("iGenreType").get_asInt(), m_pDS->fv("iGenreSubType").get_asInt(),
                      m_pDS->fv("sGenre").get_asString().c_str());
-    newTag->UpdatePath();
 
     return newTag;
   }

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -65,7 +65,9 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data,
                                int iClientId,
                                const std::shared_ptr<CPVREpgChannelData>& channelData,
                                int iEpgID)
-  : m_iParentalRating(data.iParentalRating),
+  : m_iGenreType(data.iGenreType),
+    m_iGenreSubType(data.iGenreSubType),
+    m_iParentalRating(data.iParentalRating),
     m_iStarRating(data.iStarRating),
     m_iSeriesNumber(data.iSeriesNumber),
     m_iEpisodeNumber(data.iEpisodeNumber),
@@ -103,11 +105,11 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data,
     m_channelData = std::make_shared<CPVREpgChannelData>(iClientId, data.iUniqueChannelId);
   }
 
-  SetGenre(data.iGenreType, data.iGenreSubType, data.strGenreDescription);
-
   // explicit NULL check, because there is no implicit NULL constructor for std::string
   if (data.strTitle)
     m_strTitle = data.strTitle;
+  if (data.strGenreDescription)
+    m_strGenreDescription = data.strGenreDescription;
   if (data.strPlotOutline)
     m_strPlotOutline = data.strPlotOutline;
   if (data.strPlot)
@@ -177,7 +179,7 @@ void CPVREpgInfoTag::Serialize(CVariant& value) const
   value["writer"] = DeTokenize(m_writers);
   value["year"] = m_iYear;
   value["imdbnumber"] = m_strIMDBNumber;
-  value["genre"] = m_genre;
+  value["genre"] = Genre();
   value["filenameandpath"] = Path();
   value["starttime"] = m_startTime.IsValid() ? m_startTime.GetAsDBDateTime() : StringUtils::Empty;
   value["endtime"] = m_endTime.IsValid() ? m_endTime.GetAsDBDateTime() : StringUtils::Empty;
@@ -372,7 +374,8 @@ const std::string CPVREpgInfoTag::GetWritersLabel() const
 
 const std::string CPVREpgInfoTag::GetGenresLabel() const
 {
-  return StringUtils::Join(m_genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+  return StringUtils::Join(
+      Genre(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
 }
 
 int CPVREpgInfoTag::Year() const
@@ -385,29 +388,6 @@ std::string CPVREpgInfoTag::IMDBNumber() const
   return m_strIMDBNumber;
 }
 
-void CPVREpgInfoTag::SetGenre(int iGenreType, int iGenreSubType, const char* strGenre)
-{
-  if (m_iGenreType != iGenreType || m_iGenreSubType != iGenreSubType)
-  {
-    m_iGenreType = iGenreType;
-    m_iGenreSubType = iGenreSubType;
-    if ((iGenreType == EPG_GENRE_USE_STRING || iGenreSubType == EPG_GENRE_USE_STRING) && (strGenre != NULL) && (strlen(strGenre) > 0))
-    {
-      /* Type and sub type are both not given. No EPG color coding possible unless sub type is used to specify
-       * EPG_GENRE_USE_STRING leaving type available for genre category, use the provided genre description for the text. */
-      m_genre = Tokenize(strGenre);
-    }
-  }
-
-  if (m_genre.empty())
-  {
-    // Determine the genre description from the type and subtype IDs.
-    m_genre = StringUtils::Split(
-        CPVREpg::ConvertGenreIdToString(iGenreType, iGenreSubType),
-        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
-  }
-}
-
 int CPVREpgInfoTag::GenreType() const
 {
   return m_iGenreType;
@@ -418,8 +398,30 @@ int CPVREpgInfoTag::GenreSubType() const
   return m_iGenreSubType;
 }
 
+std::string CPVREpgInfoTag::GenreDescription() const
+{
+  return m_strGenreDescription;
+}
+
 const std::vector<std::string> CPVREpgInfoTag::Genre() const
 {
+  if (m_genre.empty())
+  {
+    if ((m_iGenreType == EPG_GENRE_USE_STRING || m_iGenreSubType == EPG_GENRE_USE_STRING) &&
+        !m_strGenreDescription.empty())
+    {
+      // Type and sub type are both not given. No EPG color coding possible unless sub type is
+      // used to specify EPG_GENRE_USE_STRING leaving type available for genre category, use the
+      // provided genre description for the text.
+      m_genre = Tokenize(m_strGenreDescription);
+    }
+
+    if (m_genre.empty())
+    {
+      // Determine the genre from the type and subtype IDs.
+      m_genre = Tokenize(CPVREpg::ConvertGenreIdToString(m_iGenreType, m_iGenreSubType));
+    }
+  }
   return m_genre;
 }
 
@@ -493,7 +495,8 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /
        m_iYear != tag.m_iYear || m_strIMDBNumber != tag.m_strIMDBNumber ||
        m_startTime != tag.m_startTime || m_endTime != tag.m_endTime ||
        m_iGenreType != tag.m_iGenreType || m_iGenreSubType != tag.m_iGenreSubType ||
-       m_firstAired != tag.m_firstAired || m_iParentalRating != tag.m_iParentalRating ||
+       m_strGenreDescription != tag.m_strGenreDescription || m_firstAired != tag.m_firstAired ||
+       m_iParentalRating != tag.m_iParentalRating ||
        m_strParentalRatingCode != tag.m_strParentalRatingCode ||
        m_iStarRating != tag.m_iStarRating || m_iEpisodeNumber != tag.m_iEpisodeNumber ||
        m_iEpisodePart != tag.m_iEpisodePart || m_iSeriesNumber != tag.m_iSeriesNumber ||
@@ -523,20 +526,11 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /
     m_endTime = tag.m_endTime;
     m_iGenreType = tag.m_iGenreType;
     m_iGenreSubType = tag.m_iGenreSubType;
+    m_strGenreDescription = tag.m_strGenreDescription;
+    m_genre = tag.m_genre;
     m_iEpgID = tag.m_iEpgID;
     m_iFlags = tag.m_iFlags;
     m_strSeriesLink = tag.m_strSeriesLink;
-
-    if (m_iGenreType == EPG_GENRE_USE_STRING || m_iGenreSubType == EPG_GENRE_USE_STRING)
-    {
-      /* No type/subtype. Use the provided description */
-      m_genre = tag.m_genre;
-    }
-    else
-    {
-      /* Determine genre description by type/subtype */
-      m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(tag.m_iGenreType, tag.m_iGenreSubType), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
-    }
     m_firstAired = tag.m_firstAired;
     m_iParentalRating = tag.m_iParentalRating;
     m_strParentalRatingCode = tag.m_strParentalRatingCode;

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -59,8 +59,6 @@ CPVREpgInfoTag::CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channe
       0, 0, 0, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection);
   m_startTime = start + correction;
   m_endTime = end + correction;
-
-  UpdatePath();
 }
 
 CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data,
@@ -130,8 +128,6 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data,
     m_strSeriesLink = data.strSeriesLink;
   if (data.strParentalRatingCode)
     m_strParentalRatingCode = data.strParentalRatingCode;
-
-  UpdatePath();
 }
 
 void CPVREpgInfoTag::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
@@ -182,7 +178,7 @@ void CPVREpgInfoTag::Serialize(CVariant& value) const
   value["year"] = m_iYear;
   value["imdbnumber"] = m_strIMDBNumber;
   value["genre"] = m_genre;
-  value["filenameandpath"] = m_strFileNameAndPath;
+  value["filenameandpath"] = Path();
   value["starttime"] = m_startTime.IsValid() ? m_startTime.GetAsDBDateTime() : StringUtils::Empty;
   value["endtime"] = m_endTime.IsValid() ? m_endTime.GetAsDBDateTime() : StringUtils::Empty;
   value["runtime"] = GetDuration() / 60;
@@ -484,7 +480,7 @@ std::string CPVREpgInfoTag::ClientIconPath() const
 
 std::string CPVREpgInfoTag::Path() const
 {
-  return m_strFileNameAndPath;
+  return StringUtils::Format("pvr://guide/{:04}/{}.epg", EpgID(), m_startTime.GetAsDBDateTime());
 }
 
 bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /* = true */)
@@ -552,8 +548,6 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /
     m_iUniqueBroadcastID = tag.m_iUniqueBroadcastID;
     m_iconPath = tag.m_iconPath;
     m_channelData = tag.m_channelData;
-
-    UpdatePath();
   }
 
   return bChanged;
@@ -583,12 +577,6 @@ std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
   return edls;
 }
 
-void CPVREpgInfoTag::UpdatePath()
-{
-  m_strFileNameAndPath =
-      StringUtils::Format("pvr://guide/{:04}/{}.epg", EpgID(), m_startTime.GetAsDBDateTime());
-}
-
 int CPVREpgInfoTag::EpgID() const
 {
   return m_iEpgID;
@@ -598,7 +586,6 @@ void CPVREpgInfoTag::SetEpgID(int iEpgID)
 {
   m_iEpgID = iEpgID;
   m_iconPath.SetOwner(StringUtils::Format(IMAGE_OWNER_PATTERN, m_iEpgID));
-  UpdatePath(); // Note: path contains epg id.
 }
 
 bool CPVREpgInfoTag::IsRecordable() const

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -267,6 +267,12 @@ namespace PVR
     int GenreSubType() const;
 
     /*!
+     * @brief Get the genre description of this event.
+     * @return The genre.
+     */
+    std::string GenreDescription() const;
+
+    /*!
      * @brief Get the genre as human readable string.
      * @return The genre.
      */
@@ -453,13 +459,6 @@ namespace PVR
     CPVREpgInfoTag& operator =(const CPVREpgInfoTag& other) = delete;
 
     /*!
-     * @brief Change the genre of this event.
-     * @param iGenreType The genre type ID.
-     * @param iGenreSubType The genre subtype ID.
-     */
-    void SetGenre(int iGenreType, int iGenreSubType, const char* strGenre);
-
-    /*!
      * @brief Get current time, taking timeshifting into account.
      * @return The playing time.
      */
@@ -468,6 +467,7 @@ namespace PVR
     int m_iDatabaseID = -1; /*!< database ID */
     int m_iGenreType = 0; /*!< genre type */
     int m_iGenreSubType = 0; /*!< genre subtype */
+    std::string m_strGenreDescription; /*!< genre description */
     int m_iParentalRating = 0; /*!< parental rating */
     std::string m_strParentalRatingCode; /*!< parental rating code */
     int m_iStarRating = 0; /*!< star rating */
@@ -484,7 +484,7 @@ namespace PVR
     std::vector<std::string> m_writers; /*!< writer(s) */
     int m_iYear = 0; /*!< year */
     std::string m_strIMDBNumber; /*!< imdb number */
-    std::vector<std::string> m_genre; /*!< genre */
+    mutable std::vector<std::string> m_genre; /*!< genre */
     std::string m_strEpisodeName; /*!< episode name */
     CPVRCachedImage m_iconPath; /*!< the path to the icon */
     CDateTime m_startTime; /*!< event start time */

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -460,11 +460,6 @@ namespace PVR
     void SetGenre(int iGenreType, int iGenreSubType, const char* strGenre);
 
     /*!
-     * @brief Update the path of this tag.
-     */
-    void UpdatePath();
-
-    /*!
      * @brief Get current time, taking timeshifting into account.
      * @return The playing time.
      */
@@ -492,7 +487,6 @@ namespace PVR
     std::vector<std::string> m_genre; /*!< genre */
     std::string m_strEpisodeName; /*!< episode name */
     CPVRCachedImage m_iconPath; /*!< the path to the icon */
-    std::string m_strFileNameAndPath; /*!< the filename and path */
     CDateTime m_startTime; /*!< event start time */
     CDateTime m_endTime; /*!< event end time */
     CDateTime m_firstAired; /*!< first airdate */


### PR DESCRIPTION
EPG info tags are mass objects. Especially during Kodi startup, when updating EPG information, lots of `CPVREpgInfoTag` instances might get created. It makes sense to keep the EPG tag ctors cheap and only to compute data actually needed.

This PR removes current eager evaluation of the tag's genre and path, for my test scenario, saving measurable time on Kodi startup. As a side effect, code reads cleaner, because special data update calls like `UpdatePath` scattered now all over the place can be removed.

<img width="1118" alt="Screenshot 2022-07-28 at 21 09 43" src="https://user-images.githubusercontent.com/3226626/186091404-fb200f3a-6eaa-4ab7-b050-c7b511595be8.png">

<img width="1136" alt="Screenshot 2022-08-17 at 08 26 13" src="https://user-images.githubusercontent.com/3226626/186091448-5b4a9b95-a234-4111-9873-fc32f0dae318.png">

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish if/when you find some time for a review.