### PR TITLE
[upnp] picture playback and thumb fixes

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -239,8 +239,10 @@ bool CTextureCacheJob::UpdateableURL(const std::string &url) const
 
 std::string CTextureCacheJob::GetImageHash(const std::string &url)
 {
-  // silently ignore - we cannot state these
-  if (URIUtils::IsProtocol(url,"addons") || URIUtils::IsProtocol(url,"plugin"))
+  // silently ignore - we cannot stat these
+  // in the case of upnp thumbs are/should be provided when filling the directory list, there's no reason to stat all object ids
+  if (URIUtils::IsProtocol(url, "addons") || URIUtils::IsProtocol(url, "plugin") ||
+      URIUtils::IsProtocol(url, "upnp"))
     return "";
 
   struct __stat64 st;

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1015,8 +1015,8 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry,
         UPNP::PopulateTagFromObject(*pItem->GetMusicInfoTag(), *entry, res, upnp_service);
 
     } else if(image) {
-        //CPictureInfoTag* tag = pItem->GetPictureInfoTag();
-
+      //! @todo fill pictureinfotag?
+      GetResource(entry, *pItem);
     }
   }
 
@@ -1137,6 +1137,12 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
 
     if (resource.m_ProtocolInfo.GetContentType().Compare("application/octet-stream") != 0) {
       item.SetMimeType((const char*)resource.m_ProtocolInfo.GetContentType());
+    }
+
+    // if this is an image fill the thumb of the item
+    if (StringUtils::StartsWithNoCase(resource.m_ProtocolInfo.GetContentType(), "image"))
+    {
+      item.SetArt("thumb", std::string(resource.m_Uri));
     }
   } else {
     logger->error("invalid protocol info '{}'", (const char*)(resource.m_ProtocolInfo.ToString()));

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1326,7 +1326,7 @@ void CGUIWindowSlideShow::GetCheckedSize(float width, float height, int &maxWidt
 std::string CGUIWindowSlideShow::GetPicturePath(CFileItem *item)
 {
   bool isVideo = item->IsVideo();
-  std::string picturePath = item->GetPath();
+  std::string picturePath = item->GetDynPath();
   if (isVideo)
   {
     picturePath = item->GetArt("thumb");


### PR DESCRIPTION
## Description
This PR brings essentially two fixes:

- While testing UPNP picture playback I've found out kodi issues stat requests for all upnp object ids when browsing upnp directories in order to check the thumb hash of each item while we navigate. This not only doesn't work since all upnp items do not have thumbs (they should be provided when filling each item with the content provided by the upnp server), brings unnecessary requests to the server (e.g. we try to stat every object along with stuff like [objectid]/folder.jpg just like regular directories) and are also a common source of crashes (I got a few...). Also, it has the side effect of messing with upnp cache (and directory listings) since those requests ask for the metadata of the item. In those cases the response provided by libplatinum [is limited to 1 item](https://github.com/xbmc/xbmc/blob/master/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp#L427). So, we rewrite the cache associated to already existing object ids (directories) for no reason - breaking the folder content (see screenshots). 

- Fixes "playback" (actually the slideshow) for upnp picture items. The image uri was never set on the item and the slideshow player doesn't really resolve vfs addresses like videoplayer does. Since we have the picture url when browsing the directory we can simply fill the dynpath and set the thumb at that point. There's no need for further resolving afterwards. This code dates way back from the dynpath addition....
This should bring minimal support for upnp picture viewing.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21734
Can well fix a lot of other upnp issues/crashes...

## How has this been tested?
With minidlna installed on a raspberry pi, serving video, audio and picture content to kodi.

## What is the effect on users?
Less crashes related to upnp. Should be able to see pictures served via upnp/dlna as well as their thumbs. This does not affect/changes thumbs behaviour for regular video files.

## Screenshots (if appropriate):
**Before:**
(picture root folder broken)
![image](https://user-images.githubusercontent.com/7375276/188991160-fe92b224-975c-494c-bf52-1525cee7fd14.png)
(after fixing directory access with 6c3140ae6472a6ef379879ecbd4550a839c63929 - no thumbs and no playback)
![image](https://user-images.githubusercontent.com/7375276/188991498-328ff474-4d23-4c5e-9549-ea4a3f4ca9cb.png)
![image](https://user-images.githubusercontent.com/7375276/188991536-e362dfff-b34c-4b1c-9a6e-f1630ef2316c.png)

**PR:**
![image](https://user-images.githubusercontent.com/7375276/188990876-d34ecbf1-74ad-455a-899b-5056599e77d9.png)
![image](https://user-images.githubusercontent.com/7375276/188990817-40baca1c-4404-49df-a14b-9e51b7f8cf2f.png)
![image](https://user-images.githubusercontent.com/7375276/188991796-2758a4cc-745c-4cd3-bc02-a73f9b161c05.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

