### PR TITLE
[discs][vp] Reset state back to DVDSTATE_NORMAL on BD playlist stop

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3936,6 +3936,8 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
       m_overlayContainer.ProcessAndAddOverlayIfValid(static_cast<CDVDOverlay*>(pData));
       break;
     case BD_EVENT_PLAYLIST_STOP:
+      m_dvd.state = DVDSTATE_NORMAL;
+      m_dvd.iDVDStillTime = 0ms;
       m_messenger.Put(std::make_shared<CDVDMsg>(CDVDMsg::GENERAL_FLUSH));
       break;
     case BD_EVENT_AUDIO_STREAM:


### PR DESCRIPTION
## Description
Sometimes when starting items from the bluray menu (stopping the current playlist) the new playlist doesn't show any video timeline. This happens because VP may be on `DVDSTATE_STILL` state and `IsInMenuInternal` assumes that in that state we are in a menu:

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L4458-L4459

This makes sure that when we receive `BD_EVENT_PLAYLIST_STOP` we reset the `m_dvd` state back to `DVDSTATE_NORMAL` just like we do for dvds:

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L4165-L4169


## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21783

## How has this been tested?
Runtime tested on Linux with the files provided on the issue report.

## What is the effect on users?
Bluray playlist files should have a timeline.

