### PR TITLE
[addons] change KODI_ADDON_*_HDL to use KODI_ADDON_INSTANCE_HDL as parent

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audiodecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audiodecoder.h
@@ -45,7 +45,7 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-  typedef void* KODI_ADDON_AUDIODECODER_HDL;
+  typedef KODI_ADDON_INSTANCE_HDL KODI_ADDON_AUDIODECODER_HDL;
 
   //============================================================================
   /// @defgroup cpp_kodi_addon_audiodecoder_Defs_AUDIODECODER_READ_RETURN enum AUDIODECODER_READ_RETURN

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audioencoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audioencoder.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-  typedef void* KODI_ADDON_AUDIOENCODER_HDL;
+  typedef KODI_ADDON_INSTANCE_HDL KODI_ADDON_AUDIOENCODER_HDL;
 
   struct KODI_ADDON_AUDIOENCODER_INFO_TAG
   {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/imagedecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/imagedecoder.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-  typedef void* KODI_ADDON_IMAGEDECODER_HDL;
+  typedef KODI_ADDON_INSTANCE_HDL KODI_ADDON_IMAGEDECODER_HDL;
 
   //============================================================================
   /// @defgroup cpp_kodi_addon_imagedecoder_Defs_ADDON_IMG_FMT enum ADDON_IMG_FMT

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-  typedef void* KODI_ADDON_SCREENSAVER_HDL;
+  typedef KODI_ADDON_INSTANCE_HDL KODI_ADDON_SCREENSAVER_HDL;
 
   struct KODI_ADDON_SCREENSAVER_PROPS
   {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -75,7 +75,11 @@
 #if __GNUC__ >= 4
 #define ATTR_DLL_IMPORT __attribute__((visibility("default")))
 #define ATTR_DLL_EXPORT __attribute__((visibility("default")))
+#ifndef SWIG
 #define ATTR_DLL_LOCAL __attribute__((visibility("hidden")))
+#else
+#define ATTR_DLL_LOCAL
+#endif
 #else
 #define ATTR_DLL_IMPORT
 #define ATTR_DLL_EXPORT

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -105,9 +105,6 @@ typedef intptr_t ssize_t;
 #include <sys/types.h>
 #endif // TARGET_POSIX
 
-// Hardware specific device context interface
-#define ADDON_HARDWARE_CONTEXT void*
-
 /*
  * To have a on add-on and kodi itself handled string always on known size!
  */
@@ -123,6 +120,9 @@ extern "C"
   typedef void* KODI_ADDON_BACKEND_HDL;
   typedef void* KODI_ADDON_INSTANCE_HDL;
   typedef void* KODI_ADDON_INSTANCE_BACKEND_HDL;
+
+  // Hardware specific device context interface
+  typedef void* ADDON_HARDWARE_CONTEXT;
 
   typedef void* KODI_ADDON_FUNC_DUMMY;
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -13,8 +13,9 @@
 #define NOMINMAX
 #endif
 
-#include "stdbool.h"
-#include "stdint.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #ifndef TARGET_WINDOWS
 #ifndef __cdecl

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -37,7 +37,7 @@
 // because cmake uses this area in this form to perform its addon dependency
 // check.
 // clang-format off
-#define ADDON_GLOBAL_VERSION_MAIN                     "2.0.1"
+#define ADDON_GLOBAL_VERSION_MAIN                     "2.0.2"
 #define ADDON_GLOBAL_VERSION_MAIN_MIN                 "2.0.0"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \


### PR DESCRIPTION
## Description

The "void*" becomes needed in some parts on add-on interface, but have more clean becomes now the "KODI_ADDON_INSTANCE_HDL" used as parent. Background is to have more clean, to prevent the "void*" view as much as possible and to allow by my sandbox project to identify an related typedef.

Also an non breaking change of add-on API.

Also added few other non breaking commits to have not complete alone.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
