### PR TITLE
[Subtitles][WebVTT] Fixed "seconds" variable type to double

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -1143,8 +1143,8 @@ double CWebVTTHandler::GetTimeFromRegexTS(CRegExp& regex, int indexStart /* = 1 
 {
   int sHours = 0;
   if (!regex.GetMatch(indexStart).empty())
-    sHours = std::stoi(regex.GetMatch(indexStart).c_str());
-  int sMinutes = std::stoi(regex.GetMatch(indexStart + 1).c_str());
-  int sSeconds = std::atof(regex.GetMatch(indexStart + 2).c_str());
+    sHours = std::stoi(regex.GetMatch(indexStart));
+  int sMinutes = std::stoi(regex.GetMatch(indexStart + 1));
+  double sSeconds = std::stod(regex.GetMatch(indexStart + 2));
   return (static_cast<double>(sHours * 3600 + sMinutes * 60) + sSeconds) * DVD_TIME_BASE;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fixed "seconds" variable type oversight changed by #21763

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
attempt to fix #21807

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I will wait user feedback after make a test build because i am not able reproduce the problem in easy way
EDIT: confirmed works https://github.com/xbmc/xbmc/issues/21807#issuecomment-1236812560

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Right subtitle timing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
