### PR TITLE
[Subtitles] Fix debug info OSD placement

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -148,5 +148,5 @@ void CDebugRenderer::CRenderer::CreateSubtitlesStyle()
   m_debugOverlayStyle = std::make_shared<KODI::SUBTITLES::STYLE::style>();
   m_debugOverlayStyle->fontName = KODI::SUBTITLES::FONT_DEFAULT_FAMILYNAME;
   m_debugOverlayStyle->fontSize = 20.0;
-  m_debugOverlayStyle->marginVertical = 30;
+  m_debugOverlayStyle->marginVertical = 12;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -190,7 +190,7 @@ namespace OVERLAY {
     bool m_saveSubtitlePosition{false}; // To save subtitle position permanently
     KODI::SUBTITLES::HorizontalAlign m_subtitleHorizontalAlign{
         KODI::SUBTITLES::HorizontalAlign::CENTER};
-    KODI::SUBTITLES::Align m_subtitleAlign{KODI::SUBTITLES::Align::BOTTOM_INSIDE};
+    KODI::SUBTITLES::Align m_subtitleAlign{KODI::SUBTITLES::Align::BOTTOM_OUTSIDE};
 
     std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_overlayStyle;
     std::atomic<bool> m_isSettingsChanged{false};


### PR DESCRIPTION
## Description
[Subtitles] Fix debug info OSD placement

## Motivation and context
Debug Info OSD is wrong located after https://github.com/xbmc/xbmc/pull/21680 because has changed defaults settings how positions are calculated and Debug Info OSD gets aligned now to video instead of to screen.

This is especially noticeable with cropped videos.

The fix consists on change default OverlayRenderer `m_subtitleAlign` to `BOTTOM_OUTSIDE` to be consistent with new subtitles defaults. Anyway for normal subtitles this value always is read from settings (don't care default initialization value).


## How has this been tested?
Runtime tested Windows x64

## What is the effect on users?
Fix Debug Info OSD location

## Screenshots (if appropriate):

**Before**
![screenshot00000](https://user-images.githubusercontent.com/58434170/187171956-bd275504-88eb-474e-9a47-81777663c3f2.png)

**After**
![screenshot00005](https://user-images.githubusercontent.com/58434170/187171999-fdab5a86-4518-4dc7-8c2b-3d74a41b442d.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
