### PR TITLE
[PlayList] Fix resume on playlist STRM files

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1320,7 +1320,7 @@ bool CApplication::OnAction(const CAction &action)
       std::string player = playerCoreFactory.SelectPlayerDialog(players);
       if (!player.empty())
       {
-        item.m_lStartOffset = CUtil::ConvertSecsToMilliSecs(GetTime());
+        item.SetStartOffset(CUtil::ConvertSecsToMilliSecs(GetTime()));
         PlayFile(item, player, true);
       }
     }
@@ -2257,7 +2257,7 @@ bool CApplication::PlayStack(CFileItem& item, bool bRestart)
   int startoffset = m_stackHelper.InitializeStackStartPartAndOffset(item);
 
   CFileItem selectedStackPart = m_stackHelper.GetCurrentStackPartFileItem();
-  selectedStackPart.m_lStartOffset = startoffset;
+  selectedStackPart.SetStartOffset(startoffset);
 
   if (item.HasProperty("savedplayerstate"))
   {
@@ -2317,10 +2317,10 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   if (item.HasProperty("StartPercent"))
   {
     options.startpercent = item.GetProperty("StartPercent").asDouble();
-    item.m_lStartOffset = 0;
+    item.SetStartOffset(0);
   }
 
-  options.starttime = CUtil::ConvertMilliSecsToSecs(item.m_lStartOffset);
+  options.starttime = CUtil::ConvertMilliSecsToSecs(item.GetStartOffset());
 
   if (bRestart)
   {
@@ -2346,11 +2346,11 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
 
       if (item.HasProperty("savedplayerstate"))
       {
-        options.starttime = CUtil::ConvertMilliSecsToSecs(item.m_lStartOffset);
+        options.starttime = CUtil::ConvertMilliSecsToSecs(item.GetStartOffset());
         options.state = item.GetProperty("savedplayerstate").asString();
         item.ClearProperty("savedplayerstate");
       }
-      else if (item.m_lStartOffset == STARTOFFSET_RESUME)
+      else if (item.GetStartOffset() == STARTOFFSET_RESUME)
       {
         options.starttime = 0.0;
         if (item.IsResumePointSet())
@@ -2436,7 +2436,8 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   else if(m_stackHelper.IsPlayingRegularStack())
   {
     //! @todo - this will fail if user seeks back to first file in stack
-    if(m_stackHelper.GetCurrentPartNumber() == 0 || m_stackHelper.GetRegisteredStack(item)->m_lStartOffset != 0)
+    if (m_stackHelper.GetCurrentPartNumber() == 0 ||
+        m_stackHelper.GetRegisteredStack(item)->GetStartOffset() != 0)
       options.fullscreen = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->
           m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesMediaStartWindowed();
     else
@@ -3157,7 +3158,7 @@ void CApplication::Restart(bool bSamePosition)
   std::string state = m_appPlayer.GetPlayerState();
 
   // set the requested starttime
-  m_itemCurrentFile->m_lStartOffset = CUtil::ConvertSecsToMilliSecs(time);
+  m_itemCurrentFile->SetStartOffset(CUtil::ConvertSecsToMilliSecs(time));
 
   // reopen the file
   if (PlayFile(*m_itemCurrentFile, "", true))
@@ -3264,7 +3265,7 @@ void CApplication::SeekTime( double dTime )
       { // seeking to a new file
         m_stackHelper.SetStackPartCurrentFileItem(partNumberToPlay);
         CFileItem *item = new CFileItem(m_stackHelper.GetCurrentStackPartFileItem());
-        item->m_lStartOffset = static_cast<uint64_t>(dTime * 1000.0) - startOfNewFile;
+        item->SetStartOffset(static_cast<uint64_t>(dTime * 1000.0) - startOfNewFile);
         // don't just call "PlayFile" here, as we are quite likely called from the
         // player thread, so we won't be able to delete ourselves.
         CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 1, 0, static_cast<void*>(item));

--- a/xbmc/ApplicationStackHelper.cpp
+++ b/xbmc/ApplicationStackHelper.cpp
@@ -89,7 +89,7 @@ int CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& 
   {
     // first assume values passed to the stack
     int selectedFile = item.m_lStartPartNumber;
-    startoffset = item.m_lStartOffset;
+    startoffset = item.GetStartOffset();
 
     // check if we instructed the stack to resume from default
     if (startoffset == STARTOFFSET_RESUME) // selected file is not specified, pick the 'last' resume point
@@ -153,7 +153,7 @@ int CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& 
       if (haveTimes)
       {
         // set end time in every part
-        GetStackPartFileItem(i).m_lEndOffset = times[i];
+        GetStackPartFileItem(i).SetEndOffset(times[i]);
       }
       else
       {
@@ -165,7 +165,7 @@ int CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& 
         }
         totalTimeMs += duration;
         // set end time in every part
-        GetStackPartFileItem(i).m_lEndOffset = totalTimeMs;
+        GetStackPartFileItem(i).SetEndOffset(totalTimeMs);
         times.push_back(totalTimeMs);
       }
       // set start time in every part
@@ -176,9 +176,9 @@ int CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& 
     for (int i = 0; i < m_currentStack->Size(); i++)
       SetRegisteredStackTotalTimeMs(GetStackPartFileItem(i), totalTimeMs);
 
-    uint64_t msecs = item.m_lStartOffset;
+    uint64_t msecs = item.GetStartOffset();
 
-    if (!haveTimes || item.m_lStartOffset == STARTOFFSET_RESUME)
+    if (!haveTimes || item.GetStartOffset() == STARTOFFSET_RESUME)
     {
       if (dbs.Open())
       {
@@ -186,7 +186,7 @@ int CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& 
         if (!haveTimes && !times.empty())
           dbs.SetStackTimes(item.GetPath(), times);
 
-        if (item.m_lStartOffset == STARTOFFSET_RESUME)
+        if (item.GetStartOffset() == STARTOFFSET_RESUME)
         {
           // can only resume seek here, not dvdstate
           CBookmark bookmark;

--- a/xbmc/ApplicationStackHelper.h
+++ b/xbmc/ApplicationStackHelper.h
@@ -81,7 +81,10 @@ public:
   \brief Returns the end time of a FileItem part of a (non-ISO) stack playback
   \param partNumber the requested part number in the stack
   */
-  uint64_t GetStackPartEndTimeMs(int partNumber) const { return GetStackPartFileItem(partNumber).m_lEndOffset; }
+  uint64_t GetStackPartEndTimeMs(int partNumber) const
+  {
+    return GetStackPartFileItem(partNumber).GetEndOffset();
+  }
 
   /*!
   \brief Returns the start time of a FileItem part of a (non-ISO) stack playback

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -195,7 +195,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
               CServiceBroker::GetMediaManager().GetDiskUniqueId(strDrive);
 
           if (!startFromBeginning && !item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
-            item->m_lStartOffset = STARTOFFSET_RESUME;
+            item->SetStartOffset(STARTOFFSET_RESUME);
 
           CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
           CServiceBroker::GetPlaylistPlayer().SetShuffle (PLAYLIST_VIDEO, false);
@@ -217,7 +217,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
               CServiceBroker::GetMediaManager().GetDiskUniqueId(strDrive);
 
           if (!startFromBeginning && !item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
-            item->m_lStartOffset = STARTOFFSET_RESUME;
+            item->SetStartOffset(STARTOFFSET_RESUME);
 
           CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
           CServiceBroker::GetPlaylistPlayer().SetShuffle (PLAYLIST_VIDEO, false);
@@ -310,7 +310,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
                 CServiceBroker::GetMediaManager().GetDiskUniqueId(strDrive);
 
             if (!startFromBeginning && !item.GetVideoInfoTag()->m_strFileNameAndPath.empty())
-            item.m_lStartOffset = STARTOFFSET_RESUME;
+              item.SetStartOffset(STARTOFFSET_RESUME);
 
             // get playername
             std::string hdVideoPlayer = CServiceBroker::GetPlayerCoreFactory().GetDefaultPlayer(item);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3945,3 +3945,8 @@ bool CFileItem::GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& par
   }
   return false;
 }
+
+bool CFileItem::IsResumable() const
+{
+  return (!IsNFO() && !IsPlayList()) || IsType(".strm");
+}

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -362,6 +362,32 @@ public:
    */
   bool GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& partNumber) const;
 
+  /*!
+   * \brief Get the offset where start the playback.
+   * \return The offset value as ms.
+   *         Can return also special value -1, see define STARTOFFSET_RESUME.
+   */
+  int64_t GetStartOffset() const { return m_lStartOffset; }
+
+  /*!
+   * \brief Set the offset where start the playback.
+   * \param offset Set the offset value as ms,
+                   or the special value STARTOFFSET_RESUME.
+   */
+  void SetStartOffset(const int64_t offset) { m_lStartOffset = offset; }
+
+  /*!
+   * \brief Get the end offset.
+   * \return The offset value as ms.
+   */
+  int64_t GetEndOffset() const { return m_lEndOffset; }
+
+  /*!
+   * \brief Set the end offset.
+   * \param offset Set the offset as ms.
+   */
+  void SetEndOffset(const int64_t offset) { m_lEndOffset = offset; }
+
   inline bool HasPictureInfoTag() const
   {
     return m_pictureInfoTag != NULL;
@@ -573,9 +599,7 @@ public:
   std::string m_strTitle;
   int m_iprogramCount;
   int m_idepth;
-  int64_t m_lStartOffset;
   int m_lStartPartNumber;
-  int64_t m_lEndOffset;
   LockType m_iLockMode;
   std::string m_strLockCode;
   int m_iHasLock; // 0 - no lock 1 - lock, but unlocked 2 - locked
@@ -626,6 +650,8 @@ private:
   KODI::GAME::CGameInfoTag* m_gameInfoTag;
   EventPtr m_eventLogEntry;
   bool m_bIsAlbum;
+  int64_t m_lStartOffset;
+  int64_t m_lEndOffset;
 
   CCueDocumentPtr m_cueDocument;
 };

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -363,6 +363,12 @@ public:
   bool GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& partNumber) const;
 
   /*!
+   * \brief Test if this item type can be resumed.
+   * \return True if this item can be resumed, false otherwise.
+   */
+  bool IsResumable() const;
+
+  /*!
    * \brief Get the offset where start the playback.
    * \return The offset value as ms.
    *         Can return also special value -1, see define STARTOFFSET_RESUME.

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11291,13 +11291,13 @@ void CGUIInfoManager::ResetCache()
 void CGUIInfoManager::SetCurrentVideoTag(const CVideoInfoTag &tag)
 {
   m_currentFile->SetFromVideoInfoTag(tag);
-  m_currentFile->m_lStartOffset = 0;
+  m_currentFile->SetStartOffset(0);
 }
 
 void CGUIInfoManager::SetCurrentSongTag(const MUSIC_INFO::CMusicInfoTag &tag)
 {
   m_currentFile->SetFromMusicInfoTag(tag);
-  m_currentFile->m_lStartOffset = 0;
+  m_currentFile->SetStartOffset(0);
 }
 
 const MUSIC_INFO::CMusicInfoTag* CGUIInfoManager::GetCurrentSongTag() const

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -376,8 +376,8 @@ bool CPlayListPlayer::Play(int iSong,
   }
 
   // reset the start offset of this item
-  if (item->m_lStartOffset == STARTOFFSET_RESUME)
-    item->m_lStartOffset = 0;
+  if (item->GetStartOffset() == STARTOFFSET_RESUME)
+    item->SetStartOffset(0);
 
   //! @todo - move the above failure logic and the below success logic
   //!        to callbacks instead so we don't rely on the return value

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -332,7 +332,7 @@ bool CDVDInputStreamBluray::Open()
     m_navmode = false;
     m_titleInfo = GetTitleLongest();
   }
-  else if (resumable && m_item.m_lStartOffset == STARTOFFSET_RESUME)
+  else if (resumable && m_item.GetStartOffset() == STARTOFFSET_RESUME)
   {
     // resuming a bluray for which we have a saved state - the playlist will be open later on SetState
     m_navmode = false;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -298,10 +298,9 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
     // if this is the case we don't need to open a new stream
     std::string newURL = file.GetDynURL().GetFileName();
     std::string oldURL = m_currentStream->m_fileItem.GetDynURL().GetFileName();
-    if (newURL.compare(oldURL) == 0 &&
-        file.m_lStartOffset &&
-        file.m_lStartOffset == m_currentStream->m_fileItem.m_lEndOffset &&
-        m_currentStream && m_currentStream->m_prepareTriggered)
+    if (newURL.compare(oldURL) == 0 && file.GetStartOffset() &&
+        file.GetStartOffset() == m_currentStream->m_fileItem.GetEndOffset() && m_currentStream &&
+        m_currentStream->m_prepareTriggered)
     {
       m_currentStream->m_nextFileItem.reset(new CFileItem(file));
       m_upcomingCrossfadeMS = 0;
@@ -316,15 +315,15 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
   // Start stream at zero offset
   si->m_startOffset = 0;
   //File item start offset defines where in song to resume
-  double starttime = CUtil::ConvertMilliSecsToSecs(si->m_fileItem.m_lStartOffset);
+  double starttime = CUtil::ConvertMilliSecsToSecs(si->m_fileItem.GetStartOffset());
 
   // Music from cuesheet => "item_start" and offset match
   // Start offset defines where this song starts in file of multiple songs
   if (si->m_fileItem.HasProperty("item_start") &&
-      (si->m_fileItem.GetProperty("item_start").asInteger() == si->m_fileItem.m_lStartOffset))
+      (si->m_fileItem.GetProperty("item_start").asInteger() == si->m_fileItem.GetStartOffset()))
   {
     // Start stream at offset from cuesheet
-    si->m_startOffset = si->m_fileItem.m_lStartOffset;
+    si->m_startOffset = si->m_fileItem.GetStartOffset();
     starttime = 0; // No resume point
   }
 
@@ -369,7 +368,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
   /* init the streaminfo struct */
   si->m_audioFormat = si->m_decoder.GetFormat();
   // si->m_startOffset already initialized
-  si->m_endOffset = file.m_lEndOffset;
+  si->m_endOffset = file.GetEndOffset();
   si->m_bytesPerSample = CAEUtil::DataFormatToBits(si->m_audioFormat.m_dataFormat) >> 3;
   si->m_bytesPerFrame = si->m_bytesPerSample * si->m_audioFormat.m_channelLayout.Count();
   si->m_started = false;
@@ -798,9 +797,9 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
       CloseFileCB(*si);
 
       // update current stream with info of next track
-      si->m_startOffset = si->m_nextFileItem->m_lStartOffset;
-      if (si->m_nextFileItem->m_lEndOffset)
-        si->m_endOffset = si->m_nextFileItem->m_lEndOffset;
+      si->m_startOffset = si->m_nextFileItem->GetStartOffset();
+      if (si->m_nextFileItem->GetEndOffset())
+        si->m_endOffset = si->m_nextFileItem->GetEndOffset();
       else
         si->m_endOffset = 0;
       si->m_framesSent = 0;

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -102,19 +102,22 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
     item->SetLabel(StringUtils::Format("{0:02}. {1} - {2}", i + 1,
                                        item->GetMusicInfoTag()->GetAlbum(),
                                        item->GetMusicInfoTag()->GetTitle()));
-    item->m_lStartOffset = CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->start*av_q2d(m_fctx->chapters[i]->time_base));
-    item->m_lEndOffset = m_fctx->chapters[i]->end*av_q2d(m_fctx->chapters[i]->time_base);
+    item->SetStartOffset(CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->start *
+                                                       av_q2d(m_fctx->chapters[i]->time_base)));
+    item->SetEndOffset(m_fctx->chapters[i]->end * av_q2d(m_fctx->chapters[i]->time_base));
     int compare = m_fctx->duration / (AV_TIME_BASE);
-    if (item->m_lEndOffset < 0 || item->m_lEndOffset > compare)
+    if (item->GetEndOffset() < 0 || item->GetEndOffset() > compare)
     {
       if (i < m_fctx->nb_chapters-1)
-        item->m_lEndOffset = m_fctx->chapters[i+1]->start*av_q2d(m_fctx->chapters[i+1]->time_base);
+        item->SetEndOffset(m_fctx->chapters[i + 1]->start *
+                           av_q2d(m_fctx->chapters[i + 1]->time_base));
       else
-        item->m_lEndOffset = compare;
+        item->SetEndOffset(compare);
     }
-    item->m_lEndOffset = CUtil::ConvertSecsToMilliSecs(item->m_lEndOffset);
-    item->GetMusicInfoTag()->SetDuration(CUtil::ConvertMilliSecsToSecsInt(item->m_lEndOffset - item->m_lStartOffset));
-    item->SetProperty("item_start", item->m_lStartOffset);
+    item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(item->GetEndOffset()));
+    item->GetMusicInfoTag()->SetDuration(
+        CUtil::ConvertMilliSecsToSecsInt(item->GetEndOffset() - item->GetStartOffset()));
+    item->SetProperty("item_start", item->GetStartOffset());
     if (!thumb.empty())
       item->SetArt("thumb", thumb);
     items.Add(item);

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -236,7 +236,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
 
   if (pItem->IsAudioBook())
   {
-    if (!pItem->HasMusicInfoTag() || pItem->m_lEndOffset <= 0)
+    if (!pItem->HasMusicInfoTag() || pItem->GetEndOffset() <= 0)
     {
       std::unique_ptr<CAudioBookFileDirectory> pDir(new CAudioBookFileDirectory);
       if (pDir->ContainsFiles(url))

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -116,7 +116,7 @@ bool CPluginDirectory::GetResolvedPluginResult(CFileItem& resultItem)
     // to avoid deadlocks (plugin:// paths can resolve to plugin:// paths)
     for (unsigned int i = 0; URIUtils::IsPlugin(lastResolvedPath) && i < maxPluginResolutions; ++i)
     {
-      bool resume = resultItem.m_lStartOffset == STARTOFFSET_RESUME;
+      bool resume = resultItem.GetStartOffset() == STARTOFFSET_RESUME;
 
       // we modify the item so that it becomes a real URL
       if (!XFILE::CPluginDirectory::GetPluginResult(lastResolvedPath, resultItem, resume) ||
@@ -157,7 +157,8 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
       resultItem.MergeInfo(*newDir.m_fileResult);
 
     if (newDir.m_fileResult->HasVideoInfoTag() && newDir.m_fileResult->GetVideoInfoTag()->GetResumePoint().IsSet())
-      resultItem.m_lStartOffset = STARTOFFSET_RESUME; // resume point set in the resume item, so force resume
+      resultItem.SetStartOffset(
+          STARTOFFSET_RESUME); // resume point set in the resume item, so force resume
   }
 
   return success;

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -262,7 +262,7 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
       if (musicdatabase.Open())
       {
         CSong song;
-        if (musicdatabase.GetSongByFileName(item->GetPath(), song, item->m_lStartOffset))
+        if (musicdatabase.GetSongByFileName(item->GetPath(), song, item->GetStartOffset()))
         {
           item->GetMusicInfoTag()->SetSong(song);
           id = item->GetMusicInfoTag()->GetDatabaseId();

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -442,7 +442,7 @@ static int PlayMedia(const std::vector<std::string>& params)
     else if (StringUtils::EqualsNoCase(params[i], "resume"))
     {
       // force the item to resume (if applicable) (see CApplication::PlayMedia)
-      item.m_lStartOffset = STARTOFFSET_RESUME;
+      item.SetStartOffset(STARTOFFSET_RESUME);
       askToResume = false;
     }
     else if (StringUtils::EqualsNoCase(params[i], "noresume"))

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -850,11 +850,12 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
         if (list.Size() == 1)
         {
           if (optionResume.isBoolean() && optionResume.asBoolean())
-            list[0]->m_lStartOffset = STARTOFFSET_RESUME;
+            list[0]->SetStartOffset(STARTOFFSET_RESUME);
           else if (optionResume.isDouble())
             list[0]->SetProperty("StartPercent", optionResume);
           else if (optionResume.isObject())
-            list[0]->m_lStartOffset = CUtil::ConvertSecsToMilliSecs(ParseTimeInSeconds(optionResume));
+            list[0]->SetStartOffset(
+                CUtil::ConvertSecsToMilliSecs(ParseTimeInSeconds(optionResume)));
         }
 
         auto l = new CFileItemList(); //don't delete

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -275,7 +275,7 @@ namespace XBMCAddon
       if (lowerKey == "startoffset")
       { // special case for start offset - don't actually store in a property,
         // we store it in item.m_lStartOffset instead
-        value = StringUtils::Format("{:f}", CUtil::ConvertMilliSecsToSecs(item->m_lStartOffset));
+        value = StringUtils::Format("{:f}", CUtil::ConvertMilliSecsToSecs(item->GetStartOffset()));
       }
       else if (lowerKey == "totaltime")
       {
@@ -1015,7 +1015,7 @@ namespace XBMCAddon
     void ListItem::setStartOffsetRaw(double startOffset)
     {
       // we store the offset in frames, or 1/75th of a second
-      item->m_lStartOffset = CUtil::ConvertSecsToMilliSecs(startOffset);
+      item->SetStartOffset(CUtil::ConvertSecsToMilliSecs(startOffset));
     }
 
     void ListItem::setMimeTypeRaw(const std::string& mimetype)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3022,9 +3022,9 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   item->GetMusicInfoTag()->SetTitle(record->at(song_strTitle).get_asString());
   item->GetMusicInfoTag()->SetDiscSubtitle(record->at(song_strDiscSubtitle).get_asString());
   item->SetLabel(record->at(song_strTitle).get_asString());
-  item->m_lStartOffset = record->at(song_iStartOffset).get_asInt64();
-  item->SetProperty("item_start", item->m_lStartOffset);
-  item->m_lEndOffset = record->at(song_iEndOffset).get_asInt64();
+  item->SetStartOffset(record->at(song_iStartOffset).get_asInt64());
+  item->SetProperty("item_start", item->GetStartOffset());
+  item->SetEndOffset(record->at(song_iEndOffset).get_asInt64());
   item->GetMusicInfoTag()->SetMusicBrainzTrackID(
       record->at(song_strMusicBrainzTrackID).get_asString());
   item->GetMusicInfoTag()->SetRating(record->at(song_rating).get_asFloat());

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -66,8 +66,8 @@ CSong::CSong(CFileItem& item)
   dateAdded = tag.GetDateAdded();
   replayGain = tag.GetReplayGain();
   strThumb = item.GetUserMusicThumb(true);
-  iStartOffset = static_cast<int>(item.m_lStartOffset);
-  iEndOffset = static_cast<int>(item.m_lEndOffset);
+  iStartOffset = static_cast<int>(item.GetStartOffset());
+  iEndOffset = static_cast<int>(item.GetEndOffset());
   idSong = -1;
   iTimesPlayed = 0;
   idAlbum = -1;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -524,7 +524,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     else if (!pItem->IsNFO() && (pItem->IsAudio() || pItem->IsVideo()))
     {
       CFileItemPtr itemCheck = queuedItems.Get(pItem->GetPath());
-      if (!itemCheck || itemCheck->m_lStartOffset != pItem->m_lStartOffset)
+      if (!itemCheck || itemCheck->GetStartOffset() != pItem->GetStartOffset())
       { // add item
         CFileItemPtr item(new CFileItem(*pItem));
         m_musicdatabase.SetPropertiesForFileItem(*item);
@@ -1074,11 +1074,9 @@ bool CGUIWindowMusicBase::OnSelect(int iItem)
     if (m_musicdatabase.GetResumeBookmarkForAudioBook(*item, bookmark) && bookmark > 0)
     {
       // find which chapter the bookmark belongs to
-      auto itemIt = std::find_if(
-        m_vecItems->cbegin(),
-        m_vecItems->cend(),
-        [&](const CFileItemPtr& item) { return bookmark < item->m_lEndOffset; }
-      );
+      auto itemIt =
+          std::find_if(m_vecItems->cbegin(), m_vecItems->cend(),
+                       [&](const CFileItemPtr& item) { return bookmark < item->GetEndOffset(); });
 
       if (itemIt != m_vecItems->cend())
       {

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -476,6 +476,7 @@ bool CPlayList::Expand(int position)
   {
     (*playlist)[i]->SetDynPath((*playlist)[i]->GetPath());
     (*playlist)[i]->SetPath(item->GetPath());
+    (*playlist)[i]->SetStartOffset(item->GetStartOffset());
   }
 
   if (playlist->size() <= 0)

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -166,10 +166,10 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         newItem->SetPath(strFileName);
         if (iStartOffset != 0 || iEndOffset != 0)
         {
-          newItem->m_lStartOffset = iStartOffset;
+          newItem->SetStartOffset(iStartOffset);
           newItem->m_lStartPartNumber = 1;
           newItem->SetProperty("item_start", iStartOffset);
-          newItem->m_lEndOffset = iEndOffset;
+          newItem->SetEndOffset(iEndOffset);
           // Prevent load message from file and override offset set here
           newItem->GetMusicInfoTag()->SetLoaded();
           newItem->GetMusicInfoTag()->SetTitle(strInfo);
@@ -230,10 +230,10 @@ void CPlayListM3U::Save(const std::string& strFileName) const
                                   item->GetMusicInfoTag()->GetDuration() / 1000, strDescription);
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
-    if (item->m_lStartOffset != 0 || item->m_lEndOffset != 0)
+    if (item->GetStartOffset() != 0 || item->GetEndOffset() != 0)
     {
-      strLine =
-          StringUtils::Format("{}:{},{}\n", OffsetMarker, item->m_lStartOffset, item->m_lEndOffset);
+      strLine = StringUtils::Format("{}:{},{}\n", OffsetMarker, item->GetStartOffset(),
+                                    item->GetEndOffset());
       file.Write(strLine.c_str(),strLine.size());
     }
     std::string strFileName = ResolveURL(item);

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -253,17 +253,19 @@ void CPowerManager::StorePlayerState()
     m_lastUsedPlayer = appPlayer.GetCurrentPlayer();
     m_lastPlayedFileItem.reset(new CFileItem(g_application.CurrentFileItem()));
     // set the actual offset instead of store and load it from database
-    m_lastPlayedFileItem->m_lStartOffset = appPlayer.GetTime();
+    m_lastPlayedFileItem->SetStartOffset(appPlayer.GetTime());
     // in case of regular stack, correct the start offset by adding current part start time
     if (g_application.GetAppStackHelper().IsPlayingRegularStack())
-      m_lastPlayedFileItem->m_lStartOffset += g_application.GetAppStackHelper().GetCurrentStackPartStartTimeMs();
+      m_lastPlayedFileItem->SetStartOffset(
+          m_lastPlayedFileItem->GetStartOffset() +
+          g_application.GetAppStackHelper().GetCurrentStackPartStartTimeMs());
     // in case of iso stack, keep track of part number
     m_lastPlayedFileItem->m_lStartPartNumber = g_application.GetAppStackHelper().IsPlayingISOStack() ? g_application.GetAppStackHelper().GetCurrentPartNumber() + 1 : 1;
     // for iso and iso stacks, keep track of playerstate
     m_lastPlayedFileItem->SetProperty("savedplayerstate", appPlayer.GetPlayerState());
     CLog::Log(LOGDEBUG,
               "CPowerManager::StorePlayerState - store last played item (startOffset: {} ms)",
-              m_lastPlayedFileItem->m_lStartOffset);
+              m_lastPlayedFileItem->GetStartOffset());
   }
   else
   {
@@ -279,7 +281,7 @@ void CPowerManager::RestorePlayerState()
 
   CLog::Log(LOGDEBUG,
             "CPowerManager::RestorePlayerState - resume last played item (startOffset: {} ms)",
-            m_lastPlayedFileItem->m_lStartOffset);
+            m_lastPlayedFileItem->GetStartOffset());
   g_application.PlayFile(*m_lastPlayedFileItem, m_lastUsedPlayer);
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1201,7 +1201,7 @@ namespace PVR
       choices.Add(CONTEXT_BUTTON_PLAY_ITEM, 12021); // Play from beginning
       int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
       if (choice > 0)
-        item->m_lStartOffset = choice == CONTEXT_BUTTON_RESUME_ITEM ? STARTOFFSET_RESUME : 0;
+        item->SetStartOffset(choice == CONTEXT_BUTTON_RESUME_ITEM ? STARTOFFSET_RESUME : 0);
       else
         bPlayIt = false; // context menu cancelled
     }
@@ -1213,12 +1213,12 @@ namespace PVR
     bool bCanResume = !GetResumeLabel(*item).empty();
     if (bCanResume)
     {
-      item->m_lStartOffset = STARTOFFSET_RESUME;
+      item->SetStartOffset(STARTOFFSET_RESUME);
     }
     else
     {
       if (bFallbackToPlay)
-        item->m_lStartOffset = 0;
+        item->SetStartOffset(0);
       else
         return false;
     }
@@ -1306,7 +1306,7 @@ namespace PVR
     if (!bCheckResume || CheckResumeRecording(item))
     {
       CFileItem* itemToPlay = new CFileItem(recording);
-      itemToPlay->m_lStartOffset = item->m_lStartOffset;
+      itemToPlay->SetStartOffset(item->GetStartOffset());
       StartPlayback(itemToPlay, true);
     }
     return true;

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -215,7 +215,8 @@ void CSaveFileState::DoWork(CFileItem& item,
       if (item.IsAudioBook())
       {
         musicdatabase.Open();
-        musicdatabase.SetResumeBookmarkForAudioBook(item, item.m_lStartOffset + CUtil::ConvertSecsToMilliSecs(bookmark.timeInSeconds));
+        musicdatabase.SetResumeBookmarkForAudioBook(
+            item, item.GetStartOffset() + CUtil::ConvertSecsToMilliSecs(bookmark.timeInSeconds));
         musicdatabase.Close();
       }
     }

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -295,7 +295,7 @@ bool CResume::Execute(const CFileItemPtr& itemIn) const
     return MEDIA_DETECT::CAutorun::PlayDisc(item.GetPath(), true, false);
 #endif
 
-  item.m_lStartOffset = STARTOFFSET_RESUME;
+  item.SetStartOffset(STARTOFFSET_RESUME);
   SetPathAndPlay(item);
   return true;
 };

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -732,7 +732,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
     // close our dialog
     Close(true);
     if (resume)
-      m_movieItem->m_lStartOffset = STARTOFFSET_RESUME;
+      m_movieItem->SetStartOffset(STARTOFFSET_RESUME);
     else if (!CGUIWindowVideoBase::ShowResumeMenu(*m_movieItem))
     {
       // The Resume dialog was closed without any choice

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -651,7 +651,7 @@ bool CGUIWindowVideoBase::OnFileAction(int iItem, int action, const std::string&
 
   // Reset the current start offset. The actual resume
   // option is set in the switch, based on the action passed.
-  item->m_lStartOffset = 0;
+  item->SetStartOffset(0);
 
   switch (action)
   {
@@ -695,7 +695,7 @@ bool CGUIWindowVideoBase::OnFileAction(int iItem, int action, const std::string&
     OnPopupMenu(iItem);
     return true;
   case SELECT_ACTION_RESUME:
-    item->m_lStartOffset = STARTOFFSET_RESUME;
+    item->SetStartOffset(STARTOFFSET_RESUME);
     break;
   case SELECT_ACTION_PLAYPART:
     if (!OnPlayStackPart(iItem))
@@ -816,7 +816,7 @@ bool CGUIWindowVideoBase::ShowResumeMenu(CFileItem &item)
       if (retVal < 0)
         return false; // don't do anything
       if (retVal == 1)
-        item.m_lStartOffset = STARTOFFSET_RESUME;
+        item.SetStartOffset(STARTOFFSET_RESUME);
     }
   }
   return true;
@@ -985,7 +985,7 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
     if (CFileItem(CStackDirectory::GetFirstStackedFile(path),false).IsDiscImage())
     {
       std::string resumeString = CGUIWindowVideoBase::GetResumeString(*(parts[selectedFile].get()));
-      stack->m_lStartOffset = 0;
+      stack->SetStartOffset(0);
       if (!resumeString.empty())
       {
         CContextButtons choices;
@@ -993,7 +993,11 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
         choices.Add(SELECT_ACTION_PLAY, 12021);   // Play from beginning
         int value = CGUIDialogContextMenu::ShowAndGetChoice(choices);
         if (value == SELECT_ACTION_RESUME)
-          GetResumeItemOffset(parts[selectedFile].get(), stack->m_lStartOffset, stack->m_lStartPartNumber);
+        {
+          int64_t startOffset{0};
+          GetResumeItemOffset(parts[selectedFile].get(), startOffset, stack->m_lStartPartNumber);
+          stack->SetStartOffset(startOffset);
+        }
         else if (value != SELECT_ACTION_PLAY)
           return false; // if not selected PLAY, then we changed our mind so return
       }
@@ -1006,10 +1010,10 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
       {
         std::vector<uint64_t> times;
         if (m_database.GetStackTimes(path,times))
-          stack->m_lStartOffset = times[selectedFile - 1];
+          stack->SetStartOffset(times[selectedFile - 1]);
       }
       else
-        stack->m_lStartOffset = 0;
+        stack->SetStartOffset(0);
     }
 
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -581,7 +581,7 @@ void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int64_t& st
   startoffset = 0;
   partNumber = 0;
 
-  if (!item->IsNFO() && !item->IsPlayList())
+  if (item->IsResumable())
   {
     if (item->GetCurrentResumeTimeAndPartNumber(startoffset, partNumber))
     {

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -322,10 +322,10 @@ bool CGUIWindowVideoPlaylist::OnPlayMedia(int iItem, const std::string &player)
     std::string strPath = pItem->GetPath();
     CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
     // need to update Playlist FileItem's startOffset and resumePoint based on GUIWindowVideoPlaylist FileItem
-    if (pItem->m_lStartOffset == STARTOFFSET_RESUME)
+    if (pItem->GetStartOffset() == STARTOFFSET_RESUME)
     {
       CFileItemPtr pPlaylistItem = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_VIDEO)[iItem];
-      pPlaylistItem->m_lStartOffset = pItem->m_lStartOffset;
+      pPlaylistItem->SetStartOffset(pItem->GetStartOffset());
       if (pPlaylistItem->HasVideoInfoTag() && pItem->HasVideoInfoTag())
         pPlaylistItem->GetVideoInfoTag()->SetResumePoint(pItem->GetVideoInfoTag()->GetResumePoint());
     }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1120,7 +1120,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
   }
   else if (pItem->IsPlugin() && !pItem->GetProperty("isplayable").asBoolean())
   {
-    bool resume = pItem->m_lStartOffset == STARTOFFSET_RESUME;
+    bool resume = pItem->GetStartOffset() == STARTOFFSET_RESUME;
     return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath(), resume);
   }
 #if defined(TARGET_ANDROID)
@@ -1376,11 +1376,12 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, std::str
       strHistoryString = pItem->GetLabel() + strPath;
     }
   }
-  else if (pItem->m_lEndOffset>pItem->m_lStartOffset && pItem->m_lStartOffset != -1)
+  else if (pItem->GetEndOffset() > pItem->GetStartOffset() &&
+           pItem->GetStartOffset() != STARTOFFSET_RESUME)
   {
     // Could be a cue item, all items of a cue share the same filename
     // so add the offsets to build the history string
-    strHistoryString = StringUtils::Format("{}{}", pItem->m_lStartOffset, pItem->m_lEndOffset);
+    strHistoryString = StringUtils::Format("{}{}", pItem->GetStartOffset(), pItem->GetEndOffset());
     strHistoryString += pItem->GetPath();
   }
   else
@@ -1492,8 +1493,8 @@ bool CGUIMediaWindow::OnPlayMedia(int iItem, const std::string &player)
   else
     bResult = g_application.PlayFile(*pItem, player);
 
-  if (pItem->m_lStartOffset == STARTOFFSET_RESUME)
-    pItem->m_lStartOffset = 0;
+  if (pItem->GetStartOffset() == STARTOFFSET_RESUME)
+    pItem->SetStartOffset(0);
 
   return bResult;
 }
@@ -1607,7 +1608,7 @@ void CGUIMediaWindow::UpdateFileList()
         CServiceBroker::GetPlaylistPlayer().Add(iPlaylist, pItem);
 
       if (pItem->GetPath() == playlistItem.GetPath() &&
-          pItem->m_lStartOffset == playlistItem.m_lStartOffset)
+          pItem->GetStartOffset() == playlistItem.GetStartOffset())
         CServiceBroker::GetPlaylistPlayer().SetCurrentSong(CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).size() - 1);
     }
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This fix the bookmark resume playback on playlist STRM files
this PR superseed PR #16076, when time ago i tested old PR was not working good i dont know why or my fails or somelse changes over time, now i tried rebasing and this time has worked good, so thanks to @Acidzero2020 for his search

my tests i have done as follow:

#### Test 1: More STRM files in a folder like a tvshow episodes, no scraper
- add more strm in a folder to be add to kodi library without set scraper
- open first STRM, seek to middle then stop playback
- open second STRM, seek to middle then stop (before the fix, the first strm loose the resume)
- open again the first STRM, seek to middle then stop (before the fix, the second strm loose the resume)

#### Test 2: More STRM files in a folder like a tvshow episodes, with scraper
same steps as Test 1 but by set the tvdb scraper to the folder

#### Test 3: Test resume on a Widget "Recently added episodes"
- add new STRM files on the tvhsow folder added in kodi library and update library to make scraper works
- If Kodi not update the tv show window close Kodi and reopen it
- The category widget "Recently added episodes" should appears
- Play a STRM on the widget (see screenshot) seek to middle and stop playback
- Play same STRM or another one, before the fix the video resume will be lost and you cannot resume video

#### Test 4: Test persistent resume over Kodi app close
Try play some STRM and then check if the video resume is persistent after you close/reopen kodi

#### Test 5: STRM file with multiple links contained on same file
handled as folder, video resume not available, so behaviour unchanged

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bookmark resume on playlist files like STRM never worked on kodi
the use of STRM with kodi library is widespread in addons
and all addons have had to implement various kind of workarounds
like reimplementing video resume bookmark by sniffing kodi library database or by using an own internal addon database where save the bookmark manually

fix #19981

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
![immagine](https://user-images.githubusercontent.com/3257156/189309964-37fc1355-4697-412d-873b-c4a4ea87ce77.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
