### PR TITLE
[Application] Show busy dialog when starting (not switching !) PVR channels

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2692,9 +2692,12 @@ bool CApplication::OnMessage(CGUIMessage& message)
                                                          m_itemCurrentFile, param);
 
       // we don't want a busy dialog when switching channels
-      if (!m_itemCurrentFile->IsLiveTV())
+      if (!m_itemCurrentFile->IsLiveTV() ||
+          (!m_appPlayer.IsPlayingVideo() && !m_appPlayer.IsPlayingAudio()))
       {
-        CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+        CGUIDialogBusy* dialog =
+            CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(
+                WINDOW_DIALOG_BUSY);
         if (dialog && !dialog->IsDialogRunning())
           dialog->WaitOnEvent(m_playerEvent);
       }


### PR DESCRIPTION
Followup to #21815 

This time, the change is to only show the busy dialog when tuning to a channel when no channel is active, for example after clicking on a recently played channel in Estuary's PVR home screen section or tuning to a channel using one of the available Kodi remote control apps.

@a1rwulf @enen92 what do you think?