### PR TITLE
[addons] allow on multiple selectable instance support one as default

### DIFF
--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -32,6 +32,11 @@ constexpr const char* ADDON_SETTING_INSTANCE_ENABLED_VALUE = "kodi_addon_instanc
 constexpr AddonInstanceId ADDON_SINGLETON_INSTANCE_ID = 0;
 
 /*!
+ * @brief Identifier denoting initial first add-on instance.
+ */
+constexpr AddonInstanceId ADDON_FIRST_INSTANCE_ID = 1;
+
+/*!
  * @brief Identifier denoting add-on instance id as unused.
  *
  * @sa ADDON::IAddonInstanceHandler

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -283,8 +283,7 @@ std::vector<AddonInstanceId> CAddonInfo::GetKnownInstanceIds() const
 
   const std::string searchPath = StringUtils::Format("special://profile/addon_data/{}/", m_id);
   CFileItemList items;
-  if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".xml", XFILE::DIR_FLAG_NO_FILE_DIRS))
-    return std::vector<AddonInstanceId>();
+  XFILE::CDirectory::GetDirectory(searchPath, items, ".xml", XFILE::DIR_FLAG_NO_FILE_DIRS);
 
   std::vector<AddonInstanceId> ret;
 
@@ -300,6 +299,10 @@ std::vector<AddonInstanceId> CAddonInfo::GetKnownInstanceIds() const
         ret.emplace_back(std::atoi(uid.c_str()));
     }
   }
+
+  // If no instances are used, create first as default.
+  if (ret.empty())
+    ret.emplace_back(ADDON_FIRST_INSTANCE_ID);
 
   return ret;
 }

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -162,6 +162,8 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
     {
       while (true)
       {
+        const std::vector<ADDON::AddonInstanceId> ids = addon->GetKnownInstanceIds();
+
         CFileItemList itemsGeneral;
         CFileItemList itemsInstances;
 
@@ -175,6 +177,8 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
           item->SetProperty("id", ADD_INSTANCE);
           itemsGeneral.Add(item);
         }
+        // Have always minimal 1 available and not allow this button in this case
+        if (ids.size() > 1)
         {
           const CFileItemPtr item = std::make_shared<CFileItem>(
               g_localizeStrings.Get(10015)); // Remove add-on configuration
@@ -189,7 +193,6 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
           itemsGeneral.Add(item);
         }
 
-        const std::vector<ADDON::AddonInstanceId> ids = addon->GetKnownInstanceIds();
         ADDON::AddonInstanceId highestId = 0;
         for (const auto& id : ids)
         {

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -33,11 +33,15 @@ using namespace PVR;
 
 namespace
 {
-int ClientIdFromAddonId(const std::string& addonID, ADDON::AddonInstanceId instance)
+int ClientIdFromAddonIdAndInstanceId(const std::string& addonID, ADDON::AddonInstanceId instanceID)
 {
   std::hash<std::string> hasher;
-  int iClientId =
-      static_cast<int>(hasher((instance > 0 ? std::to_string(instance) + "@" : "") + addonID));
+
+  // Note: For database backwards compatibility reasons the hash of the first instance
+  // must be calculated just from the addonId, not from addonId and instanceId.
+  int iClientId = static_cast<int>(
+      hasher((instanceID > ADDON::ADDON_FIRST_INSTANCE_ID ? std::to_string(instanceID) + "@" : "") +
+             addonID));
   if (iClientId < 0)
     iClientId = -iClientId;
   return iClientId;
@@ -145,7 +149,7 @@ void CPVRClients::UpdateAddons(const std::string& changedAddonId /*= ""*/,
         if (instanceEnabled &&
             (!IsKnownClient(addon->ID(), instanceId) || !IsCreatedClient(addon->ID(), instanceId)))
         {
-          int iClientId = ClientIdFromAddonId(addon->ID(), instanceId);
+          int iClientId = ClientIdFromAddonIdAndInstanceId(addon->ID(), instanceId);
 
           std::shared_ptr<CPVRClient> client;
           if (IsKnownClient(addon->ID(), instanceId))
@@ -438,7 +442,8 @@ std::vector<CVariant> CPVRClients::GetClientProviderInfos() const
       if (IsKnownClient(addonInfo->ID(), instanceId))
         clientProviderInfo["clientid"] = GetClientId(addonInfo->ID(), instanceId);
       else
-        clientProviderInfo["clientid"] = ClientIdFromAddonId(addonInfo->ID(), instanceId);
+        clientProviderInfo["clientid"] =
+            ClientIdFromAddonIdAndInstanceId(addonInfo->ID(), instanceId);
       clientProviderInfo["addonid"] = addonInfo->ID();
       clientProviderInfo["instanceid"] = instanceId;
       clientProviderInfo["enabled"] =
@@ -478,7 +483,7 @@ PVR_ERROR CPVRClients::GetCallableClients(CPVRClientMap& clientsReady,
     std::vector<ADDON::AddonInstanceId> instanceIds = addon->GetKnownInstanceIds();
     for (const auto& instanceId : instanceIds)
     {
-      int iClientId = ClientIdFromAddonId(addon->ID(), instanceId);
+      int iClientId = ClientIdFromAddonIdAndInstanceId(addon->ID(), instanceId);
       std::shared_ptr<CPVRClient> client;
       GetClient(iClientId, client);
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -137,14 +137,6 @@ void CPVRClients::UpdateAddons(const std::string& changedAddonId /*= ""*/,
         }
       }
 
-      if (instanceIdsWithStatus.empty() && addon->SupportsInstanceSettings())
-      {
-        // User has not yet created an instance configuration.
-        // Create an instance with default instance settings.
-        instanceIdsWithStatus.emplace_back(
-            std::pair<ADDON::AddonInstanceId, bool>(1, bEnabled)); //! @todo get rid of magic number
-      }
-
       for (const auto& instanceInfo : instanceIdsWithStatus)
       {
         const ADDON::AddonInstanceId instanceId = instanceInfo.first;


### PR DESCRIPTION
## Description

With this change, activating an add-on that allows multiple instances via settings will automatically add one.

In addition, the add-on is deactivated again when the last instance is removed in settings.

Further becomes with this a crash fixed, if an user removed all instances in settings, leaved add-on as enabled and then goes inside Kodi's main menu to "TV" field.
```gdb
Thread 1 "kodi.bin" received signal SIGSEGV, Segmentation fault.
0x00007ffff6446994 in pthread_mutex_lock () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff6446994 in pthread_mutex_lock () at /usr/lib/libc.so.6
#1  0x0000555556d280f1 in PVR::CPVRProvider::GetIconPath[abi:cxx11]() const ()
#2  0x0000555556d3736a in PVR::CPVRGUIInfo::GetListItemAndPlayerLabel(CFileItem const*, KODI::GUILIB::GUIINFO::CGUIInfo const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) const ()
#3  0x0000555556d37ed4 in PVR::CPVRGUIInfo::GetLabel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, CFileItem const*, int, KODI::GUILIB::GUIINFO::CGUIInfo const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const ()
#4  0x00005555567feb82 in KODI::GUILIB::GUIINFO::CGUIInfoProviders::GetLabel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, CFileItem const*, int, KODI::GUILIB::GUIINFO::CGUIInfo const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const ()
#5  0x0000555556b888da in CGUIInfoManager::GetMultiInfoItemLabel(CFileItem const*, int, KODI::GUILIB::GUIINFO::CGUIInfo const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const ()
#6  0x0000555556b8938f in CGUIInfoManager::GetMultiInfoItemImage(CFileItem const*, int, KODI::GUILIB::GUIINFO::CGUIInfo const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const ()
#7  0x0000555556b89556 in CGUIInfoManager::GetItemImage(CGUIListItem const*, int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const ()
#8  0x0000555556802fd5 in KODI::GUILIB::GUIINFO::CGUIInfoLabel::GetItemLabel(CGUIListItem const*, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const ()
#9  0x0000555556879cc0 in CGUIImage::UpdateInfo(CGUIListItem const*) ()
#10 0x0000555556889e23 in CGUIListGroup::UpdateInfo(CGUIListItem const*) ()
#11 0x0000555556889e23 in CGUIListGroup::UpdateInfo(CGUIListItem const*) ()
#12 0x00005555568925b5 in CGUIListItemLayout::Process(CGUIListItem*, int, unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#13 0x0000555556837a9b in CGUIBaseContainer::ProcessItem(float, float, std::shared_ptr<CGUIListItem>&, bool, unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#14 0x000055555689c11f in CGUIPanelContainer::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#15 0x0000555556845f1b in CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#16 0x0000555556830139 in CGUIBaseContainer::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#17 0x000055555685792c in CGUIControlGroupList::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#18 0x0000555556845f1b in CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#19 0x0000555556854082 in CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#20 0x0000555556845f1b in CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#21 0x0000555556854082 in CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#22 0x0000555556845f1b in CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#23 0x0000555556854082 in CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#24 0x0000555556845f1b in CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#25 0x0000555556854082 in CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#26 0x0000555556845f1b in CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#27 0x00005555568c973d in CGUIWindow::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) ()
#28 0x00005555568cce29 in CGUIWindowManager::Process(unsigned int) ()
#29 0x0000555556b224ff in CApplication::FrameMove(bool, bool) ()
#30 0x0000555556b19605 in CApplication::Run() ()
#31 0x000055555677831e in XBMC_Run ()
#32 0x000055555602f5a8 in main ()
(gdb) 
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
