### PR TITLE
[Android] Keep XML's externally editable in newest Android versions

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -44,6 +44,7 @@ set(package_files strings.xml
                   searchable.xml
                   AndroidManifest.xml
                   build.gradle
+                  src/ExternalPermission.java
                   src/Splash.java
                   src/Main.java
                   src/XBMCBroadcastReceiver.java

--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -80,6 +80,7 @@ set(package_files strings.xml
                   src/model/Song.java
                   src/model/MusicVideo.java
                   src/model/Media.java
+                  src/content/XBMCExternalFileContentProvider.java
                   src/content/XBMCFileContentProvider.java
                   src/content/XBMCMediaContentProvider.java
                   src/content/XBMCContentProvider.java

--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -1,6 +1,6 @@
 ![Kodi Logo](resources/banner_slim.png)
 
-# Android build guide
+# Android developer guide
 This guide has been tested with Ubuntu 16.04 (Xenial) x86_64. It is meant to cross-compile Kodi for Android using **[Kodi's unified depends build system](../tools/depends/README.md)**. Please read it in full before you proceed to familiarize yourself with the build procedure.
 
 It should work if you're using macOS. If that is the case, read **[macOS specific prerequisites](#35-macos-specific-prerequisites)** first.
@@ -425,8 +425,10 @@ And you can get the result of this request in `onActivityResult`
    if (requestCode == REQ_KODI_PERM) {
     if (resultCode == Activity.RESULT_OK) {
       // Access granted by the user
+    } else if (data != null && "DENIED_PERMANENTLY".equals(data.getAction()) {
+      // The user denied access permanently. That is until your application is reinstalled.
     } else {
-      // Access not granted. The user might even denied requests from your app for it's installation time.
+      // The user denied access, but you can request again.
     }
   }
 ```

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -115,6 +115,20 @@
                 android:name="android.app.lib_name"
                 android:value="@APP_NAME_LC@" />
         </activity>
+        <activity
+            android:name=".ExternalPermission"
+            android:configChanges="orientation|keyboard|keyboardHidden|navigation|touchscreen|screenLayout|screenSize|colorMode"
+            android:finishOnTaskLaunch="true"
+            android:launchMode="singleInstance"
+            android:exported="true"
+            android:screenOrientation="sensorLandscape"
+            android:theme="@style/AppTheme">
+
+            <intent-filter>
+                <action android:name="@APP_PACKAGE@.permission.ExternalFiles" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
         <receiver android:name=".XBMCBroadcastReceiver"
                   android:exported="true">
@@ -123,6 +137,10 @@
                 <action android:name="android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED" />
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.PACKAGE_FULLY_REMOVED"  />
+                <data android:scheme="package" />
             </intent-filter>
         </receiver>
 
@@ -138,7 +156,7 @@
         <provider
             android:name=".content.XBMCExternalFileContentProvider"
             android:authorities="@APP_PACKAGE@.external.file"
-            android:exported="true" />
+            android:exported="true"/>
         <provider
             android:name=".content.XBMCYTDLContentProvider"
             android:authorities="@APP_PACKAGE@.ytdl"

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -136,6 +136,10 @@
             android:authorities="@APP_PACKAGE@.file"
             android:exported="true" />
         <provider
+            android:name=".content.XBMCExternalFileContentProvider"
+            android:authorities="@APP_PACKAGE@.external.file"
+            android:exported="true" />
+        <provider
             android:name=".content.XBMCYTDLContentProvider"
             android:authorities="@APP_PACKAGE@.ytdl"
             android:exported="true" />

--- a/tools/android/packaging/xbmc/src/ExternalPermission.java.in
+++ b/tools/android/packaging/xbmc/src/ExternalPermission.java.in
@@ -34,10 +34,10 @@ public class ExternalPermission extends Activity
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mPreferences = getSharedPreferences("external_permissions", 0);
-        setContentView(R.layout.activity_splash);
-        if (getIntent() != null && PERMISSION_ACTION.equals(getIntent().getAction())) {
-            final String requester = getReferrer().getHost();
+        final String requester = getCallingPackage();
+        if (getIntent() != null && PERMISSION_ACTION.equals(getIntent().getAction()) && requester != null) {
             if (newPackage(requester)) {
+                setContentView(R.layout.activity_splash);
                 AlertDialog dialog = new AlertDialog.Builder(this)
                     .setCancelable(false)
                     .setTitle("WARNING")

--- a/tools/android/packaging/xbmc/src/ExternalPermission.java.in
+++ b/tools/android/packaging/xbmc/src/ExternalPermission.java.in
@@ -44,21 +44,21 @@ public class ExternalPermission extends Activity
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
                             acceptPackage(requester);
-                            setResult(Activity.RESULT_OK);
+                            setResult(Activity.RESULT_OK, new Intent("ACCEPTED"));
                             finish();
                         }
                     })
                     .setNeutralButton("Deny", new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
-                            setResult(Activity.RESULT_CANCELED);
+                            setResult(Activity.RESULT_CANCELED, new Intent("DENIED"));
                             finish();
                         }
                     })
                     .setNegativeButton("Deny and don't ask again", new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
-                            setResult(Activity.RESULT_CANCELED);
+                            setResult(Activity.RESULT_CANCELED, new Intent("DENIED_PERMANENTLY"));
                             denyPackage(requester);
                             finish();
                         }

--- a/tools/android/packaging/xbmc/src/ExternalPermission.java.in
+++ b/tools/android/packaging/xbmc/src/ExternalPermission.java.in
@@ -26,6 +26,10 @@ public class ExternalPermission extends Activity
         return !mPreferences.contains(pkgName);
     }
 
+    private boolean acceptedPackage(String pkgName) {
+        return mPreferences.getBoolean(pkgName, false);
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -65,6 +69,12 @@ public class ExternalPermission extends Activity
                     })
                     .show();
                 return;
+            } else {
+                if (acceptedPackage(requester)) {
+                    setResult(Activity.RESULT_OK, new Intent("ACCEPTED"));
+                } else {
+                    setResult(Activity.RESULT_CANCELED, new Intent("DENIED_PERMANENTLY"));
+                }
             }
         }
         finish();

--- a/tools/android/packaging/xbmc/src/ExternalPermission.java.in
+++ b/tools/android/packaging/xbmc/src/ExternalPermission.java.in
@@ -1,0 +1,72 @@
+package @APP_PACKAGE@;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Bundle;
+
+public class ExternalPermission extends Activity
+{
+    public static final String PERMISSION_ACTION = "@APP_PACKAGE@.permission.ExternalFiles";
+
+    private SharedPreferences mPreferences;
+
+    private void acceptPackage(String pkgName) {
+        mPreferences.edit().putBoolean(pkgName, true).commit();
+    }
+
+    private void denyPackage(String pkgName) {
+        mPreferences.edit().putBoolean(pkgName, false).commit();
+    }
+
+    private boolean newPackage(String pkgName) {
+        return !mPreferences.contains(pkgName);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mPreferences = getSharedPreferences("external_permissions", 0);
+        setContentView(R.layout.activity_splash);
+        if (getIntent() != null && PERMISSION_ACTION.equals(getIntent().getAction())) {
+            final String requester = getReferrer().getHost();
+            if (newPackage(requester)) {
+                AlertDialog dialog = new AlertDialog.Builder(this)
+                    .setCancelable(false)
+                    .setTitle("WARNING")
+                    .setMessage(requester+" requested access to @APP_NAME@'s external settings directory. If you approve this request, "+requester+
+                        " will have permission to change your configurations, or even read stored passwords for your media sources."+
+                        "\n Only accept the request if you really trust that application!")
+                    .setPositiveButton("Accept", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            acceptPackage(requester);
+                            setResult(Activity.RESULT_OK);
+                            finish();
+                        }
+                    })
+                    .setNeutralButton("Deny", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            setResult(Activity.RESULT_CANCELED);
+                            finish();
+                        }
+                    })
+                    .setNegativeButton("Deny and don't ask again", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            setResult(Activity.RESULT_CANCELED);
+                            denyPackage(requester);
+                            finish();
+                        }
+                    })
+                    .show();
+                return;
+            }
+        }
+        finish();
+    }
+}

--- a/tools/android/packaging/xbmc/src/ExternalPermission.java.in
+++ b/tools/android/packaging/xbmc/src/ExternalPermission.java.in
@@ -43,7 +43,7 @@ public class ExternalPermission extends Activity
                     .setTitle("WARNING")
                     .setMessage(requester+" requested access to @APP_NAME@'s external settings directory. If you approve this request, "+requester+
                         " will have permission to change your configurations, or even read stored passwords for your media sources."+
-                        "\n Only accept the request if you really trust that application!")
+                        "\nOnly accept the request if you really trust that application!")
                     .setPositiveButton("Accept", new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {

--- a/tools/android/packaging/xbmc/src/XBMCBroadcastReceiver.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCBroadcastReceiver.java.in
@@ -4,6 +4,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.SharedPreferences;
+import android.net.Uri;
 import android.util.Log;
 
 public class XBMCBroadcastReceiver extends BroadcastReceiver
@@ -25,6 +27,16 @@ public class XBMCBroadcastReceiver extends BroadcastReceiver
         i = manager.getLaunchIntentForPackage("@APP_PACKAGE@");
         i.addCategory(Intent.CATEGORY_LAUNCHER);
         context.startActivity(i);
+      }
+    }
+    else if (Intent.ACTION_PACKAGE_FULLY_REMOVED.equals(intent.getAction()))
+    {
+      Uri uri = Uri.parse(intent.getDataString());
+      SharedPreferences preferences = context.getSharedPreferences("external_permissions", 0);
+      String pkgName = uri.getSchemeSpecificPart();
+      if (preferences.contains(pkgName)) {
+        Log.d(TAG, "Removed external permissions for "+pkgName);
+        preferences.edit().remove(pkgName).commit();
       }
     }
     else

--- a/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
@@ -9,9 +9,7 @@ import android.util.Log;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 
 public class XBMCExternalFileContentProvider extends XBMCContentProvider
 {
@@ -21,21 +19,11 @@ public class XBMCExternalFileContentProvider extends XBMCContentProvider
 
   private static final HashMap<String, String> MIME_TYPES=new HashMap<String, String>();
 
-  private static final List<String> ALLOWED;
-
   private SharedPreferences mPreferences;
 
   static {
     MIME_TYPES
       .put(".xml", "application/xml");
-
-    ALLOWED=Arrays.asList(
-      "/.kodi/userdata/playercorefactory.xml",
-      "/.kodi/userdata/sources.xml",
-      "/.kodi/userdata/mediasources.xml",
-      "/.kodi/userdata/passwords.xml",
-      "/.kodi/userdata/guisettings.xml"
-    );
   }
 
   private File getFileIfAllowed(Uri uri) throws FileNotFoundException {
@@ -43,9 +31,6 @@ public class XBMCExternalFileContentProvider extends XBMCContentProvider
     if (!mPreferences.getBoolean(requester, false)) {
       throw new FileNotFoundException("Denied application: "+requester);
     }
-    if (!ALLOWED.contains(uri.getPath())) {
-      throw new FileNotFoundException("Not allowed: "+uri.getPath());
-    };
     return new File(getContext().getExternalFilesDir(null), uri.getPath());
   }
 

--- a/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
@@ -1,6 +1,7 @@
 package @APP_PACKAGE@.content;
 
 import android.content.ContentValues;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
@@ -22,6 +23,8 @@ public class XBMCExternalFileContentProvider extends XBMCContentProvider
 
   private static final List<String> ALLOWED;
 
+  private SharedPreferences mPreferences;
+
   static {
     MIME_TYPES
       .put(".xml", "application/xml");
@@ -36,6 +39,10 @@ public class XBMCExternalFileContentProvider extends XBMCContentProvider
   }
 
   private File getFileIfAllowed(Uri uri) throws FileNotFoundException {
+    final String requester = getCallingPackage();
+    if (!mPreferences.getBoolean(requester, false)) {
+      throw new FileNotFoundException("Denied application: "+requester);
+    }
     if (!ALLOWED.contains(uri.getPath())) {
       throw new FileNotFoundException("Not allowed: "+uri.getPath());
     };
@@ -64,6 +71,7 @@ public class XBMCExternalFileContentProvider extends XBMCContentProvider
   @Override
   public boolean onCreate()
   {
+    mPreferences = getContext().getSharedPreferences("external_permissions", 0);
     return true;
   }
 

--- a/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
@@ -40,7 +40,7 @@ public class XBMCExternalFileContentProvider extends XBMCContentProvider
     String path=uri.toString();
 
     for (String extension : MIME_TYPES.keySet()) {
-      if (path.endsWith(extension)) {
+      if (path.toLowerCase().endsWith(extension)) {
         return(MIME_TYPES.get(extension));
       }
     }

--- a/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
@@ -6,6 +6,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -44,7 +45,16 @@ public class XBMCExternalFileContentProvider extends XBMCContentProvider
       }
     }
 
-    return(null);
+    String fileExtension = MimeTypeMap.getFileExtensionFromUrl(uri
+                .toString());
+    String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+            fileExtension.toLowerCase());
+
+    if (mimeType == null) {
+      mimeType = "text/plain";
+    }
+
+    return mimeType;
   }
 
   @Override

--- a/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCExternalFileContentProvider.java.in
@@ -1,0 +1,97 @@
+package @APP_PACKAGE@.content;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class XBMCExternalFileContentProvider extends XBMCContentProvider
+{
+  private static String TAG = "@APP_NAME@_EXTERNAL_File_Provider";
+
+  public static final String AUTHORITY = AUTHORITY_ROOT + ".external.file";
+
+  private static final HashMap<String, String> MIME_TYPES=new HashMap<String, String>();
+
+  private static final List<String> ALLOWED;
+
+  static {
+    MIME_TYPES
+      .put(".xml", "application/xml");
+
+    ALLOWED=Arrays.asList(
+      "/.kodi/userdata/playercorefactory.xml",
+      "/.kodi/userdata/sources.xml",
+      "/.kodi/userdata/mediasources.xml",
+      "/.kodi/userdata/passwords.xml",
+      "/.kodi/userdata/guisettings.xml"
+    );
+  }
+
+  private File getFileIfAllowed(Uri uri) throws FileNotFoundException {
+    if (!ALLOWED.contains(uri.getPath())) {
+      throw new FileNotFoundException("Not allowed: "+uri.getPath());
+    };
+    return new File(getContext().getExternalFilesDir(null), uri.getPath());
+  }
+
+  @Override
+  public String getType(Uri uri) {
+    String path=uri.toString();
+
+    for (String extension : MIME_TYPES.keySet()) {
+      if (path.endsWith(extension)) {
+        return(MIME_TYPES.get(extension));
+      }
+    }
+
+    return(null);
+  }
+
+  @Override
+  public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+    File f=getFileIfAllowed(uri);
+    return ParcelFileDescriptor.open(f, ParcelFileDescriptor.parseMode(mode));
+  }
+
+  @Override
+  public boolean onCreate()
+  {
+    return true;
+  }
+
+  @Override
+  public int delete(Uri arg0, String arg1, String[] arg2)
+  {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public Uri insert(Uri arg0, ContentValues arg1)
+  {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public int update(Uri arg0, ContentValues arg1, String arg2, String[] arg3)
+  {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public Cursor query(Uri uri, String[] projection, String selection,
+                      String[] selectionArgs, String sortOrder)
+  {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description
https://forum.kodi.tv/showthread.php?tid=364037

This provider makes it possible for external applications to keep interacting with some xml setting files, even after the stricter permissions of Android 11+.

## Motivation and context
Since Android 11, each Android version makes it harder for applications to access these files. There are some non-supported workarounds with SAF, but they probably won't work forever.

This will be an Android supported way of accessing these files going forward.

## How has this been tested?
Tested on Android 12 real device and Android 13 emulator with a special build of XBMCWrapper.
Tested all the open file modes, all work fine.
Tested Accept, Deny, and Don't ask again, each work as intended
Tested Uninstalling an app, which got it removed from the known list as intended.

## What is the effect on users?
Users can keep using applications that interact with these files.

## Screenshots (if appropriate):
![Screenshot_permission](https://user-images.githubusercontent.com/396582/190199081-47d589ed-441b-4509-b199-4190bc2c412e.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
