### PR TITLE
[android] Add android.intent.action.MAIN intent query to AndroidManifest.xml

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -174,8 +174,10 @@
 
     <queries>
       <intent>
-        <action
-          android:name="android.speech.RecognitionService" />
+        <action android:name="android.speech.RecognitionService" />
+      </intent>
+      <intent>
+        <action android:name="android.intent.action.MAIN" />
       </intent>
     </queries>
 


### PR DESCRIPTION
… to be able to obtain list of installed apps on Android 11+. On my Shield TV Pro 2019, since running Android 11, I noticed that under "Add-ons -> Android Apps" not all user installed apps where listed.

Solution is to extend the manifest: https://stackoverflow.com/questions/67189934/how-to-get-a-list-of-installed-apps-in-android-11

Runtime-tested on my Shield TV Pro 2019, running latest firmware (9.1.0).

@joseluismarti can you review, please?