### PR TITLE
[Windows] Fix incorrect window position when switching from fullscreen to windowed in some cases

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -485,9 +485,9 @@ bool CWinSystemWin32::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
 
   if (m_state == WINDOW_STATE_WINDOWED)
   {
-    WINDOWINFO wi;
+    WINDOWINFO wi = {};
     wi.cbSize = sizeof(WINDOWINFO);
-    if (GetWindowInfo(m_hWnd, &wi))
+    if (GetWindowInfo(m_hWnd, &wi) && wi.rcClient.top > 0)
     {
       m_nLeft = wi.rcClient.left;
       m_nTop = wi.rcClient.top;


### PR DESCRIPTION
## Description
[Windows] Fix incorrect window position when switching from fullscreen to windowed in some cases

Fixes https://github.com/xbmc/xbmc/issues/21610

## Motivation and context
This code saves the current window position prior to switch to fullscreen:

https://github.com/xbmc/xbmc/blob/33b774699725b4d6dee7ae41b07365620b85a1aa/xbmc/windowing/windows/WinSystemWin32.cpp#L486-L496

But this not works in some corner cases because `m_state` is the estate that Kodi "thinks" window is. Current state may have changed triggered externally by OS.

i.e. Kodi thinks window is WINDOWED but user has switched to fullscreen from OS with ALT + ENTER, etc.

Then is called `CWinSystemWin32::SetFullScreen` as should but window physically is already in fullscreen and are read coordinates top = 0, left  = 0 and saved with `m_ValidWindowedPosition = true`

Fix consist in not update window position if top = 0 (indicates that window title bar is not visible and should never happen in windowed mode). Anyway is not necessary save window position here because is already saved/updated when window is moved. This `if` code block could be removed entirely.

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Fix window is displayed out of desktop area with not visible title bar in some corner cases.

## Screenshots (if appropriate):

![grafik](https://user-images.githubusercontent.com/226144/175975890-cfcb9081-ab7e-421e-b540-73cd932f3e51.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
