### PR TITLE
CWinSystemGbm: add colourspace connector property

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -20,6 +20,19 @@ extern "C"
 namespace DRMPRIME
 {
 
+KODI::UTILS::Colorimetry GetColorimetry(const VideoPicture& picture)
+{
+  switch (picture.color_space)
+  {
+    case AVCOL_SPC_BT2020_CL:
+      return KODI::UTILS::Colorimetry::BT2020_CYCC;
+    case AVCOL_SPC_BT2020_NCL:
+      return KODI::UTILS::Colorimetry::BT2020_YCC;
+    default:
+      return KODI::UTILS::Colorimetry::DEFAULT;
+  }
+}
+
 std::string GetColorEncoding(const VideoPicture& picture)
 {
   switch (picture.color_space)

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -35,6 +35,7 @@ enum hdmi_eotf
   HDMI_EOTF_BT_2100_HLG,
 };
 
+KODI::UTILS::Colorimetry GetColorimetry(const VideoPicture& picture);
 std::string GetColorEncoding(const VideoPicture& picture);
 std::string GetColorRange(const VideoPicture& picture);
 KODI::UTILS::Eotf GetEOTF(const VideoPicture& picture);

--- a/xbmc/utils/DisplayInfo.cpp
+++ b/xbmc/utils/DisplayInfo.cpp
@@ -103,6 +103,12 @@ void CDisplayInfo::Parse()
 
           switch (cta_tag)
           {
+            case DI_CTA_DATA_BLOCK_COLORIMETRY:
+            {
+              m_colorimetry = di_cta_data_block_get_colorimetry(block);
+
+              break;
+            }
             case DI_CTA_DATA_BLOCK_HDR_STATIC_METADATA:
             {
               m_hdr_static_metadata = di_cta_data_block_get_hdr_static_metadata(block);
@@ -144,6 +150,21 @@ void CDisplayInfo::LogInfo() const
               m_hdr_static_metadata->desired_content_max_frame_avg_luminance,
               m_hdr_static_metadata->desired_content_max_luminance);
   }
+
+  if (m_colorimetry)
+  {
+    CLog::Log(LOGINFO, "[display-info] supported colorimetry:");
+    CLog::Log(LOGINFO, "[display-info]   xvycc_601:   {}", m_colorimetry->xvycc_601);
+    CLog::Log(LOGINFO, "[display-info]   xvycc_709:   {}", m_colorimetry->xvycc_709);
+    CLog::Log(LOGINFO, "[display-info]   sycc_601:    {}", m_colorimetry->sycc_601);
+    CLog::Log(LOGINFO, "[display-info]   opycc_601:   {}", m_colorimetry->opycc_601);
+    CLog::Log(LOGINFO, "[display-info]   oprgb:       {}", m_colorimetry->oprgb);
+    CLog::Log(LOGINFO, "[display-info]   bt2020_cycc: {}", m_colorimetry->bt2020_cycc);
+    CLog::Log(LOGINFO, "[display-info]   bt2020_ycc:  {}", m_colorimetry->bt2020_ycc);
+    CLog::Log(LOGINFO, "[display-info]   bt2020_rgb:  {}", m_colorimetry->bt2020_rgb);
+    CLog::Log(LOGINFO, "[display-info]   st2113_rgb:  {}", m_colorimetry->st2113_rgb);
+    CLog::Log(LOGINFO, "[display-info]   ictcp:       {}", m_colorimetry->ictcp);
+  }
 }
 
 bool CDisplayInfo::SupportsHDRStaticMetadataType1() const
@@ -169,6 +190,38 @@ bool CDisplayInfo::SupportsEOTF(Eotf eotf) const
       return m_hdr_static_metadata->eotfs->pq;
     case Eotf::HLG:
       return m_hdr_static_metadata->eotfs->hlg;
+    default:
+      return false;
+  }
+}
+
+bool CDisplayInfo::SupportsColorimetry(Colorimetry colorimetry) const
+{
+  if (!m_colorimetry)
+    return false;
+
+  switch (colorimetry)
+  {
+    case Colorimetry::XVYCC_601:
+      return m_colorimetry->xvycc_601;
+    case Colorimetry::XVYCC_709:
+      return m_colorimetry->xvycc_709;
+    case Colorimetry::SYCC_601:
+      return m_colorimetry->sycc_601;
+    case Colorimetry::OPYCC_601:
+      return m_colorimetry->opycc_601;
+    case Colorimetry::OPRGB:
+      return m_colorimetry->oprgb;
+    case Colorimetry::BT2020_CYCC:
+      return m_colorimetry->bt2020_cycc;
+    case Colorimetry::BT2020_YCC:
+      return m_colorimetry->bt2020_ycc;
+    case Colorimetry::BT2020_RGB:
+      return m_colorimetry->bt2020_rgb;
+    case Colorimetry::ST2113_RGB:
+      return m_colorimetry->st2113_rgb;
+    case Colorimetry::ICTCP:
+      return m_colorimetry->ictcp;
     default:
       return false;
   }

--- a/xbmc/utils/DisplayInfo.h
+++ b/xbmc/utils/DisplayInfo.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 struct di_info;
+struct di_cta_colorimetry_block;
 struct di_cta_hdr_static_metadata_block;
 
 namespace KODI
@@ -29,6 +30,21 @@ enum class Eotf
   HLG,
 };
 
+enum class Colorimetry
+{
+  DEFAULT,
+  XVYCC_601,
+  XVYCC_709,
+  SYCC_601,
+  OPYCC_601,
+  OPRGB,
+  BT2020_CYCC,
+  BT2020_YCC,
+  BT2020_RGB,
+  ST2113_RGB,
+  ICTCP,
+};
+
 class CDisplayInfo
 {
 public:
@@ -39,6 +55,8 @@ public:
   bool SupportsHDRStaticMetadataType1() const;
 
   bool SupportsEOTF(Eotf eotf) const;
+
+  bool SupportsColorimetry(Colorimetry colorimetry) const;
 
 private:
   explicit CDisplayInfo(const std::vector<uint8_t>& edid);
@@ -57,6 +75,7 @@ private:
   std::string m_make;
   std::string m_model;
 
+  const di_cta_colorimetry_block* m_colorimetry = nullptr;
   const di_cta_hdr_static_metadata_block* m_hdr_static_metadata = nullptr;
 };
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -22,6 +22,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "utils/DisplayInfo.h"
+#include "utils/Map.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -61,6 +62,27 @@ struct hdr_output_metadata
 using namespace KODI::WINDOWING::GBM;
 
 using namespace std::chrono_literals;
+
+namespace
+{
+
+// These map to the definitions in the linux kernel
+// drivers/gpu/drm/drm_connector.c
+
+constexpr auto ColorimetryMap = make_map<KODI::UTILS::Colorimetry, std::string_view>({
+    {KODI::UTILS::Colorimetry::DEFAULT, "Default"},
+    {KODI::UTILS::Colorimetry::XVYCC_601, "XVYCC_601"},
+    {KODI::UTILS::Colorimetry::XVYCC_709, "XVYCC_709"},
+    {KODI::UTILS::Colorimetry::SYCC_601, "SYCC_601"},
+    {KODI::UTILS::Colorimetry::OPYCC_601, "opYCC_601"},
+    {KODI::UTILS::Colorimetry::OPRGB, "opRGB"},
+    {KODI::UTILS::Colorimetry::BT2020_CYCC, "BT2020_CYCC"},
+    {KODI::UTILS::Colorimetry::BT2020_YCC, "BT2020_YCC"},
+    {KODI::UTILS::Colorimetry::BT2020_RGB, "BT2020_RGB"},
+    {KODI::UTILS::Colorimetry::ST2113_RGB, "Default"},
+    {KODI::UTILS::Colorimetry::ICTCP, "Default"},
+});
+} // namespace
 
 CWinSystemGbm::CWinSystemGbm() :
   m_DRM(nullptr),
@@ -343,9 +365,23 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
   if (!drm)
     return false;
 
+  auto connector = drm->GetConnector();
+  if (!connector)
+    return false;
+
   if (!videoPicture)
   {
-    auto connector = drm->GetConnector();
+    if (connector->SupportsProperty("Colorspace"))
+    {
+      std::optional<uint64_t> colorspace = connector->GetPropertyValue("Colorspace", "Default");
+      if (colorspace)
+      {
+        CLog::LogF(LOGDEBUG, "setting connector colorspace to Default");
+        drm->AddProperty(connector, "Colorspace", colorspace.value());
+        drm->SetActive(true);
+      }
+    }
+
     if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
     {
       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
@@ -359,9 +395,23 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     return true;
   }
 
+  KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
+
+  if (connector->SupportsProperty("Colorspace") && m_info &&
+      m_info->SupportsColorimetry(colorimetry))
+  {
+    std::optional<uint64_t> colorspace =
+        connector->GetPropertyValue("Colorspace", ColorimetryMap.at(colorimetry));
+    if (colorspace)
+    {
+      CLog::LogF(LOGDEBUG, "setting connector colorspace to {}", ColorimetryMap.at(colorimetry));
+      drm->AddProperty(connector, "Colorspace", colorspace.value());
+      drm->SetActive(true);
+    }
+  }
+
   KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
 
-  auto connector = drm->GetConnector();
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA") && m_info &&
       m_info->SupportsHDRStaticMetadataType1() && m_info->SupportsEOTF(eotf))
   {

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -80,8 +80,8 @@ bool CDRMObject::GetProperties(uint32_t id, uint32_t type)
   return true;
 }
 
-std::optional<uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
-                                                     const std::string& valueName) const
+std::optional<uint64_t> CDRMObject::GetPropertyValue(std::string_view name,
+                                                     std::string_view valueName) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](const auto& prop) { return prop->name == name; });

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <vector>
 
 #include <xf86drmMode.h>
@@ -35,8 +36,7 @@ public:
 
   uint32_t GetId() const { return m_id; }
   uint32_t GetPropertyId(const std::string& name) const;
-  std::optional<uint64_t> GetPropertyValue(const std::string& name,
-                                           const std::string& valueName) const;
+  std::optional<uint64_t> GetPropertyValue(std::string_view name, std::string_view valueName) const;
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);


### PR DESCRIPTION
This allows setting the Colorspace connector drm propery. This allows specifying the output colorspace and allows tv's to trigger into a specific colorspace mode (bt2020).

The Colorspace property is only exposed on intel hardware and vc4 (RPi4).

The colorspace options aren't exposed through any header (that I know of). They are currently defined in the linux kernel.

ref: https://github.com/torvalds/linux/blob/b96fbd602d35739b5cdb49baa02048f2c41fdab1/drivers/gpu/drm/drm_connector.c#L955

You can see the bt2020 mode present on my tv in this photo:

![image](https://user-images.githubusercontent.com/1616460/180618105-1af5b012-3d6b-4613-87ef-991cc2d760c0.jpeg)

