### PR TITLE
DVDFileInfo: skip calculation of aspect ratio if height is zero

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -390,7 +390,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       p->m_iWidth = vstream->iWidth;
       p->m_iHeight = vstream->iHeight;
       p->m_fAspect = static_cast<float>(vstream->fAspect);
-      if (p->m_fAspect == 0.0f)
+      if (p->m_fAspect == 0.0f && p->m_iHeight > 0)
         p->m_fAspect = (float)p->m_iWidth / p->m_iHeight;
       p->m_strCodec = pDemux->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
       p->m_iDuration = pDemux->GetStreamLength();


### PR DESCRIPTION
Aspect ratio will be NaN what lead to issues in storing the video database

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
In currently XBMC master it can happen `CStreamDetails::GetVideoAspect` do return `NaN`.
This will cause Kodi to crash when it want it to save to the database:
```text
2022-09-05 13:52:05.592 T:997     ERROR <general>: SQL: [MyVideos121.db] SQLite error SQLITE_ERROR (no such column: NaN)
                                                   Query: INSERT INTO streamdetails (idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, iVideoDuration, strStereoMode, strVideoLanguage,  strHdrType)VALUES (8,0,'hevc',NaN,0,0,27,'','','') (no such column: NaN)
2022-09-05 13:52:05.592 T:997     ERROR <general>: SetStreamDetailsForFileId (8) failed
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On currently devel CoreELEC build based on XBMC/master HEAD.
I am not sure if this is the correct place to fix this issue as I don't know the flow of this value.
It looks like it get to `0.0f` in [DVDDemuxFFmpeg](https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp#L1654) but I have no idea why `CStreamDetails::GetVideoAspect` do return `NaN` instead `0.0f`.

EDIT: bug identified by @CastagnaIT at https://github.com/xbmc/xbmc/pull/21810#issuecomment-1238048553
Changed title and adapt commit to match new solution.
The additional `isnan` check is not needed anymore as aspect ration is not set to `NaN` if `m_fAspect` and `m_iHeight` is zero.

Debug prints on the file cause this issue after implement the additional check `isnan`:
```text
2022-09-06 07:10:22.003 T:856     DEBUG <general>: DoWork - trying to extract filestream details from video file smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts
2022-09-06 07:10:22.004 T:856     DEBUG <general>: CFileCache::Open - <smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts> opening
2022-09-06 07:10:22.045 T:856     DEBUG <general>: CSMBFile::Open - opened smb://USERNAME:PASSWORD@192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts, fd=10000
2022-09-06 07:10:22.164 T:856     DEBUG <general>: CFileCache::Open - <smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts> source chunk size is 65536, setting cache chunk size to 65536
2022-09-06 07:10:22.164 T:856     DEBUG <general>: CFileCache::Open - <smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts> using single memory cache sized 20971520 bytes
2022-09-06 07:10:22.164 T:955     DEBUG <general>: Thread FileCache start, auto delete: false
2022-09-06 07:10:23.463 T:856     DEBUG <general>: Open - avformat_find_stream_info starting
2022-09-06 07:10:23.470 T:856     DEBUG <general>: ffmpeg[0x3711310]: [mpegts] Packet corrupt (stream = 0, dts = 487871090).
2022-09-06 07:10:23.470 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:23.480 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:23.480 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:23.482 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:23.484 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:23.484 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:23.747 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:23.749 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:23.749 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:24.022 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:24.024 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:24.024 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:24.289 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:24.293 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:24.293 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:24.664 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:24.666 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:24.666 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:25.105 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:25.108 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:25.108 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:25.386 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:25.389 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:25.389 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:25.651 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:25.653 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:25.653 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:26.003 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:26.005 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:26.005 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:26.274 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:26.277 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:26.277 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:26.805 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:26.808 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:26.808 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:27.072 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:27.075 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:27.075 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:27.349 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:27.351 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:27.351 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:27.718 T:856     DEBUG <general>: ffmpeg[0x3711310]: [mpegts] Packet corrupt (stream = 0, dts = 487892090).
2022-09-06 07:10:27.719 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:27.722 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:27.722 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:27.990 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:27.992 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:27.992 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:28.526 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:28.531 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:28.531 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:28.881 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:28.884 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:28.884 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:29.145 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:29.148 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:29.148 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:29.500 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:29.504 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:29.504 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:29.769 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:29.771 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:29.771 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:30.352 T:856     ERROR <general>: ffmpeg[0x3711310]: [hevc] PPS id out of range: 0
2022-09-06 07:10:30.356 T:856      INFO <general>: Skipped 1 duplicate messages..
2022-09-06 07:10:30.356 T:856     DEBUG <general>: ffmpeg[0x3711310]: [hevc] Error parsing NAL unit #1.
2022-09-06 07:10:30.466 T:955     DEBUG <general>: CFileCache::Process - <smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts> cache completely reset for seek to position 417986456
2022-09-06 07:10:30.863 T:955     DEBUG <general>: CFileCache::Process - <smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts> source read hit eof
2022-09-06 07:10:30.913 T:955     DEBUG <general>: CFileCache::Process - <smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts> cache completely reset for seek to position 417736456
2022-09-06 07:10:31.724 T:955     DEBUG <general>: CFileCache::Process - <smb://192.168.1.7/Videos/Testvideos/TURKSAT_8K-2020-04-0618-44.ts> cache completely reset for seek to position 0
2022-09-06 07:10:31.724 T:856     DEBUG <general>: ffmpeg[0x3711310]: [mpegts] Could not find codec parameters for stream 0 (Video: hevc ([36][0][0][0] / 0x0024), none): unspecified size
2022-09-06 07:10:31.724 T:856     DEBUG <general>: ffmpeg[0x3711310]: [mpegts] Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
2022-09-06 07:10:31.724 T:856     DEBUG <general>: Open - av_find_stream_info finished
2022-09-06 07:10:31.725 T:856     DEBUG <general>: DVDDemuxFFmpeg::AddStream - fps:60/1 tbr:60/1 tbn:90000/1
2022-09-06 07:10:31.725 T:856     DEBUG <general>: DVDDemuxFFmpeg::AddStream - fps:60/1p
2022-09-06 07:10:31.725 T:856      INFO <general>: ++++++++ DVDDemuxFFmpeg::AddStream: s.aspect_ratio: 0.000000
2022-09-06 07:10:31.725 T:856     DEBUG <general>: CDVDDemuxFFmpeg::AddStream ID: 0
2022-09-06 07:10:31.725 T:856     DEBUG <general>: CDVDDemuxFFmpeg::AddStream ID: 1
2022-09-06 07:10:31.816 T:955     DEBUG <general>: Thread FileCache 3494982336 terminating
2022-09-06 07:10:31.819 T:856     DEBUG <general>: CSMBFile::Close closing fd 10000
2022-09-06 07:10:31.977 T:856      INFO <general>: ++++++++ StreamDetails::GetVideoAspect(392) - m_fAspect is NaN
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More stability?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
