### PR TITLE
[addons][languages] fix use of "CSkinInfo::SettingOptionsSkinColorsFiller"

### DIFF
--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -276,7 +276,8 @@ bool CSkinInfo::HasSkinFile(const std::string &strFile) const
 
 void CSkinInfo::LoadIncludes()
 {
-  std::string includesPath = CSpecialProtocol::TranslatePathConvertCase(GetSkinPath("includes.xml"));
+  std::string includesPath =
+      CSpecialProtocol::TranslatePathConvertCase(GetSkinPath("Includes.xml"));
   CLog::Log(LOGINFO, "Loading skin includes from {}", includesPath);
   m_includes.Clear();
   m_includes.Load(includesPath);


### PR DESCRIPTION
## Description
There was as xml "defaults.xml" used, but as in skins them defined as "Defaults.xml" (first uppercase), has it not worked.
Normally not used, but as currently the "resource.language.tr_tr" defect and broken becomes it visible and no more possible to control Kodi on skin!

Log content:
```
INFO <general>: Loading skin includes from /home/alwin/Dev/kodi/kodi-fix/build/addons/skin.estuary/xml/includes.xml
INFO <general>: Error loading include file /home/alwin/Dev/kodi/kodi-fix/build/addons/skin.estuary/xml/includes.xml: Failed to open file (row: 0, col: 0)
```

After this change was it possible (without strings) to go in settings and change language :smirk:.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
To get https://github.com/xbmc/xbmc/blob/master/addons/skin.estuary/xml/Includes.xml where starts uppercase, also compared with "skin.aeon.nox.silvo" where starts uppercase too.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before:
![Screenshot_20220906_123927](https://user-images.githubusercontent.com/6879739/188657211-5b15fcab-178c-4735-a96c-f1bb8238a279.png)
After this:
![Screenshot_20220906_124942](https://user-images.githubusercontent.com/6879739/188657886-64e9ad4a-4bcc-486d-bf0b-d84cbc864585.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
