### PR TITLE
[PVR] CPVRClients::UpdateClients: No need to destroy a client that is not created

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -102,7 +102,8 @@ void CPVRClients::UpdateClients(
         if (instanceEnabled && (!IsKnownClient(clientId) || !IsCreatedClient(clientId)))
         {
           std::shared_ptr<CPVRClient> client;
-          if (IsKnownClient(clientId))
+          const bool isKnownClient = IsKnownClient(clientId);
+          if (isKnownClient)
           {
             client = GetClient(clientId);
           }
@@ -122,7 +123,7 @@ void CPVRClients::UpdateClients(
 
           if (instanceEnabled)
             clientsToCreate.emplace_back(client);
-          else
+          else if (isKnownClient)
             clientsToDestroy.emplace_back(clientId);
         }
         else if (IsCreatedClient(clientId))


### PR DESCRIPTION
Nothing serious, just something I came across while re-visiting the code.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish if/when you find some time for a review...