### PR TITLE
[addons] Fix potential crash in CAddonInstaller::CheckDependencies()

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -389,8 +389,8 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
         (!haveInstalledAddon && !optional))
     {
       // we have it but our version isn't good enough, or we don't have it and we need it
-      if (!dep->MeetsVersion(versionMin, version) ||
-          !CServiceBroker::GetAddonMgr().FindInstallableById(addonID, dep))
+      if (!CServiceBroker::GetAddonMgr().FindInstallableById(addonID, dep) ||
+          (dep && !dep->MeetsVersion(versionMin, version)))
       {
         // we don't have it in a repo, or we have it but the version isn't good enough, so dep isn't satisfied.
         CLog::Log(LOGDEBUG, "CAddonInstallJob[{}]: requires {} version {} which is not available",


### PR DESCRIPTION
fallout from https://github.com/xbmc/xbmc/pull/21777

https://github.com/xbmc/xbmc/blob/c3ca37de066fa5f4208e1f17828fc854aec0484f/xbmc/addons/AddonInstaller.cpp#L385-L394

if condition `(!haveInstalledAddon && !optional)` evaluates true the following `dep->MeetsVersion()` will crash due to nullptr dereference

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
