### PR TITLE
[Windows] Store the window position persistently in windowed mode

### DIFF
--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -1,3 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings version="1">
+  <section id="interface" label="14206" help="38102">
+    <category id="window" label="0" help="36135">
+      <visible>false</visible>
+      <group id="1">
+        <setting id="window.top" type="integer" label="0" help="36136">
+          <level>4</level>
+          <default>0</default>
+        </setting>
+        <setting id="window.left" type="integer" label="0" help="36136">
+          <level>4</level>
+          <default>0</default>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -167,6 +167,7 @@ protected:
   void OnDisplayBack();
   void ResolutionChanged();
   static void SetForegroundWindowInternal(HWND hWnd);
+  static RECT GetVirtualScreenRect();
 
   HWND m_hWnd;
   HMONITOR m_hMonitor;
@@ -195,6 +196,9 @@ protected:
   std::vector<MONITOR_DETAILS> m_displays;
 
   NOTIFYICONDATA m_trayIcon = {};
+
+  static const char* SETTING_WINDOW_TOP;
+  static const char* SETTING_WINDOW_LEFT;
 };
 
 extern HWND g_hWnd;

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -148,6 +148,17 @@ void CWinSystemWin32DX::OnMove(int x, int y)
     m_deviceResources->SetMonitor(newMonitor);
     m_hMonitor = newMonitor;
   }
+
+  // Save window position if not fullscreen
+  if (!IsFullScreen() && (m_nLeft != x || m_nTop != y))
+  {
+    m_nLeft = x;
+    m_nTop = y;
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    settings->SetInt(SETTING_WINDOW_LEFT, x);
+    settings->SetInt(SETTING_WINDOW_TOP, y);
+    settings->Save();
+  }
 }
 
 bool CWinSystemWin32DX::DPIChanged(WORD dpi, RECT windowRect) const


### PR DESCRIPTION
## Description
[Windows] Store the window position persistently in windowed mode

## Motivation and context
This is a forum feature request (https://forum.kodi.tv/showthread.php?tid=360960) which seems reasonable to me and quite easy to implement.

@lrusak: take a look to settings / Application.cpp changes. I'm not sure if there is any "historical" reason why the position of the window is not saved in settings but the size is. I have not looked at the code of the other platforms either in case they use their own method (in Windows this could be saved in the Windows registry but it seemed easier to use the Kodi settings as persistent storage).

Maybe `window.top` and `window.left` could be useful also on other platforms that use window concept (not just full screen)?

## How has this been tested?
Runtime tested Windows x64 in a setup with multiple monitors to test various use cases. Tested also with secondary monitor at left of primary witch result in negative coordinates. 

See virtual screen definition: https://docs.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen

## What is the effect on users?
Remember the application window last position and size in Windows and reopen in that position at that size. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
