### PR TITLE
[dbwrappers] Optimize string-based field lookup

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -7,17 +7,18 @@
  */
 
 #include "Database.h"
-#include "settings/AdvancedSettings.h"
-#include "filesystem/SpecialProtocol.h"
-#include "profiles/ProfileManager.h"
-#include "settings/SettingsComponent.h"
-#include "utils/log.h"
-#include "utils/SortUtils.h"
-#include "utils/StringUtils.h"
-#include "sqlitedataset.h"
+
 #include "DatabaseManager.h"
 #include "DbUrl.h"
 #include "ServiceBroker.h"
+#include "filesystem/SpecialProtocol.h"
+#include "profiles/ProfileManager.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "sqlitedataset.h"
+#include "utils/SortUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
 
 #if defined(HAS_MYSQL) || defined(HAS_MARIADB)
 #include "mysqldataset.h"
@@ -31,7 +32,7 @@ using namespace dbiplus;
 
 #define MAX_COMPRESS_COUNT 20
 
-void CDatabase::Filter::AppendField(const std::string &strField)
+void CDatabase::Filter::AppendField(const std::string& strField)
 {
   if (strField.empty())
     return;
@@ -42,7 +43,7 @@ void CDatabase::Filter::AppendField(const std::string &strField)
     fields += ", " + strField;
 }
 
-void CDatabase::Filter::AppendJoin(const std::string &strJoin)
+void CDatabase::Filter::AppendJoin(const std::string& strJoin)
 {
   if (strJoin.empty())
     return;
@@ -53,7 +54,7 @@ void CDatabase::Filter::AppendJoin(const std::string &strJoin)
     join += " " + strJoin;
 }
 
-void CDatabase::Filter::AppendWhere(const std::string &strWhere, bool combineWithAnd /* = true */)
+void CDatabase::Filter::AppendWhere(const std::string& strWhere, bool combineWithAnd /* = true */)
 {
   if (strWhere.empty())
     return;
@@ -68,7 +69,7 @@ void CDatabase::Filter::AppendWhere(const std::string &strWhere, bool combineWit
   }
 }
 
-void CDatabase::Filter::AppendOrder(const std::string &strOrder)
+void CDatabase::Filter::AppendOrder(const std::string& strOrder)
 {
   if (strOrder.empty())
     return;
@@ -79,7 +80,7 @@ void CDatabase::Filter::AppendOrder(const std::string &strOrder)
     order += ", " + strOrder;
 }
 
-void CDatabase::Filter::AppendGroup(const std::string &strGroup)
+void CDatabase::Filter::AppendGroup(const std::string& strGroup)
 {
   if (strGroup.empty())
     return;
@@ -90,7 +91,7 @@ void CDatabase::Filter::AppendGroup(const std::string &strGroup)
     group += ", " + strGroup;
 }
 
-void CDatabase::ExistsSubQuery::AppendJoin(const std::string &strJoin)
+void CDatabase::ExistsSubQuery::AppendJoin(const std::string& strJoin)
 {
   if (strJoin.empty())
     return;
@@ -101,7 +102,8 @@ void CDatabase::ExistsSubQuery::AppendJoin(const std::string &strJoin)
     join += " " + strJoin;
 }
 
-void CDatabase::ExistsSubQuery::AppendWhere(const std::string &strWhere, bool combineWithAnd /* = true */)
+void CDatabase::ExistsSubQuery::AppendWhere(const std::string& strWhere,
+                                            bool combineWithAnd /* = true */)
 {
   if (strWhere.empty())
     return;
@@ -115,7 +117,7 @@ void CDatabase::ExistsSubQuery::AppendWhere(const std::string &strWhere, bool co
   }
 }
 
-bool CDatabase::ExistsSubQuery::BuildSQL(std::string & strSQL)
+bool CDatabase::ExistsSubQuery::BuildSQL(std::string& strSQL)
 {
   if (tablename.empty())
     return false;
@@ -143,7 +145,9 @@ CDatabase::DatasetLayout::DatasetLayout(size_t totalfields)
   m_fields.resize(totalfields, DatasetFieldInfo(false, false, -1));
 }
 
-void CDatabase::DatasetLayout::SetField(int fieldNo, const std::string &strField, bool bOutput /*= false*/)
+void CDatabase::DatasetLayout::SetField(int fieldNo,
+                                        const std::string& strField,
+                                        bool bOutput /*= false*/)
 {
   if (fieldNo >= 0 && fieldNo < static_cast<int>(m_fields.size()))
   {
@@ -220,8 +224,8 @@ bool CDatabase::DatasetLayout::HasFilterFields()
   return false;
 }
 
-CDatabase::CDatabase() :
-  m_profileManager(*CServiceBroker::GetSettingsComponent()->GetProfileManager())
+CDatabase::CDatabase()
+  : m_profileManager(*CServiceBroker::GetSettingsComponent()->GetProfileManager())
 {
   m_openCount = 0;
   m_sqlite = true;
@@ -233,7 +237,9 @@ CDatabase::~CDatabase(void)
   Close();
 }
 
-void CDatabase::Split(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName)
+void CDatabase::Split(const std::string& strFileNameAndPath,
+                      std::string& strPath,
+                      std::string& strFileName)
 {
   strFileName = "";
   strPath = "";
@@ -241,8 +247,10 @@ void CDatabase::Split(const std::string& strFileNameAndPath, std::string& strPat
   while (i > 0)
   {
     char ch = strFileNameAndPath[i];
-    if (ch == ':' || ch == '/' || ch == '\\') break;
-    else i--;
+    if (ch == ':' || ch == '/' || ch == '\\')
+      break;
+    else
+      i--;
   }
   strPath = strFileNameAndPath.substr(0, i);
   strFileName = strFileNameAndPath.substr(i);
@@ -263,7 +271,7 @@ std::string CDatabase::PrepareSQL(std::string strStmt, ...) const
   return strResult;
 }
 
-std::string CDatabase::GetSingleValue(const std::string &query, std::unique_ptr<Dataset> &ds)
+std::string CDatabase::GetSingleValue(const std::string& query, std::unique_ptr<Dataset>& ds)
 {
   std::string ret;
   try
@@ -276,14 +284,17 @@ std::string CDatabase::GetSingleValue(const std::string &query, std::unique_ptr<
 
     ds->close();
   }
-  catch(...)
+  catch (...)
   {
     CLog::Log(LOGERROR, "{} - failed on query '{}'", __FUNCTION__, query);
   }
   return ret;
 }
 
-std::string CDatabase::GetSingleValue(const std::string &strTable, const std::string &strColumn, const std::string &strWhereClause /* = std::string() */, const std::string &strOrderBy /* = std::string() */)
+std::string CDatabase::GetSingleValue(const std::string& strTable,
+                                      const std::string& strColumn,
+                                      const std::string& strWhereClause /* = std::string() */,
+                                      const std::string& strOrderBy /* = std::string() */)
 {
   std::string query = PrepareSQL("SELECT %s FROM %s", strColumn.c_str(), strTable.c_str());
   if (!strWhereClause.empty())
@@ -294,7 +305,7 @@ std::string CDatabase::GetSingleValue(const std::string &strTable, const std::st
   return GetSingleValue(query, m_pDS);
 }
 
-std::string CDatabase::GetSingleValue(const std::string &query)
+std::string CDatabase::GetSingleValue(const std::string& query)
 {
   return GetSingleValue(query, m_pDS);
 }
@@ -333,7 +344,7 @@ int CDatabase::GetSingleValueInt(const std::string& query)
   return GetSingleValueInt(query, m_pDS);
 }
 
-bool CDatabase::DeleteValues(const std::string &strTable, const Filter &filter /* = Filter() */)
+bool CDatabase::DeleteValues(const std::string& strTable, const Filter& filter /* = Filter() */)
 {
   std::string strQuery;
   BuildSQL(PrepareSQL("DELETE FROM %s ", strTable.c_str()), filter, strQuery);
@@ -363,7 +374,7 @@ bool CDatabase::CommitMultipleExecute()
   return CommitTransaction();
 }
 
-bool CDatabase::ExecuteQuery(const std::string &strQuery)
+bool CDatabase::ExecuteQuery(const std::string& strQuery)
 {
   if (m_multipleExecute)
   {
@@ -413,7 +424,7 @@ bool CDatabase::ResultQuery(const std::string& strQuery) const
   return bReturn;
 }
 
-bool CDatabase::QueueInsertQuery(const std::string &strQuery)
+bool CDatabase::QueueInsertQuery(const std::string& strQuery)
 {
   if (strQuery.empty())
     return false;
@@ -446,7 +457,7 @@ bool CDatabase::CommitInsertQueries()
       m_pDS2->post();
       m_pDS2->clear_insert_sql();
     }
-    catch(...)
+    catch (...)
     {
       bReturn = false;
       CLog::Log(LOGERROR, "{} - failed to execute queries", __FUNCTION__);
@@ -505,7 +516,7 @@ bool CDatabase::Open()
   return Open(db_fallback);
 }
 
-bool CDatabase::Open(const DatabaseSettings &settings)
+bool CDatabase::Open(const DatabaseSettings& settings)
 {
   if (IsOpen())
   {
@@ -525,7 +536,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   return Connect(dbName, dbSettings, false);
 }
 
-void CDatabase::InitSettings(DatabaseSettings &dbSettings)
+void CDatabase::InitSettings(DatabaseSettings& dbSettings)
 {
   m_sqlite = true;
 
@@ -533,16 +544,18 @@ void CDatabase::InitSettings(DatabaseSettings &dbSettings)
   if (dbSettings.type == "mysql")
   {
     // check we have all information before we cancel the fallback
-    if ( ! (dbSettings.host.empty() ||
-            dbSettings.user.empty() || dbSettings.pass.empty()) )
+    if (!(dbSettings.host.empty() || dbSettings.user.empty() || dbSettings.pass.empty()))
       m_sqlite = false;
     else
-      CLog::Log(LOGINFO, "Essential mysql database information is missing. Require at least host, user and pass defined.");
+      CLog::Log(LOGINFO, "Essential mysql database information is missing. Require at least host, "
+                         "user and pass defined.");
   }
   else
 #else
   if (dbSettings.type == "mysql")
-    CLog::Log(LOGERROR, "MySQL library requested but MySQL support is not compiled in. Falling back to sqlite3.");
+    CLog::Log(
+        LOGERROR,
+        "MySQL library requested but MySQL support is not compiled in. Falling back to sqlite3.");
 #endif
   {
     dbSettings.type = "sqlite3";
@@ -565,17 +578,17 @@ void CDatabase::DropAnalytics()
   m_pDB->drop_analytics();
 }
 
-bool CDatabase::Connect(const std::string &dbName, const DatabaseSettings &dbSettings, bool create)
+bool CDatabase::Connect(const std::string& dbName, const DatabaseSettings& dbSettings, bool create)
 {
   // create the appropriate database structure
   if (dbSettings.type == "sqlite3")
   {
-    m_pDB.reset( new SqliteDatabase() ) ;
+    m_pDB.reset(new SqliteDatabase());
   }
 #if defined(HAS_MYSQL) || defined(HAS_MARIADB)
   else if (dbSettings.type == "mysql")
   {
-    m_pDB.reset( new MysqlDatabase() ) ;
+    m_pDB.reset(new MysqlDatabase());
   }
 #endif
   else
@@ -600,12 +613,8 @@ bool CDatabase::Connect(const std::string &dbName, const DatabaseSettings &dbSet
   m_pDB->setDatabase(dbName.c_str());
 
   // set configuration regardless if any are empty
-  m_pDB->setConfig(dbSettings.key.c_str(),
-                   dbSettings.cert.c_str(),
-                   dbSettings.ca.c_str(),
-                   dbSettings.capath.c_str(),
-                   dbSettings.ciphers.c_str(),
-                   dbSettings.compression);
+  m_pDB->setConfig(dbSettings.key.c_str(), dbSettings.cert.c_str(), dbSettings.ca.c_str(),
+                   dbSettings.capath.c_str(), dbSettings.ciphers.c_str(), dbSettings.compression);
 
   // create the datasets
   m_pDS.reset(m_pDB->CreateDataset());
@@ -642,7 +651,7 @@ bool CDatabase::Connect(const std::string &dbName, const DatabaseSettings &dbSet
       m_pDS->exec("PRAGMA count_changes='OFF'\n");
     }
   }
-  catch (DbErrors &error)
+  catch (DbErrors& error)
   {
     CLog::Log(LOGERROR, "{} failed with '{}'", __FUNCTION__, error.getMsg());
     m_openCount = 1; // set to open so we can execute Close()
@@ -711,7 +720,7 @@ bool CDatabase::Compress(bool bForce /* =true */)
         if (iCount > MAX_COMPRESS_COUNT)
           iCount = -1;
         m_pDS->close();
-        std::string strSQL=PrepareSQL("update version set iCompressCount=%i\n",++iCount);
+        std::string strSQL = PrepareSQL("update version set iCompressCount=%i\n", ++iCount);
         m_pDS->exec(strSQL);
         if (iCount != 0)
           return true;
@@ -782,7 +791,8 @@ bool CDatabase::CreateDatabase()
   {
     CLog::Log(LOGINFO, "creating version table");
     m_pDS->exec("CREATE TABLE version (idVersion integer, iCompressCount integer)\n");
-    std::string strSQL=PrepareSQL("INSERT INTO version (idVersion,iCompressCount) values(%i,0)\n", GetSchemaVersion());
+    std::string strSQL = PrepareSQL("INSERT INTO version (idVersion,iCompressCount) values(%i,0)\n",
+                                    GetSchemaVersion());
     m_pDS->exec(strSQL);
 
     CreateTables();
@@ -800,11 +810,11 @@ bool CDatabase::CreateDatabase()
 
 void CDatabase::UpdateVersionNumber()
 {
-  std::string strSQL=PrepareSQL("UPDATE version SET idVersion=%i\n", GetSchemaVersion());
+  std::string strSQL = PrepareSQL("UPDATE version SET idVersion=%i\n", GetSchemaVersion());
   m_pDS->exec(strSQL);
 }
 
-bool CDatabase::BuildSQL(const std::string &strQuery, const Filter &filter, std::string &strSQL)
+bool CDatabase::BuildSQL(const std::string& strQuery, const Filter& filter, std::string& strSQL)
 {
   strSQL = strQuery;
 
@@ -822,13 +832,22 @@ bool CDatabase::BuildSQL(const std::string &strQuery, const Filter &filter, std:
   return true;
 }
 
-bool CDatabase::BuildSQL(const std::string &strBaseDir, const std::string &strQuery, Filter &filter, std::string &strSQL, CDbUrl &dbUrl)
+bool CDatabase::BuildSQL(const std::string& strBaseDir,
+                         const std::string& strQuery,
+                         Filter& filter,
+                         std::string& strSQL,
+                         CDbUrl& dbUrl)
 {
   SortDescription sorting;
   return BuildSQL(strBaseDir, strQuery, filter, strSQL, dbUrl, sorting);
 }
 
-bool CDatabase::BuildSQL(const std::string &strBaseDir, const std::string &strQuery, Filter &filter, std::string &strSQL, CDbUrl &dbUrl, SortDescription &sorting /* = SortDescription() */)
+bool CDatabase::BuildSQL(const std::string& strBaseDir,
+                         const std::string& strQuery,
+                         Filter& filter,
+                         std::string& strSQL,
+                         CDbUrl& dbUrl,
+                         SortDescription& sorting /* = SortDescription() */)
 {
   // parse the base path to get additional filters
   dbUrl.Reset();

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
-namespace dbiplus {
-  class Database;
-  class Dataset;
-}
+namespace dbiplus
+{
+class Database;
+class Dataset;
+} // namespace dbiplus
 
 #include <memory>
 #include <string>
@@ -32,11 +33,11 @@ public:
     explicit Filter(const char* w) : fields("*"), where(w) {}
     explicit Filter(const std::string& w) : fields("*"), where(w) {}
 
-    void AppendField(const std::string &strField);
-    void AppendJoin(const std::string &strJoin);
-    void AppendWhere(const std::string &strWhere, bool combineWithAnd = true);
-    void AppendOrder(const std::string &strOrder);
-    void AppendGroup(const std::string &strGroup);
+    void AppendField(const std::string& strField);
+    void AppendJoin(const std::string& strJoin);
+    void AppendWhere(const std::string& strWhere, bool combineWithAnd = true);
+    void AppendOrder(const std::string& strOrder);
+    void AppendGroup(const std::string& strGroup);
 
     std::string fields;
     std::string join;
@@ -49,10 +50,9 @@ public:
   struct DatasetFieldInfo
   {
     DatasetFieldInfo(bool fetch, bool output, int recno)
-      : fetch(fetch),
-      output(output),
-      recno(recno)
-    { }
+      : fetch(fetch), output(output), recno(recno)
+    {
+    }
 
     bool fetch;
     bool output;
@@ -64,7 +64,7 @@ public:
   {
   public:
     DatasetLayout(size_t totalfields);
-    void SetField(int fieldNo, const std::string &strField, bool bOutput = false);
+    void SetField(int fieldNo, const std::string& strField, bool bOutput = false);
     void AdjustRecordNumbers(int offset);
     bool GetFetch(int fieldno);
     void SetFetch(int fieldno, bool bFetch = true);
@@ -85,9 +85,9 @@ public:
       : tablename(table), param(parameter)
     {
     }
-    void AppendJoin(const std::string &strJoin);
-    void AppendWhere(const std::string &strWhere, bool combineWithAnd = true);
-    bool BuildSQL(std::string &strSQL);
+    void AppendJoin(const std::string& strJoin);
+    void AppendWhere(const std::string& strWhere, bool combineWithAnd = true);
+    bool BuildSQL(std::string& strSQL);
 
     std::string tablename;
     std::string param;
@@ -95,15 +95,14 @@ public:
     std::string where;
   };
 
-
   CDatabase();
   virtual ~CDatabase(void);
   bool IsOpen();
   virtual void Close();
-  bool Compress(bool bForce=true);
+  bool Compress(bool bForce = true);
   void Interrupt();
 
-  bool Open(const DatabaseSettings &db);
+  bool Open(const DatabaseSettings& db);
 
   void BeginTransaction();
   virtual bool CommitTransaction();
@@ -122,15 +121,18 @@ public:
    * @param strOrderBy If set, use this ORDER BY clause.
    * @return The requested value or an empty string if it wasn't found.
    */
-  std::string GetSingleValue(const std::string &strTable, const std::string &strColumn, const std::string &strWhereClause = std::string(), const std::string &strOrderBy = std::string());
-  std::string GetSingleValue(const std::string &query);
+  std::string GetSingleValue(const std::string& strTable,
+                             const std::string& strColumn,
+                             const std::string& strWhereClause = std::string(),
+                             const std::string& strOrderBy = std::string());
+  std::string GetSingleValue(const std::string& query);
 
   /*! \brief Get a single value from a query on a dataset.
    \param query the query in question.
    \param ds the dataset to use for the query.
    \return the value from the query, empty on failure.
    */
-  std::string GetSingleValue(const std::string &query, std::unique_ptr<dbiplus::Dataset> &ds);
+  std::string GetSingleValue(const std::string& query, std::unique_ptr<dbiplus::Dataset>& ds);
 
   /*!
  * @brief Get a single integer value from a table.
@@ -160,7 +162,7 @@ public:
    * @param filter The Filter to apply to this query.
    * @return True if the query was executed successfully, false otherwise.
    */
-  bool DeleteValues(const std::string &strTable, const Filter &filter = Filter());
+  bool DeleteValues(const std::string& strTable, const Filter& filter = Filter());
 
   /*!
    * @brief Execute a query that does not return any result.
@@ -170,7 +172,7 @@ public:
    * @return True if the query was executed successfully, false otherwise.
    * @sa BeginMultipleExecute, CommitMultipleExecute
    */
-  bool ExecuteQuery(const std::string &strQuery);
+  bool ExecuteQuery(const std::string& strQuery);
 
   /*!
    * @brief Execute a query that returns a result.
@@ -205,7 +207,7 @@ public:
    * @param strQuery The query to queue.
    * @return True if the query was added successfully, false otherwise.
    */
-  bool QueueInsertQuery(const std::string &strQuery);
+  bool QueueInsertQuery(const std::string& strQuery);
 
   /*!
    * @brief Commit all queries in the queue.
@@ -238,11 +240,20 @@ public:
    */
   size_t GetDeleteQueriesCount();
 
-  virtual bool GetFilter(CDbUrl &dbUrl, Filter &filter, SortDescription &sorting) { return true; }
-  virtual bool BuildSQL(const std::string &strBaseDir, const std::string &strQuery, Filter &filter, std::string &strSQL, CDbUrl &dbUrl);
-  virtual bool BuildSQL(const std::string &strBaseDir, const std::string &strQuery, Filter &filter, std::string &strSQL, CDbUrl &dbUrl, SortDescription &sorting);
+  virtual bool GetFilter(CDbUrl& dbUrl, Filter& filter, SortDescription& sorting) { return true; }
+  virtual bool BuildSQL(const std::string& strBaseDir,
+                        const std::string& strQuery,
+                        Filter& filter,
+                        std::string& strSQL,
+                        CDbUrl& dbUrl);
+  virtual bool BuildSQL(const std::string& strBaseDir,
+                        const std::string& strQuery,
+                        Filter& filter,
+                        std::string& strSQL,
+                        CDbUrl& dbUrl,
+                        SortDescription& sorting);
 
-  bool Connect(const std::string &dbName, const DatabaseSettings &db, bool create);
+  bool Connect(const std::string& dbName, const DatabaseSettings& db, bool create);
 
 protected:
   friend class CDatabaseManager;
@@ -259,12 +270,12 @@ protected:
   /* \brief Create tables for the current database schema.
    Will be called on database creation.
    */
-  virtual void CreateTables()=0;
+  virtual void CreateTables() = 0;
 
   /* \brief Create views, indices and triggers for the current database schema.
    Will be called on database creation and database update.
    */
-  virtual void CreateAnalytics()=0;
+  virtual void CreateAnalytics() = 0;
 
   /* \brief Update database tables to the current version.
    Note that analytics (views, indices, triggers) are not present during this
@@ -278,12 +289,12 @@ protected:
 
   /* \brief The current schema version.
    */
-  virtual int GetSchemaVersion() const=0;
-  virtual const char *GetBaseDBName() const=0;
+  virtual int GetSchemaVersion() const = 0;
+  virtual const char* GetBaseDBName() const = 0;
 
   int GetDBVersion();
 
-  bool BuildSQL(const std::string &strQuery, const Filter &filter, std::string &strSQL);
+  bool BuildSQL(const std::string& strQuery, const Filter& filter, std::string& strSQL);
 
   bool m_sqlite; ///< \brief whether we use sqlite (defaults to true)
 
@@ -293,10 +304,10 @@ protected:
 
 protected:
   // Construction parameters
-  const CProfileManager &m_profileManager;
+  const CProfileManager& m_profileManager;
 
 private:
-  void InitSettings(DatabaseSettings &dbSettings);
+  void InitSettings(DatabaseSettings& dbSettings);
   void UpdateVersionNumber();
 
   bool m_bMultiInsert =

--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -24,22 +24,21 @@ typedef struct
 } operatorField;
 
 static const operatorField operators[] = {
-  { "contains",        CDatabaseQueryRule::OPERATOR_CONTAINS,          21400 },
-  { "doesnotcontain",  CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN,  21401 },
-  { "is",              CDatabaseQueryRule::OPERATOR_EQUALS,            21402 },
-  { "isnot",           CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL,    21403 },
-  { "startswith",      CDatabaseQueryRule::OPERATOR_STARTS_WITH,       21404 },
-  { "endswith",        CDatabaseQueryRule::OPERATOR_ENDS_WITH,         21405 },
-  { "greaterthan",     CDatabaseQueryRule::OPERATOR_GREATER_THAN,      21406 },
-  { "lessthan",        CDatabaseQueryRule::OPERATOR_LESS_THAN,         21407 },
-  { "after",           CDatabaseQueryRule::OPERATOR_AFTER,             21408 },
-  { "before",          CDatabaseQueryRule::OPERATOR_BEFORE,            21409 },
-  { "inthelast",       CDatabaseQueryRule::OPERATOR_IN_THE_LAST,       21410 },
-  { "notinthelast",    CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST,   21411 },
-  { "true",            CDatabaseQueryRule::OPERATOR_TRUE,              20122 },
-  { "false",           CDatabaseQueryRule::OPERATOR_FALSE,             20424 },
-  { "between",         CDatabaseQueryRule::OPERATOR_BETWEEN,           21456 }
-};
+    {"contains", CDatabaseQueryRule::OPERATOR_CONTAINS, 21400},
+    {"doesnotcontain", CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN, 21401},
+    {"is", CDatabaseQueryRule::OPERATOR_EQUALS, 21402},
+    {"isnot", CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL, 21403},
+    {"startswith", CDatabaseQueryRule::OPERATOR_STARTS_WITH, 21404},
+    {"endswith", CDatabaseQueryRule::OPERATOR_ENDS_WITH, 21405},
+    {"greaterthan", CDatabaseQueryRule::OPERATOR_GREATER_THAN, 21406},
+    {"lessthan", CDatabaseQueryRule::OPERATOR_LESS_THAN, 21407},
+    {"after", CDatabaseQueryRule::OPERATOR_AFTER, 21408},
+    {"before", CDatabaseQueryRule::OPERATOR_BEFORE, 21409},
+    {"inthelast", CDatabaseQueryRule::OPERATOR_IN_THE_LAST, 21410},
+    {"notinthelast", CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST, 21411},
+    {"true", CDatabaseQueryRule::OPERATOR_TRUE, 20122},
+    {"false", CDatabaseQueryRule::OPERATOR_FALSE, 20424},
+    {"between", CDatabaseQueryRule::OPERATOR_BETWEEN, 21456}};
 
 CDatabaseQueryRule::CDatabaseQueryRule()
 {
@@ -47,12 +46,12 @@ CDatabaseQueryRule::CDatabaseQueryRule()
   m_operator = OPERATOR_CONTAINS;
 }
 
-bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding /* = "UTF-8" */)
+bool CDatabaseQueryRule::Load(const TiXmlNode* node, const std::string& encoding /* = "UTF-8" */)
 {
   if (node == NULL)
     return false;
 
-  const TiXmlElement *element = node->ToElement();
+  const TiXmlElement* element = node->ToElement();
   if (element == NULL)
     return false;
 
@@ -60,8 +59,8 @@ bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding
   // <rule field="Genre" operator="contains">parameter</rule>
   // where parameter can either be a string or a list of
   // <value> tags containing a string
-  const char *field = element->Attribute("field");
-  const char *oper = element->Attribute("operator");
+  const char* field = element->Attribute("field");
+  const char* oper = element->Attribute("operator");
   if (field == NULL || oper == NULL)
     return false;
 
@@ -71,7 +70,7 @@ bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding
   if (m_operator == OPERATOR_TRUE || m_operator == OPERATOR_FALSE)
     return true;
 
-  const TiXmlNode *parameter = element->FirstChild();
+  const TiXmlNode* parameter = element->FirstChild();
   if (parameter == NULL)
     return false;
 
@@ -88,10 +87,10 @@ bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding
   }
   else if (parameter->Type() == TiXmlNode::TINYXML_ELEMENT)
   {
-    const TiXmlNode *valueNode = element->FirstChild("value");
+    const TiXmlNode* valueNode = element->FirstChild("value");
     while (valueNode != NULL)
     {
-      const TiXmlNode *value = valueNode->FirstChild();
+      const TiXmlNode* value = valueNode->FirstChild();
       if (value != NULL && value->Type() == TiXmlNode::TINYXML_TEXT)
       {
         std::string utf8Parameter;
@@ -113,10 +112,10 @@ bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding
   return true;
 }
 
-bool CDatabaseQueryRule::Load(const CVariant &obj)
+bool CDatabaseQueryRule::Load(const CVariant& obj)
 {
-  if (!obj.isMember("field") || !obj["field"].isString() ||
-      !obj.isMember("operator") || !obj["operator"].isString())
+  if (!obj.isMember("field") || !obj["field"].isString() || !obj.isMember("operator") ||
+      !obj["operator"].isString())
     return false;
 
   m_field = TranslateField(obj["field"].asString().c_str());
@@ -128,7 +127,7 @@ bool CDatabaseQueryRule::Load(const CVariant &obj)
   if (!obj.isMember("value") || (!obj["value"].isString() && !obj["value"].isArray()))
     return false;
 
-  const CVariant &value = obj["value"];
+  const CVariant& value = obj["value"];
   if (value.isString())
     m_parameter.push_back(value.asString());
   else if (value.isArray())
@@ -147,9 +146,10 @@ bool CDatabaseQueryRule::Load(const CVariant &obj)
   return true;
 }
 
-bool CDatabaseQueryRule::Save(TiXmlNode *parent) const
+bool CDatabaseQueryRule::Save(TiXmlNode* parent) const
 {
-  if (parent == NULL || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
+  if (parent == NULL ||
+      (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
     return false;
 
   TiXmlElement rule("rule");
@@ -169,9 +169,10 @@ bool CDatabaseQueryRule::Save(TiXmlNode *parent) const
   return true;
 }
 
-bool CDatabaseQueryRule::Save(CVariant &obj) const
+bool CDatabaseQueryRule::Save(CVariant& obj) const
 {
-  if (obj.isNull() || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
+  if (obj.isNull() ||
+      (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
     return false;
 
   obj["field"] = TranslateField(m_field);
@@ -181,28 +182,31 @@ bool CDatabaseQueryRule::Save(CVariant &obj) const
   return true;
 }
 
-CDatabaseQueryRule::SEARCH_OPERATOR CDatabaseQueryRule::TranslateOperator(const char *oper)
+CDatabaseQueryRule::SEARCH_OPERATOR CDatabaseQueryRule::TranslateOperator(const char* oper)
 {
   for (const operatorField& o : operators)
-    if (StringUtils::EqualsNoCase(oper, o.string)) return o.op;
+    if (StringUtils::EqualsNoCase(oper, o.string))
+      return o.op;
   return OPERATOR_CONTAINS;
 }
 
 std::string CDatabaseQueryRule::TranslateOperator(SEARCH_OPERATOR oper)
 {
   for (const operatorField& o : operators)
-    if (oper == o.op) return o.string;
+    if (oper == o.op)
+      return o.string;
   return "contains";
 }
 
 std::string CDatabaseQueryRule::GetLocalizedOperator(SEARCH_OPERATOR oper)
 {
   for (const operatorField& o : operators)
-    if (oper == o.op) return g_localizeStrings.Get(o.localizedString);
+    if (oper == o.op)
+      return g_localizeStrings.Get(o.localizedString);
   return g_localizeStrings.Get(16018);
 }
 
-void CDatabaseQueryRule::GetAvailableOperators(std::vector<std::string> &operatorList)
+void CDatabaseQueryRule::GetAvailableOperators(std::vector<std::string>& operatorList)
 {
   for (const operatorField& o : operators)
     operatorList.emplace_back(o.string);
@@ -213,25 +217,29 @@ std::string CDatabaseQueryRule::GetParameter() const
   return StringUtils::Join(m_parameter, DATABASEQUERY_RULE_VALUE_SEPARATOR);
 }
 
-void CDatabaseQueryRule::SetParameter(const std::string &value)
+void CDatabaseQueryRule::SetParameter(const std::string& value)
 {
   m_parameter = StringUtils::Split(value, DATABASEQUERY_RULE_VALUE_SEPARATOR);
 }
 
-void CDatabaseQueryRule::SetParameter(const std::vector<std::string> &values)
+void CDatabaseQueryRule::SetParameter(const std::vector<std::string>& values)
 {
   m_parameter.assign(values.begin(), values.end());
 }
 
-std::string CDatabaseQueryRule::ValidateParameter(const std::string &parameter) const
+std::string CDatabaseQueryRule::ValidateParameter(const std::string& parameter) const
 {
   if ((GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD ||
-       GetFieldType(m_field) == SECONDS_FIELD) && parameter.empty())
+       GetFieldType(m_field) == SECONDS_FIELD) &&
+      parameter.empty())
     return "0"; // interpret empty fields as 0
   return parameter;
 }
 
-std::string CDatabaseQueryRule::FormatParameter(const std::string &operatorString, const std::string &param, const CDatabase &db, const std::string &strType) const
+std::string CDatabaseQueryRule::FormatParameter(const std::string& operatorString,
+                                                const std::string& param,
+                                                const CDatabase& db,
+                                                const std::string& strType) const
 {
   std::string parameter;
   if (GetFieldType(m_field) == TEXTIN_FIELD)
@@ -252,10 +260,10 @@ std::string CDatabaseQueryRule::FormatParameter(const std::string &operatorStrin
   {
     if (m_operator == OPERATOR_IN_THE_LAST || m_operator == OPERATOR_NOT_IN_THE_LAST)
     { // translate time period
-      CDateTime date=CDateTime::GetCurrentDateTime();
+      CDateTime date = CDateTime::GetCurrentDateTime();
       CDateTimeSpan span;
       span.SetFromPeriod(param);
-      date-=span;
+      date -= span;
       parameter = db.PrepareSQL(operatorString, date.GetAsDBDate().c_str());
     }
   }
@@ -270,64 +278,75 @@ std::string CDatabaseQueryRule::GetOperatorString(SEARCH_OPERATOR op) const
     // the comparison piece
     switch (op)
     {
-    case OPERATOR_CONTAINS:
-      operatorString = " LIKE '%%%s%%'"; break;
-    case OPERATOR_DOES_NOT_CONTAIN:
-      operatorString = " LIKE '%%%s%%'"; break;
-    case OPERATOR_EQUALS:
-      if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString = " = %s";
-      else
-        operatorString = " LIKE '%s'";
-      break;
-    case OPERATOR_DOES_NOT_EQUAL:
-      if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString = " != %s";
-      else
-        operatorString = " LIKE '%s'";
-      break;
-    case OPERATOR_STARTS_WITH:
-      operatorString = " LIKE '%s%%'"; break;
-    case OPERATOR_ENDS_WITH:
-      operatorString = " LIKE '%%%s'"; break;
-    case OPERATOR_AFTER:
-    case OPERATOR_GREATER_THAN:
-    case OPERATOR_IN_THE_LAST:
-      operatorString = " > ";
-      if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString += "%s";
-      else
-        operatorString += "'%s'";
-      break;
-    case OPERATOR_BEFORE:
-    case OPERATOR_LESS_THAN:
-    case OPERATOR_NOT_IN_THE_LAST:
-      operatorString = " < ";
-      if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString += "%s";
-      else
-        operatorString += "'%s'";
-      break;
-    case OPERATOR_TRUE:
-      operatorString = " = 1"; break;
-    case OPERATOR_FALSE:
-      operatorString = " = 0"; break;
-    default:
-      break;
+      case OPERATOR_CONTAINS:
+        operatorString = " LIKE '%%%s%%'";
+        break;
+      case OPERATOR_DOES_NOT_CONTAIN:
+        operatorString = " LIKE '%%%s%%'";
+        break;
+      case OPERATOR_EQUALS:
+        if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD ||
+            GetFieldType(m_field) == SECONDS_FIELD)
+          operatorString = " = %s";
+        else
+          operatorString = " LIKE '%s'";
+        break;
+      case OPERATOR_DOES_NOT_EQUAL:
+        if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD ||
+            GetFieldType(m_field) == SECONDS_FIELD)
+          operatorString = " != %s";
+        else
+          operatorString = " LIKE '%s'";
+        break;
+      case OPERATOR_STARTS_WITH:
+        operatorString = " LIKE '%s%%'";
+        break;
+      case OPERATOR_ENDS_WITH:
+        operatorString = " LIKE '%%%s'";
+        break;
+      case OPERATOR_AFTER:
+      case OPERATOR_GREATER_THAN:
+      case OPERATOR_IN_THE_LAST:
+        operatorString = " > ";
+        if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD ||
+            GetFieldType(m_field) == SECONDS_FIELD)
+          operatorString += "%s";
+        else
+          operatorString += "'%s'";
+        break;
+      case OPERATOR_BEFORE:
+      case OPERATOR_LESS_THAN:
+      case OPERATOR_NOT_IN_THE_LAST:
+        operatorString = " < ";
+        if (GetFieldType(m_field) == REAL_FIELD || GetFieldType(m_field) == NUMERIC_FIELD ||
+            GetFieldType(m_field) == SECONDS_FIELD)
+          operatorString += "%s";
+        else
+          operatorString += "'%s'";
+        break;
+      case OPERATOR_TRUE:
+        operatorString = " = 1";
+        break;
+      case OPERATOR_FALSE:
+        operatorString = " = 0";
+        break;
+      default:
+        break;
     }
   }
   return operatorString;
 }
 
-std::string CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const std::string& strType) const
+std::string CDatabaseQueryRule::GetWhereClause(const CDatabase& db,
+                                               const std::string& strType) const
 {
   SEARCH_OPERATOR op = GetOperator(strType);
 
   std::string operatorString = GetOperatorString(op);
   std::string negate;
   if (op == OPERATOR_DOES_NOT_CONTAIN || op == OPERATOR_FALSE ||
-     (op == OPERATOR_DOES_NOT_EQUAL && GetFieldType(m_field) != REAL_FIELD && GetFieldType(m_field) != NUMERIC_FIELD &&
-      GetFieldType(m_field) != SECONDS_FIELD))
+      (op == OPERATOR_DOES_NOT_EQUAL && GetFieldType(m_field) != REAL_FIELD &&
+       GetFieldType(m_field) != NUMERIC_FIELD && GetFieldType(m_field) != SECONDS_FIELD))
     negate = " NOT ";
 
   // boolean operators don't have any values in m_parameter, they work on the operator
@@ -358,18 +377,25 @@ std::string CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const std::s
 
     FIELD_TYPE fieldType = GetFieldType(m_field);
     if (fieldType == REAL_FIELD)
-      return db.PrepareSQL("%s BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
+      return db.PrepareSQL("%s BETWEEN %s AND %s", GetField(m_field, strType).c_str(),
+                           m_parameter[0].c_str(), m_parameter[1].c_str());
     else if (fieldType == NUMERIC_FIELD)
-      return db.PrepareSQL("CAST(%s as DECIMAL(5,1)) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
+      return db.PrepareSQL("CAST(%s as DECIMAL(5,1)) BETWEEN %s AND %s",
+                           GetField(m_field, strType).c_str(), m_parameter[0].c_str(),
+                           m_parameter[1].c_str());
     else if (fieldType == SECONDS_FIELD)
-      return db.PrepareSQL("CAST(%s as INTEGER) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
+      return db.PrepareSQL("CAST(%s as INTEGER) BETWEEN %s AND %s",
+                           GetField(m_field, strType).c_str(), m_parameter[0].c_str(),
+                           m_parameter[1].c_str());
     else
-      return db.PrepareSQL("%s BETWEEN '%s' AND '%s'", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
+      return db.PrepareSQL("%s BETWEEN '%s' AND '%s'", GetField(m_field, strType).c_str(),
+                           m_parameter[0].c_str(), m_parameter[1].c_str());
   }
 
   // now the query parameter
   std::string wholeQuery;
-  for (std::vector<std::string>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); ++it)
+  for (std::vector<std::string>::const_iterator it = m_parameter.begin(); it != m_parameter.end();
+       ++it)
   {
     std::string query = '(' + FormatWhereClause(negate, operatorString, *it, db, strType) + ')';
 
@@ -387,8 +413,11 @@ std::string CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const std::s
   return wholeQuery;
 }
 
-std::string CDatabaseQueryRule::FormatWhereClause(const std::string &negate, const std::string &oper, const std::string &param,
-                                                 const CDatabase &db, const std::string &strType) const
+std::string CDatabaseQueryRule::FormatWhereClause(const std::string& negate,
+                                                  const std::string& oper,
+                                                  const std::string& param,
+                                                  const CDatabase& db,
+                                                  const std::string& strType) const
 {
   std::string parameter = FormatParameter(oper, param, db, strType);
 
@@ -405,9 +434,8 @@ std::string CDatabaseQueryRule::FormatWhereClause(const std::string &negate, con
     query += negate + parameter;
 
     // special case for matching parameters in fields that might be either empty or NULL.
-    if ((  param.empty() &&  negate.empty() ) ||
-        ( !param.empty() && !negate.empty() ))
-      query += " OR " + GetField(m_field,strType) + " IS NULL";
+    if ((param.empty() && negate.empty()) || (!param.empty() && !negate.empty()))
+      query += " OR " + GetField(m_field, strType) + " IS NULL";
   }
 
   if (query == negate + parameter)
@@ -422,12 +450,14 @@ void CDatabaseQueryRuleCombination::clear()
   m_type = CombinationAnd;
 }
 
-std::string CDatabaseQueryRuleCombination::GetWhereClause(const CDatabase &db, const std::string& strType) const
+std::string CDatabaseQueryRuleCombination::GetWhereClause(const CDatabase& db,
+                                                          const std::string& strType) const
 {
   std::string rule;
 
   // translate the combinations into SQL
-  for (CDatabaseQueryRuleCombinations::const_iterator it = m_combinations.begin(); it != m_combinations.end(); ++it)
+  for (CDatabaseQueryRuleCombinations::const_iterator it = m_combinations.begin();
+       it != m_combinations.end(); ++it)
   {
     if (it != m_combinations.begin())
       rule += m_type == CombinationAnd ? " AND " : " OR ";
@@ -451,7 +481,8 @@ std::string CDatabaseQueryRuleCombination::GetWhereClause(const CDatabase &db, c
   return rule;
 }
 
-bool CDatabaseQueryRuleCombination::Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory)
+bool CDatabaseQueryRuleCombination::Load(const CVariant& obj,
+                                         const IDatabaseQueryRuleFactory* factory)
 {
   if (!obj.isObject() && !obj.isArray())
     return false;
@@ -497,14 +528,14 @@ bool CDatabaseQueryRuleCombination::Load(const CVariant &obj, const IDatabaseQue
   return true;
 }
 
-bool CDatabaseQueryRuleCombination::Save(TiXmlNode *parent) const
+bool CDatabaseQueryRuleCombination::Save(TiXmlNode* parent) const
 {
   for (const auto& it : m_rules)
     it->Save(parent);
   return true;
 }
 
-bool CDatabaseQueryRuleCombination::Save(CVariant &obj) const
+bool CDatabaseQueryRuleCombination::Save(CVariant& obj) const
 {
   if (!obj.isObject() || (m_combinations.empty() && m_rules.empty()))
     return false;
@@ -518,7 +549,6 @@ bool CDatabaseQueryRuleCombination::Save(CVariant &obj) const
       if (combo->Save(comboObj))
         comboArray.push_back(comboObj);
     }
-
   }
   if (!m_rules.empty())
   {

--- a/xbmc/dbwrappers/DatabaseQuery.h
+++ b/xbmc/dbwrappers/DatabaseQuery.h
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#define DATABASEQUERY_RULE_VALUE_SEPARATOR  " / "
+#define DATABASEQUERY_RULE_VALUE_SEPARATOR " / "
 
 class CDatabase;
 class CVariant;
@@ -25,81 +25,94 @@ public:
   CDatabaseQueryRule();
   virtual ~CDatabaseQueryRule() = default;
 
-  enum SEARCH_OPERATOR { OPERATOR_START = 0,
-                         OPERATOR_CONTAINS,
-                         OPERATOR_DOES_NOT_CONTAIN,
-                         OPERATOR_EQUALS,
-                         OPERATOR_DOES_NOT_EQUAL,
-                         OPERATOR_STARTS_WITH,
-                         OPERATOR_ENDS_WITH,
-                         OPERATOR_GREATER_THAN,
-                         OPERATOR_LESS_THAN,
-                         OPERATOR_AFTER,
-                         OPERATOR_BEFORE,
-                         OPERATOR_IN_THE_LAST,
-                         OPERATOR_NOT_IN_THE_LAST,
-                         OPERATOR_TRUE,
-                         OPERATOR_FALSE,
-                         OPERATOR_BETWEEN,
-                         OPERATOR_END
-                       };
+  enum SEARCH_OPERATOR
+  {
+    OPERATOR_START = 0,
+    OPERATOR_CONTAINS,
+    OPERATOR_DOES_NOT_CONTAIN,
+    OPERATOR_EQUALS,
+    OPERATOR_DOES_NOT_EQUAL,
+    OPERATOR_STARTS_WITH,
+    OPERATOR_ENDS_WITH,
+    OPERATOR_GREATER_THAN,
+    OPERATOR_LESS_THAN,
+    OPERATOR_AFTER,
+    OPERATOR_BEFORE,
+    OPERATOR_IN_THE_LAST,
+    OPERATOR_NOT_IN_THE_LAST,
+    OPERATOR_TRUE,
+    OPERATOR_FALSE,
+    OPERATOR_BETWEEN,
+    OPERATOR_END
+  };
 
-  enum FIELD_TYPE { TEXT_FIELD = 0,
-                    REAL_FIELD,
-                    NUMERIC_FIELD,
-                    DATE_FIELD,
-                    PLAYLIST_FIELD,
-                    SECONDS_FIELD,
-                    BOOLEAN_FIELD,
-                    TEXTIN_FIELD
-                  };
+  enum FIELD_TYPE
+  {
+    TEXT_FIELD = 0,
+    REAL_FIELD,
+    NUMERIC_FIELD,
+    DATE_FIELD,
+    PLAYLIST_FIELD,
+    SECONDS_FIELD,
+    BOOLEAN_FIELD,
+    TEXTIN_FIELD
+  };
 
-  virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8");
-  virtual bool Load(const CVariant &obj);
-  virtual bool Save(TiXmlNode *parent) const;
-  virtual bool Save(CVariant &obj) const;
+  virtual bool Load(const TiXmlNode* node, const std::string& encoding = "UTF-8");
+  virtual bool Load(const CVariant& obj);
+  virtual bool Save(TiXmlNode* parent) const;
+  virtual bool Save(CVariant& obj) const;
 
-  static std::string          GetLocalizedOperator(SEARCH_OPERATOR oper);
-  static void                 GetAvailableOperators(std::vector<std::string> &operatorList);
+  static std::string GetLocalizedOperator(SEARCH_OPERATOR oper);
+  static void GetAvailableOperators(std::vector<std::string>& operatorList);
 
-  std::string                 GetParameter() const;
-  void                        SetParameter(const std::string &value);
-  void                        SetParameter(const std::vector<std::string> &values);
+  std::string GetParameter() const;
+  void SetParameter(const std::string& value);
+  void SetParameter(const std::vector<std::string>& values);
 
-  virtual std::string         GetWhereClause(const CDatabase &db, const std::string& strType) const;
+  virtual std::string GetWhereClause(const CDatabase& db, const std::string& strType) const;
 
-  int                         m_field;
-  SEARCH_OPERATOR             m_operator;
-  std::vector<std::string>    m_parameter;
+  int m_field;
+  SEARCH_OPERATOR m_operator;
+  std::vector<std::string> m_parameter;
 
 protected:
-  virtual std::string         GetField(int field, const std::string& type) const=0;
-  virtual FIELD_TYPE          GetFieldType(int field) const=0;
-  virtual int                 TranslateField(const char *field) const=0;
-  virtual std::string         TranslateField(int field) const=0;
-  std::string                 ValidateParameter(const std::string &parameter) const;
-  virtual std::string         FormatParameter(const std::string &negate, const std::string &oper, const CDatabase &db, const std::string &type) const;
-  virtual std::string         FormatWhereClause(const std::string &negate, const std::string &oper, const std::string &param,
-                                                const CDatabase &db, const std::string &type) const;
+  virtual std::string GetField(int field, const std::string& type) const = 0;
+  virtual FIELD_TYPE GetFieldType(int field) const = 0;
+  virtual int TranslateField(const char* field) const = 0;
+  virtual std::string TranslateField(int field) const = 0;
+  std::string ValidateParameter(const std::string& parameter) const;
+  virtual std::string FormatParameter(const std::string& negate,
+                                      const std::string& oper,
+                                      const CDatabase& db,
+                                      const std::string& type) const;
+  virtual std::string FormatWhereClause(const std::string& negate,
+                                        const std::string& oper,
+                                        const std::string& param,
+                                        const CDatabase& db,
+                                        const std::string& type) const;
   virtual SEARCH_OPERATOR GetOperator(const std::string& type) const { return m_operator; }
-  virtual std::string         GetOperatorString(SEARCH_OPERATOR op) const;
-  virtual std::string         GetBooleanQuery(const std::string &negate, const std::string &strType) const { return ""; }
+  virtual std::string GetOperatorString(SEARCH_OPERATOR op) const;
+  virtual std::string GetBooleanQuery(const std::string& negate, const std::string& strType) const
+  {
+    return "";
+  }
 
-  static SEARCH_OPERATOR      TranslateOperator(const char *oper);
-  static std::string          TranslateOperator(SEARCH_OPERATOR oper);
+  static SEARCH_OPERATOR TranslateOperator(const char* oper);
+  static std::string TranslateOperator(SEARCH_OPERATOR oper);
 };
 
 class CDatabaseQueryRuleCombination;
 
-typedef std::vector< std::shared_ptr<CDatabaseQueryRule> > CDatabaseQueryRules;
-typedef std::vector< std::shared_ptr<CDatabaseQueryRuleCombination> > CDatabaseQueryRuleCombinations;
+typedef std::vector<std::shared_ptr<CDatabaseQueryRule>> CDatabaseQueryRules;
+typedef std::vector<std::shared_ptr<CDatabaseQueryRuleCombination>> CDatabaseQueryRuleCombinations;
 
 class IDatabaseQueryRuleFactory
 {
 public:
   virtual ~IDatabaseQueryRuleFactory() = default;
-  virtual CDatabaseQueryRule *CreateRule() const=0;
-  virtual CDatabaseQueryRuleCombination *CreateCombination() const=0;
+  virtual CDatabaseQueryRule* CreateRule() const = 0;
+  virtual CDatabaseQueryRuleCombination* CreateCombination() const = 0;
 };
 
 class CDatabaseQueryRuleCombination
@@ -107,18 +120,19 @@ class CDatabaseQueryRuleCombination
 public:
   virtual ~CDatabaseQueryRuleCombination() = default;
 
-  typedef enum {
+  typedef enum
+  {
     CombinationOr = 0,
     CombinationAnd
   } Combination;
 
   void clear();
-  virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8") { return false; }
-  virtual bool Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory);
-  virtual bool Save(TiXmlNode *parent) const;
-  virtual bool Save(CVariant &obj) const;
+  virtual bool Load(const TiXmlNode* node, const std::string& encoding = "UTF-8") { return false; }
+  virtual bool Load(const CVariant& obj, const IDatabaseQueryRuleFactory* factory);
+  virtual bool Save(TiXmlNode* parent) const;
+  virtual bool Save(CVariant& obj) const;
 
-  std::string GetWhereClause(const CDatabase &db, const std::string& strType) const;
+  std::string GetWhereClause(const CDatabase& db, const std::string& strType) const;
   std::string TranslateCombinationType() const;
 
   Combination GetType() const { return m_type; }

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -19,32 +19,43 @@
 #include <cstring>
 
 #ifndef __GNUC__
-#pragma warning (disable:4800)
+#pragma warning(disable : 4800)
 #endif
 
-namespace dbiplus {
+namespace dbiplus
+{
 //************* Database implementation ***************
 
-Database::Database():
-  error(), //S_NO_CONNECTION,
-  host(),
-  port(),
-  db(),
-  login(),
-  passwd(),
-  sequence_table("db_sequence")
+Database::Database()
+  : error(), //S_NO_CONNECTION,
+    host(),
+    port(),
+    db(),
+    login(),
+    passwd(),
+    sequence_table("db_sequence")
 {
-  active = false;	// No connection yet
+  active = false; // No connection yet
   compression = false;
 }
 
-Database::~Database() {
-  disconnect();		// Disconnect if connected to database
+Database::~Database()
+{
+  disconnect(); // Disconnect if connected to database
 }
 
-int Database::connectFull(const char *newHost, const char *newPort, const char *newDb, const char *newLogin,
-                          const char *newPasswd, const char *newKey, const char *newCert, const char *newCA,
-                          const char *newCApath, const char *newCiphers, bool newCompression) {
+int Database::connectFull(const char* newHost,
+                          const char* newPort,
+                          const char* newDb,
+                          const char* newLogin,
+                          const char* newPasswd,
+                          const char* newKey,
+                          const char* newCert,
+                          const char* newCA,
+                          const char* newCApath,
+                          const char* newCiphers,
+                          bool newCompression)
+{
   host = newHost;
   port = newPort;
   db = newDb;
@@ -59,7 +70,7 @@ int Database::connectFull(const char *newHost, const char *newPort, const char *
   return connect(true);
 }
 
-std::string Database::prepare(const char *format, ...)
+std::string Database::prepare(const char* format, ...)
 {
   va_list args;
   va_start(args, format);
@@ -71,8 +82,7 @@ std::string Database::prepare(const char *format, ...)
 
 //************* Dataset implementation ***************
 
-Dataset::Dataset():
-  select_sql("")
+Dataset::Dataset() : select_sql("")
 {
 
   db = NULL;
@@ -87,10 +97,7 @@ Dataset::Dataset():
   edit_object = new Fields();
 }
 
-
-
-Dataset::Dataset(Database *newDb):
-  select_sql("")
+Dataset::Dataset(Database* newDb) : select_sql("")
 {
 
   db = newDb;
@@ -103,94 +110,104 @@ Dataset::Dataset(Database *newDb):
   fields_object = new Fields();
 
   edit_object = new Fields();
-
 }
 
-
-Dataset::~Dataset() {
+Dataset::~Dataset()
+{
   update_sql.clear();
   insert_sql.clear();
   delete_sql.clear();
 
-
   delete fields_object;
   delete edit_object;
-
 }
 
-
-void Dataset::setSqlParams(const char *sqlFrmt, sqlType t, ...) {
+void Dataset::setSqlParams(const char* sqlFrmt, sqlType t, ...)
+{
   va_list ap;
-  char sqlCmd[DB_BUFF_MAX+1];
+  char sqlCmd[DB_BUFF_MAX + 1];
 
   va_start(ap, t);
 #ifndef TARGET_POSIX
-  _vsnprintf(sqlCmd, DB_BUFF_MAX-1, sqlFrmt, ap);
+  _vsnprintf(sqlCmd, DB_BUFF_MAX - 1, sqlFrmt, ap);
 #else
-  vsnprintf(sqlCmd, DB_BUFF_MAX-1, sqlFrmt, ap);
+  vsnprintf(sqlCmd, DB_BUFF_MAX - 1, sqlFrmt, ap);
 #endif
   va_end(ap);
 
-   switch (t) {
-       case sqlSelect: set_select_sql(sqlCmd);
-                       break;
-       case sqlUpdate: add_update_sql(sqlCmd);
-                       break;
-       case sqlInsert: add_insert_sql(sqlCmd);
-                       break;
-       case sqlDelete: add_delete_sql(sqlCmd);
-                       break;
-       case sqlExec: sql = sqlCmd;
-             	    break;
-
+  switch (t)
+  {
+    case sqlSelect:
+      set_select_sql(sqlCmd);
+      break;
+    case sqlUpdate:
+      add_update_sql(sqlCmd);
+      break;
+    case sqlInsert:
+      add_insert_sql(sqlCmd);
+      break;
+    case sqlDelete:
+      add_delete_sql(sqlCmd);
+      break;
+    case sqlExec:
+      sql = sqlCmd;
+      break;
   }
 }
 
-
-
-void Dataset::set_select_sql(const char *sel_sql) {
- select_sql = sel_sql;
+void Dataset::set_select_sql(const char* sel_sql)
+{
+  select_sql = sel_sql;
 }
 
-void Dataset::set_select_sql(const std::string &sel_sql) {
- select_sql = sel_sql;
+void Dataset::set_select_sql(const std::string& sel_sql)
+{
+  select_sql = sel_sql;
 }
 
+void Dataset::parse_sql(std::string& sql)
+{
+  std::string fpattern, by_what;
+  for (unsigned int i = 0; i < fields_object->size(); i++)
+  {
+    fpattern = ":OLD_" + (*fields_object)[i].props.name;
+    by_what = "'" + (*fields_object)[i].val.get_asString() + "'";
+    int idx = 0;
+    int next_idx = 0;
+    while ((idx = sql.find(fpattern, next_idx)) >= 0)
+    {
+      next_idx = idx + fpattern.size();
+      if (sql.length() > ((unsigned int)next_idx))
+        if (isalnum(sql[next_idx]) || sql[next_idx] == '_')
+        {
+          continue;
+        }
+      sql.replace(idx, fpattern.size(), by_what);
+    } //while
+  } //for
 
-void Dataset::parse_sql(std::string &sql) {
-  std::string fpattern,by_what;
-  for (unsigned int i=0;i< fields_object->size();i++) {
-    fpattern = ":OLD_"+(*fields_object)[i].props.name;
-    by_what = "'"+(*fields_object)[i].val.get_asString()+"'";
-		int idx=0; int next_idx=0;
-		while ((idx = sql.find(fpattern,next_idx))>=0) {
-		       	   next_idx=idx+fpattern.size();
-			       if (sql.length() > ((unsigned int)next_idx))
-			       if(isalnum(sql[next_idx])  || sql[next_idx]=='_') {
-			       	   continue;
-			       	}
-			      sql.replace(idx,fpattern.size(),by_what);
-		}//while
-    }//for
-
-  for (unsigned int i=0;i< edit_object->size();i++) {
-    fpattern = ":NEW_"+(*edit_object)[i].props.name;
-    by_what = "'"+(*edit_object)[i].val.get_asString()+"'";
-		int idx=0; int next_idx=0;
-		while ((idx = sql.find(fpattern,next_idx))>=0) {
-		       	   next_idx=idx+fpattern.size();
-			       if (sql.length() > ((unsigned int)next_idx))
-			       if(isalnum(sql[next_idx]) || sql[next_idx]=='_') {
-			       	   continue;
-			       	}
-			      sql.replace(idx,fpattern.size(),by_what);
-			}//while
+  for (unsigned int i = 0; i < edit_object->size(); i++)
+  {
+    fpattern = ":NEW_" + (*edit_object)[i].props.name;
+    by_what = "'" + (*edit_object)[i].val.get_asString() + "'";
+    int idx = 0;
+    int next_idx = 0;
+    while ((idx = sql.find(fpattern, next_idx)) >= 0)
+    {
+      next_idx = idx + fpattern.size();
+      if (sql.length() > ((unsigned int)next_idx))
+        if (isalnum(sql[next_idx]) || sql[next_idx] == '_')
+        {
+          continue;
+        }
+      sql.replace(idx, fpattern.size(), by_what);
+    } //while
   } //for
 }
 
-
-void Dataset::close(void) {
-  haveError  = false;
+void Dataset::close(void)
+{
+  haveError = false;
   frecno = 0;
   fbof = feof = true;
   active = false;
@@ -200,105 +217,127 @@ void Dataset::close(void) {
   fieldIndexMapID = ~0;
 }
 
-
-bool Dataset::seek(int pos) {
-  frecno = (pos<num_rows()-1)? pos: num_rows()-1;
-  frecno = (frecno<0)? 0: frecno;
-  fbof = feof = (num_rows()==0)? true: false;
+bool Dataset::seek(int pos)
+{
+  frecno = (pos < num_rows() - 1) ? pos : num_rows() - 1;
+  frecno = (frecno < 0) ? 0 : frecno;
+  fbof = feof = (num_rows() == 0) ? true : false;
   return ((bool)frecno);
 }
 
-
-void Dataset::refresh() {
+void Dataset::refresh()
+{
   int row = frecno;
-  if ((row != 0) && active) {
+  if ((row != 0) && active)
+  {
     close();
     open();
     seek(row);
   }
-  else open();
+  else
+    open();
 }
 
-
-void Dataset::first() {
-  if (ds_state == dsSelect) {
+void Dataset::first()
+{
+  if (ds_state == dsSelect)
+  {
     frecno = 0;
-    feof = fbof = (num_rows()>0)? false : true;
+    feof = fbof = (num_rows() > 0) ? false : true;
   }
 }
 
-void Dataset::next() {
-  if (ds_state == dsSelect) {
+void Dataset::next()
+{
+  if (ds_state == dsSelect)
+  {
     fbof = false;
-    if (frecno<num_rows()-1) {
+    if (frecno < num_rows() - 1)
+    {
       frecno++;
       feof = false;
-    } else feof = true;
-    if (num_rows()<=0) fbof = feof = true;
+    }
+    else
+      feof = true;
+    if (num_rows() <= 0)
+      fbof = feof = true;
   }
 }
 
-void Dataset::prev() {
-  if (ds_state == dsSelect) {
+void Dataset::prev()
+{
+  if (ds_state == dsSelect)
+  {
     feof = false;
-    if (frecno) {
+    if (frecno)
+    {
       frecno--;
       fbof = false;
-    } else fbof = true;
-    if (num_rows()<=0) fbof = feof = true;
+    }
+    else
+      fbof = true;
+    if (num_rows() <= 0)
+      fbof = feof = true;
   }
 }
 
-void Dataset::last() {
-  if (ds_state == dsSelect) {
-    frecno = (num_rows()>0)? num_rows()-1: 0;
-    feof = fbof = (num_rows()>0)? false : true;
+void Dataset::last()
+{
+  if (ds_state == dsSelect)
+  {
+    frecno = (num_rows() > 0) ? num_rows() - 1 : 0;
+    feof = fbof = (num_rows() > 0) ? false : true;
   }
 }
 
-bool Dataset::goto_rec(int pos) {
-  if (ds_state == dsSelect) {
+bool Dataset::goto_rec(int pos)
+{
+  if (ds_state == dsSelect)
+  {
     return seek(pos - 1);
   }
   return false;
 }
 
-
-void Dataset::insert() {
-   edit_object->resize(field_count());
-   for (int i=0; i<field_count(); i++) {
-     (*fields_object)[i].val = "";
-     (*edit_object)[i].val = "";
-     (*edit_object)[i].props = (*fields_object)[i].props;
-   }
+void Dataset::insert()
+{
+  edit_object->resize(field_count());
+  for (int i = 0; i < field_count(); i++)
+  {
+    (*fields_object)[i].val = "";
+    (*edit_object)[i].val = "";
+    (*edit_object)[i].props = (*fields_object)[i].props;
+  }
   ds_state = dsInsert;
 }
 
-
-void Dataset::edit() {
-  if (ds_state != dsSelect) {
+void Dataset::edit()
+{
+  if (ds_state != dsSelect)
+  {
     throw DbErrors("Editing is possible only when query exists!");
   }
   edit_object->resize(field_count());
-  for (unsigned int i=0; i<fields_object->size(); i++) {
-       (*edit_object)[i].props = (*fields_object)[i].props;
-       (*edit_object)[i].val = (*fields_object)[i].val;
+  for (unsigned int i = 0; i < fields_object->size(); i++)
+  {
+    (*edit_object)[i].props = (*fields_object)[i].props;
+    (*edit_object)[i].val = (*fields_object)[i].val;
   }
   ds_state = dsEdit;
 }
 
-
-void Dataset::post() {
-  if (ds_state == dsInsert) make_insert();
-  else if (ds_state == dsEdit) make_edit();
+void Dataset::post()
+{
+  if (ds_state == dsInsert)
+    make_insert();
+  else if (ds_state == dsEdit)
+    make_edit();
 }
-
 
 void Dataset::del()
 {
   ds_state = dsDelete;
 }
-
 
 void Dataset::deletion()
 {
@@ -306,19 +345,21 @@ void Dataset::deletion()
     make_deletion();
 }
 
-
-bool Dataset::set_field_value(const char *f_name, const field_value &value) {
+bool Dataset::set_field_value(const char* f_name, const field_value& value)
+{
   bool found = false;
-  if ((ds_state == dsInsert) || (ds_state == dsEdit)) {
-      for (unsigned int i=0; i < fields_object->size(); i++)
+  if ((ds_state == dsInsert) || (ds_state == dsEdit))
+  {
+    for (unsigned int i = 0; i < fields_object->size(); i++)
+    {
+      if (StringUtils::EqualsNoCase((*edit_object)[i].props.name.c_str(), f_name))
       {
-        if (StringUtils::EqualsNoCase((*edit_object)[i].props.name.c_str(), f_name))
-        {
-          (*edit_object)[i].val = value;
-          found = true;
-        }
+        (*edit_object)[i].val = value;
+        found = true;
       }
-      if (!found) throw DbErrors("Field not found: %s",f_name);
+    }
+    if (!found)
+      throw DbErrors("Field not found: %s", f_name);
     return true;
   }
   throw DbErrors("Not in Insert or Edit state");
@@ -326,10 +367,12 @@ bool Dataset::set_field_value(const char *f_name, const field_value &value) {
 }
 
 /********* INDEXMAP SECTION START *********/
-bool Dataset::get_index_map_entry(const char *f_name) {
+bool Dataset::get_index_map_entry(const char* f_name)
+{
   if (~fieldIndexMapID)
   {
-    unsigned int next(fieldIndexMapID+1 >= fieldIndexMap_Entries.size() ? 0 : fieldIndexMapID + 1);
+    unsigned int next(fieldIndexMapID + 1 >= fieldIndexMap_Entries.size() ? 0
+                                                                          : fieldIndexMapID + 1);
     if (fieldIndexMap_Entries[next].strName == f_name) //Yes, our assumption hits.
     {
       fieldIndexMapID = next;
@@ -338,8 +381,10 @@ bool Dataset::get_index_map_entry(const char *f_name) {
   }
   // indexMap not found on the expected way, either first row strange retrieval order
   FieldIndexMapEntry tmp(f_name);
-  std::vector<unsigned int>::iterator ins(lower_bound(fieldIndexMap_Sorter.begin(), fieldIndexMap_Sorter.end(), tmp, FieldIndexMapComparator(fieldIndexMap_Entries)));
-  if (ins == fieldIndexMap_Sorter.end() || (tmp <  fieldIndexMap_Entries[*ins])) //new entry
+  std::vector<unsigned int>::iterator ins(
+      lower_bound(fieldIndexMap_Sorter.begin(), fieldIndexMap_Sorter.end(), tmp,
+                  FieldIndexMapComparator(fieldIndexMap_Entries)));
+  if (ins == fieldIndexMap_Sorter.end() || (tmp < fieldIndexMap_Entries[*ins])) //new entry
   {
     //Insert the new item just behind last retrieved item
     //In general this should be always end(), but could be different
@@ -355,18 +400,20 @@ bool Dataset::get_index_map_entry(const char *f_name) {
 }
 /********* INDEXMAP SECTION END *********/
 
-const field_value Dataset::get_field_value(const char *f_name) {
+const field_value Dataset::get_field_value(const char* f_name)
+{
   if (ds_state != dsInactive)
   {
-    if (ds_state == dsEdit || ds_state == dsInsert){
-      for (unsigned int i=0; i < edit_object->size(); i++)
+    if (ds_state == dsEdit || ds_state == dsInsert)
+    {
+      for (unsigned int i = 0; i < edit_object->size(); i++)
       {
         if (StringUtils::EqualsNoCase((*edit_object)[i].props.name.c_str(), f_name))
         {
           return (*edit_object)[i].val;
         }
       }
-      throw DbErrors("Field not found: %s",f_name);
+      throw DbErrors("Field not found: %s", f_name);
     }
     else
     {
@@ -374,11 +421,11 @@ const field_value Dataset::get_field_value(const char *f_name) {
       if (get_index_map_entry(f_name))
         return get_field_value(static_cast<int>(fieldIndexMap_Entries[fieldIndexMapID].fieldIndex));
 
-      const char* name=strstr(f_name, ".");
+      const char* name = strstr(f_name, ".");
       if (name)
         name++;
 
-      for (unsigned int i=0; i < fields_object->size(); i++)
+      for (unsigned int i = 0; i < fields_object->size(); i++)
       {
         if (StringUtils::EqualsNoCase((*fields_object)[i].props.name.c_str(), f_name) ||
             (name && StringUtils::EqualsNoCase((*fields_object)[i].props.name.c_str(), name)))
@@ -388,25 +435,28 @@ const field_value Dataset::get_field_value(const char *f_name) {
         }
       }
     }
-    throw DbErrors("Field not found: %s",f_name);
+    throw DbErrors("Field not found: %s", f_name);
   }
   throw DbErrors("Dataset state is Inactive");
   //field_value fv;
   //return fv;
 }
 
-const field_value Dataset::get_field_value(int index) {
-  if (ds_state != dsInactive) {
-    if (ds_state == dsEdit || ds_state == dsInsert){
+const field_value Dataset::get_field_value(int index)
+{
+  if (ds_state != dsInactive)
+  {
+    if (ds_state == dsEdit || ds_state == dsInsert)
+    {
       if (index < 0 || index >= field_count())
-        throw DbErrors("Field index not found: %d",index);
+        throw DbErrors("Field index not found: %d", index);
 
       return (*edit_object)[index].val;
     }
     else
     {
       if (index < 0 || index >= field_count())
-        throw DbErrors("Field index not found: %d",index);
+        throw DbErrors("Field index not found: %d", index);
 
       return (*fields_object)[index].val;
     }
@@ -422,102 +472,131 @@ const sql_record* Dataset::get_sql_record()
   return result.records[frecno];
 }
 
-const field_value Dataset::f_old(const char *f_name) {
+const field_value Dataset::f_old(const char* f_name)
+{
   if (ds_state != dsInactive)
-    for (int unsigned i=0; i < fields_object->size(); i++)
+    for (int unsigned i = 0; i < fields_object->size(); i++)
       if ((*fields_object)[i].props.name == f_name)
-	return (*fields_object)[i].val;
+        return (*fields_object)[i].val;
   field_value fv;
   return fv;
 }
 
-void Dataset::setParamList(const ParamList &params){
+void Dataset::setParamList(const ParamList& params)
+{
   plist = params;
 }
 
-
-bool Dataset::locate(){
+bool Dataset::locate()
+{
   bool result;
-  if (plist.empty()) return false;
+  if (plist.empty())
+    return false;
 
   std::map<std::string, field_value>::const_iterator i;
   first();
-  while (!eof()) {
+  while (!eof())
+  {
     result = true;
-    for (i=plist.begin();i!=plist.end();++i)
-      if (fv(i->first.c_str()).get_asString() == i->second.get_asString()) {
-	continue;
+    for (i = plist.begin(); i != plist.end(); ++i)
+      if (fv(i->first.c_str()).get_asString() == i->second.get_asString())
+      {
+        continue;
       }
-      else {result = false; break;}
-    if (result) { return result;}
+      else
+      {
+        result = false;
+        break;
+      }
+    if (result)
+    {
+      return result;
+    }
     next();
   }
   return false;
 }
 
-bool Dataset::locate(const ParamList &params) {
+bool Dataset::locate(const ParamList& params)
+{
   plist = params;
   return locate();
 }
 
-bool Dataset::findNext(void) {
+bool Dataset::findNext(void)
+{
   bool result;
-  if (plist.empty()) return false;
+  if (plist.empty())
+    return false;
 
   std::map<std::string, field_value>::const_iterator i;
-  while (!eof()) {
+  while (!eof())
+  {
     result = true;
-    for (i=plist.begin();i!=plist.end();++i)
-      if (fv(i->first.c_str()).get_asString() == i->second.get_asString()) {
-	continue;
+    for (i = plist.begin(); i != plist.end(); ++i)
+      if (fv(i->first.c_str()).get_asString() == i->second.get_asString())
+      {
+        continue;
       }
-      else {result = false; break;}
-    if (result) { return result;}
+      else
+      {
+        result = false;
+        break;
+      }
+    if (result)
+    {
+      return result;
+    }
     next();
   }
   return false;
 }
 
-
-void Dataset::add_update_sql(const char *upd_sql){
+void Dataset::add_update_sql(const char* upd_sql)
+{
   std::string s = upd_sql;
   update_sql.push_back(s);
 }
 
-
-void Dataset::add_update_sql(const std::string &upd_sql){
+void Dataset::add_update_sql(const std::string& upd_sql)
+{
   update_sql.push_back(upd_sql);
 }
 
-void Dataset::add_insert_sql(const char *ins_sql){
+void Dataset::add_insert_sql(const char* ins_sql)
+{
   std::string s = ins_sql;
   insert_sql.push_back(s);
 }
 
-
-void Dataset::add_insert_sql(const std::string &ins_sql){
+void Dataset::add_insert_sql(const std::string& ins_sql)
+{
   insert_sql.push_back(ins_sql);
 }
 
-void Dataset::add_delete_sql(const char *del_sql){
+void Dataset::add_delete_sql(const char* del_sql)
+{
   std::string s = del_sql;
   delete_sql.push_back(s);
 }
 
-
-void Dataset::add_delete_sql(const std::string &del_sql){
+void Dataset::add_delete_sql(const std::string& del_sql)
+{
   delete_sql.push_back(del_sql);
 }
 
-void Dataset::clear_update_sql(){
+void Dataset::clear_update_sql()
+{
   update_sql.clear();
 }
 
-void Dataset::clear_insert_sql(){
+void Dataset::clear_insert_sql()
+{
   insert_sql.clear();
 }
 
-void Dataset::clear_delete_sql(){
+void Dataset::clear_delete_sql()
+{
   delete_sql.clear();
 }
 
@@ -531,52 +610,57 @@ size_t Dataset::delete_sql_count()
   return delete_sql.size();
 }
 
-int Dataset::field_count() { return fields_object->size();}
-int Dataset::fieldCount() { return fields_object->size();}
+int Dataset::field_count()
+{
+  return fields_object->size();
+}
+int Dataset::fieldCount()
+{
+  return fields_object->size();
+}
 
-const char *Dataset::fieldName(int n) {
-  if ( n < field_count() && n >= 0)
+const char* Dataset::fieldName(int n)
+{
+  if (n < field_count() && n >= 0)
     return (*fields_object)[n].props.name.c_str();
   else
     return NULL;
 }
 
-int Dataset::fieldIndex(const char *fn) {
-for (unsigned int i=0; i < fields_object->size(); i++)
-      if ((*fields_object)[i].props.name == fn)
-	return i;
+int Dataset::fieldIndex(const char* fn)
+{
+  for (unsigned int i = 0; i < fields_object->size(); i++)
+    if ((*fields_object)[i].props.name == fn)
+      return i;
   return -1;
 }
 
-
-
 //************* DbErrors implementation ***************
 
-DbErrors::DbErrors():
-  msg_("Unknown Database Error")
+DbErrors::DbErrors() : msg_("Unknown Database Error")
 {
 }
 
-
-DbErrors::DbErrors(const char *msg, ...) {
+DbErrors::DbErrors(const char* msg, ...)
+{
   va_list vl;
   va_start(vl, msg);
-  char buf[DB_BUFF_MAX]="";
+  char buf[DB_BUFF_MAX] = "";
 #ifndef TARGET_POSIX
-  _vsnprintf(buf, DB_BUFF_MAX-1, msg, vl);
+  _vsnprintf(buf, DB_BUFF_MAX - 1, msg, vl);
 #else
-  vsnprintf(buf, DB_BUFF_MAX-1, msg, vl);
+  vsnprintf(buf, DB_BUFF_MAX - 1, msg, vl);
 #endif
   va_end(vl);
-  msg_ =   "SQL: ";
+  msg_ = "SQL: ";
   msg_ += buf;
 
   CLog::Log(LOGERROR, "{}", msg_);
 }
 
-const char * DbErrors::getMsg() {
-	return msg_.c_str();
-
+const char* DbErrors::getMsg()
+{
+  return msg_.c_str();
 }
 
-}// namespace
+} // namespace dbiplus

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -21,77 +21,84 @@
 #include <string>
 #include <vector>
 
-namespace dbiplus {
-class Dataset;		// forward declaration of class Dataset
-
+namespace dbiplus
+{
+class Dataset; // forward declaration of class Dataset
 
 #define S_NO_CONNECTION "No active connection";
 
-#define DB_BUFF_MAX           8*1024    // Maximum buffer's capacity
+#define DB_BUFF_MAX 8 * 1024 // Maximum buffer's capacity
 
-#define DB_CONNECTION_NONE	0
-#define DB_CONNECTION_OK	1
-#define DB_CONNECTION_BAD	2
+#define DB_CONNECTION_NONE 0
+#define DB_CONNECTION_OK 1
+#define DB_CONNECTION_BAD 2
 
-#define DB_COMMAND_OK		0	// OK - command executed
-#define DB_EMPTY_QUERY		1	// Query didn't return tuples
-#define DB_TUPLES_OK		2	// Query returned tuples
-#define DB_ERROR		5
-#define DB_BAD_RESPONSE		6
-#define DB_UNEXPECTED		7	// This shouldn't ever happen
-#define DB_UNEXPECTED_RESULT   -1       //For integer functions
+#define DB_COMMAND_OK 0 // OK - command executed
+#define DB_EMPTY_QUERY 1 // Query didn't return tuples
+#define DB_TUPLES_OK 2 // Query returned tuples
+#define DB_ERROR 5
+#define DB_BAD_RESPONSE 6
+#define DB_UNEXPECTED 7 // This shouldn't ever happen
+#define DB_UNEXPECTED_RESULT -1 //For integer functions
 
 /******************* Class Database definition ********************
 
    represents  connection with database server;
 
 ******************************************************************/
-class Database  {
+class Database
+{
 protected:
   bool active;
   bool compression;
   std::string error, // Error description
-    host, port, db, login, passwd, //Login info
-    sequence_table, //Sequence table for nextid
-    default_charset, //Default character set
-    key, cert, ca, capath, ciphers; //SSL - Encryption info
+      host, port, db, login, passwd, //Login info
+      sequence_table, //Sequence table for nextid
+      default_charset, //Default character set
+      key, cert, ca, capath, ciphers; //SSL - Encryption info
 
 public:
-/* constructor */
+  /* constructor */
   Database();
-/* destructor */
+  /* destructor */
   virtual ~Database();
-  virtual Dataset *CreateDataset() const = 0;
-/* sets a new host name */
-  virtual void setHostName(const char *newHost) { host = newHost; }
-/* gets a host name */
-  const char *getHostName(void) const { return host.c_str(); }
-/* sets a new port */
-  void setPort(const char *newPort) { port = newPort; }
-/* gets a port */
-  const char *getPort(void) const { return port.c_str(); }
-/* sets a new database name */
-  virtual void setDatabase(const char *newDb) { db = newDb; }
-/* gets a database name */
-  const char *getDatabase(void) const { return db.c_str(); }
-/* sets a new login to database */
-  void setLogin(const char *newLogin) { login = newLogin; }
-/* gets a login */
-  const char *getLogin(void) const { return login.c_str(); }
-/* sets a password */
-  void setPasswd(const char *newPasswd) { passwd = newPasswd; }
-/* gets a password */
-  const char *getPasswd(void) const { return passwd.c_str(); }
-/* active status is OK state */
+  virtual Dataset* CreateDataset() const = 0;
+  /* sets a new host name */
+  virtual void setHostName(const char* newHost) { host = newHost; }
+  /* gets a host name */
+  const char* getHostName(void) const { return host.c_str(); }
+  /* sets a new port */
+  void setPort(const char* newPort) { port = newPort; }
+  /* gets a port */
+  const char* getPort(void) const { return port.c_str(); }
+  /* sets a new database name */
+  virtual void setDatabase(const char* newDb) { db = newDb; }
+  /* gets a database name */
+  const char* getDatabase(void) const { return db.c_str(); }
+  /* sets a new login to database */
+  void setLogin(const char* newLogin) { login = newLogin; }
+  /* gets a login */
+  const char* getLogin(void) const { return login.c_str(); }
+  /* sets a password */
+  void setPasswd(const char* newPasswd) { passwd = newPasswd; }
+  /* gets a password */
+  const char* getPasswd(void) const { return passwd.c_str(); }
+  /* active status is OK state */
   virtual bool isActive(void) const { return active; }
-/* Set new name of sequence table */
+  /* Set new name of sequence table */
   void setSequenceTable(const char* new_seq_table) { sequence_table = new_seq_table; }
   /* Get name of sequence table */
-  const char *getSequenceTable(void) { return sequence_table.c_str(); }
-/* Get the default character set */
-  const char *getDefaultCharset(void) { return default_charset.c_str(); }
-/* Sets configuration */
-  virtual void setConfig(const char *newKey, const char *newCert, const char *newCA, const char *newCApath, const char *newCiphers, bool newCompression) {
+  const char* getSequenceTable(void) { return sequence_table.c_str(); }
+  /* Get the default character set */
+  const char* getDefaultCharset(void) { return default_charset.c_str(); }
+  /* Sets configuration */
+  virtual void setConfig(const char* newKey,
+                         const char* newCert,
+                         const char* newCA,
+                         const char* newCApath,
+                         const char* newCiphers,
+                         bool newCompression)
+  {
     key = newKey;
     cert = newCert;
     ca = newCA;
@@ -100,33 +107,40 @@ public:
     compression = newCompression;
   }
 
-/* virtual methods that must be overloaded in derived classes */
+  /* virtual methods that must be overloaded in derived classes */
 
   virtual int init(void) { return DB_COMMAND_OK; }
   virtual int status(void) { return DB_CONNECTION_NONE; }
-  virtual int setErr(int err_code, const char *qry)=0;
-  virtual const char *getErrorMsg(void) { return error.c_str(); }
+  virtual int setErr(int err_code, const char* qry) = 0;
+  virtual const char* getErrorMsg(void) { return error.c_str(); }
 
   virtual int connect(bool create) { return DB_COMMAND_OK; }
-  virtual int connectFull( const char *newDb, const char *newHost=NULL,
-                      const char *newLogin=NULL, const char *newPasswd=NULL,const char *newPort=NULL,
-                      const char *newKey=NULL, const char *newCert=NULL, const char *newCA=NULL,
-                      const char *newCApath=NULL, const char *newCiphers=NULL, bool newCompression = false);
+  virtual int connectFull(const char* newDb,
+                          const char* newHost = NULL,
+                          const char* newLogin = NULL,
+                          const char* newPasswd = NULL,
+                          const char* newPort = NULL,
+                          const char* newKey = NULL,
+                          const char* newCert = NULL,
+                          const char* newCA = NULL,
+                          const char* newCApath = NULL,
+                          const char* newCiphers = NULL,
+                          bool newCompression = false);
   virtual void disconnect(void) { active = false; }
   virtual int reset(void) { return DB_COMMAND_OK; }
   virtual int create(void) { return DB_COMMAND_OK; }
   virtual int drop(void) { return DB_COMMAND_OK; }
-  virtual long nextid(const char* seq_name)=0;
+  virtual long nextid(const char* seq_name) = 0;
 
-/* \brief copy database */
-  virtual int copy(const char *new_name) { return -1; }
+  /* \brief copy database */
+  virtual int copy(const char* new_name) { return -1; }
 
-/* \brief drop all extra analytics from database */
+  /* \brief drop all extra analytics from database */
   virtual int drop_analytics(void) { return -1; }
 
   virtual bool exists(void) { return false; }
 
-/* virtual methods for transaction */
+  /* virtual methods for transaction */
 
   virtual void start_transaction() {}
   virtual void commit_transaction() {}
@@ -139,20 +153,17 @@ public:
    \param ... - optional comma separated list of variables for substitution in format string placeholders.
    \return escaped and formatted string.
    */
-  virtual std::string prepare(const char *format, ...);
+  virtual std::string prepare(const char* format, ...);
 
   /*! \brief Prepare a SQL statement for execution or querying using C printf nomenclature
    \param format - C printf compliant format string
    \param args - va_list of variables for substitution in format string placeholders.
    \return escaped and formatted string.
    */
-  virtual std::string vprepare(const char *format, va_list args) = 0;
+  virtual std::string vprepare(const char* format, va_list args) = 0;
 
   virtual bool in_transaction() { return false; }
 };
-
-
-
 
 /******************* Class Dataset definition *********************
 
@@ -161,24 +172,38 @@ public:
 ******************************************************************/
 
 // define Dataset States type
-enum dsStates { dsSelect, dsInsert, dsEdit, dsUpdate, dsDelete, dsInactive };
-enum sqlType {sqlSelect,sqlUpdate,sqlInsert,sqlDelete,sqlExec};
-
+enum dsStates
+{
+  dsSelect,
+  dsInsert,
+  dsEdit,
+  dsUpdate,
+  dsDelete,
+  dsInactive
+};
+enum sqlType
+{
+  sqlSelect,
+  sqlUpdate,
+  sqlInsert,
+  sqlDelete,
+  sqlExec
+};
 
 typedef std::list<std::string> StringList;
-typedef std::map<std::string,field_value> ParamList;
+typedef std::map<std::string, field_value> ParamList;
 
-
-class Dataset  {
+class Dataset
+{
 protected:
-/*  char *Host     = ""; //WORK_HOST;
+  /*  char *Host     = ""; //WORK_HOST;
   char *Database = ""; //WORK_DATABASE;
   char *User     = ""; //WORK_USER;
   char *Password = ""; //WORK_PASSWORD;
 */
 
-  Database *db;		// info about db connection
-  dsStates ds_state;	        // current state
+  Database* db; // info about db connection
+  dsStates ds_state; // current state
   Fields *fields_object, *edit_object;
 
   /* query results*/
@@ -187,116 +212,110 @@ protected:
   bool autorefresh;
   char* errmsg;
 
-  bool active;			// Is Query Opened?
+  bool active; // Is Query Opened?
   bool haveError;
-  int frecno; 			// number of current row bei bewegung
+  int frecno; // number of current row bei bewegung
   std::string sql;
 
-  ParamList plist;              // Paramlist for locate
+  ParamList plist; // Paramlist for locate
   bool fbof, feof;
-  bool autocommit;		// for transactions
+  bool autocommit; // for transactions
 
+  /* Variables to store SQL statements */
+  std::string empty_sql; // Executed when result set is empty
+  std::string select_sql; // May be only single string variable
 
-/* Variables to store SQL statements */
-  std::string empty_sql; 		// Executed when result set is empty
-  std::string select_sql; 		// May be only single string variable
-
-  StringList update_sql; 		// May be an array in complex queries
-/* Field values for updating must has prefix :NEW_ and :OLD_ and field name
+  StringList update_sql; // May be an array in complex queries
+  /* Field values for updating must has prefix :NEW_ and :OLD_ and field name
    Example:
    update  wt_story set idobject set idobject=:NEW_idobject,body=:NEW_body
    where idobject=:OLD_idobject
    Essentially fields idobject and body must present in the
    result set (select_sql statement) */
 
-  StringList insert_sql; 		// May be an array in complex queries
-/* Field values for inserting must has prefix :NEW_ and field name
+  StringList insert_sql; // May be an array in complex queries
+  /* Field values for inserting must has prefix :NEW_ and field name
    Example:
    insert into wt_story (idobject, body) values (:NEW_idobject, :NEW_body)
    Essentially fields idobject and body must present in the
    result set (select_sql statement) */
 
-  StringList delete_sql; 		// May be an array in complex queries
-/* Field values for deleing must has prefix :OLD_ and field name
+  StringList delete_sql; // May be an array in complex queries
+  /* Field values for deleing must has prefix :OLD_ and field name
    Example:
    delete from wt_story where idobject=:OLD_idobject
    Essentially field idobject must present in the
    result set (select_sql statement) */
 
+  /* Arrays for searching */
+  //  StringList names, values;
 
-
-
-/* Arrays for searching */
-//  StringList names, values;
-
-
-/* Makes direct inserts into database via mysql_query function */
+  /* Makes direct inserts into database via mysql_query function */
   virtual void make_insert() = 0;
-/* Edit SQL */
+  /* Edit SQL */
   virtual void make_edit() = 0;
-/* Delete SQL */
+  /* Delete SQL */
   virtual void make_deletion() = 0;
 
-/* This function works only with MySQL database
+  /* This function works only with MySQL database
    Filling the fields information from select statement */
-  virtual void fill_fields(void)=0;
+  virtual void fill_fields(void) = 0;
 
-/* Parse Sql - replacing fields with prefixes :OLD_ and :NEW_ with current values of OLD or NEW field. */
-  void parse_sql(std::string &sql);
+  /* Parse Sql - replacing fields with prefixes :OLD_ and :NEW_ with current values of OLD or NEW field. */
+  void parse_sql(std::string& sql);
 
-/* Returns old field value (for :OLD) */
-  virtual const field_value f_old(const char *f);
+  /* Returns old field value (for :OLD) */
+  virtual const field_value f_old(const char* f);
 
 public:
-/* constructor */
+  /* constructor */
   Dataset();
-  explicit Dataset(Database *newDb);
+  explicit Dataset(Database* newDb);
 
-/* destructor */
+  /* destructor */
   virtual ~Dataset();
 
-/* sets a new value of connection to database */
-  void setDatabase(Database *newDb) { db = newDb; }
-/* retrieves  a database which connected */
-  Database *getDatabase(void) { return db; }
+  /* sets a new value of connection to database */
+  void setDatabase(Database* newDb) { db = newDb; }
+  /* retrieves  a database which connected */
+  Database* getDatabase(void) { return db; }
 
-/* sets a new query string to database server */
-  void setExecSql(const char *newSql) { sql = newSql; }
-/* retrieves a query string */
-  const char *getExecSql(void) { return sql.c_str(); }
+  /* sets a new query string to database server */
+  void setExecSql(const char* newSql) { sql = newSql; }
+  /* retrieves a query string */
+  const char* getExecSql(void) { return sql.c_str(); }
 
-/* status active is OK query */
+  /* status active is OK query */
   virtual bool isActive(void) { return active; }
 
-  virtual void setSqlParams(const char *sqlFrmt, sqlType t, ...);
+  virtual void setSqlParams(const char* sqlFrmt, sqlType t, ...);
 
+  /* error handling */
+  //  virtual void halt(const char *msg);
 
-/* error handling */
-//  virtual void halt(const char *msg);
-
-/* last inserted id */
+  /* last inserted id */
   virtual int64_t lastinsertid() = 0;
-/* sequence numbers */
-  virtual long nextid(const char *seq_name)=0;
-/* sequence numbers */
-  virtual int num_rows()= 0;
+  /* sequence numbers */
+  virtual long nextid(const char* seq_name) = 0;
+  /* sequence numbers */
+  virtual int num_rows() = 0;
 
-/* Open SQL query */
-  virtual void open(const std::string &sql) = 0;
+  /* Open SQL query */
+  virtual void open(const std::string& sql) = 0;
   virtual void open() = 0;
-/* func. executes a query without results to return */
-  virtual int  exec (const std::string &sql) = 0;
-  virtual int  exec() = 0;
-  virtual const void* getExecRes()=0;
-/* as open, but with our query exec Sql */
-  virtual bool query(const std::string &sql) = 0;
-/* Close SQL Query*/
+  /* func. executes a query without results to return */
+  virtual int exec(const std::string& sql) = 0;
+  virtual int exec() = 0;
+  virtual const void* getExecRes() = 0;
+  /* as open, but with our query exec Sql */
+  virtual bool query(const std::string& sql) = 0;
+  /* Close SQL Query*/
   virtual void close();
-/* This function looks for field Field_name with value equal Field_value
+  /* This function looks for field Field_name with value equal Field_value
    Returns true if found (position of dataset is set to founded position)
    and false another way (position is not changed). */
-//  virtual bool lookup(char *field_name, char*field_value);
-/* Refresh dataset (reopen it and set the same cursor position) */
+  //  virtual bool lookup(char *field_name, char*field_value);
+  /* Refresh dataset (reopen it and set the same cursor position) */
   virtual void refresh();
 
   /*! \brief Drop an index from the database table, provided it exists.
@@ -304,80 +323,78 @@ public:
    \param index - name of the index to be dropped
    \return true when the index is guaranteed to no longer exist in the database.
    */
-  virtual bool dropIndex(const char *table, const char *index) { return false; }
+  virtual bool dropIndex(const char* table, const char* index) { return false; }
 
-/* Go to record No (starting with 0) */
-  virtual bool seek(int pos=0);
-/* Go to record No (starting with 1) */
-  virtual bool goto_rec(int pos=1);
-/* Go to the first record in dataset */
+  /* Go to record No (starting with 0) */
+  virtual bool seek(int pos = 0);
+  /* Go to record No (starting with 1) */
+  virtual bool goto_rec(int pos = 1);
+  /* Go to the first record in dataset */
   virtual void first();
-/* Go to next record in dataset */
+  /* Go to next record in dataset */
   virtual void next();
-/* Go to previous record */
+  /* Go to previous record */
   virtual void prev();
-/* Go to last record in dataset */
+  /* Go to last record in dataset */
   virtual void last();
 
-/* Check for Ending dataset */
+  /* Check for Ending dataset */
   virtual bool eof(void) { return feof; }
-/* Check for Beginning dataset */
+  /* Check for Beginning dataset */
   virtual bool bof(void) { return fbof; }
 
-/* Start the insert mode */
+  /* Start the insert mode */
   virtual void insert();
-/* Start the insert mode (alias for insert() function) */
+  /* Start the insert mode (alias for insert() function) */
   virtual void append() { insert(); }
-/* Start the edit mode */
+  /* Start the edit mode */
   virtual void edit();
   /* Start the delete mode */
   virtual void del();
 
   /* Add changes, that were made during insert or edit states of dataset into the database */
   virtual void post();
-/* Delete statements from database */
+  /* Delete statements from database */
   virtual void deletion();
-/* Cancel changes, made in insert or edit states of dataset */
+  /* Cancel changes, made in insert or edit states of dataset */
   virtual void cancel() {}
   /* interrupt any pending database operation  */
   virtual void interrupt() {}
 
-  virtual void setParamList(const ParamList &params);
+  virtual void setParamList(const ParamList& params);
   virtual bool locate();
-  virtual bool locate(const ParamList &params);
+  virtual bool locate(const ParamList& params);
   virtual bool findNext();
 
-/* func. retrieves a number of fields */
-/* Number of fields in a record */
+  /* func. retrieves a number of fields */
+  /* Number of fields in a record */
   virtual int field_count();
   virtual int fieldCount();
-/* func. retrieves a field name with 'n' index */
-  virtual const char *fieldName(int n);
-/* func. retrieves a field index with 'fn' field name,return -1 when field name not found */
-  virtual int  fieldIndex(const char *fn);
+  /* func. retrieves a field name with 'n' index */
+  virtual const char* fieldName(int n);
+  /* func. retrieves a field index with 'fn' field name,return -1 when field name not found */
+  virtual int fieldIndex(const char* fn);
 
-/* Set field value */
-  virtual bool set_field_value(const char *f_name, const field_value &value);
-/* alias for set_field_value */
-  virtual bool sf(const char *f, const field_value &v) { return set_field_value(f,v); }
+  /* Set field value */
+  virtual bool set_field_value(const char* f_name, const field_value& value);
+  /* alias for set_field_value */
+  virtual bool sf(const char* f, const field_value& v) { return set_field_value(f, v); }
 
-
-
-/* Return field name by it index */
+  /* Return field name by it index */
   //  virtual char *field_name(int f_index) { return field_by_index(f_index)->get_field_name(); }
 
   /* Getting value of field for current record */
-  virtual const field_value get_field_value(const char *f_name);
+  virtual const field_value get_field_value(const char* f_name);
   virtual const field_value get_field_value(int index);
-/* Alias to get_field_value */
-  const field_value fv(const char *f) { return get_field_value(f); }
+  /* Alias to get_field_value */
+  const field_value fv(const char* f) { return get_field_value(f); }
   const field_value fv(int index) { return get_field_value(index); }
 
-/* ------------ for transaction ------------------- */
+  /* ------------ for transaction ------------------- */
   void set_autocommit(bool v) { autocommit = v; }
   bool get_autocommit() { return autocommit; }
 
-/* ----------------- for debug -------------------- */
+  /* ----------------- for debug -------------------- */
   Fields* get_fields_object() { return fields_object; }
   Fields* get_edit_object() { return edit_object; }
 
@@ -385,13 +402,13 @@ public:
   const result_set& get_result_set() { return result; }
   const sql_record* get_sql_record();
 
- private:
+private:
   Dataset(const Dataset&) = delete;
   Dataset& operator=(const Dataset&) = delete;
 
   unsigned int fieldIndexMapID;
 
-/* Struct to store an indexMapped field access entry */
+  /* Struct to store an indexMapped field access entry */
   struct FieldIndexMapEntry
   {
     explicit FieldIndexMapEntry(const char* name) : fieldIndex(~0), strName(name) {}
@@ -400,7 +417,7 @@ public:
     std::string strName;
   };
 
-/* Comparator to quickly find an indexMapped field access entry in the unsorted fieldIndexMap_Entries vector */
+  /* Comparator to quickly find an indexMapped field access entry in the unsorted fieldIndexMap_Entries vector */
   struct FieldIndexMapComparator
   {
     explicit FieldIndexMapComparator(const std::vector<FieldIndexMapEntry>& c) : c_(c) {}
@@ -408,16 +425,14 @@ public:
     bool operator()(const unsigned int& v1, const unsigned int& v2) const
     {
       return c_[v1] < c_[v2];
-   };
-   bool operator()(const FieldIndexMapEntry &o, const unsigned int &v) const
-   {
-     return o < c_[v];
-   };
+    };
+    bool operator()(const FieldIndexMapEntry& o, const unsigned int& v) const { return o < c_[v]; };
+
   private:
-   const std::vector<FieldIndexMapEntry> &c_;
+    const std::vector<FieldIndexMapEntry>& c_;
   };
 
-/* Store string to field index translation in the same order
+  /* Store string to field index translation in the same order
    fields are accessed by field_value([string]).
    Idea behind it:
    - Open a SELECT query with many results
@@ -427,15 +442,15 @@ public:
 */
   std::vector<FieldIndexMapEntry> fieldIndexMap_Entries;
 
-/* Hold the sorting order regarding FieldIndexMapEntry::strName in the
+  /* Hold the sorting order regarding FieldIndexMapEntry::strName in the
    fieldIndexMap_Entries vector.
    If "next element" in fieldIndexMap_Entries does not match,
    do a fast binary search inside it using the fieldIndexMap_Sorter.
 */
   std::vector<unsigned int> fieldIndexMap_Sorter;
 
-/* Get the column index from a string field_value request */
-  bool get_index_map_entry(const char *f_name);
+  /* Get the column index from a string field_value request */
+  bool get_index_map_entry(const char* f_name);
 
   void set_ds_state(dsStates new_state) { ds_state = new_state; }
 
@@ -444,23 +459,23 @@ public:
   dsStates get_state() { return ds_state; }
 
   /*add a new value to select_sql*/
-  void set_select_sql(const char *sel_sql);
-  void set_select_sql(const std::string &select_sql);
-/*add a new value to update_sql*/
-  void add_update_sql(const char *upd_sql);
-  void add_update_sql(const std::string &upd_sql);
-/*add a new value to insert_sql*/
-  void add_insert_sql(const char *ins_sql);
-  void add_insert_sql(const std::string &ins_sql);
+  void set_select_sql(const char* sel_sql);
+  void set_select_sql(const std::string& select_sql);
+  /*add a new value to update_sql*/
+  void add_update_sql(const char* upd_sql);
+  void add_update_sql(const std::string& upd_sql);
+  /*add a new value to insert_sql*/
+  void add_insert_sql(const char* ins_sql);
+  void add_insert_sql(const std::string& ins_sql);
   /*add a new value to delete_sql*/
-  void add_delete_sql(const char *del_sql);
-  void add_delete_sql(const std::string &del_sql);
+  void add_delete_sql(const char* del_sql);
+  void add_delete_sql(const std::string& del_sql);
 
-/*clear update_sql*/
+  /*clear update_sql*/
   void clear_update_sql();
-/*clear insert_sql*/
+  /*clear insert_sql*/
   void clear_insert_sql();
-/*clear delete_sql*/
+  /*clear delete_sql*/
   void clear_delete_sql();
 
   /* size of insert_sql*/
@@ -470,28 +485,25 @@ public:
 
   /*get value of select_sql*/
   const char* get_select_sql();
-
 };
-
-
 
 /******************** Class DbErrors definition *********************
 
 			   error handling
 
 ******************************************************************/
-class DbErrors  {
+class DbErrors
+{
 
 public:
-
-/* constructor */
+  /* constructor */
   DbErrors();
-  DbErrors(const char *msg, ...);
+  DbErrors(const char* msg, ...);
 
-  const char  * getMsg();
- private:
- std::string  msg_;
+  const char* getMsg();
+
+private:
+  std::string msg_;
 };
 
-}
-
+} // namespace dbiplus

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -29,19 +29,21 @@
 #include "platform/posix/ConvUtils.h"
 #endif
 
-#define MYSQL_OK          0
-#define ER_BAD_DB_ERROR   1049
+#define MYSQL_OK 0
+#define ER_BAD_DB_ERROR 1049
 
-namespace dbiplus {
+namespace dbiplus
+{
 
 //************* MysqlDatabase implementation ***************
 
-MysqlDatabase::MysqlDatabase() {
+MysqlDatabase::MysqlDatabase()
+{
 
   active = false;
-  _in_transaction = false;     // for transaction
+  _in_transaction = false; // for transaction
 
-  error = "Unknown database error";//S_NO_CONNECTION;
+  error = "Unknown database error"; //S_NO_CONNECTION;
   host = "localhost";
   port = "3306";
   db = "mysql";
@@ -51,20 +53,25 @@ MysqlDatabase::MysqlDatabase() {
   default_charset = "";
 }
 
-MysqlDatabase::~MysqlDatabase() {
+MysqlDatabase::~MysqlDatabase()
+{
   disconnect();
 }
 
-Dataset* MysqlDatabase::CreateDataset() const {
-   return new MysqlDataset(const_cast<MysqlDatabase*>(this));
+Dataset* MysqlDatabase::CreateDataset() const
+{
+  return new MysqlDataset(const_cast<MysqlDatabase*>(this));
 }
 
-int MysqlDatabase::status(void) {
-  if (active == false) return DB_CONNECTION_NONE;
+int MysqlDatabase::status(void)
+{
+  if (active == false)
+    return DB_CONNECTION_NONE;
   return DB_CONNECTION_OK;
 }
 
-int MysqlDatabase::setErr(int err_code, const char * qry) {
+int MysqlDatabase::setErr(int err_code, const char* qry)
+{
   switch (err_code)
   {
     case MYSQL_OK:
@@ -97,16 +104,19 @@ int MysqlDatabase::setErr(int err_code, const char * qry) {
   return err_code;
 }
 
-const char *MysqlDatabase::getErrorMsg() {
-   return error.c_str();
+const char* MysqlDatabase::getErrorMsg()
+{
+  return error.c_str();
 }
 
-void MysqlDatabase::configure_connection() {
+void MysqlDatabase::configure_connection()
+{
   char sqlcmd[512];
   int ret;
 
   // MySQL 5.7.5+: See #8393
-  strcpy(sqlcmd, "SET SESSION sql_mode = (SELECT REPLACE(@@SESSION.sql_mode,'ONLY_FULL_GROUP_BY',''))");
+  strcpy(sqlcmd,
+         "SET SESSION sql_mode = (SELECT REPLACE(@@SESSION.sql_mode,'ONLY_FULL_GROUP_BY',''))");
   if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
     throw DbErrors("Can't disable sql_mode ONLY_FULL_GROUP_BY: '%s' (%d)", db.c_str(), ret);
 
@@ -143,12 +153,13 @@ void MysqlDatabase::configure_connection() {
     CLog::Log(LOGWARNING, "Unable to query optimizer_switch: '{}' ({})", db, ret);
 }
 
-int MysqlDatabase::connect(bool create_new) {
+int MysqlDatabase::connect(bool create_new)
+{
   if (host.empty() || db.empty())
     return DB_CONNECTION_NONE;
 
   std::string resolvedHost;
-  if (!StringUtils::EqualsNoCase(host,"localhost") && CDNSNameCache::Lookup(host, resolvedHost))
+  if (!StringUtils::EqualsNoCase(host, "localhost") && CDNSNameCache::Lookup(host, resolvedHost))
   {
     CLog::Log(LOGDEBUG, "{} replacing configured host {} with resolved host {}", __FUNCTION__, host,
               resolvedHost);
@@ -159,28 +170,20 @@ int MysqlDatabase::connect(bool create_new) {
   {
     disconnect();
 
-    if (conn == NULL) {
+    if (conn == NULL)
+    {
       conn = mysql_init(conn);
-      mysql_ssl_set(
-        conn,
-        key.empty() ? NULL : key.c_str(),
-        cert.empty() ? NULL : cert.c_str(),
-        ca.empty() ? NULL : ca.c_str(),
-        capath.empty() ? NULL : capath.c_str(),
-        ciphers.empty() ? NULL : ciphers.c_str());
+      mysql_ssl_set(conn, key.empty() ? NULL : key.c_str(), cert.empty() ? NULL : cert.c_str(),
+                    ca.empty() ? NULL : ca.c_str(), capath.empty() ? NULL : capath.c_str(),
+                    ciphers.empty() ? NULL : ciphers.c_str());
     }
 
     if (!CWakeOnAccess::GetInstance().WakeUpHost(host, "MySQL : " + db))
       return DB_CONNECTION_NONE;
 
     // establish connection with just user credentials
-    if (mysql_real_connect(conn, host.c_str(),
-                                 login.c_str(),
-                                 passwd.c_str(),
-                                 NULL,
-                                 atoi(port.c_str()),
-                                 NULL,
-                                 compression ? CLIENT_COMPRESS : 0) != NULL)
+    if (mysql_real_connect(conn, host.c_str(), login.c_str(), passwd.c_str(), NULL,
+                           atoi(port.c_str()), NULL, compression ? CLIENT_COMPRESS : 0) != NULL)
     {
       static bool showed_ver_info = false;
       if (!showed_ver_info)
@@ -199,7 +202,11 @@ int MysqlDatabase::connect(bool create_new) {
 
         if (version < min_version)
         {
-          CLog::Log(LOGWARNING, "MYSQL: Your database server version {} is very old and might not be supported in future Kodi versions. Please consider upgrading to MySQL 5.7 or MariaDB 10.2.", version_string);
+          CLog::Log(
+              LOGWARNING,
+              "MYSQL: Your database server version {} is very old and might not be supported in "
+              "future Kodi versions. Please consider upgrading to MySQL 5.7 or MariaDB 10.2.",
+              version_string);
         }
       }
 
@@ -208,7 +215,7 @@ int MysqlDatabase::connect(bool create_new) {
 
       // enforce utf8 charset usage
       default_charset = mysql_character_set_name(conn);
-      if(mysql_set_character_set(conn, "utf8")) // returns 0 on success
+      if (mysql_set_character_set(conn, "utf8")) // returns 0 on success
       {
         CLog::Log(LOGERROR, "Unable to set utf8 charset: {} [{}]({})", db, mysql_errno(conn),
                   mysql_error(conn));
@@ -228,7 +235,7 @@ int MysqlDatabase::connect(bool create_new) {
 
         snprintf(sqlcmd, sizeof(sqlcmd),
                  "CREATE DATABASE `%s` CHARACTER SET utf8 COLLATE utf8_general_ci", db.c_str());
-        if ( (ret=query_with_reconnect(sqlcmd)) != MYSQL_OK )
+        if ((ret = query_with_reconnect(sqlcmd)) != MYSQL_OK)
         {
           throw DbErrors("Can't create new database: '%s' (%d)", db.c_str(), ret);
         }
@@ -258,14 +265,15 @@ int MysqlDatabase::connect(bool create_new) {
 
     return DB_CONNECTION_NONE;
   }
-  catch(...)
+  catch (...)
   {
     CLog::Log(LOGERROR, "Unable to open database: {} ({})", db, GetLastError());
   }
   return DB_CONNECTION_NONE;
 }
 
-void MysqlDatabase::disconnect(void) {
+void MysqlDatabase::disconnect(void)
+{
   if (conn != NULL)
   {
     mysql_close(conn);
@@ -275,17 +283,19 @@ void MysqlDatabase::disconnect(void) {
   active = false;
 }
 
-int MysqlDatabase::create() {
+int MysqlDatabase::create()
+{
   return connect(true);
 }
 
-int MysqlDatabase::drop() {
+int MysqlDatabase::drop()
+{
   if (!active)
     throw DbErrors("Can't drop database: no active connection...");
   char sqlcmd[512];
   int ret;
   snprintf(sqlcmd, sizeof(sqlcmd), "DROP DATABASE `%s`", db.c_str());
-  if ( (ret=query_with_reconnect(sqlcmd)) != MYSQL_OK )
+  if ((ret = query_with_reconnect(sqlcmd)) != MYSQL_OK)
   {
     throw DbErrors("Can't drop database: '%s' (%d)", db.c_str(), ret);
   }
@@ -293,20 +303,21 @@ int MysqlDatabase::drop() {
   return DB_COMMAND_OK;
 }
 
-int MysqlDatabase::copy(const char *backup_name) {
-  if ( !active || conn == NULL)
+int MysqlDatabase::copy(const char* backup_name)
+{
+  if (!active || conn == NULL)
     throw DbErrors("Can't copy database: no active connection...");
 
   char sql[4096];
   int ret;
 
   // ensure we're connected to the db we are about to copy
-  if ( (ret=mysql_select_db(conn, db.c_str())) != MYSQL_OK )
-    throw DbErrors("Can't connect to source database: '%s'",db.c_str());
+  if ((ret = mysql_select_db(conn, db.c_str())) != MYSQL_OK)
+    throw DbErrors("Can't connect to source database: '%s'", db.c_str());
 
   // grab a list of base tables only (no views)
   sprintf(sql, "SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'");
-  if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+  if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
     throw DbErrors("Can't determine base tables for copy.");
 
   // get list of all tables from old DB
@@ -323,7 +334,7 @@ int MysqlDatabase::copy(const char *backup_name) {
     // create the new database
     snprintf(sql, sizeof(sql), "CREATE DATABASE `%s` CHARACTER SET utf8 COLLATE utf8_general_ci",
              backup_name);
-    if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+    if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
     {
       mysql_free_result(res);
       throw DbErrors("Can't create database for copy: '%s' (%d)", db.c_str(), ret);
@@ -332,22 +343,22 @@ int MysqlDatabase::copy(const char *backup_name) {
     MYSQL_ROW row;
 
     // duplicate each table from old db to new db
-    while ( (row=mysql_fetch_row(res)) != NULL )
+    while ((row = mysql_fetch_row(res)) != NULL)
     {
       // copy the table definition
       snprintf(sql, sizeof(sql), "CREATE TABLE `%s`.%s LIKE %s", backup_name, row[0], row[0]);
 
-      if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+      if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
       {
         mysql_free_result(res);
         throw DbErrors("Can't copy schema for table '%s'\nError: %d", row[0], ret);
       }
 
       // copy the table data
-      snprintf(sql, sizeof(sql), "INSERT INTO `%s`.%s SELECT * FROM %s",
-              backup_name, row[0], row[0]);
+      snprintf(sql, sizeof(sql), "INSERT INTO `%s`.%s SELECT * FROM %s", backup_name, row[0],
+               row[0]);
 
-      if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+      if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
       {
         mysql_free_result(res);
         throw DbErrors("Can't copy data for table '%s'\nError: %d", row[0], ret);
@@ -362,23 +373,25 @@ int MysqlDatabase::copy(const char *backup_name) {
   return 1;
 }
 
-int MysqlDatabase::drop_analytics(void) {
-  if ( !active || conn == NULL)
+int MysqlDatabase::drop_analytics(void)
+{
+  if (!active || conn == NULL)
     throw DbErrors("Can't clean database: no active connection...");
 
   char sql[4096];
   int ret;
 
   // ensure we're connected to the db we are about to clean from stuff
-  if ( (ret=mysql_select_db(conn, db.c_str())) != MYSQL_OK )
-    throw DbErrors("Can't connect to database: '%s'",db.c_str());
+  if ((ret = mysql_select_db(conn, db.c_str())) != MYSQL_OK)
+    throw DbErrors("Can't connect to database: '%s'", db.c_str());
 
   // getting a list of indexes in the database
-  snprintf(sql, sizeof(sql), "SELECT DISTINCT table_name, index_name "
+  snprintf(sql, sizeof(sql),
+           "SELECT DISTINCT table_name, index_name "
            "FROM information_schema.statistics "
            "WHERE index_name != 'PRIMARY' AND table_schema = '%s'",
            db.c_str());
-  if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+  if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
     throw DbErrors("Can't determine list of indexes to drop.");
 
   // we will acquire lists here
@@ -387,11 +400,11 @@ int MysqlDatabase::drop_analytics(void) {
 
   if (res)
   {
-    while ( (row=mysql_fetch_row(res)) != NULL )
+    while ((row = mysql_fetch_row(res)) != NULL)
     {
       snprintf(sql, sizeof(sql), "ALTER TABLE `%s`.%s DROP INDEX %s", db.c_str(), row[0], row[1]);
 
-      if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+      if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
       {
         mysql_free_result(res);
         throw DbErrors("Can't drop index '%s'\nError: %d", row[0], ret);
@@ -403,19 +416,19 @@ int MysqlDatabase::drop_analytics(void) {
   // next topic is a views list
   snprintf(sql, sizeof(sql),
            "SELECT table_name FROM information_schema.views WHERE table_schema = '%s'", db.c_str());
-  if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+  if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
     throw DbErrors("Can't determine list of views to drop.");
 
   res = mysql_store_result(conn);
 
   if (res)
   {
-    while ( (row=mysql_fetch_row(res)) != NULL )
+    while ((row = mysql_fetch_row(res)) != NULL)
     {
       /* we do not need IF EXISTS because these views are exist */
       snprintf(sql, sizeof(sql), "DROP VIEW `%s`.%s", db.c_str(), row[0]);
 
-      if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+      if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
       {
         mysql_free_result(res);
         throw DbErrors("Can't drop view '%s'\nError: %d", row[0], ret);
@@ -428,18 +441,18 @@ int MysqlDatabase::drop_analytics(void) {
   snprintf(sql, sizeof(sql),
            "SELECT trigger_name FROM information_schema.triggers WHERE event_object_schema = '%s'",
            db.c_str());
-  if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+  if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
     throw DbErrors("Can't determine list of triggers to drop.");
 
   res = mysql_store_result(conn);
 
   if (res)
   {
-    while ( (row=mysql_fetch_row(res)) != NULL )
+    while ((row = mysql_fetch_row(res)) != NULL)
     {
       snprintf(sql, sizeof(sql), "DROP TRIGGER `%s`.%s", db.c_str(), row[0]);
 
-      if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+      if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
       {
         mysql_free_result(res);
         throw DbErrors("Can't drop trigger '%s'\nError: %d", row[0], ret);
@@ -449,9 +462,10 @@ int MysqlDatabase::drop_analytics(void) {
   }
 
   // Native functions
-  snprintf(sql, sizeof(sql), "SELECT routine_name FROM information_schema.routines "
-          "WHERE routine_type = 'FUNCTION' and routine_schema = '%s'",
-          db.c_str());
+  snprintf(sql, sizeof(sql),
+           "SELECT routine_name FROM information_schema.routines "
+           "WHERE routine_type = 'FUNCTION' and routine_schema = '%s'",
+           db.c_str());
   if ((ret = query_with_reconnect(sql)) != MYSQL_OK)
     throw DbErrors("Can't determine list of routines to drop.");
 
@@ -475,14 +489,15 @@ int MysqlDatabase::drop_analytics(void) {
   return 1;
 }
 
-int MysqlDatabase::query_with_reconnect(const char* query) {
+int MysqlDatabase::query_with_reconnect(const char* query)
+{
   int attempts = 5;
   int result;
 
   // try to reconnect if server is gone
-  while ( ((result = mysql_real_query(conn, query, strlen(query))) != MYSQL_OK) &&
-          ((result = mysql_errno(conn)) == CR_SERVER_GONE_ERROR || result == CR_SERVER_LOST) &&
-          (attempts-- > 0) )
+  while (((result = mysql_real_query(conn, query, strlen(query))) != MYSQL_OK) &&
+         ((result = mysql_errno(conn)) == CR_SERVER_GONE_ERROR || result == CR_SERVER_LOST) &&
+         (attempts-- > 0))
   {
     CLog::Log(LOGINFO, "MYSQL server has gone. Will try {} more attempt(s) to reconnect.",
               attempts);
@@ -493,15 +508,17 @@ int MysqlDatabase::query_with_reconnect(const char* query) {
   return result;
 }
 
-long MysqlDatabase::nextid(const char* sname) {
+long MysqlDatabase::nextid(const char* sname)
+{
   CLog::Log(LOGDEBUG, "MysqlDatabase::nextid for {}", sname);
-  if (!active) return DB_UNEXPECTED_RESULT;
+  if (!active)
+    return DB_UNEXPECTED_RESULT;
   const char* seq_table = "sys_seq";
-  int id;/*,nrow,ncol;*/
+  int id; /*,nrow,ncol;*/
   MYSQL_RES* res;
   char sqlcmd[512];
   snprintf(sqlcmd, sizeof(sqlcmd), "SELECT nextid FROM %s WHERE seq_name = '%s'", seq_table, sname);
-  CLog::Log(LOGDEBUG,"MysqlDatabase::nextid will request");
+  CLog::Log(LOGDEBUG, "MysqlDatabase::nextid will request");
   if ((last_err = query_with_reconnect(sqlcmd)) != 0)
   {
     return DB_UNEXPECTED_RESULT;
@@ -515,7 +532,8 @@ long MysqlDatabase::nextid(const char* sname) {
       snprintf(sqlcmd, sizeof(sqlcmd), "INSERT INTO %s (nextid,seq_name) VALUES (%d,'%s')",
                seq_table, id, sname);
       mysql_free_result(res);
-      if ((last_err = query_with_reconnect(sqlcmd)) != 0) return DB_UNEXPECTED_RESULT;
+      if ((last_err = query_with_reconnect(sqlcmd)) != 0)
+        return DB_UNEXPECTED_RESULT;
       return id;
     }
     else
@@ -524,7 +542,8 @@ long MysqlDatabase::nextid(const char* sname) {
       snprintf(sqlcmd, sizeof(sqlcmd), "UPDATE %s SET nextid=%d WHERE seq_name = '%s'", seq_table,
                id, sname);
       mysql_free_result(res);
-      if ((last_err = query_with_reconnect(sqlcmd)) != 0) return DB_UNEXPECTED_RESULT;
+      if ((last_err = query_with_reconnect(sqlcmd)) != 0)
+        return DB_UNEXPECTED_RESULT;
       return id;
     }
   }
@@ -533,39 +552,43 @@ long MysqlDatabase::nextid(const char* sname) {
 
 // methods for transactions
 // ---------------------------------------------
-void MysqlDatabase::start_transaction() {
+void MysqlDatabase::start_transaction()
+{
   if (active)
   {
     mysql_autocommit(conn, false);
-    CLog::Log(LOGDEBUG,"Mysql Start transaction");
+    CLog::Log(LOGDEBUG, "Mysql Start transaction");
     _in_transaction = true;
   }
 }
 
-void MysqlDatabase::commit_transaction() {
+void MysqlDatabase::commit_transaction()
+{
   if (active)
   {
     mysql_commit(conn);
     mysql_autocommit(conn, true);
-    CLog::Log(LOGDEBUG,"Mysql commit transaction");
+    CLog::Log(LOGDEBUG, "Mysql commit transaction");
     _in_transaction = false;
   }
 }
 
-void MysqlDatabase::rollback_transaction() {
+void MysqlDatabase::rollback_transaction()
+{
   if (active)
   {
     mysql_rollback(conn);
     mysql_autocommit(conn, true);
-    CLog::Log(LOGDEBUG,"Mysql rollback transaction");
+    CLog::Log(LOGDEBUG, "Mysql rollback transaction");
     _in_transaction = false;
   }
 }
 
-bool MysqlDatabase::exists(void) {
+bool MysqlDatabase::exists(void)
+{
   bool ret = false;
 
-  if ( conn == NULL || mysql_ping(conn) )
+  if (conn == NULL || mysql_ping(conn))
   {
     CLog::Log(LOGERROR, "Not connected to database, test of existence is not possible.");
     return ret;
@@ -574,7 +597,7 @@ bool MysqlDatabase::exists(void) {
   MYSQL_RES* result = mysql_list_dbs(conn, db.c_str());
   if (result == NULL)
   {
-    CLog::Log(LOGERROR,"Database is not present, does the user has CREATE DATABASE permission");
+    CLog::Log(LOGERROR, "Database is not present, does the user has CREATE DATABASE permission");
     return false;
   }
 
@@ -596,7 +619,7 @@ bool MysqlDatabase::exists(void) {
 
 // methods for formatting
 // ---------------------------------------------
-std::string MysqlDatabase::vprepare(const char *format, va_list args)
+std::string MysqlDatabase::vprepare(const char* format, va_list args)
 {
   std::string strFormat = format;
   std::string strResult = "";
@@ -605,13 +628,13 @@ std::string MysqlDatabase::vprepare(const char *format, va_list args)
   //  %q is the sqlite format string for %s.
   //  Any bad character, like "'", will be replaced with a proper one
   pos = 0;
-  while ( (pos = strFormat.find("%s", pos)) != std::string::npos )
+  while ((pos = strFormat.find("%s", pos)) != std::string::npos)
     strFormat.replace(pos++, 2, "%q");
 
   strResult = mysql_vmprintf(strFormat.c_str(), args);
   //  RAND() is the mysql form of RANDOM()
   pos = 0;
-  while ( (pos = strResult.find("RANDOM()", pos)) != std::string::npos )
+  while ((pos = strResult.find("RANDOM()", pos)) != std::string::npos)
   {
     strResult.replace(pos++, 8, "RAND()");
     pos += 6;
@@ -655,23 +678,24 @@ std::string MysqlDatabase::vprepare(const char *format, va_list args)
 ** Conversion types fall into various categories as defined by the
 ** following enumeration.
 */
-#define etRADIX       1 /* Integer types.  %d, %x, %o, and so forth */
-#define etFLOAT       2 /* Floating point.  %f */
-#define etEXP         3 /* Exponential notation. %e and %E */
-#define etGENERIC     4 /* Floating or exponential, depending on exponent. %g */
-#define etSIZE        5 /* Return number of characters processed so far. %n */
-#define etSTRING      6 /* Strings. %s */
-#define etDYNSTRING   7 /* Dynamically allocated strings. %z */
-#define etPERCENT     8 /* Percent symbol. %% */
-#define etCHARX       9 /* Characters. %c */
+#define etRADIX 1 /* Integer types.  %d, %x, %o, and so forth */
+#define etFLOAT 2 /* Floating point.  %f */
+#define etEXP 3 /* Exponential notation. %e and %E */
+#define etGENERIC 4 /* Floating or exponential, depending on exponent. %g */
+#define etSIZE 5 /* Return number of characters processed so far. %n */
+#define etSTRING 6 /* Strings. %s */
+#define etDYNSTRING 7 /* Dynamically allocated strings. %z */
+#define etPERCENT 8 /* Percent symbol. %% */
+#define etCHARX 9 /* Characters. %c */
 /* The rest are extensions, not normally found in printf() */
-#define etSQLESCAPE  10 /* Strings with '\'' doubled. Strings with '\\' escaped.  %q */
-#define etSQLESCAPE2 11 /* Strings with '\'' doubled and enclosed in '',
+#define etSQLESCAPE 10 /* Strings with '\'' doubled. Strings with '\\' escaped.  %q */
+#define etSQLESCAPE2 \
+  11 /* Strings with '\'' doubled and enclosed in '',
                           NULL pointers replaced by SQL NULL.  %Q */
-#define etPOINTER    14 /* The %p conversion */
+#define etPOINTER 14 /* The %p conversion */
 #define etSQLESCAPE3 15 /* %w -> Strings with '\"' doubled */
 
-#define etINVALID     0 /* Any unrecognized conversion type */
+#define etINVALID 0 /* Any unrecognized conversion type */
 
 /*
 ** An "etByte" is an 8-bit unsigned value.
@@ -682,35 +706,37 @@ typedef unsigned char etByte;
 ** Each builtin conversion character (ex: the 'd' in "%d") is described
 ** by an instance of the following structure
 */
-typedef struct et_info {   /* Information about each format field */
-  char fmttype;            /* The format field code letter */
-  etByte base;             /* The base for radix conversion */
-  etByte flags;            /* One or more of FLAG_ constants below */
-  etByte type;             /* Conversion paradigm */
-  etByte charset;          /* Offset into aDigits[] of the digits string */
-  etByte prefix;           /* Offset into aPrefix[] of the prefix string */
+typedef struct et_info
+{ /* Information about each format field */
+  char fmttype; /* The format field code letter */
+  etByte base; /* The base for radix conversion */
+  etByte flags; /* One or more of FLAG_ constants below */
+  etByte type; /* Conversion paradigm */
+  etByte charset; /* Offset into aDigits[] of the digits string */
+  etByte prefix; /* Offset into aPrefix[] of the prefix string */
 } et_info;
 
 /*
 ** An objected used to accumulate the text of a string where we
 ** do not necessarily know how big the string will be in the end.
 */
-struct StrAccum {
-  char *zBase;         /* A base allocation.  Not from malloc. */
-  char *zText;         /* The string collected so far */
-  int  nChar;          /* Length of the string so far */
-  int  nAlloc;         /* Amount of space allocated in zText */
-  int  mxAlloc;        /* Maximum allowed string length */
-  bool mallocFailed;   /* Becomes true if any memory allocation fails */
-  bool tooBig;         /* Becomes true if string size exceeds limits */
+struct StrAccum
+{
+  char* zBase; /* A base allocation.  Not from malloc. */
+  char* zText; /* The string collected so far */
+  int nChar; /* Length of the string so far */
+  int nAlloc; /* Amount of space allocated in zText */
+  int mxAlloc; /* Maximum allowed string length */
+  bool mallocFailed; /* Becomes true if any memory allocation fails */
+  bool tooBig; /* Becomes true if string size exceeds limits */
 };
 
 /*
 ** Allowed values for et_info.flags
 */
-#define FLAG_SIGNED  1     /* True if the value to convert is signed */
-#define FLAG_INTERN  2     /* True if for internal use only */
-#define FLAG_STRING  4     /* Allow infinity precision */
+#define FLAG_SIGNED 1 /* True if the value to convert is signed */
+#define FLAG_INTERN 2 /* True if for internal use only */
+#define FLAG_STRING 4 /* Allow infinity precision */
 
 /*
 ** The following table is searched linearly, so it is good to put the
@@ -756,36 +782,41 @@ constexpr std::array<et_info, 20> fmtinfo = {{
 ** 16 (the number of significant digits in a 64-bit float) '0' is
 ** always returned.
 */
-char MysqlDatabase::et_getdigit(double *val, int *cnt) {
+char MysqlDatabase::et_getdigit(double* val, int* cnt)
+{
   int digit;
   double d;
-  if( (*cnt)++ >= 16 ) return '0';
+  if ((*cnt)++ >= 16)
+    return '0';
   digit = (int)*val;
   d = digit;
   digit += '0';
-  *val = (*val - d)*10.0;
+  *val = (*val - d) * 10.0;
   return (char)digit;
 }
 
 /*
 ** Append N space characters to the given string buffer.
 */
-void MysqlDatabase::appendSpace(StrAccum *pAccum, int N) {
+void MysqlDatabase::appendSpace(StrAccum* pAccum, int N)
+{
   static const char zSpaces[] = "                             ";
-  while( N>=(int)sizeof(zSpaces)-1 ) {
-    mysqlStrAccumAppend(pAccum, zSpaces, sizeof(zSpaces)-1);
-    N -= sizeof(zSpaces)-1;
+  while (N >= (int)sizeof(zSpaces) - 1)
+  {
+    mysqlStrAccumAppend(pAccum, zSpaces, sizeof(zSpaces) - 1);
+    N -= sizeof(zSpaces) - 1;
   }
-  if( N>0 ){
+  if (N > 0)
+  {
     mysqlStrAccumAppend(pAccum, zSpaces, N);
   }
 }
 
 #ifndef MYSQL_PRINT_BUF_SIZE
-# define MYSQL_PRINT_BUF_SIZE 350
+#define MYSQL_PRINT_BUF_SIZE 350
 #endif
 
-#define etBUFSIZE MYSQL_PRINT_BUF_SIZE  /* Size of the output buffer */
+#define etBUFSIZE MYSQL_PRINT_BUF_SIZE /* Size of the output buffer */
 
 /*
 ** The maximum length of a TEXT or BLOB in bytes.   This also
@@ -795,7 +826,7 @@ void MysqlDatabase::appendSpace(StrAccum *pAccum, int N) {
 ** to count the size: 2^31-1 or 2147483647.
 */
 #ifndef MYSQL_MAX_LENGTH
-# define MYSQL_MAX_LENGTH 1000000000
+#define MYSQL_MAX_LENGTH 1000000000
 #endif
 
 /*
@@ -825,119 +856,159 @@ void MysqlDatabase::appendSpace(StrAccum *pAccum, int N) {
 ** seems to make a big difference in determining how fast this beast
 ** will run.
 */
-void MysqlDatabase::mysqlVXPrintf(
-  StrAccum *pAccum,                  /* Accumulate results here */
-  int useExtended,                   /* Allow extended %-conversions */
-  const char *fmt,                   /* Format string */
-  va_list ap                         /* arguments */
-){
-  int c;                     /* Next character in the format string */
-  char *bufpt;               /* Pointer to the conversion buffer */
-  int precision;             /* Precision of the current field */
-  int length;                /* Length of the field */
-  int idx;                   /* A general purpose loop counter */
-  int width;                 /* Width of the current field */
-  etByte flag_leftjustify;   /* True if "-" flag is present */
-  etByte flag_plussign;      /* True if "+" flag is present */
-  etByte flag_blanksign;     /* True if " " flag is present */
+void MysqlDatabase::mysqlVXPrintf(StrAccum* pAccum, /* Accumulate results here */
+                                  int useExtended, /* Allow extended %-conversions */
+                                  const char* fmt, /* Format string */
+                                  va_list ap /* arguments */
+)
+{
+  int c; /* Next character in the format string */
+  char* bufpt; /* Pointer to the conversion buffer */
+  int precision; /* Precision of the current field */
+  int length; /* Length of the field */
+  int idx; /* A general purpose loop counter */
+  int width; /* Width of the current field */
+  etByte flag_leftjustify; /* True if "-" flag is present */
+  etByte flag_plussign; /* True if "+" flag is present */
+  etByte flag_blanksign; /* True if " " flag is present */
   etByte flag_alternateform; /* True if "#" flag is present */
-  etByte flag_altform2;      /* True if "!" flag is present */
-  etByte flag_zeropad;       /* True if field width constant starts with zero */
-  etByte flag_long;          /* True if "l" flag is present */
-  etByte flag_longlong;      /* True if the "ll" flag is present */
-  etByte done;               /* Loop termination flag */
-  uint64_t longvalue;        /* Value for integer types */
-  double realvalue;          /* Value for real types */
-  const et_info *infop;      /* Pointer to the appropriate info structure */
-  char buf[etBUFSIZE];       /* Conversion buffer */
-  char prefix;               /* Prefix character.  "+" or "-" or " " or '\0'. */
-  etByte xtype = 0;          /* Conversion paradigm */
-  char *zExtra;              /* Extra memory used for etTCLESCAPE conversions */
-  int  exp, e2;              /* exponent of real numbers */
-  double rounder;            /* Used for rounding floating point values */
-  etByte flag_dp;            /* True if decimal point should be shown */
-  etByte flag_rtz;           /* True if trailing zeros should be removed */
-  etByte flag_exp;           /* True to force display of the exponent */
-  int nsd;                   /* Number of significant digits returned */
+  etByte flag_altform2; /* True if "!" flag is present */
+  etByte flag_zeropad; /* True if field width constant starts with zero */
+  etByte flag_long; /* True if "l" flag is present */
+  etByte flag_longlong; /* True if the "ll" flag is present */
+  etByte done; /* Loop termination flag */
+  uint64_t longvalue; /* Value for integer types */
+  double realvalue; /* Value for real types */
+  const et_info* infop; /* Pointer to the appropriate info structure */
+  char buf[etBUFSIZE]; /* Conversion buffer */
+  char prefix; /* Prefix character.  "+" or "-" or " " or '\0'. */
+  etByte xtype = 0; /* Conversion paradigm */
+  char* zExtra; /* Extra memory used for etTCLESCAPE conversions */
+  int exp, e2; /* exponent of real numbers */
+  double rounder; /* Used for rounding floating point values */
+  etByte flag_dp; /* True if decimal point should be shown */
+  etByte flag_rtz; /* True if trailing zeros should be removed */
+  etByte flag_exp; /* True to force display of the exponent */
+  int nsd; /* Number of significant digits returned */
 
   length = 0;
   bufpt = 0;
-  for(; (c=(*fmt))!=0; ++fmt){
+  for (; (c = (*fmt)) != 0; ++fmt)
+  {
     bool isLike = false;
-    if( c!='%' ){
+    if (c != '%')
+    {
       int amt;
-      bufpt = const_cast<char *>(fmt);
+      bufpt = const_cast<char*>(fmt);
       amt = 1;
-      while( (c=(*++fmt))!='%' && c!=0 ) amt++;
+      while ((c = (*++fmt)) != '%' && c != 0)
+        amt++;
       isLike = mysqlStrAccumAppend(pAccum, bufpt, amt);
-      if( c==0 ) break;
+      if (c == 0)
+        break;
     }
-    if( (c=(*++fmt))==0 ){
+    if ((c = (*++fmt)) == 0)
+    {
       mysqlStrAccumAppend(pAccum, "%", 1);
       break;
     }
     /* Find out what flags are present */
-    flag_leftjustify = flag_plussign = flag_blanksign = flag_alternateform = flag_altform2 = flag_zeropad = 0;
+    flag_leftjustify = flag_plussign = flag_blanksign = flag_alternateform = flag_altform2 =
+        flag_zeropad = 0;
     done = 0;
     do
     {
-      switch( c )
+      switch (c)
       {
-        case '-':   flag_leftjustify = 1;     break;
-        case '+':   flag_plussign = 1;        break;
-        case ' ':   flag_blanksign = 1;       break;
-        case '#':   flag_alternateform = 1;   break;
-        case '!':   flag_altform2 = 1;        break;
-        case '0':   flag_zeropad = 1;         break;
-        default:    done = 1;                 break;
+        case '-':
+          flag_leftjustify = 1;
+          break;
+        case '+':
+          flag_plussign = 1;
+          break;
+        case ' ':
+          flag_blanksign = 1;
+          break;
+        case '#':
+          flag_alternateform = 1;
+          break;
+        case '!':
+          flag_altform2 = 1;
+          break;
+        case '0':
+          flag_zeropad = 1;
+          break;
+        default:
+          done = 1;
+          break;
       }
-    } while( !done && (c=(*++fmt))!=0 );
+    } while (!done && (c = (*++fmt)) != 0);
     /* Get the field width */
     width = 0;
-    if( c=='*' ){
-      width = va_arg(ap,int);
-      if( width<0 ){
+    if (c == '*')
+    {
+      width = va_arg(ap, int);
+      if (width < 0)
+      {
         flag_leftjustify = 1;
         width = -width;
       }
       c = *++fmt;
-    }else{
-      while( c>='0' && c<='9' ){
-        width = width*10 + c - '0';
+    }
+    else
+    {
+      while (c >= '0' && c <= '9')
+      {
+        width = width * 10 + c - '0';
         c = *++fmt;
       }
     }
-    if( width > etBUFSIZE-10 ){
-      width = etBUFSIZE-10;
+    if (width > etBUFSIZE - 10)
+    {
+      width = etBUFSIZE - 10;
     }
     /* Get the precision */
-    if( c=='.' ){
+    if (c == '.')
+    {
       precision = 0;
       c = *++fmt;
-      if( c=='*' ){
-        precision = va_arg(ap,int);
-        if( precision<0 ) precision = -precision;
+      if (c == '*')
+      {
+        precision = va_arg(ap, int);
+        if (precision < 0)
+          precision = -precision;
         c = *++fmt;
-      }else{
-        while( c>='0' && c<='9' ){
-          precision = precision*10 + c - '0';
+      }
+      else
+      {
+        while (c >= '0' && c <= '9')
+        {
+          precision = precision * 10 + c - '0';
           c = *++fmt;
         }
       }
-    }else{
+    }
+    else
+    {
       precision = -1;
     }
     /* Get the conversion type modifier */
-    if( c=='l' ){
+    if (c == 'l')
+    {
       flag_long = 1;
       c = *++fmt;
-      if( c=='l' ){
+      if (c == 'l')
+      {
         flag_longlong = 1;
         c = *++fmt;
-      }else{
+      }
+      else
+      {
         flag_longlong = 0;
       }
-    }else{
+    }
+    else
+    {
       flag_long = flag_longlong = 0;
     }
     /* Fetch the info entry for the field */
@@ -966,8 +1037,9 @@ void MysqlDatabase::mysqlVXPrintf(
     zExtra = 0;
 
     /* Limit the precision to prevent overflowing buf[] during conversion */
-    if( precision>etBUFSIZE-40 && (infop->flags & FLAG_STRING)==0 ){
-      precision = etBUFSIZE-40;
+    if (precision > etBUFSIZE - 40 && (infop->flags & FLAG_STRING) == 0)
+    {
+      precision = etBUFSIZE - 40;
     }
 
     /*
@@ -991,88 +1063,127 @@ void MysqlDatabase::mysqlVXPrintf(
     **   xtype                       The class of the conversion.
     **   infop                       Pointer to the appropriate info struct.
     */
-    switch( xtype ){
+    switch (xtype)
+    {
       case etPOINTER:
-        flag_longlong = sizeof(char*)==sizeof(int64_t);
-        flag_long = sizeof(char*)==sizeof(long int);
+        flag_longlong = sizeof(char*) == sizeof(int64_t);
+        flag_long = sizeof(char*) == sizeof(long int);
         /* Fall through into the next case */
         [[fallthrough]];
       case etRADIX:
-        if( infop->flags & FLAG_SIGNED ){
+        if (infop->flags & FLAG_SIGNED)
+        {
           int64_t v;
-          if( flag_longlong ){
-            v = va_arg(ap,int64_t);
-          }else if( flag_long ){
-            v = va_arg(ap,long int);
-          }else{
-            v = va_arg(ap,int);
+          if (flag_longlong)
+          {
+            v = va_arg(ap, int64_t);
           }
-          if( v<0 ){
+          else if (flag_long)
+          {
+            v = va_arg(ap, long int);
+          }
+          else
+          {
+            v = va_arg(ap, int);
+          }
+          if (v < 0)
+          {
             longvalue = -v;
             prefix = '-';
-          }else{
-            longvalue = v;
-            if( flag_plussign )        prefix = '+';
-            else if( flag_blanksign )  prefix = ' ';
-            else                       prefix = 0;
           }
-        }else{
-          if( flag_longlong ){
-            longvalue = va_arg(ap,uint64_t);
-          }else if( flag_long ){
-            longvalue = va_arg(ap,unsigned long int);
-          }else{
-            longvalue = va_arg(ap,unsigned int);
+          else
+          {
+            longvalue = v;
+            if (flag_plussign)
+              prefix = '+';
+            else if (flag_blanksign)
+              prefix = ' ';
+            else
+              prefix = 0;
+          }
+        }
+        else
+        {
+          if (flag_longlong)
+          {
+            longvalue = va_arg(ap, uint64_t);
+          }
+          else if (flag_long)
+          {
+            longvalue = va_arg(ap, unsigned long int);
+          }
+          else
+          {
+            longvalue = va_arg(ap, unsigned int);
           }
           prefix = 0;
         }
-        if( longvalue==0 ) flag_alternateform = 0;
-        if( flag_zeropad && precision<width-(prefix!=0) ){
-          precision = width-(prefix!=0);
-        }
-        bufpt = &buf[etBUFSIZE-1];
+        if (longvalue == 0)
+          flag_alternateform = 0;
+        if (flag_zeropad && precision < width - (prefix != 0))
         {
-          const char *cset;
+          precision = width - (prefix != 0);
+        }
+        bufpt = &buf[etBUFSIZE - 1];
+        {
+          const char* cset;
           int base;
           cset = &aDigits[infop->charset];
           base = infop->base;
-          do{                                           /* Convert to ascii */
-            *(--bufpt) = cset[longvalue%base];
-            longvalue = longvalue/base;
-          }while( longvalue>0 );
+          do
+          { /* Convert to ascii */
+            *(--bufpt) = cset[longvalue % base];
+            longvalue = longvalue / base;
+          } while (longvalue > 0);
         }
-        length = (int)(&buf[etBUFSIZE-1]-bufpt);
-        for(idx=precision-length; idx>0; idx--){
-          *(--bufpt) = '0';                             /* Zero pad */
+        length = (int)(&buf[etBUFSIZE - 1] - bufpt);
+        for (idx = precision - length; idx > 0; idx--)
+        {
+          *(--bufpt) = '0'; /* Zero pad */
         }
-        if( prefix ) *(--bufpt) = prefix;               /* Add sign */
-        if( flag_alternateform && infop->prefix ){      /* Add "0" or "0x" */
-          const char *pre;
+        if (prefix)
+          *(--bufpt) = prefix; /* Add sign */
+        if (flag_alternateform && infop->prefix)
+        { /* Add "0" or "0x" */
+          const char* pre;
           char x;
           pre = &aPrefix[infop->prefix];
-          for(; (x=(*pre))!=0; pre++) *(--bufpt) = x;
+          for (; (x = (*pre)) != 0; pre++)
+            *(--bufpt) = x;
         }
-        length = (int)(&buf[etBUFSIZE-1]-bufpt);
+        length = (int)(&buf[etBUFSIZE - 1] - bufpt);
         bufpt[length] = 0;
         break;
       case etFLOAT:
       case etEXP:
       case etGENERIC:
-        realvalue = va_arg(ap,double);
-        if( precision<0 ) precision = 6;         /* Set default precision */
-        if( precision>etBUFSIZE/2-10 ) precision = etBUFSIZE/2-10;
-        if( realvalue<0.0 ){
+        realvalue = va_arg(ap, double);
+        if (precision < 0)
+          precision = 6; /* Set default precision */
+        if (precision > etBUFSIZE / 2 - 10)
+          precision = etBUFSIZE / 2 - 10;
+        if (realvalue < 0.0)
+        {
           realvalue = -realvalue;
           prefix = '-';
-        }else{
-          if( flag_plussign )          prefix = '+';
-          else if( flag_blanksign )    prefix = ' ';
-          else                         prefix = 0;
         }
-        if( xtype==etGENERIC && precision>0 ) precision--;
+        else
+        {
+          if (flag_plussign)
+            prefix = '+';
+          else if (flag_blanksign)
+            prefix = ' ';
+          else
+            prefix = 0;
+        }
+        if (xtype == etGENERIC && precision > 0)
+          precision--;
         /* It makes more sense to use 0.5 */
-        for(idx=precision, rounder=0.5; idx>0; idx--, rounder*=0.1){}
-        if( xtype==etFLOAT ) realvalue += rounder;
+        for (idx = precision, rounder = 0.5; idx > 0; idx--, rounder *= 0.1)
+        {
+        }
+        if (xtype == etFLOAT)
+          realvalue += rounder;
         /* Normalize realvalue to within 10.0 > realvalue >= 1.0 */
         exp = 0;
 #if 0
@@ -1082,19 +1193,46 @@ void MysqlDatabase::mysqlVXPrintf(
           break;
         }
 #endif
-        if( realvalue>0.0 ){
-          while( realvalue>=1e32 && exp<=350 ){ realvalue *= 1e-32; exp+=32; }
-          while( realvalue>=1e8 && exp<=350 ){ realvalue *= 1e-8; exp+=8; }
-          while( realvalue>=10.0 && exp<=350 ){ realvalue *= 0.1; exp++; }
-          while( realvalue<1e-8 ){ realvalue *= 1e8; exp-=8; }
-          while( realvalue<1.0 ){ realvalue *= 10.0; exp--; }
-          if( exp>350 ){
-            if( prefix=='-' ){
-              bufpt = const_cast<char *>("-Inf");
-            }else if( prefix=='+' ){
-              bufpt = const_cast<char *>("+Inf");
-            }else{
-              bufpt = const_cast<char *>("Inf");
+        if (realvalue > 0.0)
+        {
+          while (realvalue >= 1e32 && exp <= 350)
+          {
+            realvalue *= 1e-32;
+            exp += 32;
+          }
+          while (realvalue >= 1e8 && exp <= 350)
+          {
+            realvalue *= 1e-8;
+            exp += 8;
+          }
+          while (realvalue >= 10.0 && exp <= 350)
+          {
+            realvalue *= 0.1;
+            exp++;
+          }
+          while (realvalue < 1e-8)
+          {
+            realvalue *= 1e8;
+            exp -= 8;
+          }
+          while (realvalue < 1.0)
+          {
+            realvalue *= 10.0;
+            exp--;
+          }
+          if (exp > 350)
+          {
+            if (prefix == '-')
+            {
+              bufpt = const_cast<char*>("-Inf");
+            }
+            else if (prefix == '+')
+            {
+              bufpt = const_cast<char*>("+Inf");
+            }
+            else
+            {
+              bufpt = const_cast<char*>("Inf");
             }
             length = strlen(bufpt);
             break;
@@ -1105,105 +1243,142 @@ void MysqlDatabase::mysqlVXPrintf(
         ** If the field type is etGENERIC, then convert to either etEXP
         ** or etFLOAT, as appropriate.
         */
-        flag_exp = xtype==etEXP;
-        if( xtype!=etFLOAT ){
+        flag_exp = xtype == etEXP;
+        if (xtype != etFLOAT)
+        {
           realvalue += rounder;
-          if( realvalue>=10.0 ){ realvalue *= 0.1; exp++; }
+          if (realvalue >= 10.0)
+          {
+            realvalue *= 0.1;
+            exp++;
+          }
         }
-        if( xtype==etGENERIC ){
+        if (xtype == etGENERIC)
+        {
           flag_rtz = !flag_alternateform;
-          if( exp<-4 || exp>precision ){
+          if (exp < -4 || exp > precision)
+          {
             xtype = etEXP;
-          }else{
+          }
+          else
+          {
             precision = precision - exp;
             xtype = etFLOAT;
           }
-        }else{
+        }
+        else
+        {
           flag_rtz = 0;
         }
-        if( xtype==etEXP ){
+        if (xtype == etEXP)
+        {
           e2 = 0;
-        }else{
+        }
+        else
+        {
           e2 = exp;
         }
         nsd = 0;
-        flag_dp = (precision>0 ?1:0) | flag_alternateform | flag_altform2;
+        flag_dp = (precision > 0 ? 1 : 0) | flag_alternateform | flag_altform2;
         /* The sign in front of the number */
-        if( prefix ){
+        if (prefix)
+        {
           *(bufpt++) = prefix;
         }
         /* Digits prior to the decimal point */
-        if( e2<0 ){
+        if (e2 < 0)
+        {
           *(bufpt++) = '0';
-        }else{
-          for(; e2>=0; e2--){
-            *(bufpt++) = et_getdigit(&realvalue,&nsd);
+        }
+        else
+        {
+          for (; e2 >= 0; e2--)
+          {
+            *(bufpt++) = et_getdigit(&realvalue, &nsd);
           }
         }
         /* The decimal point */
-        if( flag_dp ){
+        if (flag_dp)
+        {
           *(bufpt++) = '.';
         }
         /* "0" digits after the decimal point but before the first
         ** significant digit of the number */
-        for(e2++; e2<0; precision--, e2++){
+        for (e2++; e2 < 0; precision--, e2++)
+        {
           //ASSERT( precision>0 );
           *(bufpt++) = '0';
         }
         /* Significant digits after the decimal point */
-        while( (precision--)>0 ){
-          *(bufpt++) = et_getdigit(&realvalue,&nsd);
+        while ((precision--) > 0)
+        {
+          *(bufpt++) = et_getdigit(&realvalue, &nsd);
         }
         /* Remove trailing zeros and the "." if no digits follow the "." */
-        if( flag_rtz && flag_dp ){
-          while( bufpt[-1]=='0' ) *(--bufpt) = 0;
+        if (flag_rtz && flag_dp)
+        {
+          while (bufpt[-1] == '0')
+            *(--bufpt) = 0;
           //ASSERT( bufpt>buf );
-          if( bufpt[-1]=='.' ){
-            if( flag_altform2 ){
+          if (bufpt[-1] == '.')
+          {
+            if (flag_altform2)
+            {
               *(bufpt++) = '0';
-            }else{
+            }
+            else
+            {
               *(--bufpt) = 0;
             }
           }
         }
         /* Add the "eNNN" suffix */
-        if( flag_exp || xtype==etEXP ){
+        if (flag_exp || xtype == etEXP)
+        {
           *(bufpt++) = aDigits[infop->charset];
-          if( exp<0 ){
-            *(bufpt++) = '-'; exp = -exp;
-          }else{
+          if (exp < 0)
+          {
+            *(bufpt++) = '-';
+            exp = -exp;
+          }
+          else
+          {
             *(bufpt++) = '+';
           }
-          if( exp>=100 ){
-            *(bufpt++) = (char)((exp/100)+'0');        /* 100's digit */
+          if (exp >= 100)
+          {
+            *(bufpt++) = (char)((exp / 100) + '0'); /* 100's digit */
             exp %= 100;
           }
-          *(bufpt++) = (char)(exp/10+'0');             /* 10's digit */
-          *(bufpt++) = (char)(exp%10+'0');             /* 1's digit */
+          *(bufpt++) = (char)(exp / 10 + '0'); /* 10's digit */
+          *(bufpt++) = (char)(exp % 10 + '0'); /* 1's digit */
         }
         *bufpt = 0;
 
         /* The converted number is in buf[] and zero terminated. Output it.
         ** Note that the number is in the usual order, not reversed as with
         ** integer conversions. */
-        length = (int)(bufpt-buf);
+        length = (int)(bufpt - buf);
         bufpt = buf;
 
         /* Special case:  Add leading zeros if the flag_zeropad flag is
         ** set and we are not left justified */
-        if( flag_zeropad && !flag_leftjustify && length < width){
+        if (flag_zeropad && !flag_leftjustify && length < width)
+        {
           int i;
           int nPad = width - length;
-          for(i=width; i>=nPad; i--){
-            bufpt[i] = bufpt[i-nPad];
+          for (i = width; i >= nPad; i--)
+          {
+            bufpt[i] = bufpt[i - nPad];
           }
-          i = prefix!=0;
-          while( nPad-- ) bufpt[i++] = '0';
+          i = prefix != 0;
+          while (nPad--)
+            bufpt[i++] = '0';
           length = width;
         }
         break;
       case etSIZE:
-        *(va_arg(ap,int*)) = pAccum->nChar;
+        *(va_arg(ap, int*)) = pAccum->nChar;
         length = width = 0;
         break;
       case etPERCENT:
@@ -1212,62 +1387,83 @@ void MysqlDatabase::mysqlVXPrintf(
         length = 1;
         break;
       case etCHARX:
-        c = va_arg(ap,int);
+        c = va_arg(ap, int);
         buf[0] = (char)c;
-        if( precision>=0 ){
-          for(idx=1; idx<precision; idx++) buf[idx] = (char)c;
+        if (precision >= 0)
+        {
+          for (idx = 1; idx < precision; idx++)
+            buf[idx] = (char)c;
           length = precision;
-        }else{
-          length =1;
+        }
+        else
+        {
+          length = 1;
         }
         bufpt = buf;
         break;
       case etSTRING:
       case etDYNSTRING:
-        bufpt = va_arg(ap,char*);
-        if( bufpt==0 ){
-          bufpt = const_cast<char *>("");
-        }else if( xtype==etDYNSTRING ){
+        bufpt = va_arg(ap, char*);
+        if (bufpt == 0)
+        {
+          bufpt = const_cast<char*>("");
+        }
+        else if (xtype == etDYNSTRING)
+        {
           zExtra = bufpt;
         }
-        if( precision>=0 ){
-          for(length=0; length<precision && bufpt[length]; length++){}
-        }else{
+        if (precision >= 0)
+        {
+          for (length = 0; length < precision && bufpt[length]; length++)
+          {
+          }
+        }
+        else
+        {
           length = strlen(bufpt);
         }
         break;
       case etSQLESCAPE:
       case etSQLESCAPE2:
-      case etSQLESCAPE3: {
+      case etSQLESCAPE3:
+      {
         int i, j, k, n, isnull;
         int needQuote;
         char ch;
-        char q = ((xtype==etSQLESCAPE3)?'"':'\'');   /* Quote character */
+        char q = ((xtype == etSQLESCAPE3) ? '"' : '\''); /* Quote character */
         std::string arg = va_arg(ap, char*);
         if (isLike)
           StringUtils::Replace(arg, "\\", "\\\\");
-        const char *escarg = arg.c_str();
+        const char* escarg = arg.c_str();
 
-        isnull = escarg==0;
-        if( isnull ) escarg = (xtype==etSQLESCAPE2 ? "NULL" : "(NULL)");
+        isnull = escarg == 0;
+        if (isnull)
+          escarg = (xtype == etSQLESCAPE2 ? "NULL" : "(NULL)");
         k = precision;
-        for(i=0; k!=0 && (ch=escarg[i])!=0; i++, k--);
-        needQuote = !isnull && xtype==etSQLESCAPE2;
-        n = i*2 + 1 + needQuote*2;
-        if( n>etBUFSIZE ){
-          bufpt = zExtra = (char *)malloc(n);
-          if( bufpt==0 ){
+        for (i = 0; k != 0 && (ch = escarg[i]) != 0; i++, k--)
+          ;
+        needQuote = !isnull && xtype == etSQLESCAPE2;
+        n = i * 2 + 1 + needQuote * 2;
+        if (n > etBUFSIZE)
+        {
+          bufpt = zExtra = (char*)malloc(n);
+          if (bufpt == 0)
+          {
             pAccum->mallocFailed = true;
             return;
           }
-        }else{
+        }
+        else
+        {
           bufpt = buf;
         }
         j = 0;
-        if( needQuote ) bufpt[j++] = q;
+        if (needQuote)
+          bufpt[j++] = q;
         k = i;
         j += mysql_real_escape_string(conn, bufpt, escarg, k);
-        if( needQuote ) bufpt[j++] = q;
+        if (needQuote)
+          bufpt[j++] = q;
         bufpt[j] = 0;
         length = j;
         /* The precision in %q and %Q means how many input characters to
@@ -1275,68 +1471,86 @@ void MysqlDatabase::mysqlVXPrintf(
         ** if( precision>=0 && precision<length ) length = precision; */
         break;
       }
-      default: {
+      default:
+      {
         return;
       }
-    }/* End switch over the format type */
+    } /* End switch over the format type */
     /*
     ** The text of the conversion is pointed to by "bufpt" and is
     ** "length" characters long.  The field width is "width".  Do
     ** the output.
     */
-    if( !flag_leftjustify ){
+    if (!flag_leftjustify)
+    {
       int nspace;
-      nspace = width-length;
-      if( nspace>0 ){
+      nspace = width - length;
+      if (nspace > 0)
+      {
         appendSpace(pAccum, nspace);
       }
     }
-    if( length>0 ){
+    if (length > 0)
+    {
       mysqlStrAccumAppend(pAccum, bufpt, length);
     }
-    if( flag_leftjustify ){
+    if (flag_leftjustify)
+    {
       int nspace;
-      nspace = width-length;
-      if( nspace>0 ){
+      nspace = width - length;
+      if (nspace > 0)
+      {
         appendSpace(pAccum, nspace);
       }
     }
-    if( zExtra ){
+    if (zExtra)
+    {
       free(zExtra);
     }
-  }/* End for loop over the format string */
+  } /* End for loop over the format string */
 } /* End of function */
 
 /*
 ** Append N bytes of text from z to the StrAccum object.
 */
-bool MysqlDatabase::mysqlStrAccumAppend(StrAccum *p, const char *z, int N) {
-  if( p->tooBig | p->mallocFailed ){
+bool MysqlDatabase::mysqlStrAccumAppend(StrAccum* p, const char* z, int N)
+{
+  if (p->tooBig | p->mallocFailed)
+  {
     return false;
   }
-  if( N<0 ){
+  if (N < 0)
+  {
     N = strlen(z);
   }
-  if( N==0 || z==0 ){
+  if (N == 0 || z == 0)
+  {
     return false;
   }
-  if( p->nChar+N >= p->nAlloc ){
-    char *zNew;
+  if (p->nChar + N >= p->nAlloc)
+  {
+    char* zNew;
     int szNew = p->nChar;
     szNew += N + 1;
-    if( szNew > p->mxAlloc ){
+    if (szNew > p->mxAlloc)
+    {
       mysqlStrAccumReset(p);
       p->tooBig = true;
       return false;
-    }else{
+    }
+    else
+    {
       p->nAlloc = szNew;
     }
-    zNew = (char *)malloc(p->nAlloc);
-    if( zNew ){
+    zNew = (char*)malloc(p->nAlloc);
+    if (zNew)
+    {
       memcpy(zNew, p->zText, p->nChar);
       mysqlStrAccumReset(p);
       p->zText = zNew;
-    }else{
+    }
+    else
+    {
       p->mallocFailed = true;
       mysqlStrAccumReset(p);
       return false;
@@ -1351,7 +1565,6 @@ bool MysqlDatabase::mysqlStrAccumAppend(StrAccum *p, const char *z, int N) {
               "This query part contains a like, we will double backslash in the next field: {}",
               testString);
     isLike = true;
-
   }
 
   memcpy(&p->zText[p->nChar], z, N);
@@ -1364,14 +1577,20 @@ bool MysqlDatabase::mysqlStrAccumAppend(StrAccum *p, const char *z, int N) {
 ** Return a pointer to the resulting string.  Return a NULL
 ** pointer if any kind of error was encountered.
 */
-char * MysqlDatabase::mysqlStrAccumFinish(StrAccum *p){
-  if( p->zText ){
+char* MysqlDatabase::mysqlStrAccumFinish(StrAccum* p)
+{
+  if (p->zText)
+  {
     p->zText[p->nChar] = 0;
-    if( p->zText==p->zBase ){
-      p->zText = (char *)malloc(p->nChar+1);
-      if( p->zText ){
-        memcpy(p->zText, p->zBase, p->nChar+1);
-      }else{
+    if (p->zText == p->zBase)
+    {
+      p->zText = (char*)malloc(p->nChar + 1);
+      if (p->zText)
+      {
+        memcpy(p->zText, p->zBase, p->nChar + 1);
+      }
+      else
+      {
         p->mallocFailed = true;
       }
     }
@@ -1382,8 +1601,10 @@ char * MysqlDatabase::mysqlStrAccumFinish(StrAccum *p){
 /*
 ** Reset an StrAccum string.  Reclaim all malloced memory.
 */
-void MysqlDatabase::mysqlStrAccumReset(StrAccum *p){
-  if( p->zText!=p->zBase ){
+void MysqlDatabase::mysqlStrAccumReset(StrAccum* p)
+{
+  if (p->zText != p->zBase)
+  {
     free(p->zText);
   }
   p->zText = 0;
@@ -1392,7 +1613,8 @@ void MysqlDatabase::mysqlStrAccumReset(StrAccum *p){
 /*
 ** Initialize a string accumulator
 */
-void MysqlDatabase::mysqlStrAccumInit(StrAccum *p, char *zBase, int n, int mx){
+void MysqlDatabase::mysqlStrAccumInit(StrAccum* p, char* zBase, int n, int mx)
+{
   p->zText = p->zBase = zBase;
   p->nChar = 0;
   p->nAlloc = n;
@@ -1405,7 +1627,8 @@ void MysqlDatabase::mysqlStrAccumInit(StrAccum *p, char *zBase, int n, int mx){
 ** Print into memory obtained from mysql_malloc().  Omit the internal
 ** %-conversion extensions.
 */
-std::string MysqlDatabase::mysql_vmprintf(const char *zFormat, va_list ap) {
+std::string MysqlDatabase::mysql_vmprintf(const char* zFormat, va_list ap)
+{
   char zBase[MYSQL_PRINT_BUF_SIZE];
   StrAccum acc;
 
@@ -1416,31 +1639,37 @@ std::string MysqlDatabase::mysql_vmprintf(const char *zFormat, va_list ap) {
 
 //************* MysqlDataset implementation ***************
 
-MysqlDataset::MysqlDataset():Dataset() {
+MysqlDataset::MysqlDataset() : Dataset()
+{
   haveError = false;
   db = NULL;
   errmsg = NULL;
   autorefresh = false;
 }
 
-MysqlDataset::MysqlDataset(MysqlDatabase *newDb):Dataset(newDb) {
+MysqlDataset::MysqlDataset(MysqlDatabase* newDb) : Dataset(newDb)
+{
   haveError = false;
   db = newDb;
   errmsg = NULL;
   autorefresh = false;
 }
 
-MysqlDataset::~MysqlDataset() {
-   if (errmsg) free(errmsg);
- }
+MysqlDataset::~MysqlDataset()
+{
+  if (errmsg)
+    free(errmsg);
+}
 
-void MysqlDataset::set_autorefresh(bool val) {
-    autorefresh = val;
+void MysqlDataset::set_autorefresh(bool val)
+{
+  autorefresh = val;
 }
 
 //--------- protected functions implementation -----------------//
 
-MYSQL* MysqlDataset::handle(){
+MYSQL* MysqlDataset::handle()
+{
   if (db != NULL)
   {
     return static_cast<MysqlDatabase*>(db)->getHandle();
@@ -1449,12 +1678,15 @@ MYSQL* MysqlDataset::handle(){
   return NULL;
 }
 
-void MysqlDataset::make_query(StringList &_sql) {
+void MysqlDataset::make_query(StringList& _sql)
+{
   std::string query;
-  if (db == NULL) throw DbErrors("No Database Connection");
+  if (db == NULL)
+    throw DbErrors("No Database Connection");
   try
   {
-    if (autocommit) db->start_transaction();
+    if (autocommit)
+      db->start_transaction();
 
     for (const std::string& i : _sql)
     {
@@ -1466,36 +1698,43 @@ void MysqlDataset::make_query(StringList &_sql) {
       }
     } // end of for
 
-    if (db->in_transaction() && autocommit) db->commit_transaction();
+    if (db->in_transaction() && autocommit)
+      db->commit_transaction();
 
     active = true;
     ds_state = dsSelect;
     if (autorefresh)
       refresh();
   } // end of try
-  catch(...)
+  catch (...)
   {
-    if (db->in_transaction()) db->rollback_transaction();
+    if (db->in_transaction())
+      db->rollback_transaction();
     throw;
   }
-
 }
 
-void MysqlDataset::make_insert() {
+void MysqlDataset::make_insert()
+{
   make_query(insert_sql);
   last();
 }
 
-void MysqlDataset::make_edit() {
+void MysqlDataset::make_edit()
+{
   make_query(update_sql);
 }
 
-void MysqlDataset::make_deletion() {
+void MysqlDataset::make_deletion()
+{
   make_query(delete_sql);
 }
 
-void MysqlDataset::fill_fields() {
-  if ((db == NULL) || (result.record_header.empty()) || (result.records.size() < (unsigned int)frecno)) return;
+void MysqlDataset::fill_fields()
+{
+  if ((db == NULL) || (result.record_header.empty()) ||
+      (result.records.size() < (unsigned int)frecno))
+    return;
 
   if (fields_object->size() == 0) // Filling columns name
   {
@@ -1508,7 +1747,7 @@ void MysqlDataset::fill_fields() {
   //Filling result
   if (result.records.size() != 0)
   {
-    const sql_record *row = result.records[frecno];
+    const sql_record* row = result.records[frecno];
     if (row)
     {
       const unsigned int ncols = row->size();
@@ -1525,12 +1764,13 @@ void MysqlDataset::fill_fields() {
 }
 
 //------------- public functions implementation -----------------//
-bool MysqlDataset::dropIndex(const char *table, const char *index)
+bool MysqlDataset::dropIndex(const char* table, const char* index)
 {
   std::string sql;
   std::string sql_prepared;
 
-  sql = "SELECT * FROM information_schema.statistics WHERE TABLE_SCHEMA=DATABASE() AND table_name='%s' AND index_name='%s'";
+  sql = "SELECT * FROM information_schema.statistics WHERE TABLE_SCHEMA=DATABASE() AND "
+        "table_name='%s' AND index_name='%s'";
   sql_prepared = static_cast<MysqlDatabase*>(db)->prepare(sql.c_str(), table, index);
 
   if (!query(sql_prepared))
@@ -1555,15 +1795,18 @@ static bool ci_test(char l, char r)
 
 static size_t ci_find(const std::string& where, const std::string& what)
 {
-  std::string::const_iterator loc = std::search(where.begin(), where.end(), what.begin(), what.end(), ci_test);
+  std::string::const_iterator loc =
+      std::search(where.begin(), where.end(), what.begin(), what.end(), ci_test);
   if (loc == where.end())
     return std::string::npos;
   else
     return loc - where.begin();
 }
 
-int MysqlDataset::exec(const std::string &sql) {
-  if (!handle()) throw DbErrors("No Database Connection");
+int MysqlDataset::exec(const std::string& sql)
+{
+  if (!handle())
+    throw DbErrors("No Database Connection");
   std::string qry = sql;
   int res = 0;
   exec_res.clear();
@@ -1571,14 +1814,14 @@ int MysqlDataset::exec(const std::string &sql) {
   // enforce the "auto_increment" keyword to be appended to "integer primary key"
   size_t loc;
 
-  if ( (loc=ci_find(qry, "integer primary key")) != std::string::npos)
+  if ((loc = ci_find(qry, "integer primary key")) != std::string::npos)
   {
     qry = qry.insert(loc + 19, " auto_increment ");
   }
 
   // force the charset and collation to UTF-8
-  if ( ci_find(qry, "CREATE TABLE") != std::string::npos
-    || ci_find(qry, "CREATE TEMPORARY TABLE") != std::string::npos )
+  if (ci_find(qry, "CREATE TABLE") != std::string::npos ||
+      ci_find(qry, "CREATE TEMPORARY TABLE") != std::string::npos)
   {
     // If CREATE TABLE ... SELECT Syntax is used we need to add the encoding after the table before the select
     // e.g. CREATE TABLE x CHARACTER SET utf8 COLLATE utf8_general_ci [AS] SELECT * FROM y
@@ -1593,7 +1836,8 @@ int MysqlDataset::exec(const std::string &sql) {
 
   CLog::Log(LOGDEBUG, "Mysql execute: {}", qry);
 
-  if (db->setErr( static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry.c_str()), qry.c_str()) != MYSQL_OK)
+  if (db->setErr(static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry.c_str()), qry.c_str()) !=
+      MYSQL_OK)
   {
     throw DbErrors(db->getErrorMsg());
   }
@@ -1604,20 +1848,24 @@ int MysqlDataset::exec(const std::string &sql) {
   }
 }
 
-int MysqlDataset::exec() {
-   return exec(sql);
+int MysqlDataset::exec()
+{
+  return exec(sql);
 }
 
-const void* MysqlDataset::getExecRes() {
+const void* MysqlDataset::getExecRes()
+{
   return &exec_res;
 }
 
-bool MysqlDataset::query(const std::string &query) {
-  if(!handle()) throw DbErrors("No Database Connection");
+bool MysqlDataset::query(const std::string& query)
+{
+  if (!handle())
+    throw DbErrors("No Database Connection");
   std::string qry = query;
   int fs = qry.find("select");
   int fS = qry.find("SELECT");
-  if (!( fs >= 0 || fS >=0))
+  if (!(fs >= 0 || fS >= 0))
     throw DbErrors("MUST be select SQL!");
 
   close();
@@ -1628,9 +1876,11 @@ bool MysqlDataset::query(const std::string &query) {
   while ((loc = ci_find(qry, "as integer)")) != std::string::npos)
     qry = qry.insert(loc + 3, "signed ");
 
-  MYSQL_RES *stmt = NULL;
+  MYSQL_RES* stmt = NULL;
 
-  if ( static_cast<MysqlDatabase*>(db)->setErr(static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry.c_str()), qry.c_str()) != MYSQL_OK )
+  if (static_cast<MysqlDatabase*>(db)->setErr(
+          static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry.c_str()), qry.c_str()) !=
+      MYSQL_OK)
     throw DbErrors(db->getErrorMsg());
 
   MYSQL* conn = handle();
@@ -1640,7 +1890,7 @@ bool MysqlDataset::query(const std::string &query) {
 
   // column headers
   const unsigned int numColumns = mysql_num_fields(stmt);
-  MYSQL_FIELD *fields = mysql_fetch_fields(stmt);
+  MYSQL_FIELD* fields = mysql_fetch_fields(stmt);
   MYSQL_ROW row;
   result.record_header.resize(numColumns);
   for (unsigned int i = 0; i < numColumns; i++)
@@ -1649,11 +1899,11 @@ bool MysqlDataset::query(const std::string &query) {
   // returned rows
   while ((row = mysql_fetch_row(stmt)))
   { // have a row of data
-    sql_record *res = new sql_record;
+    sql_record* res = new sql_record;
     res->resize(numColumns);
     for (unsigned int i = 0; i < numColumns; i++)
     {
-      field_value &v = res->at(i);
+      field_value& v = res->at(i);
       switch (fields[i].type)
       {
         case MYSQL_TYPE_LONGLONG:
@@ -1695,13 +1945,15 @@ bool MysqlDataset::query(const std::string &query) {
         case MYSQL_TYPE_STRING:
         case MYSQL_TYPE_VAR_STRING:
         case MYSQL_TYPE_VARCHAR:
-          if (row[i] != NULL) v.set_asString((const char *)row[i] );
+          if (row[i] != NULL)
+            v.set_asString((const char*)row[i]);
           break;
         case MYSQL_TYPE_TINY_BLOB:
         case MYSQL_TYPE_MEDIUM_BLOB:
         case MYSQL_TYPE_LONG_BLOB:
         case MYSQL_TYPE_BLOB:
-          if (row[i] != NULL) v.set_asString((const char *)row[i]);
+          if (row[i] != NULL)
+            v.set_asString((const char*)row[i]);
           break;
         case MYSQL_TYPE_NULL:
         default:
@@ -1720,12 +1972,14 @@ bool MysqlDataset::query(const std::string &query) {
   return true;
 }
 
-void MysqlDataset::open(const std::string &sql) {
-   set_select_sql(sql);
-   open();
+void MysqlDataset::open(const std::string& sql)
+{
+  set_select_sql(sql);
+  open();
 }
 
-void MysqlDataset::open() {
+void MysqlDataset::open()
+{
   if (select_sql.size())
   {
     query(select_sql);
@@ -1736,7 +1990,8 @@ void MysqlDataset::open() {
   }
 }
 
-void MysqlDataset::close() {
+void MysqlDataset::close()
+{
   Dataset::close();
   result.clear();
   edit_object->clear();
@@ -1745,8 +2000,9 @@ void MysqlDataset::close() {
   active = false;
 }
 
-void MysqlDataset::cancel() {
-  if ((ds_state == dsInsert) || (ds_state==dsEdit))
+void MysqlDataset::cancel()
+{
+  if ((ds_state == dsInsert) || (ds_state == dsEdit))
   {
     if (result.record_header.size())
       ds_state = dsSelect;
@@ -1755,37 +2011,44 @@ void MysqlDataset::cancel() {
   }
 }
 
-int MysqlDataset::num_rows() {
+int MysqlDataset::num_rows()
+{
   return result.records.size();
 }
 
-bool MysqlDataset::eof() {
+bool MysqlDataset::eof()
+{
   return feof;
 }
 
-bool MysqlDataset::bof() {
+bool MysqlDataset::bof()
+{
   return fbof;
 }
 
-void MysqlDataset::first() {
+void MysqlDataset::first()
+{
   Dataset::first();
   this->fill_fields();
 }
 
-void MysqlDataset::last() {
+void MysqlDataset::last()
+{
   Dataset::last();
   fill_fields();
 }
 
-void MysqlDataset::prev(void) {
+void MysqlDataset::prev(void)
+{
   Dataset::prev();
   fill_fields();
 }
 
-void MysqlDataset::next(void) {
+void MysqlDataset::next(void)
+{
   Dataset::next();
   if (!eof())
-      fill_fields();
+    fill_fields();
 }
 
 void MysqlDataset::free_row(void)
@@ -1793,7 +2056,7 @@ void MysqlDataset::free_row(void)
   if (frecno < 0 || (unsigned int)frecno >= result.records.size())
     return;
 
-  sql_record *row = result.records[frecno];
+  sql_record* row = result.records[frecno];
   if (row)
   {
     delete row;
@@ -1801,7 +2064,8 @@ void MysqlDataset::free_row(void)
   }
 }
 
-bool MysqlDataset::seek(int pos) {
+bool MysqlDataset::seek(int pos)
+{
   if (ds_state == dsSelect)
   {
     Dataset::seek(pos);
@@ -1812,20 +2076,24 @@ bool MysqlDataset::seek(int pos) {
   return false;
 }
 
-int64_t MysqlDataset::lastinsertid() {
-  if (!handle()) throw DbErrors("No Database Connection");
+int64_t MysqlDataset::lastinsertid()
+{
+  if (!handle())
+    throw DbErrors("No Database Connection");
   return mysql_insert_id(handle());
 }
 
-long MysqlDataset::nextid(const char *seq_name) {
+long MysqlDataset::nextid(const char* seq_name)
+{
   if (handle())
     return db->nextid(seq_name);
 
   return DB_UNEXPECTED_RESULT;
 }
 
-void MysqlDataset::interrupt() {
+void MysqlDataset::interrupt()
+{
   // Impossible
 }
 
-}//namespace
+} // namespace dbiplus

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1741,7 +1741,11 @@ void MysqlDataset::fill_fields()
     const unsigned int ncols = result.record_header.size();
     fields_object->resize(ncols);
     for (unsigned int i = 0; i < ncols; i++)
+    {
       (*fields_object)[i].props = result.record_header[i];
+      std::string name = result.record_header[i].name;
+      name2indexMap.insert({str_toLower(name.data()), i});
+    }
   }
 
   //Filling result

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -8,91 +8,90 @@
 
 #pragma once
 
-#include <stdio.h>
 #include "dataset.h"
+
+#include <stdio.h>
 #ifdef HAS_MYSQL
 #include <mysql/mysql.h>
 #elif defined(HAS_MARIADB)
 #include <mariadb/mysql.h>
 #endif
 
-namespace dbiplus {
+namespace dbiplus
+{
 /***************** Class MysqlDatabase definition ******************
 
        class 'MysqlDatabase' connects with MySQL-server
 
 ******************************************************************/
-class MysqlDatabase: public Database {
+class MysqlDatabase : public Database
+{
 protected:
-/* connect descriptor */
+  /* connect descriptor */
   MYSQL* conn;
   bool _in_transaction;
   int last_err;
 
-
 public:
-/* default constructor */
+  /* default constructor */
   MysqlDatabase();
-/* destructor */
+  /* destructor */
   ~MysqlDatabase() override;
 
-  Dataset *CreateDataset() const override;
+  Dataset* CreateDataset() const override;
 
-/* func. returns connection handle with MySQL-server */
-  MYSQL *getHandle() {  return conn; }
-/* func. returns current status about MySQL-server connection */
+  /* func. returns connection handle with MySQL-server */
+  MYSQL* getHandle() { return conn; }
+  /* func. returns current status about MySQL-server connection */
   int status() override;
-  int setErr(int err_code,const char * qry) override;
-/* func. returns error message if error occurs */
-  const char *getErrorMsg() override;
+  int setErr(int err_code, const char* qry) override;
+  /* func. returns error message if error occurs */
+  const char* getErrorMsg() override;
 
-/* func. connects to database-server */
+  /* func. connects to database-server */
   int connect(bool create) override;
-/* func. disconnects from database-server */
+  /* func. disconnects from database-server */
   void disconnect() override;
-/* func. creates new database */
+  /* func. creates new database */
   int create() override;
-/* func. deletes database */
+  /* func. deletes database */
   int drop() override;
-/* check if database exists (ie has tables/views defined) */
+  /* check if database exists (ie has tables/views defined) */
   bool exists() override;
 
-/* \brief copy database */
-  int copy(const char *backup_name) override;
+  /* \brief copy database */
+  int copy(const char* backup_name) override;
 
-/* \brief drop all extra analytics from database */
+  /* \brief drop all extra analytics from database */
   int drop_analytics(void) override;
 
   long nextid(const char* seq_name) override;
 
-/* virtual methods for transaction */
+  /* virtual methods for transaction */
 
   void start_transaction() override;
   void commit_transaction() override;
   void rollback_transaction() override;
 
-/* virtual methods for formatting */
-  std::string vprepare(const char *format, va_list args) override;
+  /* virtual methods for formatting */
+  std::string vprepare(const char* format, va_list args) override;
 
   bool in_transaction() override { return _in_transaction; }
   int query_with_reconnect(const char* query);
   void configure_connection();
 
 private:
-
   typedef struct StrAccum StrAccum;
 
-  char et_getdigit(double *val, int *cnt);
-  void appendSpace(StrAccum *pAccum, int N);
-  void mysqlVXPrintf(StrAccum *pAccum, int useExtended, const char *fmt, va_list ap);
-  bool mysqlStrAccumAppend(StrAccum *p, const char *z, int N);
-  char * mysqlStrAccumFinish(StrAccum *p);
-  void mysqlStrAccumReset(StrAccum *p);
-  void mysqlStrAccumInit(StrAccum *p, char *zBase, int n, int mx);
-  std::string mysql_vmprintf(const char *zFormat, va_list ap);
+  char et_getdigit(double* val, int* cnt);
+  void appendSpace(StrAccum* pAccum, int N);
+  void mysqlVXPrintf(StrAccum* pAccum, int useExtended, const char* fmt, va_list ap);
+  bool mysqlStrAccumAppend(StrAccum* p, const char* z, int N);
+  char* mysqlStrAccumFinish(StrAccum* p);
+  void mysqlStrAccumReset(StrAccum* p);
+  void mysqlStrAccumInit(StrAccum* p, char* zBase, int n, int mx);
+  std::string mysql_vmprintf(const char* zFormat, va_list ap);
 };
-
-
 
 /***************** Class MysqlDataset definition *******************
 
@@ -100,58 +99,58 @@ private:
 
 ******************************************************************/
 
-class MysqlDataset : public Dataset {
+class MysqlDataset : public Dataset
+{
 protected:
   MYSQL* handle();
 
-/* Makes direct queries to database */
-  virtual void make_query(StringList &_sql);
-/* Makes direct inserts into database */
+  /* Makes direct queries to database */
+  virtual void make_query(StringList& _sql);
+  /* Makes direct inserts into database */
   void make_insert() override;
-/* Edit SQL */
+  /* Edit SQL */
   void make_edit() override;
-/* Delete SQL */
+  /* Delete SQL */
   void make_deletion() override;
 
-
-/* This function works only with MySQL database
+  /* This function works only with MySQL database
   Filling the fields information from select statement */
   void fill_fields() override;
-/* Changing field values during dataset navigation */
-  virtual void free_row();  // free the memory allocated for the current row
+  /* Changing field values during dataset navigation */
+  virtual void free_row(); // free the memory allocated for the current row
 
 public:
-/* constructor */
+  /* constructor */
   MysqlDataset();
-  explicit MysqlDataset(MysqlDatabase *newDb);
+  explicit MysqlDataset(MysqlDatabase* newDb);
 
-/* destructor */
+  /* destructor */
   ~MysqlDataset() override;
 
-/* set autorefresh boolean value (if true - refresh the data after edit()
+  /* set autorefresh boolean value (if true - refresh the data after edit()
 or insert() operations default = false) */
   void set_autorefresh(bool val);
 
-/* opens a query  & then sets a query results */
+  /* opens a query  & then sets a query results */
   void open() override;
-  void open(const std::string &sql) override;
-/* func. executes a query without results to return */
-  int  exec () override;
-  int  exec (const std::string &sql) override;
+  void open(const std::string& sql) override;
+  /* func. executes a query without results to return */
+  int exec() override;
+  int exec(const std::string& sql) override;
   const void* getExecRes() override;
-/* as open, but with our query exec Sql */
-  bool query(const std::string &query) override;
-/* func. closes a query */
+  /* as open, but with our query exec Sql */
+  bool query(const std::string& query) override;
+  /* func. closes a query */
   void close(void) override;
-/* Cancel changes, made in insert or edit states of dataset */
+  /* Cancel changes, made in insert or edit states of dataset */
   void cancel() override;
-/* last insert id */
+  /* last insert id */
   int64_t lastinsertid() override;
-/* sequence numbers */
-  long nextid(const char *seq_name) override;
-/* sequence numbers */
+  /* sequence numbers */
+  long nextid(const char* seq_name) override;
+  /* sequence numbers */
   int num_rows() override;
-/* interrupt any pending database operation  */
+  /* interrupt any pending database operation  */
   void interrupt() override;
 
   bool bof() override;
@@ -160,10 +159,9 @@ or insert() operations default = false) */
   void last() override;
   void prev() override;
   void next() override;
-/* Go to record No (starting with 0) */
-  bool seek(int pos=0) override;
+  /* Go to record No (starting with 0) */
+  bool seek(int pos = 0) override;
 
-  bool dropIndex(const char *table, const char *index) override;
+  bool dropIndex(const char* table, const char* index) override;
 };
-} //namespace
-
+} // namespace dbiplus

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -22,11 +22,12 @@
 #include <stdlib.h>
 
 #ifndef __GNUC__
-#pragma warning (disable:4800)
-#pragma warning (disable:4715)
+#pragma warning(disable : 4800)
+#pragma warning(disable : 4715)
 #endif
 
-namespace dbiplus {
+namespace dbiplus
+{
 
 //Constructors
 field_value::field_value()
@@ -35,106 +36,126 @@ field_value::field_value()
   is_null = false;
 }
 
-field_value::field_value(const char *s):
-  str_value(s)
+field_value::field_value(const char* s) : str_value(s)
 {
   field_type = ft_String;
   is_null = false;
 }
 
-field_value::field_value(const bool b) {
+field_value::field_value(const bool b)
+{
   bool_value = b;
   field_type = ft_Boolean;
   is_null = false;
 }
 
-field_value::field_value(const char c) {
+field_value::field_value(const char c)
+{
   char_value = c;
   field_type = ft_Char;
   is_null = false;
 }
 
-field_value::field_value(const short s) {
+field_value::field_value(const short s)
+{
   short_value = s;
   field_type = ft_Short;
   is_null = false;
 }
 
-field_value::field_value(const unsigned short us) {
+field_value::field_value(const unsigned short us)
+{
   ushort_value = us;
   field_type = ft_UShort;
   is_null = false;
 }
 
-field_value::field_value(const int i) {
+field_value::field_value(const int i)
+{
   int_value = i;
   field_type = ft_Int;
   is_null = false;
 }
 
-field_value::field_value(const unsigned int ui) {
+field_value::field_value(const unsigned int ui)
+{
   uint_value = ui;
   field_type = ft_UInt;
   is_null = false;
 }
 
-field_value::field_value(const float f) {
+field_value::field_value(const float f)
+{
   float_value = f;
   field_type = ft_Float;
   is_null = false;
 }
 
-field_value::field_value(const double d) {
+field_value::field_value(const double d)
+{
   double_value = d;
   field_type = ft_Double;
   is_null = false;
 }
 
-field_value::field_value(const int64_t i) {
+field_value::field_value(const int64_t i)
+{
   int64_value = i;
   field_type = ft_Int64;
   is_null = false;
 }
 
-field_value::field_value (const field_value & fv) {
-  switch (fv.get_fType()) {
-    case ft_String: {
+field_value::field_value(const field_value& fv)
+{
+  switch (fv.get_fType())
+  {
+    case ft_String:
+    {
       set_asString(fv.get_asString());
       break;
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       set_asBool(fv.get_asBool());
       break;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       set_asChar(fv.get_asChar());
       break;
     }
-    case ft_Short: {
+    case ft_Short:
+    {
       set_asShort(fv.get_asShort());
       break;
     }
-    case ft_UShort: {
+    case ft_UShort:
+    {
       set_asUShort(fv.get_asUShort());
       break;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       set_asInt(fv.get_asInt());
       break;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       set_asUInt(fv.get_asUInt());
       break;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       set_asFloat(fv.get_asFloat());
       break;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       set_asDouble(fv.get_asDouble());
       break;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       set_asInt64(fv.get_asInt64());
       break;
     }
@@ -143,586 +164,739 @@ field_value::field_value (const field_value & fv) {
   }
   is_null = fv.get_isNull();
 }
-
 
 //empty destructor
 field_value::~field_value() = default;
 
-
 //Conversations functions
-std::string field_value::get_asString() const {
-    std::string tmp;
-    switch (field_type) {
-    case ft_String: {
+std::string field_value::get_asString() const
+{
+  std::string tmp;
+  switch (field_type)
+  {
+    case ft_String:
+    {
       tmp = str_value;
       return tmp;
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       if (bool_value)
-	return tmp = "True";
+        return tmp = "True";
       else
-	return tmp = "False";
+        return tmp = "False";
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return tmp = char_value;
     }
-    case ft_Short: {
+    case ft_Short:
+    {
       char t[10];
-      sprintf(t,"%i",short_value);
+      sprintf(t, "%i", short_value);
       return tmp = t;
     }
-    case ft_UShort: {
+    case ft_UShort:
+    {
       char t[10];
-      sprintf(t,"%i",ushort_value);
+      sprintf(t, "%i", ushort_value);
       return tmp = t;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       char t[12];
-      sprintf(t,"%d",int_value);
+      sprintf(t, "%d", int_value);
       return tmp = t;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       char t[12];
-      sprintf(t,"%u",uint_value);
+      sprintf(t, "%u", uint_value);
       return tmp = t;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       char t[16];
       sprintf(t, "%f", static_cast<double>(float_value));
       return tmp = t;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       char t[32];
-      sprintf(t,"%f",double_value);
+      sprintf(t, "%f", double_value);
       return tmp = t;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       char t[23];
-      sprintf(t,"%" PRId64,int64_value);
+      sprintf(t, "%" PRId64, int64_value);
       return tmp = t;
     }
     default:
       return tmp = "";
-    }
   }
+}
 
-
-
-bool field_value::get_asBool() const {
-    switch (field_type) {
-    case ft_String: {
+bool field_value::get_asBool() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       if (str_value == "True" || str_value == "true" || str_value == "1")
-          return true;
+        return true;
       else
-	return false;
+        return false;
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return bool_value;
-      }
-    case ft_Char: {
-      if (char_value == 'T' || char_value == 't')
-	return true;
-      else
-	return false;
     }
-    case ft_Short: {
+    case ft_Char:
+    {
+      if (char_value == 'T' || char_value == 't')
+        return true;
+      else
+        return false;
+    }
+    case ft_Short:
+    {
       return (bool)short_value;
     }
-    case ft_UShort: {
+    case ft_UShort:
+    {
       return (bool)ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return (bool)int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return (bool)uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return (bool)float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (bool)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return (bool)int64_value;
     }
     default:
       return false;
-    }
   }
+}
 
-
-char field_value::get_asChar() const {
-  switch (field_type) {
-    case ft_String: {
+char field_value::get_asChar() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return str_value[0];
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       if (bool_value)
-	return 'T';
+        return 'T';
       else
-	return 'F';
+        return 'F';
     }
-    case ft_Char: {
-      return  char_value;
+    case ft_Char:
+    {
+      return char_value;
     }
-    case ft_Short: {
+    case ft_Short:
+    {
       char t[10];
-      sprintf(t,"%i",short_value);
+      sprintf(t, "%i", short_value);
       return t[0];
     }
-    case ft_UShort: {
+    case ft_UShort:
+    {
       char t[10];
-      sprintf(t,"%i",ushort_value);
+      sprintf(t, "%i", ushort_value);
       return t[0];
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       char t[12];
-      sprintf(t,"%d",int_value);
+      sprintf(t, "%d", int_value);
       return t[0];
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       char t[12];
-      sprintf(t,"%u",uint_value);
+      sprintf(t, "%u", uint_value);
       return t[0];
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       char t[16];
       sprintf(t, "%f", static_cast<double>(float_value));
       return t[0];
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       char t[32];
-      sprintf(t,"%f",double_value);
+      sprintf(t, "%f", double_value);
       return t[0];
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       char t[24];
-      sprintf(t,"%" PRId64,int64_value);
+      sprintf(t, "%" PRId64, int64_value);
       return t[0];
     }
     default:
       return '\0';
-    }
   }
+}
 
-
-short field_value::get_asShort() const {
-    switch (field_type) {
-    case ft_String: {
+short field_value::get_asShort() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return (short)atoi(str_value.c_str());
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return (short)bool_value;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return (short)char_value;
     }
-    case ft_Short: {
-       return short_value;
+    case ft_Short:
+    {
+      return short_value;
     }
-    case ft_UShort: {
-       return (short)ushort_value;
+    case ft_UShort:
+    {
+      return (short)ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return (short)int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return (short)uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return (short)float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (short)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return (short)int64_value;
     }
     default:
       return 0;
-    }
   }
+}
 
-
-unsigned short field_value::get_asUShort() const {
-    switch (field_type) {
-    case ft_String: {
+unsigned short field_value::get_asUShort() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return (unsigned short)atoi(str_value.c_str());
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return (unsigned short)bool_value;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return (unsigned short)char_value;
     }
-    case ft_Short: {
-       return (unsigned short)short_value;
+    case ft_Short:
+    {
+      return (unsigned short)short_value;
     }
-    case ft_UShort: {
-       return ushort_value;
+    case ft_UShort:
+    {
+      return ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return (unsigned short)int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return (unsigned short)uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return (unsigned short)float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (unsigned short)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return (unsigned short)int64_value;
     }
     default:
       return 0;
-    }
   }
+}
 
-int field_value::get_asInt() const {
-    switch (field_type) {
-    case ft_String: {
+int field_value::get_asInt() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return atoi(str_value.c_str());
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return (int)bool_value;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return (int)char_value;
     }
-    case ft_Short: {
-       return (int)short_value;
+    case ft_Short:
+    {
+      return (int)short_value;
     }
-    case ft_UShort: {
-       return (int)ushort_value;
+    case ft_UShort:
+    {
+      return (int)ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return (int)uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return (int)float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (int)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return (int)int64_value;
     }
     default:
       return 0;
-    }
   }
+}
 
-unsigned int field_value::get_asUInt() const {
-    switch (field_type) {
-    case ft_String: {
+unsigned int field_value::get_asUInt() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return (unsigned int)atoi(str_value.c_str());
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return (unsigned int)bool_value;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return (unsigned int)char_value;
     }
-    case ft_Short: {
-       return (unsigned int)short_value;
+    case ft_Short:
+    {
+      return (unsigned int)short_value;
     }
-    case ft_UShort: {
-       return (unsigned int)ushort_value;
+    case ft_UShort:
+    {
+      return (unsigned int)ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return (unsigned int)int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return (unsigned int)float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (unsigned int)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return (unsigned int)int64_value;
     }
     default:
       return 0;
-    }
   }
+}
 
-float field_value::get_asFloat() const {
-    switch (field_type) {
-    case ft_String: {
+float field_value::get_asFloat() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return (float)atof(str_value.c_str());
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return (float)bool_value;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return (float)char_value;
     }
-    case ft_Short: {
-       return (float)short_value;
+    case ft_Short:
+    {
+      return (float)short_value;
     }
-    case ft_UShort: {
-       return (float)ushort_value;
+    case ft_UShort:
+    {
+      return (float)ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return (float)int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return (float)uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (float)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return (float)int64_value;
     }
     default:
       return 0.0;
-    }
   }
+}
 
-double field_value::get_asDouble() const {
-    switch (field_type) {
-    case ft_String: {
+double field_value::get_asDouble() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return atof(str_value.c_str());
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return (double)bool_value;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return (double)char_value;
     }
-    case ft_Short: {
-       return (double)short_value;
+    case ft_Short:
+    {
+      return (double)short_value;
     }
-    case ft_UShort: {
-       return (double)ushort_value;
+    case ft_UShort:
+    {
+      return (double)ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return (double)int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return (double)uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return (double)float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (double)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return (double)int64_value;
     }
     default:
       return 0.0;
-    }
   }
+}
 
-int64_t field_value::get_asInt64() const {
-    switch (field_type) {
-    case ft_String: {
+int64_t field_value::get_asInt64() const
+{
+  switch (field_type)
+  {
+    case ft_String:
+    {
       return std::atoll(str_value.c_str());
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       return (int64_t)bool_value;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       return (int64_t)char_value;
     }
-    case ft_Short: {
-       return (int64_t)short_value;
+    case ft_Short:
+    {
+      return (int64_t)short_value;
     }
-    case ft_UShort: {
-       return (int64_t)ushort_value;
+    case ft_UShort:
+    {
+      return (int64_t)ushort_value;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       return (int64_t)int_value;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       return (int64_t)uint_value;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       return (int64_t)float_value;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       return (int64_t)double_value;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       return int64_value;
     }
     default:
       return 0;
-    }
   }
+}
 
-
-field_value& field_value::operator= (const field_value & fv) {
-  if ( this == &fv ) return *this;
+field_value& field_value::operator=(const field_value& fv)
+{
+  if (this == &fv)
+    return *this;
 
   is_null = fv.get_isNull();
 
-  switch (fv.get_fType()) {
-    case ft_String: {
+  switch (fv.get_fType())
+  {
+    case ft_String:
+    {
       set_asString(fv.get_asString());
       return *this;
       break;
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       set_asBool(fv.get_asBool());
       return *this;
       break;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       set_asChar(fv.get_asChar());
       return *this;
       break;
     }
-    case ft_Short: {
+    case ft_Short:
+    {
       set_asShort(fv.get_asShort());
       return *this;
       break;
     }
-    case ft_UShort: {
+    case ft_UShort:
+    {
       set_asUShort(fv.get_asUShort());
       return *this;
       break;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       set_asInt(fv.get_asInt());
       return *this;
       break;
     }
-    case ft_UInt: {
+    case ft_UInt:
+    {
       set_asUInt(fv.get_asUInt());
       return *this;
       break;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       set_asFloat(fv.get_asFloat());
       return *this;
       break;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       set_asDouble(fv.get_asDouble());
       return *this;
       break;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       set_asInt64(fv.get_asInt64());
       return *this;
       break;
     }
     default:
       return *this;
-    }
+  }
 }
 
-
-
 //Set functions
-void field_value::set_asString(const char *s) {
+void field_value::set_asString(const char* s)
+{
   str_value = s;
-  field_type = ft_String;}
+  field_type = ft_String;
+}
 
-void field_value::set_asString(const std::string & s) {
+void field_value::set_asString(const std::string& s)
+{
   str_value = s;
-  field_type = ft_String;}
+  field_type = ft_String;
+}
 
-void field_value::set_asBool(const bool b) {
+void field_value::set_asBool(const bool b)
+{
   bool_value = b;
-  field_type = ft_Boolean;}
+  field_type = ft_Boolean;
+}
 
-void field_value::set_asChar(const char c) {
+void field_value::set_asChar(const char c)
+{
   char_value = c;
-  field_type = ft_Char;}
+  field_type = ft_Char;
+}
 
-void field_value::set_asShort(const short s) {
+void field_value::set_asShort(const short s)
+{
   short_value = s;
-  field_type = ft_Short;}
+  field_type = ft_Short;
+}
 
-void field_value::set_asUShort(const unsigned short us) {
+void field_value::set_asUShort(const unsigned short us)
+{
   ushort_value = us;
   field_type = ft_UShort;
 }
 
-void field_value::set_asInt(const int i) {
+void field_value::set_asInt(const int i)
+{
   int_value = i;
   field_type = ft_Int;
 }
 
-void field_value::set_asUInt(const unsigned int ui) {
+void field_value::set_asUInt(const unsigned int ui)
+{
   int_value = ui;
   field_type = ft_UInt;
 }
 
-void field_value::set_asFloat(const float f) {
+void field_value::set_asFloat(const float f)
+{
   float_value = f;
-  field_type = ft_Float;}
+  field_type = ft_Float;
+}
 
-void field_value::set_asDouble(const double d) {
+void field_value::set_asDouble(const double d)
+{
   double_value = d;
-  field_type = ft_Double;}
+  field_type = ft_Double;
+}
 
-void field_value::set_asInt64(const int64_t i) {
+void field_value::set_asInt64(const int64_t i)
+{
   int64_value = i;
-  field_type = ft_Int64;}
+  field_type = ft_Int64;
+}
 
-fType field_value::get_field_type() {
-  return field_type;}
+fType field_value::get_field_type()
+{
+  return field_type;
+}
 
-
-std::string field_value::gft() {
-    std::string tmp;
-    switch (field_type) {
-    case ft_String: {
+std::string field_value::gft()
+{
+  std::string tmp;
+  switch (field_type)
+  {
+    case ft_String:
+    {
       tmp.assign("string");
       return tmp;
     }
-    case ft_Boolean:{
+    case ft_Boolean:
+    {
       tmp.assign("bool");
       return tmp;
     }
-    case ft_Char: {
+    case ft_Char:
+    {
       tmp.assign("char");
       return tmp;
     }
-    case ft_Short: {
+    case ft_Short:
+    {
       tmp.assign("short");
       return tmp;
     }
-    case ft_Int: {
+    case ft_Int:
+    {
       tmp.assign("int");
       return tmp;
     }
-    case ft_Float: {
+    case ft_Float:
+    {
       tmp.assign("float");
       return tmp;
     }
-    case ft_Double: {
+    case ft_Double:
+    {
       tmp.assign("double");
       return tmp;
     }
-    case ft_Int64: {
+    case ft_Int64:
+    {
       tmp.assign("int64");
       return tmp;
     }
     default:
       break;
-    }
-
-  return tmp;
   }
 
-} //namespace
+  return tmp;
+}
+
+} // namespace dbiplus

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -18,53 +18,56 @@
 #include <string>
 #include <vector>
 
-namespace dbiplus {
+namespace dbiplus
+{
 
-enum fType {
-	ft_String,
-	ft_Boolean,
-	ft_Char,
-	ft_WChar,
-	ft_WideString,
-	ft_Short,
-	ft_UShort,
-	ft_Int,
-	ft_UInt,
-	ft_Float,
-	ft_Double,
-	ft_LongDouble,
+enum fType
+{
+  ft_String,
+  ft_Boolean,
+  ft_Char,
+  ft_WChar,
+  ft_WideString,
+  ft_Short,
+  ft_UShort,
+  ft_Int,
+  ft_UInt,
+  ft_Float,
+  ft_Double,
+  ft_LongDouble,
   ft_Int64,
-	ft_Object
-    };
+  ft_Object
+};
 
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(push)
 #pragma pack(8)
 #endif
 
-
-class field_value {
+class field_value
+{
 private:
   fType field_type;
   std::string str_value;
-  union {
-    bool   bool_value;
-    char   char_value;
-    short  short_value;
+  union
+  {
+    bool bool_value;
+    char char_value;
+    short short_value;
     unsigned short ushort_value;
-    int   int_value;
+    int int_value;
     unsigned int uint_value;
-    float  float_value;
+    float float_value;
     double double_value;
     int64_t int64_value;
-    void   *object_value;
-  } ;
+    void* object_value;
+  };
 
   bool is_null;
 
 public:
   field_value();
-  explicit field_value(const char *s);
+  explicit field_value(const char* s);
   explicit field_value(const bool b);
   explicit field_value(const char c);
   explicit field_value(const short s);
@@ -74,11 +77,11 @@ public:
   explicit field_value(const float f);
   explicit field_value(const double d);
   explicit field_value(const int64_t i);
-  field_value(const field_value & fv);
+  field_value(const field_value& fv);
   ~field_value();
 
-  fType get_fType() const {return field_type;}
-  bool get_isNull() const {return is_null;}
+  fType get_fType() const { return field_type; }
+  bool get_isNull() const { return is_null; }
   std::string get_asString() const;
   bool get_asBool() const;
   char get_asChar() const;
@@ -90,81 +93,124 @@ public:
   double get_asDouble() const;
   int64_t get_asInt64() const;
 
-  field_value& operator= (const char *s)
-    {set_asString(s); return *this;}
-  field_value& operator= (const std::string &s)
-    {set_asString(s); return *this;}
-  field_value& operator= (const bool b)
-    {set_asBool(b); return *this;}
-  field_value& operator= (const short s)
-    {set_asShort(s); return *this;}
-  field_value& operator= (const unsigned short us)
-    {set_asUShort(us); return *this;}
-  field_value& operator= (const int l)
-    {set_asInt(l); return *this;}
-  field_value& operator= (const unsigned int l)
-    {set_asUInt(l); return *this;}
-  field_value& operator= (const float f)
-    {set_asFloat(f); return *this;}
-  field_value& operator= (const double d)
-    {set_asDouble(d); return *this;}
-  field_value& operator= (const int64_t i)
-    {set_asInt64(i); return *this;}
-  field_value& operator= (const field_value & fv);
+  field_value& operator=(const char* s)
+  {
+    set_asString(s);
+    return *this;
+  }
+  field_value& operator=(const std::string& s)
+  {
+    set_asString(s);
+    return *this;
+  }
+  field_value& operator=(const bool b)
+  {
+    set_asBool(b);
+    return *this;
+  }
+  field_value& operator=(const short s)
+  {
+    set_asShort(s);
+    return *this;
+  }
+  field_value& operator=(const unsigned short us)
+  {
+    set_asUShort(us);
+    return *this;
+  }
+  field_value& operator=(const int l)
+  {
+    set_asInt(l);
+    return *this;
+  }
+  field_value& operator=(const unsigned int l)
+  {
+    set_asUInt(l);
+    return *this;
+  }
+  field_value& operator=(const float f)
+  {
+    set_asFloat(f);
+    return *this;
+  }
+  field_value& operator=(const double d)
+  {
+    set_asDouble(d);
+    return *this;
+  }
+  field_value& operator=(const int64_t i)
+  {
+    set_asInt64(i);
+    return *this;
+  }
+  field_value& operator=(const field_value& fv);
 
   //class ostream;
-  friend std::ostream& operator<< (std::ostream& os, const field_value &fv)
-  {switch (fv.get_fType()) {
-    case ft_String: {
-      return os << fv.get_asString();
-      break;
+  friend std::ostream& operator<<(std::ostream& os, const field_value& fv)
+  {
+    switch (fv.get_fType())
+    {
+      case ft_String:
+      {
+        return os << fv.get_asString();
+        break;
+      }
+      case ft_Boolean:
+      {
+        return os << fv.get_asBool();
+        break;
+      }
+      case ft_Char:
+      {
+        return os << fv.get_asChar();
+        break;
+      }
+      case ft_Short:
+      {
+        return os << fv.get_asShort();
+        break;
+      }
+      case ft_UShort:
+      {
+        return os << fv.get_asUShort();
+        break;
+      }
+      case ft_Int:
+      {
+        return os << fv.get_asInt();
+        break;
+      }
+      case ft_UInt:
+      {
+        return os << fv.get_asUInt();
+        break;
+      }
+      case ft_Float:
+      {
+        return os << fv.get_asFloat();
+        break;
+      }
+      case ft_Double:
+      {
+        return os << fv.get_asDouble();
+        break;
+      }
+      case ft_Int64:
+      {
+        return os << fv.get_asInt64();
+        break;
+      }
+      default:
+      {
+        return os;
+        break;
+      }
     }
-    case ft_Boolean:{
-      return os << fv.get_asBool();
-      break;
-    }
-    case ft_Char: {
-      return os << fv.get_asChar();
-      break;
-    }
-    case ft_Short: {
-      return os << fv.get_asShort();
-      break;
-    }
-    case ft_UShort: {
-      return os << fv.get_asUShort();
-      break;
-    }
-    case ft_Int: {
-      return os << fv.get_asInt();
-      break;
-    }
-    case ft_UInt: {
-      return os << fv.get_asUInt();
-      break;
-    }
-    case ft_Float: {
-      return os << fv.get_asFloat();
-      break;
-    }
-    case ft_Double: {
-      return os << fv.get_asDouble();
-      break;
-    }
-    case ft_Int64: {
-      return os << fv.get_asInt64();
-      break;
-    }
-    default: {
-      return os;
-      break;
-    }
-  }
   }
 
-  void set_isNull(){is_null=true;}
-  void set_asString(const char *s);
-  void set_asString(const std::string & s);
+  void set_isNull() { is_null = true; }
+  void set_asString(const char* s);
+  void set_asString(const std::string& s);
   void set_asBool(const bool b);
   void set_asChar(const char c);
   void set_asShort(const short s);
@@ -179,16 +225,17 @@ public:
   std::string gft();
 };
 
-struct field_prop {
-  std::string name,display_name;
+struct field_prop
+{
+  std::string name, display_name;
   std::string field_table; //?
 };
 
-struct field {
+struct field
+{
   field_prop props;
   field_value val;
 };
-
 
 typedef std::vector<field> Fields;
 typedef std::vector<field_value> sql_record;
@@ -205,10 +252,7 @@ class result_set
 {
 public:
   result_set() = default;
-  ~result_set()
-  {
-    clear();
-  };
+  ~result_set() { clear(); };
   void clear()
   {
     for (unsigned int i = 0; i < records.size(); i++)
@@ -225,5 +269,4 @@ public:
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(pop)
 #endif
-} // namespace
-
+} // namespace dbiplus

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -227,8 +227,7 @@ public:
 
 struct field_prop
 {
-  std::string name, display_name;
-  std::string field_table; //?
+  std::string name;
 };
 
 struct field

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <iostream>
-#include <map>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -241,11 +240,6 @@ typedef std::vector<field_value> sql_record;
 typedef std::vector<field_prop> record_prop;
 typedef std::vector<sql_record*> query_data;
 typedef field_value variant;
-
-//typedef Fields::iterator fld_itor;
-typedef sql_record::iterator rec_itor;
-typedef record_prop::iterator recprop_itor;
-typedef query_data::iterator qry_itor;
 
 class result_set
 {

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -12,6 +12,7 @@
 
 #include "sqlitedataset.h"
 
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
@@ -762,7 +763,11 @@ void SqliteDataset::fill_fields()
     const unsigned int ncols = result.record_header.size();
     fields_object->resize(ncols);
     for (unsigned int i = 0; i < ncols; i++)
+    {
       (*fields_object)[i].props = result.record_header[i];
+      std::string name = result.record_header[i].name;
+      name2indexMap.insert({str_toLower(name.data()), i});
+    }
   }
 
   //Filling result

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -23,152 +23,154 @@
 
 using namespace std::chrono_literals;
 
-namespace {
+namespace
+{
 #define X(VAL) std::make_pair(VAL, #VAL)
 //!@todo Remove ifdefs when sqlite version requirement has been bumped to at least 3.26.0
-const std::map<int, const char*> g_SqliteErrorStrings =
-{
-  X(SQLITE_OK),
-  X(SQLITE_ERROR),
-  X(SQLITE_INTERNAL),
-  X(SQLITE_PERM),
-  X(SQLITE_ABORT),
-  X(SQLITE_BUSY),
-  X(SQLITE_LOCKED),
-  X(SQLITE_NOMEM),
-  X(SQLITE_READONLY),
-  X(SQLITE_INTERRUPT),
-  X(SQLITE_IOERR),
-  X(SQLITE_CORRUPT),
-  X(SQLITE_NOTFOUND),
-  X(SQLITE_FULL),
-  X(SQLITE_CANTOPEN),
-  X(SQLITE_PROTOCOL),
-  X(SQLITE_EMPTY),
-  X(SQLITE_SCHEMA),
-  X(SQLITE_TOOBIG),
-  X(SQLITE_CONSTRAINT),
-  X(SQLITE_MISMATCH),
-  X(SQLITE_MISUSE),
-  X(SQLITE_NOLFS),
-  X(SQLITE_AUTH),
-  X(SQLITE_FORMAT),
-  X(SQLITE_RANGE),
-  X(SQLITE_NOTADB),
-  X(SQLITE_NOTICE),
-  X(SQLITE_WARNING),
-  X(SQLITE_ROW),
-  X(SQLITE_DONE),
+const std::map<int, const char*> g_SqliteErrorStrings = {
+    X(SQLITE_OK),
+    X(SQLITE_ERROR),
+    X(SQLITE_INTERNAL),
+    X(SQLITE_PERM),
+    X(SQLITE_ABORT),
+    X(SQLITE_BUSY),
+    X(SQLITE_LOCKED),
+    X(SQLITE_NOMEM),
+    X(SQLITE_READONLY),
+    X(SQLITE_INTERRUPT),
+    X(SQLITE_IOERR),
+    X(SQLITE_CORRUPT),
+    X(SQLITE_NOTFOUND),
+    X(SQLITE_FULL),
+    X(SQLITE_CANTOPEN),
+    X(SQLITE_PROTOCOL),
+    X(SQLITE_EMPTY),
+    X(SQLITE_SCHEMA),
+    X(SQLITE_TOOBIG),
+    X(SQLITE_CONSTRAINT),
+    X(SQLITE_MISMATCH),
+    X(SQLITE_MISUSE),
+    X(SQLITE_NOLFS),
+    X(SQLITE_AUTH),
+    X(SQLITE_FORMAT),
+    X(SQLITE_RANGE),
+    X(SQLITE_NOTADB),
+    X(SQLITE_NOTICE),
+    X(SQLITE_WARNING),
+    X(SQLITE_ROW),
+    X(SQLITE_DONE),
 #if defined(SQLITE_ERROR_MISSING_COLLSEQ)
-  X(SQLITE_ERROR_MISSING_COLLSEQ),
+    X(SQLITE_ERROR_MISSING_COLLSEQ),
 #endif
 #if defined(SQLITE_ERROR_RETRY)
-  X(SQLITE_ERROR_RETRY),
+    X(SQLITE_ERROR_RETRY),
 #endif
 #if defined(SQLITE_ERROR_SNAPSHOT)
-  X(SQLITE_ERROR_SNAPSHOT),
+    X(SQLITE_ERROR_SNAPSHOT),
 #endif
-  X(SQLITE_IOERR_READ),
-  X(SQLITE_IOERR_SHORT_READ),
-  X(SQLITE_IOERR_WRITE),
-  X(SQLITE_IOERR_FSYNC),
-  X(SQLITE_IOERR_DIR_FSYNC),
-  X(SQLITE_IOERR_TRUNCATE),
-  X(SQLITE_IOERR_FSTAT),
-  X(SQLITE_IOERR_UNLOCK),
-  X(SQLITE_IOERR_RDLOCK),
-  X(SQLITE_IOERR_DELETE),
-  X(SQLITE_IOERR_BLOCKED),
-  X(SQLITE_IOERR_NOMEM),
-  X(SQLITE_IOERR_ACCESS),
-  X(SQLITE_IOERR_CHECKRESERVEDLOCK),
-  X(SQLITE_IOERR_LOCK),
-  X(SQLITE_IOERR_CLOSE),
-  X(SQLITE_IOERR_DIR_CLOSE),
-  X(SQLITE_IOERR_SHMOPEN),
-  X(SQLITE_IOERR_SHMSIZE),
-  X(SQLITE_IOERR_SHMLOCK),
-  X(SQLITE_IOERR_SHMMAP),
-  X(SQLITE_IOERR_SEEK),
-  X(SQLITE_IOERR_DELETE_NOENT),
-  X(SQLITE_IOERR_MMAP),
-  X(SQLITE_IOERR_GETTEMPPATH),
-  X(SQLITE_IOERR_CONVPATH),
+    X(SQLITE_IOERR_READ),
+    X(SQLITE_IOERR_SHORT_READ),
+    X(SQLITE_IOERR_WRITE),
+    X(SQLITE_IOERR_FSYNC),
+    X(SQLITE_IOERR_DIR_FSYNC),
+    X(SQLITE_IOERR_TRUNCATE),
+    X(SQLITE_IOERR_FSTAT),
+    X(SQLITE_IOERR_UNLOCK),
+    X(SQLITE_IOERR_RDLOCK),
+    X(SQLITE_IOERR_DELETE),
+    X(SQLITE_IOERR_BLOCKED),
+    X(SQLITE_IOERR_NOMEM),
+    X(SQLITE_IOERR_ACCESS),
+    X(SQLITE_IOERR_CHECKRESERVEDLOCK),
+    X(SQLITE_IOERR_LOCK),
+    X(SQLITE_IOERR_CLOSE),
+    X(SQLITE_IOERR_DIR_CLOSE),
+    X(SQLITE_IOERR_SHMOPEN),
+    X(SQLITE_IOERR_SHMSIZE),
+    X(SQLITE_IOERR_SHMLOCK),
+    X(SQLITE_IOERR_SHMMAP),
+    X(SQLITE_IOERR_SEEK),
+    X(SQLITE_IOERR_DELETE_NOENT),
+    X(SQLITE_IOERR_MMAP),
+    X(SQLITE_IOERR_GETTEMPPATH),
+    X(SQLITE_IOERR_CONVPATH),
 #if defined(SQLITE_IOERR_VNODE)
-  X(SQLITE_IOERR_VNODE),
+    X(SQLITE_IOERR_VNODE),
 #endif
 #if defined(SQLITE_IOERR_AUTH)
-  X(SQLITE_IOERR_AUTH),
+    X(SQLITE_IOERR_AUTH),
 #endif
 #if defined(SQLITE_IOERR_BEGIN_ATOMIC)
-  X(SQLITE_IOERR_BEGIN_ATOMIC),
+    X(SQLITE_IOERR_BEGIN_ATOMIC),
 #endif
 #if defined(SQLITE_IOERR_COMMIT_ATOMIC)
-  X(SQLITE_IOERR_COMMIT_ATOMIC),
+    X(SQLITE_IOERR_COMMIT_ATOMIC),
 #endif
 #if defined(SQLITE_IOERR_ROLLBACK_ATOMIC)
-  X(SQLITE_IOERR_ROLLBACK_ATOMIC),
+    X(SQLITE_IOERR_ROLLBACK_ATOMIC),
 #endif
-  X(SQLITE_LOCKED_SHAREDCACHE),
+    X(SQLITE_LOCKED_SHAREDCACHE),
 #if defined(SQLITE_LOCKED_VTAB)
-  X(SQLITE_LOCKED_VTAB),
+    X(SQLITE_LOCKED_VTAB),
 #endif
-  X(SQLITE_BUSY_RECOVERY),
-  X(SQLITE_BUSY_SNAPSHOT),
-  X(SQLITE_CANTOPEN_NOTEMPDIR),
-  X(SQLITE_CANTOPEN_ISDIR),
-  X(SQLITE_CANTOPEN_FULLPATH),
-  X(SQLITE_CANTOPEN_CONVPATH),
+    X(SQLITE_BUSY_RECOVERY),
+    X(SQLITE_BUSY_SNAPSHOT),
+    X(SQLITE_CANTOPEN_NOTEMPDIR),
+    X(SQLITE_CANTOPEN_ISDIR),
+    X(SQLITE_CANTOPEN_FULLPATH),
+    X(SQLITE_CANTOPEN_CONVPATH),
 #if defined(SQLITE_CANTOPEN_DIRTYWAL)
-  X(SQLITE_CANTOPEN_DIRTYWAL),
+    X(SQLITE_CANTOPEN_DIRTYWAL),
 #endif
-  X(SQLITE_CORRUPT_VTAB),
+    X(SQLITE_CORRUPT_VTAB),
 #if defined(SQLITE_CORRUPT_SEQUENCE)
-  X(SQLITE_CORRUPT_SEQUENCE),
+    X(SQLITE_CORRUPT_SEQUENCE),
 #endif
-  X(SQLITE_READONLY_RECOVERY),
-  X(SQLITE_READONLY_CANTLOCK),
-  X(SQLITE_READONLY_ROLLBACK),
-  X(SQLITE_READONLY_DBMOVED),
+    X(SQLITE_READONLY_RECOVERY),
+    X(SQLITE_READONLY_CANTLOCK),
+    X(SQLITE_READONLY_ROLLBACK),
+    X(SQLITE_READONLY_DBMOVED),
 #if defined(SQLITE_READONLY_CANTINIT)
-  X(SQLITE_READONLY_CANTINIT),
+    X(SQLITE_READONLY_CANTINIT),
 #endif
 #if defined(SQLITE_READONLY_DIRECTORY)
-  X(SQLITE_READONLY_DIRECTORY),
+    X(SQLITE_READONLY_DIRECTORY),
 #endif
-  X(SQLITE_ABORT_ROLLBACK),
-  X(SQLITE_CONSTRAINT_CHECK),
-  X(SQLITE_CONSTRAINT_COMMITHOOK),
-  X(SQLITE_CONSTRAINT_FOREIGNKEY),
-  X(SQLITE_CONSTRAINT_FUNCTION),
-  X(SQLITE_CONSTRAINT_NOTNULL),
-  X(SQLITE_CONSTRAINT_PRIMARYKEY),
-  X(SQLITE_CONSTRAINT_TRIGGER),
-  X(SQLITE_CONSTRAINT_UNIQUE),
-  X(SQLITE_CONSTRAINT_VTAB),
-  X(SQLITE_CONSTRAINT_ROWID),
-  X(SQLITE_NOTICE_RECOVER_WAL),
-  X(SQLITE_NOTICE_RECOVER_ROLLBACK),
-  X(SQLITE_WARNING_AUTOINDEX),
-  X(SQLITE_AUTH_USER),
+    X(SQLITE_ABORT_ROLLBACK),
+    X(SQLITE_CONSTRAINT_CHECK),
+    X(SQLITE_CONSTRAINT_COMMITHOOK),
+    X(SQLITE_CONSTRAINT_FOREIGNKEY),
+    X(SQLITE_CONSTRAINT_FUNCTION),
+    X(SQLITE_CONSTRAINT_NOTNULL),
+    X(SQLITE_CONSTRAINT_PRIMARYKEY),
+    X(SQLITE_CONSTRAINT_TRIGGER),
+    X(SQLITE_CONSTRAINT_UNIQUE),
+    X(SQLITE_CONSTRAINT_VTAB),
+    X(SQLITE_CONSTRAINT_ROWID),
+    X(SQLITE_NOTICE_RECOVER_WAL),
+    X(SQLITE_NOTICE_RECOVER_ROLLBACK),
+    X(SQLITE_WARNING_AUTOINDEX),
+    X(SQLITE_AUTH_USER),
 #if defined(SQLITE_OK_LOAD_PERMANENTLY)
-  X(SQLITE_OK_LOAD_PERMANENTLY),
+    X(SQLITE_OK_LOAD_PERMANENTLY),
 #endif
 };
 #undef X
-}
+} // namespace
 
-namespace dbiplus {
+namespace dbiplus
+{
 //************* Callback function ***************************
 
-int callback(void* res_ptr,int ncol, char** result,char** cols)
+int callback(void* res_ptr, int ncol, char** result, char** cols)
 {
   result_set* r = static_cast<result_set*>(res_ptr);
 
   if (!r->record_header.size())
   {
     r->record_header.reserve(ncol);
-    for (int i=0; i < ncol; i++) {
+    for (int i = 0; i < ncol; i++)
+    {
       field_prop header;
       header.name = cols[i];
       r->record_header.push_back(header);
@@ -177,11 +179,11 @@ int callback(void* res_ptr,int ncol, char** result,char** cols)
 
   if (result != NULL)
   {
-    sql_record *rec = new sql_record;
+    sql_record* rec = new sql_record;
     rec->resize(ncol);
-    for (int i=0; i<ncol; i++)
+    for (int i = 0; i < ncol; i++)
     {
-      field_value &v = rec->at(i);
+      field_value& v = rec->at(i);
       if (result[i] == NULL)
       {
         v.set_asString("");
@@ -205,12 +207,13 @@ static int busy_callback(void*, int busyCount)
 
 //************* SqliteDatabase implementation ***************
 
-SqliteDatabase::SqliteDatabase() {
+SqliteDatabase::SqliteDatabase()
+{
 
   active = false;
-  _in_transaction = false;    // for transaction
+  _in_transaction = false; // for transaction
 
-  error = "Unknown database error";//S_NO_CONNECTION;
+  error = "Unknown database error"; //S_NO_CONNECTION;
   host = "localhost";
   port = "";
   db = "sqlite.db";
@@ -218,24 +221,26 @@ SqliteDatabase::SqliteDatabase() {
   passwd = "";
 }
 
-SqliteDatabase::~SqliteDatabase() {
+SqliteDatabase::~SqliteDatabase()
+{
   disconnect();
 }
 
-
-Dataset* SqliteDatabase::CreateDataset() const {
+Dataset* SqliteDatabase::CreateDataset() const
+{
   return new SqliteDataset(const_cast<SqliteDatabase*>(this));
 }
 
-void SqliteDatabase::setHostName(const char *newHost) {
+void SqliteDatabase::setHostName(const char* newHost)
+{
   host = newHost;
 
   // hostname is the relative folder to the database, ensure it's slash terminated
-  if (host[host.length()-1] != '/' && host[host.length()-1] != '\\')
+  if (host[host.length() - 1] != '/' && host[host.length() - 1] != '\\')
     host += "/";
 
   // ensure the fully qualified path has slashes in the correct direction
-  if ( (host[1] == ':') && isalpha(host[0]))
+  if ((host[1] == ':') && isalpha(host[0]))
   {
     size_t pos = 0;
     while ((pos = host.find('/', pos)) != std::string::npos)
@@ -249,7 +254,8 @@ void SqliteDatabase::setHostName(const char *newHost) {
   }
 }
 
-void SqliteDatabase::setDatabase(const char *newDb) {
+void SqliteDatabase::setDatabase(const char* newDb)
+{
   db = newDb;
 
   // db is the filename for the database, ensure it's not slash prefixed
@@ -257,22 +263,28 @@ void SqliteDatabase::setDatabase(const char *newDb) {
     db = db.substr(1);
 
   // ensure the ".db" extension is appended to the end
-  if ( db.find(".db") != (db.length()-3) )
+  if (db.find(".db") != (db.length() - 3))
     db += ".db";
 }
 
-int SqliteDatabase::status(void) {
-  if (active == false) return DB_CONNECTION_NONE;
+int SqliteDatabase::status(void)
+{
+  if (active == false)
+    return DB_CONNECTION_NONE;
   return DB_CONNECTION_OK;
 }
 
-int SqliteDatabase::setErr(int err_code, const char * qry) {
+int SqliteDatabase::setErr(int err_code, const char* qry)
+{
   std::stringstream ss;
   ss << "[" << db << "] ";
   auto errorIt = g_SqliteErrorStrings.find(err_code);
-  if (errorIt != g_SqliteErrorStrings.end()) {
+  if (errorIt != g_SqliteErrorStrings.end())
+  {
     ss << "SQLite error " << errorIt->second;
-  } else {
+  }
+  else
+  {
     ss << "Undefined SQLite error " << err_code;
   }
   if (conn)
@@ -282,8 +294,9 @@ int SqliteDatabase::setErr(int err_code, const char * qry) {
   return err_code;
 }
 
-const char *SqliteDatabase::getErrorMsg() {
-   return error.c_str();
+const char* SqliteDatabase::getErrorMsg()
+{
+  return error.c_str();
 }
 
 static int AlphaNumericCollation(
@@ -292,7 +305,8 @@ static int AlphaNumericCollation(
   return StringUtils::AlphaNumericCollation(nKey1, pKey1, nKey2, pKey2);
 }
 
-int SqliteDatabase::connect(bool create) {
+int SqliteDatabase::connect(bool create)
+{
   if (host.empty() || db.empty())
     return DB_CONNECTION_NONE;
 
@@ -338,7 +352,7 @@ int SqliteDatabase::connect(bool create) {
 
     return DB_CONNECTION_NONE;
   }
-  catch(const DbErrors&)
+  catch (const DbErrors&)
   {
   }
   return DB_CONNECTION_NONE;
@@ -347,14 +361,15 @@ int SqliteDatabase::connect(bool create) {
 bool SqliteDatabase::exists(void)
 {
   bool bRet = false;
-  if (!active) return bRet;
+  if (!active)
+    return bRet;
   result_set res;
   char sqlcmd[512];
 
   // performing a select all on the sqlite_master will return rows if there are tables
   // defined indicating it's not empty and therefore must "exist".
-  sprintf(sqlcmd,"SELECT * FROM sqlite_master");
-  if ((last_err = sqlite3_exec(getHandle(),sqlcmd, &callback, &res,NULL)) == SQLITE_OK)
+  sprintf(sqlcmd, "SELECT * FROM sqlite_master");
+  if ((last_err = sqlite3_exec(getHandle(), sqlcmd, &callback, &res, NULL)) == SQLITE_OK)
   {
     bRet = (res.records.size() > 0);
   }
@@ -362,17 +377,21 @@ bool SqliteDatabase::exists(void)
   return bRet;
 }
 
-void SqliteDatabase::disconnect(void) {
-  if (active == false) return;
+void SqliteDatabase::disconnect(void)
+{
+  if (active == false)
+    return;
   sqlite3_close(conn);
   active = false;
 }
 
-int SqliteDatabase::create() {
+int SqliteDatabase::create()
+{
   return connect(true);
 }
 
-int SqliteDatabase::copy(const char *backup_name) {
+int SqliteDatabase::copy(const char* backup_name)
+{
   if (active == false)
     throw DbErrors("Can't copy database: no active connection...");
 
@@ -381,15 +400,15 @@ int SqliteDatabase::copy(const char *backup_name) {
   int rc;
   std::string backup_db = backup_name;
 
-  sqlite3 *pFile;           /* Database connection opened on zFilename */
-  sqlite3_backup *pBackup;  /* Backup object used to copy data */
+  sqlite3* pFile; /* Database connection opened on zFilename */
+  sqlite3_backup* pBackup; /* Backup object used to copy data */
 
   //
   if (backup_name[0] == '/' || backup_name[0] == '\\')
     backup_db = backup_db.substr(1);
 
   // ensure the ".db" extension is appended to the end
-  if ( backup_db.find(".db") != (backup_db.length()-3) )
+  if (backup_db.find(".db") != (backup_db.length() - 3))
     backup_db += ".db";
 
   std::string backup_path = host + backup_db;
@@ -397,11 +416,11 @@ int SqliteDatabase::copy(const char *backup_name) {
   /* Open the database file identified by zFilename. Exit early if this fails
   ** for any reason. */
   rc = sqlite3_open(backup_path.c_str(), &pFile);
-  if( rc==SQLITE_OK )
+  if (rc == SQLITE_OK)
   {
     pBackup = sqlite3_backup_init(pFile, "main", getHandle(), "main");
 
-    if( pBackup )
+    if (pBackup)
     {
       (void)sqlite3_backup_step(pBackup, -1);
       (void)sqlite3_backup_finish(pBackup);
@@ -412,13 +431,14 @@ int SqliteDatabase::copy(const char *backup_name) {
 
   (void)sqlite3_close(pFile);
 
-  if( rc != SQLITE_OK )
+  if (rc != SQLITE_OK)
     throw DbErrors("Can't copy database. (%d)", rc);
 
   return rc;
 }
 
-int SqliteDatabase::drop_analytics(void) {
+int SqliteDatabase::drop_analytics(void)
+{
   // SqliteDatabase::copy used a full database copy, so we have a new version
   // with all the analytics stuff. We should clean database from everything but data
   if (active == false)
@@ -429,122 +449,145 @@ int SqliteDatabase::drop_analytics(void) {
 
   CLog::Log(LOGDEBUG, "Cleaning indexes from database {} at {}", db, host);
   sprintf(sqlcmd, "SELECT name FROM sqlite_master WHERE type == 'index' AND sql IS NOT NULL");
-  if ((last_err = sqlite3_exec(conn, sqlcmd, &callback, &res, NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+  if ((last_err = sqlite3_exec(conn, sqlcmd, &callback, &res, NULL)) != SQLITE_OK)
+    return DB_UNEXPECTED_RESULT;
 
-  for (size_t i=0; i < res.records.size(); i++) {
-    sprintf(sqlcmd,"DROP INDEX '%s'", res.records[i]->at(0).get_asString().c_str());
-    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+  for (size_t i = 0; i < res.records.size(); i++)
+  {
+    sprintf(sqlcmd, "DROP INDEX '%s'", res.records[i]->at(0).get_asString().c_str());
+    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK)
+      return DB_UNEXPECTED_RESULT;
   }
   res.clear();
 
   CLog::Log(LOGDEBUG, "Cleaning views from database {} at {}", db, host);
   sprintf(sqlcmd, "SELECT name FROM sqlite_master WHERE type == 'view'");
-  if ((last_err = sqlite3_exec(conn, sqlcmd, &callback, &res, NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+  if ((last_err = sqlite3_exec(conn, sqlcmd, &callback, &res, NULL)) != SQLITE_OK)
+    return DB_UNEXPECTED_RESULT;
 
-  for (size_t i=0; i < res.records.size(); i++) {
-    sprintf(sqlcmd,"DROP VIEW '%s'", res.records[i]->at(0).get_asString().c_str());
-    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+  for (size_t i = 0; i < res.records.size(); i++)
+  {
+    sprintf(sqlcmd, "DROP VIEW '%s'", res.records[i]->at(0).get_asString().c_str());
+    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK)
+      return DB_UNEXPECTED_RESULT;
   }
   res.clear();
 
   CLog::Log(LOGDEBUG, "Cleaning triggers from database {} at {}", db, host);
   sprintf(sqlcmd, "SELECT name FROM sqlite_master WHERE type == 'trigger'");
-  if ((last_err = sqlite3_exec(conn, sqlcmd, &callback, &res, NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+  if ((last_err = sqlite3_exec(conn, sqlcmd, &callback, &res, NULL)) != SQLITE_OK)
+    return DB_UNEXPECTED_RESULT;
 
-  for (size_t i=0; i < res.records.size(); i++) {
-    sprintf(sqlcmd,"DROP TRIGGER '%s'", res.records[i]->at(0).get_asString().c_str());
-    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+  for (size_t i = 0; i < res.records.size(); i++)
+  {
+    sprintf(sqlcmd, "DROP TRIGGER '%s'", res.records[i]->at(0).get_asString().c_str());
+    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK)
+      return DB_UNEXPECTED_RESULT;
   }
   // res would be cleared on destruct
 
   return DB_COMMAND_OK;
 }
 
-int SqliteDatabase::drop() {
-  if (active == false) throw DbErrors("Can't drop database: no active connection...");
+int SqliteDatabase::drop()
+{
+  if (active == false)
+    throw DbErrors("Can't drop database: no active connection...");
   disconnect();
-  if (!unlink(db.c_str())) {
-     throw DbErrors("Can't drop database: can't unlink the file %s,\nError: %s",db.c_str(),strerror(errno));
-     }
+  if (!unlink(db.c_str()))
+  {
+    throw DbErrors("Can't drop database: can't unlink the file %s,\nError: %s", db.c_str(),
+                   strerror(errno));
+  }
   return DB_COMMAND_OK;
 }
 
-
-long SqliteDatabase::nextid(const char* sname) {
-  if (!active) return DB_UNEXPECTED_RESULT;
-  int id;/*,nrow,ncol;*/
+long SqliteDatabase::nextid(const char* sname)
+{
+  if (!active)
+    return DB_UNEXPECTED_RESULT;
+  int id; /*,nrow,ncol;*/
   result_set res;
   char sqlcmd[512];
   snprintf(sqlcmd, sizeof(sqlcmd), "SELECT nextid FROM %s WHERE seq_name = '%s'",
            sequence_table.c_str(), sname);
-  if ((last_err = sqlite3_exec(getHandle(),sqlcmd,&callback,&res,NULL)) != SQLITE_OK) {
+  if ((last_err = sqlite3_exec(getHandle(), sqlcmd, &callback, &res, NULL)) != SQLITE_OK)
+  {
     return DB_UNEXPECTED_RESULT;
-    }
-  if (res.records.empty()) {
+  }
+  if (res.records.empty())
+  {
     id = 1;
     snprintf(sqlcmd, sizeof(sqlcmd), "INSERT INTO %s (nextid,seq_name) VALUES (%d,'%s')",
              sequence_table.c_str(), id, sname);
-    if ((last_err = sqlite3_exec(conn,sqlcmd,NULL,NULL,NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK)
+      return DB_UNEXPECTED_RESULT;
     return id;
   }
-  else {
-    id = res.records[0]->at(0).get_asInt()+1;
+  else
+  {
+    id = res.records[0]->at(0).get_asInt() + 1;
     snprintf(sqlcmd, sizeof(sqlcmd), "UPDATE %s SET nextid=%d WHERE seq_name = '%s'",
              sequence_table.c_str(), id, sname);
-    if ((last_err = sqlite3_exec(conn,sqlcmd,NULL,NULL,NULL)) != SQLITE_OK) return DB_UNEXPECTED_RESULT;
+    if ((last_err = sqlite3_exec(conn, sqlcmd, NULL, NULL, NULL)) != SQLITE_OK)
+      return DB_UNEXPECTED_RESULT;
     return id;
   }
   return DB_UNEXPECTED_RESULT;
 }
 
-
 // methods for transactions
 // ---------------------------------------------
-void SqliteDatabase::start_transaction() {
-  if (active) {
-    sqlite3_exec(conn,"begin IMMEDIATE",NULL,NULL,NULL);
+void SqliteDatabase::start_transaction()
+{
+  if (active)
+  {
+    sqlite3_exec(conn, "begin IMMEDIATE", NULL, NULL, NULL);
     _in_transaction = true;
   }
 }
 
-void SqliteDatabase::commit_transaction() {
-  if (active) {
-    sqlite3_exec(conn,"commit",NULL,NULL,NULL);
+void SqliteDatabase::commit_transaction()
+{
+  if (active)
+  {
+    sqlite3_exec(conn, "commit", NULL, NULL, NULL);
     _in_transaction = false;
   }
 }
 
-void SqliteDatabase::rollback_transaction() {
-  if (active) {
-    sqlite3_exec(conn,"rollback",NULL,NULL,NULL);
+void SqliteDatabase::rollback_transaction()
+{
+  if (active)
+  {
+    sqlite3_exec(conn, "rollback", NULL, NULL, NULL);
     _in_transaction = false;
   }
 }
-
 
 // methods for formatting
 // ---------------------------------------------
-std::string SqliteDatabase::vprepare(const char *format, va_list args)
+std::string SqliteDatabase::vprepare(const char* format, va_list args)
 {
   std::string strFormat = format;
   std::string strResult = "";
-  char *p;
+  char* p;
   size_t pos;
 
   //  %q is the sqlite format string for %s.
   //  Any bad character, like "'", will be replaced with a proper one
   pos = 0;
-  while ( (pos = strFormat.find("%s", pos)) != std::string::npos )
+  while ((pos = strFormat.find("%s", pos)) != std::string::npos)
     strFormat.replace(pos++, 2, "%q");
 
   //  the %I64 enhancement is not supported by sqlite3_vmprintf
   //  must be %ll instead
   pos = 0;
-  while ( (pos = strFormat.find("%I64", pos)) != std::string::npos )
+  while ((pos = strFormat.find("%I64", pos)) != std::string::npos)
     strFormat.replace(pos++, 4, "%ll");
 
   p = sqlite3_vmprintf(strFormat.c_str(), args);
-  if ( p )
+  if (p)
   {
     strResult = p;
     sqlite3_free(p);
@@ -601,109 +644,118 @@ std::string SqliteDatabase::vprepare(const char *format, va_list args)
   return strResult;
 }
 
-
 //************* SqliteDataset implementation ***************
 
-SqliteDataset::SqliteDataset():Dataset() {
+SqliteDataset::SqliteDataset() : Dataset()
+{
   haveError = false;
   db = NULL;
   errmsg = NULL;
   autorefresh = false;
 }
 
-
-SqliteDataset::SqliteDataset(SqliteDatabase *newDb):Dataset(newDb) {
+SqliteDataset::SqliteDataset(SqliteDatabase* newDb) : Dataset(newDb)
+{
   haveError = false;
   db = newDb;
   errmsg = NULL;
   autorefresh = false;
 }
 
- SqliteDataset::~SqliteDataset(){
-   if (errmsg) sqlite3_free(errmsg);
- }
-
-
-void SqliteDataset::set_autorefresh(bool val){
-    autorefresh = val;
+SqliteDataset::~SqliteDataset()
+{
+  if (errmsg)
+    sqlite3_free(errmsg);
 }
 
-
+void SqliteDataset::set_autorefresh(bool val)
+{
+  autorefresh = val;
+}
 
 //--------- protected functions implementation -----------------//
 
-sqlite3* SqliteDataset::handle(){
-  if (db != NULL){
-    return static_cast<SqliteDatabase*>(db)->getHandle();
-      }
-  else return NULL;
-}
-
-void SqliteDataset::make_query(StringList &_sql) {
-  std::string query;
-  if (db == NULL) throw DbErrors("No Database Connection");
-
- try {
-
-  if (autocommit) db->start_transaction();
-
-
-  for (const std::string& i : _sql)
+sqlite3* SqliteDataset::handle()
+{
+  if (db != NULL)
   {
-    query = i;
-    char* err = NULL;
-    Dataset::parse_sql(query);
-    if (db->setErr(sqlite3_exec(this->handle(), query.c_str(), NULL, NULL, &err), query.c_str()) !=
-        SQLITE_OK)
-    {
-      std::string message = db->getErrorMsg();
-      if (err)
-      {
-        message.append(" (");
-        message.append(err);
-        message.append(")");
-        sqlite3_free(err);
-      }
-      throw DbErrors("%s", message.c_str());
-    }
-  } // end of for
-
-
-  if (db->in_transaction() && autocommit) db->commit_transaction();
-
-  active = true;
-  ds_state = dsSelect;
-  if (autorefresh)
-    refresh();
-
- } // end of try
- catch(...) {
-  if (db->in_transaction()) db->rollback_transaction();
-  throw;
- }
-
+    return static_cast<SqliteDatabase*>(db)->getHandle();
+  }
+  else
+    return NULL;
 }
 
+void SqliteDataset::make_query(StringList& _sql)
+{
+  std::string query;
+  if (db == NULL)
+    throw DbErrors("No Database Connection");
 
-void SqliteDataset::make_insert() {
+  try
+  {
+
+    if (autocommit)
+      db->start_transaction();
+
+    for (const std::string& i : _sql)
+    {
+      query = i;
+      char* err = NULL;
+      Dataset::parse_sql(query);
+      if (db->setErr(sqlite3_exec(this->handle(), query.c_str(), NULL, NULL, &err),
+                     query.c_str()) != SQLITE_OK)
+      {
+        std::string message = db->getErrorMsg();
+        if (err)
+        {
+          message.append(" (");
+          message.append(err);
+          message.append(")");
+          sqlite3_free(err);
+        }
+        throw DbErrors("%s", message.c_str());
+      }
+    } // end of for
+
+    if (db->in_transaction() && autocommit)
+      db->commit_transaction();
+
+    active = true;
+    ds_state = dsSelect;
+    if (autorefresh)
+      refresh();
+
+  } // end of try
+  catch (...)
+  {
+    if (db->in_transaction())
+      db->rollback_transaction();
+    throw;
+  }
+}
+
+void SqliteDataset::make_insert()
+{
   make_query(insert_sql);
   last();
 }
 
-
-void SqliteDataset::make_edit() {
+void SqliteDataset::make_edit()
+{
   make_query(update_sql);
 }
 
-
-void SqliteDataset::make_deletion() {
+void SqliteDataset::make_deletion()
+{
   make_query(delete_sql);
 }
 
-
-void SqliteDataset::fill_fields() {
+void SqliteDataset::fill_fields()
+{
   //cout <<"rr "<<result.records.size()<<"|" << frecno <<"\n";
-  if ((db == NULL) || (result.record_header.empty()) || (result.records.size() < (unsigned int)frecno)) return;
+  if ((db == NULL) || (result.record_header.empty()) ||
+      (result.records.size() < (unsigned int)frecno))
+    return;
 
   if (fields_object->size() == 0) // Filling columns name
   {
@@ -716,7 +768,7 @@ void SqliteDataset::fill_fields() {
   //Filling result
   if (result.records.size() != 0)
   {
-    const sql_record *row = result.records[frecno];
+    const sql_record* row = result.records[frecno];
     if (row)
     {
       const unsigned int ncols = row->size();
@@ -732,9 +784,8 @@ void SqliteDataset::fill_fields() {
     (*fields_object)[i].val = "";
 }
 
-
 //------------- public functions implementation -----------------//
-bool SqliteDataset::dropIndex(const char *table, const char *index)
+bool SqliteDataset::dropIndex(const char* table, const char* index)
 {
   std::string sql;
 
@@ -743,9 +794,10 @@ bool SqliteDataset::dropIndex(const char *table, const char *index)
   return (exec(sql) == SQLITE_OK);
 }
 
-
-int SqliteDataset::exec(const std::string &sql) {
-  if (!handle()) throw DbErrors("No Database Connection");
+int SqliteDataset::exec(const std::string& sql)
+{
+  if (!handle())
+    throw DbErrors("No Database Connection");
   std::string qry = sql;
   int res;
   exec_res.clear();
@@ -757,7 +809,7 @@ int SqliteDataset::exec(const std::string &sql) {
   //   after:  CREATE UNIQUE INDEX ixPath ON path ( strPath )
   //
   // NOTE: unexpected results occur if brackets are not matched
-  if ( qry.find("CREATE UNIQUE INDEX") != std::string::npos ||
+  if (qry.find("CREATE UNIQUE INDEX") != std::string::npos ||
       (qry.find("CREATE INDEX") != std::string::npos))
   {
     size_t pos = 0;
@@ -770,7 +822,7 @@ int SqliteDataset::exec(const std::string &sql) {
       {
         if ((pos2 = qry.find(')', pos)) != std::string::npos)
         {
-          qry.replace(pos, pos2-pos+1, "");
+          qry.replace(pos, pos2 - pos + 1, "");
           pos = pos2;
         }
       }
@@ -780,52 +832,57 @@ int SqliteDataset::exec(const std::string &sql) {
   // before: DROP INDEX foo ON table
   // after:  DROP INDEX foo
   size_t pos = qry.find("DROP INDEX ");
-  if ( pos != std::string::npos )
+  if (pos != std::string::npos)
   {
-    pos = qry.find(" ON ", pos+1);
+    pos = qry.find(" ON ", pos + 1);
 
-    if ( pos != std::string::npos )
+    if (pos != std::string::npos)
       qry = qry.substr(0, pos);
   }
 
-  if((res = db->setErr(sqlite3_exec(handle(),qry.c_str(),&callback,&exec_res,&errmsg),qry.c_str())) == SQLITE_OK)
+  if ((res = db->setErr(sqlite3_exec(handle(), qry.c_str(), &callback, &exec_res, &errmsg),
+                        qry.c_str())) == SQLITE_OK)
     return res;
   else
+  {
+    if (errmsg)
     {
-      if (errmsg)
-      {
-        DbErrors err("%s (%s)", db->getErrorMsg(), errmsg);
-        sqlite3_free(errmsg);
-        throw err;
-      }
-      else
-      {
-        throw DbErrors("%s", db->getErrorMsg());
-      }
+      DbErrors err("%s (%s)", db->getErrorMsg(), errmsg);
+      sqlite3_free(errmsg);
+      throw err;
     }
+    else
+    {
+      throw DbErrors("%s", db->getErrorMsg());
+    }
+  }
 }
 
-int SqliteDataset::exec() {
+int SqliteDataset::exec()
+{
   return exec(sql);
 }
 
-const void* SqliteDataset::getExecRes() {
+const void* SqliteDataset::getExecRes()
+{
   return &exec_res;
 }
 
-
-bool SqliteDataset::query(const std::string &query) {
-    if(!handle()) throw DbErrors("No Database Connection");
-    const std::string& qry = query;
-    int fs = qry.find("select");
-    int fS = qry.find("SELECT");
-    if (!( fs >= 0 || fS >=0))
-         throw DbErrors("MUST be select SQL!");
+bool SqliteDataset::query(const std::string& query)
+{
+  if (!handle())
+    throw DbErrors("No Database Connection");
+  const std::string& qry = query;
+  int fs = qry.find("select");
+  int fS = qry.find("SELECT");
+  if (!(fs >= 0 || fS >= 0))
+    throw DbErrors("MUST be select SQL!");
 
   close();
 
-  sqlite3_stmt *stmt = NULL;
-  if (db->setErr(sqlite3_prepare_v2(handle(),query.c_str(),-1,&stmt, NULL),query.c_str()) != SQLITE_OK)
+  sqlite3_stmt* stmt = NULL;
+  if (db->setErr(sqlite3_prepare_v2(handle(), query.c_str(), -1, &stmt, NULL), query.c_str()) !=
+      SQLITE_OK)
     throw DbErrors("%s", db->getErrorMsg());
 
   // column headers
@@ -837,35 +894,35 @@ bool SqliteDataset::query(const std::string &query) {
   // returned rows
   while (sqlite3_step(stmt) == SQLITE_ROW)
   { // have a row of data
-    sql_record *res = new sql_record;
+    sql_record* res = new sql_record;
     res->resize(numColumns);
     for (unsigned int i = 0; i < numColumns; i++)
     {
-      field_value &v = res->at(i);
+      field_value& v = res->at(i);
       switch (sqlite3_column_type(stmt, i))
       {
-      case SQLITE_INTEGER:
-        v.set_asInt64(sqlite3_column_int64(stmt, i));
-        break;
-      case SQLITE_FLOAT:
-        v.set_asDouble(sqlite3_column_double(stmt, i));
-        break;
-      case SQLITE_TEXT:
-        v.set_asString((const char *)sqlite3_column_text(stmt, i));
-        break;
-      case SQLITE_BLOB:
-        v.set_asString((const char *)sqlite3_column_text(stmt, i));
-        break;
-      case SQLITE_NULL:
-      default:
-        v.set_asString("");
-        v.set_isNull();
-        break;
+        case SQLITE_INTEGER:
+          v.set_asInt64(sqlite3_column_int64(stmt, i));
+          break;
+        case SQLITE_FLOAT:
+          v.set_asDouble(sqlite3_column_double(stmt, i));
+          break;
+        case SQLITE_TEXT:
+          v.set_asString((const char*)sqlite3_column_text(stmt, i));
+          break;
+        case SQLITE_BLOB:
+          v.set_asString((const char*)sqlite3_column_text(stmt, i));
+          break;
+        case SQLITE_NULL:
+        default:
+          v.set_asString("");
+          v.set_isNull();
+          break;
       }
     }
     result.records.push_back(res);
   }
-  if (db->setErr(sqlite3_finalize(stmt),query.c_str()) == SQLITE_OK)
+  if (db->setErr(sqlite3_finalize(stmt), query.c_str()) == SQLITE_OK)
   {
     active = true;
     ds_state = dsSelect;
@@ -878,22 +935,26 @@ bool SqliteDataset::query(const std::string &query) {
   }
 }
 
-void SqliteDataset::open(const std::string &sql) {
+void SqliteDataset::open(const std::string& sql)
+{
   set_select_sql(sql);
   open();
 }
 
-void SqliteDataset::open() {
-  if (select_sql.size()) {
+void SqliteDataset::open()
+{
+  if (select_sql.size())
+  {
     query(select_sql);
   }
-  else {
+  else
+  {
     ds_state = dsInactive;
   }
 }
 
-
-void SqliteDataset::close() {
+void SqliteDataset::close()
+{
   Dataset::close();
   result.clear();
   edit_object->clear();
@@ -902,9 +963,10 @@ void SqliteDataset::close() {
   active = false;
 }
 
-
-void SqliteDataset::cancel() {
-  if ((ds_state == dsInsert) || (ds_state==dsEdit)) {
+void SqliteDataset::cancel()
+{
+  if ((ds_state == dsInsert) || (ds_state == dsEdit))
+  {
     if (result.record_header.size())
       ds_state = dsSelect;
     else
@@ -912,41 +974,44 @@ void SqliteDataset::cancel() {
   }
 }
 
-
-int SqliteDataset::num_rows() {
+int SqliteDataset::num_rows()
+{
   return result.records.size();
 }
 
-
-bool SqliteDataset::eof() {
+bool SqliteDataset::eof()
+{
   return feof;
 }
 
-
-bool SqliteDataset::bof() {
+bool SqliteDataset::bof()
+{
   return fbof;
 }
 
-
-void SqliteDataset::first() {
+void SqliteDataset::first()
+{
   Dataset::first();
   this->fill_fields();
 }
 
-void SqliteDataset::last() {
+void SqliteDataset::last()
+{
   Dataset::last();
   fill_fields();
 }
 
-void SqliteDataset::prev(void) {
+void SqliteDataset::prev(void)
+{
   Dataset::prev();
   fill_fields();
 }
 
-void SqliteDataset::next(void) {
+void SqliteDataset::next(void)
+{
   Dataset::next();
   if (!eof())
-      fill_fields();
+    fill_fields();
 }
 
 void SqliteDataset::free_row(void)
@@ -954,7 +1019,7 @@ void SqliteDataset::free_row(void)
   if (frecno < 0 || (unsigned int)frecno >= result.records.size())
     return;
 
-  sql_record *row = result.records[frecno];
+  sql_record* row = result.records[frecno];
   if (row)
   {
     delete row;
@@ -962,28 +1027,34 @@ void SqliteDataset::free_row(void)
   }
 }
 
-bool SqliteDataset::seek(int pos) {
-  if (ds_state == dsSelect) {
+bool SqliteDataset::seek(int pos)
+{
+  if (ds_state == dsSelect)
+  {
     Dataset::seek(pos);
     fill_fields();
     return true;
-    }
+  }
   return false;
 }
 
 int64_t SqliteDataset::lastinsertid()
 {
-  if(!handle()) throw DbErrors("No Database Connection");
+  if (!handle())
+    throw DbErrors("No Database Connection");
   return sqlite3_last_insert_rowid(handle());
 }
 
-
-long SqliteDataset::nextid(const char *seq_name) {
-  if (handle()) return db->nextid(seq_name);
-  else return DB_UNEXPECTED_RESULT;
+long SqliteDataset::nextid(const char* seq_name)
+{
+  if (handle())
+    return db->nextid(seq_name);
+  else
+    return DB_UNEXPECTED_RESULT;
 }
 
-void SqliteDataset::interrupt() {
+void SqliteDataset::interrupt()
+{
   sqlite3_interrupt(handle());
 }
-}//namespace
+} // namespace dbiplus

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -18,72 +18,72 @@
 
 #include <sqlite3.h>
 
-namespace dbiplus {
+namespace dbiplus
+{
 /***************** Class SqliteDatabase definition ******************
 
        class 'SqliteDatabase' connects with Sqlite-server
 
 ******************************************************************/
-class SqliteDatabase: public Database {
+class SqliteDatabase : public Database
+{
 protected:
-/* connect descriptor */
-  sqlite3 *conn;
+  /* connect descriptor */
+  sqlite3* conn;
   bool _in_transaction;
   int last_err;
 
 public:
-/* default constructor */
+  /* default constructor */
   SqliteDatabase();
-/* destructor */
+  /* destructor */
   ~SqliteDatabase() override;
 
-  Dataset *CreateDataset() const override;
+  Dataset* CreateDataset() const override;
 
-/* func. returns connection handle with SQLite-server */
-  sqlite3 *getHandle() {  return conn; }
-/* func. returns current status about SQLite-server connection */
+  /* func. returns connection handle with SQLite-server */
+  sqlite3* getHandle() { return conn; }
+  /* func. returns current status about SQLite-server connection */
   int status() override;
-  int setErr(int err_code,const char * qry) override;
-/* func. returns error message if error occurs */
-  const char *getErrorMsg() override;
-/* sets a new host name */
-  void setHostName(const char *newHost) override;
-/* sets a database name */
-  void setDatabase(const char *newDb) override;
+  int setErr(int err_code, const char* qry) override;
+  /* func. returns error message if error occurs */
+  const char* getErrorMsg() override;
+  /* sets a new host name */
+  void setHostName(const char* newHost) override;
+  /* sets a database name */
+  void setDatabase(const char* newDb) override;
 
-/* func. connects to database-server */
+  /* func. connects to database-server */
 
   int connect(bool create) override;
-/* func. disconnects from database-server */
+  /* func. disconnects from database-server */
   void disconnect() override;
-/* func. creates new database */
+  /* func. creates new database */
   int create() override;
-/* func. deletes database */
+  /* func. deletes database */
   int drop() override;
-/* check if database exists (ie has tables/views defined) */
+  /* check if database exists (ie has tables/views defined) */
   bool exists() override;
 
-/* \brief copy database */
-  int copy(const char *backup_name) override;
+  /* \brief copy database */
+  int copy(const char* backup_name) override;
 
-/* \brief drop all extra analytics from database */
+  /* \brief drop all extra analytics from database */
   int drop_analytics(void) override;
 
   long nextid(const char* seq_name) override;
 
-/* virtual methods for transaction */
+  /* virtual methods for transaction */
 
   void start_transaction() override;
   void commit_transaction() override;
   void rollback_transaction() override;
 
-/* virtual methods for formatting */
-  std::string vprepare(const char *format, va_list args) override;
+  /* virtual methods for formatting */
+  std::string vprepare(const char* format, va_list args) override;
 
   bool in_transaction() override { return _in_transaction; }
 };
-
-
 
 /***************** Class SqliteDataset definition *******************
 
@@ -91,59 +91,60 @@ public:
 
 ******************************************************************/
 
-class SqliteDataset : public Dataset {
+class SqliteDataset : public Dataset
+{
 protected:
   sqlite3* handle();
 
-/* Makes direct queries to database */
-  virtual void make_query(StringList &_sql);
-/* Makes direct inserts into database */
+  /* Makes direct queries to database */
+  virtual void make_query(StringList& _sql);
+  /* Makes direct inserts into database */
   void make_insert() override;
-/* Edit SQL */
+  /* Edit SQL */
   void make_edit() override;
-/* Delete SQL */
+  /* Delete SQL */
   void make_deletion() override;
 
   //static int sqlite_callback(void* res_ptr,int ncol, char** result, char** cols);
 
-/* This function works only with MySQL database
+  /* This function works only with MySQL database
   Filling the fields information from select statement */
   void fill_fields() override;
-/* Changing field values during dataset navigation */
-  virtual void free_row();  // free the memory allocated for the current row
+  /* Changing field values during dataset navigation */
+  virtual void free_row(); // free the memory allocated for the current row
 
 public:
-/* constructor */
+  /* constructor */
   SqliteDataset();
-  explicit SqliteDataset(SqliteDatabase *newDb);
+  explicit SqliteDataset(SqliteDatabase* newDb);
 
-/* destructor */
+  /* destructor */
   ~SqliteDataset() override;
 
-/* set autorefresh boolean value (if true - refresh the data after edit()
+  /* set autorefresh boolean value (if true - refresh the data after edit()
 or insert() operations default = false) */
   void set_autorefresh(bool val);
 
-/* opens a query  & then sets a query results */
+  /* opens a query  & then sets a query results */
   void open() override;
-  void open(const std::string &sql) override;
-/* func. executes a query without results to return */
-  int  exec () override;
-  int  exec (const std::string &sql) override;
+  void open(const std::string& sql) override;
+  /* func. executes a query without results to return */
+  int exec() override;
+  int exec(const std::string& sql) override;
   const void* getExecRes() override;
-/* as open, but with our query exec Sql */
-  bool query(const std::string &query) override;
-/* func. closes a query */
+  /* as open, but with our query exec Sql */
+  bool query(const std::string& query) override;
+  /* func. closes a query */
   void close(void) override;
-/* Cancel changes, made in insert or edit states of dataset */
+  /* Cancel changes, made in insert or edit states of dataset */
   void cancel() override;
-/* last inserted id */
+  /* last inserted id */
   int64_t lastinsertid() override;
-/* sequence numbers */
-  long nextid(const char *seq_name) override;
-/* sequence numbers */
+  /* sequence numbers */
+  long nextid(const char* seq_name) override;
+  /* sequence numbers */
   int num_rows() override;
-/* interrupt any pending database operation  */
+  /* interrupt any pending database operation  */
   void interrupt() override;
 
   bool bof() override;
@@ -152,10 +153,9 @@ or insert() operations default = false) */
   void last() override;
   void prev() override;
   void next() override;
-/* Go to record No (starting with 0) */
-  bool seek(int pos=0) override;
+  /* Go to record No (starting with 0) */
+  bool seek(int pos = 0) override;
 
-  bool dropIndex(const char *table, const char *index) override;
+  bool dropIndex(const char* table, const char* index) override;
 };
-} //namespace
-
+} // namespace dbiplus


### PR DESCRIPTION
First three commits are to cleanup dbwrappers code a bit, no functional changes.

Last commit improves string-based field lookup, increasing overall performance for many use cases, among them creation of `CPVREpgInfoTag` instances with database data.

Before:
<img width="1127" alt="Screenshot 2022-08-24 at 09 03 09" src="https://user-images.githubusercontent.com/3226626/186353208-d51b8dfb-cb2a-4f72-9597-480caa2732e8.png">

After:
<img width="1131" alt="Screenshot 2022-08-24 at 09 03 40" src="https://user-images.githubusercontent.com/3226626/186353294-9351e04d-ba86-4535-99cd-1c0a10594f79.png">

