### PR TITLE
[Application] Show busy dialog also when starting/switching PVR channels

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2691,13 +2691,9 @@ bool CApplication::OnMessage(CGUIMessage& message)
       CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay",
                                                          m_itemCurrentFile, param);
 
-      // we don't want a busy dialog when switching channels
-      if (!m_itemCurrentFile->IsLiveTV())
-      {
-        CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
-        if (dialog && !dialog->IsDialogRunning())
-          dialog->WaitOnEvent(m_playerEvent);
-      }
+      CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+      if (dialog && !dialog->IsDialogRunning())
+        dialog->WaitOnEvent(m_playerEvent);
 
       return true;
     }


### PR DESCRIPTION
… as this can also take same time...

There was a comment "we don't want a busy dialog when switching channels" in the code, but honestly, I don't see any reason for this special handling, especially as this does not only suppress the busy dialog when switching channels but also when tuning to the first channel.

Runtime-tested on macOS and Android, latest Kodi version.

@phunkyfish when you find some time for a review.