### PR TITLE
Fix race condition in CJobManager

### DIFF
--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -327,10 +327,9 @@ protected:
 
   /*!
    \brief Get a new job to process. Blocks until a new job is available, or a timeout has occurred.
-   \param worker a pointer to the current CJobWorker instance requesting a job.
    \sa CJob
    */
-  CJob *GetNextJob(const CJobWorker *worker);
+  CJob* GetNextJob();
 
   /*!
    \brief Callback from CJobWorker after a job has completed.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fixes a race condition that resulted in a use-after-free. ASAN output:
```
==68503==ERROR: AddressSanitizer: heap-use-after-free on address 0x61700001e588 at pc 0x55b4d356f5aa bp 0x7f9444cfdcc0 sp 0x7f9444cfdcb8
READ of size 4 at 0x61700001e588 thread T1
    #0 0x55b4d356f5a9 in XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock() .../xbmc/threads/Lockables.h:50:45
    #1 0x55b4d356f499 in std::unique_lock<CCriticalSection>::lock() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/unique_lock.h:139:17
    #2 0x55b4d356e209 in std::unique_lock<CCriticalSection>::unique_lock(CCriticalSection&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/unique_lock.h:69:2
    #3 0x55b4d6492acc in CJobManager::RemoveWorker(CJobWorker const*) .../xbmc/utils/JobManager.cpp:439:38
    #4 0x55b4d6492639 in CJobWorker::~CJobWorker() .../xbmc/utils/JobManager.cpp:44:17
    #5 0x55b4d6492fb8 in CJobWorker::~CJobWorker() .../xbmc/utils/JobManager.cpp:39:1
    #6 0x55b4d68e4152 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const .../xbmc/threads/Thread.cpp:143:11
    #7 0x55b4d68e2a81 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/invoke.h:61:14
    #8 0x55b4d68e24f5 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/invoke.h:96:14
    #9 0x55b4d68e2393 in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/std_thread.h:252:13
    #10 0x55b4d68e2158 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > >::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/std_thread.h:259:11
    #11 0x55b4d68e1d88 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool> > > >::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/std_thread.h:210:13
    #12 0x7f944ab952f2 in execute_native_thread_routine /usr/src/debug/gcc/libstdc++-v3/src/c++11/thread.cc:82:18
    #13 0x7f944c03b78c  (/usr/lib/libc.so.6+0x8678c) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)
    #14 0x7f944c0bc8e3 in clone (/usr/lib/libc.so.6+0x1078e3) (BuildId: 9c28cfc869012ebbd43cdb0f1eebcd14e1b8bdd8)

0x61700001e588 is located 520 bytes inside of 712-byte region [0x61700001e380,0x61700001e648)
freed by thread T0 here:
    #0 0x55b4d31b4b9a in operator delete(void*) (/home/mark/Coding/Repos/kodi-git/build/kodi-test+0x23af0b9a)
    #1 0x55b4d36386be in std::__new_allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >::deallocate(std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>*, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/new_allocator.h:158:2
    #2 0x55b4d363866e in std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >::deallocate(std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >&, std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>*, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/alloc_traits.h:496:13
    #3 0x55b4d3633b91 in std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >::~__allocated_ptr() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/allocated_ptr.h:74:4
    #4 0x55b4d36345e3 in std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_destroy() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr_base.h:623:7
    #5 0x55b4d31caf07 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr_base.h:347:8
    #6 0x55b4d31ca9b9 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr_base.h:1071:11
    #7 0x55b4d3638bac in std::__shared_ptr<CJobManager, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr_base.h:1524:31
    #8 0x55b4d8aa28a3 in std::__shared_ptr<CJobManager, (__gnu_cxx::_Lock_policy)2>::reset() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr_base.h:1642:9
    #9 0x55b4d8a9fdc0 in CServiceBroker::UnregisterJobManager() .../xbmc/ServiceBroker.cpp:376:32
    #10 0x55b4d363278d in TestJobManager::~TestJobManager() .../xbmc/utils/test/TestJobManager.cpp:75:5
    #11 0x55b4d3631bd8 in TestJobManager_AddJob_Test::~TestJobManager_AddJob_Test() .../xbmc/utils/test/TestJobManager.cpp:79:1
    #12 0x55b4d3631c28 in TestJobManager_AddJob_Test::~TestJobManager_AddJob_Test() .../xbmc/utils/test/TestJobManager.cpp:79:1
    #13 0x7f944d12b6cb  (/usr/lib/libgtest.so.1.12.1+0x4d6cb) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)

previously allocated by thread T0 here:
    #0 0x55b4d31b4102 in operator new(unsigned long) (/home/mark/Coding/Repos/kodi-git/build/kodi-test+0x23af0102)
    #1 0x55b4d3633e37 in std::__new_allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/new_allocator.h:137:27
    #2 0x55b4d3633c8a in std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/alloc_traits.h:464:20
    #3 0x55b4d3633504 in std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<CJobManager, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/allocated_ptr.h:98:21
    #4 0x55b4d3633002 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<CJobManager, std::allocator<void> >(CJobManager*&, std::_Sp_alloc_shared_tag<std::allocator<void> >) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr_base.h:969:19
    #5 0x55b4d3632d3d in std::__shared_ptr<CJobManager, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void> >(std::_Sp_alloc_shared_tag<std::allocator<void> >) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr_base.h:1712:14
    #6 0x55b4d3632ac1 in std::shared_ptr<CJobManager>::shared_ptr<std::allocator<void> >(std::_Sp_alloc_shared_tag<std::allocator<void> >) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr.h:464:4
    #7 0x55b4d36324c8 in std::shared_ptr<std::enable_if<!(is_array<CJobManager>::value), CJobManager>::type> std::make_shared<CJobManager>() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.2.0/../../../../include/c++/12.2.0/bits/shared_ptr.h:1009:14
    #8 0x55b4d363222d in TestJobManager::TestJobManager() .../xbmc/utils/test/TestJobManager.cpp:68:57
    #9 0x55b4d363206c in TestJobManager_AddJob_Test::TestJobManager_AddJob_Test() .../xbmc/utils/test/TestJobManager.cpp:79:1
    #10 0x55b4d3631f89 in testing::internal::TestFactoryImpl<TestJobManager_AddJob_Test>::CreateTest() /usr/include/gtest/internal/gtest-internal.h:469:44
    #11 0x7f944d1180d2 in testing::TestInfo::Run() (/usr/lib/libgtest.so.1.12.1+0x3a0d2) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)

Thread T1 created by T0 here:
    #0 0x55b4d30e3d48 in pthread_create (/home/mark/Coding/Repos/kodi-git/build/kodi-test+0x23a1fd48)
    #1 0x7f944ab953d9 in __gthread_create /usr/src/debug/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x7f944ab953d9 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /usr/src/debug/gcc/libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x55b4d68de2f6 in CThread::Create(bool) .../xbmc/threads/Thread.cpp:94:20
    #4 0x55b4d6492480 in CJobWorker::CJobWorker(CJobManager*) .../xbmc/utils/JobManager.cpp:33:3
    #5 0x55b4d649def8 in CJobManager::StartWorkers(CJob::PRIORITY) .../xbmc/utils/JobManager.cpp:295:27
    #6 0x55b4d649b816 in CJobManager::AddJob(CJob*, IJobCallback*, CJob::PRIORITY) .../xbmc/utils/JobManager.cpp:254:3
    #7 0x55b4d3629b07 in TestJobManager_AddJob_Test::TestBody() .../xbmc/utils/test/TestJobManager.cpp:83:36
    #8 0x7f944d12b6cb  (/usr/lib/libgtest.so.1.12.1+0x4d6cb) (BuildId: 1801a127261d0551042ee8bc187fb7b6ecebefc6)

SUMMARY: AddressSanitizer: heap-use-after-free .../xbmc/threads/Lockables.h:50:45 in XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock()
Shadow bytes around the buggy address:
  0x0c2e7fffbc60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2e7fffbc70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2e7fffbc80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2e7fffbc90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2e7fffbca0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c2e7fffbcb0: fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2e7fffbcc0: fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa
  0x0c2e7fffbcd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2e7fffbce0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c2e7fffbcf0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c2e7fffbd00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==68503==ABORTING
```
The problem was that `CJobManager::GetNextJob(...)` removed a `CJobWorker` while it hasn't removed itself yet. Later all Jobs were cancelled with `CJobManager::CancelJobs()` and then the `CJobManager` was deleted. But the `CancelJobs()` didn't wait for the already removed `CJobWorker` which still has a pointer to the CJobManager`.

By having the `CJobWorker` always remove itself when it really finished prevents the issue.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent crash from a use-after-free.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The problem was easily reproducible in the unit tests, after the change the crashes are gone. 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Could have caused crashes when shutting down Kodi.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ X All new and existing tests passed
