### PR TITLE
[addons] Fix crash in CRepositoryUpdateJob::DoWork.

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -371,8 +371,8 @@ bool CRepositoryUpdateJob::DoWork()
     for (const auto& addon : addons)
     {
       AddonPtr oldAddon;
-      if (addon->Version() > oldAddon->Version() &&
-          CServiceBroker::GetAddonMgr().FindInstallableById(addon->ID(), oldAddon))
+      if (CServiceBroker::GetAddonMgr().FindInstallableById(addon->ID(), oldAddon) && oldAddon &&
+          addon->Version() > oldAddon->Version())
       {
         if (!oldAddon->Icon().empty() || !oldAddon->Art().empty() || !oldAddon->Screenshots().empty())
           CLog::Log(LOGDEBUG, "CRepository: invalidating cached art for '{}'", addon->ID());


### PR DESCRIPTION
Fixes a crash, which is fallout from #21777 

<img width="1647" alt="Screenshot 2022-08-27 at 13 09 20" src="https://user-images.githubusercontent.com/3226626/187027844-41912227-da07-431b-b4ae-e3a83b9fdaa5.png">

Runtime-tested on macOS, latest Kodi master.

