### PR TITLE
[CFileItemList] remove unneeded const ::Get() member functions / cleanup

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2348,7 +2348,7 @@ bool CFileItemList::Copy(const CFileItemList& items, bool copyItems /* = true */
   return true;
 }
 
-CFileItemPtr CFileItemList::Get(int iItem)
+CFileItemPtr CFileItemList::Get(int iItem) const
 {
   std::unique_lock<CCriticalSection> lock(m_lock);
 
@@ -2358,46 +2358,14 @@ CFileItemPtr CFileItemList::Get(int iItem)
   return CFileItemPtr();
 }
 
-const CFileItemPtr CFileItemList::Get(int iItem) const
-{
-  std::unique_lock<CCriticalSection> lock(m_lock);
-
-  if (iItem > -1 && iItem < (int)m_items.size())
-    return m_items[iItem];
-
-  return CFileItemPtr();
-}
-
-CFileItemPtr CFileItemList::Get(const std::string& strPath)
+CFileItemPtr CFileItemList::Get(const std::string& strPath) const
 {
   std::unique_lock<CCriticalSection> lock(m_lock);
 
   if (m_fastLookup)
   {
-    IMAPFILEITEMS it = m_map.find(m_ignoreURLOptions ? CURL(strPath).GetWithoutOptions() : strPath);
-    if (it != m_map.end())
-      return it->second;
-
-    return CFileItemPtr();
-  }
-  // slow method...
-  for (unsigned int i = 0; i < m_items.size(); i++)
-  {
-    CFileItemPtr pItem = m_items[i];
-    if (pItem->IsPath(m_ignoreURLOptions ? CURL(strPath).GetWithoutOptions() : strPath))
-      return pItem;
-  }
-
-  return CFileItemPtr();
-}
-
-const CFileItemPtr CFileItemList::Get(const std::string& strPath) const
-{
-  std::unique_lock<CCriticalSection> lock(m_lock);
-
-  if (m_fastLookup)
-  {
-    std::map<std::string, CFileItemPtr>::const_iterator it = m_map.find(m_ignoreURLOptions ? CURL(strPath).GetWithoutOptions() : strPath);
+    MAPFILEITEMS::const_iterator it =
+        m_map.find(m_ignoreURLOptions ? CURL(strPath).GetWithoutOptions() : strPath);
     if (it != m_map.end())
       return it->second;
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -655,12 +655,6 @@ typedef std::vector< CFileItemPtr >::iterator IVECFILEITEMS;
 typedef std::map<std::string, CFileItemPtr > MAPFILEITEMS;
 
 /*!
-  \brief Iterator for MAPFILEITEMS
-  \sa MAPFILEITEMS
-  */
-typedef std::map<std::string, CFileItemPtr >::iterator IMAPFILEITEMS;
-
-/*!
   \brief Pair for MAPFILEITEMS
   \sa MAPFILEITEMS
   */
@@ -693,11 +687,9 @@ public:
   void AddFront(const CFileItemPtr &pItem, int itemPosition);
   void Remove(CFileItem* pItem);
   void Remove(int iItem);
-  CFileItemPtr Get(int iItem);
-  const CFileItemPtr Get(int iItem) const;
+  CFileItemPtr Get(int iItem) const;
   const VECFILEITEMS& GetList() const { return m_items; }
-  CFileItemPtr Get(const std::string& strPath);
-  const CFileItemPtr Get(const std::string& strPath) const;
+  CFileItemPtr Get(const std::string& strPath) const;
   int Size() const;
   bool IsEmpty() const;
   void Append(const CFileItemList& itemlist);


### PR DESCRIPTION
no need for member functions
- const CFileItemPtr CFileItemList::Get(int iItem) const;
- const CFileItemPtr CFileItemList::Get(const std::string& strPath) const

## Description
there are already a regular and a const version of operator[] which in turn only call the ::Get() functions.
even if the shared_ptr returned by ::Get() were const the owned resource is still non-const.

## Motivation and context
cleanup / only duplicate code removed here

## How has this been tested?
running on live setup

## What is the effect on users?
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
