### PR TITLE
[macOS] fix crash on exit

### DIFF
--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -1070,13 +1070,6 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     // restore the windowed window level
     [[last_view window] setLevel:last_window_level];
 
-    // Get rid of the new window we created.
-    if (windowedFullScreenwindow != nil)
-    {
-      [windowedFullScreenwindow close];
-      windowedFullScreenwindow = nil;
-    }
-
     // Unblank.
     // Force the unblank when returning from fullscreen, we get called with blankOtherDisplays set false.
     //if (blankOtherDisplays)

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -915,7 +915,6 @@ static bool needtoshowme = true;
 bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   static NSWindow* windowedFullScreenwindow = NULL;
-  static NSScreen* last_window_screen = NULL;
   static NSPoint last_window_origin;
   static NSView* last_view = NULL;
   static NSSize last_view_size;
@@ -977,7 +976,6 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     last_view = [cur_context view];
     last_view_size = [last_view frame].size;
     last_view_origin = [last_view frame].origin;
-    last_window_screen = [[last_view window] screen];
     last_window_origin = [[last_view window] frame].origin;
     last_window_level = [[last_view window] level];
 
@@ -1086,8 +1084,6 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     // return the mouse bounds in SDL view to previous size
     [ last_view setFrameSize:last_view_size ];
     [ last_view setFrameOrigin:last_view_origin ];
-    // done with restoring windowed window, don't set last_view to NULL as we can lose it under dual displays.
-    //last_window_screen = NULL;
 
     // Release the fullscreen context.
     if (CWinSystemOSXImpl::m_lastOwnedContext == cur_context)

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -914,9 +914,9 @@ static bool needtoshowme = true;
 
 bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
-  static NSWindow* windowedFullScreenwindow = NULL;
+  static NSWindow* windowedFullScreenwindow = nil;
   static NSPoint last_window_origin;
-  static NSView* last_view = NULL;
+  static NSView* last_view = nil;
   static NSSize last_view_size;
   static NSPoint last_view_origin;
   static NSInteger last_window_level = NSNormalWindowLevel;
@@ -961,7 +961,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     return false;
   }
 
-  if (windowedFullScreenwindow != NULL)
+  if (windowedFullScreenwindow != nil)
   {
     [windowedFullScreenwindow close];
     windowedFullScreenwindow = nil;
@@ -970,7 +970,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   if (m_bFullScreen)
   {
     // FullScreen Mode
-    NSOpenGLContext* newContext = NULL;
+    NSOpenGLContext* newContext = nil;
 
     // Save info about the windowed context so we can restore it when returning to windowed.
     last_view = [cur_context view];
@@ -982,7 +982,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     // This is Cocoa Windowed FullScreen Mode
     // Get the screen rect of our current display
     NSScreen* pScreen = [[NSScreen screens] objectAtIndex:m_lastDisplayNr];
-    NSRect    screenRect = [pScreen frame];
+    NSRect screenRect = [pScreen frame];
 
     // remove frame origin offset of original display
     screenRect.origin = NSZeroPoint;
@@ -1046,8 +1046,8 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     // Release old context if we created it.
     if (CWinSystemOSXImpl::m_lastOwnedContext == cur_context)
     {
-      [ NSOpenGLContext clearCurrentContext ];
-      [ cur_context clearDrawable ];
+      [NSOpenGLContext clearCurrentContext];
+      [cur_context clearDrawable];
     }
 
     // activate context
@@ -1082,14 +1082,14 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     [newContext setView:last_view];
     [[last_view window] setFrameOrigin:last_window_origin];
     // return the mouse bounds in SDL view to previous size
-    [ last_view setFrameSize:last_view_size ];
-    [ last_view setFrameOrigin:last_view_origin ];
+    [last_view setFrameSize:last_view_size];
+    [last_view setFrameOrigin:last_view_origin];
 
     // Release the fullscreen context.
     if (CWinSystemOSXImpl::m_lastOwnedContext == cur_context)
     {
-      [ NSOpenGLContext clearCurrentContext ];
-      [ cur_context clearDrawable ];
+      [NSOpenGLContext clearCurrentContext];
+      [cur_context clearDrawable];
     }
 
     // Activate context.

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -995,6 +995,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     backing:NSBackingStoreBuffered
     defer:NO
     screen:pScreen];
+    windowedFullScreenwindow.releasedWhenClosed = NO;
 
     [windowedFullScreenwindow setBackgroundColor:[NSColor blackColor]];
     [windowedFullScreenwindow makeKeyAndOrderFront:nil];


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- prevents over-release of a window object
- improves code style

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Crash on exit happens if you switch between fullscreen/window or if you switch Kodi between multiple displays, 100% reproducibility.

It has been reported multiple times, e.g. https://forum.kodi.tv/showthread.php?tid=359982

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on macOS 12.5.1 with the latest master.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Prevents annoying crash report on app exit.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
