### PR TITLE
[upnp] Fix url extension for JPEG_TN dlna_profile

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -609,19 +609,22 @@ BuildObject(CFileItem&                    item,
         thumb = ContentUtils::GetPreferredArtImage(item);
 
         if (!thumb.empty()) {
-            PLT_AlbumArtInfo art;
-            art.uri = upnp_server->BuildSafeResourceUri(
-                rooturi,
-                (*ips.GetFirstItem()).ToString(),
-                CTextureUtils::GetWrappedImageURL(thumb).c_str());
-
-            // Set DLNA profileID by extension, defaulting to JPEG.
-            if (URIUtils::HasExtension(thumb, ".png")) {
-                art.dlna_profile = "PNG_TN";
-            } else {
-                art.dlna_profile = "JPEG_TN";
-            }
-            object->m_ExtraInfo.album_arts.Add(art);
+          PLT_AlbumArtInfo art;
+          // Set DLNA profileID by extension, defaulting to JPEG.
+          if (URIUtils::HasExtension(thumb, ".png"))
+          {
+            art.dlna_profile = "PNG_TN";
+          }
+          else
+          {
+            art.dlna_profile = "JPEG_TN";
+          }
+          // append /thumb to the safe resource uri to avoid clients flagging the item with
+          // the incorrect mimetype (derived from the file extension)
+          art.uri = upnp_server->BuildSafeResourceUri(
+              rooturi, (*ips.GetFirstItem()).ToString(),
+              std::string(CTextureUtils::GetWrappedImageURL(thumb) + "/thumb").c_str());
+          object->m_ExtraInfo.album_arts.Add(art);
         }
 
         for (const auto& itArtwork : item.GetArt())


### PR DESCRIPTION
## Description
This is quite an obscure use case but kodi can be used as the upnp renderer of its own upnp server/library. In such cases, kodi fails to display the artwork thumb in the video osd. This happens because even though the server thumb url is created by kodi and has the dlna_profile set to jpeg, the complete url has the extension of the media item (e.g. .flac, .mp3, etc). It works and downloads the image but kodi internal mechanisms to probe media (e.g. `GetMimeType()` won't flag the item as an image). Since we have full control of these server resources, just add `/thumb` to the url to avoid the possibility of flagging the image as audio/video.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/20845

## How has this been tested?
Runtime tested, bubleupnp on android, kodi as renderer, kodi as upnp source.

## What is the effect on users?
0.0000001% of users will have thumbs when using a upnp client as remote for kodi internal music library :)

## Screenshots (if appropriate):
**Before:**
![image](https://user-images.githubusercontent.com/7375276/189396861-1aa9f88b-e389-4e40-a5ca-e7dce672b36d.png)


**Now:**
![image](https://user-images.githubusercontent.com/7375276/189396468-8735315e-4230-460b-a549-5d1eb71c8bd9.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

