### PR TITLE
Fix double free of SQLite errmsg

### DIFF
--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -212,7 +212,6 @@ protected:
   result_set result;
   result_set exec_res;
   bool autorefresh;
-  char* errmsg;
 
   bool active; // Is Query Opened?
   bool haveError;

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1643,7 +1643,6 @@ MysqlDataset::MysqlDataset() : Dataset()
 {
   haveError = false;
   db = NULL;
-  errmsg = NULL;
   autorefresh = false;
 }
 
@@ -1651,14 +1650,11 @@ MysqlDataset::MysqlDataset(MysqlDatabase* newDb) : Dataset(newDb)
 {
   haveError = false;
   db = newDb;
-  errmsg = NULL;
   autorefresh = false;
 }
 
 MysqlDataset::~MysqlDataset()
 {
-  if (errmsg)
-    free(errmsg);
 }
 
 void MysqlDataset::set_autorefresh(bool val)

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -651,7 +651,6 @@ SqliteDataset::SqliteDataset() : Dataset()
 {
   haveError = false;
   db = NULL;
-  errmsg = NULL;
   autorefresh = false;
 }
 
@@ -659,14 +658,11 @@ SqliteDataset::SqliteDataset(SqliteDatabase* newDb) : Dataset(newDb)
 {
   haveError = false;
   db = newDb;
-  errmsg = NULL;
   autorefresh = false;
 }
 
 SqliteDataset::~SqliteDataset()
 {
-  if (errmsg)
-    sqlite3_free(errmsg);
 }
 
 void SqliteDataset::set_autorefresh(bool val)
@@ -845,6 +841,7 @@ int SqliteDataset::exec(const std::string& sql)
       qry = qry.substr(0, pos);
   }
 
+  char* errmsg;
   if ((res = db->setErr(sqlite3_exec(handle(), qry.c_str(), &callback, &exec_res, &errmsg),
                         qry.c_str())) == SQLITE_OK)
     return res;


### PR DESCRIPTION
## Description
Fix a double free that has been lurking in the SQLite error path.

## Motivation and context
Crashes

## How has this been tested?
Run-test with corrupt DB that throws error on update

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
