### PR TITLE
[PVR] CPVRTimers::GetTimerForEpgTag: Add missing client id check.

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -1156,7 +1156,8 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerForEpgTag(const std::share
           return timersEntry;
 
         if (timersEntry->m_iClientChannelUid != PVR_CHANNEL_INVALID_UID &&
-            timersEntry->m_iClientChannelUid == epgTag->UniqueChannelID())
+            timersEntry->m_iClientChannelUid == epgTag->UniqueChannelID() &&
+            timersEntry->m_iClientId == epgTag->ClientID())
         {
           if (timersEntry->UniqueBroadcastID() != EPG_TAG_INVALID_UID &&
               timersEntry->UniqueBroadcastID() == epgTag->UniqueBroadcastID())


### PR DESCRIPTION
Nothing serious, just a small fix. Can happen only with multi-client setups. When looking for a timer matching a given EPG tag, we need also to check the client id, not only the channel uid. Channel uids are not unique across clients.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish should be a no-brainer.