### PR TITLE
[LanguageCodes] Fix code lookup with language addons and lang codes user defined

### DIFF
--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -59,6 +59,12 @@ public:
   // implementation of ISettingsHandler
   void OnSettingsLoaded() override;
 
+  /*
+   * \brief Get language codes list of the installed language addons.
+   * \param languages [OUT] The list of languages (language code, name).
+   */
+  static void GetAddonsLanguageCodes(std::map<std::string, std::string>& languages);
+
   /*!
    \brief Returns the language addon for the given locale (or the current one).
 
@@ -74,9 +80,17 @@ public:
   const std::string& GetLanguageCode() const { return m_languageCodeGeneral; }
 
   /*!
-   \brief Returns the given language's name in English
+   * \brief Convert an english language name to an addon locale,
+   *        by searching in the installed language addons.
+   * \param langName [IN] The english language name
+   * \return The locale for the given english name, or empty if not found
+   */
+  static std::string ConvertEnglishNameToAddonLocale(const std::string& langName);
 
-   \param locale (optional) Locale of the language (current if empty)
+  /*!
+   * \brief Get the english language name from given locale,
+   *        by searching in the installed language addons.
+   * \param locale [OPT] Locale of the language (current if empty)
    */
   std::string GetEnglishLanguageName(const std::string& locale = "") const;
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -26,6 +26,7 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SystemClock.h"
 #include "utils/FontUtils.h"
+#include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
@@ -1835,7 +1836,23 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
       }
     }
     if (langTag)
+    {
       stream->language = std::string(langTag->value, 3);
+      //! @FIXME: Matroska v4 support BCP-47 language code with LanguageIETF element
+      //! that have the priority over the Language element, but this is not currently
+      //! implemented in to ffmpeg library. Since ffmpeg read only the Language element
+      //! all tracks will be identified with same language (of Language element).
+      //! As workaround to allow set the right language code we provide the possibility
+      //! to set the language code in the title field, this allow to kodi to recognize
+      //! the right language and select the right track to be played at playback starts.
+      AVDictionaryEntry* title = av_dict_get(pStream->metadata, "title", NULL, 0);
+      if (title && title->value)
+      {
+        const std::string langCode = g_LangCodeExpander.FindLanguageCodeWithSubtag(title->value);
+        if (!langCode.empty())
+          stream->language = langCode;
+      }
+    }
 
     if (stream->type != STREAM_NONE && pStream->codecpar->extradata && pStream->codecpar->extradata_size > 0)
     {

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -8,6 +8,7 @@
 
 #include "LangCodeExpander.h"
 
+#include "LangInfo.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -84,39 +85,36 @@ void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
 
 bool CLangCodeExpander::Lookup(const std::string& code, std::string& desc)
 {
+  if (LookupInUserMap(code, desc))
+    return true;
+
+  if (LookupInLangAddons(code, desc))
+    return true;
+
+  // Language code with subtag is supported only with language addons
+  // or with user defined map, then if not found we fallback by obtaining
+  // the primary code description only and appending the remaining
   int iSplit = code.find('-');
   if (iSplit > 0)
   {
-    std::string strLeft, strRight;
-    const bool bLeft = Lookup(code.substr(0, iSplit), strLeft);
-    const bool bRight = Lookup(code.substr(iSplit + 1), strRight);
-    if (bLeft || bRight)
+    std::string primaryTagDesc;
+    const bool hasPrimaryTagDesc = Lookup(code.substr(0, iSplit), primaryTagDesc);
+    std::string subtagCode = code.substr(iSplit + 1);
+    if (hasPrimaryTagDesc)
     {
-      desc = "";
-      if (strLeft.length() > 0)
-        desc = strLeft;
+      if (primaryTagDesc.length() > 0)
+        desc = primaryTagDesc;
       else
         desc = code.substr(0, iSplit);
 
-      if (strRight.length() > 0)
-      {
-        desc += " - ";
-        desc += strRight;
-      }
-      else
-      {
-        desc += " - ";
-        desc += code.substr(iSplit + 1);
-      }
+      if (subtagCode.length() > 0)
+        desc += " - " + subtagCode;
 
       return true;
     }
 
     return false;
   }
-
-  if (LookupInUserMap(code, desc))
-    return true;
 
   if (LookupInISO639Tables(code, desc))
     return true;
@@ -201,11 +199,16 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
   }
   else if (strCharCode.size() > 3)
   {
+    // First try search on language addons
+    strISO6392B = g_langInfo.ConvertEnglishNameToAddonLocale(strCharCode);
+    if (!strISO6392B.empty())
+      return true;
+
     for (const auto& codes : g_iso639_2)
     {
       if (StringUtils::EqualsNoCase(strCharCode, codes.name))
       {
-        CodeToString(codes.code, strISO6392B);
+        strISO6392B = CodeToString(codes.code);
         return true;
       }
     }
@@ -361,6 +364,8 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
 
   std::string descTmp(desc);
   StringUtils::Trim(descTmp);
+
+  // First find to user-defined languages
   for (STRINGLOOKUPTABLE::const_iterator it = m_mapUser.begin(); it != m_mapUser.end(); ++it)
   {
     if (StringUtils::EqualsNoCase(descTmp, it->second))
@@ -370,11 +375,16 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
     }
   }
 
+  // Find on language addons
+  code = g_langInfo.ConvertEnglishNameToAddonLocale(descTmp);
+  if (!code.empty())
+    return true;
+
   for (const auto& codes : g_iso639_1)
   {
     if (StringUtils::EqualsNoCase(descTmp, codes.name))
     {
-      CodeToString(codes.code, code);
+      code = CodeToString(codes.code);
       return true;
     }
   }
@@ -383,7 +393,7 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
   {
     if (StringUtils::EqualsNoCase(descTmp, codes.name))
     {
-      CodeToString(codes.code, code);
+      code = CodeToString(codes.code);
       return true;
     }
   }
@@ -409,6 +419,20 @@ bool CLangCodeExpander::LookupInUserMap(const std::string& code, std::string& de
   }
 
   return false;
+}
+
+bool CLangCodeExpander::LookupInLangAddons(const std::string& code, std::string& desc)
+{
+  if (code.empty())
+    return false;
+
+  std::string sCode{code};
+  StringUtils::Trim(sCode);
+  StringUtils::ToLower(sCode);
+  StringUtils::Replace(sCode, '-', '_');
+
+  desc = g_langInfo.GetEnglishLanguageName(sCode);
+  return !desc.empty();
 }
 
 bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::string& desc)
@@ -448,18 +472,19 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
   return false;
 }
 
-void CLangCodeExpander::CodeToString(long code, std::string& ret)
+std::string CLangCodeExpander::CodeToString(long code)
 {
-  ret.clear();
+  std::string ret;
   for (unsigned int j = 0; j < 4; j++)
   {
     char c = (char)code & 0xFF;
     if (c == '\0')
-      return;
+      break;
 
     ret.insert(0, 1, c);
     code >>= 8;
   }
+  return ret;
 }
 
 bool CLangCodeExpander::CompareFullLanguageNames(const std::string& lang1, const std::string& lang2)
@@ -484,22 +509,40 @@ bool CLangCodeExpander::CompareFullLanguageNames(const std::string& lang1, const
 }
 
 std::vector<std::string> CLangCodeExpander::GetLanguageNames(
-    LANGFORMATS format /* = CLangCodeExpander::ISO_639_1 */, bool customNames /* = false */)
+    LANGFORMATS format /* = CLangCodeExpander::ISO_639_1 */,
+    LANG_LIST list /* = LANG_LIST::DEFAULT */)
 {
-  std::vector<std::string> languages;
+  std::map<std::string, std::string> langMap;
 
   if (format == CLangCodeExpander::ISO_639_2)
-    std::transform(g_iso639_2.begin(), g_iso639_2.end(), std::back_inserter(languages),
-                   [](const LCENTRY& e) { return e.name; });
+    std::transform(g_iso639_2.begin(), g_iso639_2.end(), std::inserter(langMap, langMap.end()),
+                   [](const LCENTRY& e) { return std::make_pair(CodeToString(e.code), e.name); });
   else
-    std::transform(g_iso639_1.begin(), g_iso639_1.end(), std::back_inserter(languages),
-                   [](const LCENTRY& e) { return e.name; });
+    std::transform(g_iso639_1.begin(), g_iso639_1.end(), std::inserter(langMap, langMap.end()),
+                   [](const LCENTRY& e) { return std::make_pair(CodeToString(e.code), e.name); });
 
-  if (customNames)
-    std::transform(m_mapUser.begin(), m_mapUser.end(), std::back_inserter(languages),
-                   [](const STRINGLOOKUPTABLE::value_type& e) { return e.second; });
+  if (list == LANG_LIST::INCLUDE_ADDONS || list == LANG_LIST::INCLUDE_ADDONS_USERDEFINED)
+  {
+    g_langInfo.GetAddonsLanguageCodes(langMap);
+  }
 
-  return languages;
+  // User-defined languages can override existing ones
+  if (list == LANG_LIST::INCLUDE_USERDEFINED || list == LANG_LIST::INCLUDE_ADDONS_USERDEFINED)
+  {
+    for (const auto& value : m_mapUser)
+    {
+      langMap[value.first] = value.second;
+    }
+  }
+
+  // Sort by name and remove duplicates
+  std::set<std::string, sortstringbyname> languages;
+  for (const auto& lang : langMap)
+  {
+    languages.insert(lang.second);
+  }
+
+  return std::vector<std::string>(languages.begin(), languages.end());
 }
 
 bool CLangCodeExpander::CompareISO639Codes(const std::string& code1, const std::string& code2)

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -8,6 +8,7 @@
 
 #include "LangCodeExpander.h"
 
+#include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 
@@ -545,6 +546,18 @@ std::string CLangCodeExpander::ConvertToISO6392T(const std::string& lang)
   }
 
   return lang;
+}
+
+std::string CLangCodeExpander::FindLanguageCodeWithSubtag(const std::string& str)
+{
+  CRegExp regLangCode;
+  if (regLangCode.RegComp(
+          "(?:^|\\s|\\()(([A-Za-z]{2,3})-([A-Za-z]{2}|[0-9]{3}|[A-Za-z]{4}))(?:$|\\s|\\))") &&
+      regLangCode.RegFind(str) >= 0)
+  {
+    return regLangCode.GetMatch(1);
+  }
+  return "";
 }
 
 // clang-format off

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -27,6 +27,20 @@ public:
     ENGLISH_NAME
   };
 
+  enum class LANG_LIST
+  {
+    // Standard ISO
+    DEFAULT,
+    // Standard ISO + Language addons
+    INCLUDE_ADDONS,
+    // Standard ISO + User defined
+    // (User defined can override language name of existing codes)
+    INCLUDE_USERDEFINED,
+    // Standard ISO + Language addons + User defined
+    // (User defined can override language name of existing codes)
+    INCLUDE_ADDONS_USERDEFINED,
+  };
+
   void LoadUserCodes(const TiXmlElement* pRootElement);
   void Clear();
 
@@ -117,17 +131,35 @@ public:
   static bool ConvertWindowsLanguageCodeToISO6392B(const std::string& strWindowsLanguageCode, std::string& strISO6392B);
 #endif
 
-  std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1, bool customNames = false);
-protected:
+  /*
+   * \brief Get the list of language names.
+   * \param format [OPT] The format type.
+   * \param list [OPT] The type of language list to retrieve.
+   * \return The languages
+   */
+  std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1,
+                                            LANG_LIST list = LANG_LIST::DEFAULT);
 
-  /** \brief Converts a language code given as a long, see #MAKECODE(a, b, c, d)
-  *          to its string representation.
-  *   \param[in] code The language code given as a long, see #MAKECODE(a, b, c, d).
-  *   \param[out] ret The string representation of the given language code code.
-  */
-  static void CodeToString(long code, std::string& ret);
+protected:
+  /*
+   * \brief Converts a language code given as a long, see #MAKECODE(a, b, c, d)
+   *        to its string representation.
+   * \param[in] code The language code given as a long, see #MAKECODE(a, b, c, d).
+   * \return The string representation of the given language code code.
+   */
+  static std::string CodeToString(long code);
 
   static bool LookupInISO639Tables(const std::string& code, std::string& desc);
+
+  /*
+   * \brief Looks up the language description for given language code
+   *        in to the installed language addons.
+   * \param[in] code The language code for which description is looked for.
+   * \param[out] desc The english language name.
+   * \return true if the language description was found, false otherwise.
+   */
+  static bool LookupInLangAddons(const std::string& code, std::string& desc);
+
   bool LookupInUserMap(const std::string& code, std::string& desc);
 
   /** \brief Looks up the ISO 639-1, ISO 639-2/T, or ISO 639-2/B, whichever it finds first,

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -102,6 +102,16 @@ public:
   */
   std::string ConvertToISO6392T(const std::string& lang);
 
+  /*
+   * \brief Find a language code with subtag (e.g. zh-tw, zh-Hans) in to a string.
+   *        This function find a limited set of IETF BCP47 specs, so:
+   *        language tag + region subtag, or, language tag + script subtag.
+   *        The language code can be found also if wrapped with round brackets.
+   * \param str The string where find the language code.
+   * \return The language code found in the string, otherwise empty string
+   */
+  static std::string FindLanguageCodeWithSubtag(const std::string& str);
+
 #ifdef TARGET_WINDOWS
   static bool ConvertISO31661Alpha2ToISO31661Alpha3(const std::string& strISO31661Alpha2, std::string& strISO31661Alpha3);
   static bool ConvertWindowsLanguageCodeToISO6392B(const std::string& strWindowsLanguageCode, std::string& strISO6392B);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
There are some ancien bugs in Kodi that prevent to correcly handle language codes,
follow use cases:

### An user has installed a language pack addon e.g. `Chinese (simple)`
**Case 1:**
When you play a streaming video we expects to see the correct language description in the subtilte/audio language list as defined in language pack addon
instead is shown a wrong name, especially if language code have the country code, for example:
`pt-br` is shown as `Portuguese - Breton` (instead of Portuguese-Brazil)
`nl-be` is shown as `Dutch - Belarusian` (instead of Dutch-Belgium)
this is wrong

so now we let to the users three possibilities:
- Install and use the addon language pack language code descriptions (if available)
- Define his language code's in xml advanced setting
- Do nothing, and the description will be as follow:
`pt-br` now will be shown as `Portuguese - br`
`nl-be` now will be shown as `Dutch - be`
which is preferable instead to show incorrect descriptions,
this can be improved in future maybe by implementing IETF BCP 47

**Case 2:**
When you play a streaming video with `Chinese (simple)`, Kodi is not able to select the subtitle (or audio) track automatically (set as `Chinese (simple)`), this because is missing the lookup in language addons, and the user has to manually select every time the correct language from the GUI audio/video language list

**Case 3:**
Similar to case 2, but for inpraticable use of advanced setting xml to define language codes with country code,
kodi do not taken in account of user defined language codes with country code, causing language selection to fail when playback,
see following point.

### Define language code with country code in advanced setting xml
You can define for example "zh-tw" (as the example below) this will be shown in the kodi setting subtitle/audio language list with right description, but if you try to play a video with that language code, not works, with all side effects mentioned before.
This because `CLangCodeExpander::Lookup` was not prioritizing the user map as happens in `CLangCodeExpander::ConvertToISO6392B`

### Playing an MKV video with tracks defined with language and country codes
If you play a mkv with tracks defined with language and country codes for example subs with
"zh-cn", "zh-tw", "zh-hans"
currenlty all tracks are identified and displayed as `Chinese` without distinction. This lead to a broken kodi track language selection when playback starts, and impossibility to the user to identify the type of language from the GUI.
MKV support IETF BCP 47 to set language codes with regions (country) but our ffmpeg demuxer not, and fallback always to the first language tag ("zh").
The only workaround possible is add the possibility to parse the language code with country code from the "title" field, to override the wrong language code.
So i have add a regex to parse following formats e.g. `zh-tw` or `(zh-hans)` (with or without round brackets)
this will require users to edit the video file, IMO it is an acceptable workaround until there is a definitive solution from ffmpeg

i am not sure about a backport to Kodi19 because to partially fix these problems many addons has implemented rather cumbersome cheats workarounds

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #21533

This also partially fix issues:
#15333
#15308
for a complete solution to display/manage right language names imo will be needed in future implement IETF BCP 47

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See example provided in the Issue #21533

A MKV with more subtitles with language code + country code

I will provide a test build to user that report to me the problem, to have a confirmation:
user confirmed that works: https://github.com/CastagnaIT/plugin.video.netflix/issues/1348#issuecomment-1229165210

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Can have an automatic subtitle (also audio) language selection working with user custom defined language codes or installed language addons, where before subtitles track was not selected when play a video

Can display the correct language name in the subtitle (and audio) language list as defined with user custom defined language codes or installed language addons

Can define their custom locale codes also with country code in the advanced setting xml, eg.
```xml
<advancedsettings>
<languagecodes>
  <code>
    <short>zh-tw</short>
    <long>MyCustomDesc(zh-tw)</long>
  </code>
</languagecodes>
</advancedsettings>
```

Can have an automatic subtitle (also audio) language selection working with MKV videos that use in tracks language+country code, and right language names, as long as the workaround on the "title" track is used

## Screenshots (if appropriate):
Follow situation is, Chinese (simple) language addon installed, and `zh-tw` language code defined in the xml advanced setting
BEFORE:
![immagine](https://user-images.githubusercontent.com/3257156/186162698-01efb5bb-1c36-423c-bfce-641d571636f5.png)
AFTER:
![immagine](https://user-images.githubusercontent.com/3257156/186162442-ff74c13c-4bda-426f-8332-0c9a388f2bc9.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
