### PR TITLE
[demux] Allow forcing rtsp transport protocol as a kodi prop

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -920,6 +920,19 @@ AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
       av_dict_set(&options, "http_proxy", urlStream.str().c_str(), 0);
     }
 
+    // rtsp options
+    if (url.IsProtocol("rtsp"))
+    {
+      CVariant transportProp{m_pInput->GetProperty("rtsp_transport")};
+      if (!transportProp.isNull() &&
+          (transportProp == "tcp" || transportProp == "udp" || transportProp == "udp_multicast"))
+      {
+        CLog::LogF(LOGDEBUG, "GetFFMpegOptionsFromInput() Forcing rtsp transport protocol to '{}'",
+                   transportProp.asString());
+        av_dict_set(&options, "rtsp_transport", transportProp.asString().c_str(), 0);
+      }
+    }
+
     // rtmp options
     if (url.IsProtocol("rtmp")  || url.IsProtocol("rtmpt")  ||
         url.IsProtocol("rtmpe") || url.IsProtocol("rtmpte") ||

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -1006,11 +1006,13 @@ namespace XBMCAddon
       /// | TotalTime     | float (7848.0) - Set the total time of the item in seconds
       /// | OverrideInfotag | string - "true", "false" - When true will override all info from previous listitem
       /// | ForceResolvePlugin | string - "true", "false" - When true ensures that a plugin will always receive callbacks to resolve paths (useful for playlist cases)
+      /// | rtsp_transport | string - "udp", "udp_multicast" or "tcp" - Allow to force the rtsp transport mode for rtsp streams
       ///
       ///-----------------------------------------------------------------------
       /// @python_v20 OverrideInfotag property added
       /// @python_v20 **ResumeTime** and **TotalTime** deprecated. Use **InfoTagVideo.setResumePoint()** instead.
       /// @python_v20 ForceResolvePlugin property added
+      /// @python_v20 rtsp_transport property added
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}


### PR DESCRIPTION
## Description
Background of this is provided in https://github.com/xbmc/xbmc/issues/21796, it seems ffmpeg 4.4.* no longer fallsback to tcp if udp transport mode doesn't work. Other mediaplayers such as mpv allow the user to force the transport protocol ([ref](https://mpv.io/manual/stable/#options-rtsp-transport)). ffmpeg provides this as an option too.
Since we can set properties on the stream via Kodi-props, this PR allows the user to specify the transport protocol.

## Motivation and context
Should fix https://github.com/xbmc/xbmc/issues/21796

## How has this been tested?
Local network stream was created using [simple-rtsp-server](https://github.com/aler9/rtsp-simple-server) and ffmpeg, forcing tcp as transport protocol.
Tried to play the stream with and without specifying the transport mode:

stream.strm
```
#KODIPROP:rtsp_transport=tcp
rtsp://localhost:8554/mystream
```

and simply:

```
rtsp://localhost:8554/mystream
```

Kodi log inspection shows the following for the first and second stream respectively:

```
2022-09-07 11:45:17.696 T:27672    INFO <general>: Creating InputStream
2022-09-07 11:45:17.696 T:27672    INFO <general>: Creating Demuxer
2022-09-07 11:45:17.696 T:27672   DEBUG <general>: GetFFMpegOptionsFromInput: GetFFMpegOptionsFromInput() Forcing rtsp transport protocol to 'tcp'
2022-09-07 11:45:17.697 T:27210   DEBUG <general>: Loading settings for /home/arch/Desktop/stream.strm
2022-09-07 11:45:17.697 T:27672   DEBUG <general>: Open - avformat_find_stream_info starting
```

```
2022-09-07 11:54:29.070 T:29837    INFO <general>: Creating InputStream
2022-09-07 11:54:29.070 T:29838   DEBUG <general>: Thread BackgroundLoader start, auto delete: false
2022-09-07 11:54:29.070 T:29837    INFO <general>: Creating Demuxer
2022-09-07 11:54:29.071 T:29621   DEBUG <general>: Loading settings for /home/arch/Desktop/stream.strm
2022-09-07 11:54:29.072 T:29837   ERROR <general>: ffmpeg[0x55555d151fa0]: [rtsp] method SETUP failed: 461 Unsupported Transport
2022-09-07 11:54:29.072 T:29837   DEBUG <general>: Open - avformat_find_stream_info starting
```

## What is the effect on users?
Users should now be able to specify the transport protocol for rtsp streams as a kodi prop ( #KODIPROP:rtsp_transport=tcp; #KODIPROP:rtsp_transport=udp; #KODIPROP:rtsp_transport=udp_multicast).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
