### PR TITLE
[utils] Fix URIUtils::HasExtension regression.

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -107,7 +107,7 @@ bool URIUtils::HasExtension(const std::string& strFileName, const std::string& s
 
   for (const auto& ext : extensionsLower)
   {
-    if (ext == extensionLower)
+    if (StringUtils::EndsWith(ext, extensionLower))
       return true;
   }
 


### PR DESCRIPTION
Fixes #21768

`URIUtils::HasExtension` must be able to handle file masks, like `*.zip|`, not only `.zip|`. File mask support got broken by #21761, sorry. This PR restores old functionality.

@CastagnaIT if you want to test, review.