### PR TITLE
Handle Standard Uppercase ReplayGain Tags for M4A and WMA

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -207,13 +207,13 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
     {}
     else if (it->first == "WM/BeatsPerMinute")
       tag.SetBPM(atoi(it->second.front().toString().toCString(true)));
-    else if (it->first == "replaygain_track_gain")
+    else if (it->first == "replaygain_track_gain" || it->first == "REPLAYGAIN_TRACK_GAIN")
       replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.front().toString().toCString(true));
-    else if (it->first == "replaygain_album_gain")
+    else if (it->first == "replaygain_album_gain" || it->first == "REPLAYGAIN_ALBUM_GAIN")
       replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.front().toString().toCString(true));
-    else if (it->first == "replaygain_track_peak")
+    else if (it->first == "replaygain_track_peak" || it->first == "REPLAYGAIN_TRACK_PEAK")
       replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.front().toString().toCString(true));
-    else if (it->first == "replaygain_album_peak")
+    else if (it->first == "replaygain_album_peak" || it->first == "REPLAYGAIN_ALBUM_PEAK")
       replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.front().toString().toCString(true));
     else if (it->first == "WM/Picture")
     { // picture
@@ -894,13 +894,17 @@ bool CTagLoaderTagLib::ParseTag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& 
       tag.SetReleaseDate(it->second.toStringList().front().to8Bit(true));
     else if (it->first == "----:com.apple.iTunes:originaldate")
       tag.SetOriginalDate(it->second.toStringList().front().to8Bit(true));
-    else if (it->first == "----:com.apple.iTunes:replaygain_track_gain")
+    else if (it->first == "----:com.apple.iTunes:replaygain_track_gain" ||
+             it->first == "----:com.apple.iTunes:REPLAYGAIN_TRACK_GAIN")
       replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.toStringList().front().toCString());
-    else if (it->first == "----:com.apple.iTunes:replaygain_album_gain")
+    else if (it->first == "----:com.apple.iTunes:replaygain_album_gain" ||
+             it->first == "----:com.apple.iTunes:REPLAYGAIN_ALBUM_GAIN")
       replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.toStringList().front().toCString());
-    else if (it->first == "----:com.apple.iTunes:replaygain_track_peak")
+    else if (it->first == "----:com.apple.iTunes:replaygain_track_peak" ||
+             it->first == "----:com.apple.iTunes:REPLAYGAIN_TRACK_PEAK")
       replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.toStringList().front().toCString());
-    else if (it->first == "----:com.apple.iTunes:replaygain_album_peak")
+    else if (it->first == "----:com.apple.iTunes:replaygain_album_peak" ||
+             it->first == "----:com.apple.iTunes:REPLAYGAIN_ALBUM_PEAK")
       replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.toStringList().front().toCString());
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Artist Id")
       tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));


### PR DESCRIPTION
## Description
The [ReplayGain standard](https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification) requires uppercase metadata tags, but Kodi currently only reads lowercase ReplayGain tags for the M4A and WMA formats.

## Motivation and context
Kodi successfully reads the standard uppercase ReplayGain tags for all other tag formats, only M4A and WMA are not supported. If this PR is merged, all audio formats supported in Kodi will be conformant with the ReplayGain standard.

## How has this been tested?
1. Generated one M4A and one WMA test file with uppercase ReplayGain tags
2. Scanned files into library using current `master`, verified that the `strReplayGain` field in the music database file is not populated for either test file
3. Made the change contained in this PR, re-scanned the test files into library, verified that the `strReplayGain` field in the music database is populated and correct for both test files.

## What is the effect on users?
The non-standard lowercase ReplayGain tags are still handled, so this won't break any existing functionality.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
