### PR TITLE
[vp] Do not look for av1 hw decoders if sw decoding is enforced

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -339,10 +339,11 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 
   // libdav1d av1 sw decoding is implemented as a separate decoder
   // in ffmpeg which is always found first when calling `avcodec_find_decoder`.
-  // To get hwaccels we look for decoders registered for `av1`.
+  // To get hwaccels we look for decoders registered for `av1` (unless sw decoding is enforced).
   // The decoder state check is needed to succesfully fallback to sw decoding if
-  // necessary.
-  if (hints.codec == AV_CODEC_ID_AV1 && m_decoderState != STATE_HW_FAILED)
+  // necessary (on retry).
+  if (hints.codec == AV_CODEC_ID_AV1 && m_decoderState != STATE_HW_FAILED &&
+      !(hints.codecOptions & CODEC_FORCE_SOFTWARE))
     pCodec = avcodec_find_decoder_by_name("av1");
 
   if (!pCodec)


### PR DESCRIPTION
## Description
For AV1 media kodi starts by looking for hardware decoders so that it can fallback to sw decoding on retry. However, when extracting thumbs SW decoding is always enforced. Unlike video playback where the hw failing state is detected and the codec is reopened, for the case of thumbs we end up in an endless failure loop.
This PR makes ffmpeg avoid looking for av1 hw decoders if we explicitly force sw decoding (the case of thumbs).

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21741

## How has this been tested?
With the samples provided by @CastagnaIT 

## What is the effect on users?
Thumbs should now be shown for AV1 media.

## Screenshots (if appropriate):

**Before:**
![image](https://user-images.githubusercontent.com/7375276/189353078-d19859db-80ad-474e-8e4c-802d3a449b45.png)

**Now:**
![image](https://user-images.githubusercontent.com/7375276/189353298-ac4d8a67-a0a1-4a17-b147-d4182cade4a0.png)


