### PR TITLE
[addons] fix Kodi crash by open add-on from repo content

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -260,7 +260,7 @@ void CGUIDialogAddonInfo::UpdateControls(PerformButtonFocus performButtonFocus)
     label = 21479;
   SET_CONTROL_LABEL(CONTROL_BTN_SELECT, label);
 
-  const bool hasSettings = m_localAddon->CanHaveAddonOrInstanceSettings();
+  const bool hasSettings = m_localAddon && m_localAddon->CanHaveAddonOrInstanceSettings();
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_SETTINGS, isInstalled && hasSettings);
   if (isInstalled && hasSettings && performButtonFocus == PerformButtonFocus::CHOICE_YES)
   {


### PR DESCRIPTION
## Description

There was tried to open local add-on with value "m_localAddon" where at repo content not set!

This has created the following crash:
```gdb
Thread 1 "kodi.bin" received signal SIGSEGV, Segmentation fault.
0x0000555557be400e in CGUIDialogAddonInfo::UpdateControls (this=0x55555bdf8a30, performButtonFocus=PerformButtonFocus::CHOICE_YES) at /home/alwin/Dev/kodi/kodi/xbmc/addons/gui/GUIDialogAddonInfo.cpp:263
263       const bool hasSettings = m_localAddon->CanHaveAddonOrInstanceSettings();
(gdb)
(gdb) bt
#0  0x0000555557be400e in CGUIDialogAddonInfo::UpdateControls(PerformButtonFocus) (this=0x55555bdf8a30, performButtonFocus=PerformButtonFocus::CHOICE_YES)
    at /home/alwin/Dev/kodi/kodi/xbmc/addons/gui/GUIDialogAddonInfo.cpp:263
#1  0x0000555557be2d95 in CGUIDialogAddonInfo::OnInitWindow() (this=0x55555bdf8a30) at /home/alwin/Dev/kodi/kodi/xbmc/addons/gui/GUIDialogAddonInfo.cpp:169
#2  0x0000555557a62565 in CGUIWindow::OnMessage(CGUIMessage&) (this=0x55555bdf8a30, message=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIWindow.cpp:588
#3  0x00005555579d4bef in CGUIDialog::OnMessage(CGUIMessage&) (this=0x55555bdf8a30, message=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIDialog.cpp:92
#4  0x0000555557be2bfc in CGUIDialogAddonInfo::OnMessage(CGUIMessage&) (this=0x55555bdf8a30, message=...) at /home/alwin/Dev/kodi/kodi/xbmc/addons/gui/GUIDialogAddonInfo.cpp:152
#5  0x00005555579d5092 in CGUIDialog::Open_Internal(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    (this=0x55555bdf8a30, bProcessRenderLoop=true, param="") at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIDialog.cpp:169
#6  0x00005555579d52a2 in CGUIDialog::Open(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (this=0x55555bdf8a30, bProcessRenderLoop=true, param="")
    at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIDialog.cpp:201
#7  0x00005555579d5182 in CGUIDialog::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (this=0x55555bdf8a30, param="")
    at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIDialog.cpp:187
#8  0x0000555557be99df in CGUIDialogAddonInfo::ShowForItem(std::shared_ptr<CFileItem> const&) (item=std::shared_ptr<CFileItem> (use count 6, weak count 0) = {...})
    at /home/alwin/Dev/kodi/kodi/xbmc/addons/gui/GUIDialogAddonInfo.cpp:806
#9  0x0000555557bf7e4c in CGUIWindowAddonBrowser::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (this=0x55555bdcdbb0, iItem=1, player="")
    at /home/alwin/Dev/kodi/kodi/xbmc/addons/gui/GUIWindowAddonBrowser.cpp:256
#10 0x00005555576ae097 in CGUIMediaWindow::OnSelect(int) (this=0x55555bdcdbb0, item=1) at /home/alwin/Dev/kodi/kodi/xbmc/windows/GUIMediaWindow.cpp:1186
#11 0x00005555576a759d in CGUIMediaWindow::OnMessage(CGUIMessage&) (this=0x55555bdcdbb0, message=...) at /home/alwin/Dev/kodi/kodi/xbmc/windows/GUIMediaWindow.cpp:309
#12 0x0000555557bf6f1d in CGUIWindowAddonBrowser::OnMessage(CGUIMessage&) (this=0x55555bdcdbb0, message=...) at /home/alwin/Dev/kodi/kodi/xbmc/addons/gui/GUIWindowAddonBrowser.cpp:150
#13 0x00005555579b1b42 in CGUIControl::SendWindowMessage(CGUIMessage&) const (this=0x55555cdfee90, message=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIControl.cpp:313
#14 0x000055555799edb2 in CGUIBaseContainer::OnClick(int) (this=0x55555cdfee90, actionID=7) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIBaseContainer.cpp:873
#15 0x000055555799c917 in CGUIBaseContainer::OnAction(CAction const&) (this=0x55555cdfee90, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIBaseContainer.cpp:450
#16 0x00005555579df9ab in CGUIFixedListContainer::OnAction(CAction const&) (this=0x55555cdfee90, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIFixedListContainer.cpp:70
#17 0x0000555557a6197b in CGUIWindow::OnAction(CAction const&) (this=0x55555bdcdbb0, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIWindow.cpp:425
#18 0x00005555576a6938 in CGUIMediaWindow::OnAction(CAction const&) (this=0x55555bdcdbb0, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/windows/GUIMediaWindow.cpp:188
#19 0x0000555557a6f570 in CGUIWindowManager::HandleAction(CAction const&) const (this=0x55555b404e80, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIWindowManager.cpp:1173
#20 0x0000555557a6f2d3 in CGUIWindowManager::OnAction(CAction const&) const (this=0x55555b404e80, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/guilib/GUIWindowManager.cpp:1118
#21 0x0000555557d216ad in CApplication::OnAction(CAction const&) (this=0x55555affd9f0, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/Application.cpp:968
#22 0x0000555557939465 in CInputManager::ExecuteInputAction(CAction const&) (this=0x55555b12cc30, action=...) at /home/alwin/Dev/kodi/kodi/xbmc/input/InputManager.cpp:718
#23 0x0000555557938d05 in CInputManager::HandleKey(CKey const&) (this=0x55555b12cc30, key=...) at /home/alwin/Dev/kodi/kodi/xbmc/input/InputManager.cpp:653
#24 0x0000555557939047 in CInputManager::OnKeyUp(CKey const&) (this=0x55555b12cc30, key=...) at /home/alwin/Dev/kodi/kodi/xbmc/input/InputManager.cpp:666
#25 0x0000555557937484 in CInputManager::OnEvent(XBMC_Event&) (this=0x55555b12cc30, newEvent=...) at /home/alwin/Dev/kodi/kodi/xbmc/input/InputManager.cpp:345
#26 0x0000555557d1d0db in CApplication::HandlePortEvents() (this=0x55555affd9f0) at /home/alwin/Dev/kodi/kodi/xbmc/Application.cpp:317
#27 0x0000555557d257d3 in CApplication::FrameMove(bool, bool) (this=0x55555affd9f0, processEvents=true, processGUI=true) at /home/alwin/Dev/kodi/kodi/xbmc/Application.cpp:1752
#28 0x0000555557d25e29 in CApplication::Run() (this=0x55555affd9f0) at /home/alwin/Dev/kodi/kodi/xbmc/Application.cpp:1855
#29 0x000055555787b5e8 in XBMC_Run(bool, std::shared_ptr<CAppParams> const&) (renderGUI=true, params=std::shared_ptr<CAppParams> (use count 3, weak count 0) = {...})
    at /home/alwin/Dev/kodi/kodi/xbmc/platform/xbmc.cpp:64
#30 0x0000555557025f89 in main(int, char**) (argc=1, argv=0x7fffffffdb28) at /home/alwin/Dev/kodi/kodi/xbmc/platform/posix/main.cpp:69
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
