### PR TITLE
[PVR] Settings: Inform user in case no client-specific actions are available

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10515,7 +10515,7 @@ msgctxt "#19191"
 msgid "PVR service"
 msgstr ""
 
-#. error message box text stating that none of the available pvr clients does support channel scanning
+#. info message box text stating that none of the available pvr clients does support channel scanning
 #: xbmc/pvr/PVRGUIActions.cpp
 msgctxt "#19192"
 msgid "None of the connected PVR backends supports scanning for channels."
@@ -11445,7 +11445,13 @@ msgctxt "#19346"
 msgid "Display and manage available PVR client add-ons."
 msgstr ""
 
-#empty strings from id 19347 to 19498
+#. info message box text stating that none of the available pvr clients does provide client-specific settings
+#: xbmc/pvr/PVRGUIActions.cpp
+msgctxt "#19347"
+msgid "None of the active PVR clients provide client-specific settings."
+msgstr ""
+
+#empty strings from id 19348 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1709,7 +1709,13 @@ namespace PVR
     }
 
     if (settingsHooks.empty())
+    {
+      HELPERS::ShowOKDialogText(
+          CVariant{19033}, // "Information"
+          CVariant{
+              19347}); // "None of the active PVR clients does provide client-specific settings."
       return true; // no settings hooks, no error
+    }
 
     auto selectedHook = settingsHooks.begin();
 


### PR DESCRIPTION
Before: 

After clicking the `Client specific settings`settings action nothing happened if none of the clients does provide such settings.

After:

![screenshot00001](https://user-images.githubusercontent.com/3226626/189522943-aa5a7076-e57f-48d5-aa6e-759bff016239.png)

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish this should be a no-brainer.