### PR TITLE
Prevent unaligned memory accesses in CZipManager

### DIFF
--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -110,8 +110,7 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
       return false;
     for (int i=blockSize-1; !found && (i >= 0); i--)
     {
-      if (Endian_SwapLE32(*(reinterpret_cast<unsigned int*>(buffer.data() + i))) ==
-          ZIP_END_CENTRAL_HEADER)
+      if (Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer.data() + i)) == ZIP_END_CENTRAL_HEADER)
       {
         // Set current position to start of end of central directory
         mFile.Seek(fileSize-ECDREC_SIZE+1-(blockSize*nb)+i,SEEK_SET);
@@ -128,8 +127,7 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
       return false;
     for (int i=extraBlockSize-1; !found && (i >= 0); i--)
     {
-      if (Endian_SwapLE32(*(reinterpret_cast<unsigned int*>(buffer.data() + i))) ==
-          ZIP_END_CENTRAL_HEADER)
+      if (Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer.data() + i)) == ZIP_END_CENTRAL_HEADER)
       {
         // Set current position to start of end of central directory
         mFile.Seek(fileSize-ECDREC_SIZE+1-searchSize+i,SEEK_SET);
@@ -274,38 +272,37 @@ bool CZipManager::ExtractArchive(const CURL& archive, const std::string& strPath
 // Read local file header
 void CZipManager::readHeader(const char* buffer, SZipEntry& info)
 {
-  info.header = Endian_SwapLE32(*(const unsigned int*)buffer);
-  info.version = Endian_SwapLE16(*(const unsigned short*)(buffer+4));
-  info.flags = Endian_SwapLE16(*(const unsigned short*)(buffer+6));
-  info.method = Endian_SwapLE16(*(const unsigned short*)(buffer+8));
-  info.mod_time = Endian_SwapLE16(*(const unsigned short*)(buffer+10));
-  info.mod_date = Endian_SwapLE16(*(const unsigned short*)(buffer+12));
-  info.crc32 = Endian_SwapLE32(*(const unsigned int*)(buffer+14));
-  info.csize = Endian_SwapLE32(*(const unsigned int*)(buffer+18));
-  info.usize = Endian_SwapLE32(*(const unsigned int*)(buffer+22));
-  info.flength = Endian_SwapLE16(*(const unsigned short*)(buffer+26));
-  info.elength = Endian_SwapLE16(*(const unsigned short*)(buffer+28));
+  info.header = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer));
+  info.version = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 4));
+  info.flags = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 6));
+  info.method = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 8));
+  info.mod_time = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 10));
+  info.mod_date = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 12));
+  info.crc32 = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer + 14));
+  info.csize = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer + 18));
+  info.usize = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer + 22));
+  info.flength = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 26));
+  info.elength = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 28));
 }
 
 // Read central file header (from central directory)
 void CZipManager::readCHeader(const char* buffer, SZipEntry& info)
 {
-  info.header = Endian_SwapLE32(*(const unsigned int*)buffer);
+  info.header = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer));
   // Skip version made by
-  info.version = Endian_SwapLE16(*(const unsigned short*)(buffer+6));
-  info.flags = Endian_SwapLE16(*(const unsigned short*)(buffer+8));
-  info.method = Endian_SwapLE16(*(const unsigned short*)(buffer+10));
-  info.mod_time = Endian_SwapLE16(*(const unsigned short*)(buffer+12));
-  info.mod_date = Endian_SwapLE16(*(const unsigned short*)(buffer+14));
-  info.crc32 = Endian_SwapLE32(*(const unsigned int*)(buffer+16));
-  info.csize = Endian_SwapLE32(*(const unsigned int*)(buffer+20));
-  info.usize = Endian_SwapLE32(*(const unsigned int*)(buffer+24));
-  info.flength = Endian_SwapLE16(*(const unsigned short*)(buffer+28));
-  info.eclength = Endian_SwapLE16(*(const unsigned short*)(buffer+30));
-  info.clength = Endian_SwapLE16(*(const unsigned short*)(buffer+32));
+  info.version = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 6));
+  info.flags = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 8));
+  info.method = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 10));
+  info.mod_time = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 12));
+  info.mod_date = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 14));
+  info.crc32 = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer + 16));
+  info.csize = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer + 20));
+  info.usize = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer + 24));
+  info.flength = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 28));
+  info.eclength = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 30));
+  info.clength = Endian_SwapLE16(ReadUnaligned<uint16_t>(buffer + 32));
   // Skip disk number start, internal/external file attributes
-  info.lhdrOffset = Endian_SwapLE32(*(const unsigned int*)(buffer+42));
-
+  info.lhdrOffset = Endian_SwapLE32(ReadUnaligned<uint32_t>(buffer + 42));
 }
 
 void CZipManager::release(const std::string& strPath)

--- a/xbmc/filesystem/ZipManager.h
+++ b/xbmc/filesystem/ZipManager.h
@@ -19,9 +19,10 @@
 #define CHDR_SIZE 46
 #define ECDREC_SIZE 22
 
+#include <cstring>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 class CURL;
 
@@ -67,6 +68,14 @@ public:
 private:
   std::map<std::string,std::vector<SZipEntry> > mZipMap;
   std::map<std::string,int64_t> mZipDate;
+
+  template<typename T>
+  static T ReadUnaligned(const void* mem)
+  {
+    T var;
+    std::memcpy(&var, mem, sizeof(T));
+    return var;
+  }
 };
 
 extern CZipManager g_ZipManager;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Prevent unaligned memory accesses by using `memcpy` instead of casts. This is the only valid way to type pun in C++ (see https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8#how-do-we-type-pun-correctly). The problem was detected with UBSAN:
```
.../xbmc/filesystem/ZipManager.cpp:283:16: runtime error: load of misaligned address 0x62800000010e for type 'const unsigned int', which requires 4 byte alignment
0x62800000010e: note: pointer points here
 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 06 00 00 00 65 6e  2e 78 6d 6c ec 9d 6b 6e  e3 4a
             ^ 
    #0 0x55a153ce3f70 in CZipManager::readHeader(char const*, SZipEntry&) .../xbmc/filesystem/ZipManager.cpp:283:16
    #1 0x55a153cd70d9 in XFILE::CZipFile::UnpackFromMemory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) .../xbmc/filesystem/ZipFile.cpp:403:7
    #2 0x55a14c406ca8 in TestZipFile_ExtendedLocalHeader_Test::TestBody() .../xbmc/filesystem/test/TestZipFile.cpp:207:23
    #3 0x7fbcd32906cb  (/usr/lib/libgtest.so.1.12.1+0x4d6cb) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)
    #4 0x7fbcd327ceb7 in testing::Test::Run() (/usr/lib/libgtest.so.1.12.1+0x39eb7) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)
    #5 0x7fbcd327d0c6 in testing::TestInfo::Run() (/usr/lib/libgtest.so.1.12.1+0x3a0c6) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)
    #6 0x7fbcd327d223 in testing::TestSuite::Run() (/usr/lib/libgtest.so.1.12.1+0x3a223) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)
    #7 0x7fbcd328975e in testing::internal::UnitTestImpl::RunAllTests() (/usr/lib/libgtest.so.1.12.1+0x4675e) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)
    #8 0x7fbcd32883f8 in testing::UnitTest::Run() (/usr/lib/libgtest.so.1.12.1+0x453f8) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)
    #9 0x55a14bad25b0 in RUN_ALL_TESTS() /usr/include/gtest/gtest.h:2293:73
    #10 0x55a14bad2297 in main .../xbmc/test/xbmc-test.cpp:29:13
    #11 0x7fbcd213d2cf  (/usr/lib/libc.so.6+0x232cf) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)
    #12 0x7fbcd213d389 in __libc_start_main (/usr/lib/libc.so.6+0x23389) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)
    #13 0x55a14b9d62d4 in _start /build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:115
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Don't rely on undefined behaviour :)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The problem occurred when installing addons as well as in the unit tests. UBSAN doesn't complain anymore after the change.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
